### PR TITLE
fix(show): refine share popup controls

### DIFF
--- a/ui/src/components/workbench/ShowPageShareControl.test.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.test.tsx
@@ -232,6 +232,9 @@ describe('ShowPageShareControl payload sequencing without prior access', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Share' }));
 
     expect(await screen.findByDisplayValue('https://alice.avibe.bot/p/stable-link/')).toBeTruthy();
+    const openLink = screen.getByRole('link', { name: 'Open' });
+    expect(openLink.getAttribute('href')).toBe('https://alice.avibe.bot/p/stable-link/');
+    expect(openLink.getAttribute('target')).toBe('_blank');
     expect(screen.getByRole('button', { name: 'Copy link' })).toBeTruthy();
   });
 
@@ -262,13 +265,14 @@ describe('ShowPageShareControl payload sequencing without prior access', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Share' }));
 
     await waitFor(() => expect(api.ensureShowPage).toHaveBeenCalledWith('ses-1'));
+    expect((screen.getByRole('button', { name: 'Open' }) as HTMLButtonElement).disabled).toBe(true);
     expect((screen.getByRole('button', { name: 'Copy link' }) as HTMLButtonElement).disabled).toBe(
       true,
     );
     expect(screen.queryByDisplayValue(/\/p\/stable-link\/$/)).toBeNull();
   });
 
-  it('keeps online state and Workspace access out of the share popover', async () => {
+  it('keeps explicit custom-link saving while online and Workspace controls stay out', async () => {
     api.getShowPageAccess.mockResolvedValue({
       ok: true,
       mode: 'local',
@@ -278,8 +282,8 @@ describe('ShowPageShareControl payload sequencing without prior access', () => {
     });
     api.ensureShowPage.mockResolvedValue({
       session_id: 'ses-1',
-      visibility: 'private',
-      active_url: '/show/ses-1/',
+      visibility: 'public',
+      active_url: '/p/stable-link/',
       share_id: 'stable-link',
       url_available: true,
       offline: false,
@@ -288,9 +292,19 @@ describe('ShowPageShareControl payload sequencing without prior access', () => {
     api.getShowAccessSettings.mockResolvedValue({
       show_access: {
         page_id: 'ses-1',
-        access_mode: 'private',
+        access_mode: 'public',
         share_id: 'stable-link',
         revision: 0,
+        normalized_emails: [],
+      },
+    });
+    api.applyShowAccess.mockResolvedValue({
+      status: 'applied',
+      show_access: {
+        page_id: 'ses-1',
+        access_mode: 'public',
+        share_id: 'new-link',
+        revision: 1,
         normalized_emails: [],
       },
     });
@@ -302,10 +316,28 @@ describe('ShowPageShareControl payload sequencing without prior access', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: 'Share' }));
 
-    expect(await screen.findByRole('button', { name: 'Access: Private' })).toBeTruthy();
+    expect(await screen.findByRole('button', { name: 'Access: Fully public' })).toBeTruthy();
+    const customLink = screen.getByRole('textbox', { name: 'Custom link' });
+    expect((customLink as HTMLInputElement).value).toBe('stable-link');
+    expect(screen.getByText('Custom link')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
+    fireEvent.change(customLink, { target: { value: 'new-link' } });
+    fireEvent.blur(customLink);
+
+    expect(api.applyShowAccess).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(api.applyShowAccess).toHaveBeenCalledWith('ses-1', {
+        expected_revision: 0,
+        target_access_mode: 'public',
+        target_share_id: 'new-link',
+        target_emails: [],
+      });
+    });
     expect(screen.queryByText('Workspace access')).toBeNull();
     expect(screen.queryByText('Page online')).toBeNull();
-    expect(screen.queryByRole('textbox', { name: 'Custom link' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Apply' })).toBeNull();
     expect(api.setShowPageAvailability).not.toHaveBeenCalled();
   });
 

--- a/ui/src/components/workbench/ShowPageShareControl.tsx
+++ b/ui/src/components/workbench/ShowPageShareControl.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Check, Copy, LayoutGrid, Loader2, Plus, Share2 } from 'lucide-react';
+import { Check, Copy, ExternalLink, LayoutGrid, Loader2, Plus, Share2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '../ui/button';
@@ -206,7 +206,7 @@ export const ShowPageShareControl: React.FC<{
       </PopoverTrigger>
       <PopoverContent
         align="end"
-        className="w-[min(27rem,calc(100vw-1rem))] space-y-3"
+        className="w-[min(23rem,calc(100vw-1rem))] space-y-3"
         data-window-owner-id={ownerWindowId}
       >
         <div className="text-sm font-medium">{t('chat.showPage.shareTitle')}</div>
@@ -229,6 +229,34 @@ export const ShowPageShareControl: React.FC<{
               onFocus={(event) => event.currentTarget.select()}
               className="h-8 min-w-0 flex-1 text-xs"
             />
+            {link ? (
+              <Button
+                asChild
+                variant="outline"
+                size="icon"
+                className="size-8 shrink-0"
+              >
+                <a
+                  href={link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={t('showPages.open')}
+                >
+                  <ExternalLink className="size-3.5" />
+                </a>
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="size-8 shrink-0"
+                disabled
+                aria-label={t('showPages.open')}
+              >
+                <ExternalLink className="size-3.5" />
+              </Button>
+            )}
             <Button
               type="button"
               variant="outline"
@@ -264,7 +292,6 @@ export const ShowPageShareControl: React.FC<{
               sessionId={sessionId}
               onApplied={handleShowAccessApplied}
               ownerWindowId={ownerWindowId}
-              showCustomLink={false}
             />
           </div>
         ) : null}

--- a/ui/src/components/workbench/ShowPageSharingSettings.test.tsx
+++ b/ui/src/components/workbench/ShowPageSharingSettings.test.tsx
@@ -104,7 +104,9 @@ describe('ShowPageSharingSettings', () => {
 
     await chooseMode('Limited');
     expect(screen.queryByRole('button', { name: 'Apply' })).toBeNull();
-    fireEvent.change(screen.getByRole('textbox', { name: 'People with access' }), {
+    const emailInput = screen.getByRole('textbox', { name: 'People with access' });
+    expect(emailInput.parentElement?.parentElement?.className).toContain('max-w-[17.5rem]');
+    fireEvent.change(emailInput, {
       target: { value: ' Guest@Example.COM ' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Add email' }));
@@ -189,7 +191,7 @@ describe('ShowPageSharingSettings', () => {
     expect(screen.getByText(/changed elsewhere/)).toBeTruthy();
   });
 
-  it('keeps the custom-link draft visible after an automatic collision response', async () => {
+  it('shows an explicit custom-link save action only after editing', async () => {
     api.getShowAccessSettings.mockResolvedValue({
       show_access: showAccess({ access_mode: 'public' }),
     });
@@ -200,8 +202,15 @@ describe('ShowPageSharingSettings', () => {
     renderSettings();
     const input = await screen.findByRole('textbox', { name: 'Custom link' });
 
+    expect(screen.getByText('Custom link')).toBeTruthy();
+    expect(input.parentElement?.className).toContain('max-w-[17.5rem]');
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
     fireEvent.change(input, { target: { value: 'taken-link' } });
     fireEvent.blur(input);
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(api.applyShowAccess).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(await screen.findByText('That custom link is already taken. Pick another.')).toBeTruthy();
     expect((screen.getByRole('textbox', { name: 'Custom link' }) as HTMLInputElement).value).toBe(
@@ -222,7 +231,7 @@ describe('ShowPageSharingSettings', () => {
     const input = await screen.findByRole('textbox', { name: 'Custom link' });
 
     fireEvent.change(input, { target: { value: 'new-link' } });
-    fireEvent.blur(input);
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
     await waitFor(() => expect(api.applyShowAccess).toHaveBeenCalledTimes(1));
     view.unmount();
 
@@ -239,6 +248,43 @@ describe('ShowPageSharingSettings', () => {
     });
 
     expect(onApplied).toHaveBeenCalledWith(expect.objectContaining({ share_id: 'new-link' }));
+  });
+
+  it('keeps an unsaved custom-link draft out of access autosaves', async () => {
+    api.getShowAccessSettings.mockResolvedValue({
+      show_access: showAccess({
+        access_mode: 'limited',
+        normalized_emails: ['first@example.com'],
+      }),
+    });
+    api.applyShowAccess.mockResolvedValue({
+      status: 'applied',
+      show_access: showAccess({
+        access_mode: 'limited',
+        normalized_emails: ['first@example.com', 'second@example.com'],
+        revision: 1,
+      }),
+    });
+    renderSettings();
+
+    const customLink = await screen.findByRole('textbox', { name: 'Custom link' });
+    fireEvent.change(customLink, { target: { value: 'unsaved-link' } });
+    fireEvent.change(screen.getByRole('textbox', { name: 'People with access' }), {
+      target: { value: 'second@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add email' }));
+
+    await waitFor(() => expect(api.applyShowAccess).toHaveBeenCalledTimes(1));
+    expect(api.applyShowAccess).toHaveBeenCalledWith('ses-1', {
+      expected_revision: 0,
+      target_access_mode: 'limited',
+      target_share_id: 'stable-link',
+      target_emails: ['first@example.com', 'second@example.com'],
+    });
+    expect((screen.getByRole('textbox', { name: 'Custom link' }) as HTMLInputElement).value).toBe(
+      'unsaved-link',
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy();
   });
 
   it('can hide custom-link editing when embedded in the share popover', async () => {

--- a/ui/src/components/workbench/ShowPageSharingSettings.test.tsx
+++ b/ui/src/components/workbench/ShowPageSharingSettings.test.tsx
@@ -172,9 +172,14 @@ describe('ShowPageSharingSettings', () => {
     expect(remove.getAttribute('title')).toBe('Switch to Private to remove the last email');
   });
 
-  it('reloads the latest snapshot after an automatic CAS conflict', async () => {
+  it('reloads the latest access snapshot without dropping a custom-link draft after a CAS conflict', async () => {
     api.getShowAccessSettings
-      .mockResolvedValueOnce({ show_access: showAccess() })
+      .mockResolvedValueOnce({
+        show_access: showAccess({
+          access_mode: 'limited',
+          normalized_emails: ['guest@example.com'],
+        }),
+      })
       .mockResolvedValueOnce({
         show_access: showAccess({ access_mode: 'public', revision: 3 }),
       });
@@ -184,11 +189,18 @@ describe('ShowPageSharingSettings', () => {
     });
     renderSettings();
 
+    const customLink = await screen.findByRole('textbox', { name: 'Custom link' });
+    fireEvent.change(customLink, { target: { value: 'unsaved-link' } });
+
     await chooseMode('Fully public');
 
     await waitFor(() => expect(api.getShowAccessSettings).toHaveBeenCalledTimes(2));
     expect(screen.getByRole('button', { name: 'Access: Fully public' })).toBeTruthy();
     expect(screen.getByText(/changed elsewhere/)).toBeTruthy();
+    expect((screen.getByRole('textbox', { name: 'Custom link' }) as HTMLInputElement).value).toBe(
+      'unsaved-link',
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy();
   });
 
   it('shows an explicit custom-link save action only after editing', async () => {

--- a/ui/src/components/workbench/ShowPageSharingSettings.test.tsx
+++ b/ui/src/components/workbench/ShowPageSharingSettings.test.tsx
@@ -203,6 +203,83 @@ describe('ShowPageSharingSettings', () => {
     expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy();
   });
 
+  it('keeps an explicitly submitted custom-link draft after a CAS conflict', async () => {
+    api.getShowAccessSettings
+      .mockResolvedValueOnce({ show_access: showAccess({ access_mode: 'public' }) })
+      .mockResolvedValueOnce({
+        show_access: showAccess({ access_mode: 'public', revision: 2, share_id: 'server-link' }),
+      });
+    api.applyShowAccess.mockResolvedValue({
+      status: 'conflict',
+      show_access: showAccess({ access_mode: 'public', revision: 1, share_id: 'other-link' }),
+    });
+    renderSettings();
+
+    const customLink = await screen.findByRole('textbox', { name: 'Custom link' });
+    fireEvent.change(customLink, { target: { value: 'submitted-link' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(api.getShowAccessSettings).toHaveBeenCalledTimes(2));
+    expect((screen.getByRole('textbox', { name: 'Custom link' }) as HTMLInputElement).value).toBe(
+      'submitted-link',
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy();
+  });
+
+  it('adopts a concurrent custom link when an access autosave had no link draft', async () => {
+    api.getShowAccessSettings
+      .mockResolvedValueOnce({
+        show_access: showAccess({
+          access_mode: 'limited',
+          normalized_emails: ['guest@example.com'],
+        }),
+      })
+      .mockResolvedValueOnce({
+        show_access: showAccess({ access_mode: 'public', revision: 2, share_id: 'server-link' }),
+      });
+    api.applyShowAccess.mockResolvedValue({
+      status: 'conflict',
+      show_access: showAccess({ access_mode: 'limited', revision: 1 }),
+    });
+    renderSettings();
+
+    await chooseMode('Fully public');
+
+    await waitFor(() => expect(api.getShowAccessSettings).toHaveBeenCalledTimes(2));
+    expect((screen.getByRole('textbox', { name: 'Custom link' }) as HTMLInputElement).value).toBe(
+      'server-link',
+    );
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
+  });
+
+  it('keeps a custom-link draft when retrying a failed access autosave', async () => {
+    api.getShowAccessSettings
+      .mockResolvedValueOnce({
+        show_access: showAccess({
+          access_mode: 'limited',
+          normalized_emails: ['guest@example.com'],
+        }),
+      })
+      .mockResolvedValueOnce({
+        show_access: showAccess({ access_mode: 'public', revision: 2, share_id: 'server-link' }),
+      });
+    api.applyShowAccess.mockRejectedValueOnce(new Error('network unavailable'));
+    renderSettings();
+
+    const customLink = await screen.findByRole('textbox', { name: 'Custom link' });
+    fireEvent.change(customLink, { target: { value: 'retry-link' } });
+    await chooseMode('Fully public');
+    await waitFor(() => expect(screen.getByText('Link access could not be loaded.')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => expect(api.getShowAccessSettings).toHaveBeenCalledTimes(2));
+    expect((screen.getByRole('textbox', { name: 'Custom link' }) as HTMLInputElement).value).toBe(
+      'retry-link',
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy();
+  });
+
   it('shows an explicit custom-link save action only after editing', async () => {
     api.getShowAccessSettings.mockResolvedValue({
       show_access: showAccess({ access_mode: 'public' }),

--- a/ui/src/components/workbench/ShowPageSharingSettings.test.tsx
+++ b/ui/src/components/workbench/ShowPageSharingSettings.test.tsx
@@ -307,6 +307,27 @@ describe('ShowPageSharingSettings', () => {
     );
   });
 
+  it('adopts the canonical custom link after a successful save', async () => {
+    api.getShowAccessSettings.mockResolvedValue({
+      show_access: showAccess({ access_mode: 'public' }),
+    });
+    api.applyShowAccess.mockResolvedValue({
+      status: 'applied',
+      show_access: showAccess({ access_mode: 'public', revision: 1, share_id: 'canonical-link' }),
+    });
+    renderSettings();
+
+    const input = await screen.findByRole('textbox', { name: 'Custom link' });
+    fireEvent.change(input, { target: { value: ' canonical-link ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(api.applyShowAccess).toHaveBeenCalledTimes(1));
+    expect((screen.getByRole('textbox', { name: 'Custom link' }) as HTMLInputElement).value).toBe(
+      'canonical-link',
+    );
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
+  });
+
   it('reconciles a successful custom-link save after the editor unmounts', async () => {
     api.getShowAccessSettings.mockResolvedValue({
       show_access: showAccess({ access_mode: 'public' }),

--- a/ui/src/components/workbench/ShowPageSharingSettings.tsx
+++ b/ui/src/components/workbench/ShowPageSharingSettings.tsx
@@ -288,7 +288,7 @@ export function ShowPageSharingSettings({
     setMode(nextMode);
     setEmailInvalid(false);
     if (nextMode === 'limited' && emails.length === 0) return;
-    void commit(nextMode, savedRef.current?.share_id ?? shareId, emails, true);
+    void commit(nextMode, savedRef.current?.share_id ?? shareId, emails, shareIdDirty);
   };
 
   const addEmail = () => {
@@ -303,7 +303,7 @@ export function ShowPageSharingSettings({
     setEmailDraft('');
     setEmailInvalid(false);
     if (mode === 'limited') {
-      void commit(mode, savedRef.current?.share_id ?? shareId, nextEmails, true);
+      void commit(mode, savedRef.current?.share_id ?? shareId, nextEmails, shareIdDirty);
     }
   };
 
@@ -312,13 +312,13 @@ export function ShowPageSharingSettings({
     const nextEmails = emails.filter((value) => value !== email);
     setEmails(nextEmails);
     if (mode === 'limited') {
-      void commit(mode, savedRef.current?.share_id ?? shareId, nextEmails, true);
+      void commit(mode, savedRef.current?.share_id ?? shareId, nextEmails, shareIdDirty);
     }
   };
 
   const saveShareId = () => {
     if (!editable || shareIdInvalid) return;
-    void commit(mode, shareId, emails);
+    void commit(mode, shareId, emails, true);
   };
 
   if (!canManage) return null;
@@ -525,7 +525,7 @@ export function ShowPageSharingSettings({
                 size="icon"
                 variant="ghost"
                 className="size-7 shrink-0"
-                onClick={() => void load()}
+                onClick={() => void load('ready', shareIdDirty)}
                 aria-label={t('common.retry')}
               >
                 <RefreshCw className="size-3.5" />
@@ -543,7 +543,7 @@ export function ShowPageSharingSettings({
             size="icon"
             variant="ghost"
             className="size-7"
-            onClick={() => void load()}
+            onClick={() => void load('ready', shareIdDirty)}
             aria-label={t('common.retry')}
           >
             <RefreshCw className="size-3.5" />

--- a/ui/src/components/workbench/ShowPageSharingSettings.tsx
+++ b/ui/src/components/workbench/ShowPageSharingSettings.tsx
@@ -216,7 +216,8 @@ export function ShowPageSharingSettings({
     nextMode: ShowAccessMode,
     nextShareId: string,
     nextEmails: string[],
-    preserveShareIdDraft = false,
+    preserveShareIdDraftOnConflict = false,
+    preserveShareIdDraftOnSuccess = preserveShareIdDraftOnConflict,
   ) => {
     const current = savedRef.current;
     const targetShareId = nextShareId.trim() || null;
@@ -262,14 +263,14 @@ export function ShowPageSharingSettings({
       if (result.status === 'conflict') {
         savingRef.current = false;
         setSaving(false);
-        await load('conflict', preserveShareIdDraft);
+        await load('conflict', preserveShareIdDraftOnConflict);
         return;
       }
       if (result.status === 'share_id_taken' || result.status === 'invalid') {
         setGate(result.status);
         return;
       }
-      adopt(result.show_access, preserveShareIdDraft);
+      adopt(result.show_access, preserveShareIdDraftOnSuccess);
       setGate('ready');
       onApplied?.(result.show_access);
     } catch {
@@ -318,7 +319,7 @@ export function ShowPageSharingSettings({
 
   const saveShareId = () => {
     if (!editable || shareIdInvalid) return;
-    void commit(mode, shareId, emails, true);
+    void commit(mode, shareId, emails, true, false);
   };
 
   if (!canManage) return null;

--- a/ui/src/components/workbench/ShowPageSharingSettings.tsx
+++ b/ui/src/components/workbench/ShowPageSharingSettings.tsx
@@ -166,13 +166,16 @@ export function ShowPageSharingSettings({
     [sessionId],
   );
 
-  const load = useCallback(async (settledGate: Gate = 'ready') => {
+  const load = useCallback(async (
+    settledGate: Gate = 'ready',
+    preserveShareIdDraft = false,
+  ) => {
     const generation = ++generationRef.current;
     setGate('loading');
     try {
       const result = await api.getShowAccessSettings(sessionId);
       if (generation !== generationRef.current) return;
-      adopt(result.show_access);
+      adopt(result.show_access, preserveShareIdDraft);
       setGate(settledGate);
     } catch {
       if (generation !== generationRef.current) return;
@@ -259,7 +262,7 @@ export function ShowPageSharingSettings({
       if (result.status === 'conflict') {
         savingRef.current = false;
         setSaving(false);
-        await load('conflict');
+        await load('conflict', preserveShareIdDraft);
         return;
       }
       if (result.status === 'share_id_taken' || result.status === 'invalid') {

--- a/ui/src/components/workbench/ShowPageSharingSettings.tsx
+++ b/ui/src/components/workbench/ShowPageSharingSettings.tsx
@@ -152,16 +152,19 @@ export function ShowPageSharingSettings({
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
 
-  const adopt = useCallback((showAccess: ShowAccess) => {
-    if (showAccess.page_id !== sessionId) throw new Error('ShowAccess page identity mismatch');
-    savedRef.current = showAccess;
-    setSaved(showAccess);
-    setMode(showAccess.access_mode);
-    setShareId(showAccess.share_id ?? '');
-    setEmails(showAccess.normalized_emails);
-    setEmailDraft('');
-    setEmailInvalid(false);
-  }, [sessionId]);
+  const adopt = useCallback(
+    (showAccess: ShowAccess, preserveShareIdDraft = false) => {
+      if (showAccess.page_id !== sessionId) throw new Error('ShowAccess page identity mismatch');
+      savedRef.current = showAccess;
+      setSaved(showAccess);
+      setMode(showAccess.access_mode);
+      if (!preserveShareIdDraft) setShareId(showAccess.share_id ?? '');
+      setEmails(showAccess.normalized_emails);
+      setEmailDraft('');
+      setEmailInvalid(false);
+    },
+    [sessionId],
+  );
 
   const load = useCallback(async (settledGate: Gate = 'ready') => {
     const generation = ++generationRef.current;
@@ -199,9 +202,10 @@ export function ShowPageSharingSettings({
   const normalizedShareId = shareId.trim() || null;
   const sharedMode = mode === 'limited' || mode === 'public';
   const shareIdInvalid = sharedMode && (!normalizedShareId || !isValidShareId(normalizedShareId));
-  const dirty = Boolean(
-    saved && showAccessDraftChanged(saved, mode, normalizedShareId, emails),
+  const accessDirty = Boolean(
+    saved && showAccessDraftChanged(saved, mode, saved.share_id, emails),
   );
+  const shareIdDirty = Boolean(saved && normalizedShareId !== saved.share_id);
   const emailLimitReached = emails.length >= SHOW_ACCESS_EMAIL_MAX_COUNT;
   const editable = canManage && gate !== 'loading' && !saving;
 
@@ -209,11 +213,13 @@ export function ShowPageSharingSettings({
     nextMode: ShowAccessMode,
     nextShareId: string,
     nextEmails: string[],
+    preserveShareIdDraft = false,
   ) => {
     const current = savedRef.current;
     const targetShareId = nextShareId.trim() || null;
     const nextTargetEmails = showAccessTargetEmails(nextMode, nextEmails);
-    const nextInvalid = (nextMode !== 'private' && (!targetShareId || !isValidShareId(targetShareId)))
+    const nextInvalid =
+      (nextMode !== 'private' && (!targetShareId || !isValidShareId(targetShareId)))
       || (nextMode === 'limited' && nextTargetEmails.length === 0);
     if (
       !current
@@ -222,12 +228,13 @@ export function ShowPageSharingSettings({
       || !canManage
       || gate === 'loading'
       || !showAccessDraftChanged(current, nextMode, targetShareId, nextEmails)
-    ) return;
+    ) {
+      return;
+    }
     const generation = generationRef.current;
     const requestSessionId = sessionId;
-    const isCurrent = () => (
-      generation === generationRef.current && requestSessionId === sessionIdRef.current
-    );
+    const isCurrent = () =>
+      generation === generationRef.current && requestSessionId === sessionIdRef.current;
     savingRef.current = true;
     setSaving(true);
     try {
@@ -237,7 +244,9 @@ export function ShowPageSharingSettings({
         target_share_id: targetShareId,
         target_emails: nextTargetEmails,
       });
-      if (result.show_access.page_id !== requestSessionId) throw new Error('ShowAccess page identity mismatch');
+      if (result.show_access.page_id !== requestSessionId) {
+        throw new Error('ShowAccess page identity mismatch');
+      }
       if (!isCurrent()) {
         // Collapsing the row unmounts this editor, but the successful write still
         // has to reconcile the shared inventory so its copied link is not stale.
@@ -257,7 +266,7 @@ export function ShowPageSharingSettings({
         setGate(result.status);
         return;
       }
-      adopt(result.show_access);
+      adopt(result.show_access, preserveShareIdDraft);
       setGate('ready');
       onApplied?.(result.show_access);
     } catch {
@@ -276,7 +285,7 @@ export function ShowPageSharingSettings({
     setMode(nextMode);
     setEmailInvalid(false);
     if (nextMode === 'limited' && emails.length === 0) return;
-    void commit(nextMode, shareId, emails);
+    void commit(nextMode, savedRef.current?.share_id ?? shareId, emails, true);
   };
 
   const addEmail = () => {
@@ -290,14 +299,18 @@ export function ShowPageSharingSettings({
     setEmails(nextEmails);
     setEmailDraft('');
     setEmailInvalid(false);
-    if (mode === 'limited') void commit(mode, shareId, nextEmails);
+    if (mode === 'limited') {
+      void commit(mode, savedRef.current?.share_id ?? shareId, nextEmails, true);
+    }
   };
 
   const removeEmail = (email: string) => {
     if (!editable || (mode === 'limited' && emails.length <= 1)) return;
     const nextEmails = emails.filter((value) => value !== email);
     setEmails(nextEmails);
-    if (mode === 'limited') void commit(mode, shareId, nextEmails);
+    if (mode === 'limited') {
+      void commit(mode, savedRef.current?.share_id ?? shareId, nextEmails, true);
+    }
   };
 
   const saveShareId = () => {
@@ -308,7 +321,7 @@ export function ShowPageSharingSettings({
   if (!canManage) return null;
 
   return (
-    <section className="space-y-2.5" aria-label={t('chat.showPage.sharingAccess')}>
+    <div className="space-y-2.5">
       {gate === 'loading' || gate === 'idle' ? (
         <div className="flex min-h-9 items-center justify-between gap-3">
           <div className="text-sm font-medium">{t('chat.showPage.sharingAccess')}</div>
@@ -319,124 +332,13 @@ export function ShowPageSharingSettings({
         </div>
       ) : saved ? (
         <>
-          <div className="flex items-center justify-between gap-3">
-            <div className="min-w-0">
-              <div className="text-sm font-medium">{t('chat.showPage.sharingAccess')}</div>
-              <div className="mt-0.5 flex items-center gap-1 text-[11px] text-muted" role="status">
-                {saving ? (
-                  <>
-                    <Loader2 className="size-3 animate-spin" />
-                    {t('common.saving')}
-                  </>
-                ) : (
-                  <>
-                    <Check className="size-3 text-mint-ink" />
-                    {t('chat.showPage.sharingAutoSave')}
-                  </>
-                )}
-              </div>
-            </div>
-            <AccessModeSelect
-              value={mode}
-              disabled={!editable}
-              onChange={changeMode}
-              ownerWindowId={ownerWindowId}
-            />
-          </div>
-
-          {mode === 'limited' ? (
-            <div className="space-y-2">
-              <div className="flex items-center justify-between gap-2">
-                <span className="text-[11px] font-medium text-foreground">
-                  {t('chat.showPage.limitedEmails')}
-                </span>
-                {saved.access_mode === 'limited' && !dirty && !saving ? (
-                  <span className="flex items-center gap-1 text-[11px] text-mint-ink">
-                    <Check className="size-3" />
-                    {t('common.saved')}
-                  </span>
-                ) : null}
-              </div>
-              <div className="flex items-start gap-1.5">
-                <div className="min-w-0 flex-1">
-                  <Input
-                    type="email"
-                    value={emailDraft}
-                    disabled={!editable || emailLimitReached}
-                    onChange={(event) => {
-                      setEmailDraft(event.target.value);
-                      setEmailInvalid(false);
-                    }}
-                    onKeyDown={(event) => {
-                      if (event.key !== 'Enter') return;
-                      event.preventDefault();
-                      addEmail();
-                    }}
-                    placeholder={t('chat.showPage.emailPlaceholder')}
-                    aria-label={t('chat.showPage.limitedEmails')}
-                    aria-invalid={emailInvalid || undefined}
-                    className={clsx('h-8 text-xs', emailInvalid && 'border-destructive')}
-                  />
-                  {emailInvalid ? (
-                    <p className="mt-1 text-[11px] text-destructive-ink">
-                      {t('chat.showPage.emailInvalid')}
-                    </p>
-                  ) : null}
-                </div>
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="outline"
-                  className="size-8 shrink-0"
-                  disabled={!editable || !emailDraft || emailLimitReached}
-                  onClick={addEmail}
-                  aria-label={t('chat.showPage.addEmail')}
-                >
-                  <Plus className="size-3.5" />
-                </Button>
-              </div>
-              {emails.length ? (
-                <div className="flex max-h-32 flex-wrap gap-1.5 overflow-y-auto">
-                  {emails.map((email) => {
-                    const lastLimitedEmail = mode === 'limited' && emails.length === 1;
-                    return (
-                      <span
-                        key={email}
-                        className="inline-flex h-7 max-w-full items-center gap-1 rounded-md border border-border bg-foreground/[0.04] pl-2.5 pr-1 text-[11px] text-foreground"
-                      >
-                        <span className="min-w-0 truncate font-mono">{email}</span>
-                        <Button
-                          type="button"
-                          size="icon"
-                          variant="ghost"
-                          className="size-5 shrink-0"
-                          disabled={!editable || lastLimitedEmail}
-                          onClick={() => removeEmail(email)}
-                          aria-label={t('chat.showPage.removeEmail', { email })}
-                          title={lastLimitedEmail
-                            ? t('chat.showPage.keepOneLimitedEmail')
-                            : t('chat.showPage.removeEmail', { email })}
-                        >
-                          <X className="size-3" />
-                        </Button>
-                      </span>
-                    );
-                  })}
-                </div>
-              ) : (
-                <p className="text-[11px] text-destructive-ink">
-                  {t('chat.showPage.limitedEmailRequired')}
-                </p>
-              )}
-              <p className="text-[11px] text-muted">
-                {t('chat.showPage.limitedEmailHint', { count: SHOW_ACCESS_EMAIL_MAX_COUNT })}
-              </p>
-            </div>
-          ) : null}
-
           {showCustomLink && sharedMode ? (
-            <div className="space-y-1">
-              <div className="flex items-center gap-1.5">
+            <section
+              className="space-y-1.5"
+              aria-label={t('showPages.shareId.label')}
+            >
+              <div className="text-sm font-medium">{t('showPages.shareId.label')}</div>
+              <div className="grid w-full max-w-[17.5rem] grid-cols-[auto_minmax(0,1fr)_2rem] items-center gap-1.5">
                 <span className="shrink-0 font-mono text-xs text-muted">/p/</span>
                 <Input
                   value={shareId}
@@ -449,19 +351,33 @@ export function ShowPageSharingSettings({
                     setShareId(event.target.value);
                     if (gate === 'share_id_taken') setGate('ready');
                   }}
-                  onBlur={saveShareId}
-                  onKeyDown={(event) => {
-                    if (event.key !== 'Enter') return;
-                    event.preventDefault();
-                    event.currentTarget.blur();
-                  }}
                   aria-label={t('showPages.shareId.label')}
                   aria-invalid={shareIdInvalid || gate === 'share_id_taken' || undefined}
                   className={clsx(
-                    'h-8 min-w-0 flex-1 font-mono text-xs',
+                    'h-8 min-w-0 w-full font-mono text-xs',
                     (shareIdInvalid || gate === 'share_id_taken') && 'border-destructive',
                   )}
                 />
+                <div className="size-8 shrink-0">
+                  {shareIdDirty ? (
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="outline"
+                      className="size-8"
+                      disabled={
+                        !editable
+                        || shareIdInvalid
+                        || (mode === 'limited' && emails.length === 0)
+                      }
+                      onClick={saveShareId}
+                      aria-label={t('common.save')}
+                      title={t('common.save')}
+                    >
+                      <Check className="size-3.5" />
+                    </Button>
+                  ) : null}
+                </div>
               </div>
               {shareIdInvalid || gate === 'share_id_taken' ? (
                 <p className="text-[11px] text-destructive-ink">
@@ -469,11 +385,132 @@ export function ShowPageSharingSettings({
                     ? t('showPages.shareId.errors.taken')
                     : t('showPages.shareId.errors.invalid')}
                 </p>
-              ) : (
-                <p className="text-[11px] text-muted">{t('chat.showPage.shareIdAutoSaveHint')}</p>
-              )}
-            </div>
+              ) : null}
+            </section>
           ) : null}
+
+          <section
+            aria-label={t('chat.showPage.sharingAccess')}
+            className={clsx(
+              'space-y-2.5',
+              showCustomLink && sharedMode && 'border-t border-border pt-3',
+            )}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="text-sm font-medium">{t('chat.showPage.sharingAccess')}</div>
+                <div className="mt-0.5 flex items-center gap-1 text-[11px] text-muted" role="status">
+                  {saving ? (
+                    <>
+                      <Loader2 className="size-3 animate-spin" />
+                      {t('common.saving')}
+                    </>
+                  ) : (
+                    <>
+                      <Check className="size-3 text-mint-ink" />
+                      {t('chat.showPage.sharingAutoSave')}
+                    </>
+                  )}
+                </div>
+              </div>
+              <AccessModeSelect
+                value={mode}
+                disabled={!editable}
+                onChange={changeMode}
+                ownerWindowId={ownerWindowId}
+              />
+            </div>
+
+            {mode === 'limited' ? (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-[11px] font-medium text-foreground">
+                    {t('chat.showPage.limitedEmails')}
+                  </span>
+                  {saved.access_mode === 'limited' && !accessDirty && !saving ? (
+                    <span className="flex items-center gap-1 text-[11px] text-mint-ink">
+                      <Check className="size-3" />
+                      {t('common.saved')}
+                    </span>
+                  ) : null}
+                </div>
+                <div className="flex w-full max-w-[17.5rem] items-start gap-1.5">
+                  <div className="min-w-0 flex-1">
+                    <Input
+                      type="email"
+                      value={emailDraft}
+                      disabled={!editable || emailLimitReached}
+                      onChange={(event) => {
+                        setEmailDraft(event.target.value);
+                        setEmailInvalid(false);
+                      }}
+                      onKeyDown={(event) => {
+                        if (event.key !== 'Enter') return;
+                        event.preventDefault();
+                        addEmail();
+                      }}
+                      placeholder={t('chat.showPage.emailPlaceholder')}
+                      aria-label={t('chat.showPage.limitedEmails')}
+                      aria-invalid={emailInvalid || undefined}
+                      className={clsx('h-8 text-xs', emailInvalid && 'border-destructive')}
+                    />
+                    {emailInvalid ? (
+                      <p className="mt-1 text-[11px] text-destructive-ink">
+                        {t('chat.showPage.emailInvalid')}
+                      </p>
+                    ) : null}
+                  </div>
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="outline"
+                    className="size-8 shrink-0"
+                    disabled={!editable || !emailDraft || emailLimitReached}
+                    onClick={addEmail}
+                    aria-label={t('chat.showPage.addEmail')}
+                  >
+                    <Plus className="size-3.5" />
+                  </Button>
+                </div>
+                {emails.length ? (
+                  <div className="flex max-h-32 flex-wrap gap-1.5 overflow-y-auto">
+                    {emails.map((email) => {
+                      const lastLimitedEmail = mode === 'limited' && emails.length === 1;
+                      return (
+                        <span
+                          key={email}
+                          className="inline-flex h-7 max-w-full items-center gap-1 rounded-md border border-border bg-foreground/[0.04] pl-2.5 pr-1 text-[11px] text-foreground"
+                        >
+                          <span className="min-w-0 truncate font-mono">{email}</span>
+                          <Button
+                            type="button"
+                            size="icon"
+                            variant="ghost"
+                            className="size-5 shrink-0"
+                            disabled={!editable || lastLimitedEmail}
+                            onClick={() => removeEmail(email)}
+                            aria-label={t('chat.showPage.removeEmail', { email })}
+                            title={lastLimitedEmail
+                              ? t('chat.showPage.keepOneLimitedEmail')
+                              : t('chat.showPage.removeEmail', { email })}
+                          >
+                            <X className="size-3" />
+                          </Button>
+                        </span>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <p className="text-[11px] text-destructive-ink">
+                    {t('chat.showPage.limitedEmailRequired')}
+                  </p>
+                )}
+                <p className="text-[11px] text-muted">
+                  {t('chat.showPage.limitedEmailHint', { count: SHOW_ACCESS_EMAIL_MAX_COUNT })}
+                </p>
+              </div>
+            ) : null}
+          </section>
 
           {['conflict', 'invalid', 'error'].includes(gate) ? (
             <div className="flex items-center justify-between gap-2 border-t border-border pt-2">
@@ -510,6 +547,6 @@ export function ShowPageSharingSettings({
           </Button>
         </div>
       )}
-    </section>
+    </div>
   );
 }

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -3563,7 +3563,6 @@
       "limitedEmailRequired": "Add at least one email address.",
       "limitedEmailHint": "Enter an email and press Enter to add · up to {{count}}",
       "keepOneLimitedEmail": "Switch to Private to remove the last email",
-      "shareIdAutoSaveHint": "Press Enter or leave the field to save",
       "sharingErrors": {
         "conflict": "Link access changed elsewhere. The latest version has been loaded.",
         "invalid": "Review the mode, link, and email list.",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -3563,7 +3563,6 @@
       "limitedEmailRequired": "请至少添加一个邮箱。",
       "limitedEmailHint": "输入邮箱后按回车添加 · 最多 {{count}} 个",
       "keepOneLimitedEmail": "切换为私有后可移除最后一个邮箱",
-      "shareIdAutoSaveHint": "按回车或离开输入框后自动保存",
       "sharingErrors": {
         "conflict": "链接访问设置已在其他位置更新，已载入最新版本。",
         "invalid": "请检查访问模式、链接和邮箱列表。",


### PR DESCRIPTION
## What changed

- Refine the Show Page share popup to a compact 368px layout with responsive narrow-screen sizing.
- Add an icon-only Open action next to Copy and native Share for the final share URL.
- Keep custom link editing as an explicit check-button save action; the button only appears after the suffix changes.
- Keep access mode and allowed-email changes on their existing autosave path, while preserving an unsaved custom-link draft.
- Keep availability and Workspace controls out of the share popup.

## Evidence

- Unit: `ui/src/components/workbench/ShowPageShareControl.test.tsx`, `ui/src/components/workbench/ShowPageSharingSettings.test.tsx` (21 focused tests passed).
- Contract/consumer: tests cover Open URL semantics, disabled unavailable links, explicit custom-link save, autosaved email changes, and draft isolation.
- Lint/build: UI lint, TypeScript/Vite build, Ruff, and `git diff --check` passed.
- Manual: local Incus regression at 1664x1329 and 360x800; verified compact popup, icon actions, save-button visibility, and no mobile overflow.

## Dependencies and residual checks

- Dependencies: none; this PR targets `master` directly.
- Residual manual check: confirm the final visual balance and Open action in the owner's authenticated regression session with a generated external share URL.

## Known-by-design

- The Open action is disabled when the current page has no usable share URL; no fallback network request is initiated by the control.
