### PR TITLE
fix(ui): trigger revalidation on page reactivation edges only

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -63,6 +63,7 @@ import {
     shouldDeferRemoteAuthRedirect,
 } from './lib/remoteAuth';
 import { useIsDesktop } from './lib/useIsDesktop';
+import { onPageReactivated } from './lib/pageActivity';
 
 // Apps layer pages are lazy: they share their chunk with the windowed app bodies
 // (registry.tsx) instead of being pulled into the main entry by these routes, so
@@ -346,17 +347,11 @@ export const AuthGuard = ({ children }: { children: ReactNode }) => {
         if (guardStatus !== 'remote-login-required' || !shouldDeferRemoteAuthRedirect()) return;
 
         let recheckStarted = false;
-        const recheckAfterLogin = () => {
-            if (document.visibilityState !== 'visible' || recheckStarted) return;
+        return onPageReactivated(() => {
+            if (recheckStarted) return;
             recheckStarted = true;
             setAuthCheckVersion((version) => version + 1);
-        };
-        document.addEventListener('visibilitychange', recheckAfterLogin);
-        window.addEventListener('focus', recheckAfterLogin);
-        return () => {
-            document.removeEventListener('visibilitychange', recheckAfterLogin);
-            window.removeEventListener('focus', recheckAfterLogin);
-        };
+        });
     }, [guardStatus]);
 
     useEffect(() => {

--- a/ui/src/components/RemoteAccess.tsx
+++ b/ui/src/components/RemoteAccess.tsx
@@ -25,6 +25,7 @@ import {
   useApi,
 } from '../context/ApiContext';
 import { useToast } from '../context/ToastContext';
+import { onPageReactivated } from '../lib/pageActivity';
 import { getTunnelQualityDisplayState, getTunnelRequestPathDisplayState } from '../lib/tunnelQuality';
 import { CompactField } from './settings/SettingsPrimitives';
 import { Button } from './ui/button';
@@ -112,13 +113,11 @@ export const RemoteAccess: React.FC = () => {
       if (document.visibilityState === 'visible') refresh(true).catch(() => undefined);
     };
     const interval = window.setInterval(refreshVisible, 30_000);
-    document.addEventListener('visibilitychange', refreshVisible);
-    window.addEventListener('focus', refreshVisible);
+    const stopReactivation = onPageReactivated(refreshVisible);
     return () => {
       disconnect();
       window.clearInterval(interval);
-      document.removeEventListener('visibilitychange', refreshVisible);
-      window.removeEventListener('focus', refreshVisible);
+      stopReactivation();
     };
   }, [api, refresh]);
 

--- a/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
+++ b/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
@@ -9,6 +9,7 @@ import type { HarnessRun, HarnessTask, HarnessWatch } from '../../context/ApiCon
 import { useToast } from '../../context/ToastContext';
 import { Button } from '../ui/button';
 import { Switch } from '../ui/switch';
+import { onPageReactivated } from '../../lib/pageActivity';
 import { formatLocalDateTime } from '../../lib/datetime';
 import { formatRelativeTime } from '../../lib/relativeTime';
 import {
@@ -210,7 +211,7 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
     void refresh(false);
     // Skip ticks while the tab is hidden — an idle backgrounded panel must not
     // keep issuing unpaginated list reads every 4s (matches AgentGraphTab's
-    // visibility-gated poll) — and refresh at once when visibility returns.
+    // visibility-gated poll) — and refresh at once when the page comes back.
     let timer: number | undefined;
     const tick = () => {
       if (stopped) return;
@@ -218,15 +219,12 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
       timer = window.setTimeout(tick, TRIGGER_DETAIL_POLL_MS);
     };
     timer = window.setTimeout(tick, TRIGGER_DETAIL_POLL_MS);
-    const onVisibility = () => {
-      if (document.visibilityState === 'visible') void refresh(true);
-    };
-    document.addEventListener('visibilitychange', onVisibility);
+    const stopReactivation = onPageReactivated(() => void refresh(true));
 
     return () => {
       stopped = true;
       if (timer !== undefined) window.clearTimeout(timer);
-      document.removeEventListener('visibilitychange', onVisibility);
+      stopReactivation();
     };
   }, [api, definitionId, isWatch, chipEnabled]);
 

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -47,6 +47,7 @@ import type { ComboboxOption } from '../ui/combobox';
 import { Textarea } from '../ui/textarea';
 import { EditorDialog } from '../ui/editor-dialog';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+import { onPageReactivated } from '../../lib/pageActivity';
 import { estimateTokens } from '../../lib/tokenEstimate';
 import { loadBackendModelsWithRefresh, modelOptionLabel } from '../../lib/backendModels';
 import { resolveEffortOptions } from '../../lib/effortOptions';
@@ -271,18 +272,12 @@ export const AgentsPage: React.FC = () => {
       timer = window.setTimeout(tick, intervalMs);
     };
 
-    const refreshNow = () => {
-      if (document.visibilityState === 'visible') void tick();
-    };
-
     timer = window.setTimeout(tick, intervalMs);
-    document.addEventListener('visibilitychange', refreshNow);
-    window.addEventListener('focus', refreshNow);
+    const stopReactivation = onPageReactivated(() => void tick());
     return () => {
       cancelled = true;
       window.clearTimeout(timer);
-      document.removeEventListener('visibilitychange', refreshNow);
-      window.removeEventListener('focus', refreshNow);
+      stopReactivation();
     };
   }, [capabilities.can_use_agents, eventBridgeConnected, fetchRunningActiveCount]);
 

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -38,7 +38,7 @@ import { isEditableFile, isEditableMeta, previewOverlayKind } from '../../lib/fi
 import { recentPathLabel } from '../../lib/editorRecents';
 import type { LocalFileLinkTarget } from '../../lib/localFileLinks';
 import { formatLocalDateTime, formatRelativeTime } from '../../lib/relativeTime';
-import { canMarkConversationRead, readPageActivity } from '../../lib/pageActivity';
+import { canMarkConversationRead, onPageReactivated, usePageActive } from '../../lib/pageActivity';
 import { isDesktopViewport, useIsDesktop } from '../../lib/useIsDesktop';
 import { resultFooterParts } from '../../lib/resultFooter';
 import {
@@ -239,22 +239,7 @@ export const ChatPage: React.FC = () => {
   const { unreadBySession, markRead: markInboxRead } = useWorkbenchInbox();
   const { focusedId: foregroundAppWindowId, focusCanvas } = useWindowManager();
   const isDesktop = useIsDesktop();
-  const [pageActive, setPageActive] = useState(() => readPageActivity());
-  useEffect(() => {
-    const syncPageActivity = () => setPageActive(readPageActivity());
-    document.addEventListener('visibilitychange', syncPageActivity);
-    window.addEventListener('focus', syncPageActivity);
-    window.addEventListener('blur', syncPageActivity);
-    window.addEventListener('pageshow', syncPageActivity);
-    window.addEventListener('pagehide', syncPageActivity);
-    return () => {
-      document.removeEventListener('visibilitychange', syncPageActivity);
-      window.removeEventListener('focus', syncPageActivity);
-      window.removeEventListener('blur', syncPageActivity);
-      window.removeEventListener('pageshow', syncPageActivity);
-      window.removeEventListener('pagehide', syncPageActivity);
-    };
-  }, []);
+  const pageActive = usePageActive();
   // The mobile chat surface is a fixed full-screen flex column; this keeps the
   // composer glued to the iOS keyboard (settle-then-correct; see the hook).
   const chatSurfaceRef = useRef<HTMLDivElement>(null);
@@ -1501,8 +1486,8 @@ export const ChatPage: React.FC = () => {
 
   // Mobile tabs (the common case for IM users) get backgrounded mid-turn; the
   // SSE feed can be suspended without a clean reconnect, dropping the reply.
-  // Reconcile when the page becomes visible again so the answer + working state
-  // catch up to durable storage.
+  // Reconcile when the page comes back so the answer + working state catch up
+  // to durable storage.
   useEffect(() => {
     if (!sessionId) return;
     const resync = () => {
@@ -1514,13 +1499,12 @@ export const ChatPage: React.FC = () => {
       void syncTurnState({ quiet: true });
       void refreshSessionRow();
     };
-    document.addEventListener('visibilitychange', resync);
+    // Regaining the network is its own gap, independent of the page coming back.
+    const stopReactivation = onPageReactivated(resync);
     window.addEventListener('online', resync);
-    window.addEventListener('focus', resync);
     return () => {
-      document.removeEventListener('visibilitychange', resync);
+      stopReactivation();
       window.removeEventListener('online', resync);
-      window.removeEventListener('focus', resync);
     };
   }, [sessionId, reconcile, refreshQueue, syncTurnState, refreshSessionRow]);
 

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -10,6 +10,7 @@ import { Button } from '../ui/button';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { VaultLockIndicator } from '../ui/vault-lock-indicator';
+import { onPageReactivated } from '../../lib/pageActivity';
 import { cn } from '../../lib/utils';
 import { partitionTags } from '../../lib/vaultTags';
 import { useApi, type VaultAuditEvent, type VaultGrant, type VaultRequest, type VaultSecret } from '../../context/ApiContext';
@@ -600,18 +601,12 @@ export const VaultsPage: React.FC = () => {
       timer = window.setTimeout(tick, 5000);
     };
 
-    const refreshNow = () => {
-      if (document.visibilityState === 'visible') void tick();
-    };
-
     void tick();
-    document.addEventListener('visibilitychange', refreshNow);
-    window.addEventListener('focus', refreshNow);
+    const stopReactivation = onPageReactivated(() => void tick());
     return () => {
       cancelled = true;
       window.clearTimeout(timer);
-      document.removeEventListener('visibilitychange', refreshNow);
-      window.removeEventListener('focus', refreshNow);
+      stopReactivation();
     };
   }, [eventBridgeConnected, refresh]);
 

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -6,6 +6,7 @@ import { apiFetch, recoverRemoteAuthFromSessionProbe } from '../lib/apiFetch';
 import { isAuthorizationSensitiveReadPath } from '../lib/authorizationCache';
 import type { TurnActivityGroupWire } from '../lib/agentActivity';
 import type { AgentGraphParams, AgentGraphResult, AgentGraphVisibility } from '../lib/agentGraph';
+import { onPageReactivated } from '../lib/pageActivity';
 import { visibilityActivityEvents } from '../lib/sessionVisibilityEvents';
 import { normalizeSessionInfo, type InstanceCapabilities, type SessionInfo } from '../lib/sessionInfo';
 import type { VaultSessionPolicy } from '../lib/vaultSandboxPolicy';
@@ -3024,14 +3025,13 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       wakeWorkbenchEventsRef.current();
       syncSessionDraftsRef.current();
     };
-    document.addEventListener('visibilitychange', wakeIfVisible);
+    // Regaining the network is its own gap, independent of the page coming back.
+    const stopReactivation = onPageReactivated(wakeIfVisible);
     window.addEventListener('online', wakeIfVisible);
-    window.addEventListener('focus', wakeIfVisible);
     if (document.visibilityState === 'visible') syncSessionDraftsRef.current();
     return () => {
-      document.removeEventListener('visibilitychange', wakeIfVisible);
+      stopReactivation();
       window.removeEventListener('online', wakeIfVisible);
-      window.removeEventListener('focus', wakeIfVisible);
       stopWorkbenchEventsRef.current();
     };
   }, []);

--- a/ui/src/context/StatusProvider.tsx
+++ b/ui/src/context/StatusProvider.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { apiFetch } from '../lib/apiFetch';
+import { onPageReactivated } from '../lib/pageActivity';
 import { StatusContext, type RuntimeStatus } from './StatusContext';
 
 // Polling cadence for GET /status. The probe is cheap server-side (it reads a
@@ -158,22 +159,15 @@ export const StatusProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
     void tick();
 
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === 'visible') refreshNow();
-    };
-    // Wrap so the DOM event object is not forwarded as `enterRestartWindow`: a
-    // truthy Event would otherwise wrongly open the fast restart window.
-    const handleFocus = () => refreshNow();
-
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    window.addEventListener('focus', handleFocus);
+    // Wrap so the reactivation callback's arguments are not forwarded as
+    // `enterRestartWindow`, which would wrongly open the fast restart window.
+    const stopReactivation = onPageReactivated(() => refreshNow());
 
     return () => {
       cancelled = true;
       wakePollRef.current = null;
       window.clearTimeout(timer);
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-      window.removeEventListener('focus', handleFocus);
+      stopReactivation();
     };
   }, [refreshStatus]);
 

--- a/ui/src/context/WorkbenchInboxProvider.tsx
+++ b/ui/src/context/WorkbenchInboxProvider.tsx
@@ -6,6 +6,7 @@ import type { InboxSession } from './ApiContext';
 import { WorkbenchInboxContext, type InboxState } from './WorkbenchInboxContext';
 import { sessionActivityInboxAction } from '../lib/inboxActivity';
 import { syncFaviconBadge } from '../lib/faviconBadge';
+import { onPageReactivated } from '../lib/pageActivity';
 import {
   createWorkbenchSessionReadOwnership,
   type WorkbenchSessionReadStamp,
@@ -583,19 +584,18 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // Recover after the OS suspended us. A backgrounded mobile PWA has its page
   // frozen and its SSE socket dropped, and the broker never replays the gap;
   // iOS can leave EventSource in a zombie OPEN state without onerror. ApiContext
-  // reopens the shared stream on visibility, online, and focus; independently
-  // reconcile the durable feed here so missed events never gate data freshness.
+  // reopens the shared stream when the page comes back and when the network
+  // returns; independently reconcile the durable feed here so missed events
+  // never gate data freshness.
   useEffect(() => {
     const resync = () => {
       if (document.visibilityState === 'visible') void reconcile();
     };
-    document.addEventListener('visibilitychange', resync);
+    const stopReactivation = onPageReactivated(resync);
     window.addEventListener('online', resync);
-    window.addEventListener('focus', resync);
     return () => {
-      document.removeEventListener('visibilitychange', resync);
+      stopReactivation();
       window.removeEventListener('online', resync);
-      window.removeEventListener('focus', resync);
     };
   }, [reconcile]);
 

--- a/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
+++ b/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
@@ -106,14 +106,33 @@ function settle() {
   });
 }
 
+// The inbox reconciles when the page comes back, which is an edge rather than a
+// level: the shared page-activity sampler ignores a `focus` event on a page that
+// never left. Simulate a real gap by hiding the document and revealing it again.
+function simulatePageResume() {
+  const setVisibility = (state: DocumentVisibilityState) => {
+    Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+  };
+  setVisibility('hidden');
+  setVisibility('visible');
+  // Drop the shadowing property so the rest of the suite reads jsdom's own getter.
+  Reflect.deleteProperty(document, 'visibilityState');
+}
+
 describe('Workbench session read ownership', () => {
   beforeEach(() => {
     apiRef.current = null;
+    // jsdom never reports window focus, so no reading would ever count as "the
+    // page is presented". Model a focused window and let visibility carry the
+    // transitions `simulatePageResume` needs.
+    document.hasFocus = () => true;
   });
 
   afterEach(() => {
     cleanup();
     apiRef.current = null;
+    Reflect.deleteProperty(document, 'hasFocus');
   });
 
   it('does not let a bootstrap issued before hide repopulate the projects tree', async () => {
@@ -1253,7 +1272,7 @@ describe('Workbench session read ownership', () => {
     );
     await settle();
     act(() => {
-      window.dispatchEvent(new Event('focus'));
+      simulatePageResume();
     });
     await settle();
     act(() => {
@@ -1319,7 +1338,7 @@ describe('Workbench session read ownership', () => {
     );
     await settle();
     act(() => {
-      window.dispatchEvent(new Event('focus'));
+      simulatePageResume();
     });
     await settle();
     act(() => {
@@ -1409,7 +1428,7 @@ describe('Workbench session read ownership', () => {
     );
     await settle();
     act(() => {
-      window.dispatchEvent(new Event('focus'));
+      simulatePageResume();
     });
     await settle();
     act(() => {
@@ -1505,7 +1524,7 @@ describe('Workbench session read ownership', () => {
     await settle();
     act(() => {
       void inbox?.loadMore();
-      window.dispatchEvent(new Event('focus'));
+      simulatePageResume();
     });
     await settle();
     expect(listInbox).toHaveBeenCalledTimes(2);
@@ -1573,8 +1592,8 @@ describe('Workbench session read ownership', () => {
     );
     await settle();
     act(() => {
-      document.dispatchEvent(new Event('visibilitychange'));
-      window.dispatchEvent(new Event('focus'));
+      simulatePageResume();
+      simulatePageResume();
     });
     await settle();
     expect(listInbox).toHaveBeenCalledTimes(2);

--- a/ui/src/lib/avibeFetch.ts
+++ b/ui/src/lib/avibeFetch.ts
@@ -13,6 +13,7 @@
 //  - fallback: before any cloud request, throws CloudUnavailableError when no
 //    token can be obtained so callers may use the local relay instead
 import { apiFetch } from './apiFetch';
+import { onPageReactivated } from './pageActivity';
 
 export type CloudToken = { token: string; baseUrl: string; expiresAt: number };
 
@@ -74,11 +75,8 @@ const bindActivityListeners = (): void => {
   const topUp = (): void => {
     if (!isFresh(current)) void mint().catch(() => undefined);
   };
-  window.addEventListener('focus', topUp);
+  onPageReactivated(topUp);
   window.addEventListener('online', topUp);
-  document.addEventListener('visibilitychange', () => {
-    if (document.visibilityState === 'visible') topUp();
-  });
 };
 
 // Single-flight: concurrent callers share one in-flight /api/cloud/token request.

--- a/ui/src/lib/pageActivity.test.ts
+++ b/ui/src/lib/pageActivity.test.ts
@@ -248,19 +248,38 @@ describe('onPageReactivated', () => {
     expect(reactivated).toHaveBeenCalledTimes(1);
   });
 
-  it('treats coming back from a cross-origin frame as coming back', () => {
-    document.hasFocus = () => true;
-
-    const reactivated = listen();
+  const focusCrossOriginFrame = (): HTMLIFrameElement => {
     const frame = addFrame();
     const refuse = () => {
       throw new Error('cross-origin');
     };
     Object.defineProperty(frame, 'contentDocument', { get: refuse, configurable: true });
     Object.defineProperty(frame, 'contentWindow', { get: refuse, configurable: true });
-
     focusIn(document, frame);
     window.dispatchEvent(new Event('blur'));
+    return frame;
+  };
+
+  it('stays silent while an out-of-sight frame reloads without giving focus back', () => {
+    document.hasFocus = () => true;
+
+    const reactivated = listen();
+    const frame = focusCrossOriginFrame();
+
+    // The sandboxed preview, Vault surface, or Show Page reloads itself while it
+    // still owns focus. Being unable to see the page is what the sampler has
+    // been told; only seeing it again is news.
+    frame.dispatchEvent(new Event('load'));
+    frame.dispatchEvent(new Event('load'));
+
+    expect(reactivated).not.toHaveBeenCalled();
+  });
+
+  it('treats coming back from a cross-origin frame as coming back', () => {
+    document.hasFocus = () => true;
+
+    const reactivated = listen();
+    focusCrossOriginFrame();
     expect(reactivated).not.toHaveBeenCalled();
 
     // A switch away and back while the frame owns focus reaches neither window.

--- a/ui/src/lib/pageActivity.test.ts
+++ b/ui/src/lib/pageActivity.test.ts
@@ -1,12 +1,76 @@
 import { describe, expect, it } from 'vitest';
 
-import { canMarkConversationRead, isPageActive } from './pageActivity';
+import {
+  canMarkConversationRead,
+  createPageActivityTracker,
+  isPageActive,
+  type PageActivitySnapshot,
+} from './pageActivity';
 
 describe('isPageActive', () => {
   it('requires both a visible document and window focus', () => {
     expect(isPageActive({ visibilityState: 'visible', hasFocus: true })).toBe(true);
     expect(isPageActive({ visibilityState: 'visible', hasFocus: false })).toBe(false);
     expect(isPageActive({ visibilityState: 'hidden', hasFocus: true })).toBe(false);
+  });
+});
+
+describe('createPageActivityTracker', () => {
+  const observeAll = (initial: boolean, snapshots: PageActivitySnapshot[]): boolean[] => {
+    const tracker = createPageActivityTracker(initial);
+    return snapshots.map((snapshot) => tracker.observe(isPageActive(snapshot)));
+  };
+
+  it('reports the inactive -> active edge once per gap', () => {
+    expect(
+      observeAll(true, [
+        { visibilityState: 'hidden', hasFocus: false },
+        { visibilityState: 'visible', hasFocus: true },
+        { visibilityState: 'visible', hasFocus: true },
+      ]),
+    ).toEqual([false, true, false]);
+  });
+
+  it('reports a return of window focus without a visibility change', () => {
+    expect(
+      observeAll(true, [
+        { visibilityState: 'visible', hasFocus: false },
+        { visibilityState: 'visible', hasFocus: true },
+      ]),
+    ).toEqual([false, true]);
+  });
+
+  it('waits for focus when a revealed tab is not focused yet', () => {
+    expect(
+      observeAll(true, [
+        { visibilityState: 'hidden', hasFocus: false },
+        { visibilityState: 'visible', hasFocus: false },
+        { visibilityState: 'visible', hasFocus: true },
+      ]),
+    ).toEqual([false, false, true]);
+  });
+
+  it('stays silent while focus moves inside a page that never left', () => {
+    // Focusing an embedded Show Page iframe blurs the parent window, but the
+    // parent document stays visible and keeps `document.hasFocus()`.
+    expect(
+      observeAll(true, [
+        { visibilityState: 'visible', hasFocus: true },
+        { visibilityState: 'visible', hasFocus: true },
+      ]),
+    ).toEqual([false, false]);
+  });
+
+  it('does not treat a first active reading as a return when it starts active', () => {
+    const tracker = createPageActivityTracker(true);
+    expect(tracker.isActive()).toBe(true);
+    expect(tracker.observe(true)).toBe(false);
+  });
+
+  it('treats becoming active for the first time as a return when it starts inactive', () => {
+    const tracker = createPageActivityTracker(false);
+    expect(tracker.observe(true)).toBe(true);
+    expect(tracker.isActive()).toBe(true);
   });
 });
 

--- a/ui/src/lib/pageActivity.test.ts
+++ b/ui/src/lib/pageActivity.test.ts
@@ -1,9 +1,12 @@
-import { describe, expect, it } from 'vitest';
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   canMarkConversationRead,
   createPageActivityTracker,
   isPageActive,
+  onPageReactivated,
   type PageActivitySnapshot,
 } from './pageActivity';
 
@@ -71,6 +74,68 @@ describe('createPageActivityTracker', () => {
     const tracker = createPageActivityTracker(false);
     expect(tracker.observe(true)).toBe(true);
     expect(tracker.isActive()).toBe(true);
+  });
+});
+
+describe('onPageReactivated', () => {
+  let frame: HTMLIFrameElement | null = null;
+
+  // jsdom never moves focus into a frame, so drive both halves of the delegated
+  // state directly: `activeElement` is what the sampler reads to decide whether
+  // the parent window can still be told about a focus change, and `hasFocus` is
+  // the system-focus truth it polls for while it cannot.
+  const delegateFocusToFrame = () => {
+    frame = document.createElement('iframe');
+    document.body.appendChild(frame);
+    Object.defineProperty(document, 'activeElement', { value: frame, configurable: true });
+  };
+
+  afterEach(() => {
+    Reflect.deleteProperty(document, 'activeElement');
+    Reflect.deleteProperty(document, 'hasFocus');
+    frame?.remove();
+    frame = null;
+    vi.useRealTimers();
+  });
+
+  it('reports a system focus loss that happened while an embedded frame held focus', () => {
+    vi.useFakeTimers();
+    let systemFocus = true;
+    document.hasFocus = () => systemFocus;
+    delegateFocusToFrame();
+
+    const reactivated = vi.fn();
+    const stop = onPageReactivated(reactivated);
+    // The parent window blurs when focus enters the frame; nothing left the page.
+    window.dispatchEvent(new Event('blur'));
+    expect(reactivated).not.toHaveBeenCalled();
+
+    // Switching to another application from there reaches the parent as no event
+    // at all, and switching back only re-focuses the frame.
+    systemFocus = false;
+    vi.advanceTimersByTime(2000);
+    systemFocus = true;
+    vi.advanceTimersByTime(2000);
+
+    expect(reactivated).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it('stops polling once focus leaves the frame', () => {
+    vi.useFakeTimers();
+    document.hasFocus = () => true;
+    delegateFocusToFrame();
+
+    const stop = onPageReactivated(() => {});
+    expect(vi.getTimerCount()).toBe(1);
+
+    Object.defineProperty(document, 'activeElement', {
+      value: document.body,
+      configurable: true,
+    });
+    window.dispatchEvent(new Event('focus'));
+    expect(vi.getTimerCount()).toBe(0);
+    stop();
   });
 });
 

--- a/ui/src/lib/pageActivity.test.ts
+++ b/ui/src/lib/pageActivity.test.ts
@@ -80,14 +80,23 @@ describe('createPageActivityTracker', () => {
 describe('onPageReactivated', () => {
   let frame: HTMLIFrameElement | null = null;
 
-  // jsdom never moves focus into a frame, so drive both halves of the delegated
-  // state directly: `activeElement` is what the sampler reads to decide whether
-  // the parent window can still be told about a focus change, and `hasFocus` is
-  // the system-focus truth it polls for while it cannot.
-  const delegateFocusToFrame = () => {
+  // jsdom never moves focus into a frame, so put it there by hand: `activeElement`
+  // is how the sampler finds the window that now owns focus events, and
+  // `hasFocus` is the system-focus truth those events are read against.
+  const focusFrame = (): Window => {
     frame = document.createElement('iframe');
     document.body.appendChild(frame);
     Object.defineProperty(document, 'activeElement', { value: frame, configurable: true });
+    // The parent window blurs as focus enters the frame; nothing left the page.
+    window.dispatchEvent(new Event('blur'));
+    return frame.contentWindow as Window;
+  };
+
+  const focusParent = () => {
+    Object.defineProperty(document, 'activeElement', {
+      value: document.body,
+      configurable: true,
+    });
   };
 
   afterEach(() => {
@@ -95,46 +104,59 @@ describe('onPageReactivated', () => {
     Reflect.deleteProperty(document, 'hasFocus');
     frame?.remove();
     frame = null;
-    vi.useRealTimers();
   });
 
-  it('reports a system focus loss that happened while an embedded frame held focus', () => {
-    vi.useFakeTimers();
+  it('reports a system focus loss that arrived at the frame holding focus', () => {
     let systemFocus = true;
     document.hasFocus = () => systemFocus;
-    delegateFocusToFrame();
 
     const reactivated = vi.fn();
     const stop = onPageReactivated(reactivated);
-    // The parent window blurs when focus enters the frame; nothing left the page.
-    window.dispatchEvent(new Event('blur'));
+    const frameWindow = focusFrame();
     expect(reactivated).not.toHaveBeenCalled();
 
-    // Switching to another application from there reaches the parent as no event
-    // at all, and switching back only re-focuses the frame.
+    // Switching to another application blurs the frame's window, not ours.
     systemFocus = false;
-    vi.advanceTimersByTime(2000);
+    frameWindow.dispatchEvent(new Event('blur'));
     systemFocus = true;
-    vi.advanceTimersByTime(2000);
+    frameWindow.dispatchEvent(new Event('focus'));
 
     expect(reactivated).toHaveBeenCalledTimes(1);
     stop();
   });
 
-  it('stops polling once focus leaves the frame', () => {
-    vi.useFakeTimers();
+  it('stays silent while focus only moves between the page and its frame', () => {
     document.hasFocus = () => true;
-    delegateFocusToFrame();
 
-    const stop = onPageReactivated(() => {});
-    expect(vi.getTimerCount()).toBe(1);
+    const reactivated = vi.fn();
+    const stop = onPageReactivated(reactivated);
+    const frameWindow = focusFrame();
 
-    Object.defineProperty(document, 'activeElement', {
-      value: document.body,
-      configurable: true,
-    });
+    // Clicking workbench chrome blurs the frame and focuses the parent again.
+    frameWindow.dispatchEvent(new Event('blur'));
+    focusParent();
     window.dispatchEvent(new Event('focus'));
-    expect(vi.getTimerCount()).toBe(0);
+
+    expect(reactivated).not.toHaveBeenCalled();
+    stop();
+  });
+
+  it('stops listening to a frame that no longer holds focus', () => {
+    document.hasFocus = () => true;
+
+    const reactivated = vi.fn();
+    const stop = onPageReactivated(reactivated);
+    const frameWindow = focusFrame();
+    focusParent();
+    window.dispatchEvent(new Event('focus'));
+
+    // A stale frame must not be able to report the page inactive from the side.
+    document.hasFocus = () => false;
+    frameWindow.dispatchEvent(new Event('blur'));
+    document.hasFocus = () => true;
+    frameWindow.dispatchEvent(new Event('focus'));
+
+    expect(reactivated).not.toHaveBeenCalled();
     stop();
   });
 });

--- a/ui/src/lib/pageActivity.test.ts
+++ b/ui/src/lib/pageActivity.test.ts
@@ -77,87 +77,200 @@ describe('createPageActivityTracker', () => {
   });
 });
 
+// Every way a page can hand focus to an embedded context, so the partition the
+// sampler rests on — walkable chains stay exact, unwalkable ones fail toward one
+// redundant revalidation — is asserted member by member rather than assumed.
 describe('onPageReactivated', () => {
-  let frame: HTMLIFrameElement | null = null;
+  const created: Element[] = [];
+  const shadowed: Array<Document | ShadowRoot> = [];
+  const stops: Array<() => void> = [];
 
-  // jsdom never moves focus into a frame, so put it there by hand: `activeElement`
-  // is how the sampler finds the window that now owns focus events, and
-  // `hasFocus` is the system-focus truth those events are read against.
-  const focusFrame = (): Window => {
-    frame = document.createElement('iframe');
-    document.body.appendChild(frame);
-    Object.defineProperty(document, 'activeElement', { value: frame, configurable: true });
-    // The parent window blurs as focus enters the frame; nothing left the page.
-    window.dispatchEvent(new Event('blur'));
-    return frame.contentWindow as Window;
+  // Unsubscribing from a cleanup rather than the end of each test keeps a failed
+  // assertion from leaving the shared sampler attached for the next one.
+  const listen = (): ReturnType<typeof vi.fn> => {
+    const reactivated = vi.fn();
+    stops.push(onPageReactivated(reactivated));
+    return reactivated;
   };
 
-  const focusParent = () => {
-    Object.defineProperty(document, 'activeElement', {
-      value: document.body,
-      configurable: true,
-    });
+  // jsdom never moves focus into a frame, so put it there by hand: `activeElement`
+  // is how the sampler finds the window that owns focus events, and `hasFocus` is
+  // the system-focus truth those events are read against.
+  const focusIn = (root: Document | ShadowRoot, element: Element | null) => {
+    Object.defineProperty(root, 'activeElement', { value: element, configurable: true });
+    if (!shadowed.includes(root)) shadowed.push(root);
+  };
+
+  const addFrame = (parent: Document = document): HTMLIFrameElement => {
+    const element = parent.createElement('iframe');
+    (parent.body ?? parent.documentElement).appendChild(element);
+    created.push(element);
+    return element;
+  };
+
+  const focusFrame = (): HTMLIFrameElement => {
+    const frame = addFrame();
+    focusIn(document, frame);
+    // The parent window blurs as focus enters the frame; nothing left the page.
+    window.dispatchEvent(new Event('blur'));
+    return frame;
+  };
+
+  const focusParent = () => focusIn(document, document.body);
+
+  // An application switch reaches whichever window currently owns focus.
+  const switchAwayAndBack = (target: Window) => {
+    document.hasFocus = () => false;
+    target.dispatchEvent(new Event('blur'));
+    document.hasFocus = () => true;
+    target.dispatchEvent(new Event('focus'));
   };
 
   afterEach(() => {
-    Reflect.deleteProperty(document, 'activeElement');
+    for (const stop of stops) stop();
+    stops.length = 0;
+    for (const root of shadowed) Reflect.deleteProperty(root, 'activeElement');
+    shadowed.length = 0;
     Reflect.deleteProperty(document, 'hasFocus');
-    frame?.remove();
-    frame = null;
+    for (const element of created) element.remove();
+    created.length = 0;
   });
 
   it('reports a system focus loss that arrived at the frame holding focus', () => {
-    let systemFocus = true;
-    document.hasFocus = () => systemFocus;
+    document.hasFocus = () => true;
 
-    const reactivated = vi.fn();
-    const stop = onPageReactivated(reactivated);
-    const frameWindow = focusFrame();
+    const reactivated = listen();
+    const frame = focusFrame();
     expect(reactivated).not.toHaveBeenCalled();
 
-    // Switching to another application blurs the frame's window, not ours.
-    systemFocus = false;
-    frameWindow.dispatchEvent(new Event('blur'));
-    systemFocus = true;
-    frameWindow.dispatchEvent(new Event('focus'));
+    switchAwayAndBack(frame.contentWindow as Window);
 
     expect(reactivated).toHaveBeenCalledTimes(1);
-    stop();
   });
 
   it('stays silent while focus only moves between the page and its frame', () => {
     document.hasFocus = () => true;
 
-    const reactivated = vi.fn();
-    const stop = onPageReactivated(reactivated);
-    const frameWindow = focusFrame();
+    const reactivated = listen();
+    const frame = focusFrame();
 
     // Clicking workbench chrome blurs the frame and focuses the parent again.
-    frameWindow.dispatchEvent(new Event('blur'));
+    (frame.contentWindow as Window).dispatchEvent(new Event('blur'));
     focusParent();
     window.dispatchEvent(new Event('focus'));
 
     expect(reactivated).not.toHaveBeenCalled();
-    stop();
   });
 
   it('stops listening to a frame that no longer holds focus', () => {
     document.hasFocus = () => true;
 
-    const reactivated = vi.fn();
-    const stop = onPageReactivated(reactivated);
-    const frameWindow = focusFrame();
+    const reactivated = listen();
+    const frame = focusFrame();
     focusParent();
     window.dispatchEvent(new Event('focus'));
 
     // A stale frame must not be able to report the page inactive from the side.
-    document.hasFocus = () => false;
-    frameWindow.dispatchEvent(new Event('blur'));
-    document.hasFocus = () => true;
-    frameWindow.dispatchEvent(new Event('focus'));
+    switchAwayAndBack(frame.contentWindow as Window);
 
     expect(reactivated).not.toHaveBeenCalled();
-    stop();
+  });
+
+  it('rebinds onto the window a navigation put behind the focused frame', () => {
+    document.hasFocus = () => true;
+
+    const reactivated = listen();
+    const frame = focusFrame();
+    const before = frame.contentWindow as Window;
+
+    // Navigating a frame keeps its `WindowProxy` identity while replacing the
+    // document — and with it every listener registered on the old window.
+    const carrier = addFrame();
+    const after = carrier.contentWindow as Window;
+    Object.defineProperty(frame, 'contentWindow', { value: after, configurable: true });
+    Object.defineProperty(frame, 'contentDocument', {
+      value: carrier.contentDocument,
+      configurable: true,
+    });
+    frame.dispatchEvent(new Event('load'));
+
+    switchAwayAndBack(after);
+    expect(reactivated).toHaveBeenCalledTimes(1);
+
+    // The window the navigation discarded must no longer speak for the page.
+    switchAwayAndBack(before);
+    expect(reactivated).toHaveBeenCalledTimes(1);
+  });
+
+  it('follows focus into a frame nested inside the focused frame', () => {
+    document.hasFocus = () => true;
+
+    const reactivated = listen();
+    const outer = addFrame();
+    const outerDocument = outer.contentDocument as Document;
+    const inner = addFrame(outerDocument);
+
+    focusIn(outerDocument, inner);
+    focusIn(document, outer);
+    window.dispatchEvent(new Event('blur'));
+
+    switchAwayAndBack(inner.contentWindow as Window);
+
+    expect(reactivated).toHaveBeenCalledTimes(1);
+  });
+
+  it('follows focus into a frame behind a shadow root', () => {
+    document.hasFocus = () => true;
+
+    const reactivated = listen();
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    created.push(host);
+    const shadow = host.attachShadow({ mode: 'open' });
+    const frame = document.createElement('iframe');
+    shadow.appendChild(frame);
+    // jsdom gives no browsing context to a frame inside a shadow tree, so lend
+    // it one; what is under test is the walk descending through the shadow root.
+    const carrier = addFrame();
+    const frameWindow = carrier.contentWindow as Window;
+    Object.defineProperty(frame, 'contentWindow', { value: frameWindow, configurable: true });
+    Object.defineProperty(frame, 'contentDocument', {
+      value: carrier.contentDocument,
+      configurable: true,
+    });
+
+    focusIn(shadow, frame);
+    focusIn(document, host);
+    window.dispatchEvent(new Event('blur'));
+
+    switchAwayAndBack(frameWindow);
+
+    expect(reactivated).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats coming back from a cross-origin frame as coming back', () => {
+    document.hasFocus = () => true;
+
+    const reactivated = listen();
+    const frame = addFrame();
+    const refuse = () => {
+      throw new Error('cross-origin');
+    };
+    Object.defineProperty(frame, 'contentDocument', { get: refuse, configurable: true });
+    Object.defineProperty(frame, 'contentWindow', { get: refuse, configurable: true });
+
+    focusIn(document, frame);
+    window.dispatchEvent(new Event('blur'));
+    expect(reactivated).not.toHaveBeenCalled();
+
+    // A switch away and back while the frame owns focus reaches neither window.
+    // Clicking the workbench is the first thing this document can observe, and
+    // it cannot vouch for the gap, so it revalidates rather than assume nothing
+    // happened.
+    focusParent();
+    window.dispatchEvent(new Event('focus'));
+
+    expect(reactivated).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/ui/src/lib/pageActivity.ts
+++ b/ui/src/lib/pageActivity.ts
@@ -1,3 +1,5 @@
+import { useSyncExternalStore } from 'react';
+
 export type PageActivitySnapshot = {
   visibilityState: DocumentVisibilityState;
   hasFocus: boolean;
@@ -39,4 +41,109 @@ export function readPageActivity(): boolean {
     visibilityState: document.visibilityState,
     hasFocus: typeof document.hasFocus !== 'function' || document.hasFocus(),
   });
+}
+
+export type PageActivityTracker = {
+  isActive: () => boolean;
+  /** Fold one reading in; true only on the inactive -> active edge. */
+  observe: (nextActive: boolean) => boolean;
+};
+
+/**
+ * Edge detector over `isPageActive`. A reactivation is the moment a page that
+ * really was away — hidden, or with window focus gone elsewhere — becomes
+ * active again. A page that never left reports nothing.
+ *
+ * That distinction is what a raw `focus` listener cannot make. An embedded
+ * browsing context (a Show Page iframe) is focused and blurred independently of
+ * its parent, so clicking workbench chrome fires `blur`/`focus` on the parent
+ * window while `document.visibilityState` stays `visible` and
+ * `document.hasFocus()` stays `true` the whole time. Level-triggered listeners
+ * read that as "the user came back" and each revalidate; this tracker sees no
+ * transition at all.
+ */
+export function createPageActivityTracker(initialActive: boolean): PageActivityTracker {
+  let active = initialActive;
+  return {
+    isActive: () => active,
+    observe: (nextActive) => {
+      const reactivated = nextActive && !active;
+      active = nextActive;
+      return reactivated;
+    },
+  };
+}
+
+// One sampler for the whole app. Consumers subscribe to the derived facts —
+// "the page is active" and "the page just came back" — rather than each binding
+// its own focus/visibility listeners and re-deriving them.
+
+const activeListeners = new Set<() => void>();
+const reactivationListeners = new Set<() => void>();
+
+let tracker: PageActivityTracker | null = null;
+let detach: (() => void) | null = null;
+
+// Copy first: a listener may unsubscribe while the set is being walked.
+const notify = (listeners: Set<() => void>) => {
+  for (const listener of [...listeners]) listener();
+};
+
+const sample = () => {
+  if (!tracker) return;
+  const wasActive = tracker.isActive();
+  const reactivated = tracker.observe(readPageActivity());
+  if (tracker.isActive() !== wasActive) notify(activeListeners);
+  if (reactivated) notify(reactivationListeners);
+};
+
+const attach = () => {
+  tracker = createPageActivityTracker(readPageActivity());
+  // `pageshow`/`pagehide` cover bfcache restores, which resume a page without
+  // a visibility change.
+  document.addEventListener('visibilitychange', sample);
+  window.addEventListener('focus', sample);
+  window.addEventListener('blur', sample);
+  window.addEventListener('pageshow', sample);
+  window.addEventListener('pagehide', sample);
+  detach = () => {
+    document.removeEventListener('visibilitychange', sample);
+    window.removeEventListener('focus', sample);
+    window.removeEventListener('blur', sample);
+    window.removeEventListener('pageshow', sample);
+    window.removeEventListener('pagehide', sample);
+    tracker = null;
+    detach = null;
+  };
+};
+
+const subscribe = (listeners: Set<() => void>, listener: () => void): (() => void) => {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return () => {};
+  listeners.add(listener);
+  if (!detach) attach();
+  return () => {
+    listeners.delete(listener);
+    if (activeListeners.size === 0 && reactivationListeners.size === 0) detach?.();
+  };
+};
+
+const getPageActive = (): boolean => (tracker ? tracker.isActive() : readPageActivity());
+
+const subscribePageActive = (listener: () => void): (() => void) =>
+  subscribe(activeListeners, listener);
+
+/**
+ * Run `listener` each time the page comes back after being hidden or after
+ * losing window focus, and returns the unsubscribe. This is the trigger for
+ * revalidating data that may have gone stale during the gap; a bare `focus`
+ * listener over-fires because it cannot tell a return from a focus move that
+ * never left the page.
+ */
+export function onPageReactivated(listener: () => void): () => void {
+  return subscribe(reactivationListeners, listener);
+}
+
+/** Whether the page is presented right now, kept live by the shared sampler. */
+export function usePageActive(): boolean {
+  return useSyncExternalStore(subscribePageActive, getPageActive, () => false);
 }

--- a/ui/src/lib/pageActivity.ts
+++ b/ui/src/lib/pageActivity.ts
@@ -89,12 +89,39 @@ const notify = (listeners: Set<() => void>) => {
   for (const listener of [...listeners]) listener();
 };
 
+/** Whether the focused element hosts a child browsing context (`<iframe>` & co). */
+const focusIsDelegated = (): boolean => {
+  const focused = document.activeElement as HTMLIFrameElement | null;
+  return focused != null && focused.contentWindow != null;
+};
+
+// Chrome blurs the parent window when focus moves into an embedded frame, and
+// then delivers it nothing more: losing system focus from there fires on the
+// frame's window, not on ours, so the away period would pass unobserved and the
+// user's return would read as `true -> true`. `document.hasFocus()` still
+// reports it, so poll while — and only while — an embedded frame holds focus.
+// Browsers that instead keep the parent window focused report the same gap as an
+// ordinary `blur`, so between them the two focus models are both covered.
+const DELEGATED_FOCUS_POLL_MS = 1000;
+let delegatedFocusPoll: ReturnType<typeof setInterval> | null = null;
+
+const stopDelegatedFocusPoll = () => {
+  if (delegatedFocusPoll === null) return;
+  clearInterval(delegatedFocusPoll);
+  delegatedFocusPoll = null;
+};
+
 const sample = () => {
   if (!tracker) return;
   const wasActive = tracker.isActive();
   const reactivated = tracker.observe(readPageActivity());
   if (tracker.isActive() !== wasActive) notify(activeListeners);
   if (reactivated) notify(reactivationListeners);
+
+  if (!focusIsDelegated()) stopDelegatedFocusPoll();
+  else if (delegatedFocusPoll === null) {
+    delegatedFocusPoll = setInterval(sample, DELEGATED_FOCUS_POLL_MS);
+  }
 };
 
 const attach = () => {
@@ -112,9 +139,13 @@ const attach = () => {
     window.removeEventListener('blur', sample);
     window.removeEventListener('pageshow', sample);
     window.removeEventListener('pagehide', sample);
+    stopDelegatedFocusPoll();
     tracker = null;
     detach = null;
   };
+  // Fold the current reading in once, so a page that mounts while an embedded
+  // frame already holds focus starts polling without waiting for an event.
+  sample();
 };
 
 const subscribe = (listeners: Set<() => void>, listener: () => void): (() => void) => {

--- a/ui/src/lib/pageActivity.ts
+++ b/ui/src/lib/pageActivity.ts
@@ -94,12 +94,16 @@ const sample = () => {
   const wasActive = tracker.isActive();
   const wasOutOfSight = focusOutOfSight;
   const active = readPageActivity();
+  // Re-walk before deciding: what makes an unobservable gap a return is
+  // regaining sight of the page, not merely having lost it. An out-of-sight
+  // frame reloading itself samples too, and it never left.
+  syncFocusChain();
+  const regainedSight = wasOutOfSight && !focusOutOfSight;
   // Either edge is a return: one this document watched happen, or one it could
-  // only have missed because focus sat where it cannot observe.
-  const reactivated = tracker.observe(active) || (active && wasOutOfSight);
+  // only have missed while focus sat where it cannot look.
+  const reactivated = tracker.observe(active) || (active && regainedSight);
   if (tracker.isActive() !== wasActive) notify(activeListeners);
   if (reactivated) notify(reactivationListeners);
-  syncFocusChain();
 };
 
 // Focus events go to the window that holds focus, and Chrome hands focus to an

--- a/ui/src/lib/pageActivity.ts
+++ b/ui/src/lib/pageActivity.ts
@@ -92,46 +92,137 @@ const notify = (listeners: Set<() => void>) => {
 const sample = () => {
   if (!tracker) return;
   const wasActive = tracker.isActive();
-  const reactivated = tracker.observe(readPageActivity());
+  const wasOutOfSight = focusOutOfSight;
+  const active = readPageActivity();
+  // Either edge is a return: one this document watched happen, or one it could
+  // only have missed because focus sat where it cannot observe.
+  const reactivated = tracker.observe(active) || (active && wasOutOfSight);
   if (tracker.isActive() !== wasActive) notify(activeListeners);
   if (reactivated) notify(reactivationListeners);
-  bindFocusedFrame();
+  syncFocusChain();
 };
 
 // Focus events go to the window that holds focus, and Chrome hands focus to an
-// embedded frame's window while blurring ours: from then on a system focus loss
-// is delivered there and never here. So follow it — listen on whichever child
-// window currently holds focus. `document.hasFocus()` is already false inside a
-// blur that really left the page and still true when focus merely returned to
-// the parent document, so the same edge detector separates the two without
-// having to guess what the gap was.
+// embedded browsing context while blurring ours: from then on a system focus
+// loss is delivered there and never here. Following focus one level down is not
+// enough, because a frame can navigate, nest another frame, sit behind a shadow
+// root, or be cross-origin — each a separate way for the page to lose focus out
+// of this document's sight, and the list of embedding shapes has no end.
+//
+// So partition rather than enumerate. Walk the focus chain as far as this
+// document is allowed to see and listen on every window in it; a chain that
+// ends somewhere it cannot enter means the page went out of sight, and coming
+// back from an unobservable context counts as a return by definition. Every
+// topology is then either walkable, where the edge detector stays exact, or
+// not, where it fails toward one redundant revalidation instead of toward
+// silently stale data.
 const FRAME_FOCUS_EVENTS = ['focus', 'blur', 'pagehide'] as const;
 
-let focusedFrame: Window | null = null;
+// A focus chain deeper than this is pathological. Stopping counts as losing
+// sight, so the cap fails toward revalidating rather than toward silence.
+const MAX_FOCUS_DEPTH = 10;
 
-const unbindFocusedFrame = () => {
-  if (!focusedFrame) return;
-  try {
-    for (const type of FRAME_FOCUS_EVENTS) focusedFrame.removeEventListener(type, sample);
-  } catch {
-    // The frame was torn down together with its document; nothing left to detach.
-  }
-  focusedFrame = null;
+type FocusChain = {
+  /** Same-origin windows along the chain, innermost last. */
+  windows: Window[];
+  /** The frame elements that own them, watched for navigation. */
+  frames: Element[];
+  /** The chain ended at a context this document cannot look into. */
+  outOfSight: boolean;
 };
 
-const bindFocusedFrame = () => {
-  const focused = document.activeElement as HTMLIFrameElement | null;
-  const frame = focused?.contentWindow ?? null;
-  if (frame === focusedFrame) return;
-  unbindFocusedFrame();
-  if (!frame) return;
-  try {
-    for (const type of FRAME_FOCUS_EVENTS) frame.addEventListener(type, sample);
-    focusedFrame = frame;
-  } catch {
-    // A cross-origin frame refuses listeners, and hides its focus changes from
-    // this document anyway. Leave it unobserved rather than guessing.
+const isFrameElement = (element: Element): boolean =>
+  // Cross-realm elements fail `instanceof`, so compare the tag instead.
+  element.tagName === 'IFRAME' || element.tagName === 'FRAME';
+
+const walkFocusChain = (): FocusChain => {
+  const windows: Window[] = [];
+  const frames: Element[] = [];
+  let root: Document | ShadowRoot = document;
+  for (let depth = 0; depth < MAX_FOCUS_DEPTH; depth += 1) {
+    // Annotated because the loop feeds `root` from this value, and inference
+    // would otherwise chase its own tail through the narrowing of `root`.
+    const focused: Element | null = root.activeElement;
+    // No delegation left: focus rests on an element of this document.
+    if (!focused) return { windows, frames, outOfSight: false };
+    if (focused.shadowRoot) {
+      root = focused.shadowRoot;
+      continue;
+    }
+    if (!isFrameElement(focused)) return { windows, frames, outOfSight: false };
+    frames.push(focused);
+    let frameDocument: Document | null = null;
+    let frameWindow: Window | null = null;
+    try {
+      frameDocument = (focused as HTMLIFrameElement).contentDocument;
+      frameWindow = (focused as HTMLIFrameElement).contentWindow;
+    } catch {
+      // A cross-origin frame refuses both, which is the out-of-sight case.
+    }
+    if (!frameDocument || !frameWindow) return { windows, frames, outOfSight: true };
+    windows.push(frameWindow);
+    root = frameDocument;
   }
+  return { windows, frames, outOfSight: true };
+};
+
+const boundWindows = new Set<Window>();
+const boundFrames = new Set<Element>();
+let focusOutOfSight = false;
+
+const releaseFocusChain = () => {
+  for (const frameWindow of boundWindows) {
+    try {
+      for (const type of FRAME_FOCUS_EVENTS) frameWindow.removeEventListener(type, sample);
+    } catch {
+      // The window was torn down with its frame; nothing left to detach.
+    }
+  }
+  boundWindows.clear();
+  for (const frame of boundFrames) frame.removeEventListener('load', sample);
+  boundFrames.clear();
+  focusOutOfSight = false;
+};
+
+const syncFocusChain = () => {
+  const chain = walkFocusChain();
+  const nextWindows = new Set(chain.windows);
+  const nextFrames = new Set(chain.frames);
+
+  for (const frameWindow of boundWindows) {
+    if (nextWindows.has(frameWindow)) continue;
+    try {
+      for (const type of FRAME_FOCUS_EVENTS) frameWindow.removeEventListener(type, sample);
+    } catch {
+      // Same as above: a discarded window needs no detaching.
+    }
+    boundWindows.delete(frameWindow);
+  }
+  for (const frame of boundFrames) {
+    if (nextFrames.has(frame)) continue;
+    frame.removeEventListener('load', sample);
+    boundFrames.delete(frame);
+  }
+
+  // Re-registering an identical listener is a no-op, so one pass both binds new
+  // windows and reinstalls on a window whose document a navigation replaced —
+  // navigation keeps the `WindowProxy` identity but empties its listener table.
+  for (const frameWindow of nextWindows) {
+    try {
+      for (const type of FRAME_FOCUS_EVENTS) frameWindow.addEventListener(type, sample);
+      boundWindows.add(frameWindow);
+    } catch {
+      // Lost same-origin access mid-walk; the chain reading below covers it.
+    }
+  }
+  // `load` fires on the element for same-origin and cross-origin frames alike,
+  // which is what makes a navigated frame rebind before it can be focused again.
+  for (const frame of nextFrames) {
+    frame.addEventListener('load', sample);
+    boundFrames.add(frame);
+  }
+
+  focusOutOfSight = chain.outOfSight;
 };
 
 const attach = () => {
@@ -149,12 +240,13 @@ const attach = () => {
     window.removeEventListener('blur', sample);
     window.removeEventListener('pageshow', sample);
     window.removeEventListener('pagehide', sample);
-    unbindFocusedFrame();
+    releaseFocusChain();
     tracker = null;
     detach = null;
   };
   // Fold the current reading in once, so a page that mounts while an embedded
-  // frame already holds focus starts listening to it without waiting for an event.
+  // frame already holds focus starts watching that chain without waiting for an
+  // event it would never receive.
   sample();
 };
 

--- a/ui/src/lib/pageActivity.ts
+++ b/ui/src/lib/pageActivity.ts
@@ -89,38 +89,48 @@ const notify = (listeners: Set<() => void>) => {
   for (const listener of [...listeners]) listener();
 };
 
-/** Whether the focused element hosts a child browsing context (`<iframe>` & co). */
-const focusIsDelegated = (): boolean => {
-  const focused = document.activeElement as HTMLIFrameElement | null;
-  return focused != null && focused.contentWindow != null;
-};
-
-// Chrome blurs the parent window when focus moves into an embedded frame, and
-// then delivers it nothing more: losing system focus from there fires on the
-// frame's window, not on ours, so the away period would pass unobserved and the
-// user's return would read as `true -> true`. `document.hasFocus()` still
-// reports it, so poll while — and only while — an embedded frame holds focus.
-// Browsers that instead keep the parent window focused report the same gap as an
-// ordinary `blur`, so between them the two focus models are both covered.
-const DELEGATED_FOCUS_POLL_MS = 1000;
-let delegatedFocusPoll: ReturnType<typeof setInterval> | null = null;
-
-const stopDelegatedFocusPoll = () => {
-  if (delegatedFocusPoll === null) return;
-  clearInterval(delegatedFocusPoll);
-  delegatedFocusPoll = null;
-};
-
 const sample = () => {
   if (!tracker) return;
   const wasActive = tracker.isActive();
   const reactivated = tracker.observe(readPageActivity());
   if (tracker.isActive() !== wasActive) notify(activeListeners);
   if (reactivated) notify(reactivationListeners);
+  bindFocusedFrame();
+};
 
-  if (!focusIsDelegated()) stopDelegatedFocusPoll();
-  else if (delegatedFocusPoll === null) {
-    delegatedFocusPoll = setInterval(sample, DELEGATED_FOCUS_POLL_MS);
+// Focus events go to the window that holds focus, and Chrome hands focus to an
+// embedded frame's window while blurring ours: from then on a system focus loss
+// is delivered there and never here. So follow it — listen on whichever child
+// window currently holds focus. `document.hasFocus()` is already false inside a
+// blur that really left the page and still true when focus merely returned to
+// the parent document, so the same edge detector separates the two without
+// having to guess what the gap was.
+const FRAME_FOCUS_EVENTS = ['focus', 'blur', 'pagehide'] as const;
+
+let focusedFrame: Window | null = null;
+
+const unbindFocusedFrame = () => {
+  if (!focusedFrame) return;
+  try {
+    for (const type of FRAME_FOCUS_EVENTS) focusedFrame.removeEventListener(type, sample);
+  } catch {
+    // The frame was torn down together with its document; nothing left to detach.
+  }
+  focusedFrame = null;
+};
+
+const bindFocusedFrame = () => {
+  const focused = document.activeElement as HTMLIFrameElement | null;
+  const frame = focused?.contentWindow ?? null;
+  if (frame === focusedFrame) return;
+  unbindFocusedFrame();
+  if (!frame) return;
+  try {
+    for (const type of FRAME_FOCUS_EVENTS) frame.addEventListener(type, sample);
+    focusedFrame = frame;
+  } catch {
+    // A cross-origin frame refuses listeners, and hides its focus changes from
+    // this document anyway. Leave it unobserved rather than guessing.
   }
 };
 
@@ -139,12 +149,12 @@ const attach = () => {
     window.removeEventListener('blur', sample);
     window.removeEventListener('pageshow', sample);
     window.removeEventListener('pagehide', sample);
-    stopDelegatedFocusPoll();
+    unbindFocusedFrame();
     tracker = null;
     detach = null;
   };
   // Fold the current reading in once, so a page that mounts while an embedded
-  // frame already holds focus starts polling without waiting for an event.
+  // frame already holds focus starts listening to it without waiting for an event.
   sample();
 };
 

--- a/ui/src/lib/useVaultRequestRefresh.ts
+++ b/ui/src/lib/useVaultRequestRefresh.ts
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 
 import { useApi } from '@/context/ApiContext';
 
+import { onPageReactivated } from './pageActivity';
+
 const FALLBACK_POLL_INTERVAL_MS = 5000;
 
 export function shouldPollVaultRequests(eventBridgeConnected: boolean): boolean {
@@ -62,18 +64,12 @@ export function useVaultRequestRefresh(refresh: () => void | Promise<void>): voi
       timer = window.setTimeout(tick, FALLBACK_POLL_INTERVAL_MS);
     };
 
-    const refreshNow = () => {
-      if (document.visibilityState === 'visible') void tick();
-    };
-
     void tick();
-    document.addEventListener('visibilitychange', refreshNow);
-    window.addEventListener('focus', refreshNow);
+    const stopReactivation = onPageReactivated(() => void tick());
     return () => {
       cancelled = true;
       window.clearTimeout(timer);
-      document.removeEventListener('visibilitychange', refreshNow);
-      window.removeEventListener('focus', refreshNow);
+      stopReactivation();
     };
   }, [eventBridgeConnected, refresh]);
 }


### PR DESCRIPTION
## What changed

Opening the Show Page share popup fired a **~16-request burst** at the backend —
messages ×2, queue ×2, session ×2, activity ×2, turn-state ×3, and more. None of
it belonged to the popup.

Nine components each bound their own `window focus` listener and treated every
one as "the user came back to the tab", guarded only by
`document.visibilityState === 'visible'`.

A Show Page is an `<iframe>`, so it is a **separate browsing context**. Clicking
it moves focus off the parent window; clicking workbench chrome moves it back.
Both fire `blur`/`focus` on the parent while the tab is never hidden — measured
in the browser as `window:blur vis=visible hasFocus=true active=IFRAME`. The
visibility guard cannot see the difference, so every listener revalidated on a
page that had not gone anywhere.

This PR promotes `ui/src/lib/pageActivity.ts` into the **single owner** of "the
page came back" and makes it **edge-triggered**:

- one shared sampler folds visibility and window focus into
  `active = visible && hasFocus`;
- `onPageReactivated(fn)` fires only on the `inactive -> active` transition, so
  focus moving between an iframe and its parent produces no event at all;
- `usePageActive()` exposes the same reading to `ChatPage` via
  `useSyncExternalStore`, replacing its hand-rolled five-listener effect.

Call sites now subscribe to that fact instead of re-deriving it: `App`,
`ApiContext`, `StatusProvider`, `WorkbenchInboxProvider`, `ChatPage`,
`RemoteAccess`, `AgentsPage`, `VaultsPage`, `AgentGraphTriggerDetail`,
`useVaultRequestRefresh`, `avibeFetch`.

`online` stays a **direct** trigger — regaining the network is its own gap,
independent of the page coming back.

## Observing focus across embedded contexts

Focus events go to the window that holds focus, and a browser hands focus to an
embedded browsing context while blurring ours: from then on a system focus loss
is delivered there and never here. Edge-triggering therefore needs to observe
frames, and observing *one* frame is not enough — a frame can navigate, nest
another frame, sit behind a shadow root, or be cross-origin.

Review found those members one head at a time, which is the signal that
enumerating them is not a terminal rule: embedding shapes have no end, and each
new one is a fresh silent gap. See the diagnosis below.

The sampler **partitions** instead. `walkFocusChain()` descends from the
document through shadow roots and same-origin frames as far as it is permitted
to look, and `syncFocusChain()` binds focus/blur/pagehide on every window along
that chain plus `load` on the frame elements. Listener registration is repeated
on each pass rather than guarded by identity, because a navigation keeps the
`WindowProxy` while emptying its listener table, and re-registering an identical
pair is a no-op.

A chain that ends where the walk cannot enter sets `focusOutOfSight`, and the
next reading that finds the page active while that flag is set is reported as a
reactivation — coming back from a context we could not observe *is* a return,
because nothing can vouch for the gap.

So every topology is either **walkable**, where the edge detector stays exact
and the Show Page case stays silent, or **unwalkable**, where it costs one
redundant revalidation instead of leaving data stale. There is no clock, no
threshold, and no member list to keep extending.

## Coverage is not reduced

Every case the old listeners covered still fires: a backgrounded tab, a mobile
PWA resume, and an app switch with the parent focused all move
`visibilityState` or `hasFocus`. An app switch while focus sits inside an
embedded frame — the old code's blind spot — now fires too, exactly when
the frame is observable and conservatively when it is not.

## Review-loop diagnosis (circuit breaker)

The breaker tripped twice on this PR, and the second trip is what produced the
design above. Recorded here because the rule requires the scope decision to be
written down, not just acted on.

| head | findings | class |
| --- | --- | --- |
| `41c050e4` | 1 | A: focus loss delivered to the frame, not to us |
| `8d402625` | 1 | A: same, and a poll cannot fix it (sleep suspends timers) |
| `2c1184e9` | 3 | A: same — navigation, nesting, cross-origin |
| `a5b5a15f` | 1 | B: a signal read as a level rather than an edge |

Class A ran three heads — *reconstruct a page-global fact from per-window
events the top document is not guaranteed to receive* — with shadow-root
delegation and dynamic frame insertion already predictable behind them. Patching
the named members would have bought exactly the rounds already spent. The
decision was to close the class by partitioning observable from unobservable and
making the unobservable half fail safe; that is smaller than the bridge
alternative (which would have reached into the Show Page runtime and
vault-sandbox), reversible, and leaves `onPageReactivated`'s contract untouched.

Class B is one finding on one head and a distinct root cause, so it does not
re-trip the breaker — but it is the PR's own thesis broken inside the fallback:
the out-of-sight gate tested *that* sight had been lost instead of *that it had
just been regained*, so a cross-origin frame reloading under its own focus
reproduced the burst. Its enumeration is closed rather than argued: the sampler
holds exactly two signals, `tracker` (an edge by construction) and
`focusOutOfSight` (an edge as of `4170cdc35`); `boundWindows` / `boundFrames` are
topology, not signals. There is no third candidate for a reviewer to find.

## Known-by-design ledger

- **`InboxPage`, `useVisibleNow`, `voiceRecording` keep their own
  `visibilitychange` listeners.** They track *leaving* the page, poll gating, and
  recording lifecycle respectively — different concepts from "came back", and
  none of them is focus-triggered, so none contributed to the burst.
- **`readPageActivity` stays exported** although the sampler is now its only
  caller; it is the module's documented one-shot reading and is used by the
  sampler itself.
- **The share popup still issues its own duplicate
  `POST /access-settings/read`.** Trimming the popup's own three-to-four requests
  (skipping the `access` refetch when `initialAccess` is present, replacing the
  write-shaped `POST /ensure` read) is deliberately out of scope here and left as
  follow-up.
- **Regaining sight of an unobservable context revalidates once, on purpose.**
  A cross-origin frame refuses listeners and hides its focus changes either way,
  so when the page becomes observable again the sampler reports the return rather
  than assuming nothing happened. The trigger is that transition, not the flag:
  while focus stays in the frame — including across its own reloads — nothing
  fires, because losing sight is what the sampler was already told and only
  seeing the page again is news. In
  this tree that is the Vault sandbox confirmation surface and the `sandbox=""`
  HTML preview in `ui/src/components/ui/file-preview.tsx`; every Show Page frame
  carries `allow-same-origin` and stays on the exact path.
- **One reactivation still fans out to several independent revalidations.**
  Batching them into a single pass is the follow-up to this PR; this change
  removes the *spurious* fires, not the fan-out of a genuine one.

## Evidence

**Unit** — `ui/src/lib/pageActivity.test.ts` covers the edge detector (the
inactive→active edge fires once per gap; a return of window focus with no
visibility change fires; a revealed-but-unfocused tab waits for focus; focus
moving inside a page that never left stays silent; both initial-state cases) and
then asserts the partition member by member: a system focus loss arriving at the
frame that holds focus, focus bouncing between page and frame, a stale frame
that must not speak for the page, rebinding onto the window a navigation put
behind the frame, descending into a nested frame, descending through a shadow
root, and treating a return from a cross-origin frame as a return.

**Regression** — `ui/src/context/WorkbenchSessionReadOrdering.test.tsx` simulated
a resume with a bare `window.dispatchEvent(new Event('focus'))`, which encoded
exactly the level-triggered behaviour this PR removes. Those five tests now call
a `simulatePageResume()` helper that models a real gap. The behaviour under test
(reconcile serialisation and ordering) is unchanged.

**Manual, in the browser against a live session** — with focus first moved into
the Show Page iframe, then the share popup opened:

| | before | after |
| --- | --- | --- |
| popup open | ~16 requests | **4**, all the popup's own |
| popup close | several | **0** |

The parent `window:focus vis=visible hasFocus=true active=BODY` event still
fires after the change — the old trigger condition is still met — and now
produces no revalidation.

**Gates** — `npm run build` ✓, `npm run lint` ✓ (708 sources, no drift in any
(file, rule) pair), `npm test` 2831/2832. The single failure,
`SourceDetailPanel > gives every repair kind a reachable declared destination`,
is a pre-existing full-suite-load timeout: it reproduces identically on
`origin/master` (1 failed / 2818 passed) and passes 68/68 when that file is run
alone.

