### PR TITLE
fix(attachments): anchor inbound lease root at the resolved Avibe home

### DIFF
--- a/config/paths.py
+++ b/config/paths.py
@@ -13,6 +13,22 @@ def _expand_path(value: str | Path) -> Path:
     return Path(value).expanduser().resolve()
 
 
+def physical_home(home: Path | str) -> Path:
+    """Resolve an Avibe home to the path a no-follow walk can traverse.
+
+    The home is a trust anchor, not an attack surface. Supported layouts reach
+    it through symlinks that Avibe or the operating system created: a
+    ``/home/<user>`` entry pointing at another volume, or the legacy
+    ``~/.vibe_remote`` back-symlink. A per-component ``O_NOFOLLOW`` walk that
+    starts at ``/`` rejects exactly those layouts, because Linux reports
+    ``ENOTDIR`` when ``O_NOFOLLOW | O_DIRECTORY`` meets a symlink. Callers
+    resolve the home once here and keep ``O_NOFOLLOW`` for every component
+    Avibe owns below it, where a planted symlink would be an actual escape.
+    """
+
+    return Path(os.path.realpath(os.path.expanduser(os.fspath(home))))
+
+
 def _default_avibe_dir(home: Path | None = None) -> Path:
     return (home or Path.home()) / AVIBE_HOME_DIRNAME
 

--- a/core/handlers/inbound_attachments.py
+++ b/core/handlers/inbound_attachments.py
@@ -128,11 +128,17 @@ class InboundAttachmentMaterializer:
     ) -> None:
         home = paths.get_vibe_remote_dir() if effective_home is None else effective_home
         self._home = Path(os.path.abspath(os.path.expanduser(os.fspath(home))))
-        self._root = (
-            self._home / "attachments" / "im"
-            if attachments_root is None
-            else Path(attachments_root) / "im"
-        )
+        # The anchor is trusted and resolved once; every component below it is
+        # Avibe-owned and stays under a per-component no-follow walk.
+        if attachments_root is None:
+            anchor = paths.physical_home(self._home)
+            self._owned_parts = ("attachments", "im")
+        else:
+            declared_root = Path(os.path.abspath(os.path.expanduser(os.fspath(attachments_root))))
+            anchor = paths.physical_home(declared_root.parent)
+            self._owned_parts = (declared_root.name, "im")
+        self._anchor = anchor
+        self._root = anchor.joinpath(*self._owned_parts)
 
     async def materialize(
         self,
@@ -144,7 +150,7 @@ class InboundAttachmentMaterializer:
         max_concurrency: int = 1,
         language: str = "en",
     ) -> MaterializedAttachmentBatch:
-        root_fd = _open_or_create_private_directory(self._root)
+        root_fd = _open_or_create_private_directory(self._anchor, self._owned_parts)
         lease_id = secrets.token_hex(16)
         lease_dir = self._root / lease_id
         lease_fd: int | None = None
@@ -571,14 +577,27 @@ def _remove_lease_directory(state: _LeaseState) -> None:
         os.close(state.root_fd)
 
 
-def _open_or_create_private_directory(directory: Path) -> int:
-    """Create a private root while refusing symlinks in every path component."""
+def _open_or_create_private_directory(anchor: Path, owned_parts: tuple[str, ...]) -> int:
+    """Create a private root while refusing symlinks in every owned component.
 
-    if not directory.is_absolute():
+    ``anchor`` is the already-resolved Avibe home: the operator owns the path
+    that reaches it, so it is opened in one step and its own symlinked parents
+    stay legal. ``owned_parts`` are the components Avibe creates underneath,
+    and each one is opened with ``O_NOFOLLOW`` so a planted symlink cannot
+    redirect a lease outside Avibe-owned storage.
+    """
+
+    if not anchor.is_absolute():
         raise RuntimeError("attachment lease root must be absolute")
-    descriptor = os.open(directory.anchor, _directory_open_flags())
+    if not owned_parts or any(part in {"", ".", ".."} for part in owned_parts):
+        raise RuntimeError("attachment lease root must name owned components")
     try:
-        for component in directory.parts[1:]:
+        descriptor = os.open(anchor, _directory_open_flags())
+    except FileNotFoundError:
+        os.makedirs(anchor, mode=0o700, exist_ok=True)
+        descriptor = os.open(anchor, _directory_open_flags())
+    try:
+        for component in owned_parts:
             try:
                 next_descriptor = os.open(
                     component,

--- a/core/handlers/inbound_attachments.py
+++ b/core/handlers/inbound_attachments.py
@@ -130,15 +130,28 @@ class InboundAttachmentMaterializer:
         self._home = Path(os.path.abspath(os.path.expanduser(os.fspath(home))))
         # The anchor is trusted and resolved once; every component below it is
         # Avibe-owned and stays under a per-component no-follow walk.
+        anchor = paths.physical_home(self._home)
         if attachments_root is None:
-            anchor = paths.physical_home(self._home)
-            self._owned_parts = ("attachments", "im")
+            owned_parts: tuple[str, ...] = ("attachments", "im")
         else:
             declared_root = Path(os.path.abspath(os.path.expanduser(os.fspath(attachments_root))))
-            anchor = paths.physical_home(declared_root.parent)
-            self._owned_parts = (declared_root.name, "im")
+            relative_parts = _owned_parts_below(anchor, self._home, declared_root)
+            if relative_parts is None:
+                # A declared root outside the home is its own anchor, on the same
+                # rule as the home: the path reaching it is operator config, and
+                # Avibe only owns what it creates underneath.
+                anchor = paths.physical_home(declared_root)
+                owned_parts = ("im",)
+            else:
+                # Every component between the home and a declared root inside it
+                # is Avibe-owned space, so all of them stay in the no-follow walk
+                # instead of being resolved: a symlink planted at an intermediate
+                # component such as ``<home>/custom`` must not redirect leases out
+                # of the tree.
+                owned_parts = (*relative_parts, "im")
         self._anchor = anchor
-        self._root = anchor.joinpath(*self._owned_parts)
+        self._owned_parts = owned_parts
+        self._root = anchor.joinpath(*owned_parts)
 
     async def materialize(
         self,
@@ -577,14 +590,34 @@ def _remove_lease_directory(state: _LeaseState) -> None:
         os.close(state.root_fd)
 
 
+def _owned_parts_below(
+    anchor: Path,
+    home: Path,
+    declared_root: Path,
+) -> tuple[str, ...] | None:
+    """Components from the home down to ``declared_root``, or ``None`` if outside.
+
+    A declared root under the home is accepted in either spelling: as written
+    against the logical home, or already resolved against the physical one. The
+    returned components are relative to the anchor either way, so the caller can
+    keep every one of them inside the ``O_NOFOLLOW`` walk.
+    """
+
+    for base in (home, anchor):
+        if declared_root.is_relative_to(base):
+            return declared_root.relative_to(base).parts
+    return None
+
+
 def _open_or_create_private_directory(anchor: Path, owned_parts: tuple[str, ...]) -> int:
     """Create a private root while refusing symlinks in every owned component.
 
-    ``anchor`` is the already-resolved Avibe home: the operator owns the path
-    that reaches it, so it is opened in one step and its own symlinked parents
-    stay legal. ``owned_parts`` are the components Avibe creates underneath,
-    and each one is opened with ``O_NOFOLLOW`` so a planted symlink cannot
-    redirect a lease outside Avibe-owned storage.
+    ``anchor`` is the already-resolved trust anchor -- the Avibe home, or a
+    declared root the operator put outside it: the operator owns the path that
+    reaches it, so it is opened in one step and its own symlinked parents stay
+    legal. ``owned_parts`` are every component Avibe creates underneath, and
+    each one is opened with ``O_NOFOLLOW`` so a planted symlink cannot redirect
+    a lease outside Avibe-owned storage.
     """
 
     if not anchor.is_absolute():

--- a/tests/test_inbound_attachments.py
+++ b/tests/test_inbound_attachments.py
@@ -315,6 +315,68 @@ async def test_materializer_traverses_a_symlinked_parent_for_a_declared_root(
 
 
 @pytest.mark.asyncio
+async def test_materializer_rejects_symlinked_parent_inside_a_nested_declared_root(
+    tmp_path: Path,
+) -> None:
+    """Intermediate components of a nested declared root stay no-follow.
+
+    A declared root such as ``<home>/custom/downloads`` reaches it through
+    ``custom``, which is Avibe-owned space below the trusted home. Resolving the
+    declared root's parents would follow a symlink planted there before the
+    protected walk starts, redirecting leases outside the declared tree.
+    """
+
+    home = tmp_path / "avibe-home"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    home.mkdir()
+    (home / "custom").symlink_to(outside, target_is_directory=True)
+    context = MessageContext(
+        user_id="U1",
+        channel_id="D1",
+        platform="slack",
+        files=[FileAttachment("notes.txt", "text/plain", url="ref", size=5)],
+    )
+
+    with pytest.raises(OSError):
+        await InboundAttachmentMaterializer(
+            effective_home=home,
+            attachments_root=home / "custom" / "downloads",
+        ).materialize(context, _StubClient({"notes.txt": b"notes"}))
+
+    assert list(outside.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_materializer_keeps_a_nested_declared_root_under_the_home(
+    tmp_path: Path,
+) -> None:
+    """A nested declared root still materializes below the resolved home."""
+
+    physical = tmp_path / "volume" / "user"
+    physical.mkdir(parents=True)
+    (tmp_path / "home").symlink_to(tmp_path / "volume", target_is_directory=True)
+    home = tmp_path / "home" / "user" / ".avibe"
+    context = MessageContext(
+        user_id="U1",
+        channel_id="D1",
+        platform="slack",
+        files=[FileAttachment("notes.txt", "text/plain", url="ref", size=5)],
+    )
+
+    batch = await InboundAttachmentMaterializer(
+        effective_home=home,
+        attachments_root=home / "custom" / "downloads",
+    ).materialize(context, _StubClient({"notes.txt": b"notes"}))
+
+    assert batch.errors == ()
+    path = Path(batch.attachments[0].local_path or "")
+    assert path.read_bytes() == b"notes"
+    assert path.is_relative_to(physical / ".avibe" / "custom" / "downloads" / "im")
+    batch.lease.release()
+
+
+@pytest.mark.asyncio
 async def test_materializer_keeps_download_writes_on_anchored_descriptor(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_inbound_attachments.py
+++ b/tests/test_inbound_attachments.py
@@ -221,13 +221,19 @@ async def test_materializer_preserves_legacy_two_argument_path_clients(tmp_path:
 
 
 @pytest.mark.asyncio
-async def test_materializer_rejects_symlinked_attachment_root(tmp_path: Path) -> None:
+@pytest.mark.parametrize("owned_component", ["attachments", "im"])
+async def test_materializer_rejects_symlinked_attachment_root(
+    tmp_path: Path,
+    owned_component: str,
+) -> None:
+    """Every component Avibe owns below the home stays a no-follow boundary."""
+
     home = tmp_path / "avibe-home"
-    attachments = home / "attachments"
     outside = tmp_path / "outside"
-    attachments.mkdir(parents=True)
     outside.mkdir()
-    (attachments / "im").symlink_to(outside, target_is_directory=True)
+    planted = home / "attachments" if owned_component == "attachments" else home / "attachments" / "im"
+    planted.parent.mkdir(parents=True, exist_ok=True)
+    planted.symlink_to(outside, target_is_directory=True)
     context = MessageContext(
         user_id="U1",
         channel_id="D1",
@@ -242,6 +248,70 @@ async def test_materializer_rejects_symlinked_attachment_root(tmp_path: Path) ->
         )
 
     assert list(outside.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_materializer_traverses_a_symlinked_parent_above_the_home(
+    tmp_path: Path,
+) -> None:
+    """A home reached through symlinked parents is a layout, not an escape.
+
+    Installs where ``/home/<user>`` points at another volume, and the legacy
+    ``~/.vibe_remote`` back-symlink, both reach the Avibe home through a
+    symlink the operator owns. Linux answers ``O_NOFOLLOW | O_DIRECTORY`` on a
+    symlink with ``ENOTDIR``, so a walk that starts at ``/`` used to fail on
+    the symlinked component before reaching anything Avibe owns.
+    """
+
+    physical = tmp_path / "volume" / "user"
+    physical.mkdir(parents=True)
+    (tmp_path / "home").symlink_to(tmp_path / "volume", target_is_directory=True)
+    home = tmp_path / "home" / "user" / ".avibe"
+    client = _StubClient({"notes.txt": b"notes"})
+    context = MessageContext(
+        user_id="U1",
+        channel_id="D1",
+        platform="slack",
+        files=[FileAttachment("notes.txt", "text/plain", url="ref", size=5)],
+    )
+
+    batch = await InboundAttachmentMaterializer(effective_home=home).materialize(
+        context,
+        client,
+    )
+
+    assert batch.errors == ()
+    path = Path(batch.attachments[0].local_path or "")
+    assert path.read_bytes() == b"notes"
+    assert path.is_relative_to(physical / ".avibe" / "attachments" / "im")
+    batch.lease.release()
+
+
+@pytest.mark.asyncio
+async def test_materializer_traverses_a_symlinked_parent_for_a_declared_root(
+    tmp_path: Path,
+) -> None:
+    """The declared ``attachments_root`` carries the same anchor rule."""
+
+    physical = tmp_path / "volume" / "user"
+    physical.mkdir(parents=True)
+    (tmp_path / "home").symlink_to(tmp_path / "volume", target_is_directory=True)
+    attachments_root = tmp_path / "home" / "user" / ".avibe" / "attachments"
+    context = MessageContext(
+        user_id="U1",
+        channel_id="D1",
+        platform="slack",
+        files=[FileAttachment("notes.txt", "text/plain", url="ref", size=5)],
+    )
+
+    batch = await InboundAttachmentMaterializer(
+        attachments_root=attachments_root,
+    ).materialize(context, _StubClient({"notes.txt": b"notes"}))
+
+    assert batch.errors == ()
+    path = Path(batch.attachments[0].local_path or "")
+    assert path.is_relative_to(physical / ".avibe" / "attachments" / "im")
+    batch.lease.release()
 
 
 @pytest.mark.asyncio

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -113,6 +113,25 @@ async def _start_watch_service(service: ManagedWatchService) -> None:
         await startup_task
 
 
+async def _await_fused_watch(
+    service: ManagedWatchService,
+    watch_id: str,
+    timeout: float = 10.0,
+) -> None:
+    """Wait for a watch to be fused instead of sleeping a fixed interval.
+
+    Fusing needs a real waiter subprocess to start and its result to reach the
+    raising store, so the wait covers a process spawn plus interpreter startup.
+    A fixed 0.12s was enough locally and not on a loaded CI runner, where the
+    assertion saw an empty fused set.
+    """
+
+    deadline = time.monotonic() + timeout
+    while watch_id not in service._fused_watch_ids:
+        assert time.monotonic() < deadline, "watch was never fused after the store error"
+        await asyncio.sleep(0.02)
+
+
 def _add_recovery_watch(
     store: ManagedWatchStore,
     *,
@@ -2314,8 +2333,8 @@ def test_managed_watch_service_fuses_watch_after_store_error(tmp_path: Path) -> 
 
     async def _run() -> None:
         await _start_watch_service(service)
-        await asyncio.sleep(0.12)
-        assert watch.id in service._fused_watch_ids
+        await _await_fused_watch(service, watch.id)
+        # Settle briefly: a fused store must not let the cycle start again.
         await asyncio.sleep(0.08)
         await service.stop()
 
@@ -2374,8 +2393,8 @@ def test_managed_watch_service_fuses_quiet_cycle_after_store_error(tmp_path: Pat
 
     async def _run() -> None:
         await _start_watch_service(service)
-        await asyncio.sleep(0.12)
-        assert watch.id in service._fused_watch_ids
+        await _await_fused_watch(service, watch.id)
+        # Settle briefly: a fused store must not let the cycle start again.
         await asyncio.sleep(0.08)
         await service.stop()
 


### PR DESCRIPTION
## Capability

Inbound IM attachment materialization now works on installs whose Avibe home is reached through a symlink.

`InboundAttachmentMaterializer` opened its lease root by walking the absolute path one component at a time with `O_NOFOLLOW | O_DIRECTORY`, starting at `/`. Linux answers that combination with `ENOTDIR` (not `ELOOP`) when a component is a symlink, so any install where `/home/<user>` points at another volume failed every attachment-bearing message with:

```
NotADirectoryError: [Errno 20] Not a directory: '<user>'
```

The bare component name in the message is the relative `openat` argument, which is why it reads as an unrelated filename. The legacy `~/.vibe_remote` back-symlink is the same shape. Regression introduced in #1461; text-only messages were unaffected.

## Change

- `config/paths.physical_home()` — one documented trust anchor: the home is resolved once, because the path that reaches it belongs to the operator, not to Avibe.
- `_open_or_create_private_directory(anchor, owned_parts)` — opens the resolved anchor in a single step, then keeps the per-component `O_NOFOLLOW` walk for every component Avibe creates below it, where a planted symlink would be a real escape.
- `_owned_parts_below()` — a declared `attachments_root` inside the home contributes *all* of its components below the home to the owned walk, in either spelling (written against the logical home, or already resolved). A root the operator declares outside the home is its own anchor, on the same trust rule as the home.

The security boundary is unchanged: a symlink at any Avibe-owned component below the home is still refused.

## Evidence

- **Unit** — `tests/test_inbound_attachments.py`
  - `test_materializer_traverses_a_symlinked_parent_above_the_home` and `..._for_a_declared_root` reproduce the production failure (`[Errno 20] Not a directory: 'home'`) against the pre-fix walk and pass after it.
  - `test_materializer_rejects_symlinked_attachment_root` is now parametrized over every owned component (`attachments`, `im`), so a component added below the home fails the test instead of silently losing its no-follow check.
  - `test_materializer_rejects_symlinked_parent_inside_a_nested_declared_root` covers the nested declared root `<home>/custom/downloads` with a symlink planted at the intermediate `custom`: previously resolved away before the protected walk, now refused with nothing written outside. `test_materializer_keeps_a_nested_declared_root_under_the_home` is its positive counterpart through a symlinked home.
  - Full file: 16 passed. Repo-wide `-k attachment`: 242 passed. `ruff check` clean on the changed files.
- **CI reliability** — `tests/test_watches.py`: both store-error fuse tests slept a fixed `0.12s` before asserting the fuse, which needs a waiter subprocess to start and its result to reach the raising store. That failed `unit-tests (3/6)` on this PR while master was green. They now poll for the fuse with a bounded deadline. Reproduced with eight busy loops on a 4-core host: the pre-fix sleep fails both tests, the polling version passes under the same load. Unrelated to the attachment change, fixed here to unblock the gate.
- **Contract / scenario** — no catalog covers this path; none updated.
- **Residual manual check** — send an attachment from any IM surface on a host whose home is symlinked. Verified in production diagnosis only, not re-run post-fix.

## Known by design

- `self._root` is now the physical path, so lease paths handed downstream are already symlink-free for other no-follow consumers.
- Sibling walkers with the same shape are **not** touched here: `core/memory/attachments.py` (`_ensure_private_directory`, `_open_directory_no_follow`), `core/memory/store.py:782`, `core/memory/process.py:1578`. They walk from `/` over an Avibe-home path and will hit the same `ENOTDIR`; `physical_home()` is the anchor they should adopt. Deliberately out of scope for this fix — follow-up.
