### PR TITLE
docs(model-service): define key availability contract

### DIFF
--- a/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
+++ b/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
@@ -223,7 +223,9 @@ scope per instance behind them.
   `force: true` — a live org's config change is never blindly activated (mirrors the local
   settings ladder's probe-before-apply). Both successful verify responses (200) and failed verify
   responses (422) carry the scope's current `revision`, so a caller can settle its optimistic
-  snapshot without another read.
+  snapshot without another read. Managed-key custody failures are never force-overridable: if any
+  enabled candidate cannot complete its encrypt/decrypt round trip, `PUT` returns
+  `model_service_key_unavailable` (503), performs no upstream probe, and persists nothing.
 - **Platform admin (user session; email ∈ `PLATFORM_ADMIN_EMAILS`, new env following the
   `ORGANIZATION_CREATION_ALLOWED_EMAILS` pattern)**:
   `GET/PUT /api/admin/model-service` (platform slots + limits), `GET /api/admin/model-service/usage`
@@ -274,10 +276,12 @@ scope per instance behind them.
   so unattributed-legacy usage can only ever be platform-scope in fact and invariant 2 holds.
   **Error mapping on legacy voice routes** (invariant 6): `model_service_not_configured` surfaces
   through the existing voice error vocabulary (`asr_not_configured` 503 family; a missing chat
-  slot degrades cleanup per §6.5-5); `model_service_key_unavailable` (503),
-  `model_quota_exhausted` (429), and `model_service_unavailable` (503) pass through as new
-  additive codes — released clients already treat unknown codes as generic errors of their
-  status class.
+  slot degrades cleanup per §6.5-5). On required ASR and the dedicated cleanup endpoint,
+  `model_service_key_unavailable` (503), `model_quota_exhausted` (429), and
+  `model_service_unavailable` (503) pass through as new additive codes — released clients already
+  treat unknown codes as generic errors of their status class. Composite voice flows catch every
+  optional cleanup failure, including `model_service_key_unavailable`, and return the successful
+  raw ASR transcript per §6.5-5.
 
 ### 6.4 Quota (platform scope only, v1)
 
@@ -447,11 +451,12 @@ required.
 }
 ```
 
-`mode` ∈ `organization | platform`. `embedding_identity` is an opaque hash of the embedding slot's
-(base_url, model); it changes iff vector-space identity changes, and is `null` when the bound
-scope has no enabled embedding slot (e.g. a voice-only enterprise org) — the client then treats
-cloud memory as unavailable, matching `capabilities.embedding: false`. Before serializing a saved
-scope, the endpoint decrypt-validates every enabled slot and immediately discards the plaintext.
+`mode` ∈ `organization | platform`. While the effective memory pair is available,
+`embedding_identity` is an opaque hash of the embedding slot's (base_url, model) and changes iff
+vector-space identity changes. It is `null` whenever `capabilities.embedding` is false — including
+a missing/disabled slot or a custody failure in either member of the required chat+embedding pair —
+so released clients can parse the degraded payload and pause cloud memory. Before serializing a
+saved scope, the endpoint decrypt-validates every enabled slot and immediately discards the plaintext.
 An enabled slot whose key cannot be decrypted is reported as unavailable and the response adds a
 per-slot reason map, for example `"degraded": { "asr": "model_service_key_unavailable" }`;
 `degraded` is omitted when no slot is degraded.
@@ -477,10 +482,12 @@ turns on.
 ### 8.4 Error codes (stable, machine-readable `code` field)
 
 - `model_service_not_configured` (503) — resolved scope lacks an enabled slot for the capability.
-- `model_service_key_unavailable` (503) — an enabled saved slot exists but its API key cannot be
-  decrypted with the deployed `MODEL_SERVICE_KEY_SECRET`. It never maps to
-  `model_service_not_configured`; no upstream call is made, status marks the affected capability
-  false with the same reason, and a scrubbed high-priority Sentry event is emitted.
+- `model_service_key_unavailable` (503) — an enabled save candidate cannot complete its managed
+  encrypt/decrypt round trip, or an enabled saved slot cannot be decrypted with the deployed
+  `MODEL_SERVICE_KEY_SECRET`. The failure is not overrideable by `force: true`, never maps to
+  `model_service_not_configured`, makes no upstream call, and persists no candidate change. For
+  saved-slot failures, status marks the affected capability false with the same reason. Every path
+  emits a scrubbed high-priority Sentry event.
 - `model_service_unavailable` (503) — quota **reservation** persistence failed on an
   enforcement-on path, before any upstream call. A **settlement** failure after upstream completion
   never produces this error: the response is served and the un-settled reservation is reaped as a
@@ -518,8 +525,10 @@ turns on.
    model-configuration affordance.
 6. Released voice clients keep working unchanged across the M1 rewiring (device-secret path,
    cloud-token path, realtime WS).
-7. `embedding_identity` changes iff the embedding slot's (base_url, model) changes, and every
-   member instance's sidecar treats it exactly like a local embedding change (rebuild ladder).
+7. While `capabilities.embedding` remains true, `embedding_identity` changes iff the embedding
+   slot's (base_url, model) changes, and every member instance's sidecar treats it exactly like a
+   local embedding change (rebuild ladder). It is `null` whenever the effective chat+embedding
+   pair is unavailable; restoring the same pair restores the same identity.
 8. With enforcement on, an over-cap free-pool call fails before reaching any upstream.
 9. Changing any API key (slot key or mak) with base_url and model unchanged never alters
    `embedding_identity`, never triggers a rebuild or re-embedding, and never loses or duplicates

--- a/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
+++ b/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
@@ -200,14 +200,19 @@ scope per instance behind them.
   skips the upstream probe. Status uses decrypt-validate-and-discard and never retains or returns
   plaintext. This status-only read-path exception supersedes the earlier proxy-only wording.
   All read APIs return `has_api_key: true/false`, never the value. Keys and ciphertext never enter
-  API responses, logs, Sentry, or usage events. Missing or invalid key-secret material is reported
-  as a high-priority Sentry event tagged by scope, capability, and instance, using only scrubbed
-  metadata. Emission is transition-deduplicated by scope, config revision, and capability so
-  status polling cannot create one event per instance per minute; the first observing instance
-  remains a context tag but is not part of the deduplication key. A successful validation clears
-  that transition so a later outage at the same revision alerts again. The transition claim/clear
-  is an atomic shared-store operation, never process-local state, so concurrent and cold-started
-  Vercel isolates observe the same edge.
+  API responses, logs, Sentry, or usage events. Missing or invalid key-secret material for a
+  committed saved slot is reported as a high-priority Sentry event tagged by scope, capability,
+  instance, and config revision, using only scrubbed metadata. Emission is transition-deduplicated
+  by scope, config revision, and capability so status polling cannot create one event per instance
+  per minute; the first observing instance remains a context tag but is not part of the
+  deduplication key. Both adapters atomically upsert `available`/`unavailable` state in a shared
+  transition table; only a successfully persisted transition to `unavailable` grants permission
+  to emit the outage event. A successful managed decrypt attempts the `available` transition on
+  every call. If that recovery write fails, the usable call still proceeds, the write is retried
+  on the next successful decrypt, and the persistence failure itself is reported directly to
+  Sentry without relying on the unavailable transition table. Concurrent and cold-started Vercel
+  isolates therefore observe the same edges without making alert infrastructure part of service
+  availability.
 
 ### 6.3 APIs
 
@@ -322,7 +327,7 @@ Every cross-cutting property has exactly one code owner; routes never re-impleme
    `resolveCallSnapshot` (instance+org+plan+config+limits in ONE snapshot — every security decision
    reads one consistent state), `reserveQuota`/`extendQuota`/`settleQuota`, and
    `readUsageSummarySnapshot`; key-unavailable alert edges use a small additive transition table
-   keyed by scope/config revision/capability and atomic claim/clear operations.
+   keyed by scope/config revision/capability and atomic `available`/`unavailable` upserts.
 3. **ModelServiceUpstreamClient** — the only egress owner: destination classification
    (allow-only-global-unicast per the IANA IPv4/IPv6 special-purpose registries; transition/tunnel
    prefixes — NAT64 incl. local-use, 6to4, Teredo — rejected outright), **TLS-only upstreams**
@@ -500,12 +505,15 @@ turns on.
   encrypt/decrypt round trip after an actual key has been selected, or an enabled saved slot has
   neither decryptable custody nor an eligible same-scope platform env recovery under the shared
   effectiveness predicate. The failure is not overrideable by `force: true`, never maps to
-  `model_service_not_configured`, makes no upstream call, and persists no candidate change. For
-  unrecovered saved-slot failures, status marks the affected capability false with the same reason.
-  Every saved-key decryption-failure transition, including one masked by approved platform recovery,
-  emits one scrubbed high-priority Sentry event per scope/config revision/capability; repeated
-  failures at the same active edge emit none, and a successful managed-key validation clears the
-  edge so a later failure can emit again.
+  `model_service_not_configured`, makes no upstream call, and persists no candidate change. A
+  rejected pre-save custody check writes a scrubbed structured log only: it creates no transition
+  row and emits no ops alert because the request response and admin UI are its presentation surface.
+  For unrecovered saved-slot failures, status marks the affected capability false with the same
+  reason. Every saved-key decryption-failure transition, including one masked by approved platform
+  recovery, emits one scrubbed high-priority Sentry event per scope/config revision/capability;
+  repeated failures at the same active edge emit none, and a successful managed-key validation
+  rearms a later failure through the persisted `available` state. Failure to persist that recovery
+  state never changes the successful call or truthful status result.
 - `model_service_unavailable` (503) — quota **reservation** persistence failed on an
   enforcement-on path, before any upstream call. A **settlement** failure after upstream completion
   never produces this error: the response is served and the un-settled reservation is reaped as a

--- a/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
+++ b/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
@@ -205,7 +205,9 @@ scope per instance behind them.
   instance, and config revision, using only scrubbed metadata. Emission is transition-deduplicated
   by scope, config revision, and capability so status polling cannot create one event per instance
   per minute; the first observing instance remains a context tag but is not part of the
-  deduplication key. Both adapters atomically upsert `available`/`unavailable` state in a shared
+  deduplication key. Explicit admin verification uses the fixed non-customer
+  `model-service-probe` context when there is no calling instance. Both adapters atomically upsert
+  `available`/`unavailable` state in a shared
   transition table; only a successfully persisted transition to `unavailable` grants permission
   to emit the outage event. A successful managed decrypt attempts the `available` transition on
   every call. If that recovery write fails, the usable call still proceeds, the write is retried
@@ -574,7 +576,9 @@ turns on.
 - **M1 — Config Center core + enterprise voice (backend only)**: schema migrations; key custody;
   org/platform config APIs; platform-admin gate + plan lever; resolution + metering middleware
   wired into all existing voice routes (incl. realtime + cleanup); usage dashboards (shared panel,
-  two mounts); env→platform-scope seeding (env fallback retained until platform config saved).
+  two mounts); env→platform-scope seeding (ordinary env fallback ends when platform config is
+  saved; the address-matched emergency recovery in §8.2 remains available for an undecryptable
+  saved key).
   Acceptance: invariants 1–4, 6 hold on staging (`dev.avibe.tech`); an enterprise org with its own
   DashScope key sees its voice usage in its dashboard and the platform pool records none of it.
 - **M2 — memory over the cloud**: `mak_` mint/rotate; OpenAI-compatible proxy (chat / embeddings /

--- a/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
+++ b/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
@@ -210,10 +210,11 @@ scope per instance behind them.
   realtime uses its existing fixed `unattributed-legacy` context. Neither value identifies a
   customer instance. Both adapters atomically upsert `available`/`unavailable` state in a shared
   transition table; only a successfully persisted transition to `unavailable` grants permission
-  to emit the outage event. A successful managed decrypt attempts the `available` transition on
-  every call. If that recovery write fails, the usable call still proceeds, the write is retried
-  on the next successful decrypt, and the persistence failure itself is reported directly to
-  Sentry without relying on the unavailable transition table. Concurrent and cold-started Vercel
+  to emit the outage event. A successful managed decrypt of committed saved ciphertext attempts
+  the `available` transition on every call; candidate save round trips never read or write alert
+  state. If that recovery write fails, the usable call still proceeds, the write is retried on the
+  next successful decrypt, and the persistence failure itself is reported directly to Sentry
+  without relying on the unavailable transition table. Concurrent and cold-started Vercel
   isolates therefore observe the same edges without making alert infrastructure part of service
   availability.
 
@@ -502,8 +503,10 @@ turns on.
 
 - `model_service_not_configured` (503) — resolved scope lacks an enabled slot for the capability.
 - `model_service_api_key_required` (400) — an enabled save candidate has no submitted, retained,
-  or materialized API key. This client-input validation runs before managed custody validation and
-  never emits a custody alert.
+  or materialized API key, or any candidate (enabled or disabled) changes `base_url` or
+  `realtime_url` while trying to retain ciphertext bound to the prior address. Address changes
+  never carry prior ciphertext forward. This client-input validation runs before managed custody
+  validation and never emits a custody alert.
 - `model_service_key_unavailable` (503) — an enabled save candidate cannot complete its managed
   encrypt/decrypt round trip after an actual key has been selected, or an enabled saved slot has
   neither decryptable custody nor an eligible same-scope platform env recovery under the shared
@@ -514,9 +517,10 @@ turns on.
   For unrecovered saved-slot failures, status marks the affected capability false with the same
   reason. Every saved-key decryption-failure transition, including one masked by approved platform
   recovery, emits one scrubbed high-priority Sentry event per scope/config revision/capability;
-  repeated failures at the same active edge emit none, and a successful managed-key validation
-  rearms a later failure through the persisted `available` state. Failure to persist that recovery
-  state never changes the successful call or truthful status result.
+  repeated failures at the same active edge emit none, and successful decryption of the committed
+  saved ciphertext rearms a later failure through the persisted `available` state. Candidate
+  round trips never rearm that state. Failure to persist the committed recovery state never changes
+  the successful call or truthful status result.
 - `model_service_unavailable` (503) — quota **reservation** persistence failed on an
   enforcement-on path, before any upstream call. A **settlement** failure after upstream completion
   never produces this error: the response is served and the un-settled reservation is reaped as a

--- a/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
+++ b/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
@@ -205,7 +205,9 @@ scope per instance behind them.
   metadata. Emission is transition-deduplicated by scope, config revision, and capability so
   status polling cannot create one event per instance per minute; the first observing instance
   remains a context tag but is not part of the deduplication key. A successful validation clears
-  that transition so a later outage at the same revision alerts again.
+  that transition so a later outage at the same revision alerts again. The transition claim/clear
+  is an atomic shared-store operation, never process-local state, so concurrent and cold-started
+  Vercel isolates observe the same edge.
 
 ### 6.3 APIs
 
@@ -316,10 +318,11 @@ Every cross-cutting property has exactly one code owner; routes never re-impleme
 
 1. **ModelServiceConfigService** — the only config write path: key⇄address binding, encryption,
    revision, sanitized responses.
-2. **ModelServiceStore** — three atomic contracts only, identical semantics in both adapters:
+2. **ModelServiceStore** — atomic contracts with identical semantics in both adapters:
    `resolveCallSnapshot` (instance+org+plan+config+limits in ONE snapshot — every security decision
    reads one consistent state), `reserveQuota`/`extendQuota`/`settleQuota`, and
-   `readUsageSummarySnapshot`.
+   `readUsageSummarySnapshot`; key-unavailable alert edges use a small additive transition table
+   keyed by scope/config revision/capability and atomic claim/clear operations.
 3. **ModelServiceUpstreamClient** — the only egress owner: destination classification
    (allow-only-global-unicast per the IANA IPv4/IPv6 special-purpose registries; transition/tunnel
    prefixes — NAT64 incl. local-use, 6to4, Teredo — rejected outright), **TLS-only upstreams**
@@ -332,6 +335,8 @@ Every cross-cutting property has exactly one code owner; routes never re-impleme
    certainly-not-sent vs possibly-accepted). Routes never call `fetch`/`WebSocket` or parse usage.
 4. **ModelServiceGateway** — the only call-lifecycle owner, fixed order:
    snapshot → reserve → just-in-time decrypt → client → exactly-once settlement → error mapping.
+   The shared saved-key effectiveness predicate is the only owner of `key_status` judgment;
+   status serialization and call routing consume that result rather than defining another test.
 5. **Voice orchestration** — product composition only (required ASR + optional cleanup); cleanup
    failure of ANY kind (quota or upstream) degrades to the raw transcript in composite flows; the
    dedicated cleanup endpoint alone returns 429 on quota.
@@ -454,15 +459,16 @@ required.
 }
 ```
 
-`mode` ∈ `organization | platform`. While the effective memory pair is available,
-`embedding_identity` is an opaque hash of the embedding slot's (base_url, model) and changes iff
-vector-space identity changes. It is `null` whenever `capabilities.embedding` is false — including
-a missing/disabled slot or a custody failure in either member of the required chat+embedding pair —
-so released clients can parse the degraded payload and pause cloud memory. Before serializing a
-saved scope, the endpoint decrypt-validates every enabled slot and immediately discards the plaintext.
-An enabled slot whose key cannot be decrypted is reported as unavailable and the response adds a
-per-slot reason map, for example `"degraded": { "asr": "model_service_key_unavailable" }`;
-`degraded` is omitted when no slot is degraded.
+`mode` ∈ `organization | platform`. `embedding_identity` is an opaque hash of the embedding slot's
+(base_url, model) and changes iff vector-space identity changes. It is `null` exactly when
+`capabilities.embedding` is false because the embedding slot itself is missing, disabled, or
+undecryptable. A chat-only degradation leaves the healthy embedding capability and identity intact;
+the released client pauses cloud memory through its existing `chat && embedding` pair predicate.
+Before serializing a saved scope, the endpoint consumes the shared saved-key effectiveness predicate
+for every enabled slot and immediately discards any plaintext. An enabled slot whose key cannot be
+decrypted is reported as unavailable and the response adds a per-slot reason map, for example
+`"degraded": { "asr": "model_service_key_unavailable" }`; `degraded` is omitted when no slot is
+degraded.
 
 ### 8.3 Usage row
 
@@ -489,8 +495,10 @@ turns on.
   encrypt/decrypt round trip, or an enabled saved slot cannot be decrypted with the deployed
   `MODEL_SERVICE_KEY_SECRET`. The failure is not overrideable by `force: true`, never maps to
   `model_service_not_configured`, makes no upstream call, and persists no candidate change. For
-  saved-slot failures, status marks the affected capability false with the same reason. Every path
-  emits a scrubbed high-priority Sentry event.
+  saved-slot failures, status marks the affected capability false with the same reason. Each
+  unavailable transition emits one scrubbed high-priority Sentry event per scope/config
+  revision/capability; repeated failures at the same active edge emit none, and a successful
+  validation clears the edge so a later failure can emit again.
 - `model_service_unavailable` (503) — quota **reservation** persistence failed on an
   enforcement-on path, before any upstream call. A **settlement** failure after upstream completion
   never produces this error: the response is served and the un-settled reservation is reaped as a
@@ -530,8 +538,9 @@ turns on.
    cloud-token path, realtime WS).
 7. While `capabilities.embedding` remains true, `embedding_identity` changes iff the embedding
    slot's (base_url, model) changes, and every member instance's sidecar treats it exactly like a
-   local embedding change (rebuild ladder). It is `null` whenever the effective chat+embedding
-   pair is unavailable; restoring the same pair restores the same identity.
+   local embedding change (rebuild ladder). It is `null` exactly when the embedding capability is
+   unavailable; chat-only degradation leaves the identity unchanged while the client pair predicate
+   pauses memory.
 8. With enforcement on, an over-cap free-pool call fails before reaching any upstream.
 9. Changing any API key (slot key or mak) with base_url and model unchanged never alters
    `embedding_identity`, never triggers a rebuild or re-embedding, and never loses or duplicates

--- a/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
+++ b/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
@@ -462,13 +462,15 @@ required.
 `mode` ∈ `organization | platform`. `embedding_identity` is an opaque hash of the embedding slot's
 (base_url, model) and changes iff vector-space identity changes. It is `null` exactly when
 `capabilities.embedding` is false because the embedding slot itself is missing, disabled, or
-undecryptable. A chat-only degradation leaves the healthy embedding capability and identity intact;
-the released client pauses cloud memory through its existing `chat && embedding` pair predicate.
-Before serializing a saved scope, the endpoint consumes the shared saved-key effectiveness predicate
-for every enabled slot and immediately discards any plaintext. An enabled slot whose key cannot be
-decrypted is reported as unavailable and the response adds a per-slot reason map, for example
-`"degraded": { "asr": "model_service_key_unavailable" }`; `degraded` is omitted when no slot is
-degraded.
+unavailable through the shared effectiveness predicate. A chat-only degradation leaves the healthy
+embedding capability and identity intact; the released client pauses cloud memory through its
+existing `chat && embedding` pair predicate. Before serializing a saved scope, the endpoint consumes
+that predicate for every enabled slot and immediately discards any plaintext. It includes the
+platform scope's approved legacy-env recovery only when the normalized saved and env provider
+addresses match; organization scope never receives that recovery. A slot with neither decryptable
+saved custody nor eligible recovery is reported unavailable and the response adds a per-slot reason
+map, for example `"degraded": { "asr": "model_service_key_unavailable" }`; `degraded` is omitted
+when no slot is degraded.
 
 ### 8.3 Usage row
 
@@ -492,13 +494,14 @@ turns on.
 
 - `model_service_not_configured` (503) — resolved scope lacks an enabled slot for the capability.
 - `model_service_key_unavailable` (503) — an enabled save candidate cannot complete its managed
-  encrypt/decrypt round trip, or an enabled saved slot cannot be decrypted with the deployed
-  `MODEL_SERVICE_KEY_SECRET`. The failure is not overrideable by `force: true`, never maps to
-  `model_service_not_configured`, makes no upstream call, and persists no candidate change. For
-  saved-slot failures, status marks the affected capability false with the same reason. Each
-  unavailable transition emits one scrubbed high-priority Sentry event per scope/config
-  revision/capability; repeated failures at the same active edge emit none, and a successful
-  validation clears the edge so a later failure can emit again.
+  encrypt/decrypt round trip, or an enabled saved slot has neither decryptable custody nor an
+  eligible same-scope platform env recovery under the shared effectiveness predicate. The failure
+  is not overrideable by `force: true`, never maps to `model_service_not_configured`, makes no
+  upstream call, and persists no candidate change. For unrecovered saved-slot failures, status
+  marks the affected capability false with the same reason. Every saved-key decryption-failure
+  transition, including one masked by approved platform recovery, emits one scrubbed high-priority
+  Sentry event per scope/config revision/capability; repeated failures at the same active edge emit
+  none, and a successful managed-key validation clears the edge so a later failure can emit again.
 - `model_service_unavailable` (503) — quota **reservation** persistence failed on an
   enforcement-on path, before any upstream call. A **settlement** failure after upstream completion
   never produces this error: the response is served and the un-settled reservation is reaped as a
@@ -526,8 +529,9 @@ turns on.
 3. No API response, log line, Sentry event, usage event, or error message ever contains a slot API
    key or its ciphertext; a `mak_` key appears exactly once — in the body of its own mint/rotate
    response (shown once by design) — and nowhere else; config reads expose only `has_api_key`.
-   Every enabled saved slot is decrypt-valid before persistence, and status reflects current
-   decryptability rather than ciphertext presence.
+   Every enabled saved slot is decrypt-valid before persistence, and status reflects the shared
+   runtime effectiveness result, including only the approved platform env recovery, rather than
+   ciphertext presence.
 4. The upstream model invoked is always the configured slot's model, regardless of any
    client-supplied model string (documented exception: the legacy env cleanup chain, until a
    platform config is saved — each attempt's actual model is metered per §6.6).

--- a/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
+++ b/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
@@ -520,8 +520,9 @@ turns on.
    reservations per §6.4). Failure responses bearing upstream usage are metered with that usage.
    Dashboard aggregates equal the sum of recorded events.
 2. An instance in an enterprise-configured org never consumes platform credentials or platform
-   quota, for any capability; a misconfigured org yields `model_service_not_configured`, never a
-   silent fallback.
+   quota, for any capability; a missing or disabled organization slot yields
+   `model_service_not_configured`, while an enabled slot with unavailable key custody yields
+   `model_service_key_unavailable`, never a silent fallback.
 3. No API response, log line, Sentry event, usage event, or error message ever contains a slot API
    key or its ciphertext; a `mak_` key appears exactly once — in the body of its own mint/rotate
    response (shown once by design) — and nowhere else; config reads expose only `has_api_key`.

--- a/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
+++ b/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
@@ -193,8 +193,16 @@ scope per instance behind them.
 ### 6.2 Key custody
 
 - Slot API keys encrypted at rest with AES-256-GCM under a new env `MODEL_SERVICE_KEY_SECRET`;
-  decrypted only in the proxy call path. All read APIs return `has_api_key: true/false`, never the
-  value. Keys never enter logs, Sentry, or usage events.
+  decrypted only for a model call, a bounded save/explicit-verification probe, or the instance
+  status key-availability check. A save first encrypts the candidate, decrypts that managed
+  ciphertext, and uses only the decrypted value for any upstream probe; every enabled candidate
+  must complete the encrypt/decrypt round trip before persistence, including when `force: true`
+  skips the upstream probe. Status uses decrypt-validate-and-discard and never retains or returns
+  plaintext. This status-only read-path exception supersedes the earlier proxy-only wording.
+  All read APIs return `has_api_key: true/false`, never the value. Keys and ciphertext never enter
+  API responses, logs, Sentry, or usage events. Missing or invalid key-secret material is reported
+  as a high-priority Sentry event tagged by scope, capability, and instance, using only scrubbed
+  metadata.
 
 ### 6.3 APIs
 
@@ -266,9 +274,10 @@ scope per instance behind them.
   so unattributed-legacy usage can only ever be platform-scope in fact and invariant 2 holds.
   **Error mapping on legacy voice routes** (invariant 6): `model_service_not_configured` surfaces
   through the existing voice error vocabulary (`asr_not_configured` 503 family; a missing chat
-  slot degrades cleanup per §6.5-5); `model_quota_exhausted` (429) and `model_service_unavailable`
-  (503) pass through as new additive codes — released clients already treat unknown codes as
-  generic errors of their status class.
+  slot degrades cleanup per §6.5-5); `model_service_key_unavailable` (503),
+  `model_quota_exhausted` (429), and `model_service_unavailable` (503) pass through as new
+  additive codes — released clients already treat unknown codes as generic errors of their
+  status class.
 
 ### 6.4 Quota (platform scope only, v1)
 
@@ -441,7 +450,11 @@ required.
 `mode` ∈ `organization | platform`. `embedding_identity` is an opaque hash of the embedding slot's
 (base_url, model); it changes iff vector-space identity changes, and is `null` when the bound
 scope has no enabled embedding slot (e.g. a voice-only enterprise org) — the client then treats
-cloud memory as unavailable, matching `capabilities.embedding: false`.
+cloud memory as unavailable, matching `capabilities.embedding: false`. Before serializing a saved
+scope, the endpoint decrypt-validates every enabled slot and immediately discards the plaintext.
+An enabled slot whose key cannot be decrypted is reported as unavailable and the response adds a
+per-slot reason map, for example `"degraded": { "asr": "model_service_key_unavailable" }`;
+`degraded` is omitted when no slot is degraded.
 
 ### 8.3 Usage row
 
@@ -464,6 +477,10 @@ turns on.
 ### 8.4 Error codes (stable, machine-readable `code` field)
 
 - `model_service_not_configured` (503) — resolved scope lacks an enabled slot for the capability.
+- `model_service_key_unavailable` (503) — an enabled saved slot exists but its API key cannot be
+  decrypted with the deployed `MODEL_SERVICE_KEY_SECRET`. It never maps to
+  `model_service_not_configured`; no upstream call is made, status marks the affected capability
+  false with the same reason, and a scrubbed high-priority Sentry event is emitted.
 - `model_service_unavailable` (503) — quota **reservation** persistence failed on an
   enforcement-on path, before any upstream call. A **settlement** failure after upstream completion
   never produces this error: the response is served and the un-settled reservation is reaped as a
@@ -487,9 +504,11 @@ turns on.
 2. An instance in an enterprise-configured org never consumes platform credentials or platform
    quota, for any capability; a misconfigured org yields `model_service_not_configured`, never a
    silent fallback.
-3. No API response, log line, usage event, or error message ever contains a slot API key; a `mak_`
-   key appears exactly once — in the body of its own mint/rotate response (shown once by design) —
-   and nowhere else; config reads expose only `has_api_key`.
+3. No API response, log line, Sentry event, usage event, or error message ever contains a slot API
+   key or its ciphertext; a `mak_` key appears exactly once — in the body of its own mint/rotate
+   response (shown once by design) — and nowhere else; config reads expose only `has_api_key`.
+   Every enabled saved slot is decrypt-valid before persistence, and status reflects current
+   decryptability rather than ciphertext presence.
 4. The upstream model invoked is always the configured slot's model, regardless of any
    client-supplied model string (documented exception: the legacy env cleanup chain, until a
    platform config is saved — each attempt's actual model is metered per §6.6).

--- a/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
+++ b/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
@@ -202,7 +202,10 @@ scope per instance behind them.
   All read APIs return `has_api_key: true/false`, never the value. Keys and ciphertext never enter
   API responses, logs, Sentry, or usage events. Missing or invalid key-secret material is reported
   as a high-priority Sentry event tagged by scope, capability, and instance, using only scrubbed
-  metadata.
+  metadata. Emission is transition-deduplicated by scope, config revision, and capability so
+  status polling cannot create one event per instance per minute; the first observing instance
+  remains a context tag but is not part of the deduplication key. A successful validation clears
+  that transition so a later outage at the same revision alerts again.
 
 ### 6.3 APIs
 

--- a/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
+++ b/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
@@ -493,15 +493,19 @@ turns on.
 ### 8.4 Error codes (stable, machine-readable `code` field)
 
 - `model_service_not_configured` (503) — resolved scope lacks an enabled slot for the capability.
+- `model_service_api_key_required` (400) — an enabled save candidate has no submitted, retained,
+  or materialized API key. This client-input validation runs before managed custody validation and
+  never emits a custody alert.
 - `model_service_key_unavailable` (503) — an enabled save candidate cannot complete its managed
-  encrypt/decrypt round trip, or an enabled saved slot has neither decryptable custody nor an
-  eligible same-scope platform env recovery under the shared effectiveness predicate. The failure
-  is not overrideable by `force: true`, never maps to `model_service_not_configured`, makes no
-  upstream call, and persists no candidate change. For unrecovered saved-slot failures, status
-  marks the affected capability false with the same reason. Every saved-key decryption-failure
-  transition, including one masked by approved platform recovery, emits one scrubbed high-priority
-  Sentry event per scope/config revision/capability; repeated failures at the same active edge emit
-  none, and a successful managed-key validation clears the edge so a later failure can emit again.
+  encrypt/decrypt round trip after an actual key has been selected, or an enabled saved slot has
+  neither decryptable custody nor an eligible same-scope platform env recovery under the shared
+  effectiveness predicate. The failure is not overrideable by `force: true`, never maps to
+  `model_service_not_configured`, makes no upstream call, and persists no candidate change. For
+  unrecovered saved-slot failures, status marks the affected capability false with the same reason.
+  Every saved-key decryption-failure transition, including one masked by approved platform recovery,
+  emits one scrubbed high-priority Sentry event per scope/config revision/capability; repeated
+  failures at the same active edge emit none, and a successful managed-key validation clears the
+  edge so a later failure can emit again.
 - `model_service_unavailable` (503) — quota **reservation** persistence failed on an
   enforcement-on path, before any upstream call. A **settlement** failure after upstream completion
   never produces this error: the response is served and the un-settled reservation is reaped as a

--- a/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
+++ b/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
@@ -195,10 +195,12 @@ scope per instance behind them.
 - Slot API keys encrypted at rest with AES-256-GCM under a new env `MODEL_SERVICE_KEY_SECRET`;
   decrypted only for a model call, a bounded save/explicit-verification probe, or the instance
   status key-availability check. A save first encrypts the candidate, decrypts that managed
-  ciphertext, and uses only the decrypted value for any upstream probe; every enabled candidate
-  must complete the encrypt/decrypt round trip before persistence, including when `force: true`
-  skips the upstream probe. Status uses decrypt-validate-and-discard and never retains or returns
-  plaintext. This status-only read-path exception supersedes the earlier proxy-only wording.
+  ciphertext, and uses only the decrypted value for any upstream probe. Every newly submitted or
+  legacy-materialized key, including one for a disabled slot, must complete the encrypt/decrypt
+  round trip before persistence; every enabled candidate retaining saved ciphertext must do the
+  same, including when `force: true` skips the upstream probe. A disabled slot that retains its
+  unchanged saved ciphertext is exempt. Status uses decrypt-validate-and-discard and never retains
+  or returns plaintext. This status-only read-path exception supersedes the earlier proxy-only wording.
   All read APIs return `has_api_key: true/false`, never the value. Keys and ciphertext never enter
   API responses, logs, Sentry, or usage events. Missing or invalid key-secret material for a
   committed saved slot is reported as a high-priority Sentry event tagged by scope, capability,
@@ -238,8 +240,9 @@ scope per instance behind them.
   settings ladder's probe-before-apply). Both successful verify responses (200) and failed verify
   responses (422) carry the scope's current `revision`, so a caller can settle its optimistic
   snapshot without another read. Managed-key custody failures are never force-overridable: if any
-  enabled candidate cannot complete its encrypt/decrypt round trip, `PUT` returns
-  `model_service_key_unavailable` (503), performs no upstream probe, and persists nothing.
+  newly submitted or legacy-materialized key, or any enabled retained key, cannot complete its
+  encrypt/decrypt round trip, `PUT` returns `model_service_key_unavailable` (503), performs no
+  upstream probe, and persists nothing.
 - **Platform admin (user session; email ∈ `PLATFORM_ADMIN_EMAILS`, new env following the
   `ORGANIZATION_CREATION_ALLOWED_EMAILS` pattern)**:
   `GET/PUT /api/admin/model-service` (platform slots + limits), `GET /api/admin/model-service/usage`
@@ -507,10 +510,11 @@ turns on.
   `realtime_url` while trying to retain ciphertext bound to the prior address. Address changes
   never carry prior ciphertext forward. This client-input validation runs before managed custody
   validation and never emits a custody alert.
-- `model_service_key_unavailable` (503) — an enabled save candidate cannot complete its managed
-  encrypt/decrypt round trip after an actual key has been selected, or an enabled saved slot has
-  neither decryptable custody nor an eligible same-scope platform env recovery under the shared
-  effectiveness predicate. The failure is not overrideable by `force: true`, never maps to
+- `model_service_key_unavailable` (503) — a newly submitted or legacy-materialized candidate key,
+  including one for a disabled slot, cannot complete its managed encrypt/decrypt round trip; an
+  enabled candidate retaining saved ciphertext cannot complete that round trip; or an enabled
+  saved slot has neither decryptable custody nor an eligible same-scope platform env recovery under
+  the shared effectiveness predicate. The failure is not overrideable by `force: true`, never maps to
   `model_service_not_configured`, makes no upstream call, and persists no candidate change. A
   rejected pre-save custody check writes a scrubbed structured log only: it creates no transition
   row and emits no ops alert because the request response and admin UI are its presentation surface.
@@ -548,9 +552,10 @@ turns on.
 3. No API response, log line, Sentry event, usage event, or error message ever contains a slot API
    key or its ciphertext; a `mak_` key appears exactly once — in the body of its own mint/rotate
    response (shown once by design) — and nowhere else; config reads expose only `has_api_key`.
-   Every enabled saved slot is decrypt-valid before persistence, and status reflects the shared
-   runtime effectiveness result, including only the approved platform env recovery, rather than
-   ciphertext presence.
+   Every newly submitted or legacy-materialized key is decrypt-valid before persistence, including
+   for a disabled slot; every enabled retained key is likewise decrypt-valid. Status reflects the
+   shared runtime effectiveness result, including only the approved platform env recovery, rather
+   than ciphertext presence.
 4. The upstream model invoked is always the configured slot's model, regardless of any
    client-supplied model string (documented exception: the legacy env cleanup chain, until a
    platform config is saved — each attempt's actual model is metered per §6.6).

--- a/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
+++ b/docs/plans/2026-08-16-cloud-model-service-and-config-center.md
@@ -206,8 +206,9 @@ scope per instance behind them.
   by scope, config revision, and capability so status polling cannot create one event per instance
   per minute; the first observing instance remains a context tag but is not part of the
   deduplication key. Explicit admin verification uses the fixed non-customer
-  `model-service-probe` context when there is no calling instance. Both adapters atomically upsert
-  `available`/`unavailable` state in a shared
+  `model-service-probe` context when there is no calling instance; transition-window claimless
+  realtime uses its existing fixed `unattributed-legacy` context. Neither value identifies a
+  customer instance. Both adapters atomically upsert `available`/`unavailable` state in a shared
   transition table; only a successfully persisted transition to `unavailable` grants permission
   to emit the outage event. A successful managed decrypt attempts the `available` transition on
   every call. If that recovery write fails, the usable call still proceeds, the write is retried


### PR DESCRIPTION
## Summary

- Ratify the status-path decrypt-validate-and-discard exception to the original proxy-only custody rule.
- Freeze `model_service_key_unavailable`, per-slot `degraded` reasons, independent capability/identity behavior, and atomic available/unavailable alert semantics.
- Require every newly submitted or legacy-materialized key, including for a disabled slot, and every enabled retained key to complete the strict managed encrypt/decrypt round trip before persistence; unchanged disabled retained ciphertext is exempt.
- Align status and calls on the single saved-key effectiveness predicate, including only the approved address-bound platform env recovery.

## Ownership boundary

- The effectiveness predicate delivered by the P0 backend lane is the sole owner of `key_status` judgment.
- Backend PR #241 only consumes and presents that judgment, owns durable alert transitions and client error handling, and must not define a second validity predicate.
- The owner controls merge ordering. This contract PR has no UX dependency or UX-lane ownership.

## Contract scope

- Affected sections: §6.2, §6.3 voice error mapping, §8.2, §8.4, invariants 2-3.
- Scenario IDs: none; the model-service contract currently has no scenario-catalog entry.

## Evidence

- Documentation-only PR; executable coverage is carried by backend head `75ea4cf3ca8d715d53574c005341f6987cd2d74d` in https://github.com/avibe-bot/avibe-backend/pull/241.
- The contract explicitly covers parseable per-slot degradation, independent embedding identity, approved address-matched platform recovery after save, composite cleanup fallback, non-overridable save-time 503 without ops alerting, managed round trips for disabled submitted/materialized keys, exact alert edge identity, and custody boundaries.
- No runtime behavior changes in this repository.
- Residual manual: production secret repair and post-deploy status/voice verification remain in the integration pass.

## Known by design

- `degraded` is omitted when every enabled slot is effective.
- Status validation immediately discards plaintext and never probes the upstream provider.
- A chat-only failure does not alter embedding capability or identity; pairing remains a client concern.
- Alert state is shared across Vercel isolates. Only a persisted unavailable transition emits; every successful managed decrypt retries the available transition, and recovery persistence failure never interrupts a usable call.
