### PR TITLE
fix(agents): derive opencode session titles from first user message

### DIFF
--- a/docs/plans/backend-session-title-backfill.md
+++ b/docs/plans/backend-session-title-backfill.md
@@ -166,13 +166,21 @@ class BackendSessionTitleProvider(Protocol):
 Provider behavior:
 
 - `OpenCodeSessionTitleProvider`: read `session.title` by native id, ignore
-  default `New session - ...` and `Child session - ...`.
+  default `New session - ...` and `Child session - ...`. When no usable
+  backend title exists, derive from the first user message like Claude.
 - `CodexSessionTitleProvider`: read `threads.title` by native thread id, ignore
   empty/default-looking values. Use `first_user_message` only if we explicitly
   choose derived fallback.
 - `ClaudeSessionTitleProvider`: derive a fallback from the first user message's
   first 10 visible characters with `source="derived_first_prompt"` and
   `confidence="low"`.
+
+The `derived_first_prompt` construction is shared:
+`modules.agents.native_sessions.base.derive_first_prompt_title()` is the single
+home for the truncated-first-message title, used by all three providers, so an
+agent backend that never sets a title (observed with GLM on OpenCode, which
+under-complies with the proactive title prompt) still gets a deterministic
+backfilled title.
 
 Implemented shape:
 

--- a/modules/agents/native_sessions/base.py
+++ b/modules/agents/native_sessions/base.py
@@ -51,6 +51,15 @@ def normalize_title_text(text: str, *, limit: int | None = None) -> str:
     return cleaned[:limit] if limit is not None else cleaned
 
 
+def derive_first_prompt_title(first_user_message: str, *, limit: int = 10) -> BackendSessionTitle | None:
+    """Derive a low-confidence backfill title from the first user message."""
+
+    title = normalize_title_text(first_user_message, limit=limit)
+    if not title:
+        return None
+    return BackendSessionTitle(title=title, source="derived_first_prompt", confidence="low")
+
+
 def normalize_multiline_preview_text(
     text: str,
     *,

--- a/modules/agents/native_sessions/claude.py
+++ b/modules/agents/native_sessions/claude.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from .base import (
     NativeSessionProvider,
     build_tail_preview,
+    derive_first_prompt_title,
     dt_from_ts,
     normalize_title_text,
     normalize_preview_text,
@@ -348,13 +349,11 @@ class ClaudeNativeSessionProvider(NativeSessionProvider):
         working_path: str,
         first_user_message: str = "",
     ) -> BackendSessionTitle | None:
-        title = normalize_title_text(first_user_message, limit=10)
-        if not title:
+        title_text = normalize_title_text(first_user_message)
+        if not title_text:
             for item in self.list_metadata(working_path):
                 if item.native_session_id != native_session_id:
                     continue
-                title = normalize_title_text(str(item.locator.get("first_prompt") or ""), limit=10)
+                title_text = str(item.locator.get("first_prompt") or "")
                 break
-        if not title:
-            return None
-        return BackendSessionTitle(title=title, source="derived_first_prompt", confidence="low")
+        return derive_first_prompt_title(title_text)

--- a/modules/agents/native_sessions/codex.py
+++ b/modules/agents/native_sessions/codex.py
@@ -5,7 +5,14 @@ import os
 import sqlite3
 from pathlib import Path
 
-from .base import NativeSessionProvider, build_tail_preview, dt_from_ts, normalize_title_text, read_json_lines
+from .base import (
+    NativeSessionProvider,
+    build_tail_preview,
+    derive_first_prompt_title,
+    dt_from_ts,
+    normalize_title_text,
+    read_json_lines,
+)
 from .types import BackendSessionTitle, NativeResumeSession
 
 logger = logging.getLogger(__name__)
@@ -145,10 +152,9 @@ class CodexNativeSessionProvider(NativeSessionProvider):
             first_user_value = None
         stored_first_user_message = normalize_title_text(str(first_user_value or ""))
         if has_first_user_message_column and stored_first_user_message:
-            fallback_first_user_message = normalize_title_text(first_user_message)
-            derived = normalize_title_text(first_user_message or stored_first_user_message, limit=10)
-            if derived:
-                return BackendSessionTitle(title=derived, source="derived_first_prompt", confidence="low")
+            derived = derive_first_prompt_title(first_user_message or stored_first_user_message)
+            if derived is not None:
+                return derived
 
         title = normalize_title_text(str(title_value or ""))
         if not title or self.is_placeholder_title(title):

--- a/modules/agents/native_sessions/opencode.py
+++ b/modules/agents/native_sessions/opencode.py
@@ -6,7 +6,14 @@ import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 
-from .base import NativeSessionProvider, build_tail_preview, dt_from_ts, normalize_title_text, parse_json_blob
+from .base import (
+    NativeSessionProvider,
+    build_tail_preview,
+    derive_first_prompt_title,
+    dt_from_ts,
+    normalize_title_text,
+    parse_json_blob,
+)
 from .types import BackendSessionTitle, NativeResumeSession
 
 logger = logging.getLogger(__name__)
@@ -169,23 +176,23 @@ class OpenCodeNativeSessionProvider(NativeSessionProvider):
         working_path: str,
         first_user_message: str = "",
     ) -> BackendSessionTitle | None:
-        if not self.db_path.exists():
-            return None
-        try:
-            with self._connect() as conn:
-                row = conn.execute(
-                    """
-                    SELECT title
-                    FROM session
-                    WHERE id = ? AND directory = ?
-                    LIMIT 1
-                    """,
-                    (native_session_id, working_path),
-                ).fetchone()
-        except Exception as exc:
-            logger.warning("Failed to read OpenCode session title %s: %s", native_session_id, exc)
-            return None
-        title = normalize_title_text(str(row[0] or "")) if row else ""
-        if not title or self.is_ignored_title(title):
-            return None
-        return BackendSessionTitle(title=title, source="backend", confidence="high")
+        title = ""
+        if self.db_path.exists():
+            try:
+                with self._connect() as conn:
+                    row = conn.execute(
+                        """
+                        SELECT title
+                        FROM session
+                        WHERE id = ? AND directory = ?
+                        LIMIT 1
+                        """,
+                        (native_session_id, working_path),
+                    ).fetchone()
+            except Exception as exc:
+                logger.warning("Failed to read OpenCode session title %s: %s", native_session_id, exc)
+                row = None
+            title = normalize_title_text(str(row[0] or "")) if row else ""
+        if title and not self.is_ignored_title(title):
+            return BackendSessionTitle(title=title, source="backend", confidence="high")
+        return derive_first_prompt_title(first_user_message)

--- a/tests/test_native_session_providers.py
+++ b/tests/test_native_session_providers.py
@@ -276,6 +276,65 @@ def test_opencode_title_provider_uses_xdg_data_home(tmp_path: Path, monkeypatch)
     assert title.title == "Use XDG data home"
 
 
+def test_opencode_title_provider_derives_from_first_user_message(tmp_path: Path) -> None:
+    db_path = tmp_path / "opencode.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("create table session (id text primary key, directory text, title text)")
+        conn.execute(
+            "insert into session (id, directory, title) values (?, ?, ?)",
+            ("ses_default", "/repo", "New session - 2026-06-02T07:35:03.127Z"),
+        )
+        conn.execute(
+            "insert into session (id, directory, title) values (?, ?, ?)",
+            ("ses_untitled", "/repo", ""),
+        )
+        conn.execute(
+            "insert into session (id, directory, title) values (?, ?, ?)",
+            ("ses_title", "/repo", "Implement session titles"),
+        )
+
+    provider = OpenCodeNativeSessionProvider(db_path=str(db_path))
+
+    for session_id in ("ses_default", "ses_untitled", "ses_missing_row"):
+        title = provider.get_title(
+            native_session_id=session_id,
+            working_path="/repo",
+            first_user_message="帮我修一下登录页面的报错",
+        )
+        assert title is not None
+        assert title.title == "帮我修一下登录页面的"
+        assert title.source == "derived_first_prompt"
+        assert title.confidence == "low"
+
+    backend_title = provider.get_title(
+        native_session_id="ses_title",
+        working_path="/repo",
+        first_user_message="帮我修一下登录页面的报错",
+    )
+    assert backend_title is not None
+    assert backend_title.title == "Implement session titles"
+    assert backend_title.source == "backend"
+    assert backend_title.confidence == "high"
+
+
+def test_opencode_title_provider_derives_without_db(tmp_path: Path) -> None:
+    provider = OpenCodeNativeSessionProvider(db_path=str(tmp_path / "missing.db"))
+
+    title = provider.get_title(
+        native_session_id="ses_any",
+        working_path="/repo",
+        first_user_message="排查标题回填",
+    )
+    assert title is not None
+    assert title.title == "排查标题回填"
+    assert title.source == "derived_first_prompt"
+
+    assert (
+        provider.get_title(native_session_id="ses_any", working_path="/repo", first_user_message="")
+        is None
+    )
+
+
 def test_codex_title_provider_reads_thread_title(tmp_path: Path) -> None:
     db_path = tmp_path / "state_5.sqlite"
     with sqlite3.connect(db_path) as conn:


### PR DESCRIPTION
## Changed capability

OpenCode sessions now always receive a backfilled title: when the opencode
native `session.title` holds no usable value (missing row, empty, `New session - ...`,
or the sqlite store itself absent), the title provider derives a
`derived_first_prompt` title from the session's first user message, matching
the existing claude/codex fallback behavior.

## Why

Injected-prompt compliance is model-dependent: GLM on OpenCode reliably skips
the proactive `vibe session update --title` instruction (soft-triggered
meta-task competing with the harness's brevity rules), leaving Web sessions
untitled. Claude/Codex models comply, so only the OpenCode path lacked a
deterministic floor. The derived title is not in `DELIBERATE_TITLE_SOURCES`,
so compliant models still upgrade it to a proper title.

## Implementation

- Promote the truncated-first-message title construction into
  `modules/agents/native_sessions/base.py::derive_first_prompt_title()`
  (third occurrence of the pattern -> shared home; codex's dead
  `fallback_first_user_message` local removed on the way).
- Wire it into all three providers: opencode (new fallback), claude and codex
  (behavior-preserving refactor to the shared helper).
- Update `docs/plans/backend-session-title-backfill.md` provider table.

## Evidence layers

- Unit: `tests/test_native_session_providers.py` — new
  `test_opencode_title_provider_derives_from_first_user_message` (covers
  ignored default title / empty title / missing row, and asserts a real
  backend title still wins with `source=backend`) and
  `test_opencode_title_provider_derives_without_db`; existing claude/codex
  title tests unchanged and green.
- Focused suites: `test_native_session_providers.py`,
  `test_session_titles.py`, `test_session_cli.py`,
  `test_core_services_sessions.py` — 101 passed; `ruff check` clean.

## Residual manual checks

Live behavior on the local opencode + GLM session (title backfill after next
turn) left to the orchestrator's integration pass; no scenario catalog entry
exists for session-title backfill.
