### PR TITLE
test(memory): stop interleaved config-writer tests from flaking

### DIFF
--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -42,6 +42,49 @@ def _complete_processing(*, llm_url: str = "https://llm.example.test/v1") -> dic
     }
 
 
+# Budget for one interleaved config writer, shared by every test below so the
+# value has a single owner. It looks like a handoff between two threads, but it
+# has to cover *two* sequential load -> merge -> validate -> write cycles: a
+# writer holds CONFIG_LOCK plus the Memory file lock across the rendezvous, so
+# the other one cannot even start its own cycle until the first one is done.
+# One cycle measures ~0.5s median and ~1.7s worst case on a fast dev machine, so
+# the pair alone can reach several seconds before a slower CI runner is priced
+# in; the previous 5s went flaky on the `memory-first` orders. These budgets are
+# timing slack and never part of what the tests assert, so prefer them loose.
+_WRITER_TIMEOUT_SECONDS = 30
+# A writer parked on a rendezvous only gives up after `_WRITER_TIMEOUT_SECONDS`
+# and still has its write to finish, so joining on that same budget could call a
+# writer stuck one moment before it unwinds on its own.
+_WRITER_JOIN_TIMEOUT_SECONDS = _WRITER_TIMEOUT_SECONDS * 2
+
+
+def _join_config_writers(
+    *writers: threading.Thread,
+    timeout: float = _WRITER_JOIN_TIMEOUT_SECONDS,
+) -> None:
+    """Join every writer, and fail here rather than leaving one running.
+
+    `api.save_config` resolves its target from the process-global `AVIBE_HOME`,
+    so a writer that outlives its test keeps writing after monkeypatch restores
+    the env: it lands in the *next* test's config, which surfaces as a bogus
+    assertion there instead of a hang here, or lands outside `tmp_path`
+    entirely. Call this from a `finally` so a failed wait above still reports
+    the writer that actually hung.
+    """
+
+    stuck: list[str] = []
+    for writer in writers:
+        # An unstarted writer (an earlier wait failed before its `start()`)
+        # reports the same `is_alive()` as a finished one, and `join()` would
+        # raise on it.
+        if writer.is_alive():
+            writer.join(timeout)
+        if writer.is_alive():
+            stuck.append(writer.name)
+    if stuck:
+        pytest.fail(f"config writers still running: {', '.join(stuck)}")
+
+
 def _stale_whole_config_writer(
     config_path,
     loaded,
@@ -50,7 +93,7 @@ def _stale_whole_config_writer(
 ) -> None:
     stale = V2Config.load(config_path)
     loaded.set()
-    if not start.wait(10):
+    if not start.wait(_WRITER_TIMEOUT_SECONDS):
         raise TimeoutError("whole-config writer was not released")
     stale.language = "zh"
     stale.save(config_path)
@@ -65,7 +108,7 @@ def _memory_writer(
     done,
 ) -> None:
     ready.set()
-    if not start.wait(10):
+    if not start.wait(_WRITER_TIMEOUT_SECONDS):
         raise TimeoutError("Memory writer was not released")
 
     def update(memory: MemoryConfig) -> MemoryConfig:
@@ -868,6 +911,24 @@ def test_generic_config_save_preserves_memory_keys(monkeypatch, tmp_path) -> Non
     assert saved.memory.recovery_intent == "rebuild"
 
 
+def test_join_config_writers_reports_a_writer_that_overruns() -> None:
+    """An overrunning writer is named here instead of leaking into a later test."""
+
+    release = threading.Event()
+    worker = threading.Thread(
+        target=release.wait,
+        args=(_WRITER_TIMEOUT_SECONDS,),
+        name="slow-writer",
+    )
+    worker.start()
+    try:
+        with pytest.raises(pytest.fail.Exception, match="slow-writer"):
+            _join_config_writers(worker, timeout=0.05)
+    finally:
+        release.set()
+        _join_config_writers(worker)
+
+
 def test_concurrent_generic_config_saves_preserve_both_updates(
     monkeypatch,
     tmp_path,
@@ -886,7 +947,7 @@ def test_concurrent_generic_config_saves_preserve_both_updates(
         merged = merge(base, update)
         if threading.current_thread().name == "first-config-save":
             first_merged.set()
-            if not release_first.wait(5):
+            if not release_first.wait(_WRITER_TIMEOUT_SECONDS):
                 raise TimeoutError("first config save was not released")
         return merged
 
@@ -909,16 +970,15 @@ def test_concurrent_generic_config_saves_preserve_both_updates(
         name="second-config-save",
     )
 
-    first.start()
-    assert first_merged.wait(5)
-    second.start()
-    assert second_entered.wait(5)
-    release_first.set()
-    first.join(5)
-    second.join(5)
+    try:
+        first.start()
+        assert first_merged.wait(_WRITER_TIMEOUT_SECONDS)
+        second.start()
+        assert second_entered.wait(_WRITER_TIMEOUT_SECONDS)
+    finally:
+        release_first.set()
+        _join_config_writers(first, second)
 
-    assert not first.is_alive()
-    assert not second.is_alive()
     assert failures == []
     persisted = V2Config.load()
     assert persisted.language == "zh"
@@ -946,7 +1006,7 @@ def test_generic_config_save_preserves_interleaved_memory_update(
             }
         )
     ).save()
-    rendezvous = threading.Barrier(2, timeout=5)
+    rendezvous = threading.Barrier(2, timeout=_WRITER_TIMEOUT_SECONDS)
     failures: list[BaseException] = []
     merge = api._deep_merge_dicts
 
@@ -983,20 +1043,19 @@ def test_generic_config_save_preserves_interleaved_memory_update(
             failures.append(exc)
 
     monkeypatch.setattr(api, "_deep_merge_dicts", hold_config_first)
-    generic_thread = threading.Thread(target=save_generic)
-    memory_thread = threading.Thread(target=save_memory)
+    generic_thread = threading.Thread(target=save_generic, name="generic-config-save")
+    memory_thread = threading.Thread(target=save_memory, name="memory-config-save")
     first, second = (
         (memory_thread, generic_thread)
         if memory_first
         else (generic_thread, memory_thread)
     )
-    first.start()
-    second.start()
-    first.join(5)
-    second.join(5)
+    try:
+        first.start()
+        second.start()
+    finally:
+        _join_config_writers(first, second)
 
-    assert not first.is_alive()
-    assert not second.is_alive()
     assert failures == []
     persisted = V2Config.load()
     assert persisted.language == "zh"
@@ -1158,8 +1217,8 @@ def test_spawned_writers_preserve_memory_and_non_memory_updates(
     try:
         for process in processes:
             process.start()
-        assert stale_loaded.wait(10)
-        assert memory_ready.wait(10)
+        assert stale_loaded.wait(_WRITER_TIMEOUT_SECONDS)
+        assert memory_ready.wait(_WRITER_TIMEOUT_SECONDS)
 
         first_start, first_done, second_start = (
             (memory_start, memory_done, config_start)
@@ -1167,13 +1226,13 @@ def test_spawned_writers_preserve_memory_and_non_memory_updates(
             else (config_start, config_done, memory_start)
         )
         first_start.set()
-        assert first_done.wait(10)
+        assert first_done.wait(_WRITER_TIMEOUT_SECONDS)
         second_start.set()
 
-        assert config_done.wait(10)
-        assert memory_done.wait(10)
+        assert config_done.wait(_WRITER_TIMEOUT_SECONDS)
+        assert memory_done.wait(_WRITER_TIMEOUT_SECONDS)
         for process in processes:
-            process.join(10)
+            process.join(_WRITER_TIMEOUT_SECONDS)
             assert process.exitcode == 0
     finally:
         for process in processes:

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import json
 import multiprocessing
 import threading
@@ -58,18 +59,38 @@ _WRITER_TIMEOUT_SECONDS = 30
 _WRITER_JOIN_TIMEOUT_SECONDS = _WRITER_TIMEOUT_SECONDS * 2
 
 
+def _config_writer(
+    target,
+    *,
+    name: str,
+    args: tuple = (),
+) -> threading.Thread:
+    """Build a config writer that cannot outlive the test session.
+
+    `get_vibe_remote_dir()` reads `AVIBE_HOME` on every call and falls back to
+    `Path.home()`, so a writer still running once monkeypatch has restored the
+    environment resolves against the developer's real home -- measured: a
+    non-daemon writer released after the session resolved
+    `$HOME/.avibe/config/config.json`. A daemon thread is killed at interpreter
+    shutdown rather than joined, so a writer nothing can release still cannot
+    reach real user state.
+    """
+
+    return threading.Thread(target=target, name=name, args=args, daemon=True)
+
+
 def _join_config_writers(
     *writers: threading.Thread,
     timeout: float = _WRITER_JOIN_TIMEOUT_SECONDS,
 ) -> None:
     """Join every writer, and fail here rather than leaving one running.
 
-    `api.save_config` resolves its target from the process-global `AVIBE_HOME`,
-    so a writer that outlives its test keeps writing after monkeypatch restores
-    the env: it lands in the *next* test's config, which surfaces as a bogus
-    assertion there instead of a hang here, or lands outside `tmp_path`
-    entirely. Call this from a `finally` so a failed wait above still reports
-    the writer that actually hung.
+    A writer that outlives its test resolves against whatever the environment
+    holds by then; while the session is still running that is the *next* test's
+    config, which surfaces as a bogus assertion there instead of a hang here.
+    `_config_writer` bounds what happens past the end of the session, and this
+    reports the overrun at the test that caused it. Call it from a `finally` so
+    a failed wait above still names the writer that actually hung.
     """
 
     stuck: list[str] = []
@@ -911,12 +932,44 @@ def test_generic_config_save_preserves_memory_keys(monkeypatch, tmp_path) -> Non
     assert saved.memory.recovery_intent == "rebuild"
 
 
+def test_config_writers_cannot_outlive_the_test_session() -> None:
+    """No writer can resolve a config path once the isolation is restored.
+
+    Asserted at the single owner, plus the property that every writer is built
+    there -- listing today's writers would pass forever while the next one
+    added silently reopens the escape.
+    """
+
+    assert _config_writer(lambda: None, name="probe").daemon is True
+
+    module = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    factory = next(
+        node
+        for node in ast.walk(module)
+        if isinstance(node, ast.FunctionDef) and node.name == "_config_writer"
+    )
+    built_outside_the_factory = [
+        node.lineno
+        for node in ast.walk(module)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "Thread"
+        and not (factory.lineno <= node.lineno <= factory.end_lineno)
+    ]
+    assert built_outside_the_factory == []
+
+
 def test_join_config_writers_reports_a_writer_that_overruns() -> None:
-    """An overrunning writer is named here instead of leaking into a later test."""
+    """An overrunning writer is named here instead of leaking into a later test.
+
+    The `finally` releases the worker so this test does not itself leak one.
+    Containment for a writer that *cannot* be released is a separate property,
+    owned by `test_config_writers_cannot_outlive_the_test_session`.
+    """
 
     release = threading.Event()
-    worker = threading.Thread(
-        target=release.wait,
+    worker = _config_writer(
+        release.wait,
         args=(_WRITER_TIMEOUT_SECONDS,),
         name="slow-writer",
     )
@@ -959,13 +1012,13 @@ def test_concurrent_generic_config_saves_preserve_both_updates(
 
     monkeypatch.setattr(api, "CONFIG_LOCK", _ObservedConfigLock(second_entered))
     monkeypatch.setattr(api, "_deep_merge_dicts", hold_first_merge)
-    first = threading.Thread(
-        target=save,
+    first = _config_writer(
+        save,
         args=({"language": "zh"},),
         name="first-config-save",
     )
-    second = threading.Thread(
-        target=save,
+    second = _config_writer(
+        save,
         args=({"runtime": {"log_level": "DEBUG"}},),
         name="second-config-save",
     )
@@ -1043,8 +1096,8 @@ def test_generic_config_save_preserves_interleaved_memory_update(
             failures.append(exc)
 
     monkeypatch.setattr(api, "_deep_merge_dicts", hold_config_first)
-    generic_thread = threading.Thread(target=save_generic, name="generic-config-save")
-    memory_thread = threading.Thread(target=save_memory, name="memory-config-save")
+    generic_thread = _config_writer(save_generic, name="generic-config-save")
+    memory_thread = _config_writer(save_memory, name="memory-config-save")
     first, second = (
         (memory_thread, generic_thread)
         if memory_first


### PR DESCRIPTION
## Capability

Makes the interleaved config-writer tests in `tests/test_memory_config.py` report what they mean to assert — that a generic config save and a Memory save preserve both units in either lock order — instead of failing on timing slack. No product code changes.

Observed on `master` (run 32104426337) and on #1533's head (run 32133519763): `test_generic_config_save_preserves_interleaved_memory_update[memory-first-*]`.

## Root cause

Two defects, both in the test harness.

**1. The budget covered half of what it had to cover.** The rendezvous barrier, event waits, and joins were all 5s. A writer holds `CONFIG_LOCK` plus the Memory file lock across the rendezvous, so its peer cannot begin its own cycle until the first one finishes — a single budget therefore has to cover *two* sequential `load → merge → validate → write` cycles. Measured on an idle dev machine (fast SSD), one cycle is ~0.5s median and ~1.7s worst case, so the pair alone approaches 5s before a slower CI runner is priced in. This is why only the `memory-first` orders flaked: there the generic writer's whole cycle is gated behind the Memory writer's.

**2. Overrunning was silent, and leaked across tests.** The tests joined with a bounded budget and then asserted `not thread.is_alive()`, which leaves a live writer behind precisely when it fails. `api.save_config` resolves its target from the process-global `AVIBE_HOME`, so the leaked writer kept running after `monkeypatch` restored the env and landed in the *next* test's config. That is the direct explanation for the second failure in run 32133519763: `[memory-first-candidate]` overran, and its writer wrote `embed-next` into `[memory-first-settle]`'s config, which then failed `assert 'embed-next' == 'embed'` — a test that was never broken. Past the end of a run the same leak resolves outside `tmp_path` entirely: `get_vibe_remote_dir()` reads `AVIBE_HOME` on every call and falls back to `Path.home()`, and the autouse isolation in `tests/conftest.py` is function-scoped `monkeypatch`, so both are restored at teardown.

## Change

- One owner for the budget: `_WRITER_TIMEOUT_SECONDS`, used by every writer test in the file (the spawned-writer test's per-phase `10` folds into it), sized for two cycles rather than one handoff. `_WRITER_JOIN_TIMEOUT_SECONDS` derives from it so a writer unwinding from a broken rendezvous is never reported as stuck.
- One owner for cleanup: `_join_config_writers()`, called from `finally`, joins every writer and fails naming any that overran — so the flake is reported at the test that hung, not at whichever test it corrupted next.
- One owner for containment: `_config_writer()` builds every writer in the file as a daemon thread, so a writer that nothing can release is killed at interpreter shutdown rather than left to resolve a path once the isolation is gone. Reporting an overrun and containing one are separate properties; `_join_config_writers` owns the first, `_config_writer` the second.
- Both in-process interleaving tests now start their writers inside `try` and join in `finally`, so a failed wait no longer leaks a writer either.

## Evidence

- **Unit** — `tests/test_memory_config.py`: 119 passed (117 existing + 2 new). Whole file run 25× in the CI shape (`-m "not integration" -p no:randomly -o addopts=""`): 0 failures. The interleaving test alone run 40×, and a standalone harness run 240× under 12 competing CPU burners: 0 failures. None of these reproduce the flake locally — this machine is too fast, which is consistent with the measured margins above rather than evidence against them.
- **New invariants** — `test_join_config_writers_reports_a_writer_that_overruns` locks the property that made this expensive to diagnose: an overrunning writer is named at its own test instead of leaking. `test_config_writers_cannot_outlive_the_test_session` locks containment at the factory *and* asserts no `threading.Thread` is constructed outside it, so a writer added later cannot silently reopen the escape. Both assert the property, not the list of ways a writer can overrun.
- **Measurement** — writer cycle durations were measured directly (median/worst, both lock orders) rather than assumed; the first hypothesis for the asymmetry was wrong and the numbers corrected it. Recorded in the constant's comment so the number is not re-guessed later. The escape was measured the same way: with `HOME` redirected to a throwaway directory, a leaked non-daemon writer released after the session ended recorded `AVIBE_HOME=None` resolving to `$HOME/.avibe/config/config.json`; the identical probe with `daemon=True` produced no post-session resolution at all. The guard test was verified to fail by reintroducing one bare `threading.Thread` construction.
- **Lint** — `ruff check tests/test_memory_config.py` clean.
- **Contract / scenario** — n/a; no catalog covers config-writer interleaving.

## Residual manual checks

None. The change is test-local; the merge gate is CI itself. Worth noting for the integration pass: since the flake is timing-dependent and does not reproduce locally, a single green run does not prove it fixed — the real signal is the absence of recurrence on `master` over subsequent runs.

## Known-by-design

- **Budgets stay generous rather than tight.** They are slack, never part of an assertion; a tight one buys nothing on the passing path and costs a false failure on the slow one. A genuine deadlock is still bounded — it reports within the join budget rather than hanging CI.
- **No product change.** The lock order (`CONFIG_LOCK` → file lock, nested re-entrantly) is deadlock-free in both interleavings, and the failures were budget overruns, not lost updates. The tests' own subject — that both units survive — never failed.
- **A writer wedged on `CONFIG_LOCK` can still perturb a later test in the same process.** That is a genuine product deadlock — the thing these tests exist to catch — and Python cannot kill a thread, so no in-process mechanism closes it. What is closed: it is reported by name at its own test, and it can no longer reach real user state. Every rendezvous the tests themselves introduce is bounded by `_WRITER_TIMEOUT_SECONDS`, well inside the join budget, so a parked writer unwinds on its own; a `release=` escape hatch for the rendezvous would be dead code in every path that has one.
- **The containment guard is an AST check over this file, not a lint rule.** The property is local to a file whose whole subject is spawning config writers; a repo-wide rule would carry a rationale that only holds here.
