### PR TITLE
fix(memory): activate config after runtime install

### DIFF
--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -607,6 +607,21 @@ class EverOSProcess:
         return self._down
 
     @property
+    def restart_authorized(self) -> bool:
+        """Whether this supervisor still owns a current or future launch."""
+
+        restart_task = self._restart_task
+        return bool(
+            self._desired_running
+            and not self._down
+            and (
+                self.running
+                or self._starting
+                or (restart_task is not None and not restart_task.done())
+            )
+        )
+
+    @property
     def last_error(self) -> MemoryErrorCode | None:
         return self._last_error
 
@@ -3790,7 +3805,7 @@ class EverOSProcessPort(Protocol):
     def starting(self) -> bool: ...
 
     @property
-    def down(self) -> bool: ...
+    def restart_authorized(self) -> bool: ...
 
     async def start(self) -> bool: ...
 
@@ -3849,6 +3864,8 @@ class FakeEverOSProcess:
     _running: bool = True
     _starting: bool = False
     _down: bool = False
+    _desired_running: bool = True
+    _restart_pending: bool = False
 
     @property
     def running(self) -> bool:
@@ -3862,15 +3879,27 @@ class FakeEverOSProcess:
     def down(self) -> bool:
         return self._down
 
+    @property
+    def restart_authorized(self) -> bool:
+        return bool(
+            self._desired_running
+            and not self._down
+            and (self._running or self._starting or self._restart_pending)
+        )
+
     async def start(self) -> bool:
         self.starts += 1
+        self._desired_running = True
         self._down = False
+        self._restart_pending = False
         before_start = self.before_start
         if before_start is not None:
             result = before_start()
             if inspect.isawaitable(result):
                 await result
         if self.start_failure is not None:
+            self._desired_running = False
+            self._down = True
             self._running = False
             await self._notify_reaped()
             raise self.start_failure
@@ -3880,12 +3909,15 @@ class FakeEverOSProcess:
         if started:
             await self.ready()
         else:
+            self._restart_pending = True
             await self._notify_reaped()
         return started
 
     async def stop(self) -> None:
         self.stops += 1
         self.stopped = True
+        self._desired_running = False
+        self._restart_pending = False
         self._running = False
         self._starting = False
         if self.stop_failure is not None:

--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -3777,7 +3777,7 @@ class _SystemProcessHost:
 class EverOSProcessPort(Protocol):
     """What the runtime needs from a supervised sidecar, and nothing more.
 
-    Deliberately five members over ``EverOSProcess``'s ~990 lines: the runtime
+    Deliberately six members over ``EverOSProcess``'s ~990 lines: the runtime
     never inspects the child tree, the generated config, or the signal handling.
     Keeping those out of this interface is what lets tests substitute a fake
     instead of patching ``psutil``, ``os``, and private attributes.
@@ -3788,6 +3788,9 @@ class EverOSProcessPort(Protocol):
 
     @property
     def starting(self) -> bool: ...
+
+    @property
+    def down(self) -> bool: ...
 
     async def start(self) -> bool: ...
 
@@ -3845,6 +3848,7 @@ class FakeEverOSProcess:
     stopped: bool = False
     _running: bool = True
     _starting: bool = False
+    _down: bool = False
 
     @property
     def running(self) -> bool:
@@ -3854,8 +3858,13 @@ class FakeEverOSProcess:
     def starting(self) -> bool:
         return self._starting
 
+    @property
+    def down(self) -> bool:
+        return self._down
+
     async def start(self) -> bool:
         self.starts += 1
+        self._down = False
         before_start = self.before_start
         if before_start is not None:
             result = before_start()

--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -610,6 +610,7 @@ class EverOSProcess:
     def restart_authorized(self) -> bool:
         """Whether this supervisor still owns a current or future launch."""
 
+        watch_task = self._watch_task
         restart_task = self._restart_task
         return bool(
             self._desired_running
@@ -617,6 +618,7 @@ class EverOSProcess:
             and (
                 self.running
                 or self._starting
+                or (watch_task is not None and not watch_task.done())
                 or (restart_task is not None and not restart_task.done())
             )
         )

--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -624,6 +624,16 @@ class EverOSProcess:
         )
 
     @property
+    def retains_active_config(self) -> bool:
+        """Whether owned execution can still use this supervisor's settings."""
+
+        return bool(
+            self._process is not None
+            or self._owned_processes
+            or self.restart_authorized
+        )
+
+    @property
     def last_error(self) -> MemoryErrorCode | None:
         return self._last_error
 
@@ -3794,7 +3804,7 @@ class _SystemProcessHost:
 class EverOSProcessPort(Protocol):
     """What the runtime needs from a supervised sidecar, and nothing more.
 
-    Deliberately six members over ``EverOSProcess``'s ~990 lines: the runtime
+    Deliberately seven members over ``EverOSProcess``'s ~990 lines: the runtime
     never inspects the child tree, the generated config, or the signal handling.
     Keeping those out of this interface is what lets tests substitute a fake
     instead of patching ``psutil``, ``os``, and private attributes.
@@ -3808,6 +3818,9 @@ class EverOSProcessPort(Protocol):
 
     @property
     def restart_authorized(self) -> bool: ...
+
+    @property
+    def retains_active_config(self) -> bool: ...
 
     async def start(self) -> bool: ...
 
@@ -3868,6 +3881,7 @@ class FakeEverOSProcess:
     _down: bool = False
     _desired_running: bool = True
     _restart_pending: bool = False
+    _process_tree_retained: bool = False
 
     @property
     def running(self) -> bool:
@@ -3889,11 +3903,16 @@ class FakeEverOSProcess:
             and (self._running or self._starting or self._restart_pending)
         )
 
+    @property
+    def retains_active_config(self) -> bool:
+        return self._running or self._process_tree_retained or self.restart_authorized
+
     async def start(self) -> bool:
         self.starts += 1
         self._desired_running = True
         self._down = False
         self._restart_pending = False
+        self._process_tree_retained = False
         before_start = self.before_start
         if before_start is not None:
             result = before_start()
@@ -3918,12 +3937,15 @@ class FakeEverOSProcess:
     async def stop(self) -> None:
         self.stops += 1
         self.stopped = True
+        owned_execution = self._running or self._process_tree_retained
         self._desired_running = False
         self._restart_pending = False
         self._running = False
         self._starting = False
         if self.stop_failure is not None:
+            self._process_tree_retained = owned_execution
             raise self.stop_failure
+        self._process_tree_retained = False
         await self._notify_reaped()
 
     async def _notify_reaped(self) -> None:

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -1125,8 +1125,9 @@ class MemoryRuntime:
         python = await asyncio.to_thread(self._artifact_manager.resolve_python)
         if python is None:
             error = _runtime_error_for_status(await asyncio.to_thread(self._artifact_manager.status))
-            if self._process is None:
-                # No retained supervisor can relaunch with the prior settings.
+            if not self._sidecar.snapshot().supervisor_can_restart:
+                # No retained supervisor can relaunch with the prior settings,
+                # including one that exhausted its restart budget.
                 # Retain the desired config so a first artifact install can
                 # activate it without waiting for another reconciliation.
                 self._config = config
@@ -3488,8 +3489,10 @@ class MemoryRuntime:
                             if previous_python is None:
                                 # First artifact admission is durable even when
                                 # its desired config cannot activate immediately.
-                                # A later reconcile can retry the retained config
-                                # without forcing the user to download it again.
+                                # Publish restart authority only when the failed
+                                # start retained a supervisor carrying that config.
+                                if self._sidecar.snapshot().supervisor_can_restart:
+                                    self._restart_config = deepcopy(self._config)
                                 return
                             raise MemoryRuntimeActivationError("candidate runtime reconciliation failed")
                         self._restart_config = deepcopy(self._config)

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -1125,9 +1125,9 @@ class MemoryRuntime:
         python = await asyncio.to_thread(self._artifact_manager.resolve_python)
         if python is None:
             error = _runtime_error_for_status(await asyncio.to_thread(self._artifact_manager.status))
-            if not self._sidecar.snapshot().supervisor_can_restart:
-                # No retained supervisor can relaunch with the prior settings,
-                # including one that exhausted its restart budget.
+            if not self._sidecar.snapshot().retains_active_config:
+                # No retained supervisor can run now or relaunch with the prior
+                # settings, including one that exhausted its restart budget.
                 # Retain the desired config so a first artifact install can
                 # activate it without waiting for another reconciliation.
                 self._config = config

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -2407,10 +2407,10 @@ class MemoryRuntime:
             # including its terminal "down" state, while claims are fenced so a
             # repair can safely replace the executable it might otherwise relaunch.
             supervisor = self._process
-            # A HEALTHY running sidecar must not be force-stopped/replaced through
-            # Repair — that requires a coordinated disable first. Only a retained
-            # supervisor in its terminal "down" state (no live child) may be stopped
-            # here so Repair can recover enabled/down Memory.
+            # A healthy running sidecar must not be force-stopped/replaced through
+            # Repair — that requires a coordinated disable first. Any retained
+            # supervisor without a live child can be stopped here: Stop revokes
+            # delayed-retry authority before Repair adopts the durable config.
             if supervisor is not None and supervisor.running:
                 return {
                     "ok": False,
@@ -2431,6 +2431,20 @@ class MemoryRuntime:
                             "download_error": None,
                         }
                     try:
+                        activation_config = await asyncio.to_thread(
+                            lambda: V2Config.load().memory
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Memory Runtime repair could not load the durable config"
+                        )
+                        self._runtime_error = "memory_runtime_install_failed"
+                        return {
+                            "ok": False,
+                            "reason": self._runtime_error,
+                            "download_error": None,
+                        }
+                    try:
                         await supervisor.stop()
                     except Exception:
                         self._runtime_error = "memory_runtime_install_failed"
@@ -2442,6 +2456,10 @@ class MemoryRuntime:
                     self._process = None
                     self._process_records_calls = False
                     self._ensure_call_log_retention()
+                    # The prior supervisor's launch authority is now retired.
+                    # Artifact activation must use the durable desired settings,
+                    # not the active snapshot that was kept while it could retry.
+                    self._config = deepcopy(activation_config)
             self._artifact_installing = True
         ensure_task = asyncio.create_task(
             asyncio.to_thread(self._artifact_manager.ensure, force=True)

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -1125,10 +1125,10 @@ class MemoryRuntime:
         python = await asyncio.to_thread(self._artifact_manager.resolve_python)
         if python is None:
             error = _runtime_error_for_status(await asyncio.to_thread(self._artifact_manager.status))
-            if not (self._process and self._process.running):
-                # No active child can still depend on the prior settings. Retain
-                # the desired config so a first artifact install can activate it
-                # immediately instead of waiting for another reconciliation.
+            if self._process is None:
+                # No retained supervisor can relaunch with the prior settings.
+                # Retain the desired config so a first artifact install can
+                # activate it without waiting for another reconciliation.
                 self._config = config
                 self._runtime_error = error
             if claims_paused and resume_claims_on_failure:
@@ -3474,6 +3474,9 @@ class MemoryRuntime:
                                 meta,
                                 candidate,
                             )
+                        previous_python = await asyncio.to_thread(
+                            self._artifact_manager.resolve_python
+                        )
                         commit()
                         result = await self._reconcile_locked(
                             self._config,
@@ -3482,6 +3485,12 @@ class MemoryRuntime:
                             resume_claims_on_failure=False,
                         )
                         if result.get("ok") is not True:
+                            if previous_python is None:
+                                # First artifact admission is durable even when
+                                # its desired config cannot activate immediately.
+                                # A later reconcile can retry the retained config
+                                # without forcing the user to download it again.
+                                return
                             raise MemoryRuntimeActivationError("candidate runtime reconciliation failed")
                         self._restart_config = deepcopy(self._config)
                         return

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -1097,16 +1097,10 @@ class MemoryRuntime:
             claims_paused = True
             embedding_guard_rejected = False
             try:
-                if await asyncio.to_thread(self._provider_data_exists_strict):
+                if not await self._embedding_change_is_admissible(self._config, config):
                     embedding_guard_rejected = True
                     self._runtime_error = "memory_clear_failed"
                     return {"ok": False, "error": self._runtime_error}
-            except Exception:
-                # An indeterminate root/queue state cannot safely accept an
-                # embedding change because it could mix vector spaces.
-                embedding_guard_rejected = True
-                self._runtime_error = "memory_clear_failed"
-                return {"ok": False, "error": self._runtime_error}
             finally:
                 if embedding_guard_rejected and resume_claims_on_failure:
                     self.module.resume_claims()
@@ -2456,6 +2450,19 @@ class MemoryRuntime:
                     self._process = None
                     self._process_records_calls = False
                     self._ensure_call_log_retention()
+                    if (
+                        activation_config.recovery_intent is None
+                        and not await self._embedding_change_is_admissible(
+                            self._config,
+                            activation_config,
+                        )
+                    ):
+                        self._runtime_error = "memory_clear_failed"
+                        return {
+                            "ok": False,
+                            "reason": self._runtime_error,
+                            "download_error": None,
+                        }
                     # The prior supervisor's launch authority is now retired.
                     # Artifact activation must use the durable desired settings,
                     # not the active snapshot that was kept while it could retry.
@@ -3760,6 +3767,22 @@ class MemoryRuntime:
         root_has_data = self._provider_root_owner.has_data()
         stats = self._store.queue_stats()
         return bool(root_has_data or stats.pending or stats.processing or stats.dead or self._store.has_provider_data_history())
+
+    async def _embedding_change_is_admissible(
+        self,
+        current: MemoryConfig,
+        candidate: MemoryConfig,
+    ) -> bool:
+        """Require a freshly proven-empty vector surface for an embedding change."""
+
+        if not _embedding_configuration_changed(current, candidate):
+            return True
+        try:
+            return not await asyncio.to_thread(self._provider_data_exists_strict)
+        except Exception:
+            # An indeterminate root/queue state cannot safely accept an
+            # embedding change because it could mix vector spaces.
+            return False
 
     def _settle_rebuild_intent(self, candidate: MemoryConfig) -> MemoryConfig | None:
         """Clear a rebuild intent when the durable vector-space identity still matches.

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -1126,6 +1126,10 @@ class MemoryRuntime:
         if python is None:
             error = _runtime_error_for_status(await asyncio.to_thread(self._artifact_manager.status))
             if not (self._process and self._process.running):
+                # No active child can still depend on the prior settings. Retain
+                # the desired config so a first artifact install can activate it
+                # immediately instead of waiting for another reconciliation.
+                self._config = config
                 self._runtime_error = error
             if claims_paused and resume_claims_on_failure:
                 self.module.resume_claims()

--- a/core/memory/sidecar_lifecycle.py
+++ b/core/memory/sidecar_lifecycle.py
@@ -32,7 +32,7 @@ class SidecarSnapshot:
     def supervisor_can_restart(self) -> bool:
         """Whether retained launch authority can still produce a child."""
 
-        return bool(self.process and not self.process.down)
+        return bool(self.process and self.process.restart_authorized)
 
 
 @dataclass(frozen=True, slots=True)

--- a/core/memory/sidecar_lifecycle.py
+++ b/core/memory/sidecar_lifecycle.py
@@ -38,7 +38,7 @@ class SidecarSnapshot:
     def retains_active_config(self) -> bool:
         """Whether this supervisor can still execute under captured settings."""
 
-        return self.running or self.supervisor_can_restart
+        return bool(self.process and self.process.retains_active_config)
 
 
 @dataclass(frozen=True, slots=True)

--- a/core/memory/sidecar_lifecycle.py
+++ b/core/memory/sidecar_lifecycle.py
@@ -34,6 +34,12 @@ class SidecarSnapshot:
 
         return bool(self.process and self.process.restart_authorized)
 
+    @property
+    def retains_active_config(self) -> bool:
+        """Whether this supervisor can still execute under captured settings."""
+
+        return self.running or self.supervisor_can_restart
+
 
 @dataclass(frozen=True, slots=True)
 class RecorderAdmission:

--- a/core/memory/sidecar_lifecycle.py
+++ b/core/memory/sidecar_lifecycle.py
@@ -28,6 +28,12 @@ class SidecarSnapshot:
     def running(self) -> bool:
         return bool(self.process and self.process.running)
 
+    @property
+    def supervisor_can_restart(self) -> bool:
+        """Whether retained launch authority can still produce a child."""
+
+        return bool(self.process and not self.process.down)
+
 
 @dataclass(frozen=True, slots=True)
 class RecorderAdmission:

--- a/tests/test_memory_process.py
+++ b/tests/test_memory_process.py
@@ -613,7 +613,9 @@ async def test_sidecar_rejects_sun_path_overflow_without_launching_child(tmp_pat
     assert await process.start() is False
     assert process.last_error == "memory_sidecar_unavailable"
     assert process.consecutive_failures == 1
+    assert process.restart_authorized is True
     await process.stop()
+    assert process.restart_authorized is False
 
 
 async def test_sidecar_start_failure_never_relaunches_beside_an_unreaped_child(monkeypatch, tmp_path: Path) -> None:
@@ -2060,6 +2062,7 @@ async def test_unplanned_sidecar_signals_still_consume_crash_budget(
     assert process.consecutive_failures == 5
     assert process.down is True
     assert process._restart_task is None
+    assert process.restart_authorized is False
 
 
 async def test_planned_reap_from_exited_issuer_cannot_exempt_same_generation(
@@ -3753,6 +3756,7 @@ async def test_sidecar_stop_and_cancellation_end_a_busy_root_wait(
         assert process.last_error is None
         assert process.down is False
         assert process.starting is False
+        assert process.restart_authorized is False
         assert host.spawn_calls == []
 
         lock_attempted.clear()
@@ -3765,6 +3769,7 @@ async def test_sidecar_stop_and_cancellation_end_a_busy_root_wait(
         assert process.last_error is None
         assert process.down is False
         assert process.starting is False
+        assert process.restart_authorized is False
         assert host.spawn_calls == []
     finally:
         await process.stop()
@@ -3913,6 +3918,7 @@ async def test_cancelled_sidecar_start_holds_root_lock_through_owned_cleanup(
         assert retention_started.is_set()
         assert process.consecutive_failures == 0
         assert process.starting is False
+        assert process.restart_authorized is False
 
         rebuild_child = _RebuildChild(0, pid=_ORPHAN_DESCENDANT_PID)
         rebuild_identities = {

--- a/tests/test_memory_process.py
+++ b/tests/test_memory_process.py
@@ -1944,6 +1944,44 @@ def _supervising(process: EverOSProcess, child: _ExitedChild) -> None:
     process._owned_processes = {_ORPHAN_PID: _ORPHAN_CREATE_TIME}
 
 
+async def test_exited_child_watcher_retains_restart_authority_until_retry_is_scheduled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An exit watcher owns the old settings until it chooses a terminal state."""
+
+    process = EverOSProcess(
+        sys.executable,
+        effective_home=tmp_path,
+        settings=_settings(),
+    )
+    child = _ExitedChild()
+    _supervising(process, child)
+    process._desired_running = True
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    async def terminate(*_args, **_kwargs) -> None:
+        cleanup_started.set()
+        await release_cleanup.wait()
+
+    monkeypatch.setattr(process, "_terminate_owned_tree", terminate)
+    watch_task = asyncio.create_task(process._watch_child(child))
+    process._watch_task = watch_task
+
+    await asyncio.wait_for(cleanup_started.wait(), timeout=0.5)
+    assert process.running is False
+    assert process._restart_task is None
+    assert process.restart_authorized is True
+
+    release_cleanup.set()
+    await asyncio.wait_for(watch_task, timeout=0.5)
+    assert process._restart_task is not None
+    assert process.restart_authorized is True
+    await process.stop()
+    assert process.restart_authorized is False
+
+
 def test_sidecar_notifies_reaped_callback_only_after_tree_cleanup(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_memory_process.py
+++ b/tests/test_memory_process.py
@@ -1982,6 +1982,45 @@ async def test_exited_child_watcher_retains_restart_authority_until_retry_is_sch
     assert process.restart_authorized is False
 
 
+async def test_unreaped_descendants_retain_active_config_until_stop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Captured settings remain authoritative while any owned tree may survive."""
+
+    process = EverOSProcess(
+        sys.executable,
+        effective_home=tmp_path,
+        settings=_settings(),
+    )
+    child = _ExitedChild()
+    _supervising(process, child)
+    process._owned_processes[_ORPHAN_DESCENDANT_PID] = _ORPHAN_CREATE_TIME + 1
+    process._desired_running = True
+    cleanup_attempts = 0
+
+    async def terminate(*_args, **_kwargs) -> None:
+        nonlocal cleanup_attempts
+        cleanup_attempts += 1
+        if cleanup_attempts == 1:
+            raise RuntimeError("descendant tree still alive")
+
+    monkeypatch.setattr(process, "_terminate_owned_tree", terminate)
+    monkeypatch.setattr(process._ownership, "retire_if_group_is_clear", lambda *_args: None)
+
+    await process._watch_child(child)
+
+    assert process.running is False
+    assert process.restart_authorized is False
+    assert process.retains_active_config is True
+    assert process._process is child
+    assert _ORPHAN_DESCENDANT_PID in process._owned_processes
+
+    await process.stop()
+    assert cleanup_attempts == 2
+    assert process.retains_active_config is False
+
+
 def test_sidecar_notifies_reaped_callback_only_after_tree_cleanup(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -2912,6 +2912,78 @@ async def test_repair_rechecks_vectors_after_retiring_restart_authority(
     await memory_runtime_factory.close(runtime)
 
 
+async def test_repair_rechecks_vectors_after_retiring_owned_descendants(
+    tmp_path: Path,
+    memory_runtime_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreaped old-model tree keeps its config until Stop proves it gone."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    active = MemoryConfig(enabled=True, processing=_processing_config())
+    durable = replace(
+        active,
+        processing=replace(
+            active.processing,
+            embedding=replace(active.processing.embedding, model="embed-v2"),
+        ),
+    )
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=durable,
+    ).save()
+    artifact = _FirstInstallArtifact()
+    artifact.status_payload = {
+        "installed": False,
+        "status": "missing",
+        "reason": "memory_runtime_missing",
+    }
+    runtime = memory_runtime_factory(
+        active,
+        artifact_manager=artifact,
+        effective_home=tmp_path,
+    )
+    retained_tree = FakeEverOSProcess(
+        _running=False,
+        _down=True,
+        _desired_running=False,
+    )
+    retained_tree._process_tree_retained = True
+    runtime._process = retained_tree
+    vector_state = {"exists": False}
+    monkeypatch.setattr(
+        runtime,
+        "_provider_data_exists_strict",
+        lambda: vector_state["exists"],
+    )
+
+    assert await runtime.reconcile(active) == {
+        "ok": False,
+        "error": "memory_runtime_missing",
+    }
+    assert retained_tree.restart_authorized is False
+    assert runtime._sidecar.snapshot().retains_active_config is True
+    assert runtime._config == active
+
+    vector_state["exists"] = True
+    assert await runtime.install_artifact() == {
+        "ok": False,
+        "reason": "memory_clear_failed",
+        "download_error": None,
+    }
+    assert retained_tree.stopped is True
+    assert retained_tree.retains_active_config is False
+    assert runtime._process is None
+    assert runtime._config == active
+    assert runtime._restart_config == active
+    assert artifact.ensure_calls == []
+    await memory_runtime_factory.close(runtime)
+
+
 async def test_missing_artifact_retains_active_config_until_rejected_child_is_gone(
     tmp_path: Path,
     memory_runtime_factory,

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -2840,6 +2840,78 @@ async def test_missing_artifact_defers_config_until_repair_retires_restart_autho
     await memory_runtime_factory.close(runtime)
 
 
+async def test_repair_rechecks_vectors_after_retiring_restart_authority(
+    tmp_path: Path,
+    memory_runtime_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A delayed old-model write must block durable embedding adoption."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    active = MemoryConfig(enabled=True, processing=_processing_config())
+    durable = replace(
+        active,
+        processing=replace(
+            active.processing,
+            embedding=replace(active.processing.embedding, model="embed-v2"),
+        ),
+    )
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=durable,
+    ).save()
+    artifact = _FirstInstallArtifact()
+    artifact.status_payload = {
+        "installed": False,
+        "status": "missing",
+        "reason": "memory_runtime_missing",
+    }
+    runtime = memory_runtime_factory(
+        active,
+        artifact_manager=artifact,
+        effective_home=tmp_path,
+    )
+    restarting = FakeEverOSProcess(
+        _running=False,
+        _down=False,
+        _desired_running=True,
+        _restart_pending=True,
+    )
+    runtime._process = restarting
+    vector_state = {"exists": False}
+    monkeypatch.setattr(
+        runtime,
+        "_provider_data_exists_strict",
+        lambda: vector_state["exists"],
+    )
+
+    assert await runtime.reconcile(active) == {
+        "ok": False,
+        "error": "memory_runtime_missing",
+    }
+    assert runtime._config == active
+
+    # The retained supervisor can resume and write with the old embedding before
+    # exhausting its restart budget. Repair must inspect that newer state only
+    # after it has retired the supervisor and fenced claims.
+    vector_state["exists"] = True
+    assert await runtime.install_artifact() == {
+        "ok": False,
+        "reason": "memory_clear_failed",
+        "download_error": None,
+    }
+    assert restarting.stopped is True
+    assert runtime._process is None
+    assert runtime._config == active
+    assert runtime._restart_config == active
+    assert artifact.ensure_calls == []
+    await memory_runtime_factory.close(runtime)
+
+
 async def test_missing_artifact_retains_active_config_until_rejected_child_is_gone(
     tmp_path: Path,
     memory_runtime_factory,

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -2772,7 +2772,7 @@ async def test_runtime_install_activates_config_retained_after_missing_artifact(
     await memory_runtime_factory.close(runtime)
 
 
-async def test_missing_artifact_does_not_publish_config_while_supervisor_can_restart(
+async def test_missing_artifact_defers_config_until_repair_retires_restart_authority(
     tmp_path: Path,
     memory_runtime_factory,
     monkeypatch: pytest.MonkeyPatch,
@@ -2796,6 +2796,74 @@ async def test_missing_artifact_does_not_publish_config_while_supervisor_can_res
         agents=AgentsConfig(),
         memory=candidate,
     ).save()
+    artifact = _FirstInstallArtifact()
+    artifact.status_payload = {
+        "installed": False,
+        "status": "missing",
+        "reason": "memory_runtime_missing",
+    }
+    process_factory = FakeEverOSProcessFactory()
+    runtime = memory_runtime_factory(
+        active,
+        artifact_manager=artifact,
+        process_factory=process_factory,
+        effective_home=tmp_path,
+    )
+    restarting = FakeEverOSProcess(
+        _running=False,
+        _down=False,
+        _desired_running=True,
+        _restart_pending=True,
+    )
+    runtime._process = restarting
+    monkeypatch.setattr(runtime, "_provider_data_exists_strict", lambda: False)
+
+    assert await runtime.reconcile(active) == {
+        "ok": False,
+        "error": "memory_runtime_missing",
+    }
+    assert runtime._config == active
+    assert runtime._restart_config == active
+    assert runtime._process is restarting
+    assert restarting.stopped is False
+
+    assert await runtime.install_artifact() == {
+        "ok": True,
+        "reason": None,
+        "download_error": None,
+    }
+    assert restarting.stopped is True
+    assert runtime._config == candidate
+    assert runtime._restart_config == candidate
+    assert process_factory.supervised[0].settings is not None
+    assert process_factory.supervised[0].settings.embedding_model == "embed-v2"
+    await memory_runtime_factory.close(runtime)
+
+
+async def test_missing_artifact_publishes_config_from_cancelled_supervisor(
+    tmp_path: Path,
+    memory_runtime_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retained supervisor without launch authority cannot keep stale settings."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    active = MemoryConfig(enabled=True, processing=_processing_config())
+    durable = replace(
+        active,
+        processing=replace(
+            active.processing,
+            embedding=replace(active.processing.embedding, model="embed-v2"),
+        ),
+    )
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=durable,
+    ).save()
     artifact = FakeMemoryArtifactManager(
         python=None,
         status_payload={
@@ -2809,20 +2877,22 @@ async def test_missing_artifact_does_not_publish_config_while_supervisor_can_res
         artifact_manager=artifact,
         effective_home=tmp_path,
     )
-    restarting = FakeEverOSProcess()
-    restarting._running = False
-    restarting._down = False
-    runtime._process = restarting
+    cancelled = FakeEverOSProcess(
+        _running=False,
+        _down=False,
+        _desired_running=False,
+    )
+    runtime._process = cancelled
     monkeypatch.setattr(runtime, "_provider_data_exists_strict", lambda: False)
 
     assert await runtime.reconcile(active) == {
         "ok": False,
         "error": "memory_runtime_missing",
     }
-    assert runtime._config == active
+    assert cancelled.restart_authorized is False
+    assert runtime._config == durable
     assert runtime._restart_config == active
-    assert runtime._process is restarting
-    assert restarting.stopped is False
+    assert runtime._process is cancelled
     await memory_runtime_factory.close(runtime)
 
 
@@ -3509,8 +3579,17 @@ async def test_runtime_repair_stops_retained_down_supervisor_before_replacing_ar
         llm=MemoryEndpointConfig("https://llm.example.test/v1", "chat", "llm-key"),
         embedding=MemoryEndpointConfig("https://embed.example.test/v1", "embed", "embed-key"),
     )
+    config = MemoryConfig(enabled=True, processing=processing)
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=config,
+    ).save()
     runtime = memory_runtime_factory(
-        MemoryConfig(enabled=True, processing=processing),
+        config,
         artifact_manager=_Artifact(root_format=None, fingerprint=None),
         effective_home=tmp_path,
     )

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -2840,6 +2840,81 @@ async def test_missing_artifact_defers_config_until_repair_retires_restart_autho
     await memory_runtime_factory.close(runtime)
 
 
+async def test_missing_artifact_retains_active_config_until_rejected_child_is_gone(
+    tmp_path: Path,
+    memory_runtime_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A live child keeps its captured config after restart authority is revoked."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    active = MemoryConfig(enabled=True, processing=_processing_config())
+    durable = replace(
+        active,
+        processing=replace(
+            active.processing,
+            embedding=replace(active.processing.embedding, model="embed-v2"),
+        ),
+    )
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=durable,
+    ).save()
+    artifact = _FirstInstallArtifact()
+    artifact.status_payload = {
+        "installed": False,
+        "status": "missing",
+        "reason": "memory_runtime_missing",
+    }
+    process_factory = FakeEverOSProcessFactory()
+    runtime = memory_runtime_factory(
+        active,
+        artifact_manager=artifact,
+        process_factory=process_factory,
+        effective_home=tmp_path,
+    )
+    rejected = FakeEverOSProcess(
+        _running=True,
+        _down=True,
+        _desired_running=False,
+    )
+    runtime._process = rejected
+    monkeypatch.setattr(runtime, "_provider_data_exists_strict", lambda: False)
+
+    assert await runtime.reconcile(active) == {
+        "ok": False,
+        "error": "memory_runtime_missing",
+    }
+    assert rejected.restart_authorized is False
+    assert runtime._sidecar.snapshot().retains_active_config is True
+    assert runtime._config == active
+    assert runtime._restart_config == active
+
+    assert await runtime.install_artifact() == {
+        "ok": False,
+        "reason": "memory_runtime_install_requires_disabled_memory",
+        "download_error": None,
+    }
+    assert rejected.stopped is False
+
+    rejected._running = False
+    assert await runtime.install_artifact() == {
+        "ok": True,
+        "reason": None,
+        "download_error": None,
+    }
+    assert rejected.stopped is True
+    assert runtime._config == durable
+    assert runtime._restart_config == durable
+    assert process_factory.supervised[0].settings is not None
+    assert process_factory.supervised[0].settings.embedding_model == "embed-v2"
+    await memory_runtime_factory.close(runtime)
+
+
 async def test_missing_artifact_publishes_config_from_cancelled_supervisor(
     tmp_path: Path,
     memory_runtime_factory,

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -2811,6 +2811,7 @@ async def test_missing_artifact_does_not_publish_config_while_supervisor_can_res
     )
     restarting = FakeEverOSProcess()
     restarting._running = False
+    restarting._down = False
     runtime._process = restarting
     monkeypatch.setattr(runtime, "_provider_data_exists_strict", lambda: False)
 
@@ -2822,6 +2823,68 @@ async def test_missing_artifact_does_not_publish_config_while_supervisor_can_res
     assert runtime._restart_config == active
     assert runtime._process is restarting
     assert restarting.stopped is False
+    await memory_runtime_factory.close(runtime)
+
+
+async def test_missing_artifact_publishes_config_from_terminal_supervisor_for_install(
+    tmp_path: Path,
+    memory_runtime_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A terminal supervisor cannot retain launch authority over desired config."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    active = MemoryConfig(enabled=True, processing=_processing_config())
+    durable = replace(
+        active,
+        processing=replace(
+            active.processing,
+            embedding=replace(active.processing.embedding, model="embed-v2"),
+        ),
+    )
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=durable,
+    ).save()
+    artifact = _FirstInstallArtifact()
+    artifact.status_payload = {
+        "installed": False,
+        "status": "missing",
+        "reason": "memory_runtime_missing",
+    }
+    process_factory = FakeEverOSProcessFactory()
+    runtime = memory_runtime_factory(
+        active,
+        artifact_manager=artifact,
+        process_factory=process_factory,
+        effective_home=tmp_path,
+    )
+    terminal = FakeEverOSProcess(_running=False, _down=True)
+    runtime._process = terminal
+    monkeypatch.setattr(runtime, "_provider_data_exists_strict", lambda: False)
+
+    assert await runtime.reconcile(active) == {
+        "ok": False,
+        "error": "memory_runtime_missing",
+    }
+    assert runtime._config == durable
+    assert runtime._restart_config == active
+    assert runtime._process is terminal
+
+    assert await runtime.install_artifact() == {
+        "ok": True,
+        "reason": None,
+        "download_error": None,
+    }
+    assert terminal.stopped is True
+    assert runtime._config == durable
+    assert runtime._restart_config == durable
+    assert process_factory.supervised[0].settings is not None
+    assert process_factory.supervised[0].settings.embedding_model == "embed-v2"
     await memory_runtime_factory.close(runtime)
 
 
@@ -2878,6 +2941,62 @@ async def test_first_install_keeps_artifact_when_immediate_config_probe_fails(
     assert runtime._restart_config.enabled is False
     assert runtime._runtime_error == "memory_processing_failed"
     assert process_factory.supervised == []
+    await memory_runtime_factory.close(runtime)
+
+
+async def test_first_install_admits_retry_from_retained_supervisor(
+    tmp_path: Path,
+    memory_runtime_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A first launch failure may recover under the retained desired settings."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    durable = MemoryConfig(enabled=True, processing=_processing_config())
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=durable,
+    ).save()
+    artifact = _FirstInstallArtifact()
+    artifact.status_payload = {
+        "installed": False,
+        "status": "missing",
+        "reason": "memory_runtime_missing",
+    }
+    process_factory = FakeEverOSProcessFactory(
+        template=lambda: FakeEverOSProcess(start_results=deque((False, True)))
+    )
+    runtime = memory_runtime_factory(
+        MemoryConfig(enabled=False),
+        artifact_manager=artifact,
+        process_factory=process_factory,
+        effective_home=tmp_path,
+    )
+    assert await runtime.reconcile(MemoryConfig(enabled=False)) == {
+        "ok": False,
+        "error": "memory_runtime_missing",
+    }
+
+    assert await runtime.install_artifact() == {
+        "ok": True,
+        "reason": None,
+        "download_error": None,
+    }
+    recovering = process_factory.supervised[0]
+    assert recovering.running is False
+    assert runtime._config == durable
+    assert runtime._restart_config == durable
+    assert runtime.module._worker._claims_paused is True
+
+    assert await recovering.start() is True
+    await asyncio.wait_for(runtime._sidecar._ready_task, timeout=1.0)
+    assert runtime._runtime_error is None
+    assert runtime.module._worker._claims_paused is False
+    assert runtime._worker_task is not None
     await memory_runtime_factory.close(runtime)
 
 

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -132,6 +132,50 @@ def _installed_artifact(**overrides) -> FakeMemoryArtifactManager:
     return FakeMemoryArtifactManager(**defaults)
 
 
+class _FirstInstallArtifact(FakeMemoryArtifactManager):
+    """Commit a fake first-install pointer through the real activation bridge."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            python=None,
+            root_format=None,
+            fingerprint=None,
+            compatible_formats=frozenset(),
+        )
+        self.commits = 0
+        self.rollbacks = 0
+
+    def ensure(self, *, force: bool = False) -> dict:
+        self.ensure_calls.append(force)
+        assert self.activation_coordinator is not None
+
+        def commit() -> None:
+            self.commits += 1
+            self.python = Path(sys.executable)
+            self.root_format = "everos-1.2.3"
+            self.fingerprint = "first-install"
+            self.compatible_formats = frozenset({"everos-1.2.3"})
+
+        def rollback() -> None:
+            self.rollbacks += 1
+            self.python = None
+            self.root_format = None
+            self.fingerprint = None
+            self.compatible_formats = frozenset()
+
+        self.activation_coordinator(
+            MemoryArtifactCandidate(
+                provider_root_format="everos-1.2.3",
+                compatible_provider_root_formats=frozenset({"everos-1.2.3"}),
+                artifact_fingerprint="first-install",
+            ),
+            MemoryProviderRootState(exists=False),
+            commit,
+            rollback,
+        )
+        return dict(self.ensure_payload)
+
+
 @pytest.fixture(autouse=True)
 def _preflight_passes_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep runtime lifecycle tests hermetic unless they exercise preflight."""
@@ -2665,6 +2709,56 @@ async def test_runtime_install_artifact_uses_controller_owned_manager(
     assert callable(artifact.activation_coordinator)
     assert calls == [True]
     assert runtime._config.enabled is False
+    await memory_runtime_factory.close(runtime)
+
+
+async def test_runtime_install_activates_config_retained_after_missing_artifact(
+    tmp_path: Path,
+    memory_runtime_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A first install must not wait for another process to retry reconciliation."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    durable = MemoryConfig(enabled=True, processing=_processing_config())
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=durable,
+    ).save()
+    artifact = _FirstInstallArtifact()
+    artifact.status_payload = {
+        "installed": False,
+        "status": "missing",
+        "reason": "memory_runtime_missing",
+    }
+    process_factory = FakeEverOSProcessFactory()
+    runtime = memory_runtime_factory(
+        MemoryConfig(enabled=False),
+        artifact_manager=artifact,
+        process_factory=process_factory,
+        effective_home=tmp_path,
+    )
+
+    reconcile_result = await runtime.reconcile(MemoryConfig(enabled=False))
+
+    assert reconcile_result == {"ok": False, "error": "memory_runtime_missing"}
+    assert runtime._config == durable
+    assert runtime._restart_config.enabled is False
+    assert process_factory.supervised == []
+
+    install_result = await runtime.install_artifact()
+
+    assert install_result == {"ok": True, "reason": None, "download_error": None}
+    assert artifact.commits == 1
+    assert artifact.rollbacks == 0
+    assert runtime._config == durable
+    assert runtime._restart_config == durable
+    assert len(process_factory.supervised) == 1
+    assert process_factory.supervised[0].starts == 1
     await memory_runtime_factory.close(runtime)
 
 

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -155,6 +155,11 @@ class _FirstInstallArtifact(FakeMemoryArtifactManager):
             self.root_format = "everos-1.2.3"
             self.fingerprint = "first-install"
             self.compatible_formats = frozenset({"everos-1.2.3"})
+            self.status_payload = {
+                "installed": True,
+                "status": "ready",
+                "reason": None,
+            }
 
         def rollback() -> None:
             self.rollbacks += 1
@@ -162,6 +167,11 @@ class _FirstInstallArtifact(FakeMemoryArtifactManager):
             self.root_format = None
             self.fingerprint = None
             self.compatible_formats = frozenset()
+            self.status_payload = {
+                "installed": False,
+                "status": "missing",
+                "reason": "memory_runtime_missing",
+            }
 
         self.activation_coordinator(
             MemoryArtifactCandidate(
@@ -2759,6 +2769,115 @@ async def test_runtime_install_activates_config_retained_after_missing_artifact(
     assert runtime._restart_config == durable
     assert len(process_factory.supervised) == 1
     assert process_factory.supervised[0].starts == 1
+    await memory_runtime_factory.close(runtime)
+
+
+async def test_missing_artifact_does_not_publish_config_while_supervisor_can_restart(
+    tmp_path: Path,
+    memory_runtime_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A childless retained supervisor still owns its previous launch settings."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    active = MemoryConfig(enabled=True, processing=_processing_config())
+    candidate = replace(
+        active,
+        processing=replace(
+            active.processing,
+            embedding=replace(active.processing.embedding, model="embed-v2"),
+        ),
+    )
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=candidate,
+    ).save()
+    artifact = FakeMemoryArtifactManager(
+        python=None,
+        status_payload={
+            "installed": False,
+            "status": "missing",
+            "reason": "memory_runtime_missing",
+        },
+    )
+    runtime = memory_runtime_factory(
+        active,
+        artifact_manager=artifact,
+        effective_home=tmp_path,
+    )
+    restarting = FakeEverOSProcess()
+    restarting._running = False
+    runtime._process = restarting
+    monkeypatch.setattr(runtime, "_provider_data_exists_strict", lambda: False)
+
+    assert await runtime.reconcile(active) == {
+        "ok": False,
+        "error": "memory_runtime_missing",
+    }
+    assert runtime._config == active
+    assert runtime._restart_config == active
+    assert runtime._process is restarting
+    assert restarting.stopped is False
+    await memory_runtime_factory.close(runtime)
+
+
+async def test_first_install_keeps_artifact_when_immediate_config_probe_fails(
+    tmp_path: Path,
+    memory_runtime_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Artifact admission and immediate desired-config activation are independent."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    durable = MemoryConfig(enabled=True, processing=_processing_config())
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=durable,
+    ).save()
+    artifact = _FirstInstallArtifact()
+    artifact.status_payload = {
+        "installed": False,
+        "status": "missing",
+        "reason": "memory_runtime_missing",
+    }
+    process_factory = FakeEverOSProcessFactory()
+    runtime = memory_runtime_factory(
+        MemoryConfig(enabled=False),
+        artifact_manager=artifact,
+        process_factory=process_factory,
+        effective_home=tmp_path,
+    )
+    assert await runtime.reconcile(MemoryConfig(enabled=False)) == {
+        "ok": False,
+        "error": "memory_runtime_missing",
+    }
+    monkeypatch.setattr(
+        runtime,
+        "_probe_processing",
+        lambda *_args: asyncio.sleep(0, result=False),
+    )
+
+    assert await runtime.install_artifact() == {
+        "ok": True,
+        "reason": None,
+        "download_error": None,
+    }
+    assert artifact.commits == 1
+    assert artifact.rollbacks == 0
+    assert artifact.resolve_python() == Path(sys.executable)
+    assert artifact.status()["installed"] is True
+    assert runtime._config == durable
+    assert runtime._restart_config.enabled is False
+    assert runtime._runtime_error == "memory_processing_failed"
+    assert process_factory.supervised == []
     await memory_runtime_factory.close(runtime)
 
 


### PR DESCRIPTION
## Capability

Start Memory immediately after a first managed Runtime install when the preceding durable-config reconciliation failed only because the Runtime artifact was missing.

The controller now treats supervisor launch authority as an explicit process-owned contract. A running, exit-watching, scheduled, or process-tree-owning supervisor preserves its active config; cancelled, inert, and terminal supervisors yield to durable desired settings. Repair transfers authority only after stopping the prior supervisor, then activates the artifact with the durable V2 config. First artifact admission remains durable when immediate activation fails, and a retained desired-settings supervisor can complete activation through its supervised retry.

## Evidence

- Unit: `pytest -q tests/test_memory_runtime.py` (211 passed)
- Unit: `pytest -q tests/test_memory_process.py` (142 passed)
- Unit: `pytest -q tests/test_memory_sidecar_lifecycle.py` (13 passed)
- Unit: `pytest -q tests/test_model_service.py` (45 passed)
- Contract: closed-loop persisted-config -> missing artifact -> Repair -> activation coverage, including processing-probe failure, failed launch followed by supervised retry, delayed-retry config deferral, exit-watcher-to-retry authority, and Repair handoff, cancelled/inert supervision, and terminal-down supervision, safety-rejected live-child and unreaped-descendant config retention, and fresh post-supervisor embedding admission against vector-bearing state
- Scenario IDs: none; the current catalog has no first managed Runtime installation scenario
- Lint: `ruff check core/memory/process.py core/memory/sidecar_lifecycle.py core/memory/runtime.py tests/test_memory_process.py tests/test_memory_runtime.py`
- Residual manual: the pre-fix local flow established a 52.1-second Runtime-ready-to-health delay and a 2-4-second sidecar startup; a destructive fresh local reinstall was not repeated after this code change

## Known by design

- `memory.cloud.runtime_apply_pending` remains owned and cleared by the Cloud Model Service worker. It may cause one later managed reconciliation, but it is no longer required for first-install readiness.