### PR TITLE
fix(show): hide denied identity access

### DIFF
--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -617,6 +617,25 @@ def test_limited_show_callback_maps_outages_and_rechecks_share_binding(
     assert unavailable.status_code == 503
     assert unavailable.get_json()["error"] == "identity_unavailable"
 
+    not_verified_login = client.get(
+        f"/p/{share_id}/",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+        headers={"Accept": "text/html"},
+        follow_redirects=False,
+    )
+    not_verified_state = urllib.parse.parse_qs(
+        urllib.parse.urlsplit(not_verified_login.headers["Location"]).query
+    )["state"][0]
+    not_verified = client.post(
+        show_identity.CALLBACK_PATH,
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+        data={"state": not_verified_state, "error": "identity_not_verified"},
+    )
+    assert not_verified.status_code == 404
+    assert not_verified.get_json() == {"error": "not_found"}
+
     verifier_login = client.get(
         f"/p/{share_id}/",
         base_url="https://alex.avibe.bot",
@@ -683,8 +702,8 @@ def test_limited_show_callback_maps_outages_and_rechecks_share_binding(
         environ_base=_remote_peer(),
         data={"state": next_state, "assertion": "signed-assertion"},
     )
-    assert rotated.status_code == 403
-    assert rotated.get_json()["error"] == "show_access_forbidden"
+    assert rotated.status_code == 404
+    assert rotated.get_json() == {"error": "not_found"}
     assert "Set-Cookie" not in rotated.headers
 
 
@@ -730,8 +749,8 @@ def test_limited_show_callback_rejects_offline_page_and_rate_limits_verification
         environ_base=_remote_peer(),
         data={"state": state, "assertion": "signed-assertion"},
     )
-    assert offline.status_code == 403
-    assert offline.get_json()["error"] == "show_access_forbidden"
+    assert offline.status_code == 404
+    assert offline.get_json() == {"error": "not_found"}
     assert "Set-Cookie" not in offline.headers
 
     monkeypatch.setattr(ui_server, "_auth_rate_limited", lambda: True)
@@ -855,9 +874,23 @@ def test_show_identity_callback_does_not_charge_denied_identity_to_replay_ledger
         data={"state": state, "assertion": "signed-assertion"},
     )
 
-    assert denied.status_code == 403
-    assert denied.get_json()["error"] == "show_access_forbidden"
+    assert denied.status_code == 404
+    assert denied.get_json() == {"error": "not_found"}
     assert "Set-Cookie" not in denied.headers
+
+
+def test_show_identity_not_found_is_a_generic_html_page_for_browsers():
+    with app.test_request_context(
+        show_identity.CALLBACK_PATH,
+        method="POST",
+        headers={"Accept": "text/html"},
+    ):
+        response = ui_server._show_identity_not_found_response()
+
+    assert response.status_code == 404
+    assert response.headers["Content-Type"].startswith("text/html")
+    assert b"This page is unavailable" in response.body
+    assert b"show_access_forbidden" not in response.body
 
 
 def test_show_identity_callback_body_stops_at_the_streaming_limit():
@@ -1141,7 +1174,8 @@ def test_limited_show_guest_is_admitted_once_and_not_live_revoked(
                 "assertion": "signed-assertion",
             },
         )
-        assert denied.status_code == 403
+        assert denied.status_code == 404
+        assert denied.get_json() == {"error": "not_found"}
 
         store = ShowPageStore()
         try:
@@ -1171,6 +1205,8 @@ def test_limited_show_guest_is_admitted_once_and_not_live_revoked(
             headers={"Accept": "text/html"},
         )
         assert new_visit.status_code == 404
+        assert b"This page is unavailable" in new_visit.content
+        assert b"does not exist or is no longer available" in new_visit.content
 
         store = ShowPageStore()
         try:
@@ -7679,6 +7715,19 @@ def test_public_and_private_paths_are_canonical_by_visibility(monkeypatch, tmp_p
     # private page is never reachable there.
     public_response = app.test_client().get(f"/p/{share_id}/", base_url="http://127.0.0.1:5123")
     assert public_response.status_code == 404
+
+
+def test_public_show_not_found_is_a_generic_html_page_for_browsers():
+    response = app.test_client().get(
+        "/p/unknown-share/",
+        base_url="http://127.0.0.1:5123",
+        headers={"Accept": "text/html"},
+    )
+
+    assert response.status_code == 404
+    assert response.headers["Content-Type"].startswith("text/html")
+    assert b"This page is unavailable" in response.content
+    assert b"not_found" not in response.content
 
 
 def test_rotated_public_share_url_stops_working(monkeypatch, tmp_path):

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -883,14 +883,37 @@ def test_show_identity_not_found_is_a_generic_html_page_for_browsers():
     with app.test_request_context(
         show_identity.CALLBACK_PATH,
         method="POST",
-        headers={"Accept": "text/html"},
+        headers={"Accept": "text/html", "Accept-Language": "zh-CN,zh;q=0.9"},
     ):
         response = ui_server._show_identity_not_found_response()
 
     assert response.status_code == 404
     assert response.headers["Content-Type"].startswith("text/html")
-    assert b"This page is unavailable" in response.body
+    body = response.body.decode("utf-8")
+    assert 'lang="zh"' in body
+    assert "此页面暂时不可用" in body
+    assert "页面不存在，或已不再提供访问。" in body
     assert b"show_access_forbidden" not in response.body
+
+
+@pytest.mark.parametrize(
+    "accept",
+    [
+        "application/json, text/html;q=0",
+        "application/json, text/html;q=0.5",
+        "*/*",
+    ],
+)
+def test_show_identity_not_found_prefers_json_when_html_is_not_preferred(accept):
+    with app.test_request_context(
+        show_identity.CALLBACK_PATH,
+        method="POST",
+        headers={"Accept": accept},
+    ):
+        response = ui_server._show_identity_not_found_response()
+
+    assert response.status_code == 404
+    assert json.loads(response.body) == {"error": "not_found"}
 
 
 def test_show_identity_callback_body_stops_at_the_streaming_limit():
@@ -7728,6 +7751,17 @@ def test_public_show_not_found_is_a_generic_html_page_for_browsers():
     assert response.headers["Content-Type"].startswith("text/html")
     assert b"This page is unavailable" in response.content
     assert b"not_found" not in response.content
+
+
+def test_public_show_not_found_respects_html_quality():
+    response = app.test_client().get(
+        "/p/unknown-share/",
+        base_url="http://127.0.0.1:5123",
+        headers={"Accept": "application/json, text/html;q=0"},
+    )
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "not_found"}
 
 
 def test_rotated_public_share_url_stops_working(monkeypatch, tmp_path):

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -18,6 +18,11 @@
       "dispatchFailed": "The Show event was recorded, but its agent turn could not be delivered.",
       "idConflict": "This Show event ID is already bound to different event contents.",
       "unsupportedEventType": "Show Page writes require a supported human event or mark resolution type."
+    },
+    "pageUnavailable": {
+      "title": "Show Page unavailable",
+      "heading": "This page is unavailable",
+      "message": "The page does not exist or is no longer available."
     }
   },
   "harness": {

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -18,6 +18,11 @@
       "dispatchFailed": "Show 事件已记录，但未能投递对应的 Agent turn。",
       "idConflict": "此 Show 事件 ID 已绑定到不同的事件内容。",
       "unsupportedEventType": "Show Page 写入必须使用受支持的人类事件或标记解析类型。"
+    },
+    "pageUnavailable": {
+      "title": "Show Page 暂时不可用",
+      "heading": "此页面暂时不可用",
+      "message": "页面不存在，或已不再提供访问。"
     }
   },
   "harness": {

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -12969,13 +12969,59 @@ def _show_page_offline_response():
     return Response(html, status=401, mimetype="text/html; charset=utf-8")
 
 
+def _show_page_accept_quality(accept: str, target: str) -> float:
+    """Return the preferred quality for a response media type."""
+    target_type, target_subtype = target.split("/", 1)
+    best_specificity = -1
+    best_quality = 0.0
+    for item in accept.split(","):
+        parts = [part.strip() for part in item.split(";")]
+        media_range = parts[0].lower()
+        if "/" not in media_range:
+            continue
+        range_type, range_subtype = media_range.split("/", 1)
+        if range_type not in {target_type, "*"} or range_subtype not in {target_subtype, "*"}:
+            continue
+        specificity = (range_type != "*") + (range_subtype != "*")
+        quality = 1.0
+        for parameter in parts[1:]:
+            name, separator, value = parameter.partition("=")
+            if name.strip().lower() != "q" or not separator:
+                continue
+            try:
+                quality = float(value.strip().strip('"'))
+            except ValueError:
+                quality = 0.0
+            break
+        if not 0.0 <= quality <= 1.0:
+            quality = 0.0
+        if specificity > best_specificity:
+            best_specificity = specificity
+            best_quality = quality
+    return best_quality
+
+
+def _show_page_accepts_html() -> bool:
+    """Choose HTML only when it is preferred and explicitly acceptable."""
+    accept = request.headers.get("Accept", "").strip()
+    if not accept:
+        return False
+    html_quality = _show_page_accept_quality(accept, "text/html")
+    json_quality = _show_page_accept_quality(accept, "application/json")
+    return html_quality > 0.0 and html_quality > json_quality
+
+
 def _show_page_not_found_html_response():
-    html = """<!doctype html>
-<html lang="en">
+    language = _request_ui_language()
+    title = html.escape(t("show.pageUnavailable.title", language), quote=True)
+    heading = html.escape(t("show.pageUnavailable.heading", language))
+    message = html.escape(t("show.pageUnavailable.message", language))
+    html_body = """<!doctype html>
+<html lang="__LANGUAGE__">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Show Page unavailable</title>
+    <title>__TITLE__</title>
     <style>
       body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 24px; box-sizing: border-box; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #f7f8fb; color: #172033; }
       main { width: min(560px, 100%); border: 1px solid rgba(23, 32, 51, 0.12); border-radius: 12px; background: white; padding: 32px; box-shadow: 0 20px 60px rgba(23, 32, 51, 0.10); }
@@ -12985,13 +13031,13 @@ def _show_page_not_found_html_response():
   </head>
   <body>
     <main>
-      <h1>This page is unavailable</h1>
-      <p>The page does not exist or is no longer available.</p>
+      <h1>__HEADING__</h1>
+      <p>__MESSAGE__</p>
     </main>
   </body>
 </html>
-"""
-    response = Response(html, status=404, mimetype="text/html; charset=utf-8")
+""".replace("__LANGUAGE__", language).replace("__TITLE__", title).replace("__HEADING__", heading).replace("__MESSAGE__", message)
+    response = Response(html_body, status=404, mimetype="text/html; charset=utf-8")
     response.headers["Cache-Control"] = "private, no-store"
     response.headers["Referrer-Policy"] = "no-referrer"
     return response
@@ -13000,7 +13046,7 @@ def _show_page_not_found_html_response():
 def _show_page_not_found_response():
     if (
         request.method in {"GET", "HEAD"}
-        and "text/html" in request.headers.get("accept", "").lower()
+        and _show_page_accepts_html()
     ):
         return _show_page_not_found_html_response()
     return jsonify({"error": "not_found"}), 404
@@ -15024,7 +15070,7 @@ def _show_identity_error_response(error: str, status: int):
 
 def _show_identity_not_found_response():
     """Hide whether a share exists when identity admission is denied."""
-    if "text/html" in request.headers.get("accept", "").lower():
+    if _show_page_accepts_html():
         return _show_page_not_found_html_response()
     response = jsonify({"error": "not_found"})
     response.status_code = 404

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -12969,7 +12969,40 @@ def _show_page_offline_response():
     return Response(html, status=401, mimetype="text/html; charset=utf-8")
 
 
+def _show_page_not_found_html_response():
+    html = """<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Show Page unavailable</title>
+    <style>
+      body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 24px; box-sizing: border-box; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #f7f8fb; color: #172033; }
+      main { width: min(560px, 100%); border: 1px solid rgba(23, 32, 51, 0.12); border-radius: 12px; background: white; padding: 32px; box-shadow: 0 20px 60px rgba(23, 32, 51, 0.10); }
+      h1 { margin: 0; font-size: clamp(28px, 7vw, 42px); line-height: 1.05; letter-spacing: 0; }
+      p { margin: 14px 0 0; line-height: 1.65; color: #526078; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>This page is unavailable</h1>
+      <p>The page does not exist or is no longer available.</p>
+    </main>
+  </body>
+</html>
+"""
+    response = Response(html, status=404, mimetype="text/html; charset=utf-8")
+    response.headers["Cache-Control"] = "private, no-store"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    return response
+
+
 def _show_page_not_found_response():
+    if (
+        request.method in {"GET", "HEAD"}
+        and "text/html" in request.headers.get("accept", "").lower()
+    ):
+        return _show_page_not_found_html_response()
     return jsonify({"error": "not_found"}), 404
 
 
@@ -14989,6 +15022,17 @@ def _show_identity_error_response(error: str, status: int):
     return response
 
 
+def _show_identity_not_found_response():
+    """Hide whether a share exists when identity admission is denied."""
+    if "text/html" in request.headers.get("accept", "").lower():
+        return _show_page_not_found_html_response()
+    response = jsonify({"error": "not_found"})
+    response.status_code = 404
+    response.headers["Cache-Control"] = "private, no-store"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    return response
+
+
 def _show_identity_error_status(error: str, *, default: int = 400) -> int:
     if error == "identity_unavailable":
         return 503
@@ -15093,6 +15137,8 @@ async def complete_show_identity_login():
         if "error" in fields:
             if fields["error"] not in {"identity_not_verified", "identity_unavailable"}:
                 raise show_identity.ShowIdentityError("invalid_callback")
+            if fields["error"] == "identity_not_verified":
+                return _show_identity_not_found_response()
             return _show_identity_error_response(
                 fields["error"],
                 _show_identity_error_status(fields["error"]),
@@ -15116,13 +15162,15 @@ async def complete_show_identity_login():
     try:
         page = store.get_by_share_id(state.share_id)
         if page is None:
-            return _show_identity_error_response("not_found", 404)
+            return _show_identity_not_found_response()
         if page.visibility == "offline":
-            return _show_identity_error_response("show_access_forbidden", 403)
+            return _show_identity_not_found_response()
         access = store.get_access(page.session_id)
         if access is None:
-            return _show_identity_error_response("not_found", 404)
+            return _show_identity_not_found_response()
         if access.access_mode == "public":
+            if page.visibility != "public":
+                return _show_identity_not_found_response()
             try:
                 show_identity.consume_verified_show_identity(identity)
             except show_identity.ShowIdentityError as exc:
@@ -15133,10 +15181,11 @@ async def complete_show_identity_login():
             return redirect(state.return_target, code=303)
         if (
             access.access_mode != "limited"
+            or page.visibility != "limited"
             or access.share_id != state.share_id
             or identity.normalized_email not in access.normalized_emails
         ):
-            return _show_identity_error_response("show_access_forbidden", 403)
+            return _show_identity_not_found_response()
 
         try:
             show_identity.consume_verified_show_identity(identity)


### PR DESCRIPTION
## What changed
- Return the same 404 not_found response for denied, unverified, offline, stale, and private identity admissions.
- Render a generic browser-friendly unavailable page for HTML 404 responses without revealing Show Page existence.
- Keep identity-service outages as retryable 503 responses and preserve already-admitted page behavior.

## Validation
- uv run pytest -q tests/test_ui_show_pages.py
- uv run pytest -q tests/test_resource_acl_show_pages.py tests/test_show_identity.py
- uv run ruff check vibe/ui_server.py tests/test_ui_show_pages.py
- npm ci && npm run build (ui)

## Risk
The public denial surface is intentionally less descriptive; internal logs and service errors retain operational detail.