### PR TITLE
fix(show): forward host Esc into the annotation overlay so Esc exits annotation mode

### DIFF
--- a/ui/src/components/AccountMenu.test.tsx
+++ b/ui/src/components/AccountMenu.test.tsx
@@ -1,0 +1,46 @@
+/* @vitest-environment jsdom */
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AccountMenu } from './AccountMenu';
+
+const auth = vi.hoisted(() => ({
+  email: 'alex@example.com' as string | null,
+  signingOut: false,
+  signOut: vi.fn(),
+}));
+
+vi.mock('../lib/useAuthAccount', () => ({
+  useAuthAccount: () => auth,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+beforeEach(() => {
+  auth.email = 'alex@example.com';
+  auth.signingOut = false;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('AccountMenu', () => {
+  it('closes its open menu and marks Escape as consumed', () => {
+    render(<AccountMenu />);
+    fireEvent.click(screen.getByRole('button', { name: 'appShell.accountMenuLabel' }));
+
+    const menuItem = screen.getByRole('menuitem');
+    const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+    act(() => menuItem.dispatchEvent(event));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+});

--- a/ui/src/components/AccountMenu.tsx
+++ b/ui/src/components/AccountMenu.tsx
@@ -24,7 +24,10 @@ export const AccountMenu: React.FC<{ openUpward?: boolean }> = ({ openUpward = f
       }
     };
     const handleKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setIsOpen(false);
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setIsOpen(false);
+      }
     };
     if (isOpen) {
       document.addEventListener('mousedown', handleClickOutside);

--- a/ui/src/components/ui/context-menu.test.tsx
+++ b/ui/src/components/ui/context-menu.test.tsx
@@ -1,0 +1,25 @@
+/* @vitest-environment jsdom */
+
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ContextMenu } from './context-menu';
+
+afterEach(cleanup);
+
+describe('ContextMenu', () => {
+  it('closes and marks Escape as consumed', () => {
+    const onClose = vi.fn();
+    render(
+      <ContextMenu x={0} y={0} onClose={onClose}>
+        <button type="button">Menu item</button>
+      </ContextMenu>,
+    );
+    const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+
+    act(() => window.dispatchEvent(event));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+});

--- a/ui/src/components/ui/context-menu.tsx
+++ b/ui/src/components/ui/context-menu.tsx
@@ -45,7 +45,10 @@ export const ContextMenu: React.FC<{
 }> = ({ x, y, onClose, children, width = 196, itemCount = 4 }) => {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);

--- a/ui/src/components/workbench/useShowPageAnnotation.test.ts
+++ b/ui/src/components/workbench/useShowPageAnnotation.test.ts
@@ -147,6 +147,22 @@ describe('useShowPageAnnotation host Escape forwarding', () => {
     expect(frameKeydown).not.toHaveBeenCalled();
   });
 
+  it('leaves Escape with an outside target while a custom menu is open', () => {
+    const { iframe } = mountBridge();
+    const frameKeydown = listenForFrameKeydown(iframe);
+    reportState(iframe, true);
+
+    const menu = document.createElement('div');
+    menu.setAttribute('role', 'menu');
+    document.body.append(menu);
+    const invokingButton = document.createElement('button');
+    document.body.append(invokingButton);
+
+    dispatchParentKeydown(invokingButton);
+
+    expect(frameKeydown).not.toHaveBeenCalled();
+  });
+
   it('leaves Escape with an expanded popup trigger', () => {
     const { iframe } = mountBridge();
     const frameKeydown = listenForFrameKeydown(iframe);

--- a/ui/src/components/workbench/useShowPageAnnotation.test.ts
+++ b/ui/src/components/workbench/useShowPageAnnotation.test.ts
@@ -131,6 +131,23 @@ describe('useShowPageAnnotation host Escape forwarding', () => {
     expect(frameKeydown).not.toHaveBeenCalled();
   });
 
+  it('forwards Escape from the non-modal pinned Show Page window container', () => {
+    const { iframe } = mountBridge();
+    const frameKeydown = listenForFrameKeydown(iframe);
+    reportState(iframe, true);
+
+    const appWindow = document.createElement('div');
+    appWindow.setAttribute('role', 'dialog');
+    appWindow.dataset.windowId = 'show-window';
+    const titleBarButton = document.createElement('button');
+    appWindow.append(titleBarButton);
+    document.body.append(appWindow);
+
+    dispatchParentKeydown(titleBarButton);
+
+    expect(frameKeydown).toHaveBeenCalledTimes(1);
+  });
+
   it('does not forward an already-prevented parent Escape', () => {
     const { iframe } = mountBridge();
     const frameKeydown = listenForFrameKeydown(iframe);

--- a/ui/src/components/workbench/useShowPageAnnotation.test.ts
+++ b/ui/src/components/workbench/useShowPageAnnotation.test.ts
@@ -131,6 +131,51 @@ describe('useShowPageAnnotation host Escape forwarding', () => {
     expect(frameKeydown).not.toHaveBeenCalled();
   });
 
+  it('leaves Escape with a target inside a custom menu', () => {
+    const { iframe } = mountBridge();
+    const frameKeydown = listenForFrameKeydown(iframe);
+    reportState(iframe, true);
+
+    const menu = document.createElement('div');
+    menu.setAttribute('role', 'menu');
+    const menuItem = document.createElement('button');
+    menu.append(menuItem);
+    document.body.append(menu);
+
+    dispatchParentKeydown(menuItem);
+
+    expect(frameKeydown).not.toHaveBeenCalled();
+  });
+
+  it('leaves Escape with an expanded popup trigger', () => {
+    const { iframe } = mountBridge();
+    const frameKeydown = listenForFrameKeydown(iframe);
+    reportState(iframe, true);
+
+    const trigger = document.createElement('button');
+    trigger.setAttribute('aria-expanded', 'true');
+    trigger.setAttribute('aria-haspopup', 'menu');
+    document.body.append(trigger);
+
+    dispatchParentKeydown(trigger);
+
+    expect(frameKeydown).not.toHaveBeenCalled();
+  });
+
+  it('forwards Escape from an expanded non-popup control', () => {
+    const { iframe } = mountBridge();
+    const frameKeydown = listenForFrameKeydown(iframe);
+    reportState(iframe, true);
+
+    const accordionTrigger = document.createElement('button');
+    accordionTrigger.setAttribute('aria-expanded', 'true');
+    document.body.append(accordionTrigger);
+
+    dispatchParentKeydown(accordionTrigger);
+
+    expect(frameKeydown).toHaveBeenCalledTimes(1);
+  });
+
   it('forwards Escape from the non-modal pinned Show Page window container', () => {
     const { iframe } = mountBridge();
     const frameKeydown = listenForFrameKeydown(iframe);

--- a/ui/src/components/workbench/useShowPageAnnotation.test.ts
+++ b/ui/src/components/workbench/useShowPageAnnotation.test.ts
@@ -1,0 +1,190 @@
+/* @vitest-environment jsdom */
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useShowPageAnnotation } from './useShowPageAnnotation';
+
+let teardown: (() => void) | null = null;
+
+afterEach(() => {
+  teardown?.();
+  teardown = null;
+  document.body.replaceChildren();
+});
+
+const mountBridge = (initialSrc: string | null = '/show/session') => {
+  const iframe = document.createElement('iframe');
+  document.body.append(iframe);
+  const hook = renderHook(({ src }) => useShowPageAnnotation(src), {
+    initialProps: { src: initialSrc },
+  });
+
+  act(() => hook.result.current.setIframe(iframe));
+  teardown = () => {
+    act(() => hook.result.current.setIframe(null));
+    hook.unmount();
+    iframe.remove();
+  };
+
+  return { iframe, ...hook };
+};
+
+const reportState = (iframe: HTMLIFrameElement, enabled: boolean) => {
+  const source = iframe.contentWindow;
+  if (!source) throw new Error('Expected the attached iframe to have a contentWindow');
+
+  act(() => {
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: window.location.origin,
+        source,
+        data: {
+          type: 'avibe:annotation:state',
+          enabled,
+          mode: 'smart',
+          available: true,
+        },
+      }),
+    );
+  });
+};
+
+const listenForFrameKeydown = (iframe: HTMLIFrameElement) => {
+  const listener = vi.fn();
+  const frameDocument = iframe.contentDocument;
+  if (!frameDocument) throw new Error('Expected the attached iframe to have a contentDocument');
+  frameDocument.addEventListener('keydown', listener);
+  return listener;
+};
+
+const dispatchParentKeydown = (target: EventTarget, key = 'Escape', preventDefault = false) => {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+  if (preventDefault) event.preventDefault();
+  act(() => target.dispatchEvent(event));
+};
+
+describe('useShowPageAnnotation host Escape forwarding', () => {
+  it('forwards parent Escape to the iframe document while annotation is enabled', () => {
+    const { iframe } = mountBridge();
+    const frameKeydown = listenForFrameKeydown(iframe);
+    reportState(iframe, true);
+
+    dispatchParentKeydown(document.body, 'Enter');
+    expect(frameKeydown).not.toHaveBeenCalled();
+
+    dispatchParentKeydown(document.body);
+
+    expect(frameKeydown).toHaveBeenCalledTimes(1);
+    expect(frameKeydown.mock.calls[0]?.[0]).toMatchObject({ key: 'Escape', bubbles: true, cancelable: true });
+  });
+
+  it('leaves Escape with an editable target or editable ancestor', () => {
+    const { iframe } = mountBridge();
+    const frameKeydown = listenForFrameKeydown(iframe);
+    reportState(iframe, true);
+
+    const textarea = document.createElement('textarea');
+    document.body.append(textarea);
+    dispatchParentKeydown(textarea);
+
+    const input = document.createElement('input');
+    document.body.append(input);
+    dispatchParentKeydown(input);
+
+    const editor = document.createElement('div');
+    editor.setAttribute('contenteditable', 'true');
+    const child = document.createElement('span');
+    editor.append(child);
+    document.body.append(editor);
+    dispatchParentKeydown(child);
+
+    expect(frameKeydown).not.toHaveBeenCalled();
+  });
+
+  it('leaves Escape with targets inside an open overlay or dialog', () => {
+    const { iframe } = mountBridge();
+    const frameKeydown = listenForFrameKeydown(iframe);
+    reportState(iframe, true);
+
+    const openPopover = document.createElement('div');
+    openPopover.dataset.state = 'open';
+    const popoverTarget = document.createElement('button');
+    openPopover.append(popoverTarget);
+    document.body.append(openPopover);
+    dispatchParentKeydown(popoverTarget);
+
+    const roleDialog = document.createElement('div');
+    roleDialog.setAttribute('role', 'dialog');
+    const roleDialogTarget = document.createElement('button');
+    roleDialog.append(roleDialogTarget);
+    document.body.append(roleDialog);
+    dispatchParentKeydown(roleDialogTarget);
+
+    const nativeDialog = document.createElement('dialog');
+    nativeDialog.open = true;
+    const nativeDialogTarget = document.createElement('button');
+    nativeDialog.append(nativeDialogTarget);
+    document.body.append(nativeDialog);
+    dispatchParentKeydown(nativeDialogTarget);
+
+    expect(frameKeydown).not.toHaveBeenCalled();
+  });
+
+  it('does not forward an already-prevented parent Escape', () => {
+    const { iframe } = mountBridge();
+    const frameKeydown = listenForFrameKeydown(iframe);
+    reportState(iframe, true);
+
+    dispatchParentKeydown(document.body, 'Escape', true);
+
+    expect(frameKeydown).not.toHaveBeenCalled();
+  });
+
+  it('disarms forwarding when annotation becomes disabled', () => {
+    const { iframe } = mountBridge();
+    const frameKeydown = listenForFrameKeydown(iframe);
+    reportState(iframe, true);
+    dispatchParentKeydown(document.body);
+    expect(frameKeydown).toHaveBeenCalledTimes(1);
+
+    reportState(iframe, false);
+    dispatchParentKeydown(document.body);
+
+    expect(frameKeydown).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not arm forwarding before the overlay reports state', () => {
+    const { iframe } = mountBridge();
+    const frameKeydown = listenForFrameKeydown(iframe);
+
+    dispatchParentKeydown(document.body);
+
+    expect(frameKeydown).not.toHaveBeenCalled();
+  });
+
+  it('disarms forwarding when the source resets state to unknown', () => {
+    const { iframe, result, rerender } = mountBridge();
+    const frameKeydown = listenForFrameKeydown(iframe);
+    reportState(iframe, true);
+    dispatchParentKeydown(document.body);
+    expect(frameKeydown).toHaveBeenCalledTimes(1);
+
+    rerender({ src: null });
+    expect(result.current.state).toBeNull();
+    dispatchParentKeydown(document.body);
+
+    expect(frameKeydown).toHaveBeenCalledTimes(1);
+  });
+
+  it('disarms forwarding when the iframe unmounts', () => {
+    const { iframe, result } = mountBridge();
+    const frameKeydown = listenForFrameKeydown(iframe);
+    reportState(iframe, true);
+
+    act(() => result.current.setIframe(null));
+    dispatchParentKeydown(document.body);
+
+    expect(frameKeydown).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/workbench/useShowPageAnnotation.ts
+++ b/ui/src/components/workbench/useShowPageAnnotation.ts
@@ -101,6 +101,9 @@ export function useShowPageAnnotation(src: string | null): AnnotationBridge {
     if (event.key !== 'Escape' || event.defaultPrevented) return;
     const target = event.target;
     if (target instanceof Element && target.closest(PARENT_ESCAPE_CLAIM_SELECTOR)) return;
+    // Custom menus render role=menu only while open, so its presence is an
+    // open-state fact even when focus remains on the invoking element.
+    if (document.querySelector('[role="menu"]')) return;
 
     try {
       const frameDocument = iframeRef.current?.contentDocument;

--- a/ui/src/components/workbench/useShowPageAnnotation.ts
+++ b/ui/src/components/workbench/useShowPageAnnotation.ts
@@ -36,7 +36,7 @@ type ControlMessage =
   | { type: 'avibe:annotation:query' };
 
 const PARENT_ESCAPE_CLAIM_SELECTOR =
-  'input, textarea, [contenteditable]:not([contenteditable="false"]), [data-state="open"], [role="dialog"]:not([data-window-id]), dialog[open]';
+  'input, textarea, [contenteditable]:not([contenteditable="false"]), [data-state="open"], [role="menu"], [aria-expanded="true"][aria-haspopup], [role="dialog"]:not([data-window-id]), dialog[open]';
 
 /**
  * `src` is the current iframe URL; changing it (first open, or a private↔public

--- a/ui/src/components/workbench/useShowPageAnnotation.ts
+++ b/ui/src/components/workbench/useShowPageAnnotation.ts
@@ -35,6 +35,9 @@ type ControlMessage =
   | { type: 'avibe:annotation:control'; action: 'set-mode'; mode: AnnotationMode }
   | { type: 'avibe:annotation:query' };
 
+const PARENT_ESCAPE_CLAIM_SELECTOR =
+  'input, textarea, [contenteditable]:not([contenteditable="false"]), [data-state="open"], [role="dialog"], dialog[open]';
+
 /**
  * `src` is the current iframe URL; changing it (first open, or a private↔public
  * re-point, or a session switch that clears it) drops the derived state back to
@@ -94,6 +97,41 @@ export function useShowPageAnnotation(src: string | null): AnnotationBridge {
     return stopListening;
   }, [startListening, stopListening]);
 
+  const onParentKeyDown = useCallback((event: KeyboardEvent) => {
+    if (event.key !== 'Escape' || event.defaultPrevented) return;
+    const target = event.target;
+    if (target instanceof Element && target.closest(PARENT_ESCAPE_CLAIM_SELECTOR)) return;
+
+    try {
+      const frameDocument = iframeRef.current?.contentDocument;
+      if (!frameDocument) return;
+      const FrameKeyboardEvent = frameDocument.defaultView?.KeyboardEvent ?? KeyboardEvent;
+      frameDocument.dispatchEvent(
+        new FrameKeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+      );
+    } catch {
+      // The frame may be sandboxed, navigating, or already torn down.
+    }
+  }, []);
+
+  const escapeListeningRef = useRef(false);
+  const startEscapeListening = useCallback(() => {
+    if (escapeListeningRef.current) return;
+    window.addEventListener('keydown', onParentKeyDown);
+    escapeListeningRef.current = true;
+  }, [onParentKeyDown]);
+  const stopEscapeListening = useCallback(() => {
+    if (!escapeListeningRef.current) return;
+    window.removeEventListener('keydown', onParentKeyDown);
+    escapeListeningRef.current = false;
+  }, [onParentKeyDown]);
+
+  useEffect(() => {
+    if (state?.enabled === true && iframeRef.current) startEscapeListening();
+    else stopEscapeListening();
+    return stopEscapeListening;
+  }, [startEscapeListening, state?.enabled, stopEscapeListening]);
+
   const post = useCallback((message: ControlMessage) => {
     const win = iframeRef.current?.contentWindow;
     if (win) win.postMessage(message, window.location.origin);
@@ -101,10 +139,14 @@ export function useShowPageAnnotation(src: string | null): AnnotationBridge {
 
   const setIframe = useCallback<React.RefCallback<HTMLIFrameElement>>(
     (iframe) => {
+      if (iframeRef.current !== iframe) stopEscapeListening();
       iframeRef.current = iframe;
-      if (iframe) startListening();
+      if (iframe) {
+        startListening();
+        if (state?.enabled === true) startEscapeListening();
+      }
     },
-    [startListening],
+    [startEscapeListening, startListening, state?.enabled, stopEscapeListening],
   );
 
   const enable = useCallback(

--- a/ui/src/components/workbench/useShowPageAnnotation.ts
+++ b/ui/src/components/workbench/useShowPageAnnotation.ts
@@ -36,7 +36,7 @@ type ControlMessage =
   | { type: 'avibe:annotation:query' };
 
 const PARENT_ESCAPE_CLAIM_SELECTOR =
-  'input, textarea, [contenteditable]:not([contenteditable="false"]), [data-state="open"], [role="dialog"], dialog[open]';
+  'input, textarea, [contenteditable]:not([contenteditable="false"]), [data-state="open"], [role="dialog"]:not([data-window-id]), dialog[open]';
 
 /**
  * `src` is the current iframe URL; changing it (first open, or a private↔public


### PR DESCRIPTION
## Changed capability

- Forward host-document Escape keydowns into the active Show Page annotation iframe while the overlay reports `enabled: true`.
- Preserve parent ownership of Escape for editable targets, open overlays/dialogs, custom menus, expanded popup triggers, and already-prevented events.
- Arm and disarm forwarding with annotation state, iframe mount state, and Show Page source resets, so both chat-hosted and pinned-window Show Pages inherit the fix.

## Root cause

The annotation entry control lives in the parent workbench document. Enabling annotation from the chat header or app-window chrome left keyboard focus in that parent, and keydown events do not cross the iframe boundary. The host bridge had no Escape forwarding path, so the runtime overlay never received the key until the user first focused the Show Page iframe.

## Evidence

- Unit: focused hook, AccountMenu, and ContextMenu suites cover forwarding, target and state-based parent claims, popup semantics, consumer marking, pinned-window chrome, disabled/unknown state, source reset, and iframe unmount; full UI suite passes (223 files, 2772 tests).
- Contract: the frozen postMessage protocol is unchanged; the synthetic event is dispatched on the iframe document so the runtime's native Escape handler remains the single owner of draft-cancel/disable semantics.
- Scenario: no scenario catalog entry exists for this surface.
- Build: `npm run build` passes.
- Lint: `npm run lint` passes with no baseline drift.
- Residual manual check: the orchestrator will verify the host-entry flow in-browser after merge, including chat-header and pinned-window annotation entry.

## Known by design

- When several annotated Show Page surfaces are live at once (chat view plus pinned windows), one host Escape exits all of them. This is acceptable and rare.
- The synthetic dispatch reaches the overlay's document-level native Escape handler only, not React-delegated overlay handlers. This is intentional and keeps the overlay as the single decision maker for its two-step Escape semantics.
- The bridge owns host Escape forwarding; parent surfaces claim Escape through standard open-popup semantics (including a mounted `role="menu"` when focus remains elsewhere) or by marking consumption with `preventDefault()`.
- Accordion-style controls with `aria-expanded="true"` but no `aria-haspopup` do not claim Escape, so they continue forwarding to the annotation overlay.
