### PR TITLE
fix(show): reject stale guest navigation

### DIFF
--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -975,7 +975,7 @@ def test_public_show_ignores_an_existing_limited_guest_lease(monkeypatch, tmp_pa
     assert "Cookie" not in response.headers.get("Vary", "")
 
 
-def test_limited_guest_lease_survives_rotation_only_for_that_browser(
+def test_limited_guest_lease_is_rejected_after_rotation(
     monkeypatch,
     tmp_path,
 ):
@@ -1016,7 +1016,6 @@ def test_limited_guest_lease_survives_rotation_only_for_that_browser(
         base_url="https://alex.avibe.bot",
         environ_base=_remote_peer(),
     )
-    assert continuing.status_code == 200
     rotated_navigation = admitted.get(
         f"/p/{old_share_id}/",
         base_url="https://alex.avibe.bot",
@@ -1029,6 +1028,7 @@ def test_limited_guest_lease_survives_rotation_only_for_that_browser(
         follow_redirects=False,
     )
     assert rotated_navigation.status_code == 404
+    assert continuing.status_code == 404
     fresh_old_link = app.test_client().get(
         f"/p/{old_share_id}/",
         base_url="https://alex.avibe.bot",
@@ -1038,7 +1038,7 @@ def test_limited_guest_lease_survives_rotation_only_for_that_browser(
     assert fresh_old_link.status_code == 404
 
 
-def test_limited_show_guest_is_admitted_once_and_not_live_revoked(
+def test_limited_show_guest_is_rechecked_after_access_changes(
     monkeypatch,
     tmp_path,
 ):
@@ -1187,14 +1187,14 @@ def test_limited_show_guest_is_admitted_once_and_not_live_revoked(
             base_url="https://alex.avibe.bot",
             environ_base=_remote_peer(),
         )
-        assert existing_asset.status_code == 200
+        assert existing_asset.status_code == 404
         html_subresource = client.get(
             f"/p/{share_id}/index.html",
             base_url="https://alex.avibe.bot",
             environ_base=_remote_peer(),
             headers={"Accept": "text/html"},
         )
-        assert html_subresource.status_code == 200
+        assert html_subresource.status_code == 404
 
         stale_limited_navigation = client.get(
             f"/p/{share_id}/",
@@ -1203,10 +1203,7 @@ def test_limited_show_guest_is_admitted_once_and_not_live_revoked(
             headers={"Accept": "text/html"},
             follow_redirects=False,
         )
-        assert stale_limited_navigation.status_code == 302
-        assert urllib.parse.urlsplit(stale_limited_navigation.headers["Location"]).path == (
-            "/api/v1/instances/inst_123/show-identity/authorize"
-        )
+        assert stale_limited_navigation.status_code == 404
 
         fresh_client = app.test_client()
         fresh_login = fresh_client.get(
@@ -1251,7 +1248,7 @@ def test_limited_show_guest_is_admitted_once_and_not_live_revoked(
             base_url="https://alex.avibe.bot",
             environ_base=_remote_peer(),
         )
-        assert still_open.status_code == 200
+        assert still_open.status_code == 404
         stale_private_navigation = client.get(
             f"/p/{share_id}/",
             base_url="https://alex.avibe.bot",

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -1020,6 +1020,8 @@ def test_rotated_public_share_rejects_an_old_guest_lease(monkeypatch, tmp_path):
     )
 
     assert old_response.status_code == 404
+    assert old_response.headers["Cache-Control"] == "private, no-store"
+    assert "Cookie" in old_response.headers["Vary"]
     assert new_response.status_code == 200
 
 
@@ -1236,6 +1238,8 @@ def test_limited_show_guest_is_rechecked_after_access_changes(
             environ_base=_remote_peer(),
         )
         assert existing_asset.status_code == 404
+        assert existing_asset.headers["Cache-Control"] == "private, no-store"
+        assert "Cookie" in existing_asset.headers["Vary"]
         html_subresource = client.get(
             f"/p/{share_id}/index.html",
             base_url="https://alex.avibe.bot",

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -1017,6 +1017,18 @@ def test_limited_guest_lease_survives_rotation_only_for_that_browser(
         environ_base=_remote_peer(),
     )
     assert continuing.status_code == 200
+    rotated_navigation = admitted.get(
+        f"/p/{old_share_id}/",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+        headers={
+            "Accept": "text/html",
+            "Sec-Fetch-Mode": "navigate",
+            "Sec-Fetch-Dest": "document",
+        },
+        follow_redirects=False,
+    )
+    assert rotated_navigation.status_code == 404
     fresh_old_link = app.test_client().get(
         f"/p/{old_share_id}/",
         base_url="https://alex.avibe.bot",
@@ -1176,6 +1188,13 @@ def test_limited_show_guest_is_admitted_once_and_not_live_revoked(
             environ_base=_remote_peer(),
         )
         assert existing_asset.status_code == 200
+        html_subresource = client.get(
+            f"/p/{share_id}/index.html",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+            headers={"Accept": "text/html"},
+        )
+        assert html_subresource.status_code == 200
 
         stale_limited_navigation = client.get(
             f"/p/{share_id}/",

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -975,6 +975,54 @@ def test_public_show_ignores_an_existing_limited_guest_lease(monkeypatch, tmp_pa
     assert "Cookie" not in response.headers.get("Vary", "")
 
 
+def test_rotated_public_share_rejects_an_old_guest_lease(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    old_share_id = _create_show_page("ses123", "limited")
+    lease = show_identity.make_show_guest_lease(
+        config,
+        page_id="ses123",
+        share_id=old_share_id,
+        normalized_email="viewer@example.com",
+    )
+    client = app.test_client()
+    client.set_cookie(
+        show_identity.show_guest_cookie_name(old_share_id),
+        lease,
+        domain="alex.avibe.bot",
+        path=show_identity.show_guest_cookie_path(old_share_id),
+    )
+
+    store = ShowPageStore()
+    try:
+        access = store.get_access("ses123")
+        assert access is not None
+        result = store.apply_access(
+            "ses123",
+            expected_revision=access.revision,
+            target_access_mode="public",
+            target_share_id="rotated-public-share",
+            target_emails=[],
+        )
+        assert result.status == "applied"
+    finally:
+        store.close()
+
+    old_response = client.get(
+        f"/p/{old_share_id}/",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+    new_response = app.test_client().get(
+        "/p/rotated-public-share/",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+
+    assert old_response.status_code == 404
+    assert new_response.status_code == 200
+
+
 def test_limited_guest_lease_is_rejected_after_rotation(
     monkeypatch,
     tmp_path,

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -1177,6 +1177,18 @@ def test_limited_show_guest_is_admitted_once_and_not_live_revoked(
         )
         assert existing_asset.status_code == 200
 
+        stale_limited_navigation = client.get(
+            f"/p/{share_id}/",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+            headers={"Accept": "text/html"},
+            follow_redirects=False,
+        )
+        assert stale_limited_navigation.status_code == 302
+        assert urllib.parse.urlsplit(stale_limited_navigation.headers["Location"]).path == (
+            "/api/v1/instances/inst_123/show-identity/authorize"
+        )
+
         fresh_client = app.test_client()
         fresh_login = fresh_client.get(
             f"/p/{share_id}/",
@@ -1221,6 +1233,14 @@ def test_limited_show_guest_is_admitted_once_and_not_live_revoked(
             environ_base=_remote_peer(),
         )
         assert still_open.status_code == 200
+        stale_private_navigation = client.get(
+            f"/p/{share_id}/",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+            headers={"Accept": "text/html"},
+            follow_redirects=False,
+        )
+        assert stale_private_navigation.status_code == 404
         new_visit = app.test_client().get(
             f"/p/{share_id}/",
             base_url="https://alex.avibe.bot",

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -15321,6 +15321,19 @@ async def serve_public_show_page(share_id, asset_path):
             asset_path,
             request._request,
         )
+        if limited_guest and is_spa_navigation:
+            # A guest lease keeps an already-open page usable after an access
+            # change, but it must not authorize a new page navigation after the
+            # current limited-access record no longer admits that guest.
+            access = store.get_access(page.session_id)
+            if (
+                access is None
+                or page.visibility != "limited"
+                or access.access_mode != "limited"
+                or access.share_id != share_id
+                or lease.normalized_email not in access.normalized_emails
+            ):
+                limited_guest = False
         if page.visibility != "public" and is_spa_navigation:
             editor_context = await asyncio.to_thread(_show_public_editor_context)
             if editor_context is not None:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -15308,6 +15308,10 @@ async def serve_public_show_page(share_id, asset_path):
         page = store.get_by_share_id(share_id)
         if page is None and lease is not None:
             page = store.get(lease.page_id)
+            if page is not None:
+                access = store.get_access(page.session_id)
+                if access is None or access.share_id != share_id:
+                    return _show_page_not_found_response()
         if page is None:
             return _show_page_not_found_response()
         limited_guest = (

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -15163,6 +15163,14 @@ def _with_limited_show_policy(response: Response) -> Response:
     return response
 
 
+def _show_limited_not_found_response():
+    result = _show_page_not_found_response()
+    if isinstance(result, tuple):
+        response, status = result
+        return _with_limited_show_policy(response), status
+    return _with_limited_show_policy(result)
+
+
 @app.route("/auth/show-identity/callback", methods=["POST"])
 async def complete_show_identity_login():
     from core.show_pages import ShowPageStore
@@ -15311,7 +15319,7 @@ async def serve_public_show_page(share_id, asset_path):
             if page is not None:
                 access = store.get_access(page.session_id)
                 if access is None or access.share_id != share_id:
-                    return _show_page_not_found_response()
+                    return _show_limited_not_found_response()
         if page is None:
             return _show_page_not_found_response()
         limited_guest = (
@@ -15355,7 +15363,7 @@ async def serve_public_show_page(share_id, asset_path):
                 or access.share_id != share_id
                 or lease.normalized_email not in access.normalized_emails
             ):
-                return _show_page_not_found_response()
+                return _show_limited_not_found_response()
         if page.visibility == "limited":
             if not limited_guest:
                 if request.method != "GET" or not is_spa_navigation:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -13092,6 +13092,22 @@ def _is_show_page_spa_route_request(asset_path: str, starlette_request: FastAPIR
     return True
 
 
+def _is_show_page_document_navigation(
+    asset_path: str,
+    starlette_request: FastAPIRequest,
+) -> bool:
+    """Return whether a request carries browser document-navigation evidence."""
+    if starlette_request.method not in {"GET", "HEAD"}:
+        return False
+    fetch_mode = starlette_request.headers.get("sec-fetch-mode", "").lower()
+    fetch_dest = starlette_request.headers.get("sec-fetch-dest", "").lower()
+    if fetch_mode or fetch_dest:
+        return fetch_mode == "navigate" and fetch_dest in {"document", "iframe"}
+    # Clients without Fetch Metadata can only identify the share root safely;
+    # nested paths remain resource requests unless the browser says otherwise.
+    return _decode_show_page_asset_path(asset_path) == ""
+
+
 def _show_page_runtime_asset_exists(session_id: str, asset_path: str) -> bool:
     relative = _decode_show_page_asset_path(asset_path)
     if not relative:
@@ -15321,7 +15337,11 @@ async def serve_public_show_page(share_id, asset_path):
             asset_path,
             request._request,
         )
-        if limited_guest and is_spa_navigation:
+        is_document_navigation = _is_show_page_document_navigation(
+            asset_path,
+            request._request,
+        )
+        if limited_guest and is_document_navigation:
             # A guest lease keeps an already-open page usable after an access
             # change, but it must not authorize a new page navigation after the
             # current limited-access record no longer admits that guest.
@@ -15333,6 +15353,8 @@ async def serve_public_show_page(share_id, asset_path):
                 or access.share_id != share_id
                 or lease.normalized_email not in access.normalized_emails
             ):
+                if access is not None and access.share_id != share_id:
+                    return _show_page_not_found_response()
                 limited_guest = False
         if page.visibility != "public" and is_spa_navigation:
             editor_context = await asyncio.to_thread(_show_public_editor_context)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -13092,22 +13092,6 @@ def _is_show_page_spa_route_request(asset_path: str, starlette_request: FastAPIR
     return True
 
 
-def _is_show_page_document_navigation(
-    asset_path: str,
-    starlette_request: FastAPIRequest,
-) -> bool:
-    """Return whether a request carries browser document-navigation evidence."""
-    if starlette_request.method not in {"GET", "HEAD"}:
-        return False
-    fetch_mode = starlette_request.headers.get("sec-fetch-mode", "").lower()
-    fetch_dest = starlette_request.headers.get("sec-fetch-dest", "").lower()
-    if fetch_mode or fetch_dest:
-        return fetch_mode == "navigate" and fetch_dest in {"document", "iframe"}
-    # Clients without Fetch Metadata can only identify the share root safely;
-    # nested paths remain resource requests unless the browser says otherwise.
-    return _decode_show_page_asset_path(asset_path) == ""
-
-
 def _show_page_runtime_asset_exists(session_id: str, asset_path: str) -> bool:
     relative = _decode_show_page_asset_path(asset_path)
     if not relative:
@@ -15337,25 +15321,6 @@ async def serve_public_show_page(share_id, asset_path):
             asset_path,
             request._request,
         )
-        is_document_navigation = _is_show_page_document_navigation(
-            asset_path,
-            request._request,
-        )
-        if limited_guest and is_document_navigation:
-            # A guest lease keeps an already-open page usable after an access
-            # change, but it must not authorize a new page navigation after the
-            # current limited-access record no longer admits that guest.
-            access = store.get_access(page.session_id)
-            if (
-                access is None
-                or page.visibility != "limited"
-                or access.access_mode != "limited"
-                or access.share_id != share_id
-                or lease.normalized_email not in access.normalized_emails
-            ):
-                if access is not None and access.share_id != share_id:
-                    return _show_page_not_found_response()
-                limited_guest = False
         if page.visibility != "public" and is_spa_navigation:
             editor_context = await asyncio.to_thread(_show_public_editor_context)
             if editor_context is not None:
@@ -15374,6 +15339,19 @@ async def serve_public_show_page(share_id, asset_path):
                     if query:
                         private_target = f"{private_target}?{query}"
                     return redirect(private_target)
+        if limited_guest:
+            # A guest lease does not grant a grace period after access changes.
+            # Already-rendered pages are not proactively closed, but every
+            # subsequent request must match the current local access record.
+            access = store.get_access(page.session_id)
+            if (
+                access is None
+                or page.visibility != "limited"
+                or access.access_mode != "limited"
+                or access.share_id != share_id
+                or lease.normalized_email not in access.normalized_emails
+            ):
+                return _show_page_not_found_response()
         if page.visibility == "limited":
             if not limited_guest:
                 if request.method != "GET" or not is_spa_navigation:


### PR DESCRIPTION
## Summary

- Recheck the current local access record on every request carrying a guest lease.
- Reject private transitions, removed limited-access emails, and rotated share IDs with the same not-found response.
- Do not add WebSocket revocation, forced refresh, lease TTL, or grace-period behavior; an already-rendered page is not proactively closed.
- Preserve the editor route before guest-lease validation.

## Validation

- Full Show-page tests: 270 passed.
- Focused stale-lease and editor-route tests passed.
- Ruff check and diff check passed.