### PR TITLE
fix(memory): anchor filesystem state at physical home

### DIFF
--- a/core/memory/attachments.py
+++ b/core/memory/attachments.py
@@ -19,7 +19,10 @@ from urllib.parse import unquote_to_bytes, urlsplit
 from config import paths
 from core.memory.confined_filesystem import (
     ConfinedFilesystemError,
+    ConfinedRoot,
     SpilledDirectoryOrder,
+    ensure_private_directory,
+    open_confined_directory,
     required_no_follow_flag,
 )
 from core.memory.modality import SUPPORTED_ATTACHMENT_EXTENSIONS
@@ -224,21 +227,28 @@ class AttachmentPinStore:
         effective_home: Path | str | None = None,
         source_root: Path | None = None,
     ) -> None:
-        self._effective_home = _absolute_lexical(
-            paths.get_vibe_remote_dir()
-            if effective_home is None
-            else effective_home
-        )
-        self._root = (
-            _absolute_lexical(root)
-            if root is not None
-            else attachment_pin_root(self._effective_home)
-        )
-        self._source_root = _absolute_lexical(
-            source_root
-            if source_root is not None
-            else self._effective_home / "attachments" / "avibe"
-        )
+        try:
+            self._filesystem_root = ConfinedRoot.from_home(
+                paths.get_vibe_remote_dir()
+                if effective_home is None
+                else effective_home
+            )
+            self._effective_home = self._filesystem_root.physical_home
+            self._root = self._filesystem_root.confine(
+                root
+                if root is not None
+                else self._filesystem_root.logical_home / "memory" / "attachments"
+            )
+            self._source_root = self._filesystem_root.confine(
+                source_root
+                if source_root is not None
+                else self._filesystem_root.logical_home / "attachments" / "avibe"
+            )
+        except ConfinedFilesystemError as error:
+            raise AttachmentPinError(
+                "memory_store_unavailable",
+                "attachment paths must stay below the effective Avibe home",
+            ) from error
         self._staging = self._root / "staging"
         self._bundles = self._root / "bundles"
         self._lock = threading.RLock()
@@ -269,8 +279,8 @@ class AttachmentPinStore:
         source_root, allowed_records = self._pin_source(source_lease)
         with self._lock:
             self._verify_private_layout()
-            staging_fd = _open_private_directory(self._staging, "attachment staging root")
-            bundles_fd = _open_private_directory(self._bundles, "attachment bundles root")
+            staging_fd = _open_private_directory(self._effective_home, self._staging, "attachment staging root")
+            bundles_fd = _open_private_directory(self._effective_home, self._bundles, "attachment bundles root")
             bundle_id: str | None = None
             stage_name: str | None = None
             renamed = False
@@ -379,7 +389,7 @@ class AttachmentPinStore:
 
         with self._lock:
             self._verify_private_layout()
-            bundles_fd = _open_private_directory(self._bundles, "attachment bundles root")
+            bundles_fd = _open_private_directory(self._effective_home, self._bundles, "attachment bundles root")
             try:
                 observed_files = _validate_private_bundle(bundles_fd, checked.bundle_id)
                 expected_files = tuple(
@@ -422,7 +432,7 @@ class AttachmentPinStore:
             raise AttachmentPinError("memory_invalid_input", "invalid attachment bundle id")
         with self._lock:
             self._verify_private_layout()
-            bundles_fd = _open_private_directory(self._bundles, "attachment bundles root")
+            bundles_fd = _open_private_directory(self._effective_home, self._bundles, "attachment bundles root")
             try:
                 _remove_private_bundle(bundles_fd, bundle_id, strict_files=True)
             finally:
@@ -445,8 +455,8 @@ class AttachmentPinStore:
 
         with self._lock:
             self._verify_private_layout()
-            staging_fd = _open_private_directory(self._staging, "attachment staging root")
-            bundles_fd = _open_private_directory(self._bundles, "attachment bundles root")
+            staging_fd = _open_private_directory(self._effective_home, self._staging, "attachment staging root")
+            bundles_fd = _open_private_directory(self._effective_home, self._bundles, "attachment bundles root")
             removed: list[str] = []
             try:
                 for name in _directory_entry_names(staging_fd):
@@ -481,8 +491,8 @@ class AttachmentPinStore:
 
         with self._lock:
             self._verify_private_layout()
-            staging_fd = _open_private_directory(self._staging, "attachment staging root")
-            bundles_fd = _open_private_directory(self._bundles, "attachment bundles root")
+            staging_fd = _open_private_directory(self._effective_home, self._staging, "attachment staging root")
+            bundles_fd = _open_private_directory(self._effective_home, self._bundles, "attachment bundles root")
             try:
                 for directory_fd in (staging_fd, bundles_fd):
                     for name in _directory_entry_names(directory_fd):
@@ -499,7 +509,13 @@ class AttachmentPinStore:
 
     def _prepare_private_layout(self) -> None:
         for directory in (self._root, self._staging, self._bundles):
-            _ensure_private_directory(directory)
+            try:
+                ensure_private_directory(self._effective_home, directory)
+            except ConfinedFilesystemError as error:
+                raise AttachmentPinError(
+                    "memory_store_unavailable",
+                    "attachment storage path contains an unsafe directory component",
+                ) from error
 
     def _verify_private_layout(self) -> None:
         for directory, label in (
@@ -507,7 +523,7 @@ class AttachmentPinStore:
             (self._staging, "attachment staging root"),
             (self._bundles, "attachment bundles root"),
         ):
-            descriptor = _open_private_directory(directory, label)
+            descriptor = _open_private_directory(self._effective_home, directory, label)
             os.close(descriptor)
 
     def _validate_sources(self, sources: tuple[CaptureAttachment, ...]) -> None:
@@ -612,6 +628,13 @@ class AttachmentPinStore:
         source_lease: InboundAttachmentLease | None,
     ) -> tuple[int, os.stat_result, str | None]:
         source_path = _path_from_file_uri(source.uri)
+        try:
+            source_path = self._filesystem_root.confine(source_path)
+        except ConfinedFilesystemError as error:
+            raise AttachmentPinError(
+                "memory_invalid_input",
+                "attachment is outside the source root",
+            ) from error
         if allowed_records is not None and source_path not in allowed_records:
             raise AttachmentPinError(
                 "memory_invalid_input",
@@ -676,7 +699,8 @@ def workbench_capture_attachments(files: object) -> tuple[CaptureAttachment, ...
 
     if not isinstance(files, list):
         return ()
-    source_root = _absolute_lexical(paths.get_attachments_dir() / "avibe")
+    filesystem_root = ConfinedRoot.from_home(paths.get_vibe_remote_dir())
+    source_root = filesystem_root.confine(paths.get_attachments_dir() / "avibe")
     converted: list[CaptureAttachment] = []
     for file in files:
         local_path = getattr(file, "local_path", None)
@@ -685,13 +709,13 @@ def workbench_capture_attachments(files: object) -> tuple[CaptureAttachment, ...
         if not all(isinstance(value, str) and value for value in (local_path, name, mimetype)):
             continue
         try:
-            path = Path(local_path)
+            path = filesystem_root.confine(Path(local_path))
             if not path.is_absolute():
                 continue
             relative = path.relative_to(source_root)
             if not relative.parts or any(part in {"", ".", ".."} for part in relative.parts):
                 continue
-        except (OSError, ValueError):
+        except (ConfinedFilesystemError, OSError, ValueError):
             continue
         extension = path.suffix.lstrip(".").lower()
         if _EXTENSION_PATTERN.fullmatch(extension) is None:
@@ -805,64 +829,6 @@ def _file_write_flags() -> int:
     )
 
 
-def _ensure_private_directory(directory: Path) -> None:
-    if not directory.is_absolute():
-        raise AttachmentPinError("memory_store_unavailable", "attachment storage path must be absolute")
-    try:
-        descriptor = os.open(directory.anchor, _directory_open_flags())
-    except OSError as error:
-        raise _storage_failure(error, "attachment storage anchor is unavailable") from error
-    try:
-        for component in directory.parts[1:]:
-            try:
-                next_descriptor = os.open(
-                    component,
-                    _directory_open_flags(),
-                    dir_fd=descriptor,
-                )
-            except FileNotFoundError:
-                try:
-                    os.mkdir(component, mode=0o700, dir_fd=descriptor)
-                    _fsync_fd(descriptor, "attachment directory parent")
-                except FileExistsError:
-                    pass
-                except AttachmentPinError:
-                    raise
-                except OSError as error:
-                    raise _storage_failure(
-                        error,
-                        "attachment directory could not be created",
-                    ) from error
-                try:
-                    next_descriptor = os.open(
-                        component,
-                        _directory_open_flags(),
-                        dir_fd=descriptor,
-                    )
-                except OSError as error:
-                    raise _storage_failure(
-                        error,
-                        "attachment directory is unavailable",
-                    ) from error
-            except OSError as error:
-                raise _storage_failure(
-                    error,
-                    "attachment storage path contains an unsafe directory component",
-                ) from error
-            os.close(descriptor)
-            descriptor = next_descriptor
-
-        _require_current_owner(os.fstat(descriptor), "attachment storage directory", storage=True)
-        try:
-            os.fchmod(descriptor, 0o700)
-        except OSError as error:
-            raise _storage_failure(error, "attachment directory could not be made private") from error
-        _require_private_directory(os.fstat(descriptor), "attachment storage directory")
-        _fsync_fd(descriptor, "attachment storage directory")
-    finally:
-        os.close(descriptor)
-
-
 def _open_directory_no_follow(path: Path, label: str) -> int:
     if not path.is_absolute():
         raise AttachmentPinError("memory_store_unavailable", f"{label} path must be absolute")
@@ -891,8 +857,14 @@ def _open_directory_no_follow(path: Path, label: str) -> int:
         raise
 
 
-def _open_private_directory(path: Path, label: str) -> int:
-    descriptor = _open_directory_no_follow(path, label)
+def _open_private_directory(home: Path, path: Path, label: str) -> int:
+    try:
+        descriptor = open_confined_directory(home, path)
+    except ConfinedFilesystemError as error:
+        raise AttachmentPinError(
+            "memory_store_unavailable",
+            f"{label} is unavailable",
+        ) from error
     try:
         _require_private_directory(os.fstat(descriptor), label)
     except BaseException:

--- a/core/memory/confined_filesystem.py
+++ b/core/memory/confined_filesystem.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence
 
+from config import paths
+
 
 _DIRECTORY_ORDER_INSERT_BATCH_SIZE = 256
 _DIRECTORY_DESCRIPTOR_CACHE_SIZE = 48
@@ -35,6 +37,49 @@ class _LinuxOpenHow(ctypes.Structure):
 
 class ConfinedFilesystemError(RuntimeError):
     """A confined filesystem operation refused an unsafe path or entry."""
+
+
+@dataclass(frozen=True, slots=True)
+class ConfinedRoot:
+    """Map one logical trust anchor and its children to one physical spelling."""
+
+    logical_home: Path
+    physical_home: Path
+
+    @classmethod
+    def from_home(cls, home: Path | str) -> "ConfinedRoot":
+        logical_home = Path(
+            os.path.abspath(os.path.expanduser(os.fspath(home)))
+        )
+        return cls(
+            logical_home=logical_home,
+            physical_home=paths.physical_home(logical_home),
+        )
+
+    def confine(self, path: Path | str) -> Path:
+        """Return the same lexical child below the physical root.
+
+        Only the trusted root is resolved. Descendant components remain lexical
+        so a symlink planted below the root is still visible to no-follow opens.
+        """
+
+        candidate = Path(
+            os.path.abspath(os.path.expanduser(os.fspath(path)))
+        )
+        for base in (self.logical_home, self.physical_home):
+            if candidate.is_relative_to(base):
+                return self.physical_home.joinpath(*candidate.relative_to(base).parts)
+        raise ConfinedFilesystemError(
+            "confined path must stay within the confinement root"
+        )
+
+    def confine_if_child(self, path: Path | str) -> Path | None:
+        """Map a child when confined, preserving explicit external paths."""
+
+        try:
+            return self.confine(path)
+        except ConfinedFilesystemError:
+            return None
 
 
 @dataclass(slots=True)

--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -32,6 +32,7 @@ from config import paths
 from core.memory.attachments import attachment_pin_root
 from core.memory.confined_filesystem import (
     ConfinedFilesystemError,
+    ConfinedRoot,
     create_confined_file,
     ensure_private_directory,
     open_confined_directory,
@@ -533,14 +534,26 @@ class EverOSProcess:
         effective_home_path = (
             Path(effective_home) if effective_home is not None else paths.get_vibe_remote_dir()
         )
-        self._effective_home = Path(os.path.abspath(os.fspath(effective_home_path)))
+        filesystem_root = ConfinedRoot.from_home(effective_home_path)
+        self._effective_home = filesystem_root.physical_home
         self._memory_dir = self._effective_home / "memory"
         self._attachments_root = attachment_pin_root(self._effective_home)
         provider_root_path = (
             Path(provider_root) if provider_root is not None else self._memory_dir / "everos-root"
         )
-        self._provider_root = Path(os.path.abspath(os.fspath(provider_root_path)))
-        self._socket_path = Path(socket_path) if socket_path is not None else self._memory_dir / ".rt" / "everos.sock"
+        self._provider_root = (
+            filesystem_root.confine_if_child(provider_root_path)
+            or Path(os.path.abspath(os.fspath(provider_root_path)))
+        )
+        socket_path_value = (
+            Path(socket_path)
+            if socket_path is not None
+            else self._memory_dir / ".rt" / "everos.sock"
+        )
+        self._socket_path = (
+            filesystem_root.confine_if_child(socket_path_value)
+            or Path(os.path.abspath(os.fspath(socket_path_value)))
+        )
         self._settings = settings or EverOSProcessSettings()
         self._host = _SystemProcessHost() if _host is None else _host
         self._ownership = SidecarOwnership(
@@ -1315,13 +1328,17 @@ class EverOSRebuildProcess:
         effective_home_path = (
             Path(effective_home) if effective_home is not None else paths.get_vibe_remote_dir()
         )
-        self._effective_home = Path(os.path.abspath(os.fspath(effective_home_path)))
+        filesystem_root = ConfinedRoot.from_home(effective_home_path)
+        self._effective_home = filesystem_root.physical_home
         self._memory_dir = self._effective_home / "memory"
         self._attachments_root = attachment_pin_root(self._effective_home)
         provider_root_path = (
             Path(provider_root) if provider_root is not None else self._memory_dir / "everos-root"
         )
-        self._provider_root = Path(os.path.abspath(os.fspath(provider_root_path)))
+        self._provider_root = (
+            filesystem_root.confine_if_child(provider_root_path)
+            or Path(os.path.abspath(os.fspath(provider_root_path)))
+        )
         self._socket_path = self._memory_dir / ".rt" / "everos.sock"
         self._settings = settings or EverOSProcessSettings()
         self._timeout_seconds = _positive_timeout(timeout_seconds, _REBUILD_TIMEOUT_SECONDS)
@@ -1623,7 +1640,7 @@ def _require_provider_root_access_path(provider_root: Path) -> None:
         current = current.parent
 
 
-def _provider_roots_match(value: object, expected: Path) -> bool:
+def _paths_match(value: object, expected: Path) -> bool:
     if not isinstance(value, str) or not value:
         return False
     try:
@@ -1639,6 +1656,10 @@ def _provider_roots_match(value: object, expected: Path) -> bool:
         )
     except (OSError, RuntimeError):
         return False
+
+
+def _provider_roots_match(value: object, expected: Path) -> bool:
+    return _paths_match(value, expected)
 
 
 def sidecar_record_path(memory_dir: Path | str) -> Path:
@@ -2734,7 +2755,7 @@ def _record_for_this_installation(
     if not isinstance(record, dict):
         return None
     if (
-        record.get("socket_path") != str(socket_path)
+        not _paths_match(record.get("socket_path"), socket_path)
         or not _provider_roots_match(record.get("provider_root"), provider_root)
     ):
         return None
@@ -2841,7 +2862,8 @@ def _process_names_owned_runtime(
             return False
         cmdline = _disclosed_identity_field(process.cmdline)
         if role is None and cmdline is not None and (
-            str(socket_path) in cmdline or str(provider_root) in cmdline
+            _cmdline_serves_socket(cmdline, socket_path)
+            or str(provider_root) in cmdline
         ):
             return True
         environment = _disclosed_process_environment(process)
@@ -2875,7 +2897,10 @@ def _disclosed_process_environment(process: psutil.Process) -> Mapping[str, str]
 
 
 def _cmdline_serves_socket(cmdline: tuple[str, ...], socket_path: Path) -> bool:
-    return _SIDECAR_ENTRYPOINT_MODULE in cmdline and "--uds" in cmdline and str(socket_path) in cmdline
+    if _SIDECAR_ENTRYPOINT_MODULE not in cmdline or "--uds" not in cmdline:
+        return False
+    index = cmdline.index("--uds")
+    return index + 1 < len(cmdline) and _paths_match(cmdline[index + 1], socket_path)
 
 
 def _cmdline_is_sidecar(cmdline: tuple[str, ...]) -> bool:
@@ -2898,11 +2923,15 @@ def _cmdline_matches_role(
     if python is not None and cmdline[0] != str(python):
         return False
     if role is _MemoryChildRole.SIDECAR:
-        return cmdline[1:] == (
-            "-m",
-            _SIDECAR_ENTRYPOINT_MODULE,
-            "--uds",
-            str(socket_path),
+        return (
+            cmdline[1:4]
+            == (
+                "-m",
+                _SIDECAR_ENTRYPOINT_MODULE,
+                "--uds",
+            )
+            and len(cmdline) == 5
+            and _paths_match(cmdline[4], socket_path)
         )
     if role is _MemoryChildRole.CASCADE_SYNC:
         return cmdline[1:] == (

--- a/core/memory/provider_root.py
+++ b/core/memory/provider_root.py
@@ -12,6 +12,7 @@ from typing import Protocol
 
 from core.memory.confined_filesystem import (
     ConfinedFilesystemError,
+    ConfinedRoot,
     SpilledDirectoryOrder,
     create_confined_file,
     ensure_private_directory,
@@ -83,8 +84,14 @@ class ProviderRoot:
     """Own all synchronous security, format, and transition policy for one root."""
 
     def __init__(self, path: Path | str, *, effective_home: Path | str) -> None:
-        self.path = Path(path)
-        self._effective_home = Path(effective_home)
+        try:
+            root = ConfinedRoot.from_home(effective_home)
+            self.path = root.confine(path)
+        except ConfinedFilesystemError as error:
+            raise ProviderRootError(
+                "memory provider root must stay within the effective Avibe home"
+            ) from error
+        self._effective_home = root.physical_home
 
     def inspect(self, candidate_metadata: ProviderRootMetadata) -> ProviderRootState:
         """Inspect compatibility without requiring the store-owned root id."""

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -39,7 +39,7 @@ from core.memory.artifact import (
 from core.memory.attachments import IM_ATTACHMENT_CAPTURE_PLATFORMS
 from core.memory.blocking import run_blocking
 from core.memory.clear_intent import ClearSurface
-from core.memory.confined_filesystem import required_no_follow_flag
+from core.memory.confined_filesystem import ConfinedRoot, required_no_follow_flag
 from core.memory.everos import (
     EverOSPort,
     MemoryProviderFailure,
@@ -380,7 +380,10 @@ class MemoryRuntime:
     ) -> None:
         self._config = config
         self._restart_config = deepcopy(config)
-        self._effective_home = effective_home or paths.get_vibe_remote_dir()
+        self._filesystem_root = ConfinedRoot.from_home(
+            effective_home or paths.get_vibe_remote_dir()
+        )
+        self._effective_home = self._filesystem_root.physical_home
         self._maintenance: MemoryMaintenance | None = None
         self._artifact_manager: MemoryArtifactPort = artifact_manager or get_memory_artifact_manager()
         self._provider_root_owner = ProviderRoot(
@@ -448,7 +451,7 @@ class MemoryRuntime:
             return True
         try:
             required_no_follow_flag()
-            opened = store or MemoryStore()
+            opened = store or MemoryStore(effective_home=self._effective_home)
             self._artifact_manager.set_provider_root(self._provider_root)
             module = MemoryModule(
                 opened,

--- a/core/memory/store.py
+++ b/core/memory/store.py
@@ -17,6 +17,11 @@ from pathlib import Path
 from typing import Literal
 
 from config import paths
+from core.memory.confined_filesystem import (
+    ConfinedFilesystemError,
+    ConfinedRoot,
+    ensure_private_directory,
+)
 from core.memory.observations import (
     AddAck,
     AddRejected,
@@ -767,32 +772,6 @@ def _verify_current_schema(conn: sqlite3.Connection) -> None:
         raise RuntimeError("Memory store failed integrity check")
 
 
-def _absolute_path_without_resolve(value: Path | str) -> Path:
-    """Make a lexical absolute path without following any filesystem links."""
-
-    return Path(os.path.abspath(os.path.expanduser(os.fspath(value))))
-
-
-def _ensure_no_follow_directory_chain(directory: Path) -> None:
-    """Create and validate each directory component before SQLite can open a file."""
-
-    if not directory.is_absolute():
-        raise OSError("Memory store path must be absolute")
-    current = Path(directory.anchor)
-    for component in directory.parts[1:]:
-        current /= component
-        try:
-            info = os.lstat(current)
-        except FileNotFoundError:
-            try:
-                os.mkdir(current, mode=0o700)
-            except FileExistsError:
-                pass
-            info = os.lstat(current)
-        if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
-            raise OSError("Memory store path contains an unsafe directory component")
-
-
 @dataclass(frozen=True)
 class MemoryMeta:
     epoch: int
@@ -1017,10 +996,27 @@ class ProcessingHealthCommit:
 class MemoryStore:
     """Own the small, durable Memory queue without exposing SQLite to callers."""
 
-    def __init__(self, db_path: Path | None = None) -> None:
-        self._effective_home = _absolute_path_without_resolve(paths.get_vibe_remote_dir())
-        requested_path = db_path if db_path is not None else memory_store_path()
-        self.path = _absolute_path_without_resolve(requested_path)
+    def __init__(
+        self,
+        db_path: Path | None = None,
+        *,
+        effective_home: Path | str | None = None,
+    ) -> None:
+        root = ConfinedRoot.from_home(
+            paths.get_vibe_remote_dir() if effective_home is None else effective_home
+        )
+        self._effective_home = root.physical_home
+        requested_path = (
+            db_path
+            if db_path is not None
+            else root.logical_home / "state" / MEMORY_STORE_DIRNAME / MEMORY_STORE_FILENAME
+        )
+        try:
+            self.path = root.confine(requested_path)
+        except ConfinedFilesystemError as error:
+            raise OSError(
+                "Memory store path must stay within the effective Avibe home"
+            ) from error
         self._validate_store_confinement()
         self._prepare_private_directory()
         self._initialize()
@@ -3572,8 +3568,10 @@ class MemoryStore:
         )
 
     def _prepare_private_directory(self) -> None:
-        _ensure_no_follow_directory_chain(self._effective_home)
-        _ensure_no_follow_directory_chain(self.path.parent)
+        try:
+            ensure_private_directory(self._effective_home, self.path.parent)
+        except ConfinedFilesystemError as error:
+            raise OSError("Memory store path contains an unsafe directory component") from error
         directory_info = os.lstat(self.path.parent)
         if stat.S_ISLNK(directory_info.st_mode) or not stat.S_ISDIR(directory_info.st_mode):
             raise OSError("Memory store directory must be an owned directory")

--- a/docs/plans/memory-symlinked-home-confinement.md
+++ b/docs/plans/memory-symlinked-home-confinement.md
@@ -1,0 +1,39 @@
+# Memory symlinked-home confinement
+
+Issue: [#1520](https://github.com/avibe-bot/avibe/issues/1520)
+
+## Background
+
+Memory currently derives several mutable paths from the logical Avibe home, but
+its attachment store, SQLite store, provider-root guard, and process supervisor
+do not share one trust-anchor decision. A supported home reached through a
+symlink can therefore fail an absolute no-follow walk before the walk reaches
+anything Avibe owns.
+
+## Goal
+
+Resolve the operator-controlled effective home once to a physical trust anchor,
+derive Memory-owned paths lexically below it, and preserve no-follow rejection
+for every Avibe-owned descendant.
+
+## First implementation slice
+
+- add one confined-root value in `core/memory/confined_filesystem.py` that maps
+  logical and already-physical child spellings to the same physical root without
+  resolving child components;
+- make `MemoryRuntime`, `MemoryStore`, `AttachmentPinStore`, `ProviderRoot`,
+  `EverOSProcess`, and `EverOSRebuildProcess` consume that physical identity;
+- route attachment storage layout and Memory-store directory preparation through
+  the existing confined-filesystem interface while retaining domain error types;
+- add contract tests for a symlinked parent, the legacy final-home symlink shape,
+  one physical provider/lock identity, and rejection of symlinks below the home.
+
+## Non-goals
+
+- no changes to attachment limits, modality, hashing, bundle lifetime, SQLite
+  transaction semantics, provider sentinel semantics, or child lifecycle;
+- no change to explicitly configured provider roots or socket paths outside the
+  effective home;
+- the remaining caller audit (`operation_lock`, call-log storage, artifacts,
+  clear intent, and factory reset) stays tracked by #1520 and is not declared
+  complete by this first slice.

--- a/tests/test_memory_attachments.py
+++ b/tests/test_memory_attachments.py
@@ -101,6 +101,47 @@ def test_pin_is_private_relative_durable_and_releasable(attachment_roots) -> Non
     assert not pinned_path.parent.exists()
 
 
+def test_pin_store_uses_one_physical_home_through_a_symlinked_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    physical_home = tmp_path / "volume" / "user" / ".avibe"
+    source_root = physical_home / "attachments" / "avibe"
+    source_root.mkdir(parents=True, mode=0o700)
+    source = _source_file(source_root, "notes.txt", b"physical source")
+    logical_parent = tmp_path / "home"
+    logical_parent.symlink_to(tmp_path / "volume", target_is_directory=True)
+    logical_home = logical_parent / "user" / ".avibe"
+    monkeypatch.setattr(
+        attachment_module.paths,
+        "get_vibe_remote_dir",
+        lambda: logical_home,
+    )
+
+    store = AttachmentPinStore(
+        effective_home=logical_home,
+        source_root=logical_home / "attachments" / "avibe",
+    )
+    converted = workbench_capture_attachments(
+        [
+            SimpleNamespace(
+                name=source.name,
+                mimetype="text/plain",
+                local_path=str(source),
+            )
+        ]
+    )
+    bundle = store.pin(converted)
+
+    assert converted == (_attachment(source),)
+    assert store._effective_home == physical_home
+    assert store._root == physical_home / "memory" / "attachments"
+    assert store.provider_attachments(bundle)[0].uri.startswith(
+        (physical_home / "memory" / "attachments").as_uri()
+    )
+    store.release(bundle.bundle_id)
+
+
 def test_workbench_conversion_preserves_symlink_for_pin_rejection(attachment_roots) -> None:
     _home, source_root = attachment_roots
     target = _source_file(source_root, "real.txt")
@@ -207,18 +248,19 @@ def test_pin_rejects_group_or_world_writable_sources(attachment_roots, unsafe_ta
 def test_pin_rejects_unowned_source(attachment_roots, monkeypatch: pytest.MonkeyPatch) -> None:
     _home, source_root = attachment_roots
     source = _source_file(source_root, "notes.txt")
+    source_info = source.stat()
     store = AttachmentPinStore()
-    real_uid = os.getuid()
-    calls = 0
+    real_fstat = os.fstat
 
-    def uid_for_layout_then_source() -> int:
-        nonlocal calls
-        calls += 1
-        # Pin verifies the three durable roots, reopens staging/bundles, then
-        # creates and reopens the staging bundle before it reaches the source.
-        return real_uid + 1 if calls == 8 else real_uid
+    def unowned_source_fstat(descriptor: int) -> os.stat_result:
+        info = real_fstat(descriptor)
+        if (info.st_dev, info.st_ino) != (source_info.st_dev, source_info.st_ino):
+            return info
+        values = list(info)
+        values[4] = os.getuid() + 1
+        return os.stat_result(values)
 
-    monkeypatch.setattr(attachment_module.os, "getuid", uid_for_layout_then_source)
+    monkeypatch.setattr(attachment_module.os, "fstat", unowned_source_fstat)
     with pytest.raises(AttachmentPinError) as error:
         store.pin((_attachment(source),))
 

--- a/tests/test_memory_confined_filesystem.py
+++ b/tests/test_memory_confined_filesystem.py
@@ -13,11 +13,37 @@ import pytest
 
 from core.memory.confined_filesystem import (
     ConfinedFilesystemError,
+    ConfinedRoot,
     PrivateSqliteDatabase,
     remove_anchored_entry,
     remove_confined_path,
     replace_confined,
 )
+
+
+def test_confined_root_maps_home_aliases_without_resolving_owned_children(
+    tmp_path: Path,
+) -> None:
+    physical_home = tmp_path / "volume" / "user" / ".avibe"
+    physical_home.mkdir(parents=True, mode=0o700)
+    logical_parent = tmp_path / "home"
+    logical_parent.symlink_to(tmp_path / "volume", target_is_directory=True)
+    logical_home = logical_parent / "user" / ".avibe"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (physical_home / "memory").symlink_to(outside, target_is_directory=True)
+
+    root = ConfinedRoot.from_home(logical_home)
+
+    expected_child = physical_home / "memory" / "state.sqlite"
+    assert root.physical_home == physical_home
+    assert root.confine(logical_home / "memory" / "state.sqlite") == expected_child
+    assert root.confine(physical_home / "memory" / "state.sqlite") == expected_child
+    assert not root.confine(logical_home / "memory" / "state.sqlite").is_relative_to(
+        outside
+    )
+    with pytest.raises(ConfinedFilesystemError, match="confinement root"):
+        root.confine(tmp_path / "other" / "state.sqlite")
 
 
 def test_memory_persistence_fails_closed_without_no_follow_before_touching_path(

--- a/tests/test_memory_process.py
+++ b/tests/test_memory_process.py
@@ -20,6 +20,7 @@ from types import SimpleNamespace
 import psutil
 import pytest
 
+from config import paths
 from config.v2_config import (
     MemoryConfig,
     MemoryEndpointConfig,
@@ -2636,6 +2637,79 @@ async def test_rebuild_normalizes_relative_provider_root_before_launch(
     assert memory_process._provider_rebuild_lock_path(
         provider_root=process._provider_root
     ).parent.parent == provider_parent
+
+
+def test_sidecar_and_rebuild_use_one_physical_identity_for_a_symlinked_home(
+    tmp_path: Path,
+) -> None:
+    physical_home = tmp_path / ".avibe"
+    physical_home.mkdir(mode=0o700)
+    logical_home = tmp_path / ".vibe_remote"
+    logical_home.symlink_to(physical_home, target_is_directory=True)
+    expected_home = paths.physical_home(logical_home)
+
+    sidecar = EverOSProcess(
+        sys.executable,
+        effective_home=logical_home,
+        settings=_settings(),
+    )
+    rebuild = EverOSRebuildProcess(
+        sys.executable,
+        effective_home=logical_home,
+        settings=_settings(),
+    )
+    memory_process._prepare_memory_child_directories(
+        memory_dir=sidecar._memory_dir,
+        provider_root=sidecar.provider_root,
+        settings=sidecar._settings,
+    )
+
+    expected_provider_root = expected_home / "memory" / "everos-root"
+    assert sidecar._effective_home == expected_home
+    assert sidecar.provider_root == expected_provider_root
+    assert sidecar.socket_path == expected_home / "memory" / ".rt" / "everos.sock"
+    assert sidecar._child_environment()["EVEROS_ROOT"] == str(expected_provider_root)
+    assert rebuild._effective_home == expected_home
+    assert rebuild._provider_root == expected_provider_root
+    assert memory_process._provider_rebuild_lock_path(
+        provider_root=sidecar.provider_root,
+    ) == memory_process._provider_rebuild_lock_path(
+        provider_root=rebuild._provider_root,
+    )
+
+    logical_socket = logical_home / "memory" / ".rt" / "everos.sock"
+    logical_provider_root = logical_home / "memory" / "everos-root"
+    legacy_spelling_record = {
+        "pid": _ORPHAN_PID,
+        "create_time": _ORPHAN_CREATE_TIME,
+        "process_group": _ORPHAN_PID,
+        "socket_path": str(logical_socket),
+        "provider_root": str(logical_provider_root),
+        "role": "sidecar",
+        "python": sys.executable,
+    }
+    legacy_spelling_identity = _ProcessIdentity(
+        create_time=_ORPHAN_CREATE_TIME,
+        cmdline=(
+            sys.executable,
+            "-m",
+            _SIDECAR_ENTRYPOINT_MODULE,
+            "--uds",
+            str(logical_socket),
+        ),
+        uid=os.getuid() if hasattr(os, "getuid") else None,
+        environment={
+            "EVEROS_ROOT": str(logical_provider_root),
+            "AVIBE_MEMORY_CHILD_ROLE": "sidecar",
+        },
+    )
+    assert _classify_recorded_child(
+        legacy_spelling_record,
+        legacy_spelling_identity,
+        socket_path=sidecar.socket_path,
+        provider_root=sidecar.provider_root,
+        role=_MemoryChildRole.SIDECAR,
+    ) is _RecordedSidecar.OURS
 
 
 def test_provider_root_aliases_share_lock_identity_without_changing_access_path(

--- a/tests/test_memory_provider_root.py
+++ b/tests/test_memory_provider_root.py
@@ -130,23 +130,25 @@ def test_provider_root_refuses_to_harden_an_unowned_effective_home(
     assert not (home / "memory").exists()
 
 
-def test_provider_root_refuses_a_symlinked_effective_home_without_touching_target(
+def test_provider_root_accepts_the_supported_legacy_home_symlink(
     tmp_path: Path,
 ) -> None:
-    outside = tmp_path / "outside"
-    outside.mkdir(mode=0o755)
-    outside.chmod(0o755)
-    home = tmp_path / "linked-home"
-    home.symlink_to(outside, target_is_directory=True)
-    root = ProviderRoot(home / "memory" / "everos-root", effective_home=home)
+    physical_home = tmp_path / ".avibe"
+    physical_home.mkdir(mode=0o700)
+    logical_home = tmp_path / ".vibe_remote"
+    logical_home.symlink_to(physical_home, target_is_directory=True)
+    root = ProviderRoot(
+        logical_home / "memory" / "everos-root",
+        effective_home=logical_home,
+    )
     meta = SimpleNamespace(provider_root_id="root-id")
 
-    with pytest.raises(ProviderRootError, match="chain contains a symlink"):
-        root.ensure(meta, _metadata())
+    root.ensure(meta, _metadata())
 
-    assert home.is_symlink()
-    assert stat.S_IMODE(outside.stat().st_mode) == 0o755
-    assert list(outside.iterdir()) == []
+    assert root.path == physical_home / "memory" / "everos-root"
+    assert root.path.is_dir()
+    assert logical_home.is_symlink()
+    assert json.loads((root.path / ROOT_SENTINEL_FILENAME).read_text())["provider_root_id"] == "root-id"
 
 
 def test_provider_root_translates_temporary_ordering_database_failure(

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -7222,6 +7222,37 @@ _FOREIGN_UID_GROUP_PID = 424_247
 _ORPHAN_CREATE_TIME = 1_700_000_000.5
 
 
+async def test_runtime_resolves_a_symlinked_home_once_for_all_file_owners(
+    tmp_path: Path,
+    memory_runtime_factory,
+) -> None:
+    physical_home = tmp_path / ".avibe"
+    physical_home.mkdir(mode=0o700)
+    logical_home = tmp_path / ".vibe_remote"
+    logical_home.symlink_to(physical_home, target_is_directory=True)
+    store = MemoryStore(effective_home=logical_home)
+
+    runtime = memory_runtime_factory(
+        MemoryConfig(),
+        store=store,
+        artifact_manager=_installed_artifact(),
+        effective_home=logical_home,
+    )
+
+    assert runtime.effective_home == physical_home
+    assert store._effective_home == physical_home
+    assert runtime.module._effective_home == physical_home
+    assert runtime.module._attachment_store._effective_home == physical_home
+    assert runtime.module._attachment_store._root == (
+        physical_home / "memory" / "attachments"
+    )
+    assert runtime._provider_root_owner.path == (
+        physical_home / "memory" / "everos-root"
+    )
+    assert runtime._sidecar._effective_home == physical_home
+    await memory_runtime_factory.close(runtime)
+
+
 async def test_runtime_effective_home_owns_the_attachment_pipeline(
     monkeypatch,
     tmp_path: Path,

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -2566,6 +2566,35 @@ def test_default_store_path_uses_effective_avibe_home(tmp_path: Path, monkeypatc
     assert MAX_NONTERMINAL_QUEUE_ROWS == 500
 
 
+def test_store_uses_one_physical_home_through_a_symlinked_parent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    physical_home = tmp_path / "volume" / "user" / ".avibe"
+    physical_home.mkdir(parents=True, mode=0o700)
+    logical_parent = tmp_path / "home"
+    logical_parent.symlink_to(tmp_path / "volume", target_is_directory=True)
+    logical_home = logical_parent / "user" / ".avibe"
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: logical_home)
+
+    store = MemoryStore()
+
+    assert store.path == physical_home / "state" / "memory" / "memory.sqlite"
+    assert store.ensure_meta().provider_root_id
+
+
+def test_store_rejects_a_path_outside_the_effective_home_without_writing(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    outside = tmp_path / "outside" / "memory.sqlite"
+
+    with pytest.raises(OSError, match="within the effective Avibe home"):
+        MemoryStore(outside, effective_home=home)
+
+    assert not outside.parent.exists()
+
+
 def test_store_enforces_owner_only_directory_and_database_modes_under_open_umask(tmp_path: Path) -> None:
     database = _store_path(tmp_path / "memory-private")
     original_umask = os.umask(0o022)


### PR DESCRIPTION
## Capability

Memory filesystem state now works when the effective Avibe home is reached through a supported symlink, while Memory-owned descendants remain confined by descriptor-relative no-follow traversal.

This is the first implementation slice of #1520. It builds on merged PR #1518 and does not close the remaining filesystem-caller audit.

## Change

- add `ConfinedRoot`, which resolves only the operator-controlled home and maps logical or physical child spellings to one physical identity without resolving child components
- pin `MemoryRuntime`, `MemoryStore`, `AttachmentPinStore`, `ProviderRoot`, `EverOSProcess`, and `EverOSRebuildProcess` to that physical home
- route Memory SQLite directory preparation and attachment storage layout through `core/memory/confined_filesystem.py`
- keep explicit provider/socket paths outside the home compatible with the existing process interface
- canonicalize persisted socket identity so pre-fix logical sidecar records still authenticate against the physical runtime path
- preserve Workbench attachment conversion when upload paths are already physical

## Evidence

- **Unit**: 434 passed, 5 skipped across confined filesystem, Store, attachments, ProviderRoot, Runtime, Module, and IM attachment tests
- **Contract**: symlinked parent, legacy final-home symlink, logical/physical child mapping, Workbench pinning, Store confinement, provider/process/lock identity, and old sidecar-record authentication
- **Attachment regression**: repo-wide `pytest -k attachment`: 243 passed
- **Lint**: Ruff clean on every changed Python file; `git diff --check` clean
- **Scenario**: no scenario catalog currently covers a symlinked Avibe home; no scenario ID changed
- **Residual manual**: no post-fix live sidecar launch was run; local service state was not touched

## Known by design

- Attachment limits, modality checks, hashing, bundle lifecycle, SQLite transactions, provider sentinel semantics, and process lifecycle remain in their domain owners.
- Explicit provider roots and socket paths outside the effective home retain their existing access spelling; only paths lexically below the logical or physical home are remapped.
- #1520 remains open for the second-pass audit of operation locks, call-log storage, artifacts, clear intent, and factory reset.
