### PR TITLE
chore(prompt): narrow the use-avibe playbook trigger to state changes

### DIFF
--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -36,7 +36,7 @@ _BASE_CAPABILITIES_BODY = """\
 Avibe is the local-first Agent OS: it turns this machine into the runtime an agent lives in, and the user operates that runtime through Web or IM surfaces such as Slack, Discord, Telegram, WeChat, and Lark/Feishu. \
 The user is interacting with you through Avibe.
 
-Before changing Avibe configuration or state, or disrupting its running service, consult the `use-avibe` playbook; use `https://github.com/avibe-bot/avibe/raw/master/skills/use-avibe/SKILL.md` when it is not installed locally. Answer Avibe questions this prompt already covers directly, and load the playbook for explanation only when the answer is not here.
+Consult the `use-avibe` playbook before any Avibe operation: changing configuration or state, disrupting the running service, or inspecting logs, service status, and runtime state. Use `https://github.com/avibe-bot/avibe/raw/master/skills/use-avibe/SKILL.md` when it is not installed locally. Answer Avibe questions this prompt already covers directly, and load the playbook for explanation only when the answer is not here.
 
 Avibe provides optional capabilities:
 

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -36,7 +36,7 @@ _BASE_CAPABILITIES_BODY = """\
 Avibe is the local-first Agent OS: it turns this machine into the runtime an agent lives in, and the user operates that runtime through Web or IM surfaces such as Slack, Discord, Telegram, WeChat, and Lark/Feishu. \
 The user is interacting with you through Avibe.
 
-Use the `use-avibe` playbook for Avibe configuration, repair, explanation, and operations. Before changing Avibe state or disrupting its running service, consult that playbook; use `https://github.com/avibe-bot/avibe/raw/master/skills/use-avibe/SKILL.md` when it is not installed locally.
+Before changing Avibe configuration or state, or disrupting its running service, consult the `use-avibe` playbook; use `https://github.com/avibe-bot/avibe/raw/master/skills/use-avibe/SKILL.md` when it is not installed locally. Answer Avibe questions this prompt already covers directly, and load the playbook for explanation only when the answer is not here.
 
 Avibe provides optional capabilities:
 

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -36,7 +36,7 @@ _BASE_CAPABILITIES_BODY = """\
 Avibe is the local-first Agent OS: it turns this machine into the runtime an agent lives in, and the user operates that runtime through Web or IM surfaces such as Slack, Discord, Telegram, WeChat, and Lark/Feishu. \
 The user is interacting with you through Avibe.
 
-Consult the `use-avibe` playbook before operating Avibe (config, state, service, logs, runtime), not to explain what this prompt already covers; use `https://github.com/avibe-bot/avibe/raw/master/skills/use-avibe/SKILL.md` when it is not installed locally.
+Consult the `use-avibe` playbook to operate Avibe (config, state, service, logs, runtime) or answer anything about it this prompt does not cover; use `https://github.com/avibe-bot/avibe/raw/master/skills/use-avibe/SKILL.md` when it is not installed locally.
 
 Avibe provides optional capabilities:
 

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -36,7 +36,7 @@ _BASE_CAPABILITIES_BODY = """\
 Avibe is the local-first Agent OS: it turns this machine into the runtime an agent lives in, and the user operates that runtime through Web or IM surfaces such as Slack, Discord, Telegram, WeChat, and Lark/Feishu. \
 The user is interacting with you through Avibe.
 
-Consult the `use-avibe` playbook before any Avibe operation: changing configuration or state, disrupting the running service, or inspecting logs, service status, and runtime state. Use `https://github.com/avibe-bot/avibe/raw/master/skills/use-avibe/SKILL.md` when it is not installed locally. Answer Avibe questions this prompt already covers directly, and load the playbook for explanation only when the answer is not here.
+Consult the `use-avibe` playbook before operating Avibe (config, state, service, logs, runtime), not to explain what this prompt already covers; use `https://github.com/avibe-bot/avibe/raw/master/skills/use-avibe/SKILL.md` when it is not installed locally.
 
 Avibe provides optional capabilities:
 

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -101,29 +101,22 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn("## Silent replies", prompt)
         self.assertIn("<silent>reason not shown to the user</silent>", prompt)
+        # The gate covers operating Avibe, not every Avibe-flavored question: a
+        # blanket "explanation" trigger made questions this prompt already answers
+        # pull in a 1000-line SKILL.md. `logs` and `runtime` keep read-only
+        # inspection inside the gate, which is where agents learn to read logs
+        # through the API and treat internal runtime state as opaque.
         self.assertIn(
-            "Consult the `use-avibe` playbook before any Avibe operation",
+            "Consult the `use-avibe` playbook before operating Avibe "
+            "(config, state, service, logs, runtime), not to explain what this "
+            "prompt already covers",
             prompt,
         )
-        # Read-only operations stay inside the gate: the playbook is where agents
-        # learn to read logs through the API and to treat internal runtime state
-        # as opaque, so dropping them would invite direct file inspection.
         self.assertIn(
-            "inspecting logs, service status, and runtime state",
-            prompt,
-        )
-        self.assertIn(
-            "Use `https://github.com/avibe-bot/avibe/raw/master/skills/use-avibe/SKILL.md` "
+            "use `https://github.com/avibe-bot/avibe/raw/master/skills/use-avibe/SKILL.md` "
             "when it is not installed locally",
             prompt,
         )
-        self.assertIn(
-            "load the playbook for explanation only when the answer is not here",
-            prompt,
-        )
-        # The gate covers Avibe operations, not every Avibe-flavored question. A
-        # blanket "explanation" trigger made questions this prompt already answers
-        # pull in a 1000-line SKILL.md.
         self.assertNotIn("configuration, repair, explanation, and operations", prompt)
         self.assertIn("skills/use-avibe/SKILL.md", prompt)
         self.assertNotIn("new user turn", prompt)

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -101,15 +101,16 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn("## Silent replies", prompt)
         self.assertIn("<silent>reason not shown to the user</silent>", prompt)
-        # The gate covers operating Avibe, not every Avibe-flavored question: a
-        # blanket "explanation" trigger made questions this prompt already answers
-        # pull in a 1000-line SKILL.md. `logs` and `runtime` keep read-only
-        # inspection inside the gate, which is where agents learn to read logs
-        # through the API and treat internal runtime state as opaque.
+        # One positive trigger, so its complement does the excluding and there is
+        # no carve-out list to erode: `logs`/`runtime` keep read-only inspection
+        # gated (that is where agents learn to read logs through the API and treat
+        # internal state as opaque), and "does not cover" gates every Avibe
+        # explanation this prompt cannot answer. Phrasing it as gate-plus-carve-out
+        # cost two review rounds re-adding cases each compression shaved off.
         self.assertIn(
-            "Consult the `use-avibe` playbook before operating Avibe "
-            "(config, state, service, logs, runtime), not to explain what this "
-            "prompt already covers",
+            "Consult the `use-avibe` playbook to operate Avibe "
+            "(config, state, service, logs, runtime) or answer anything about it "
+            "this prompt does not cover",
             prompt,
         )
         self.assertIn(

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -102,12 +102,8 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("## Silent replies", prompt)
         self.assertIn("<silent>reason not shown to the user</silent>", prompt)
         self.assertIn(
-            "Use the `use-avibe` playbook for Avibe configuration, repair, explanation, "
-            "and operations",
-            prompt,
-        )
-        self.assertIn(
-            "Before changing Avibe state or disrupting its running service, consult that playbook",
+            "Before changing Avibe configuration or state, or disrupting its running "
+            "service, consult the `use-avibe` playbook",
             prompt,
         )
         self.assertIn(
@@ -115,6 +111,14 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
             "when it is not installed locally",
             prompt,
         )
+        self.assertIn(
+            "load the playbook for explanation only when the answer is not here",
+            prompt,
+        )
+        # The playbook is a mutation gate, not a general Avibe-topic trigger. A
+        # blanket "explanation" trigger made every Avibe question pull in a
+        # 1000-line SKILL.md that this prompt already answers.
+        self.assertNotIn("configuration, repair, explanation, and operations", prompt)
         self.assertIn("skills/use-avibe/SKILL.md", prompt)
         self.assertNotIn("new user turn", prompt)
         self.assertNotIn("active Agent Session context", prompt)

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -102,12 +102,18 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("## Silent replies", prompt)
         self.assertIn("<silent>reason not shown to the user</silent>", prompt)
         self.assertIn(
-            "Before changing Avibe configuration or state, or disrupting its running "
-            "service, consult the `use-avibe` playbook",
+            "Consult the `use-avibe` playbook before any Avibe operation",
+            prompt,
+        )
+        # Read-only operations stay inside the gate: the playbook is where agents
+        # learn to read logs through the API and to treat internal runtime state
+        # as opaque, so dropping them would invite direct file inspection.
+        self.assertIn(
+            "inspecting logs, service status, and runtime state",
             prompt,
         )
         self.assertIn(
-            "use `https://github.com/avibe-bot/avibe/raw/master/skills/use-avibe/SKILL.md` "
+            "Use `https://github.com/avibe-bot/avibe/raw/master/skills/use-avibe/SKILL.md` "
             "when it is not installed locally",
             prompt,
         )
@@ -115,9 +121,9 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
             "load the playbook for explanation only when the answer is not here",
             prompt,
         )
-        # The playbook is a mutation gate, not a general Avibe-topic trigger. A
-        # blanket "explanation" trigger made every Avibe question pull in a
-        # 1000-line SKILL.md that this prompt already answers.
+        # The gate covers Avibe operations, not every Avibe-flavored question. A
+        # blanket "explanation" trigger made questions this prompt already answers
+        # pull in a 1000-line SKILL.md.
         self.assertNotIn("configuration, repair, explanation, and operations", prompt)
         self.assertIn("skills/use-avibe/SKILL.md", prompt)
         self.assertNotIn("new user turn", prompt)


### PR DESCRIPTION
## Changed capability

The injected Avibe system prompt's `use-avibe` line was a general Avibe-topic trigger:

> Use the `use-avibe` playbook for Avibe configuration, repair, **explanation**, and operations. Before changing Avibe state or disrupting its running service, consult that playbook; ...

`explanation` put every Avibe-flavored question inside the trigger — including the many
the injected prompt already answers inline (Harness commands, Show Pages, Vault, silent
replies). The result is agents loading a 1000+ line `skills/use-avibe/SKILL.md` — or
web-fetching it when the skill is not installed locally — to explain text that is already
in their context.

The line is now a single positive trigger:

> Consult the `use-avibe` playbook to operate Avibe (config, state, service, logs, runtime) or answer anything about it this prompt does not cover; use `https://github.com/avibe-bot/avibe/raw/master/skills/use-avibe/SKILL.md` when it is not installed locally.

- `operate Avibe (… logs, runtime)` keeps mutations, service disruption, **and read-only
  inspection** gated — the playbook is where agents learn to read logs through the API and
  to treat internal runtime state as opaque;
- `answer anything about it this prompt does not cover` gates every Avibe explanation this
  prompt cannot answer (`proxy_url`, remote-access pairing, state edits);
- only questions this prompt already answers fall outside, which is the entire narrowing.

Net effect on the prompt itself: 288 → 257 characters, 31 → 30 words. The playbook's own
scope is untouched; this changes *when the prompt tells agents to reach for it*.

**Why one positive trigger rather than a gate plus a carve-out.** The first two heads each
lost a case that had to stay gated — read-only operations, then uncovered explanations.
Both came from the same shape: a carve-out forces an enumeration of what stays inside, and
each compression pass shaved an item off it. Stating one positive trigger lets the
complement do the excluding, so there is no list left to erode.

## Evidence

- **unit** — `tests/test_reply_enhancer_platform.py::test_prompt_can_exclude_quick_replies`
  locks the exact sentence and the not-installed-locally URL fallback, and asserts the old
  broad phrasing is absent so a revert to a general-topic trigger fails a test. The comment
  above it records why the carve-out phrasing must not come back.
- **contract** — `tests/test_harness_skill_guidance.py` passes unchanged; the embedded
  `vibe task` / `vibe watch` CLI examples and the playbook's documented scope are untouched
  by this diff.
- Focused run: `tests/test_reply_enhancer_platform.py tests/test_harness_skill_guidance.py`
  — 169 passed, 40 subtests passed.
- `ruff check` clean on both changed files.

No scenario catalog covers the injected-prompt wording, so no scenario IDs apply.

## Residual manual checks

Deferred to the integration pass: confirm in a live session that Avibe questions already
answered by the injected prompt no longer pull in the playbook, while a config/state
change, a log/status inspection, or a question this prompt does not cover still does.

## Dependencies

None.
