### PR TITLE
fix(ui): stop Model Hub info hint popover flicker on hover

### DIFF
--- a/ui/src/components/settings/models/ModelHubInfoHint.tsx
+++ b/ui/src/components/settings/models/ModelHubInfoHint.tsx
@@ -12,7 +12,7 @@ export const ModelHubInfoHint: React.FC<{
 }> = ({ label, content, className, align = 'start' }) => {
   const [open, setOpen] = React.useState(false);
   return (
-    <Popover open={open} onOpenChange={setOpen} modal>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <button
           type="button"


### PR DESCRIPTION
## What

Stop the Model Hub info-hint popover from flickering while hovering the info icons.

## Root cause

`ModelHubInfoHint` (the shared component behind every info icon on the Model Hub page: overview cards, sources card, supply graph legend, source order drawer) rendered its Radix `Popover` with `modal`. On open, the modal content layer sets `document.body` to `pointer-events: none`, so the trigger icon immediately stops being hit-tested: `pointerleave` fires and closes the popover, body pointer events are restored, `pointerenter` fires again, and the open/close loop renders as a flickering tip.

## Change

Remove the `modal` prop from the `Popover` in `ui/src/components/settings/models/ModelHubInfoHint.tsx`. The non-modal popover keeps pointer events on the page, still dismisses on outside pointer-down / Esc, and does not steal focus (`onOpenAutoFocus` was already prevented). One shared component fix covers every info icon on the page.

## Capability / scenarios

Capability: Model Hub UI info hints. The `model_hub` scenario catalog covers configured routes and turn contracts (backend resolution), not UI hover interaction, so no existing scenario ID applies to this change.

## Evidence

- Unit: `npx vitest run src/components/settings/models` — 67 files, 826 tests passed (branch content, post `npm ci`).
- Build gate: `npm run build` in `ui/` — passed.
- Residual manual check: hover each info icon on the Model Hub page and confirm the tip stays open steadily (deferred to review; the mechanism is fully explained by the body-level `pointer-events: none` cycle).

## Dependencies

None.
