### PR TITLE
fix(opencode): settle the owning assistant, not messages[-1]

### DIFF
--- a/docs/plans/opencode-poll-settlement-owner.md
+++ b/docs/plans/opencode-poll-settlement-owner.md
@@ -18,6 +18,7 @@ An unreadable status is treated as live so an accepted steer is not closed.
 
 ## Solution
 
-`_settlement_assistant_message` walks the snapshot backward and takes
-``native_live`` from ``/session/status``. Both prompt and restored poll loops
-use it instead of ``messages[-1]``.
+`_settlement_assistant_message` walks the snapshot backward. Native liveness
+comes from the same status sample that produced the snapshot when the
+steering wrapper already read it; otherwise from ``/session/status``. A
+successful omission (``None``) is idle. An unread or failed status is live.

--- a/docs/plans/opencode-poll-settlement-owner.md
+++ b/docs/plans/opencode-poll-settlement-owner.md
@@ -21,4 +21,8 @@ An unreadable status is treated as live so an accepted steer is not closed.
 `_settlement_assistant_message` walks the snapshot backward. Native liveness
 comes from the same status sample that produced the snapshot when the
 steering wrapper already read it; otherwise from ``/session/status``. A
-successful omission (``None``) is idle. An unread or failed status is live.
+successful omission (``None``) is idle. An unread or failed status is live. After posting auto-retry
+``continue``, the inject stays pending for a short confirmation window
+even if status already reports idle. Restored polls do not take the
+empty-success finish path until the error retry budget is exhausted.
+The status probe is bounded by the remaining turn budget.

--- a/docs/plans/opencode-poll-settlement-owner.md
+++ b/docs/plans/opencode-poll-settlement-owner.md
@@ -11,9 +11,9 @@ error never became a terminal result.
 ## Goal
 
 Settle from the assistant that owns the current turn: skip trailing user
-injects; treat an empty in-flight assistant after a completed error as leftover
-generation, not a live turn. A follow-up assistant that already has parts stays
-the live turn.
+injects. An in-flight assistant after that inject — including an empty one
+just created by auto-retry ``continue`` or an accepted steer — stays pending.
+Only a completed assistant with nothing newer generating is terminal.
 
 ## Solution
 

--- a/docs/plans/opencode-poll-settlement-owner.md
+++ b/docs/plans/opencode-poll-settlement-owner.md
@@ -25,4 +25,7 @@ successful omission (``None``) is idle. An unread or failed status is live. Afte
 ``continue``, the inject stays pending for a short confirmation window
 even if status already reports idle. Restored polls do not take the
 empty-success finish path until the error retry budget is exhausted.
-The status probe is bounded by the remaining turn budget.
+The status probe is bounded by the remaining turn budget. Auto-retry
+``continue`` now arms the same awaiting-after boundary steer already uses,
+so settlement will not close the previous error until a post-boundary
+assistant exists.

--- a/docs/plans/opencode-poll-settlement-owner.md
+++ b/docs/plans/opencode-poll-settlement-owner.md
@@ -1,0 +1,21 @@
+# OpenCode poll settles the owning assistant, not messages[-1]
+
+## Background
+
+Two live OpenCode sessions hung with Avibe still polling: a completed
+assistant already carried `UnknownError: unknown certificate verification
+error`, then a user inject ("继续" / a watch callback) and an empty leftover
+generation sat after it. The poll loop only inspected `messages[-1]`, so the
+error never became a terminal result.
+
+## Goal
+
+Settle from the assistant that owns the current turn: skip trailing user
+injects; treat an empty in-flight assistant after a completed error as leftover
+generation, not a live turn. A follow-up assistant that already has parts stays
+the live turn.
+
+## Solution
+
+`_settlement_assistant_message` walks the snapshot backward. Both prompt and
+restored poll loops use it instead of `messages[-1]`.

--- a/docs/plans/opencode-poll-settlement-owner.md
+++ b/docs/plans/opencode-poll-settlement-owner.md
@@ -10,12 +10,14 @@ error never became a terminal result.
 
 ## Goal
 
-Settle from the assistant that owns the current turn: skip trailing user
-injects. An in-flight assistant after that inject — including an empty one
-just created by auto-retry ``continue`` or an accepted steer — stays pending.
-Only a completed assistant with nothing newer generating is terminal.
+Settle from the assistant that owns the current turn, using both the message
+snapshot and native session status. A trailing user while OpenCode is
+busy/retry is a live steer or auto-retry. The same snapshot while idle is a
+hang (watch callback / typed "继续" after a completed error) and can settle.
+An unreadable status is treated as live so an accepted steer is not closed.
 
 ## Solution
 
-`_settlement_assistant_message` walks the snapshot backward. Both prompt and
-restored poll loops use it instead of `messages[-1]`.
+`_settlement_assistant_message` walks the snapshot backward and takes
+``native_live`` from ``/session/status``. Both prompt and restored poll loops
+use it instead of ``messages[-1]``.

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -515,7 +515,8 @@ class _SteeringAwareOpenCodeServer:
                                 )
                                 if has_final_insert_result or has_post_boundary_error:
                                     self._clear_awaiting_reconciliation()
-                                    self._state.closing = True
+                                    if has_final_insert_result:
+                                        self._state.closing = True
                                     return messages
                                 start_deadline = (
                                     self._state.awaiting_start_confirmation_deadline
@@ -599,22 +600,26 @@ class _SteeringAwareOpenCodeServer:
                 ]
                 return
             kwargs_map = dict(kwargs)
-            session_id = str(kwargs_map.get("session_id") or "")
-            directory = str(kwargs_map.get("directory") or "")
             prompt_text = str(kwargs_map.get("text") or "")
-            if session_id and directory:
-                try:
-                    current = await self._server.list_messages(session_id, directory)
-                except Exception:
-                    current = []
-                self._state.awaiting_after_message_ids = self._message_ids(current)
+            snapshot_ids = kwargs_map.pop("awaiting_after_ids", None)
+            if snapshot_ids is None:
+                session_id = str(kwargs_map.get("session_id") or "")
+                directory = str(kwargs_map.get("directory") or "")
+                if session_id and directory:
+                    try:
+                        current = await self._server.list_messages(session_id, directory)
+                    except Exception:
+                        current = []
+                    snapshot_ids = self._message_ids(current)
+            if snapshot_ids is not None:
+                self._state.awaiting_after_message_ids = set(snapshot_ids)
                 self._state.awaiting_user_text = prompt_text or None
                 self._state.awaiting_start_confirmation_deadline = (
                     time.monotonic() + _ASYNC_PROMPT_START_CONFIRMATION_TIMEOUT_SECONDS
                 )
                 self._state.awaiting_active_status_observed = False
                 self._state.awaiting_result_confirmation_deadline = None
-            await self._server.prompt_async(*args, **kwargs)
+            await self._server.prompt_async(*args, **{k: v for k, v in kwargs.items() if k != "awaiting_after_ids"})
 
     async def abort_session(self, *args, **kwargs) -> bool:
         async with self._state.lock:

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -141,6 +141,7 @@ class _SteeringAwareOpenCodeServer:
     ) -> None:
         self._server = server
         self._state = state
+        self.last_list_native_live: bool | None = None
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._server, name)
@@ -326,6 +327,7 @@ class _SteeringAwareOpenCodeServer:
         while True:
             wait_for_insert = False
             async with self._state.lock:
+                self.last_list_native_live = None
                 if self._state.terminal_status_failure_messages is not None:
                     return self._state.terminal_status_failure_messages
                 messages = await self._server.list_messages(session_id, directory)
@@ -340,6 +342,9 @@ class _SteeringAwareOpenCodeServer:
                 if reconcile_insert or final_snapshot or reconcile_initial_status:
                     try:
                         status = await self._server.get_session_status(session_id, directory)
+                        from modules.agents.opencode.poll_loop import _native_session_is_live
+
+                        self.last_list_native_live = _native_session_is_live(status)
                     except Exception as exc:
                         self._state.status_reconciliation_failures += 1
                         if (

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -567,6 +567,22 @@ class _SteeringAwareOpenCodeServer:
                     {**failure, "info": info},
                 ]
                 return
+            kwargs_map = dict(kwargs)
+            session_id = str(kwargs_map.get("session_id") or "")
+            directory = str(kwargs_map.get("directory") or "")
+            prompt_text = str(kwargs_map.get("text") or "")
+            if session_id and directory:
+                try:
+                    current = await self._server.list_messages(session_id, directory)
+                except Exception:
+                    current = []
+                self._state.awaiting_after_message_ids = self._message_ids(current)
+                self._state.awaiting_user_text = prompt_text or None
+                self._state.awaiting_start_confirmation_deadline = (
+                    time.monotonic() + _ASYNC_PROMPT_START_CONFIRMATION_TIMEOUT_SECONDS
+                )
+                self._state.awaiting_active_status_observed = False
+                self._state.awaiting_result_confirmation_deadline = None
             await self._server.prompt_async(*args, **kwargs)
 
     async def abort_session(self, *args, **kwargs) -> bool:

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -248,6 +248,32 @@ class _SteeringAwareOpenCodeServer:
             for index, message in enumerate(messages)
         )
 
+    @classmethod
+    def _has_completed_error_after(
+        cls,
+        messages: list[Dict[str, Any]],
+        excluded_message_ids: set[str],
+        *,
+        inserted_user_text: str | None = None,
+    ) -> bool:
+        inserted_user_index = -1
+        if inserted_user_text is not None:
+            inserted_user_index = cls._inserted_user_index(
+                messages,
+                excluded_message_ids,
+                inserted_user_text,
+            )
+            if inserted_user_index < 0:
+                return False
+        return any(
+            index > inserted_user_index
+            and message.get("info", {}).get("role") == "assistant"
+            and message.get("info", {}).get("id") not in excluded_message_ids
+            and message.get("info", {}).get("time", {}).get("completed")
+            and message.get("info", {}).get("error")
+            for index, message in enumerate(messages)
+        )
+
     def _has_pending_question_tool(self, messages: list[Dict[str, Any]]) -> bool:
         return any(
             message.get("info", {}).get("id") not in self._state.baseline_message_ids
@@ -482,7 +508,12 @@ class _SteeringAwareOpenCodeServer:
                                         inserted_user_text=inserted_user_text,
                                     )
                                 )
-                                if has_final_insert_result:
+                                has_post_boundary_error = self._has_completed_error_after(
+                                    messages,
+                                    awaiting,
+                                    inserted_user_text=inserted_user_text,
+                                )
+                                if has_final_insert_result or has_post_boundary_error:
                                     self._clear_awaiting_reconciliation()
                                     self._state.closing = True
                                     return messages

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -617,6 +617,7 @@ class OpenCodePollLoop:
                     emitted_assistant_messages.add(message_id)
 
             if messages:
+                remaining = deadline - time.monotonic()
                 last_message = _settlement_assistant_message(
                     messages,
                     baseline_message_ids,
@@ -932,6 +933,7 @@ class OpenCodePollLoop:
                             await self._agent.controller.emit_agent_message(context, "tool_call", tool_summary)
 
                 if messages:
+                    remaining = deadline - time.monotonic()
                     last_message = _settlement_assistant_message(
                         messages,
                         baseline_message_ids,

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -51,37 +51,51 @@ def _message_info(message: Dict[str, Any]) -> Dict[str, Any]:
     return info if isinstance(info, dict) else {}
 
 
+def _native_session_is_live(status: Optional[Dict[str, Any]]) -> bool:
+    """True when OpenCode still owns the turn (busy/retry).
+
+    A successful ``/session/status`` that omits this session is idle. A missing
+    or unreadable status is treated as live so an accepted steer is not closed
+    during the window where the user message exists and the assistant does not.
+    """
+
+    if not isinstance(status, dict):
+        return True
+    return status.get("type") in {"busy", "retry"}
+
+
 def _settlement_assistant_message(
     messages: list[Dict[str, Any]],
     baseline_message_ids: set[str],
+    *,
+    native_live: bool,
 ) -> Optional[Dict[str, Any]]:
     """The assistant message that owns this poll's settlement.
 
-    Trailing user injects (steer, watch callbacks, typed "继续", auto-retry
-    ``continue``) are not the turn. An in-flight assistant after that inject —
-    even with no parts yet — is the live follow-up and must stay pending.
-    Only when nothing new is generating do we settle the latest completed
-    assistant behind the inject.
+    Trailing user injects are not the turn. While the native session is live,
+    a trailing user or an in-flight assistant — even with no parts yet — means
+    a steer or auto-retry is still running. When the native session is idle, an
+    empty leftover generation is skipped and the completed assistant behind it
+    can settle.
     """
 
-    latest_new: Optional[Dict[str, Any]] = None
+    skipped_user = False
     for message in reversed(messages):
         info = _message_info(message)
         message_id = info.get("id")
         if not message_id or message_id in baseline_message_ids:
             continue
-        if latest_new is None:
-            latest_new = message
         if info.get("role") != "assistant":
+            if info.get("role") == "user":
+                skipped_user = True
             continue
-        if info.get("time", {}).get("completed"):
-            return message
-        return None
-    if latest_new is None:
-        return None
-    info = _message_info(latest_new)
-    if info.get("role") == "assistant" and info.get("time", {}).get("completed"):
-        return latest_new
+        if not info.get("time", {}).get("completed"):
+            if native_live or (message.get("parts") or []):
+                return None
+            continue
+        if skipped_user and native_live:
+            return None
+        return message
     return None
 
 
@@ -220,6 +234,26 @@ class OpenCodePollLoop:
         """Map an infinite remaining budget to ``wait_for``'s no-timeout form."""
 
         return None if math.isinf(remaining) else remaining
+
+    async def _native_session_is_live(
+        self,
+        server: OpenCodeServerManager,
+        session_id: str,
+        directory: str,
+    ) -> bool:
+        reader = getattr(server, "get_session_status", None)
+        if not callable(reader):
+            return True
+        try:
+            status = await reader(session_id, directory)
+        except Exception as err:
+            logger.debug(
+                "OpenCode session status unavailable for %s: %s",
+                session_id,
+                err,
+            )
+            return True
+        return _native_session_is_live(status)
 
     @staticmethod
     async def _sleep_with_deadline(deadline: float) -> None:
@@ -543,7 +577,13 @@ class OpenCodePollLoop:
                     emitted_assistant_messages.add(message_id)
 
             if messages:
-                last_message = _settlement_assistant_message(messages, baseline_message_ids)
+                last_message = _settlement_assistant_message(
+                    messages,
+                    baseline_message_ids,
+                    native_live=await self._native_session_is_live(
+                        server, session_id, request.working_path
+                    ),
+                )
                 last_info = _message_info(last_message) if last_message else {}
                 last_id = last_info.get("id")
 
@@ -840,7 +880,11 @@ class OpenCodePollLoop:
 
                 if messages:
                     last_message = _settlement_assistant_message(
-                        messages, baseline_message_ids
+                        messages,
+                        baseline_message_ids,
+                        native_live=await self._native_session_is_live(
+                            server, session_id, poll_info.working_path
+                        ),
                     )
                     last_info = _message_info(last_message) if last_message else {}
                     if last_info.get("id"):

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -75,20 +75,37 @@ def _native_session_is_live(
     return status.get("type") in {"busy", "retry"}
 
 
+def _has_post_boundary_assistant(
+    messages: list[Dict[str, Any]],
+    boundary_ids: set[str],
+) -> bool:
+    return any(
+        (info := _message_info(message)).get("id")
+        and info.get("id") not in boundary_ids
+        and info.get("role") == "assistant"
+        for message in messages
+    )
+
+
 def _settlement_assistant_message(
     messages: list[Dict[str, Any]],
     baseline_message_ids: set[str],
     *,
     native_live: bool,
+    awaiting_after_ids: Optional[set[str]] = None,
 ) -> Optional[Dict[str, Any]]:
     """The assistant message that owns this poll's settlement.
 
     Trailing user injects are not the turn. While the native session is live,
-    a trailing user or an in-flight assistant — even with no parts yet — means
-    a steer or auto-retry is still running. When the native session is idle, an
-    empty leftover generation is skipped and the completed assistant behind it
-    can settle.
+    or an awaiting inject boundary has no post-boundary assistant yet, keep
+    the previous completed assistant pending. When idle and the inject has
+    produced no new assistant, settle the completed owner behind it.
     """
+
+    if awaiting_after_ids and not _has_post_boundary_assistant(
+        messages, awaiting_after_ids
+    ):
+        return None
 
     skipped_user = False
     for message in reversed(messages):
@@ -610,6 +627,11 @@ class OpenCodePollLoop:
                         remaining=remaining,
                         pending_inject_until=pending_inject_until,
                     ),
+                    awaiting_after_ids=getattr(
+                        getattr(server, "_state", None),
+                        "awaiting_after_message_ids",
+                        None,
+                    ),
                 )
                 last_info = _message_info(last_message) if last_message else {}
                 last_id = last_info.get("id")
@@ -919,6 +941,11 @@ class OpenCodePollLoop:
                             poll_info.working_path,
                             remaining=remaining,
                             pending_inject_until=pending_inject_until,
+                        ),
+                        awaiting_after_ids=getattr(
+                            getattr(server, "_state", None),
+                            "awaiting_after_message_ids",
+                            None,
                         ),
                     )
                     last_info = _message_info(last_message) if last_message else {}

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -87,6 +87,33 @@ def _has_post_boundary_assistant(
     )
 
 
+def _snapshot_needs_native_liveness(
+    messages: list[Dict[str, Any]],
+    baseline_message_ids: set[str],
+    awaiting_after_ids: Optional[set[str]] = None,
+) -> bool:
+    """True only when idle vs busy can change which completed assistant settles."""
+
+    if awaiting_after_ids and not _has_post_boundary_assistant(
+        messages, awaiting_after_ids
+    ):
+        return False
+    latest_new: Optional[Dict[str, Any]] = None
+    for message in reversed(messages):
+        info = _message_info(message)
+        message_id = info.get("id")
+        if not message_id or message_id in baseline_message_ids:
+            continue
+        latest_new = message
+        break
+    if latest_new is None:
+        return False
+    info = _message_info(latest_new)
+    if info.get("role") == "assistant" and not info.get("time", {}).get("completed"):
+        return False
+    return info.get("role") == "user"
+
+
 def _settlement_assistant_message(
     messages: list[Dict[str, Any]],
     baseline_message_ids: set[str],
@@ -118,9 +145,7 @@ def _settlement_assistant_message(
                 skipped_user = True
             continue
         if not info.get("time", {}).get("completed"):
-            if native_live or (message.get("parts") or []):
-                return None
-            continue
+            return None
         if skipped_user and native_live:
             return None
         return message
@@ -618,21 +643,27 @@ class OpenCodePollLoop:
 
             if messages:
                 remaining = deadline - time.monotonic()
-                last_message = _settlement_assistant_message(
-                    messages,
-                    baseline_message_ids,
-                    native_live=await self._native_session_is_live(
+                awaiting_after_ids = getattr(
+                    getattr(server, "_state", None),
+                    "awaiting_after_message_ids",
+                    None,
+                )
+                native_live = False
+                if _snapshot_needs_native_liveness(
+                    messages, baseline_message_ids, awaiting_after_ids
+                ):
+                    native_live = await self._native_session_is_live(
                         server,
                         session_id,
                         request.working_path,
                         remaining=remaining,
                         pending_inject_until=pending_inject_until,
-                    ),
-                    awaiting_after_ids=getattr(
-                        getattr(server, "_state", None),
-                        "awaiting_after_message_ids",
-                        None,
-                    ),
+                    )
+                last_message = _settlement_assistant_message(
+                    messages,
+                    baseline_message_ids,
+                    native_live=native_live,
+                    awaiting_after_ids=awaiting_after_ids,
                 )
                 last_info = _message_info(last_message) if last_message else {}
                 last_id = last_info.get("id")
@@ -673,6 +704,11 @@ class OpenCodePollLoop:
                                     model=model_dict,
                                     reasoning_effort=reasoning_effort,
                                     tools={"question": False},
+                                    awaiting_after_ids={
+                                        str(_message_info(item).get("id"))
+                                        for item in messages
+                                        if _message_info(item).get("id")
+                                    },
                                 )
                                 pending_inject_until = (
                                     time.monotonic() + _POST_INJECT_CONFIRMATION_SECONDS
@@ -934,21 +970,27 @@ class OpenCodePollLoop:
 
                 if messages:
                     remaining = deadline - time.monotonic()
-                    last_message = _settlement_assistant_message(
-                        messages,
-                        baseline_message_ids,
-                        native_live=await self._native_session_is_live(
+                    awaiting_after_ids = getattr(
+                        getattr(server, "_state", None),
+                        "awaiting_after_message_ids",
+                        None,
+                    )
+                    native_live = False
+                    if _snapshot_needs_native_liveness(
+                        messages, baseline_message_ids, awaiting_after_ids
+                    ):
+                        native_live = await self._native_session_is_live(
                             server,
                             session_id,
                             poll_info.working_path,
                             remaining=remaining,
                             pending_inject_until=pending_inject_until,
-                        ),
-                        awaiting_after_ids=getattr(
-                            getattr(server, "_state", None),
-                            "awaiting_after_message_ids",
-                            None,
-                        ),
+                        )
+                    last_message = _settlement_assistant_message(
+                        messages,
+                        baseline_message_ids,
+                        native_live=native_live,
+                        awaiting_after_ids=awaiting_after_ids,
                     )
                     last_info = _message_info(last_message) if last_message else {}
                     if last_info.get("id"):

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -51,16 +51,24 @@ def _message_info(message: Dict[str, Any]) -> Dict[str, Any]:
     return info if isinstance(info, dict) else {}
 
 
-def _native_session_is_live(status: Optional[Dict[str, Any]]) -> bool:
+def _native_session_is_live(
+    status: Optional[Dict[str, Any]],
+    *,
+    status_known: bool = True,
+) -> bool:
     """True when OpenCode still owns the turn (busy/retry).
 
-    A successful ``/session/status`` that omits this session is idle. A missing
-    or unreadable status is treated as live so an accepted steer is not closed
-    during the window where the user message exists and the assistant does not.
+    A successful ``/session/status`` that omits this session is idle
+    (``get_session_status`` returns ``None``). An unread or failed status
+    (``status_known=False``) is treated as live so an accepted steer is not
+    closed during the window where the user message exists and the assistant
+    does not.
     """
 
-    if not isinstance(status, dict):
+    if not status_known:
         return True
+    if not isinstance(status, dict):
+        return False
     return status.get("type") in {"busy", "retry"}
 
 
@@ -241,6 +249,9 @@ class OpenCodePollLoop:
         session_id: str,
         directory: str,
     ) -> bool:
+        snapshot_live = getattr(server, "last_list_native_live", None)
+        if isinstance(snapshot_live, bool):
+            return snapshot_live
         reader = getattr(server, "get_session_status", None)
         if not callable(reader):
             return True

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -35,6 +35,9 @@ _TIMEOUT_ABORT_GRACE_SECONDS = 10.0
 # never total duration — drive this settlement, so an intermittent blip that
 # recovers between polls resets the count and never trips it.
 _POLL_FAILURE_SETTLE_LIMIT = 10
+# OpenCode can report idle after accepting ``continue`` / a steer, before the
+# replacement assistant is visible. Keep that inject pending for this window.
+_POST_INJECT_CONFIRMATION_SECONDS = 5.0
 
 
 def _opencode_error_text(error: object) -> str:
@@ -248,7 +251,12 @@ class OpenCodePollLoop:
         server: OpenCodeServerManager,
         session_id: str,
         directory: str,
+        *,
+        remaining: float,
+        pending_inject_until: float = 0.0,
     ) -> bool:
+        if pending_inject_until and time.monotonic() < pending_inject_until:
+            return True
         snapshot_live = getattr(server, "last_list_native_live", None)
         if isinstance(snapshot_live, bool):
             return snapshot_live
@@ -256,7 +264,10 @@ class OpenCodePollLoop:
         if not callable(reader):
             return True
         try:
-            status = await reader(session_id, directory)
+            status = await asyncio.wait_for(
+                reader(session_id, directory),
+                timeout=self._wait_timeout(remaining),
+            )
         except Exception as err:
             logger.debug(
                 "OpenCode session status unavailable for %s: %s",
@@ -447,6 +458,7 @@ class OpenCodePollLoop:
         )
         last_error_message_id: Optional[str] = None
         poll_failures = 0
+        pending_inject_until = 0.0
 
         def _relative_path(path: str) -> str:
             return self._agent._to_relative_path(path, request.working_path)
@@ -592,7 +604,11 @@ class OpenCodePollLoop:
                     messages,
                     baseline_message_ids,
                     native_live=await self._native_session_is_live(
-                        server, session_id, request.working_path
+                        server,
+                        session_id,
+                        request.working_path,
+                        remaining=remaining,
+                        pending_inject_until=pending_inject_until,
                     ),
                 )
                 last_info = _message_info(last_message) if last_message else {}
@@ -634,6 +650,9 @@ class OpenCodePollLoop:
                                     model=model_dict,
                                     reasoning_effort=reasoning_effort,
                                     tools={"question": False},
+                                )
+                                pending_inject_until = (
+                                    time.monotonic() + _POST_INJECT_CONFIRMATION_SECONDS
                                 )
                                 await self._sleep_with_deadline(deadline)
                                 continue
@@ -731,6 +750,7 @@ class OpenCodePollLoop:
             DEFAULT_OPENCODE_ERROR_RETRY_LIMIT,
         )
         last_error_message_id: Optional[str] = None
+        pending_inject_until = 0.0
 
         started_at = time.monotonic()
 
@@ -894,7 +914,11 @@ class OpenCodePollLoop:
                         messages,
                         baseline_message_ids,
                         native_live=await self._native_session_is_live(
-                            server, session_id, poll_info.working_path
+                            server,
+                            session_id,
+                            poll_info.working_path,
+                            remaining=remaining,
+                            pending_inject_until=pending_inject_until,
                         ),
                     )
                     last_info = _message_info(last_message) if last_message else {}
@@ -923,6 +947,8 @@ class OpenCodePollLoop:
                                     self._agent.sessions.remove_active_poll(session_id)
                                     await self.remove_restored_ack(poll_info)
                                     return
+                                await self._sleep_with_deadline(deadline)
+                                continue
 
                             if last_info.get("finish") != "tool-calls":
                                 if not msg_error:

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -57,35 +57,32 @@ def _settlement_assistant_message(
 ) -> Optional[Dict[str, Any]]:
     """The assistant message that owns this poll's settlement.
 
-    Trailing user injects (steer, watch callbacks, a typed "继续") are not the
-    turn. Walk back to the latest new assistant. An in-flight assistant with
-    parts is still that turn. An empty in-flight assistant after a completed
-    error is leftover generation from a retry or follow-up — the completed
-    error is the terminal evidence.
+    Trailing user injects (steer, watch callbacks, typed "继续", auto-retry
+    ``continue``) are not the turn. An in-flight assistant after that inject —
+    even with no parts yet — is the live follow-up and must stay pending.
+    Only when nothing new is generating do we settle the latest completed
+    assistant behind the inject.
     """
 
-    latest_assistant: Optional[Dict[str, Any]] = None
-    latest_completed_error: Optional[Dict[str, Any]] = None
+    latest_new: Optional[Dict[str, Any]] = None
     for message in reversed(messages):
         info = _message_info(message)
         message_id = info.get("id")
         if not message_id or message_id in baseline_message_ids:
             continue
+        if latest_new is None:
+            latest_new = message
         if info.get("role") != "assistant":
             continue
-        if latest_assistant is None:
-            latest_assistant = message
-        if info.get("time", {}).get("completed") and info.get("error"):
-            latest_completed_error = message
-            break
-    if latest_assistant is None:
+        if info.get("time", {}).get("completed"):
+            return message
         return None
-    latest_info = _message_info(latest_assistant)
-    if latest_info.get("time", {}).get("completed"):
-        return latest_assistant
-    if latest_completed_error is not None and not (latest_assistant.get("parts") or []):
-        return latest_completed_error
-    return latest_assistant
+    if latest_new is None:
+        return None
+    info = _message_info(latest_new)
+    if info.get("role") == "assistant" and info.get("time", {}).get("completed"):
+        return latest_new
+    return None
 
 
 def restored_platform_from_poll_info(poll_info) -> str:

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -46,6 +46,48 @@ def _opencode_error_text(error: object) -> str:
     return f"{error_name} - {error_message[:500]}".strip(" -")
 
 
+def _message_info(message: Dict[str, Any]) -> Dict[str, Any]:
+    info = message.get("info")
+    return info if isinstance(info, dict) else {}
+
+
+def _settlement_assistant_message(
+    messages: list[Dict[str, Any]],
+    baseline_message_ids: set[str],
+) -> Optional[Dict[str, Any]]:
+    """The assistant message that owns this poll's settlement.
+
+    Trailing user injects (steer, watch callbacks, a typed "继续") are not the
+    turn. Walk back to the latest new assistant. An in-flight assistant with
+    parts is still that turn. An empty in-flight assistant after a completed
+    error is leftover generation from a retry or follow-up — the completed
+    error is the terminal evidence.
+    """
+
+    latest_assistant: Optional[Dict[str, Any]] = None
+    latest_completed_error: Optional[Dict[str, Any]] = None
+    for message in reversed(messages):
+        info = _message_info(message)
+        message_id = info.get("id")
+        if not message_id or message_id in baseline_message_ids:
+            continue
+        if info.get("role") != "assistant":
+            continue
+        if latest_assistant is None:
+            latest_assistant = message
+        if info.get("time", {}).get("completed") and info.get("error"):
+            latest_completed_error = message
+            break
+    if latest_assistant is None:
+        return None
+    latest_info = _message_info(latest_assistant)
+    if latest_info.get("time", {}).get("completed"):
+        return latest_assistant
+    if latest_completed_error is not None and not (latest_assistant.get("parts") or []):
+        return latest_completed_error
+    return latest_assistant
+
+
 def restored_platform_from_poll_info(poll_info) -> str:
     snapshot = poll_info.processing_indicator if isinstance(poll_info.processing_indicator, dict) else {}
     platform = str(snapshot.get("platform") or poll_info.platform or "")
@@ -504,14 +546,13 @@ class OpenCodePollLoop:
                     emitted_assistant_messages.add(message_id)
 
             if messages:
-                last_message = messages[-1]
-                last_info = last_message.get("info", {})
+                last_message = _settlement_assistant_message(messages, baseline_message_ids)
+                last_info = _message_info(last_message) if last_message else {}
                 last_id = last_info.get("id")
 
                 if (
-                    last_id
-                    and last_id not in baseline_message_ids
-                    and last_info.get("role") == "assistant"
+                    last_message is not None
+                    and last_id
                     and last_info.get("time", {}).get("completed")
                 ):
                     msg_error = last_info.get("error")
@@ -801,9 +842,11 @@ class OpenCodePollLoop:
                             await self._agent.controller.emit_agent_message(context, "tool_call", tool_summary)
 
                 if messages:
-                    last_message = messages[-1]
-                    last_info = last_message.get("info", {})
-                    if last_info.get("role") == "assistant":
+                    last_message = _settlement_assistant_message(
+                        messages, baseline_message_ids
+                    )
+                    last_info = _message_info(last_message) if last_message else {}
+                    if last_info.get("id"):
                         time_info = last_info.get("time") or {}
                         if time_info.get("completed"):
                             msg_error = last_info.get("error")

--- a/tests/test_agent_steering.py
+++ b/tests/test_agent_steering.py
@@ -1749,7 +1749,7 @@ async def test_opencode_idle_post_boundary_error_clears_awaiting_boundary() -> N
         assert snapshot[-1]["info"]["id"] == "retry-error"
         assert snapshot[-1]["info"]["error"]["name"] == "UnknownError"
         assert state.awaiting_after_message_ids is None
-        assert state.closing is True
+        assert state.closing is False
     finally:
         await _cancel_tasks(gate_task)
 

--- a/tests/test_agent_steering.py
+++ b/tests/test_agent_steering.py
@@ -1712,6 +1712,49 @@ async def test_opencode_retry_keeps_completed_error_snapshots_gated() -> None:
 
 
 @pytest.mark.anyio
+async def test_opencode_idle_post_boundary_error_clears_awaiting_boundary() -> None:
+    """A completed retry error must reach the poll owner, not a synthetic idle failure."""
+
+    primary = _primary_request(backend="opencode")
+    gate_task = await _held_task()
+    server = _OpenCodeServer(
+        messages=[
+            {
+                "info": {"id": "primary-user", "role": "user"},
+                "parts": [{"type": "text", "text": "continue"}],
+            },
+            {
+                "info": {
+                    "id": "retry-error",
+                    "role": "assistant",
+                    "time": {"completed": 1},
+                    "error": {"name": "UnknownError", "data": {"message": "tls"}},
+                },
+                "parts": [],
+            },
+        ],
+        status={"type": "idle"},
+    )
+    agent = _opencode_agent(primary, gate_task, server)
+    state = agent._steering_states[primary.base_session_id]
+    state.awaiting_after_message_ids = {"older-error"}
+    state.awaiting_user_text = "continue"
+    state.awaiting_active_status_observed = True
+    poll_server = _SteeringAwareOpenCodeServer(server, state)
+    try:
+        snapshot = await asyncio.wait_for(
+            poll_server.list_messages("opencode-session", primary.working_path),
+            timeout=1,
+        )
+        assert snapshot[-1]["info"]["id"] == "retry-error"
+        assert snapshot[-1]["info"]["error"]["name"] == "UnknownError"
+        assert state.awaiting_after_message_ids is None
+        assert state.closing is True
+    finally:
+        await _cancel_tasks(gate_task)
+
+
+@pytest.mark.anyio
 async def test_opencode_refuses_after_poll_owner_claims_terminal_result() -> None:
     primary = _primary_request(backend="opencode")
     gate_task = await _held_task()

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -1544,10 +1544,11 @@ def test_settlement_assistant_message_walks_back_to_the_owning_turn():
     cases = (
         ([error_assistant], "msg-err"),
         ([error_assistant, trailing_user], "msg-err"),
-        ([error_assistant, trailing_user, empty_inflight], "msg-err"),
-        ([error_assistant, live_followup], "msg-live"),
+        ([error_assistant, trailing_user, empty_inflight], None),
+        ([error_assistant, live_followup], None),
         ([completed_ok, trailing_user], "msg-ok"),
         ([trailing_user], None),
+        ([error_assistant, trailing_user, empty_inflight, completed_ok], "msg-ok"),
     )
     for messages, expected_id in cases:
         owner = _settlement_assistant_message(messages, set())
@@ -1762,10 +1763,14 @@ def test_opencode_poll_settles_error_when_trailing_user_is_last():
     ]
 
 
-def test_opencode_poll_settles_error_behind_empty_inflight_assistant():
-    """An empty leftover generation after a completed error is not a live turn."""
+def test_opencode_poll_keeps_retry_pending_on_empty_inflight_assistant(monkeypatch):
+    """Auto-retry ``continue`` must stay live until the new assistant completes."""
 
+    monkeypatch.setattr(
+        "modules.agents.opencode.poll_loop._POLL_INTERVAL_SECONDS", 0.01
+    )
     emitted = []
+    polls = {"n": 0}
 
     class _AuthSvc:
         async def maybe_emit_auth_recovery_message(
@@ -1800,13 +1805,15 @@ def test_opencode_poll_settles_error_behind_empty_inflight_assistant():
         controller = _Controller()
 
         def _extract_response_text(self, message):
-            return ""
+            return "recovered"
 
         async def record_model_hub_native_failure(self, context, diagnostic):
-            return True
+            raise AssertionError("must not settle while retry is in flight")
 
     class _Server:
         async def list_messages(self, session_id, directory):
+            polls["n"] += 1
+            followup_completed = polls["n"] >= 3
             return [
                 {
                     "info": {
@@ -1819,16 +1826,18 @@ def test_opencode_poll_settles_error_behind_empty_inflight_assistant():
                 },
                 {
                     "info": {"id": "msg-user", "role": "user", "time": {}},
-                    "parts": [{"type": "text", "text": "继续"}],
+                    "parts": [{"type": "text", "text": "continue"}],
                 },
                 {
                     "info": {
                         "id": "msg-empty",
                         "role": "assistant",
-                        "time": {},
-                        "finish": None,
+                        "time": {"completed": 1} if followup_completed else {},
+                        "finish": "stop" if followup_completed else None,
                     },
-                    "parts": [],
+                    "parts": (
+                        [{"type": "text", "text": "recovered"}] if followup_completed else []
+                    ),
                 },
             ]
 
@@ -1854,9 +1863,9 @@ def test_opencode_poll_settles_error_behind_empty_inflight_assistant():
         )
     )
 
-    assert (final_text, should_emit) == (None, False)
-    assert [item[0] for item in emitted] == ["notify", "result"]
-    assert "tls failed" in emitted[0][1]
+    assert (final_text, should_emit) == ("recovered", True)
+    assert polls["n"] == 3
+    assert not any(item[0] == "result" for item in emitted)
 
 
 def test_opencode_poll_does_not_settle_error_while_followup_has_parts():

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -26,7 +26,10 @@ from modules.agents.base import AgentRequest
 from modules.agents.model_hub import launch_for_context
 from modules.agents.service import AgentService
 from modules.agents.opencode.agent import OpenCodeAgent
-from modules.agents.opencode.poll_loop import OpenCodePollLoop
+from modules.agents.opencode.poll_loop import (
+    OpenCodePollLoop,
+    _settlement_assistant_message,
+)
 from modules.agents.opencode.utils import resolve_opencode_reasoning_effort
 
 
@@ -1498,6 +1501,60 @@ def test_opencode_poll_aborts_disabled_question_toolcall():
     assert emitted[0][1] == "translated:error.opencodeQuestionToolDisabled"
 
 
+def test_settlement_assistant_message_walks_back_to_the_owning_turn():
+    """Every live snapshot shape settles the same owning assistant.
+
+    Seed the shapes already seen in production: last-is-assistant, a trailing
+    user inject, an empty leftover generation after a completed error, and a
+    follow-up that already has parts. The owner is a property of the snapshot,
+    not of which id happens to sit at messages[-1].
+    """
+
+    error_assistant = {
+        "info": {
+            "id": "msg-err",
+            "role": "assistant",
+            "time": {"completed": 1},
+            "error": {"name": "UnknownError"},
+        },
+        "parts": [],
+    }
+    trailing_user = {
+        "info": {"id": "msg-user", "role": "user", "time": {}},
+        "parts": [{"type": "text", "text": "继续"}],
+    }
+    empty_inflight = {
+        "info": {"id": "msg-empty", "role": "assistant", "time": {}},
+        "parts": [],
+    }
+    live_followup = {
+        "info": {"id": "msg-live", "role": "assistant", "time": {}},
+        "parts": [{"type": "text", "text": "working"}],
+    }
+    completed_ok = {
+        "info": {
+            "id": "msg-ok",
+            "role": "assistant",
+            "time": {"completed": 1},
+            "finish": "stop",
+        },
+        "parts": [{"type": "text", "text": "done"}],
+    }
+
+    cases = (
+        ([error_assistant], "msg-err"),
+        ([error_assistant, trailing_user], "msg-err"),
+        ([error_assistant, trailing_user, empty_inflight], "msg-err"),
+        ([error_assistant, live_followup], "msg-live"),
+        ([completed_ok, trailing_user], "msg-ok"),
+        ([trailing_user], None),
+    )
+    for messages, expected_id in cases:
+        owner = _settlement_assistant_message(messages, set())
+        actual_id = None if owner is None else owner["info"]["id"]
+        assert actual_id == expected_id, (expected_id, actual_id)
+
+
 def test_opencode_poll_notifies_and_settles_on_retry_exhaustion():
     # A completed assistant message carrying an error, with retries exhausted
     # (error_retry_limit=0) and the auth-recovery path declining (non-auth error),
@@ -1602,6 +1659,279 @@ def test_opencode_poll_notifies_and_settles_on_retry_exhaustion():
     assert emitted[0][1] == "OpenCode error: ProviderError - rate limited"
     assert emitted[1][1:] == ("", True, "silent", "ProviderError - rate limited")
     assert model_hub_failures == [(request.context, "ProviderError - rate limited")]
+
+
+def test_opencode_poll_settles_error_when_trailing_user_is_last():
+    """A watch/steer inject after a completed error is not the turn.
+
+    The live hang was: assistant completed with error, then a user message
+    ("继续" / a watch callback) became messages[-1], so the last-only
+    settlement never ran.
+    """
+
+    emitted = []
+    model_hub_failures = []
+
+    class _AuthSvc:
+        async def maybe_emit_auth_recovery_message(
+            self, context, backend, message, *, output=None, terminal_error=None
+        ):
+            return False
+
+    class _Controller:
+        agent_auth_service = _AuthSvc()
+
+        def _t(self, key, **kwargs):
+            if key == "error.opencodeBackendError":
+                return f"OpenCode error: {kwargs['error']}"
+            return f"translated:{key}"
+
+        async def emit_agent_message(
+            self,
+            context,
+            message_type,
+            text,
+            parse_mode=None,
+            *,
+            is_error=False,
+            level="normal",
+            output=None,
+            terminal_error=None,
+        ):
+            emitted.append((message_type, text, is_error, level, terminal_error))
+
+    class _Agent:
+        opencode_config = type("OpenCodeConfig", (), {"error_retry_limit": 0})()
+        controller = _Controller()
+
+        def _extract_response_text(self, message):
+            return ""
+
+        async def record_model_hub_native_failure(self, context, diagnostic):
+            model_hub_failures.append(diagnostic)
+            return True
+
+    class _Server:
+        async def list_messages(self, session_id, directory):
+            return [
+                {
+                    "info": {
+                        "id": "msg-err",
+                        "role": "assistant",
+                        "time": {"completed": 1},
+                        "error": {
+                            "name": "UnknownError",
+                            "data": {"message": "unknown certificate verification error"},
+                        },
+                    },
+                    "parts": [],
+                },
+                {
+                    "info": {"id": "msg-user", "role": "user", "time": {}},
+                    "parts": [{"type": "text", "text": "继续"}],
+                },
+            ]
+
+    request = AgentRequest(
+        context=MessageContext(user_id="u", channel_id="c", platform="slack"),
+        message="hello",
+        user_message="hello",
+        working_path="/tmp/work",
+        base_session_id="base",
+        composite_session_id="base:/tmp/work",
+        session_key="slack::c",
+    )
+
+    final_text, should_emit = asyncio.run(
+        OpenCodePollLoop(_Agent()).run_prompt_poll(
+            request,
+            _Server(),
+            "oc-session",
+            agent_to_use=None,
+            model_dict=None,
+            reasoning_effort=None,
+            baseline_message_ids=set(),
+        )
+    )
+
+    assert (final_text, should_emit) == (None, False)
+    assert [item[0] for item in emitted] == ["notify", "result"]
+    assert "certificate verification" in emitted[0][1]
+    assert model_hub_failures == [
+        "UnknownError - unknown certificate verification error"
+    ]
+
+
+def test_opencode_poll_settles_error_behind_empty_inflight_assistant():
+    """An empty leftover generation after a completed error is not a live turn."""
+
+    emitted = []
+
+    class _AuthSvc:
+        async def maybe_emit_auth_recovery_message(
+            self, context, backend, message, *, output=None, terminal_error=None
+        ):
+            return False
+
+    class _Controller:
+        agent_auth_service = _AuthSvc()
+
+        def _t(self, key, **kwargs):
+            if key == "error.opencodeBackendError":
+                return f"OpenCode error: {kwargs['error']}"
+            return f"translated:{key}"
+
+        async def emit_agent_message(
+            self,
+            context,
+            message_type,
+            text,
+            parse_mode=None,
+            *,
+            is_error=False,
+            level="normal",
+            output=None,
+            terminal_error=None,
+        ):
+            emitted.append((message_type, text, is_error, level, terminal_error))
+
+    class _Agent:
+        opencode_config = type("OpenCodeConfig", (), {"error_retry_limit": 0})()
+        controller = _Controller()
+
+        def _extract_response_text(self, message):
+            return ""
+
+        async def record_model_hub_native_failure(self, context, diagnostic):
+            return True
+
+    class _Server:
+        async def list_messages(self, session_id, directory):
+            return [
+                {
+                    "info": {
+                        "id": "msg-err",
+                        "role": "assistant",
+                        "time": {"completed": 1},
+                        "error": {"name": "UnknownError", "data": {"message": "tls failed"}},
+                    },
+                    "parts": [],
+                },
+                {
+                    "info": {"id": "msg-user", "role": "user", "time": {}},
+                    "parts": [{"type": "text", "text": "继续"}],
+                },
+                {
+                    "info": {
+                        "id": "msg-empty",
+                        "role": "assistant",
+                        "time": {},
+                        "finish": None,
+                    },
+                    "parts": [],
+                },
+            ]
+
+    request = AgentRequest(
+        context=MessageContext(user_id="u", channel_id="c", platform="slack"),
+        message="hello",
+        user_message="hello",
+        working_path="/tmp/work",
+        base_session_id="base",
+        composite_session_id="base:/tmp/work",
+        session_key="slack::c",
+    )
+
+    final_text, should_emit = asyncio.run(
+        OpenCodePollLoop(_Agent()).run_prompt_poll(
+            request,
+            _Server(),
+            "oc-session",
+            agent_to_use=None,
+            model_dict=None,
+            reasoning_effort=None,
+            baseline_message_ids=set(),
+        )
+    )
+
+    assert (final_text, should_emit) == (None, False)
+    assert [item[0] for item in emitted] == ["notify", "result"]
+    assert "tls failed" in emitted[0][1]
+
+
+def test_opencode_poll_does_not_settle_error_while_followup_has_parts():
+    """A follow-up assistant that already has parts is still the live turn."""
+
+    emitted = []
+    polls = {"n": 0}
+
+    class _Controller:
+        def _t(self, key, **kwargs):
+            return f"translated:{key}"
+
+        async def emit_agent_message(self, *args, **kwargs):
+            emitted.append((args, kwargs))
+
+    class _Agent:
+        opencode_config = type("OpenCodeConfig", (), {"error_retry_limit": 0})()
+        controller = _Controller()
+
+        def _extract_response_text(self, message):
+            return "recovered"
+
+        async def record_model_hub_native_failure(self, context, diagnostic):
+            raise AssertionError("must not settle the earlier error")
+
+    class _Server:
+        async def list_messages(self, session_id, directory):
+            polls["n"] += 1
+            followup_completed = polls["n"] >= 2
+            return [
+                {
+                    "info": {
+                        "id": "msg-err",
+                        "role": "assistant",
+                        "time": {"completed": 1},
+                        "error": {"name": "UnknownError", "data": {"message": "old"}},
+                    },
+                    "parts": [],
+                },
+                {
+                    "info": {
+                        "id": "msg-live",
+                        "role": "assistant",
+                        "time": {"completed": 1} if followup_completed else {},
+                        "finish": "stop" if followup_completed else None,
+                    },
+                    "parts": [{"type": "text", "text": "recovered"}],
+                },
+            ]
+
+    request = AgentRequest(
+        context=MessageContext(user_id="u", channel_id="c", platform="slack"),
+        message="hello",
+        user_message="hello",
+        working_path="/tmp/work",
+        base_session_id="base",
+        composite_session_id="base:/tmp/work",
+        session_key="slack::c",
+    )
+
+    final_text, should_emit = asyncio.run(
+        OpenCodePollLoop(_Agent()).run_prompt_poll(
+            request,
+            _Server(),
+            "oc-session",
+            agent_to_use=None,
+            model_dict=None,
+            reasoning_effort=None,
+            baseline_message_ids=set(),
+        )
+    )
+
+    assert (final_text, should_emit) == ("recovered", True)
+    assert polls["n"] == 2
+    assert not any(item[0][1] == "result" for item in emitted)
 
 
 def test_opencode_poll_keeps_explicit_empty_completion_on_success_path():

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -2082,6 +2082,145 @@ def test_opencode_poll_keeps_retry_pending_on_empty_inflight_assistant(monkeypat
     assert not any(item[0] == "result" for item in emitted)
 
 
+def test_opencode_poll_keeps_continue_pending_through_idle_visibility_gap(monkeypatch):
+    """After posting continue, an idle trailing-user snapshot is still live."""
+
+    monkeypatch.setattr(
+        "modules.agents.opencode.poll_loop._POLL_INTERVAL_SECONDS", 0.01
+    )
+    monkeypatch.setattr(
+        "modules.agents.opencode.poll_loop._POST_INJECT_CONFIRMATION_SECONDS", 1.0
+    )
+    emitted = []
+    polls = {"n": 0}
+
+    class _AuthSvc:
+        async def maybe_emit_auth_recovery_message(
+            self, context, backend, message, *, output=None, terminal_error=None
+        ):
+            return False
+
+    class _Controller:
+        agent_auth_service = _AuthSvc()
+
+        def _t(self, key, **kwargs):
+            if key == "error.opencodeBackendError":
+                return f"OpenCode error: {kwargs['error']}"
+            return f"translated:{key}"
+
+        async def emit_agent_message(
+            self,
+            context,
+            message_type,
+            text,
+            parse_mode=None,
+            *,
+            is_error=False,
+            level="normal",
+            output=None,
+            terminal_error=None,
+        ):
+            emitted.append((message_type, text, is_error, level, terminal_error))
+
+    class _Agent:
+        opencode_config = type("OpenCodeConfig", (), {"error_retry_limit": 1})()
+        controller = _Controller()
+
+        def _extract_response_text(self, message):
+            return "recovered"
+
+        async def record_model_hub_native_failure(self, context, diagnostic):
+            raise AssertionError("must not settle during the continue visibility gap")
+
+    class _Server:
+        async def list_messages(self, session_id, directory):
+            polls["n"] += 1
+            if polls["n"] == 1:
+                return [
+                    {
+                        "info": {
+                            "id": "msg-err",
+                            "role": "assistant",
+                            "time": {"completed": 1},
+                            "error": {"name": "UnknownError", "data": {"message": "tls"}},
+                        },
+                        "parts": [],
+                    }
+                ]
+            if polls["n"] == 2:
+                return [
+                    {
+                        "info": {
+                            "id": "msg-err",
+                            "role": "assistant",
+                            "time": {"completed": 1},
+                            "error": {"name": "UnknownError", "data": {"message": "tls"}},
+                        },
+                        "parts": [],
+                    },
+                    {
+                        "info": {"id": "msg-continue", "role": "user", "time": {}},
+                        "parts": [{"type": "text", "text": "continue"}],
+                    },
+                ]
+            return [
+                {
+                    "info": {
+                        "id": "msg-err",
+                        "role": "assistant",
+                        "time": {"completed": 1},
+                        "error": {"name": "UnknownError", "data": {"message": "tls"}},
+                    },
+                    "parts": [],
+                },
+                {
+                    "info": {"id": "msg-continue", "role": "user", "time": {}},
+                    "parts": [{"type": "text", "text": "continue"}],
+                },
+                {
+                    "info": {
+                        "id": "msg-new",
+                        "role": "assistant",
+                        "time": {"completed": 1},
+                        "finish": "stop",
+                    },
+                    "parts": [{"type": "text", "text": "recovered"}],
+                },
+            ]
+
+        async def prompt_async(self, **kwargs):
+            return None
+
+        async def get_session_status(self, session_id, directory):
+            return None
+
+    request = AgentRequest(
+        context=MessageContext(user_id="u", channel_id="c", platform="slack"),
+        message="hello",
+        user_message="hello",
+        working_path="/tmp/work",
+        base_session_id="base",
+        composite_session_id="base:/tmp/work",
+        session_key="slack::c",
+    )
+
+    final_text, should_emit = asyncio.run(
+        OpenCodePollLoop(_Agent()).run_prompt_poll(
+            request,
+            _Server(),
+            "oc-session",
+            agent_to_use=None,
+            model_dict=None,
+            reasoning_effort=None,
+            baseline_message_ids=set(),
+        )
+    )
+
+    assert (final_text, should_emit) == ("recovered", True)
+    assert polls["n"] >= 3
+    assert not any(item[0] == "result" for item in emitted)
+
+
 def test_opencode_poll_does_not_settle_error_while_followup_has_parts():
     """A follow-up assistant that already has parts is still the live turn."""
 
@@ -2270,6 +2409,121 @@ def test_opencode_poll_keeps_explicit_empty_completion_on_success_path():
     assert final_text is None
     assert should_emit is True
     assert emitted == []
+
+
+def test_opencode_restored_poll_settles_error_after_retry_budget(monkeypatch):
+    """A restored poll must emit the backend error, not (No response)."""
+
+    monkeypatch.setattr(
+        "modules.agents.opencode.poll_loop._POLL_INTERVAL_SECONDS", 0.01
+    )
+    emitted = []
+    removed = []
+    results = []
+
+    class _AuthSvc:
+        async def maybe_emit_auth_recovery_message(
+            self, context, backend, message, *, output=None, terminal_error=None
+        ):
+            return False
+
+    class _Controller:
+        agent_auth_service = _AuthSvc()
+
+        def __init__(self):
+            self.config = type("Config", (), {"language": "en"})()
+            self.processing_indicator = ProcessingIndicatorService(self)
+
+        def _t(self, key, **kwargs):
+            if key == "error.opencodeBackendError":
+                return f"OpenCode error: {kwargs['error']}"
+            return f"translated:{key}"
+
+        async def emit_agent_message(
+            self,
+            context,
+            message_type,
+            text,
+            parse_mode=None,
+            *,
+            is_error=False,
+            level="normal",
+            output=None,
+            terminal_error=None,
+        ):
+            emitted.append((message_type, text, is_error, level, terminal_error))
+
+    class _Sessions:
+        def remove_active_poll(self, session_id):
+            removed.append(session_id)
+
+        def update_active_poll_state(self, session_id, **kwargs):
+            return None
+
+    class _Server:
+        async def list_messages(self, session_id, directory):
+            return [
+                {
+                    "info": {
+                        "id": "msg-err",
+                        "role": "assistant",
+                        "time": {"completed": 1},
+                        "error": {
+                            "name": "UnknownError",
+                            "data": {"message": "certificate failed"},
+                        },
+                    },
+                    "parts": [],
+                },
+                {
+                    "info": {"id": "msg-user", "role": "user", "time": {}},
+                    "parts": [{"type": "text", "text": "继续"}],
+                },
+            ]
+
+        async def get_session_status(self, session_id, directory):
+            return None
+
+    server = _Server()
+
+    class _Agent:
+        opencode_config = type("OpenCodeConfig", (), {"error_retry_limit": 1})()
+        controller = _Controller()
+        sessions = _Sessions()
+
+        async def _get_server(self):
+            return server
+
+        def _extract_response_text(self, message):
+            return ""
+
+        async def emit_result_message(self, context, text, **kwargs):
+            results.append(text)
+
+        async def _remove_ack_reaction(self, request):
+            return None
+
+        async def record_model_hub_native_failure(self, context, diagnostic):
+            return True
+
+    poll = ActivePollInfo(
+        opencode_session_id="oc-session",
+        base_session_id="base",
+        channel_id="c",
+        thread_id="t",
+        settings_key="c",
+        working_path="/tmp/work",
+        baseline_message_ids=[],
+        platform="slack",
+        prompt_started_at=time.time(),
+    )
+
+    asyncio.run(OpenCodePollLoop(_Agent()).run_restored_poll_loop(poll))
+
+    assert removed == ["oc-session"]
+    assert any(item[0] == "result" and item[2] is True for item in emitted)
+    assert all("No response from OpenCode" not in str(item) for item in results)
+    assert any("certificate failed" in (item[1] or "") for item in emitted)
 
 
 def test_opencode_restored_poll_keeps_empty_completion_successful():

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -1546,7 +1546,7 @@ def test_settlement_assistant_message_walks_back_to_the_owning_turn():
         ([error_assistant], True, "msg-err"),
         ([error_assistant, trailing_user], False, "msg-err"),
         ([error_assistant, trailing_user], True, None),
-        ([error_assistant, trailing_user, empty_inflight], False, "msg-err"),
+        ([error_assistant, trailing_user, empty_inflight], False, None),
         ([error_assistant, trailing_user, empty_inflight], True, None),
         ([error_assistant, live_followup], True, None),
         ([error_assistant, live_followup], False, None),

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -1542,18 +1542,26 @@ def test_settlement_assistant_message_walks_back_to_the_owning_turn():
     }
 
     cases = (
-        ([error_assistant], "msg-err"),
-        ([error_assistant, trailing_user], "msg-err"),
-        ([error_assistant, trailing_user, empty_inflight], None),
-        ([error_assistant, live_followup], None),
-        ([completed_ok, trailing_user], "msg-ok"),
-        ([trailing_user], None),
-        ([error_assistant, trailing_user, empty_inflight, completed_ok], "msg-ok"),
+        ([error_assistant], False, "msg-err"),
+        ([error_assistant], True, "msg-err"),
+        ([error_assistant, trailing_user], False, "msg-err"),
+        ([error_assistant, trailing_user], True, None),
+        ([error_assistant, trailing_user, empty_inflight], False, "msg-err"),
+        ([error_assistant, trailing_user, empty_inflight], True, None),
+        ([error_assistant, live_followup], True, None),
+        ([error_assistant, live_followup], False, None),
+        ([completed_ok, trailing_user], False, "msg-ok"),
+        ([completed_ok, trailing_user], True, None),
+        ([trailing_user], False, None),
+        ([trailing_user], True, None),
+        ([error_assistant, trailing_user, empty_inflight, completed_ok], False, "msg-ok"),
     )
-    for messages, expected_id in cases:
-        owner = _settlement_assistant_message(messages, set())
+    for messages, native_live, expected_id in cases:
+        owner = _settlement_assistant_message(
+            messages, set(), native_live=native_live
+        )
         actual_id = None if owner is None else owner["info"]["id"]
-        assert actual_id == expected_id, (expected_id, actual_id)
+        assert actual_id == expected_id, (native_live, expected_id, actual_id)
 
 
 def test_opencode_poll_notifies_and_settles_on_retry_exhaustion():
@@ -1733,6 +1741,9 @@ def test_opencode_poll_settles_error_when_trailing_user_is_last():
                 },
             ]
 
+        async def get_session_status(self, session_id, directory):
+            return {"type": "idle"}
+
     request = AgentRequest(
         context=MessageContext(user_id="u", channel_id="c", platform="slack"),
         message="hello",
@@ -1761,6 +1772,105 @@ def test_opencode_poll_settles_error_when_trailing_user_is_last():
     assert model_hub_failures == [
         "UnknownError - unknown certificate verification error"
     ]
+
+
+def test_opencode_poll_keeps_accepted_steer_pending_while_native_busy(monkeypatch):
+    """A trailing user while OpenCode is busy is a live steer, not a hang."""
+
+    monkeypatch.setattr(
+        "modules.agents.opencode.poll_loop._POLL_INTERVAL_SECONDS", 0.01
+    )
+    emitted = []
+    polls = {"n": 0}
+
+    class _AuthSvc:
+        async def maybe_emit_auth_recovery_message(
+            self, context, backend, message, *, output=None, terminal_error=None
+        ):
+            return False
+
+    class _Controller:
+        agent_auth_service = _AuthSvc()
+
+        def _t(self, key, **kwargs):
+            return f"translated:{key}"
+
+        async def emit_agent_message(self, *args, **kwargs):
+            emitted.append((args, kwargs))
+
+    class _Agent:
+        opencode_config = type("OpenCodeConfig", (), {"error_retry_limit": 0})()
+        controller = _Controller()
+
+        def _extract_response_text(self, message):
+            return "steered"
+
+        async def record_model_hub_native_failure(self, context, diagnostic):
+            raise AssertionError("must not settle the prior turn while steer is live")
+
+    class _Server:
+        async def list_messages(self, session_id, directory):
+            polls["n"] += 1
+            followup_ready = polls["n"] >= 3
+            rows = [
+                {
+                    "info": {
+                        "id": "msg-ok",
+                        "role": "assistant",
+                        "time": {"completed": 1},
+                        "finish": "stop",
+                    },
+                    "parts": [{"type": "text", "text": "old"}],
+                },
+                {
+                    "info": {"id": "msg-steer", "role": "user", "time": {}},
+                    "parts": [{"type": "text", "text": "steer"}],
+                },
+            ]
+            if followup_ready:
+                rows.append(
+                    {
+                        "info": {
+                            "id": "msg-new",
+                            "role": "assistant",
+                            "time": {"completed": 1},
+                            "finish": "stop",
+                        },
+                        "parts": [{"type": "text", "text": "steered"}],
+                    }
+                )
+            return rows
+
+        async def get_session_status(self, session_id, directory):
+            if polls["n"] >= 3:
+                return {"type": "idle"}
+            return {"type": "busy"}
+
+    request = AgentRequest(
+        context=MessageContext(user_id="u", channel_id="c", platform="slack"),
+        message="hello",
+        user_message="hello",
+        working_path="/tmp/work",
+        base_session_id="base",
+        composite_session_id="base:/tmp/work",
+        session_key="slack::c",
+    )
+
+    final_text, should_emit = asyncio.run(
+        OpenCodePollLoop(_Agent()).run_prompt_poll(
+            request,
+            _Server(),
+            "oc-session",
+            agent_to_use=None,
+            model_dict=None,
+            reasoning_effort=None,
+            baseline_message_ids=set(),
+        )
+    )
+
+    assert (final_text, should_emit) == ("steered", True)
+    assert polls["n"] == 3
+    assert not any(item[0][1] == "result" for item in emitted)
 
 
 def test_opencode_poll_keeps_retry_pending_on_empty_inflight_assistant(monkeypatch):

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -1742,7 +1742,7 @@ def test_opencode_poll_settles_error_when_trailing_user_is_last():
             ]
 
         async def get_session_status(self, session_id, directory):
-            return {"type": "idle"}
+            return None
 
     request = AgentRequest(
         context=MessageContext(user_id="u", channel_id="c", platform="slack"),
@@ -1870,6 +1870,110 @@ def test_opencode_poll_keeps_accepted_steer_pending_while_native_busy(monkeypatc
 
     assert (final_text, should_emit) == ("steered", True)
     assert polls["n"] == 3
+    assert not any(item[0][1] == "result" for item in emitted)
+
+
+def test_opencode_poll_uses_snapshot_live_flag_instead_of_rereading_status(monkeypatch):
+    """The wrapper's busy decision wins over a later idle status read."""
+
+    monkeypatch.setattr(
+        "modules.agents.opencode.poll_loop._POLL_INTERVAL_SECONDS", 0.01
+    )
+    emitted = []
+    polls = {"n": 0}
+    status_reads = {"n": 0}
+
+    class _AuthSvc:
+        async def maybe_emit_auth_recovery_message(
+            self, context, backend, message, *, output=None, terminal_error=None
+        ):
+            return False
+
+    class _Controller:
+        agent_auth_service = _AuthSvc()
+
+        def _t(self, key, **kwargs):
+            return f"translated:{key}"
+
+        async def emit_agent_message(self, *args, **kwargs):
+            emitted.append((args, kwargs))
+
+    class _Agent:
+        opencode_config = type("OpenCodeConfig", (), {"error_retry_limit": 0})()
+        controller = _Controller()
+
+        def _extract_response_text(self, message):
+            return "steered"
+
+        async def record_model_hub_native_failure(self, context, diagnostic):
+            raise AssertionError("stale idle status must not settle the pre-steer turn")
+
+    class _Server:
+        last_list_native_live = True
+
+        async def list_messages(self, session_id, directory):
+            polls["n"] += 1
+            followup_ready = polls["n"] >= 3
+            if followup_ready:
+                self.last_list_native_live = False
+            rows = [
+                {
+                    "info": {
+                        "id": "msg-ok",
+                        "role": "assistant",
+                        "time": {"completed": 1},
+                        "finish": "stop",
+                    },
+                    "parts": [{"type": "text", "text": "old"}],
+                },
+                {
+                    "info": {"id": "msg-steer", "role": "user", "time": {}},
+                    "parts": [{"type": "text", "text": "steer"}],
+                },
+            ]
+            if followup_ready:
+                rows.append(
+                    {
+                        "info": {
+                            "id": "msg-new",
+                            "role": "assistant",
+                            "time": {"completed": 1},
+                            "finish": "stop",
+                        },
+                        "parts": [{"type": "text", "text": "steered"}],
+                    }
+                )
+            return rows
+
+        async def get_session_status(self, session_id, directory):
+            status_reads["n"] += 1
+            return None
+
+    request = AgentRequest(
+        context=MessageContext(user_id="u", channel_id="c", platform="slack"),
+        message="hello",
+        user_message="hello",
+        working_path="/tmp/work",
+        base_session_id="base",
+        composite_session_id="base:/tmp/work",
+        session_key="slack::c",
+    )
+
+    final_text, should_emit = asyncio.run(
+        OpenCodePollLoop(_Agent()).run_prompt_poll(
+            request,
+            _Server(),
+            "oc-session",
+            agent_to_use=None,
+            model_dict=None,
+            reasoning_effort=None,
+            baseline_message_ids=set(),
+        )
+    )
+
+    assert (final_text, should_emit) == ("steered", True)
+    assert polls["n"] == 3
+    assert status_reads["n"] == 0
     assert not any(item[0][1] == "result" for item in emitted)
 
 

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -1563,6 +1563,28 @@ def test_settlement_assistant_message_walks_back_to_the_owning_turn():
         actual_id = None if owner is None else owner["info"]["id"]
         assert actual_id == expected_id, (native_live, expected_id, actual_id)
 
+    owner = _settlement_assistant_message(
+        [error_assistant],
+        set(),
+        native_live=False,
+        awaiting_after_ids={"msg-err"},
+    )
+    assert owner is None
+    owner = _settlement_assistant_message(
+        [error_assistant, trailing_user],
+        set(),
+        native_live=False,
+        awaiting_after_ids={"msg-err"},
+    )
+    assert owner is None
+    owner = _settlement_assistant_message(
+        [error_assistant, trailing_user, completed_ok],
+        set(),
+        native_live=False,
+        awaiting_after_ids={"msg-err"},
+    )
+    assert owner is not None and owner["info"]["id"] == "msg-ok"
+
 
 def test_opencode_poll_notifies_and_settles_on_retry_exhaustion():
     # A completed assistant message carrying an error, with retries exhausted
@@ -2219,6 +2241,121 @@ def test_opencode_poll_keeps_continue_pending_through_idle_visibility_gap(monkey
     assert (final_text, should_emit) == ("recovered", True)
     assert polls["n"] >= 3
     assert not any(item[0] == "result" for item in emitted)
+
+
+def test_opencode_poll_keeps_retry_pending_before_continue_user_appears(monkeypatch):
+    """Awaiting boundary holds the old error until post-inject evidence exists."""
+
+    monkeypatch.setattr(
+        "modules.agents.opencode.poll_loop._POLL_INTERVAL_SECONDS", 0.01
+    )
+    emitted = []
+    polls = {"n": 0}
+
+    class _AuthSvc:
+        async def maybe_emit_auth_recovery_message(
+            self, context, backend, message, *, output=None, terminal_error=None
+        ):
+            return False
+
+    class _Controller:
+        agent_auth_service = _AuthSvc()
+
+        def _t(self, key, **kwargs):
+            if key == "error.opencodeBackendError":
+                return f"OpenCode error: {kwargs['error']}"
+            return f"translated:{key}"
+
+        async def emit_agent_message(self, *args, **kwargs):
+            emitted.append((args, kwargs))
+
+    class _State:
+        awaiting_after_message_ids = {"msg-err"}
+        awaiting_user_text = "continue"
+
+    class _Agent:
+        opencode_config = type("OpenCodeConfig", (), {"error_retry_limit": 1})()
+        controller = _Controller()
+
+        def _extract_response_text(self, message):
+            return "recovered"
+
+        async def record_model_hub_native_failure(self, context, diagnostic):
+            raise AssertionError("must not settle the prior error before continue appears")
+
+    class _Server:
+        def __init__(self):
+            self._state = _State()
+
+        async def list_messages(self, session_id, directory):
+            polls["n"] += 1
+            error = {
+                "info": {
+                    "id": "msg-err",
+                    "role": "assistant",
+                    "time": {"completed": 1},
+                    "error": {"name": "UnknownError", "data": {"message": "tls"}},
+                },
+                "parts": [],
+            }
+            if polls["n"] == 1:
+                return [error]
+            if polls["n"] == 2:
+                return [
+                    error,
+                    {
+                        "info": {"id": "msg-continue", "role": "user", "time": {}},
+                        "parts": [{"type": "text", "text": "continue"}],
+                    },
+                ]
+            return [
+                error,
+                {
+                    "info": {"id": "msg-continue", "role": "user", "time": {}},
+                    "parts": [{"type": "text", "text": "continue"}],
+                },
+                {
+                    "info": {
+                        "id": "msg-new",
+                        "role": "assistant",
+                        "time": {"completed": 1},
+                        "finish": "stop",
+                    },
+                    "parts": [{"type": "text", "text": "recovered"}],
+                },
+            ]
+
+        async def get_session_status(self, session_id, directory):
+            return None
+
+        async def prompt_async(self, **kwargs):
+            return None
+
+    request = AgentRequest(
+        context=MessageContext(user_id="u", channel_id="c", platform="slack"),
+        message="hello",
+        user_message="hello",
+        working_path="/tmp/work",
+        base_session_id="base",
+        composite_session_id="base:/tmp/work",
+        session_key="slack::c",
+    )
+
+    final_text, should_emit = asyncio.run(
+        OpenCodePollLoop(_Agent()).run_prompt_poll(
+            request,
+            _Server(),
+            "oc-session",
+            agent_to_use=None,
+            model_dict=None,
+            reasoning_effort=None,
+            baseline_message_ids=set(),
+        )
+    )
+
+    assert (final_text, should_emit) == ("recovered", True)
+    assert polls["n"] >= 3
+    assert not any(item[0][1] == "result" for item in emitted)
 
 
 def test_opencode_poll_does_not_settle_error_while_followup_has_parts():


### PR DESCRIPTION
## Capability

OpenCode poll settlement no longer keys off `messages[-1]`. It walks back to the owning assistant and consults native `/session/status`:

- trailing user + busy/retry → live steer or auto-retry `continue`, stay pending
- trailing user + idle → hang after a completed error / watch inject, settle
- in-flight assistant (even empty) while live → pending
- missing status → treated as live so an accepted steer is not closed

## Scenario IDs

No catalog ID. Live hang: sessions `sesk2vjqnnnch` / `sesy6d3vv8fuy`.

## Evidence

- Unit: snapshot×busy owner table; idle trailing-user error settlement; busy steer stays pending; empty retry follow-up stays pending; existing retry-exhaustion and empty-completion tests
- Residual: aborting the two live hung native sessions is operator-side and not in this PR

## Known-by-design

Missing or unreadable `/session/status` is treated as live. That can delay settlement of a true hang until status is readable again; it will not drop an accepted steer.
