### PR TITLE
fix(ui): keep diagnostics from bouncing owners home

### DIFF
--- a/ui/src/App.remoteAuth.test.tsx
+++ b/ui/src/App.remoteAuth.test.tsx
@@ -3,10 +3,12 @@
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import { useLayoutEffect } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Navigate, Route, Routes } from 'react-router-dom';
 
 import { AuthGuard } from './App';
-import { DENIED_INSTANCE_CAPABILITIES } from './lib/sessionInfo';
+import { useInstanceAuthorization } from './context/InstanceAuthorizationContext';
+import { DENIED_INSTANCE_CAPABILITIES, OWNER_INSTANCE_CAPABILITIES } from './lib/sessionInfo';
+import { isOwnerOnlyPath } from './lib/adminNavigation';
 import { reportRemoteAuthorizationState, REMOTE_AUTH_STATE_EVENT } from './lib/remoteAuth';
 
 vi.hoisted(() => {
@@ -128,5 +130,71 @@ describe('AuthGuard remote authorization recovery', () => {
 
     expect(api.getAuthSession).toHaveBeenCalledTimes(2);
     expect(screen.getByText('protected shell')).toBeTruthy();
+  });
+});
+
+const CapabilityProbe = () => {
+  const { capabilities } = useInstanceAuthorization();
+  return <div>{capabilities.can_manage_instance ? 'owner-shell' : 'denied-shell'}</div>;
+};
+
+const OwnerOnlyGate = () => {
+  const { capabilities } = useInstanceAuthorization();
+  if (isOwnerOnlyPath('/admin/settings/diagnostics') && !capabilities.can_manage_instance) {
+    return <Navigate to="/" replace />;
+  }
+  return <div>diagnostics-page</div>;
+};
+
+describe('AuthGuard setup-bypass authorization', () => {
+  const localOwnerSession = {
+    remote: false as const,
+    instance_kind: 'personal' as const,
+    instance_role: 'owner' as const,
+    capabilities: OWNER_INSTANCE_CAPABILITIES,
+  };
+
+  it.each(['/admin/settings/diagnostics', '/admin/logs'])(
+    'keeps the instance owner on %s instead of treating the setup bypass as denied',
+    async (path) => {
+      api.getAuthSession.mockResolvedValue(localOwnerSession);
+      api.getConfig.mockResolvedValue({
+        mode: 'v2',
+        setup_state: { needs_setup: false },
+      });
+
+      render(
+        <MemoryRouter initialEntries={[path]}>
+          <AuthGuard>
+            <CapabilityProbe />
+          </AuthGuard>
+        </MemoryRouter>,
+      );
+
+      expect(await screen.findByText('owner-shell')).toBeTruthy();
+      expect(screen.queryByText('denied-shell')).toBeNull();
+    },
+  );
+
+  it('lets an owner open Diagnostics from Advanced Settings without bouncing home', async () => {
+    api.getAuthSession.mockResolvedValue(localOwnerSession);
+    api.getConfig.mockResolvedValue({
+      mode: 'v2',
+      setup_state: { needs_setup: false },
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/admin/settings/diagnostics']}>
+        <AuthGuard>
+          <Routes>
+            <Route path="/admin/settings/diagnostics" element={<OwnerOnlyGate />} />
+            <Route path="/" element={<div>workbench-home</div>} />
+          </Routes>
+        </AuthGuard>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('diagnostics-page')).toBeTruthy();
+    expect(screen.queryByText('workbench-home')).toBeNull();
   });
 });

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -504,8 +504,7 @@ export const AuthGuard = ({ children }: { children: ReactNode }) => {
     if (guardStatus === 'access-blocked') {
         return <AccessBlocked code={blockedCode} />;
     }
-    if (bypassSetupGuard) return children;
-    if (guardStatus === 'needs-setup') {
+    if (guardStatus === 'needs-setup' && !bypassSetupGuard) {
         if (location.pathname === '/setup' && authorizationSession) {
             return <InstanceAuthorizationProvider session={authorizationSession}>{children}</InstanceAuthorizationProvider>;
         }
@@ -526,6 +525,10 @@ export const AuthGuard = ({ children }: { children: ReactNode }) => {
         return <Navigate to="/setup" replace />;
     }
     if (!authorizationSession) {
+        // Diagnostics / Logs remain reachable before a session exists so an
+        // unfinished install can still inspect doctor output. Once the session
+        // lands, wrap it so AppShell does not treat the owner as denied.
+        if (bypassSetupGuard) return children;
         return <div className="min-h-screen flex items-center justify-center bg-bg text-text">{t('common.loading')}</div>;
     }
     return (


### PR DESCRIPTION
## Summary
Opening **高级设置 → 诊断** on latest master immediately bounced the instance owner back to the workbench home.

`/admin/settings/diagnostics` (and `/admin/logs`) bypass the setup wizard so an unfinished install can still inspect doctor output. That bypass returned bare children and dropped `InstanceAuthorizationProvider`. After #1395, `AppShell` treats missing owner capabilities as denied and sends owner-only pages home. The two changes together made Diagnostics unusable for a local owner.

This keeps the setup bypass, but still wraps the already-fetched session so the owner projection reaches `AppShell`.

## Evidence
- Unit: `ui/src/App.remoteAuth.test.tsx` covers Diagnostics / Logs setup-bypass authorization and the Advanced Settings → Diagnostics bounce.
- Contract: none. This is a client-side AuthGuard / AppShell interaction.
- Scenario: none. No catalog entry exists for this settings-tab navigation.
- Residual manual: after merge, click 高级设置 → 诊断 on a local owner session and confirm the Doctor panel stays on `/admin/settings/diagnostics`.

## Known-by-design
None.