### PR TITLE
fix(show): keep one runtime across private and public views

### DIFF
--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -54,6 +54,7 @@ _PREWARM_MAX_DEPTH = 4
 SHOW_RUNTIME_PROTOCOL_VERSION = 1
 SHOW_RUNTIME_PROTOCOL_HEADER = "X-Avibe-Show-Protocol"
 SHOW_RUNTIME_CONTEXT_HEADER = "X-Avibe-Show-Context"
+SHOW_RUNTIME_BASE_HEADER = "x-vibe-show-base"
 SHOW_RUNTIME_CONTEXT_KEY_FEATURE = "show-context-key-v1"
 _CAPABILITY_RETRY_BASE_SECONDS = 0.25
 _CAPABILITY_RETRY_MAX_SECONDS = 5.0
@@ -257,11 +258,18 @@ class ShowRuntimeManager:
         if not ready.available or not ready.base_url:
             raise RuntimeError(ready.reason or "show runtime unavailable")
         await self._negotiate_context_key_capability(ready.base_url)
+        request_headers = {
+            key: value
+            for key, value in envelope.headers(headers).items()
+            if key.lower() != SHOW_RUNTIME_BASE_HEADER
+        }
+        if session_part := _show_runtime_app_session_part(path):
+            request_headers[SHOW_RUNTIME_BASE_HEADER] = f"/show/{session_part}/"
         async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=5.0)) as client:
             return await client.request(
                 method,
                 f"{ready.base_url}{path}",
-                headers=envelope.headers(headers),
+                headers=request_headers,
                 content=body,
             )
 
@@ -277,7 +285,11 @@ class ShowRuntimeManager:
         ready = await self.ensure()
         if not ready.available or not ready.base_url:
             raise RuntimeError(ready.reason or "show runtime unavailable")
-        blocked = {SHOW_RUNTIME_PROTOCOL_HEADER.lower(), SHOW_RUNTIME_CONTEXT_HEADER.lower()}
+        blocked = {
+            SHOW_RUNTIME_PROTOCOL_HEADER.lower(),
+            SHOW_RUNTIME_CONTEXT_HEADER.lower(),
+            SHOW_RUNTIME_BASE_HEADER.lower(),
+        }
         forwarded = {
             key: value
             for key, value in (headers or {}).items()
@@ -291,21 +303,19 @@ class ShowRuntimeManager:
         session_id: str,
         *,
         context: ShowRuntimeContext,
-        base_path: str | None = None,
     ) -> ShowRuntimeResult:
         session_part = urllib.parse.quote(session_id, safe="")
         runtime_path = f"/sessions/{session_part}/app/"
-        headers = {"x-vibe-show-base": base_path} if base_path else None
+        base_path = f"/show/{session_part}/"
         envelope = ShowRuntimeProtocolEnvelope(context)
         try:
-            response = await self.request("GET", runtime_path, envelope=envelope, headers=headers)
+            response = await self.request("GET", runtime_path, envelope=envelope)
             if response.status_code >= 500:
                 return ShowRuntimeResult(False, reason=f"session_prewarm_failed:{response.status_code}")
             result = await self._prewarm_session_module_graph(
                 session_id,
                 runtime_path=runtime_path,
                 envelope=envelope,
-                headers=headers,
                 seed_responses=[(runtime_path, response)],
                 base_path=base_path,
             )
@@ -321,7 +331,6 @@ class ShowRuntimeManager:
         *,
         runtime_path: str,
         envelope: ShowRuntimeProtocolEnvelope,
-        headers: dict[str, str] | None,
         seed_responses: list[tuple[str, httpx.Response]],
         base_path: str | None,
     ) -> ShowRuntimeResult:
@@ -343,7 +352,7 @@ class ShowRuntimeManager:
             if path in visited or depth > _PREWARM_MAX_DEPTH:
                 continue
             visited.add(path)
-            response = await self.request("GET", path, envelope=envelope, headers=headers)
+            response = await self.request("GET", path, envelope=envelope)
             if response.status_code >= 500:
                 return ShowRuntimeResult(False, reason=f"session_prewarm_module_failed:{response.status_code}:{path}")
             if response.status_code >= 400:
@@ -1522,13 +1531,16 @@ async def prewarm_show_page_session(
     session_id: str,
     *,
     context: ShowRuntimeContext,
-    base_path: str | None = None,
 ) -> ShowRuntimeResult:
     return await get_show_runtime_manager().prewarm_session(
         session_id,
         context=context,
-        base_path=base_path,
     )
+
+
+def _show_runtime_app_session_part(path: str) -> str | None:
+    match = re.match(r"^/sessions/([^/]+)/app(?:/|$)", path)
+    return match.group(1) if match else None
 
 
 def set_show_runtime_manager_for_tests(manager: ShowRuntimeManager | None) -> None:

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -1083,10 +1083,9 @@ def test_startup_show_page_prewarm_targets_recent_non_offline(monkeypatch, tmp_p
     assert out["pages"][0]["context"] == "private"
     assert out["pages"][1]["visibility"] == "limited"
     assert out["pages"][1]["context"] == "private"
-    assert out["pages"][1]["base_path"] is None
     assert out["pages"][2]["visibility"] == "public"
     assert out["pages"][2]["context"] == "shared"
-    assert out["pages"][2]["base_path"].startswith("/p/")
+    assert all("base_path" not in page for page in out["pages"])
 
 
 def test_startup_show_page_prewarm_limit_env(monkeypatch):

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -2392,10 +2392,9 @@ def test_show_update_cli_reports_transition_urls(monkeypatch, tmp_path, capsys):
     assert public_payload["active_url"] == public_payload["public_url"]
     assert public_payload["public_url"].startswith("https://alex.avibe.bot/p/")
     assert public_payload["previous_private_url"] == "https://alex.avibe.bot/show/ses123/"
-    share_path = "/" + public_payload["public_url"].split("https://alex.avibe.bot/", 1)[1]
     assert prewarmed[-1] == (
         "http://127.0.0.1:5123/api/show/sessions/ses123/prewarm",
-        {"context": "shared", "base_path": share_path},
+        {"context": "shared"},
     )
 
     args = parser.parse_args(["show", "update", "--session-id", "ses123", "--visibility", "private", "--json"])

--- a/tests/test_show_runtime_protocol.py
+++ b/tests/test_show_runtime_protocol.py
@@ -6,6 +6,7 @@ import pytest
 
 import core.show_runtime as show_runtime
 from core.show_runtime import (
+    SHOW_RUNTIME_BASE_HEADER,
     SHOW_RUNTIME_CONTEXT_HEADER,
     SHOW_RUNTIME_PROTOCOL_HEADER,
     ShowRuntimeContext,
@@ -132,7 +133,12 @@ def test_show_live_015_transient_probe_keeps_shared_request_live_and_retries(
     envelope = ShowRuntimeProtocolEnvelope(ShowRuntimeContext.SHARED)
 
     async def exercise():
-        first = await manager.request("GET", "/sessions/ses/app/", envelope=envelope)
+        first = await manager.request(
+            "GET",
+            "/sessions/ses/app/",
+            envelope=envelope,
+            headers={"X-Vibe-Show-Base": "/p/untrusted/"},
+        )
         second = await manager.request("GET", "/sessions/ses/app/src/main.tsx", envelope=envelope)
         clock["now"] = 101.0
         third = await manager.request("GET", "/sessions/ses/app/src/App.tsx", envelope=envelope)
@@ -144,6 +150,8 @@ def test_show_live_015_transient_probe_keeps_shared_request_live_and_retries(
     assert probes == [manager._base_url, manager._base_url]
     assert all(call[2][SHOW_RUNTIME_PROTOCOL_HEADER] == "1" for call in requests)
     assert all(call[2][SHOW_RUNTIME_CONTEXT_HEADER] == "shared" for call in requests)
+    assert all(call[2][SHOW_RUNTIME_BASE_HEADER] == "/show/ses/" for call in requests)
+    assert all("X-Vibe-Show-Base" not in call[2] for call in requests)
 
 
 def test_show_live_014_capability_cache_resets_with_process_base_and_manager_lifetime(

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -1319,7 +1319,7 @@ def test_show_live_005_protocol_context_crosses_non_ascii_avibe_request_boundary
 
 @pytest.mark.parametrize("surface", ["private", "public"])
 @pytest.mark.parametrize("route_path", ["reports/daily", "users/alice@example.com"])
-def test_show_page_history_route_retries_entry_after_runtime_404(monkeypatch, tmp_path, surface, route_path):
+def test_show_page_history_route_requests_entry_directly(monkeypatch, tmp_path, surface, route_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     if surface == "private":
@@ -1336,14 +1336,12 @@ def test_show_page_history_route_retries_entry_after_runtime_404(monkeypatch, tm
             "environ_base": _remote_peer(),
         }
 
-    route_runtime_path = f"/sessions/ses123/app/{route_path}?vibe-embed=1"
     entry_runtime_path = "/sessions/ses123/app/?vibe-embed=1"
     entry = (
         '<!doctype html><html><head><base href="/show/ses123/"></head><body>'
         '<script type="module" src="/show/ses123/src/main.tsx"></script></body></html>'
     ).encode()
     manager = _FakeShowRuntimeManager(
-        status_code=404,
         status_by_path={entry_runtime_path: 200},
         bodies_by_path={entry_runtime_path: entry},
     )
@@ -1362,12 +1360,12 @@ def test_show_page_history_route_retries_entry_after_runtime_404(monkeypatch, tm
     assert f'<base href="{expected_base}">' in body
     assert f'"basePath":"{expected_base}"' in body
     assert response.headers["cache-control"] == "no-store"
-    assert [call[1] for call in manager.calls] == [route_runtime_path, entry_runtime_path]
+    assert [call[1] for call in manager.calls] == [entry_runtime_path]
     expected_context = "private" if surface == "private" else "shared"
     assert all(call[2]["X-Avibe-Show-Protocol"] == "1" for call in manager.calls)
     assert all(call[2]["X-Avibe-Show-Context"] == expected_context for call in manager.calls)
-    if surface == "public":
-        assert all(call[2]["x-vibe-show-base"] == expected_base for call in manager.calls)
+    assert manager.calls[0][2]["accept"] == "text/html"
+    assert all("x-vibe-show-base" not in call[2] for call in manager.calls)
 
 
 @pytest.mark.parametrize("surface", ["private", "public"])
@@ -1403,7 +1401,7 @@ def test_show_page_history_route_uses_recovery_when_runtime_unavailable(monkeypa
     assert b"standard shadcn variables" in response.content
     assert b"--background" in response.content
     assert b"components from @/components/ui and @avibe/show-ui" not in response.content
-    assert [call[1] for call in manager.calls] == ["/sessions/ses123/app/reports/daily"]
+    assert [call[1] for call in manager.calls] == ["/sessions/ses123/app/"]
 
 
 @pytest.mark.parametrize(
@@ -1444,6 +1442,7 @@ def test_private_show_page_real_extensionless_asset_precedes_spa_fallback(monkey
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_show_page("ses123", "private")
+    (paths.get_show_page_dir("ses123") / "robots").write_text("real extensionless asset", encoding="utf-8")
     asset_runtime_path = "/sessions/ses123/app/robots"
     manager = _FakeShowRuntimeManager(
         status_code=404,
@@ -4700,8 +4699,8 @@ def test_cli_show_prewarm_ingress_uses_ui_runtime_manager(monkeypatch, tmp_path)
     _save_config(tmp_path)
     calls = []
 
-    async def fake_prewarm(session_id, *, context, base_path=None):
-        calls.append((session_id, context, base_path))
+    async def fake_prewarm(session_id, *, context):
+        calls.append((session_id, context))
         return SimpleNamespace(available=True, reason=None, base_url="http://127.0.0.1:49200")
 
     monkeypatch.setattr("core.show_runtime.prewarm_show_page_session", fake_prewarm)
@@ -4719,7 +4718,7 @@ def test_cli_show_prewarm_ingress_uses_ui_runtime_manager(monkeypatch, tmp_path)
 
     assert response.status_code == 200
     assert response.get_json()["ok"] is True
-    assert calls == [("ses123", ShowRuntimeContext.SHARED, "/p/share123/")]
+    assert calls == [("ses123", ShowRuntimeContext.SHARED)]
 
 
 def test_show_live_017_cli_show_prewarm_rejects_missing_context_before_runtime(
@@ -5559,13 +5558,11 @@ def test_show_runtime_manager_prewarm_loads_entry_module(monkeypatch, tmp_path):
         manager.prewarm_session(
             "ses123",
             context=ShowRuntimeContext.PRIVATE,
-            base_path="/show/ses123/",
         )
     )
 
     assert result.available is True
     private_headers = {
-        "x-vibe-show-base": "/show/ses123/",
         "X-Avibe-Show-Protocol": "1",
         "X-Avibe-Show-Context": "private",
     }
@@ -5592,12 +5589,12 @@ def test_show_runtime_manager_prewarm_reports_nested_module_failures(monkeypatch
     responses = {
         "/sessions/ses123/app/": (
             200,
-            b'<script type="module" src="/p/share123/src/main.tsx"></script>',
+            b'<script type="module" src="/show/ses123/src/main.tsx"></script>',
             {"content-type": "text/html"},
         ),
         "/sessions/ses123/app/src/main.tsx": (
             200,
-            b'import App from "/p/share123/src/App.tsx";',
+            b'import App from "/show/ses123/src/App.tsx";',
             {"content-type": "text/javascript"},
         ),
         "/sessions/ses123/app/src/App.tsx": (
@@ -5624,7 +5621,6 @@ def test_show_runtime_manager_prewarm_reports_nested_module_failures(monkeypatch
         manager.prewarm_session(
             "ses123",
             context=ShowRuntimeContext.SHARED,
-            base_path="/p/share123/",
         )
     )
 
@@ -6698,8 +6694,8 @@ def test_startup_dependency_reconcile_prewarms_runtime_after_prepare(monkeypatch
         called["runtime"] += 1
         return SimpleNamespace(available=True, reason=None)
 
-    async def fake_session_prewarm(session_id, *, context, base_path=None):
-        called["sessions"].append((session_id, context, base_path))
+    async def fake_session_prewarm(session_id, *, context):
+        called["sessions"].append((session_id, context))
         return SimpleNamespace(available=True, reason=None)
 
     monkeypatch.setattr("vibe.api.reconcile_startup_dependencies", fake_reconcile)
@@ -6709,8 +6705,8 @@ def test_startup_dependency_reconcile_prewarms_runtime_after_prepare(monkeypatch
             "ok": True,
             "limit": 2,
             "pages": [
-                {"session_id": "ses_private", "context": "private", "base_path": None},
-                {"session_id": "ses_public", "context": "shared", "base_path": "/p/share123/"},
+                {"session_id": "ses_private", "context": "private"},
+                {"session_id": "ses_public", "context": "shared"},
             ],
         },
     )
@@ -6723,8 +6719,8 @@ def test_startup_dependency_reconcile_prewarms_runtime_after_prepare(monkeypatch
         "reconcile": 1,
         "runtime": 1,
         "sessions": [
-            ("ses_private", ShowRuntimeContext.PRIVATE, None),
-            ("ses_public", ShowRuntimeContext.SHARED, "/p/share123/"),
+            ("ses_private", ShowRuntimeContext.PRIVATE),
+            ("ses_public", ShowRuntimeContext.SHARED),
         ],
     }
 
@@ -7261,9 +7257,46 @@ def test_public_show_page_uses_runtime_when_available(monkeypatch, tmp_path):
     assert b"Public Runtime Page" in response.content
     assert manager.calls[0][0] == "GET"
     assert manager.calls[0][1] == "/sessions/ses123/app/"
-    assert manager.calls[0][2]["x-vibe-show-base"] == f"/p/{share_id}/"
+    assert "x-vibe-show-base" not in manager.calls[0][2]
     assert manager.calls[0][2]["X-Avibe-Show-Protocol"] == "1"
     assert manager.calls[0][2]["X-Avibe-Show-Context"] == "shared"
+
+
+def test_private_and_public_surfaces_share_one_stable_runtime_base(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+    manager = _FakeShowRuntimeManager(
+        body=b'<script type="module" src="/show/ses123/src/main.tsx"></script>'
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        private_before = app.test_client().get(
+            "/show/ses123/",
+            base_url="http://127.0.0.1:5123",
+        )
+        public = app.test_client().get(
+            f"/p/{share_id}/",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+        )
+        private_after = app.test_client().get(
+            "/show/ses123/",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert [response.status_code for response in (private_before, public, private_after)] == [200, 200, 200]
+    assert b'/show/ses123/src/main.tsx' in private_before.content
+    assert f'/p/{share_id}/src/main.tsx'.encode() in public.content
+    assert b'/show/ses123/src/main.tsx' in private_after.content
+    assert [call[2]["X-Avibe-Show-Context"] for call in manager.calls] == [
+        "private",
+        "shared",
+        "private",
+    ]
+    assert all("x-vibe-show-base" not in call[2] for call in manager.calls)
 
 
 def test_public_show_page_materializes_workspace_before_runtime_proxy(monkeypatch, tmp_path):
@@ -7287,7 +7320,7 @@ def test_public_show_page_materializes_workspace_before_runtime_proxy(monkeypatc
     assert b"Public Runtime Page" in response.content
     assert (page_dir / "src" / "App.tsx").exists()
     assert manager.calls[0][1] == "/sessions/ses123/app/"
-    assert manager.calls[0][2]["x-vibe-show-base"] == f"/p/{share_id}/"
+    assert "x-vibe-show-base" not in manager.calls[0][2]
 
 
 def test_public_show_page_rewrites_runtime_redirect_location(monkeypatch, tmp_path):
@@ -7339,7 +7372,7 @@ def test_public_show_page_proxies_runtime_api_methods(monkeypatch, tmp_path):
     assert manager.calls[0][0] == "POST"
     assert manager.calls[0][1] == "/sessions/ses123/app/api/health"
     assert manager.calls[0][2]["content-type"] == "application/json"
-    assert manager.calls[0][2]["x-vibe-show-base"] == f"/p/{share_id}/"
+    assert "x-vibe-show-base" not in manager.calls[0][2]
     assert manager.calls[0][2]["X-Avibe-Show-Protocol"] == "1"
     assert manager.calls[0][2]["X-Avibe-Show-Context"] == "shared"
     assert "cookie" not in manager.calls[0][2]

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -5495,6 +5495,37 @@ def test_private_show_page_rewrites_absolute_runtime_redirect_location(monkeypat
     assert response.headers["location"] == "/show/ses123/foo/?x=1#top"
 
 
+@pytest.mark.parametrize(
+    "external_location",
+    [
+        "https://example.test/show/ses123/foo?x=1#top",
+        "https://example.test/sessions/ses123/app/foo?x=1#top",
+    ],
+)
+def test_public_show_page_preserves_external_redirect_location(monkeypatch, tmp_path, external_location):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+    manager = _FakeShowRuntimeManager(
+        body=b"",
+        status_code=302,
+        extra_headers={"location": external_location},
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/foo",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+            follow_redirects=False,
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 302
+    assert response.headers["location"] == external_location
+
+
 def test_show_runtime_manager_reports_missing_command(tmp_path):
     manager = ShowRuntimeManager(
         command="definitely-missing-avibe-show-runtime",
@@ -7384,6 +7415,33 @@ def test_public_show_page_rewrites_runtime_redirect_location(monkeypatch, tmp_pa
 
     assert response.status_code == 302
     assert response.headers["location"] == f"/p/{share_id}/foo/"
+
+
+def test_public_show_page_rewrites_runtime_source_map_headers(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+    manager = _FakeShowRuntimeManager(
+        body=b"export default true",
+        extra_headers={
+            "content-type": "text/javascript",
+            "sourcemap": "/show/ses123/src/App.tsx.map?x=1",
+            "x-sourcemap": "https://example.test/show/ses123/external.map",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/src/App.tsx",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert response.headers["sourcemap"] == f"/p/{share_id}/src/App.tsx.map?x=1"
+    assert response.headers["x-sourcemap"] == "https://example.test/show/ses123/external.map"
 
 
 @pytest.mark.parametrize("asset_path", ["docs/", "robots"])

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -2231,6 +2231,38 @@ def test_public_show_runtime_html_rewrites_private_runtime_client_paths(monkeypa
     assert "etag" not in response.headers
 
 
+def test_public_show_runtime_css_rewrites_private_runtime_paths(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+    manager = _FakeShowRuntimeManager(
+        body=(
+            b'@import "/show/ses123/src/theme.css";\n'
+            b'@font-face { src: url("/show/ses123/assets/font.woff2") format("woff2"); }\n'
+        ),
+        extra_headers={
+            "content-type": "text/css; charset=utf-8",
+            "cache-control": "no-cache",
+            "etag": "source-etag",
+        },
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/src/styles.css",
+            base_url="http://127.0.0.1:5123",
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert f'@import "/p/{share_id}/src/theme.css"'.encode() in response.content
+    assert f'url("/p/{share_id}/assets/font.woff2")'.encode() in response.content
+    assert b"/show/ses123/" not in response.content
+    assert response.headers["cache-control"] == "no-store"
+    assert "etag" not in response.headers
+
+
 def test_show_runtime_public_client_shims_are_cacheable():
     client = app.test_client()
     vite_client = client.get("/_show-runtime/client-shim-v1.js", base_url="http://127.0.0.1:5123")
@@ -7323,14 +7355,21 @@ def test_public_show_page_materializes_workspace_before_runtime_proxy(monkeypatc
     assert "x-vibe-show-base" not in manager.calls[0][2]
 
 
-def test_public_show_page_rewrites_runtime_redirect_location(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    "runtime_location",
+    [
+        "/sessions/ses123/app/foo/",
+        "/show/ses123/foo/",
+    ],
+)
+def test_public_show_page_rewrites_runtime_redirect_location(monkeypatch, tmp_path, runtime_location):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
     manager = _FakeShowRuntimeManager(
         body=b"",
         status_code=302,
-        extra_headers={"location": "/sessions/ses123/app/foo/"},
+        extra_headers={"location": runtime_location},
     )
     set_show_runtime_manager_for_tests(manager)
     try:
@@ -7345,6 +7384,35 @@ def test_public_show_page_rewrites_runtime_redirect_location(monkeypatch, tmp_pa
 
     assert response.status_code == 302
     assert response.headers["location"] == f"/p/{share_id}/foo/"
+
+
+@pytest.mark.parametrize("asset_path", ["docs/", "robots"])
+def test_public_show_page_preserves_vite_public_dir_assets(monkeypatch, tmp_path, asset_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+    public_path = paths.get_show_page_dir("ses123") / "public" / asset_path
+    if asset_path.endswith("/"):
+        public_path.mkdir(parents=True)
+        (public_path / "index.html").write_text("<h1>docs</h1>", encoding="utf-8")
+    else:
+        public_path.parent.mkdir(parents=True, exist_ok=True)
+        public_path.write_text("robots", encoding="utf-8")
+    manager = _FakeShowRuntimeManager(body=b"public asset", extra_headers={"content-type": "text/plain"})
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/{asset_path}",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+            headers={"Accept": "text/html"},
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert response.content == b"public asset"
+    assert manager.calls[0][1] == f"/sessions/ses123/app/{asset_path}"
 
 
 def test_public_show_page_proxies_runtime_api_methods(monkeypatch, tmp_path):

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -8467,14 +8467,12 @@ def startup_show_page_prewarm_targets(limit: int | None = None) -> dict:
     candidates.sort(key=lambda page: (page.updated_at, page.session_id), reverse=True)
     pages = []
     for page in candidates[:resolved_limit]:
-        base_path = f"/p/{page.share_id}/" if page.visibility == VISIBILITY_PUBLIC and page.share_id else None
-        context = ShowRuntimeContext.SHARED if base_path else ShowRuntimeContext.PRIVATE
+        context = ShowRuntimeContext.SHARED if page.visibility == VISIBILITY_PUBLIC else ShowRuntimeContext.PRIVATE
         pages.append(
             {
                 "session_id": page.session_id,
                 "visibility": page.visibility,
                 "updated_at": page.updated_at,
-                "base_path": base_path,
                 "context": context.value,
             }
         )

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -12813,9 +12813,8 @@ def _prewarm_show_page_session_best_effort(
     session_id: str,
     *,
     context: str,
-    base_path: str | None = None,
 ) -> None:
-    if _request_show_page_prewarm_best_effort(session_id, context=context, base_path=base_path) is None:
+    if _request_show_page_prewarm_best_effort(session_id, context=context) is None:
         logger.debug("Show Page session prewarm skipped for %s", session_id)
 
 
@@ -12910,12 +12909,10 @@ def cmd_show_update(args):
                 message = "Show Page has been taken offline. Local files were not deleted."
 
         if updated.visibility != "offline":
-            base_path = f"/p/{updated.share_id}/" if updated.visibility == "public" and updated.share_id else None
-            context = ShowRuntimeContext.SHARED if base_path else ShowRuntimeContext.PRIVATE
+            context = ShowRuntimeContext.SHARED if updated.visibility == "public" else ShowRuntimeContext.PRIVATE
             _prewarm_show_page_session_best_effort(
                 updated.session_id,
                 context=context.value,
-                base_path=base_path,
             )
         payload = _show_page_result(updated, message=message, extra=extra)
         if getattr(args, "json", False):
@@ -13039,7 +13036,6 @@ def _request_show_page_prewarm_best_effort(
     session_id: str,
     *,
     context: str,
-    base_path: str | None = None,
 ) -> dict | None:
     from core.show_pages import SHOW_CLI_EVENT_TOKEN_HEADER, show_cli_event_token
 
@@ -13047,8 +13043,6 @@ def _request_show_page_prewarm_best_effort(
     if not targets:
         return None
     payload = {"context": context}
-    if base_path:
-        payload["base_path"] = base_path
     body = json.dumps(payload).encode("utf-8")
     headers = {
         "Content-Type": "application/json",

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -13005,16 +13005,23 @@ def _is_show_page_spa_route_request(asset_path: str, starlette_request: FastAPIR
     relative = _decode_show_page_asset_path(asset_path)
     if relative in {"", "index.html"}:
         return True
+    if "text/html" not in starlette_request.headers.get("accept", "").lower():
+        return False
     segments = [segment for segment in relative.split("/") if segment]
     if not segments or segments[0] in {"api", "__show"}:
         return False
-    if "." not in segments[-1]:
-        return True
+    return True
 
-    # The runtime gets first refusal for real files. After a 404, Accept is the
-    # remaining distinction between a dotted route parameter (document navigation)
-    # and a missing script/style/image asset.
-    return "text/html" in starlette_request.headers.get("accept", "").lower()
+
+def _show_page_runtime_asset_exists(session_id: str, asset_path: str) -> bool:
+    relative = _decode_show_page_asset_path(asset_path)
+    if not relative:
+        return False
+    candidate = paths.get_show_page_dir(session_id) / relative
+    try:
+        return candidate.is_file() or (candidate.is_dir() and (candidate / "index.html").is_file())
+    except OSError:
+        return False
 
 
 def _decode_show_page_asset_path(asset_path: str) -> str:
@@ -14117,9 +14124,6 @@ async def show_session_prewarm(session_id: str):
     if not _is_cli_show_event_request():
         return jsonify({"ok": False, "code": "forbidden"}), 403
     payload = _show_events_payload_from_request()
-    base_path = payload.get("base_path")
-    if base_path is not None and not isinstance(base_path, str):
-        return jsonify({"ok": False, "code": "invalid_base_path"}), 400
     from core.show_runtime import ShowRuntimeContext, prewarm_show_page_session
 
     try:
@@ -14127,7 +14131,7 @@ async def show_session_prewarm(session_id: str):
     except (TypeError, ValueError):
         return jsonify({"ok": False, "code": "invalid_show_runtime_context"}), 400
 
-    result = await prewarm_show_page_session(session_id, context=context, base_path=base_path)
+    result = await prewarm_show_page_session(session_id, context=context)
     status_code = 200 if result.available else 202
     return jsonify({"ok": result.available, "reason": result.reason, "base_url": result.base_url}), status_code
 
@@ -14294,10 +14298,16 @@ async def _show_page_runtime_response(
             path = f"{path}?{starlette_request.url.query}"
         return path
 
-    runtime_path = runtime_app_path(asset_path)
     forwarded_headers = _show_runtime_forwarded_headers(starlette_request.headers)
-    if external_prefix:
-        forwarded_headers["x-vibe-show-base"] = f"{external_prefix.rstrip('/')}/"
+    history_route_candidate = (
+        not _is_show_page_entry_asset(asset_path)
+        and _is_show_page_spa_route_request(asset_path, starlette_request)
+    )
+    served_entry_fallback = history_route_candidate and not _show_page_runtime_asset_exists(
+        session_id,
+        asset_path,
+    )
+    runtime_path = runtime_app_path("" if served_entry_fallback else asset_path)
     context = ShowRuntimeContext.SHARED if external_prefix else ShowRuntimeContext.PRIVATE
     envelope = ShowRuntimeProtocolEnvelope(context)
     body = await starlette_request.body()
@@ -14310,20 +14320,6 @@ async def _show_page_runtime_response(
         headers=forwarded_headers,
         body=body or None,
     )
-    served_entry_fallback = False
-    if proxied.status_code == 404 and _is_show_page_spa_route_request(asset_path, starlette_request):
-        # Compatibility fallback for runtimes predating History-mode serving.
-        # The requested file/handler had first refusal above; only a route-shaped
-        # miss retries the entry document under the same private/public base.
-        runtime_path = runtime_app_path("")
-        proxied = await manager.request(
-            starlette_request.method,
-            runtime_path,
-            envelope=envelope,
-            headers=forwarded_headers,
-            body=body or None,
-        )
-        served_entry_fallback = True
     proxy_duration_ms = int((time.monotonic() - request_started) * 1000)
     if (
         proxy_duration_ms >= SHOW_RUNTIME_SLOW_REQUEST_MS
@@ -15530,7 +15526,6 @@ async def _reconcile_startup_dependencies_task() -> None:
                     session_prewarm = await prewarm_show_page_session(
                         session_id,
                         context=context,
-                        base_path=page.get("base_path") if isinstance(page.get("base_path"), str) else None,
                     )
                     page_results.append(
                         {

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -13017,11 +13017,14 @@ def _show_page_runtime_asset_exists(session_id: str, asset_path: str) -> bool:
     relative = _decode_show_page_asset_path(asset_path)
     if not relative:
         return False
-    candidate = paths.get_show_page_dir(session_id) / relative
+    workspace = paths.get_show_page_dir(session_id)
     try:
-        return candidate.is_file() or (candidate.is_dir() and (candidate / "index.html").is_file())
+        for candidate in (workspace / relative, workspace / "public" / relative):
+            if candidate.is_file() or (candidate.is_dir() and (candidate / "index.html").is_file()):
+                return True
     except OSError:
         return False
+    return False
 
 
 def _decode_show_page_asset_path(asset_path: str) -> str:
@@ -14501,7 +14504,11 @@ def _show_response_is_compressible(content_type: str | None) -> bool:
 
 
 def _show_response_is_rewritable_show_runtime_source(content_type: str | None) -> bool:
-    return _show_response_is_javascript(content_type) or _show_response_is_html(content_type)
+    return (
+        _show_response_is_javascript(content_type)
+        or _show_response_is_html(content_type)
+        or bool(content_type and "text/css" in content_type.lower())
+    )
 
 
 def _rewrite_public_show_runtime_client(
@@ -14758,12 +14765,18 @@ def _inject_show_runtime_config(
 def _rewrite_show_runtime_location(session_id: str, location: str, *, external_prefix: str | None = None) -> str:
     parsed = urlsplit(location)
     internal_prefix = f"/sessions/{quote(session_id, safe='')}/app"
-    external_prefix = (external_prefix or f"/show/{quote(session_id, safe='')}").rstrip("/")
+    private_prefix = f"/show/{quote(session_id, safe='')}"
+    resolved_external_prefix = (external_prefix or private_prefix).rstrip("/")
     if parsed.path == internal_prefix:
-        public_path = f"{external_prefix}/"
+        public_path = f"{resolved_external_prefix}/"
     elif parsed.path.startswith(f"{internal_prefix}/"):
         suffix = parsed.path[len(internal_prefix) :].lstrip("/")
-        public_path = f"{external_prefix}/{suffix}"
+        public_path = f"{resolved_external_prefix}/{suffix}"
+    elif external_prefix and parsed.path == private_prefix:
+        public_path = f"{resolved_external_prefix}/"
+    elif external_prefix and parsed.path.startswith(f"{private_prefix}/"):
+        suffix = parsed.path[len(private_prefix) :].lstrip("/")
+        public_path = f"{resolved_external_prefix}/{suffix}"
     else:
         return location
     return urlunsplit(("", "", public_path, parsed.query, parsed.fragment))

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -14343,12 +14343,11 @@ async def _show_page_runtime_response(
         for key, value in proxied.headers.items()
         if key.lower() in _SHOW_RUNTIME_RESPONSE_HEADER_ALLOWLIST
     }
-    if location := response_headers.get("location"):
-        response_headers["location"] = _rewrite_show_runtime_location(
-            session_id,
-            location,
-            external_prefix=external_prefix,
-        )
+    _rewrite_show_runtime_url_headers(
+        response_headers,
+        session_id=session_id,
+        external_prefix=external_prefix,
+    )
     response_headers["X-Content-Type-Options"] = "nosniff"
     response_headers["Referrer-Policy"] = "no-referrer"
     content = proxied.content
@@ -14762,8 +14761,27 @@ def _inject_show_runtime_config(
     return html.encode("utf-8")
 
 
-def _rewrite_show_runtime_location(session_id: str, location: str, *, external_prefix: str | None = None) -> str:
-    parsed = urlsplit(location)
+def _rewrite_show_runtime_url_headers(
+    headers: dict[str, str],
+    *,
+    session_id: str,
+    external_prefix: str | None,
+) -> None:
+    for header in ("location", "sourcemap", "x-sourcemap"):
+        value = _response_header(headers, header)
+        if value is None:
+            continue
+        _set_response_header(
+            headers,
+            header,
+            _rewrite_show_runtime_url(session_id, value, external_prefix=external_prefix),
+        )
+
+
+def _rewrite_show_runtime_url(session_id: str, value: str, *, external_prefix: str | None = None) -> str:
+    parsed = urlsplit(value)
+    if (parsed.scheme or parsed.netloc) and not _is_local_show_runtime_url(parsed):
+        return value
     internal_prefix = f"/sessions/{quote(session_id, safe='')}/app"
     private_prefix = f"/show/{quote(session_id, safe='')}"
     resolved_external_prefix = (external_prefix or private_prefix).rstrip("/")
@@ -14778,8 +14796,22 @@ def _rewrite_show_runtime_location(session_id: str, location: str, *, external_p
         suffix = parsed.path[len(private_prefix) :].lstrip("/")
         public_path = f"{resolved_external_prefix}/{suffix}"
     else:
-        return location
+        return value
     return urlunsplit(("", "", public_path, parsed.query, parsed.fragment))
+
+
+def _is_local_show_runtime_url(parsed) -> bool:
+    if parsed.scheme.lower() != "http":
+        return False
+    hostname = parsed.hostname
+    if not hostname:
+        return False
+    if hostname.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
 
 
 def _with_show_event_write_cookie(response: Response, session_id: str, *, enabled: bool) -> Response:


### PR DESCRIPTION
## Summary

- keep each Show session on one canonical Runtime base: `/show/<session>/`
- let the Python server own public `/p/<share>/` routing and response rewriting without restarting Vite
- route History-mode document requests straight to the entry document when no real workspace asset exists
- remove public base-path input from CLI and startup prewarming

## Product behavior

- private and public views share one Node/Vite Runtime per session
- private views retain HMR
- public views remain read-only and do not open an HMR WebSocket
- nested routes load directly without corrupting relative module paths
- real extensionless workspace assets still take precedence over SPA fallback

## Verification

- 508 focused Show/runtime tests passed
- Ruff 0.4.9 passed on all changed Python files
- local Incus browser regression passed for private/public parity, private HMR, public no-HMR, and fresh nested-route navigation
