### PR TITLE
feat(show): share only in Show Page mode + window title-bar Share

### DIFF
--- a/ui/src/components/apps/AppWindow.tsx
+++ b/ui/src/components/apps/AppWindow.tsx
@@ -304,7 +304,7 @@ export const AppWindow: React.FC<{
         onDoubleClick={() => wm.toggleMaximize(win.id)}
         className="flex h-9 shrink-0 select-none items-center gap-3 border-b border-border px-3.5"
       >
-        <div className={clsx('flex shrink-0 items-center gap-2', showpageSid ? 'w-20' : 'w-[52px]')}>
+        <div className={clsx('flex shrink-0 items-center gap-2', showpageSid ? 'w-28' : 'w-[52px]')}>
           {lights.map((l) => (
             <button
               key={l.key}
@@ -342,8 +342,9 @@ export const AppWindow: React.FC<{
         </div>
         {/* Mirror the left cluster so the title stays centered. Show Page windows
             add a compact annotation control and a Share control before chat +
-            open-in-new-tab. */}
-        <div className={clsx('flex shrink-0 items-center justify-end gap-1', showpageSid ? 'w-20' : 'w-[52px]')}>
+            open-in-new-tab — up to four size-6 controls plus gaps (108px), so both
+            clusters reserve w-28 (112px) to keep them from crowding the title. */}
+        <div className={clsx('flex shrink-0 items-center justify-end gap-1', showpageSid ? 'w-28' : 'w-[52px]')}>
           {showpageSid && annotationHost?.src && !win.minimized && exitKind === null && (
             <div
               onPointerDown={(e) => e.stopPropagation()}

--- a/ui/src/components/apps/AppWindow.tsx
+++ b/ui/src/components/apps/AppWindow.tsx
@@ -16,7 +16,9 @@ import { WindowBodyGestureShield } from './WindowBodyGestureShield';
 import { shouldShieldWindowBody } from './windowGesture';
 import { ErrorBoundary } from '../ui/error-boundary';
 import { ShowPageAnnotateControl } from '../workbench/ShowPageAnnotateControl';
+import { ShowPageShareControl } from '../workbench/ShowPageShareControl';
 import { useShowPageAnnotationHost } from '../workbench/ShowPageAnnotationHostContext';
+import { useInstanceAuthorization } from '../../context/InstanceAuthorizationContext';
 
 const RESIZE_HANDLES: { dir: ResizeDir; className: string }[] = [
   { dir: 'n', className: 'left-2 right-2 top-0 h-1.5 cursor-ns-resize' },
@@ -57,6 +59,7 @@ export const AppWindow: React.FC<{
   // maximize/restore don't animate at all.
   const [dragging, setDragging] = useState(false);
   const [annotateOpen, setAnnotateOpen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
   const focusWindow = wm.focus;
   const handleAnnotateOpenChange = useCallback(
     (open: boolean) => {
@@ -65,6 +68,16 @@ export const AppWindow: React.FC<{
     },
     [focusWindow, win.id],
   );
+  // The Share popover floats over the window's iframe exactly like the annotate
+  // popover: opening it also claims window focus so the portal stays owned here.
+  const handleShareOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) focusWindow(win.id);
+      setShareOpen(open);
+    },
+    [focusWindow, win.id],
+  );
+  const { capabilities } = useInstanceAuthorization();
 
   // Keep a visible window reachable when the geometry around it changes without a
   // drag: the layer shrinking, or the window being restored / un-maximized after the
@@ -328,7 +341,8 @@ export const AppWindow: React.FC<{
           <span className="truncate text-[13px] font-semibold text-foreground">{win.title ?? t(def.titleKey)}</span>
         </div>
         {/* Mirror the left cluster so the title stays centered. Show Page windows
-            add a compact annotation control before chat + open-in-new-tab. */}
+            add a compact annotation control and a Share control before chat +
+            open-in-new-tab. */}
         <div className={clsx('flex shrink-0 items-center justify-end gap-1', showpageSid ? 'w-20' : 'w-[52px]')}>
           {showpageSid && annotationHost?.src && !win.minimized && exitKind === null && (
             <div
@@ -376,6 +390,23 @@ export const AppWindow: React.FC<{
               <MessageCircle className="size-3.5" />
             </button>
           )}
+          {showpageSid && annotationHost?.src && !win.minimized && exitKind === null
+            && capabilities.can_use_show_pages && (
+            <div
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => e.stopPropagation()}
+              onDoubleClick={(e) => e.stopPropagation()}
+              className="flex size-6 shrink-0 items-center justify-center"
+            >
+              <ShowPageShareControl
+                compact
+                sessionId={showpageSid}
+                canManageInstance={capabilities.can_manage_instance}
+                onOpenChange={handleShareOpenChange}
+                ownerWindowId={win.id}
+              />
+            </div>
+          )}
           {safeExternalHref && (
             <a
               href={safeExternalHref}
@@ -404,7 +435,7 @@ export const AppWindow: React.FC<{
             transparent overlay so a gesture's pointer can't be stolen by the iframe and the
             cursor doesn't flicker over it — belt-and-braces with the gesture's pointer capture. */}
         <WindowBodyGestureShield active={shouldShieldWindowBody(wm.gestureActive, win.minimized)} />
-        {annotateOpen && annotationHost?.src && (
+        {(annotateOpen || shareOpen) && annotationHost?.src && (
           <div aria-hidden data-annotation-shield className="absolute inset-0 z-20" />
         )}
       </div>

--- a/ui/src/components/ui/confirm-dialog.tsx
+++ b/ui/src/components/ui/confirm-dialog.tsx
@@ -33,6 +33,12 @@ export interface ConfirmDialogProps {
    * theme and clash with its opener.
    */
   dataTheme?: 'dark';
+  /**
+   * Associate the body-portalled dialog with its owning app window so window
+   * keyboard chords (e.g. ⌘W) still resolve to that window while the dialog
+   * holds focus. See windowChords.ts `data-window-owner-id`.
+   */
+  windowOwnerId?: string;
 }
 
 /**
@@ -53,6 +59,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   confirmDisabled = false,
   onConfirm,
   dataTheme,
+  windowOwnerId,
 }) => {
   const { t } = useTranslation();
   const [remaining, setRemaining] = React.useState(0);
@@ -98,7 +105,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
         if (!busy) onOpenChange(next);
       }}
     >
-      <DialogContent className="max-w-md" data-theme={dataTheme}>
+      <DialogContent className="max-w-md" data-theme={dataTheme} data-window-owner-id={windowOwnerId}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           {description ? <DialogDescription>{description}</DialogDescription> : null}

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -3062,9 +3062,10 @@ export const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, d
   const sessionReadOnly = readOnlyReason !== null;
   const showPageActions = showPageControlActions(sessionReadOnly, showPageMode);
   const showLaunchControl = showPageActions.visualize && (showPageMode || canOpenShowPage);
-  const showShareControl = !sessionReadOnly
-    && canManageShowPage
-    && (showPageMode || showPageAccess !== null);
+  // Share lives ONLY while the page is framed (owner ruling 2026-08-17): the
+  // chat header never carries it, for anyone — access-only managers reach it
+  // from the framed view (or the app window title bar) instead.
+  const showShareControl = showPageActions.share && canManageShowPage;
   // ``!readOnly`` twice over: useSessionActions already yields an empty list for a
   // read-only session, and the withdrawal is re-stated here so this header cannot
   // grow a ⋯ full of guaranteed-409 rows if a future caller passes actions anyway.
@@ -3180,7 +3181,7 @@ export const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, d
             icon-only on mobile. In Show Page mode a Share control sits beside the
             back-to-chat button. */}
         {/* In Show Page mode the order is: annotation control, launch/back, Share.
-            Access-only managers can open Share from chat without receiving page use. */}
+            Share exists only there — never on the plain chat header. */}
         {(showLaunchControl || showShareControl || hasMobileSessionActions) && (
           <div className="ml-auto flex items-center gap-1.5">
             {showPageActions.annotate && writable && (

--- a/ui/src/components/workbench/ShowPageEmailAccessEditor.tsx
+++ b/ui/src/components/workbench/ShowPageEmailAccessEditor.tsx
@@ -27,11 +27,14 @@ export function ShowPageEmailAccessEditor({
   canManage,
   sessionId,
   onConfirmationOpenChange,
+  ownerWindowId,
 }: {
   active: boolean;
   canManage: boolean;
   sessionId: string;
   onConfirmationOpenChange?: (open: boolean) => void;
+  /** Attribute this control's body-portalled ConfirmDialog to its owning app window. */
+  ownerWindowId?: string;
 }) {
   const { t } = useTranslation();
   const api = useApi();
@@ -261,6 +264,7 @@ export function ShowPageEmailAccessEditor({
         description={t('organization.resources.narrowBody')}
         confirmLabel={t('organization.actions.saveChanges')}
         onConfirm={commit}
+        windowOwnerId={ownerWindowId}
       />
     </>
   );

--- a/ui/src/components/workbench/ShowPageShareControl.test.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.test.tsx
@@ -12,11 +12,24 @@ const api = {
   ensureShowPage: vi.fn(),
   getShowPageAccess: vi.fn(),
   getShowPageAuthorizedEmails: vi.fn(),
+  replaceShowPageAuthorizedEmails: vi.fn(),
+  listOrganizationResources: vi.fn(),
+  listOrganizationGroups: vi.fn(),
   setShowPageVisibility: vi.fn(),
   rotateShowPageShare: vi.fn(),
 };
 
 vi.mock('../../context/ApiContext', () => ({
+  ApiError: class ApiError extends Error {
+    code = null;
+  },
+  useApi: () => api,
+}));
+
+vi.mock('@/context/ApiContext', () => ({
+  ApiError: class ApiError extends Error {
+    code = null;
+  },
   useApi: () => api,
 }));
 
@@ -148,5 +161,87 @@ describe('ShowPageShareControl payload sequencing without prior access', () => {
       },
       { timeout: 250 },
     );
+  });
+
+  it('issues exactly one payload read on the authorized parallel path', async () => {
+    // A caller holding access (the chat header passes initialAccess) reads the
+    // payload and access in parallel — the post-access hook must NOT fire a
+    // second ensure request.
+    api.getShowPageAccess.mockResolvedValue({
+      ok: true,
+      mode: 'local',
+      can_use: true,
+      can_manage: true,
+      can_publish_public: true,
+      public_link_enabled: false,
+    });
+    api.ensureShowPage.mockResolvedValue({
+      session_id: 'ses-1',
+      visibility: 'private',
+      active_url: '/show/ses-1/',
+      share_id: null,
+      url_available: true,
+      offline: false,
+      title: null,
+    });
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <ShowPageShareControl
+          sessionId="ses-1"
+          initialAccess={{
+            ok: true,
+            mode: 'local',
+            can_use: true,
+            can_manage: true,
+            can_publish_public: true,
+            public_link_enabled: false,
+          } as never}
+        />
+      </I18nextProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }));
+
+    await waitFor(() => {
+      expect(api.getShowPageAccess).toHaveBeenCalled();
+    });
+    await vi.waitFor(() => {
+      expect(api.ensureShowPage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('shows the loading state while a first access read is pending', async () => {
+    // The app-window caller has no access yet: while the access read is in
+    // flight the popover must show the loading row, not the load-error text.
+    let release: (() => void) | null = null;
+    api.getShowPageAccess.mockImplementation(
+      () => new Promise((resolve) => {
+        release = () => resolve({
+          ok: true,
+          mode: 'local',
+          can_use: false,
+          can_manage: true,
+          can_publish_public: false,
+          public_link_enabled: false,
+        });
+      }),
+    );
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <ShowPageShareControl sessionId="ses-1" />
+      </I18nextProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Loading...')).toBeTruthy();
+      expect(screen.queryByText("Couldn't load this Show Page.")).toBeNull();
+    });
+
+    (release ?? (() => undefined))();
+    await waitFor(() => {
+      expect(api.getShowPageAccess).toHaveBeenCalled();
+    });
   });
 });

--- a/ui/src/components/workbench/ShowPageShareControl.test.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.test.tsx
@@ -1,0 +1,74 @@
+import { createInstance } from 'i18next';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it, vi } from 'vitest';
+
+import en from '../../i18n/en.json';
+import { ShowPageShareControl } from './ShowPageShareControl';
+
+vi.mock('../../context/ApiContext', () => ({
+  useApi: () => ({
+    ensureShowPage: vi.fn(),
+    getShowPageAccess: vi.fn(),
+    setShowPageVisibility: vi.fn(),
+    rotateShowPageShare: vi.fn(),
+  }),
+}));
+
+vi.mock('../../context/DockContext', () => ({
+  useDock: () => ({
+    isDocked: vi.fn(() => false),
+    isPinned: vi.fn(() => false),
+    dock: vi.fn(),
+    pin: vi.fn(),
+    undock: vi.fn(),
+  }),
+}));
+
+vi.mock('../useShowPages', () => ({
+  useShowPageInventory: () => ({
+    pages: [],
+    mergePage: vi.fn(),
+    removePage: vi.fn(),
+    reload: vi.fn(),
+  }),
+}));
+
+const i18n = createInstance();
+void i18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  resources: { en: { translation: en } },
+  interpolation: { escapeValue: false },
+});
+
+const renderControl = (compact: boolean) =>
+  renderToStaticMarkup(
+    <I18nextProvider i18n={i18n}>
+      <ShowPageShareControl sessionId="ses-1" compact={compact} />
+    </I18nextProvider>,
+  );
+
+describe('ShowPageShareControl trigger presentation', () => {
+  it('renders the header-sized trigger by default', () => {
+    const html = renderControl(false);
+
+    expect(html.match(/<button/g)).toHaveLength(1);
+    expect(html).toContain('aria-label="Share"');
+    expect(html).toContain('size-7');
+    expect(html).not.toContain('size-6');
+  });
+
+  it('renders the window-chrome trigger when compact', () => {
+    const html = renderControl(true);
+
+    expect(html.match(/<button/g)).toHaveLength(1);
+    expect(html).toContain('aria-label="Share"');
+    // Mirrors the compact annotate control's title-bar styling (§ design q4E5l chrome).
+    expect(html).toContain('size-6');
+    expect(html).toContain('rounded-md');
+    expect(html).toContain('text-muted');
+    expect(html).toContain('hover:text-foreground');
+    expect(html).not.toContain('size-7');
+  });
+});

--- a/ui/src/components/workbench/ShowPageShareControl.test.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.test.tsx
@@ -1,18 +1,23 @@
+/** @vitest-environment jsdom */
 import { createInstance } from 'i18next';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import en from '../../i18n/en.json';
 import { ShowPageShareControl } from './ShowPageShareControl';
 
+const api = {
+  ensureShowPage: vi.fn(),
+  getShowPageAccess: vi.fn(),
+  getShowPageAuthorizedEmails: vi.fn(),
+  setShowPageVisibility: vi.fn(),
+  rotateShowPageShare: vi.fn(),
+};
+
 vi.mock('../../context/ApiContext', () => ({
-  useApi: () => ({
-    ensureShowPage: vi.fn(),
-    getShowPageAccess: vi.fn(),
-    setShowPageVisibility: vi.fn(),
-    rotateShowPageShare: vi.fn(),
-  }),
+  useApi: () => api,
 }));
 
 vi.mock('../../context/DockContext', () => ({
@@ -33,6 +38,11 @@ vi.mock('../useShowPages', () => ({
     reload: vi.fn(),
   }),
 }));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 const i18n = createInstance();
 void i18n.use(initReactI18next).init({
@@ -70,5 +80,73 @@ describe('ShowPageShareControl trigger presentation', () => {
     expect(html).toContain('text-muted');
     expect(html).toContain('hover:text-foreground');
     expect(html).not.toContain('size-7');
+  });
+});
+
+describe('ShowPageShareControl payload sequencing without prior access', () => {
+  it('loads the payload after access resolves for a granted non-manager', async () => {
+    // The app-window call site: no initialAccess, no instance authority. The
+    // payload read is gated on access, so it must start only once access
+    // resolves — the first open still shows the link.
+    api.getShowPageAccess.mockResolvedValue({
+      ok: true,
+      mode: 'local',
+      can_use: true,
+      can_manage: false,
+      can_publish_public: false,
+      public_link_enabled: false,
+    });
+    api.ensureShowPage.mockResolvedValue({
+      session_id: 'ses-1',
+      visibility: 'private',
+      active_url: '/show/ses-1/',
+      share_id: null,
+      url_available: true,
+      offline: false,
+      title: null,
+    });
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <ShowPageShareControl sessionId="ses-1" />
+      </I18nextProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }));
+
+    await waitFor(() => {
+      expect(api.ensureShowPage).toHaveBeenCalledWith('ses-1');
+    });
+    await waitFor(() => {
+      expect((screen.getByDisplayValue(/\/show\/ses-1\//) as HTMLInputElement).value).toContain('/show/ses-1/');
+    });
+  });
+
+  it('never loads the payload when access resolves without page use', async () => {
+    api.getShowPageAccess.mockResolvedValue({
+      ok: true,
+      mode: 'local',
+      can_use: false,
+      can_manage: true,
+      can_publish_public: false,
+      public_link_enabled: false,
+    });
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <ShowPageShareControl sessionId="ses-1" />
+      </I18nextProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }));
+
+    await waitFor(() => {
+      expect(api.getShowPageAccess).toHaveBeenCalledWith('ses-1');
+    });
+    // Metadata-only manager: no payload read is ever issued.
+    await vi.waitFor(
+      () => {
+        expect(api.ensureShowPage).not.toHaveBeenCalled();
+      },
+      { timeout: 250 },
+    );
   });
 });

--- a/ui/src/components/workbench/ShowPageShareControl.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.tsx
@@ -205,7 +205,7 @@ export const ShowPageShareControl: React.FC<{
         setLoading(false);
       }
     };
-    const readAccess = () => {
+    const readAccess = (thenLoadPayload: boolean) => {
       setAccessLoading(!access);
       setAccessError(false);
       void (async () => {
@@ -225,14 +225,19 @@ export const ShowPageShareControl: React.FC<{
         } finally {
           setAccessLoading(false);
         }
-        await loadPayload(canManageInstance || nextAccess?.can_use === true);
+        // Only the sequenced caller loads here: the parallel branch already
+        // started its payload read alongside this one — loading twice would
+        // duplicate the ensure request and the inventory merge.
+        if (thenLoadPayload) {
+          await loadPayload(canManageInstance || nextAccess?.can_use === true);
+        }
       })();
     };
     if (canManageInstance || access?.can_use === true) {
       void loadPayload(true);
-      readAccess();
+      readAccess(false);
     } else {
-      readAccess();
+      readAccess(true);
     }
   };
 
@@ -326,7 +331,10 @@ export const ShowPageShareControl: React.FC<{
       >
         <div className="text-sm font-medium">{t('chat.showPage.shareTitle')}</div>
 
-        {loading && !access ? (
+        {/* Access-less callers (the app-window title bar) resolve access first, so
+            the access read itself is part of the loading presentation — without
+            it the popover would flash the load-error text for the whole request. */}
+        {(loading || accessLoading) && !access ? (
           <div className="flex items-center gap-2 py-2 text-sm text-muted">
             <Loader2 className="size-4 animate-spin" />
             {t('common.loading')}
@@ -398,6 +406,7 @@ export const ShowPageShareControl: React.FC<{
             active={open}
             sessionId={sessionId}
             onConfirmationOpenChange={setWorkspaceConfirmationOpen}
+            ownerWindowId={ownerWindowId}
           />
           {accessError ? (
             <p className="mt-2 text-[11px] leading-snug text-destructive-ink">

--- a/ui/src/components/workbench/ShowPageShareControl.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.tsx
@@ -181,42 +181,59 @@ export const ShowPageShareControl: React.FC<{
   // refreshing so reopening doesn't flash a spinner.
   const refresh = () => {
     const seq = ++reqSeq.current;
-    const canLoadPayload = canManageInstance || access?.can_use === true;
-    setLoading(canLoadPayload && !payload);
-    setAccessLoading(!access);
-    setAccessError(false);
-    void (async () => {
-      if (canLoadPayload) {
-        try {
-          const res: ShowPagePayload = await api.ensureShowPage(sessionId);
-          if (seq !== reqSeq.current) return;
-          applyPayload(res);
-          if (!inventoryPage) reload();
-        } catch {
-          // An archived Show Page cannot be ensured, but its applied access
-          // metadata is still useful and is loaded below.
-        } finally {
-          setLoading(false);
-        }
-      } else {
+    // Callers that already hold authority (instance managers, or a caller that
+    // passed initialAccess) read the payload and the access in parallel like
+    // before. A caller with NEITHER (the app window title bar) must sequence:
+    // the payload read is gated on access, so it starts only after access
+    // resolves — otherwise a granted can_use arrives with no payload behind it
+    // until the popover is reopened.
+    const loadPayload = async (granted: boolean) => {
+      if (!granted) {
+        setLoading(false);
+        return;
+      }
+      setLoading(!payload);
+      try {
+        const res: ShowPagePayload = await api.ensureShowPage(sessionId);
+        if (seq !== reqSeq.current) return;
+        applyPayload(res);
+        if (!inventoryPage) reload();
+      } catch {
+        // An archived Show Page cannot be ensured, but its applied access
+        // metadata is still useful and is loaded below.
+      } finally {
         setLoading(false);
       }
-
-      try {
-        const nextAccess = await api.getShowPageAccess(sessionId);
-        if (seq !== reqSeq.current) return;
-        setAccess(nextAccess);
-      } catch {
-        if (seq !== reqSeq.current) return;
-        // A failed refresh cannot leave the previous authority actionable. The
-        // payload stays cached for a later successful refresh, but is withdrawn
-        // while accessError invalidates this control's authorization state.
-        setAccess(null);
-        setAccessError(true);
-      } finally {
-        setAccessLoading(false);
-      }
-    })();
+    };
+    const readAccess = () => {
+      setAccessLoading(!access);
+      setAccessError(false);
+      void (async () => {
+        let nextAccess: ShowPageAccess | null = null;
+        try {
+          nextAccess = await api.getShowPageAccess(sessionId);
+          if (seq !== reqSeq.current) return;
+          setAccess(nextAccess);
+        } catch {
+          if (seq !== reqSeq.current) return;
+          // A failed refresh cannot leave the previous authority actionable. The
+          // payload stays cached for a later successful refresh, but is withdrawn
+          // while accessError invalidates this control's authorization state.
+          setAccess(null);
+          setAccessError(true);
+          return;
+        } finally {
+          setAccessLoading(false);
+        }
+        await loadPayload(canManageInstance || nextAccess?.can_use === true);
+      })();
+    };
+    if (canManageInstance || access?.can_use === true) {
+      void loadPayload(true);
+      readAccess();
+    } else {
+      readAccess();
+    }
   };
 
   const handleOpenChange = (next: boolean) => {

--- a/ui/src/components/workbench/ShowPageShareControl.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.tsx
@@ -48,12 +48,19 @@ export const ShowPageShareControl: React.FC<{
   // inert while it is open so an outside tap there falls through to the parent
   // document and Radix can dismiss (a tap inside an iframe never reaches us).
   onOpenChange?: (open: boolean) => void;
+  // Keep a single icon trigger at every viewport size (window title bars),
+  // matching the compact annotate control's chrome styling.
+  compact?: boolean;
+  // Associate portalled popover focus with its owning app window.
+  ownerWindowId?: string;
 }> = ({
   sessionId,
   initialAccess = null,
   canManageInstance = false,
   onPayloadChange,
   onOpenChange,
+  compact = false,
+  ownerWindowId,
 }) => {
   const { t } = useTranslation();
   const api = useApi();
@@ -283,7 +290,9 @@ export const ShowPageShareControl: React.FC<{
           type="button"
           variant="ghost"
           size="icon"
-          className="size-7 shrink-0"
+          className={compact
+            ? 'size-6 shrink-0 rounded-md text-muted hover:bg-foreground/[0.06] hover:text-foreground'
+            : 'size-7 shrink-0'}
           aria-label={t('chat.showPage.share')}
           title={t('chat.showPage.share')}
         >
@@ -293,6 +302,7 @@ export const ShowPageShareControl: React.FC<{
       <PopoverContent
         align="end"
         className="w-80 space-y-3"
+        data-window-owner-id={ownerWindowId}
         onInteractOutside={(event) => {
           if (workspaceConfirmationOpen) event.preventDefault();
         }}

--- a/ui/src/components/workbench/ShowPageWorkspaceAccessControl.tsx
+++ b/ui/src/components/workbench/ShowPageWorkspaceAccessControl.tsx
@@ -120,11 +120,14 @@ export function ShowPageWorkspaceAccessControl({
   active,
   sessionId,
   onConfirmationOpenChange,
+  ownerWindowId,
 }: {
   access: ShowPageAccess | null;
   active: boolean;
   sessionId: string;
   onConfirmationOpenChange?: (open: boolean) => void;
+  /** Attribute this control's body-portalled ConfirmDialog to its owning app window. */
+  ownerWindowId?: string;
 }) {
   const { t } = useTranslation();
   const [gate, setGate] = useState<ManagementGate>('idle');
@@ -438,6 +441,7 @@ export function ShowPageWorkspaceAccessControl({
           canManage={access.can_publish_public}
           sessionId={sessionId}
           onConfirmationOpenChange={onConfirmationOpenChange}
+          ownerWindowId={ownerWindowId}
         />
       ) : null}
       </section>
@@ -448,6 +452,7 @@ export function ShowPageWorkspaceAccessControl({
         description={t('organization.resources.narrowBody')}
         confirmLabel={t('organization.actions.saveChanges')}
         onConfirm={commit}
+        windowOwnerId={ownerWindowId}
       />
     </>
   );


### PR DESCRIPTION
## Changed capability

Show Page **Share** placement:

1. The chat header no longer carries Share in plain chat mode — Share exists only while the Show Page is framed (owner ruling 2026-08-17), for every role including access-only managers. The header condition collapses onto the tested `showPageControlActions().share` fact (the same source the annotate control already uses) instead of its own `showPageMode || showPageAccess !== null` branch.
2. Show Page app windows gain a compact **Share** control in the title bar, placed immediately left of **Open in New Tab** (second from right). It reuses `ShowPageShareControl` via two new optional props:
   - `compact` — window-chrome trigger styling mirroring the compact annotate control
   - `ownerWindowId` — associates the portalled popover with the owning window (same `data-window-owner-id` mechanism as annotate)

The window's iframe shield now covers the Share popover exactly like the annotate popover (outside taps dismiss instead of being swallowed by the iframe).

## Affected scenario IDs

No scenario catalog entry for this surface.

## Evidence layers

- Unit: new `ShowPageShareControl.test.tsx` (default vs compact trigger presentation); full UI suite 224 files / 2774 tests green.
- Build: `npm run build` green. Lint baseline green (704 sources).
- Docs: `avibe-docs/concepts/apps-dock.mdx` + zh counterpart updated 1:1 (title-bar button list).
- Residual manual checks: orchestrator verifies in the Incus regression env after merge — (a) chat header has no Share even for a session with an existing page; (b) framed Show Page shows Share; (c) window title bar order Annotate → Open Chat → Share → Open in New Tab; (d) Share popover opens over the window iframe and outside-tap dismisses.

## Known-by-design ledger

- Share disappears from chat mode for access-only managers by owner ruling; they reach it from the framed view or the app window title bar.
- The window Share button is gated on the instance-level `can_use_show_pages` capability; per-page authorization is resolved by the popover itself (same degradation as the header control).
- Visibility flips made from the window popover do not re-point that window's iframe src (the chat view's re-point callback stays chat-side); the shared inventory store still updates everywhere else.
