### PR TITLE
fix(auth): recover same-tick authorization outages

### DIFF
--- a/ui/src/App.remoteAuth.test.tsx
+++ b/ui/src/App.remoteAuth.test.tsx
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { useLayoutEffect } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -56,24 +57,27 @@ describe('AuthGuard remote authorization recovery', () => {
       authorization_state: 'current' as const,
     };
     api.getAuthSession.mockResolvedValue(session);
+    let recoveryReported = false;
+
+    const SameTickRecoverySignal = () => {
+      useLayoutEffect(() => {
+        if (recoveryReported) return;
+        recoveryReported = true;
+        window.dispatchEvent(new CustomEvent(REMOTE_AUTH_STATE_EVENT, {
+          detail: { state: 'unavailable' },
+        }));
+        window.dispatchEvent(new CustomEvent(REMOTE_AUTH_STATE_EVENT, {
+          detail: { state: 'current' },
+        }));
+      }, []);
+      return <div>protected shell</div>;
+    };
 
     render(
       <MemoryRouter initialEntries={['/']}>
-        <AuthGuard><div>protected shell</div></AuthGuard>
+        <AuthGuard><SameTickRecoverySignal /></AuthGuard>
       </MemoryRouter>,
     );
-
-    expect(await screen.findByText('protected shell')).toBeTruthy();
-    expect(api.getAuthSession).toHaveBeenCalledOnce();
-
-    act(() => {
-      window.dispatchEvent(new CustomEvent(REMOTE_AUTH_STATE_EVENT, {
-        detail: { state: 'unavailable' },
-      }));
-      window.dispatchEvent(new CustomEvent(REMOTE_AUTH_STATE_EVENT, {
-        detail: { state: 'current' },
-      }));
-    });
 
     await waitFor(() => expect(api.getAuthSession).toHaveBeenCalledTimes(2));
     expect(await screen.findByText('protected shell')).toBeTruthy();

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -312,11 +312,12 @@ export const AuthGuard = ({ children }: { children: ReactNode }) => {
                 setAuthorizationUnavailable(false);
                 setGuardStatus('authorization-revoked');
             } else if (state === 'unavailable') {
+                // This listener can still hold the previous guardStatus until its
+                // dependency effect re-runs, so track recovery independently.
+                authorizationUnavailableRef.current = true;
                 if (guardStatus === 'ready') {
-                    authorizationUnavailableRef.current = true;
                     setAuthorizationUnavailable(true);
                 } else {
-                    authorizationUnavailableRef.current = false;
                     setGuardStatus('authorization-unavailable');
                 }
             } else if (state === 'current') {


### PR DESCRIPTION
## Summary

- recover remote authorization when `unavailable` and `current` arrive in the same browser turn
- replace the timing-sensitive recovery test with a deterministic layout-effect reproduction

## Root Cause

The remote-authorization event listener depended on `guardStatus`. During the passive-effect resubscription window, it could still hold the previous `loading` status even though the protected shell had rendered. An `unavailable` event then cleared the recovery marker, so an immediately following `current` event did not revalidate the session.

## Evidence

- Unit: `src/App.remoteAuth.test.tsx` reproduces the stale-listener window deterministically
- Stress: focused recovery test passed 20/20 consecutive runs
- UI suite: 2,780/2,780 tests passed with Node 24.12.0
- Contract: no API contract changed
- Scenario: no catalog scenario ID applies; existing remote authorization recovery coverage was hardened
- Build: `npm run build` passed
- Lint: UI lint baseline passed
- Residual manual: none; this is a synchronous event-ordering regression covered at the component boundary

## CI Context

This addresses the flaky `App.remoteAuth.test.tsx` failure from Actions run `32000639269`. Later runs passed because the original test only hit the stale-effect window intermittently.
