### PR TITLE
fix(memory): keep sidecar stop working after create_time clock steps

### DIFF
--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -12,6 +12,7 @@ import math
 import os
 import signal
 import stat
+import subprocess
 import sys
 import time
 from collections import deque
@@ -19,7 +20,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from typing import Any, Deque, Protocol, TypeVar, runtime_checkable
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -3124,17 +3125,9 @@ def _cmdline_matches_recorded_child(
     )
 
 
-def _legacy_live_wall_create_time(
-    record: object,
-    identity: _ProcessIdentity,
-) -> float | None:
-    """Wall-clock create_time for a legacy record, preferring a live read."""
+def _legacy_recorded_wall_create_time(identity: _ProcessIdentity) -> float | None:
+    """Wall-clock create_time captured with the rest of the identity snapshot."""
 
-    pid = _recorded_sidecar_pid(record)
-    if pid is not None:
-        live = _process_wall_create_time(pid)
-        if live is not None and _is_identity_stamp(live):
-            return live
     wall = identity.wall_create_time
     if wall is not None and not _is_identity_stamp(wall):
         return None
@@ -3212,7 +3205,7 @@ def _classify_recorded_child(
         provider_root=provider_root,
     )
     live_recorded_stamp = (
-        identity.stamp if has_starttime_ticks else _legacy_live_wall_create_time(record, identity)
+        identity.stamp if has_starttime_ticks else _legacy_recorded_wall_create_time(identity)
     )
     getuid = getattr(os, "getuid", None)
     own_uid = getuid() if callable(getuid) else None
@@ -3657,6 +3650,8 @@ def _confirmed_owned_processes(identities: Mapping[int, float]) -> dict[int, flo
 def _group_contains_only_confirmed_owned_processes(
     process_group: int | None,
     identities: Mapping[int, float],
+    *,
+    trusted_pids: Iterable[int] | None = None,
 ) -> bool:
     """Whether a group can be signaled without bypassing PID identity checks."""
 
@@ -3664,8 +3659,10 @@ def _group_contains_only_confirmed_owned_processes(
         return False
     group_members = _snapshot_process_group(process_group)
     confirmed = _confirmed_owned_processes(identities)
+    trusted = set() if trusted_pids is None else set(trusted_pids)
     return bool(group_members) and all(
-        confirmed.get(process_id) == created_at for process_id, created_at in group_members.items()
+        process_id in trusted or confirmed.get(process_id) == created_at
+        for process_id, created_at in group_members.items()
     )
 
 
@@ -3673,18 +3670,25 @@ def _signal_owned_group(
     process_group: int | None,
     identities: Mapping[int, float],
     signum: int,
+    *,
+    trusted_pids: Iterable[int] | None = None,
 ) -> bool:
     """Signal a whole isolated group, but only if every member is confirmed owned.
 
     Returns whether the group signal settled the delivery, so a caller holding a
     direct child handle can fall back to it without widening the blast radius: a
-    group with an unverifiable member is never signaled group-wide.
+    group with an unverifiable member is never signaled group-wide. A live
+    spawned ``Popen`` child may be treated as confirmed for the direct child only.
     """
 
     if (
         process_group is None
         or not hasattr(os, "killpg")
-        or not _group_contains_only_confirmed_owned_processes(process_group, identities)
+        or not _group_contains_only_confirmed_owned_processes(
+            process_group,
+            identities,
+            trusted_pids=trusted_pids,
+        )
     ):
         return False
     try:
@@ -3696,21 +3700,46 @@ def _signal_owned_group(
     return True
 
 
+def _live_direct_child_handle(process: asyncio.subprocess.Process) -> bool:
+    """Whether ``process`` is an unreaped child this process actually spawned.
+
+    Only a live stdlib ``Popen`` is authoritative. A constructed asyncio
+    Process — even one that fakes ``_transport._proc`` — still requires a stamp.
+    """
+
+    if (
+        not isinstance(process, asyncio.subprocess.Process)
+        or process.returncode is not None
+        or process.pid is None
+    ):
+        return False
+    transport = getattr(process, "_transport", None)
+    popen = getattr(transport, "_proc", None)
+    return isinstance(popen, subprocess.Popen) and popen.returncode is None
+
+
 def _signal_owned_group_or_process(
     process: asyncio.subprocess.Process,
     process_group: int | None,
     identities: Mapping[int, float],
     signum: int,
 ) -> None:
-    if _signal_owned_group(process_group, identities, signum):
+    trusted = {int(process.pid)} if _live_direct_child_handle(process) else set()
+    if _signal_owned_group(
+        process_group,
+        identities,
+        signum,
+        trusted_pids=trusted,
+    ):
         return
     if process.returncode is not None:
         return
-    created_at = identities.get(process.pid)
-    if created_at is None or process.pid not in _confirmed_owned_processes(
-        {process.pid: created_at}
-    ):
-        return
+    if not trusted:
+        created_at = identities.get(process.pid)
+        if created_at is None or process.pid not in _confirmed_owned_processes(
+            {process.pid: created_at}
+        ):
+            return
     try:
         process.send_signal(signum)
     except ProcessLookupError:

--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -120,9 +120,6 @@ _SAFETY_MONITOR_INTERVAL_SECONDS = 0.2
 _TREE_INSPECTION_INTERVAL_SECONDS = 1.0
 _HEALTH_OBSERVATION_INTERVAL_SECONDS = 5.0
 _SIDECAR_RECORD_FILENAME = "everos.sidecar.json"
-# Legacy records store wall-clock ``create_time``. Accept a bounded drift only
-# when every other deciding fact still names this installation's child.
-_LEGACY_CREATE_TIME_DRIFT_SECONDS = 300.0
 _SIDECAR_RECORD_MAX_BYTES = 4 * 1024
 _SIDECAR_ENTRYPOINT_MODULE = "core.memory.sidecar"
 _REBUILD_ENTRYPOINT_MODULE = "core.memory.rebuild_child"
@@ -3136,8 +3133,6 @@ def _legacy_recorded_wall_create_time(identity: _ProcessIdentity) -> float | Non
 def _legacy_create_time_mismatch_verdict(
     record: object,
     identity: _ProcessIdentity,
-    recorded_create_time: float,
-    live_wall_create_time: float | None,
     *,
     socket_path: Path,
     provider_root: Path,
@@ -3145,18 +3140,13 @@ def _legacy_create_time_mismatch_verdict(
 ) -> _RecordedSidecar | None:
     """Resolve a legacy wall-clock ``create_time`` mismatch.
 
-    Returns ``None`` when the mismatch is a bounded clock step of our own
-    child, so the caller continues as if the stamp matched. A disclosed
-    contradiction is ``NOT_OURS``. A withheld deciding fact other than
-    ``EVEROS_ROOT`` is ``UNVERIFIABLE``. ``EVEROS_ROOT`` is required positive
-    proof for the clock-step exception; without it the mismatch stays the
-    historical recycled-pid ``NOT_OURS`` verdict.
+    Legacy wall-clock values can move by any amount after a clock correction,
+    so their magnitude is not identity evidence. Returns ``None`` only when
+    the exact command, uid, and provider root still prove this installation's
+    child. A disclosed contradiction is ``NOT_OURS`` and a withheld deciding
+    fact is ``UNVERIFIABLE``.
     """
 
-    if live_wall_create_time is None:
-        return _RecordedSidecar.UNVERIFIABLE
-    if abs(live_wall_create_time - recorded_create_time) > _LEGACY_CREATE_TIME_DRIFT_SECONDS:
-        return _RecordedSidecar.NOT_OURS
     if _recorded_child_python_missing(record):
         return _RecordedSidecar.UNVERIFIABLE
     command_match = _cmdline_matches_recorded_child(
@@ -3218,8 +3208,6 @@ def _classify_recorded_child(
         drift_verdict = _legacy_create_time_mismatch_verdict(
             record,
             identity,
-            recorded_create_time,
-            live_recorded_stamp,
             socket_path=socket_path,
             provider_root=provider_root,
             role=role,
@@ -3267,8 +3255,8 @@ def _classify_recorded_sidecar(
     the identity stamp, the real uid, and the exact ``-m`` entrypoint plus
     ``--uds`` argument all agree with the record. New records prefer
     ``starttime_ticks``; a legacy wall-clock ``create_time`` mismatch may still
-    be ``OURS`` when cmdline, uid, and ``EVEROS_ROOT`` all match within a
-    bounded drift. Any single disclosed fact that contradicts the record
+    be ``OURS`` when cmdline, uid, and ``EVEROS_ROOT`` all match. Any single
+    disclosed fact that contradicts the record
     settles the matter as ``NOT_OURS`` -- a recycled pid or another user's
     process is safe to stop worrying about. What must not be waved through is
     a live pid whose deciding facts were never disclosed: treating it as gone

--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -12,7 +12,6 @@ import math
 import os
 import signal
 import stat
-import subprocess
 import sys
 import time
 from collections import deque
@@ -20,7 +19,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from collections.abc import Awaitable, Callable, Iterable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, Deque, Protocol, TypeVar, runtime_checkable
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -3650,8 +3649,6 @@ def _confirmed_owned_processes(identities: Mapping[int, float]) -> dict[int, flo
 def _group_contains_only_confirmed_owned_processes(
     process_group: int | None,
     identities: Mapping[int, float],
-    *,
-    trusted_pids: Iterable[int] | None = None,
 ) -> bool:
     """Whether a group can be signaled without bypassing PID identity checks."""
 
@@ -3659,10 +3656,8 @@ def _group_contains_only_confirmed_owned_processes(
         return False
     group_members = _snapshot_process_group(process_group)
     confirmed = _confirmed_owned_processes(identities)
-    trusted = set() if trusted_pids is None else set(trusted_pids)
     return bool(group_members) and all(
-        process_id in trusted or confirmed.get(process_id) == created_at
-        for process_id, created_at in group_members.items()
+        confirmed.get(process_id) == created_at for process_id, created_at in group_members.items()
     )
 
 
@@ -3670,25 +3665,18 @@ def _signal_owned_group(
     process_group: int | None,
     identities: Mapping[int, float],
     signum: int,
-    *,
-    trusted_pids: Iterable[int] | None = None,
 ) -> bool:
     """Signal a whole isolated group, but only if every member is confirmed owned.
 
     Returns whether the group signal settled the delivery, so a caller holding a
     direct child handle can fall back to it without widening the blast radius: a
-    group with an unverifiable member is never signaled group-wide. A live
-    spawned ``Popen`` child may be treated as confirmed for the direct child only.
+    group with an unverifiable member is never signaled group-wide.
     """
 
     if (
         process_group is None
         or not hasattr(os, "killpg")
-        or not _group_contains_only_confirmed_owned_processes(
-            process_group,
-            identities,
-            trusted_pids=trusted_pids,
-        )
+        or not _group_contains_only_confirmed_owned_processes(process_group, identities)
     ):
         return False
     try:
@@ -3700,46 +3688,21 @@ def _signal_owned_group(
     return True
 
 
-def _live_direct_child_handle(process: asyncio.subprocess.Process) -> bool:
-    """Whether ``process`` is an unreaped child this process actually spawned.
-
-    Only a live stdlib ``Popen`` is authoritative. A constructed asyncio
-    Process — even one that fakes ``_transport._proc`` — still requires a stamp.
-    """
-
-    if (
-        not isinstance(process, asyncio.subprocess.Process)
-        or process.returncode is not None
-        or process.pid is None
-    ):
-        return False
-    transport = getattr(process, "_transport", None)
-    popen = getattr(transport, "_proc", None)
-    return isinstance(popen, subprocess.Popen) and popen.returncode is None
-
-
 def _signal_owned_group_or_process(
     process: asyncio.subprocess.Process,
     process_group: int | None,
     identities: Mapping[int, float],
     signum: int,
 ) -> None:
-    trusted = {int(process.pid)} if _live_direct_child_handle(process) else set()
-    if _signal_owned_group(
-        process_group,
-        identities,
-        signum,
-        trusted_pids=trusted,
-    ):
+    if _signal_owned_group(process_group, identities, signum):
         return
     if process.returncode is not None:
         return
-    if not trusted:
-        created_at = identities.get(process.pid)
-        if created_at is None or process.pid not in _confirmed_owned_processes(
-            {process.pid: created_at}
-        ):
-            return
+    created_at = identities.get(process.pid)
+    if created_at is None or process.pid not in _confirmed_owned_processes(
+        {process.pid: created_at}
+    ):
+        return
     try:
         process.send_signal(signum)
     except ProcessLookupError:

--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -2745,9 +2745,10 @@ def _is_identity_stamp(value: object) -> bool:
     if not isinstance(value, (int, float)) or isinstance(value, bool):
         return False
     try:
-        return math.isfinite(float(value))
+        stamp = float(value)
     except (OverflowError, ValueError):
         return False
+    return math.isfinite(stamp) and stamp >= 0.0
 
 
 class _RecordedSidecar(Enum):

--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import hashlib
 import inspect
 import json
@@ -17,7 +18,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from typing import Any, Deque, Protocol, TypeVar, runtime_checkable
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -118,6 +119,9 @@ _SAFETY_MONITOR_INTERVAL_SECONDS = 0.2
 _TREE_INSPECTION_INTERVAL_SECONDS = 1.0
 _HEALTH_OBSERVATION_INTERVAL_SECONDS = 5.0
 _SIDECAR_RECORD_FILENAME = "everos.sidecar.json"
+# Legacy records store wall-clock ``create_time``. Accept a bounded drift only
+# when every other deciding fact still names this installation's child.
+_LEGACY_CREATE_TIME_DRIFT_SECONDS = 300.0
 _SIDECAR_RECORD_MAX_BYTES = 4 * 1024
 _SIDECAR_ENTRYPOINT_MODULE = "core.memory.sidecar"
 _REBUILD_ENTRYPOINT_MODULE = "core.memory.rebuild_child"
@@ -1075,7 +1079,22 @@ class EverOSProcess:
         except Exception:
             if not self._desired_running:
                 return
-            logger.warning("EverOS sidecar safety monitor rejected the child tree")
+            recorded_stamp = (
+                self._owned_processes.get(process.pid) if process.pid is not None else None
+            )
+            live_stamp = None
+            if process.pid is not None:
+                try:
+                    live_stamp = _process_creation_stamp(psutil.Process(process.pid))
+                except Exception:
+                    live_stamp = None
+            logger.exception(
+                "EverOS sidecar safety monitor rejected the child tree "
+                "(pid %s recorded_stamp=%s live_stamp=%s)",
+                process.pid,
+                recorded_stamp,
+                live_stamp,
+            )
             async with self._lifecycle_lock:
                 if process is not self._process:
                     return
@@ -1811,6 +1830,14 @@ class SidecarOwnership:
             "socket_path": str(self._socket_path),
             "provider_root": str(self._provider_root),
         }
+        if _uses_linux_starttime_stamp():
+            # In-memory identity is boot-relative starttime ticks. Keep the
+            # historical wall-clock field so older readers still parse the file,
+            # and persist the stamp so a later boot does not depend on CLOCK_REALTIME.
+            record["starttime_ticks"] = created_at
+            wall_create_time = _process_wall_create_time(pid)
+            if wall_create_time is not None:
+                record["create_time"] = wall_create_time
         if role is not None:
             record["role"] = role.value
             record["python"] = str(python) if python is not None else None
@@ -2621,12 +2648,90 @@ class _ProcessIdentity:
     about a process and withhold others: macOS reads ``create_time`` and ``uids``
     for any pid but refuses ``cmdline`` outside the caller's own uid. ``None``
     therefore means "not disclosed", never "does not match".
+
+    ``create_time`` is the identity stamp from ``_process_creation_stamp``:
+    Linux starttime ticks, or ``psutil.Process.create_time()`` elsewhere.
     """
 
     create_time: float | None
     cmdline: tuple[str, ...] | None
     uid: int | None
     environment: Mapping[str, str] | None = None
+
+
+def _uses_linux_starttime_stamp() -> bool:
+    """Whether this host identifies processes by boot-relative starttime ticks."""
+
+    return sys.platform.startswith("linux")
+
+
+def _parse_proc_stat_starttime(stat_text: str) -> float:
+    """Parse ``/proc/<pid>/stat`` field 22 (starttime, clock ticks).
+
+    Field 2 (``comm``) is parenthesized and may contain spaces or parentheses,
+    so tokens after the last ``)`` are field 3 onward.
+    """
+
+    close = stat_text.rfind(")")
+    if close < 0:
+        raise ValueError("proc stat comm field is missing")
+    fields = stat_text[close + 1 :].split()
+    try:
+        return float(fields[19])
+    except (IndexError, ValueError) as exc:
+        raise ValueError("proc stat starttime field is missing") from exc
+
+
+def _read_linux_starttime_ticks(pid: int) -> float:
+    """Read boot-relative starttime ticks for ``pid`` from ``/proc``."""
+
+    try:
+        text = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise psutil.NoSuchProcess(pid=pid) from exc
+    except PermissionError as exc:
+        raise psutil.AccessDenied(pid=pid) from exc
+    except OSError as exc:
+        if exc.errno in {errno.EACCES, errno.EPERM}:
+            raise psutil.AccessDenied(pid=pid) from exc
+        if exc.errno in {errno.ENOENT, errno.ESRCH}:
+            raise psutil.NoSuchProcess(pid=pid) from exc
+        raise
+    try:
+        return _parse_proc_stat_starttime(text)
+    except ValueError as exc:
+        raise psutil.AccessDenied(pid=pid) from exc
+
+
+def _process_creation_stamp(process: psutil.Process) -> float:
+    """Stable process-identity stamp.
+
+    On Linux this is ``/proc/<pid>/stat`` starttime ticks, which do not move
+    when CLOCK_REALTIME is stepped. Other platforms keep the spawn-time
+    ``psutil.Process.create_time()`` value, which those kernels record
+    absolutely and do not drift. Missing ``/proc`` falls back to
+    ``create_time()`` so test doubles without a real pid still work.
+    """
+
+    if _uses_linux_starttime_stamp():
+        try:
+            return _read_linux_starttime_ticks(int(process.pid))
+        except psutil.NoSuchProcess:
+            return float(process.create_time())
+    return float(process.create_time())
+
+
+def _process_wall_create_time(pid: int) -> float | None:
+    """Wall-clock ``psutil`` create_time, or ``None`` when the OS withholds it."""
+
+    try:
+        return float(psutil.Process(pid).create_time())
+    except psutil.Error:
+        return None
+
+
+def _is_identity_stamp(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
 class _RecordedSidecar(Enum):
@@ -2666,7 +2771,7 @@ def _inspect_process_identity(pid: int) -> _ProcessIdentity | None:
     try:
         cmdline = _disclosed_identity_field(process.cmdline)
         return _ProcessIdentity(
-            create_time=_disclosed_identity_field(process.create_time),
+            create_time=_disclosed_identity_field(lambda: _process_creation_stamp(process)),
             cmdline=None if cmdline is None else tuple(str(value) for value in cmdline),
             uid=_process_real_uid(process),
             environment=_disclosed_process_environment(process),
@@ -2768,19 +2873,33 @@ def _recorded_sidecar_create_time(
     socket_path: Path,
     provider_root: Path,
 ) -> float | None:
-    """The creation time a record can be matched against, or ``None``.
+    """The identity stamp a record can be matched against, or ``None``.
 
-    A malformed creation time can never be matched by any process, so it yields
-    nothing this launch may act on.
+    New Linux records persist ``starttime_ticks`` and that stamp is preferred.
+    Legacy records keep wall-clock ``create_time``. A malformed stamp can never
+    be matched by any process, so it yields nothing this launch may act on.
     """
 
     matched = _record_for_this_installation(record, socket_path=socket_path, provider_root=provider_root)
     if matched is None:
         return None
+    ticks = matched.get("starttime_ticks")
+    if _is_identity_stamp(ticks):
+        return float(ticks)
     created_at = matched.get("create_time")
-    if not isinstance(created_at, (int, float)) or isinstance(created_at, bool):
+    if not _is_identity_stamp(created_at):
         return None
     return float(created_at)
+
+
+def _recorded_sidecar_has_starttime_ticks(
+    record: object,
+    *,
+    socket_path: Path,
+    provider_root: Path,
+) -> bool:
+    matched = _record_for_this_installation(record, socket_path=socket_path, provider_root=provider_root)
+    return matched is not None and _is_identity_stamp(matched.get("starttime_ticks"))
 
 
 def _recorded_sidecar_group(
@@ -2950,6 +3069,61 @@ def _cmdline_matches_role(
     )
 
 
+def _legacy_create_time_mismatch_verdict(
+    record: object,
+    identity: _ProcessIdentity,
+    recorded_create_time: float,
+    *,
+    socket_path: Path,
+    provider_root: Path,
+    role: _MemoryChildRole,
+) -> _RecordedSidecar | None:
+    """Resolve a legacy wall-clock ``create_time`` mismatch.
+
+    Returns ``None`` when the mismatch is a bounded clock step of our own
+    child, so the caller continues as if the stamp matched. A disclosed
+    contradiction is ``NOT_OURS``. A withheld deciding fact other than
+    ``EVEROS_ROOT`` is ``UNVERIFIABLE``. ``EVEROS_ROOT`` is required positive
+    proof for the clock-step exception; without it the mismatch stays the
+    historical recycled-pid ``NOT_OURS`` verdict.
+    """
+
+    if identity.create_time is None:
+        return _RecordedSidecar.UNVERIFIABLE
+    if abs(identity.create_time - recorded_create_time) > _LEGACY_CREATE_TIME_DRIFT_SECONDS:
+        return _RecordedSidecar.NOT_OURS
+    if identity.cmdline is None:
+        return _RecordedSidecar.UNVERIFIABLE
+    legacy_sidecar = isinstance(record, dict) and record.get("role") is None
+    recorded_python = None if legacy_sidecar else _recorded_child_python(record)
+    if not legacy_sidecar and recorded_python is None:
+        return _RecordedSidecar.UNVERIFIABLE
+    matches_command = (
+        _cmdline_serves_socket(identity.cmdline, socket_path)
+        if legacy_sidecar
+        else _cmdline_matches_role(
+            identity.cmdline,
+            role=role,
+            socket_path=socket_path,
+            python=recorded_python,
+        )
+    )
+    if not matches_command:
+        return _RecordedSidecar.NOT_OURS
+    getuid = getattr(os, "getuid", None)
+    own_uid = getuid() if callable(getuid) else None
+    if own_uid is not None:
+        if identity.uid is None:
+            return _RecordedSidecar.UNVERIFIABLE
+        if identity.uid != own_uid:
+            return _RecordedSidecar.NOT_OURS
+    if identity.environment is None:
+        return _RecordedSidecar.NOT_OURS
+    if not _provider_roots_match(identity.environment.get("EVEROS_ROOT"), provider_root):
+        return _RecordedSidecar.NOT_OURS
+    return None
+
+
 def _classify_recorded_child(
     record: object,
     identity: _ProcessIdentity | None,
@@ -2970,7 +3144,22 @@ def _classify_recorded_child(
     if identity.uid is not None and own_uid is not None and identity.uid != own_uid:
         return _RecordedSidecar.NOT_OURS
     if identity.create_time is not None and identity.create_time != recorded_create_time:
-        return _RecordedSidecar.NOT_OURS
+        if _recorded_sidecar_has_starttime_ticks(
+            record,
+            socket_path=socket_path,
+            provider_root=provider_root,
+        ):
+            return _RecordedSidecar.NOT_OURS
+        drift_verdict = _legacy_create_time_mismatch_verdict(
+            record,
+            identity,
+            recorded_create_time,
+            socket_path=socket_path,
+            provider_root=provider_root,
+            role=role,
+        )
+        if drift_verdict is not None:
+            return drift_verdict
     legacy_sidecar = isinstance(record, dict) and record.get("role") is None
     recorded_python = None if legacy_sidecar else _recorded_child_python(record)
     if not legacy_sidecar and recorded_python is None:
@@ -3016,12 +3205,15 @@ def _classify_recorded_sidecar(
     """Decide what a recorded pid is, so the caller knows what it may do.
 
     ``OURS`` is the only verdict that permits a signal, and it still demands that
-    the creation time, the real uid, and the exact ``-m`` entrypoint plus
-    ``--uds`` argument all agree with the record. Any single disclosed fact that
-    contradicts the record settles the matter as ``NOT_OURS`` -- a recycled pid
-    or another user's process is safe to stop worrying about. What must not be
-    waved through is a live pid whose deciding facts were never disclosed:
-    treating it as gone would start a replacement sidecar beside it.
+    the identity stamp, the real uid, and the exact ``-m`` entrypoint plus
+    ``--uds`` argument all agree with the record. New records prefer
+    ``starttime_ticks``; a legacy wall-clock ``create_time`` mismatch may still
+    be ``OURS`` when cmdline, uid, and ``EVEROS_ROOT`` all match within a
+    bounded drift. Any single disclosed fact that contradicts the record
+    settles the matter as ``NOT_OURS`` -- a recycled pid or another user's
+    process is safe to stop worrying about. What must not be waved through is
+    a live pid whose deciding facts were never disclosed: treating it as gone
+    would start a replacement sidecar beside it.
     """
 
     return _classify_recorded_child(
@@ -3089,7 +3281,7 @@ def _processes_serving_owned_socket(*, socket_path: Path) -> dict[int, float]:
             cmdline = _disclosed_identity_field(candidate.cmdline)
             if cmdline is None or not _cmdline_serves_socket(tuple(str(value) for value in cmdline), socket_path):
                 continue
-            created_at = _disclosed_identity_field(candidate.create_time)
+            created_at = _disclosed_identity_field(lambda: _process_creation_stamp(candidate))
         except psutil.Error:
             continue
         # A claimed process whose creation time is withheld carries the negative
@@ -3120,7 +3312,7 @@ def _processes_serving_owned_root(*, provider_root: Path) -> dict[int, float]:
             if not _cmdline_is_sidecar(rendered):
                 continue
             environment = _disclosed_process_environment(candidate)
-            created_at = _disclosed_identity_field(candidate.create_time)
+            created_at = _disclosed_identity_field(lambda: _process_creation_stamp(candidate))
         except psutil.NoSuchProcess:
             continue
         except psutil.Error:
@@ -3170,7 +3362,7 @@ def _processes_rebuilding_owned_root(
                 python=python,
             ):
                 continue
-            created_at = _disclosed_identity_field(candidate.create_time)
+            created_at = _disclosed_identity_field(lambda: _process_creation_stamp(candidate))
             environment = _disclosed_process_environment(candidate)
         except psutil.NoSuchProcess:
             continue
@@ -3232,7 +3424,7 @@ def _processes_syncing_owned_root(
         ):
             continue
         try:
-            created_at = _disclosed_identity_field(candidate.create_time)
+            created_at = _disclosed_identity_field(lambda: _process_creation_stamp(candidate))
             environment = _disclosed_process_environment(candidate)
         except psutil.NoSuchProcess:
             continue
@@ -3281,7 +3473,7 @@ async def _wait_for_identities_exit(identities: Mapping[int, float], timeout_sec
 
 
 def _snapshot_owned_processes(pid: int, process_group: int | None) -> dict[int, float]:
-    """Record `(pid, create_time)` identities while the child is still owned."""
+    """Record `(pid, stamp)` identities while the child is still owned."""
 
     identities: dict[int, float] = {}
     try:
@@ -3291,7 +3483,7 @@ def _snapshot_owned_processes(pid: int, process_group: int | None) -> dict[int, 
         candidates = []
     for candidate in candidates:
         try:
-            identities.setdefault(candidate.pid, candidate.create_time())
+            identities.setdefault(candidate.pid, _process_creation_stamp(candidate))
         except psutil.Error:
             continue
     _merge_owned_processes(identities, _snapshot_process_group(process_group))
@@ -3305,7 +3497,7 @@ def _snapshot_process_group(process_group: int | None) -> dict[int, float]:
     for candidate in psutil.process_iter():
         try:
             if os.getpgid(candidate.pid) == process_group:
-                identities[candidate.pid] = candidate.create_time()
+                identities[candidate.pid] = _process_creation_stamp(candidate)
         except psutil.AccessDenied:
             # The member exists but its identity cannot be verified. Keep it with a
             # sentinel so the "all confirmed" check sees an unverifiable member and
@@ -3344,7 +3536,7 @@ def _live_owned_processes(identities: Mapping[int, float]) -> dict[int, float]:
     for process_id, created_at in identities.items():
         try:
             candidate = psutil.Process(process_id)
-            if candidate.create_time() != created_at:
+            if _process_creation_stamp(candidate) != created_at:
                 continue
             if candidate.status() == psutil.STATUS_ZOMBIE:
                 continue
@@ -3360,13 +3552,13 @@ def _live_owned_processes(identities: Mapping[int, float]) -> dict[int, float]:
 
 
 def _confirmed_owned_processes(identities: Mapping[int, float]) -> dict[int, float]:
-    """Return identities whose current creation time is readable and unchanged."""
+    """Return identities whose current creation stamp is readable and unchanged."""
 
     confirmed: dict[int, float] = {}
     for process_id, created_at in identities.items():
         try:
             candidate = psutil.Process(process_id)
-            if candidate.create_time() != created_at or candidate.status() == psutil.STATUS_ZOMBIE:
+            if _process_creation_stamp(candidate) != created_at or candidate.status() == psutil.STATUS_ZOMBIE:
                 continue
         except psutil.Error:
             # AccessDenied is live-but-unverified: retain it for reaping, but
@@ -3379,6 +3571,8 @@ def _confirmed_owned_processes(identities: Mapping[int, float]) -> dict[int, flo
 def _group_contains_only_confirmed_owned_processes(
     process_group: int | None,
     identities: Mapping[int, float],
+    *,
+    trusted_pids: Iterable[int] | None = None,
 ) -> bool:
     """Whether a group can be signaled without bypassing PID identity checks."""
 
@@ -3386,8 +3580,10 @@ def _group_contains_only_confirmed_owned_processes(
         return False
     group_members = _snapshot_process_group(process_group)
     confirmed = _confirmed_owned_processes(identities)
+    trusted = set() if trusted_pids is None else set(trusted_pids)
     return bool(group_members) and all(
-        confirmed.get(process_id) == created_at for process_id, created_at in group_members.items()
+        process_id in trusted or confirmed.get(process_id) == created_at
+        for process_id, created_at in group_members.items()
     )
 
 
@@ -3395,18 +3591,26 @@ def _signal_owned_group(
     process_group: int | None,
     identities: Mapping[int, float],
     signum: int,
+    *,
+    trusted_pids: Iterable[int] | None = None,
 ) -> bool:
     """Signal a whole isolated group, but only if every member is confirmed owned.
 
     Returns whether the group signal settled the delivery, so a caller holding a
     direct child handle can fall back to it without widening the blast radius: a
-    group with an unverifiable member is never signaled group-wide.
+    group with an unverifiable member is never signaled group-wide. A live
+    direct child this process spawned may be treated as confirmed without a
+    stamp match; every other member stays fail-closed.
     """
 
     if (
         process_group is None
         or not hasattr(os, "killpg")
-        or not _group_contains_only_confirmed_owned_processes(process_group, identities)
+        or not _group_contains_only_confirmed_owned_processes(
+            process_group,
+            identities,
+            trusted_pids=trusted_pids,
+        )
     ):
         return False
     try:
@@ -3418,19 +3622,46 @@ def _signal_owned_group(
     return True
 
 
+def _live_direct_child_pid(process: asyncio.subprocess.Process) -> int | None:
+    """The pid of an unreaped asyncio child this process spawned, if any.
+
+    ``returncode is None`` on an ``asyncio.subprocess.Process`` means the handle
+    has not been reaped, so the pid cannot have been recycled (the worst case
+    is a zombie). That handle is authoritative for signaling the direct child.
+    """
+
+    if (
+        not isinstance(process, asyncio.subprocess.Process)
+        or process.returncode is not None
+        or process.pid is None
+    ):
+        return None
+    return int(process.pid)
+
+
 def _signal_owned_group_or_process(
     process: asyncio.subprocess.Process,
     process_group: int | None,
     identities: Mapping[int, float],
     signum: int,
 ) -> None:
-    if _signal_owned_group(process_group, identities, signum):
+    trusted_pid = _live_direct_child_pid(process)
+    trusted = set() if trusted_pid is None else {trusted_pid}
+    if _signal_owned_group(
+        process_group,
+        identities,
+        signum,
+        trusted_pids=trusted,
+    ):
         return
     if process.returncode is not None:
         return
-    created_at = identities.get(process.pid)
-    if created_at is None or process.pid not in _confirmed_owned_processes({process.pid: created_at}):
-        return
+    if trusted_pid is None:
+        created_at = identities.get(process.pid)
+        if created_at is None or process.pid not in _confirmed_owned_processes(
+            {process.pid: created_at}
+        ):
+            return
     try:
         process.send_signal(signum)
     except ProcessLookupError:
@@ -3441,7 +3672,7 @@ def _signal_owned_processes(identities: Mapping[int, float], signum: int) -> Non
     for process_id, created_at in _confirmed_owned_processes(identities).items():
         try:
             candidate = psutil.Process(process_id)
-            if candidate.create_time() != created_at:
+            if _process_creation_stamp(candidate) != created_at:
                 continue
             candidate.send_signal(signum)
         except (psutil.NoSuchProcess, psutil.AccessDenied):
@@ -3463,7 +3694,7 @@ async def _wait_for_owned_exit(
     waiter = asyncio.create_task(process.wait(), name="memory-everos-reap")
     try:
         while time.monotonic() < deadline:
-            if _owned_process_identity_is_live(process.pid, identities):
+            if process.returncode is None or _owned_process_identity_is_live(process.pid, identities):
                 _merge_owned_processes(identities, _snapshot_owned_processes(process.pid, process_group))
             if waiter.done() and not _live_owned_processes(identities):
                 await waiter

--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -8,6 +8,7 @@ import hashlib
 import inspect
 import json
 import logging
+import math
 import os
 import signal
 import stat
@@ -18,7 +19,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from typing import Any, Deque, Protocol, TypeVar, runtime_checkable
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -979,12 +980,13 @@ class EverOSProcess:
         while time.monotonic() < deadline:
             if process.returncode is not None:
                 raise RuntimeError("sidecar exited before readiness")
-            if not _host_identity_is_live(self._host, process.pid, self._owned_processes):
-                raise RuntimeError("sidecar ownership changed before readiness")
-            _merge_owned_processes(
+            if not _refresh_owned_process_tree(
+                self._host,
                 self._owned_processes,
-                self._host.snapshot_tree(process.pid, self._process_group),
-            )
+                process.pid,
+                self._process_group,
+            ):
+                raise RuntimeError("sidecar ownership changed before readiness")
             if self._socket_path.exists():
                 self._secure_socket()
                 if await client.health():
@@ -1210,10 +1212,13 @@ class EverOSProcess:
             return
 
     def _refresh_owned_processes(self, pid: int) -> dict[int, float]:
-        _merge_owned_processes(
+        if not _refresh_owned_process_tree(
+            self._host,
             self._owned_processes,
-            self._host.snapshot_tree(pid, self._process_group),
-        )
+            pid,
+            self._process_group,
+        ):
+            raise RuntimeError("sidecar ownership changed during monitoring")
         unverifiable = {
             process_id: created_at
             for process_id, created_at in self._owned_processes.items()
@@ -1484,14 +1489,15 @@ class EverOSRebuildProcess:
                     _REBUILD_HANDSHAKE_TIMEOUT_SECONDS,
                 )
             )
-            _merge_owned_processes(
+            if not _refresh_owned_process_tree(
+                self._host,
                 identities,
-                self._host.snapshot_tree(process.pid, process_group),
-            )
+                process.pid,
+                process_group,
+            ):
+                raise RuntimeError("could not establish rebuild process ownership")
             if not stopped:
                 raise RuntimeError("rebuild child did not enter ownership handshake")
-            if not _host_identity_is_live(self._host, process.pid, identities):
-                raise RuntimeError("could not establish rebuild process ownership")
             self._ownership.record_launch(
                 process.pid,
                 identities[process.pid],
@@ -1836,8 +1842,9 @@ class SidecarOwnership:
             # and persist the stamp so a later boot does not depend on CLOCK_REALTIME.
             record["starttime_ticks"] = created_at
             wall_create_time = _process_wall_create_time(pid)
-            if wall_create_time is not None:
-                record["create_time"] = wall_create_time
+            # Never store ticks in create_time: older readers treat that field
+            # as epoch seconds. Omit a wall value rather than invent one.
+            record["create_time"] = wall_create_time
         if role is not None:
             record["role"] = role.value
             record["python"] = str(python) if python is not None else None
@@ -1915,7 +1922,7 @@ class SidecarOwnership:
                 await self._reap_unidentified_child()
                 _remove_sidecar_record(self.record_path)
             return
-        confirmed_create_time = identity.create_time if identity is not None else None
+        confirmed_create_time = identity.stamp if identity is not None else None
         if verdict is _RecordedSidecar.UNVERIFIABLE or confirmed_create_time is None:
             # A live pid the OS will not describe well enough to rule out as our
             # own sidecar. Keep the record and fail the launch, exactly as for an
@@ -1983,7 +1990,13 @@ class SidecarOwnership:
                 # Only rediscover while the recorded root is still the process we
                 # identified; a dead root's pid may already have been recycled.
                 process_group = self._host.process_group(pid)
-                _merge_owned_processes(identities, self._host.snapshot_tree(pid, process_group))
+                if not _refresh_owned_process_tree(
+                    self._host,
+                    identities,
+                    pid,
+                    process_group,
+                ):
+                    process_group = None
             else:
                 process_group = None
             self._host.signal(identities, signum, process_group=process_group)
@@ -2214,7 +2227,7 @@ class SidecarOwnership:
                 identity = self._host.inspect_identity(pid)
                 if (
                     identity is None
-                    or identity.create_time != created_at
+                    or identity.stamp != created_at
                     or identity.cmdline is None
                     or not _cmdline_matches_role(
                         identity.cmdline,
@@ -2238,7 +2251,7 @@ class SidecarOwnership:
                 own_uid = getuid() if callable(getuid) else None
                 if (
                     identity is None
-                    or identity.create_time != created_at
+                    or identity.stamp != created_at
                     or identity.cmdline is None
                     or not identity.cmdline
                     or not _cmdline_matches_role(
@@ -2561,8 +2574,7 @@ async def _terminate_owned_process_tree(
     stop_timeout_seconds: float,
 ) -> None:
     identities = dict(owned_processes or {})
-    if _host_identity_is_live(host, process.pid, identities):
-        _merge_owned_processes(identities, host.snapshot_tree(process.pid, process_group))
+    _refresh_owned_process_tree(host, identities, process.pid, process_group)
     host.signal(
         identities,
         signal.SIGTERM,
@@ -2578,8 +2590,7 @@ async def _terminate_owned_process_tree(
         return
 
     kill_signal = getattr(signal, "SIGKILL", signal.SIGTERM)
-    if _host_identity_is_live(host, process.pid, identities):
-        _merge_owned_processes(identities, host.snapshot_tree(process.pid, process_group))
+    _refresh_owned_process_tree(host, identities, process.pid, process_group)
     host.signal(
         identities,
         kill_signal,
@@ -2649,13 +2660,13 @@ class _ProcessIdentity:
     for any pid but refuses ``cmdline`` outside the caller's own uid. ``None``
     therefore means "not disclosed", never "does not match".
 
-    ``create_time`` is the identity stamp from ``_process_creation_stamp``:
+    ``stamp`` is the identity value from ``_process_creation_stamp``:
     Linux starttime ticks, or ``psutil.Process.create_time()`` elsewhere.
     ``wall_create_time`` retains the epoch value needed to compare a live Linux
     process with a legacy record that predates ``starttime_ticks``.
     """
 
-    create_time: float | None
+    stamp: float | None
     cmdline: tuple[str, ...] | None
     uid: int | None
     environment: Mapping[str, str] | None = None
@@ -2668,17 +2679,17 @@ def _uses_linux_starttime_stamp() -> bool:
     return sys.platform.startswith("linux")
 
 
-def _parse_proc_stat_starttime(stat_text: str) -> float:
+def _parse_proc_stat_starttime(stat_data: bytes) -> float:
     """Parse ``/proc/<pid>/stat`` field 22 (starttime, clock ticks).
 
     Field 2 (``comm``) is parenthesized and may contain spaces or parentheses,
     so tokens after the last ``)`` are field 3 onward.
     """
 
-    close = stat_text.rfind(")")
+    close = stat_data.rfind(b")")
     if close < 0:
         raise ValueError("proc stat comm field is missing")
-    fields = stat_text[close + 1 :].split()
+    fields = stat_data[close + 1 :].split()
     try:
         return float(fields[19])
     except (IndexError, ValueError) as exc:
@@ -2689,7 +2700,7 @@ def _read_linux_starttime_ticks(pid: int) -> float:
     """Read boot-relative starttime ticks for ``pid`` from ``/proc``."""
 
     try:
-        text = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+        data = Path(f"/proc/{pid}/stat").read_bytes()
     except FileNotFoundError as exc:
         raise psutil.NoSuchProcess(pid=pid) from exc
     except PermissionError as exc:
@@ -2701,7 +2712,7 @@ def _read_linux_starttime_ticks(pid: int) -> float:
             raise psutil.NoSuchProcess(pid=pid) from exc
         raise
     try:
-        return _parse_proc_stat_starttime(text)
+        return _parse_proc_stat_starttime(data)
     except ValueError as exc:
         raise psutil.AccessDenied(pid=pid) from exc
 
@@ -2734,7 +2745,12 @@ def _process_wall_create_time(pid: int) -> float | None:
 
 
 def _is_identity_stamp(value: object) -> bool:
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return False
+    try:
+        return math.isfinite(float(value))
+    except (OverflowError, ValueError):
+        return False
 
 
 class _RecordedSidecar(Enum):
@@ -2763,7 +2779,7 @@ def _inspect_process_identity(pid: int) -> _ProcessIdentity | None:
     except psutil.NoSuchProcess:
         return None
     except psutil.Error:
-        return _ProcessIdentity(create_time=None, cmdline=None, uid=None, environment=None)
+        return _ProcessIdentity(stamp=None, cmdline=None, uid=None, environment=None)
     try:
         if process.status() == psutil.STATUS_ZOMBIE:
             return None
@@ -2774,7 +2790,7 @@ def _inspect_process_identity(pid: int) -> _ProcessIdentity | None:
     try:
         cmdline = _disclosed_identity_field(process.cmdline)
         return _ProcessIdentity(
-            create_time=_disclosed_identity_field(lambda: _process_creation_stamp(process)),
+            stamp=_disclosed_identity_field(lambda: _process_creation_stamp(process)),
             cmdline=None if cmdline is None else tuple(str(value) for value in cmdline),
             uid=_process_real_uid(process),
             environment=_disclosed_process_environment(process),
@@ -2887,9 +2903,9 @@ def _recorded_sidecar_create_time(
     matched = _record_for_this_installation(record, socket_path=socket_path, provider_root=provider_root)
     if matched is None:
         return None
-    ticks = matched.get("starttime_ticks")
-    if _is_identity_stamp(ticks):
-        return float(ticks)
+    if "starttime_ticks" in matched:
+        ticks = matched.get("starttime_ticks")
+        return float(ticks) if _is_identity_stamp(ticks) else None
     created_at = matched.get("create_time")
     if not _is_identity_stamp(created_at):
         return None
@@ -3073,6 +3089,58 @@ def _cmdline_matches_role(
     )
 
 
+def _legacy_sidecar_record(record: object) -> bool:
+    return isinstance(record, dict) and record.get("role") is None
+
+
+def _recorded_child_python_missing(record: object) -> bool:
+    return not _legacy_sidecar_record(record) and _recorded_child_python(record) is None
+
+
+def _cmdline_matches_recorded_child(
+    record: object,
+    cmdline: tuple[str, ...] | None,
+    *,
+    socket_path: Path,
+    role: _MemoryChildRole,
+) -> bool | None:
+    """Whether a disclosed cmdline matches the record.
+
+    ``None`` means the command line was not disclosed.
+    """
+
+    if cmdline is None:
+        return None
+    if _legacy_sidecar_record(record):
+        return _cmdline_serves_socket(cmdline, socket_path)
+    recorded_python = _recorded_child_python(record)
+    if recorded_python is None:
+        return False
+    return _cmdline_matches_role(
+        cmdline,
+        role=role,
+        socket_path=socket_path,
+        python=recorded_python,
+    )
+
+
+def _legacy_live_wall_create_time(
+    record: object,
+    identity: _ProcessIdentity,
+) -> float | None:
+    """Wall-clock create_time for a legacy record, preferring a live read."""
+
+    pid = _recorded_sidecar_pid(record)
+    if pid is not None:
+        live = _process_wall_create_time(pid)
+        if live is not None and _is_identity_stamp(live):
+            return live
+    wall = identity.wall_create_time
+    if wall is not None and not _is_identity_stamp(wall):
+        return None
+    return wall
+
+
 def _legacy_create_time_mismatch_verdict(
     record: object,
     identity: _ProcessIdentity,
@@ -3097,23 +3165,17 @@ def _legacy_create_time_mismatch_verdict(
         return _RecordedSidecar.UNVERIFIABLE
     if abs(live_wall_create_time - recorded_create_time) > _LEGACY_CREATE_TIME_DRIFT_SECONDS:
         return _RecordedSidecar.NOT_OURS
-    if identity.cmdline is None:
+    if _recorded_child_python_missing(record):
         return _RecordedSidecar.UNVERIFIABLE
-    legacy_sidecar = isinstance(record, dict) and record.get("role") is None
-    recorded_python = None if legacy_sidecar else _recorded_child_python(record)
-    if not legacy_sidecar and recorded_python is None:
-        return _RecordedSidecar.UNVERIFIABLE
-    matches_command = (
-        _cmdline_serves_socket(identity.cmdline, socket_path)
-        if legacy_sidecar
-        else _cmdline_matches_role(
-            identity.cmdline,
-            role=role,
-            socket_path=socket_path,
-            python=recorded_python,
-        )
+    command_match = _cmdline_matches_recorded_child(
+        record,
+        identity.cmdline,
+        socket_path=socket_path,
+        role=role,
     )
-    if not matches_command:
+    if command_match is None:
+        return _RecordedSidecar.UNVERIFIABLE
+    if not command_match:
         return _RecordedSidecar.NOT_OURS
     getuid = getattr(os, "getuid", None)
     own_uid = getuid() if callable(getuid) else None
@@ -3149,11 +3211,15 @@ def _classify_recorded_child(
         socket_path=socket_path,
         provider_root=provider_root,
     )
-    live_recorded_stamp = identity.create_time if has_starttime_ticks else identity.wall_create_time
+    live_recorded_stamp = (
+        identity.stamp if has_starttime_ticks else _legacy_live_wall_create_time(record, identity)
+    )
     getuid = getattr(os, "getuid", None)
     own_uid = getuid() if callable(getuid) else None
     if identity.uid is not None and own_uid is not None and identity.uid != own_uid:
         return _RecordedSidecar.NOT_OURS
+    if live_recorded_stamp is not None and not _is_identity_stamp(live_recorded_stamp):
+        return _RecordedSidecar.UNVERIFIABLE
     if live_recorded_stamp is not None and live_recorded_stamp != recorded_create_time:
         if has_starttime_ticks:
             return _RecordedSidecar.NOT_OURS
@@ -3168,24 +3234,17 @@ def _classify_recorded_child(
         )
         if drift_verdict is not None:
             return drift_verdict
-    legacy_sidecar = isinstance(record, dict) and record.get("role") is None
-    recorded_python = None if legacy_sidecar else _recorded_child_python(record)
-    if not legacy_sidecar and recorded_python is None:
+    if _recorded_child_python_missing(record):
         return _RecordedSidecar.UNVERIFIABLE
-    if identity.cmdline is not None:
-        matches_command = (
-            _cmdline_serves_socket(identity.cmdline, socket_path)
-            if legacy_sidecar
-            else _cmdline_matches_role(
-                identity.cmdline,
-                role=role,
-                socket_path=socket_path,
-                python=recorded_python,
-            )
-        )
-        if not matches_command:
-            return _RecordedSidecar.NOT_OURS
-    if not legacy_sidecar and identity.environment is not None:
+    command_match = _cmdline_matches_recorded_child(
+        record,
+        identity.cmdline,
+        socket_path=socket_path,
+        role=role,
+    )
+    if command_match is False:
+        return _RecordedSidecar.NOT_OURS
+    if not _legacy_sidecar_record(record) and identity.environment is not None:
         if (
             not _provider_roots_match(
                 identity.environment.get("EVEROS_ROOT"),
@@ -3194,11 +3253,11 @@ def _classify_recorded_child(
             or identity.environment.get("AVIBE_MEMORY_CHILD_ROLE") != role.value
         ):
             return _RecordedSidecar.NOT_OURS
-    if live_recorded_stamp is None or identity.cmdline is None:
+    if live_recorded_stamp is None or command_match is None:
         return _RecordedSidecar.UNVERIFIABLE
     if own_uid is not None and identity.uid is None:
         return _RecordedSidecar.UNVERIFIABLE
-    if not legacy_sidecar and identity.environment is None:
+    if not _legacy_sidecar_record(record) and identity.environment is None:
         return _RecordedSidecar.UNVERIFIABLE
     return _RecordedSidecar.OURS
 
@@ -3532,11 +3591,30 @@ def _host_identity_is_live(
     return created_at is not None and process_id in host.live({process_id: created_at})
 
 
-def _owned_process_identity_is_live(process_id: int, identities: Mapping[int, float]) -> bool:
+def _refresh_owned_process_tree(
+    host: _ProcessHost,
+    identities: dict[int, float],
+    process_id: int,
+    process_group: int | None,
+) -> bool:
+    """Extend ownership only while the captured root identity remains live."""
+
     created_at = identities.get(process_id)
-    if created_at is None:
+    if created_at is None or not _host_identity_is_live(
+        host,
+        process_id,
+        {process_id: created_at},
+    ):
         return False
-    return process_id in _live_owned_processes({process_id: created_at})
+    discovered = host.snapshot_tree(process_id, process_group)
+    if discovered.get(process_id) != created_at or not _host_identity_is_live(
+        host,
+        process_id,
+        {process_id: created_at},
+    ):
+        return False
+    _merge_owned_processes(identities, discovered)
+    return True
 
 
 def _live_owned_processes(identities: Mapping[int, float]) -> dict[int, float]:
@@ -3579,6 +3657,8 @@ def _confirmed_owned_processes(identities: Mapping[int, float]) -> dict[int, flo
 def _group_contains_only_confirmed_owned_processes(
     process_group: int | None,
     identities: Mapping[int, float],
+    *,
+    trusted_pids: Iterable[int] | None = None,
 ) -> bool:
     """Whether a group can be signaled without bypassing PID identity checks."""
 
@@ -3586,8 +3666,10 @@ def _group_contains_only_confirmed_owned_processes(
         return False
     group_members = _snapshot_process_group(process_group)
     confirmed = _confirmed_owned_processes(identities)
+    trusted = set() if trusted_pids is None else set(trusted_pids)
     return bool(group_members) and all(
-        confirmed.get(process_id) == created_at for process_id, created_at in group_members.items()
+        process_id in trusted or confirmed.get(process_id) == created_at
+        for process_id, created_at in group_members.items()
     )
 
 
@@ -3595,18 +3677,25 @@ def _signal_owned_group(
     process_group: int | None,
     identities: Mapping[int, float],
     signum: int,
+    *,
+    trusted_pids: Iterable[int] | None = None,
 ) -> bool:
     """Signal a whole isolated group, but only if every member is confirmed owned.
 
     Returns whether the group signal settled the delivery, so a caller holding a
     direct child handle can fall back to it without widening the blast radius: a
-    group with an unverifiable member is never signaled group-wide.
+    group with an unverifiable member is never signaled group-wide. A live
+    spawned asyncio child may be treated as confirmed for the direct child only.
     """
 
     if (
         process_group is None
         or not hasattr(os, "killpg")
-        or not _group_contains_only_confirmed_owned_processes(process_group, identities)
+        or not _group_contains_only_confirmed_owned_processes(
+            process_group,
+            identities,
+            trusted_pids=trusted_pids,
+        )
     ):
         return False
     try:
@@ -3618,21 +3707,48 @@ def _signal_owned_group(
     return True
 
 
+def _live_direct_child_handle(process: asyncio.subprocess.Process) -> bool:
+    """Whether ``process`` is an unreaped asyncio child this process spawned.
+
+    Requires the stdlib Popen the transport still holds. A constructed
+    ``asyncio.subprocess.Process`` with only a fake transport is not trusted,
+    and a Popen whose ``returncode`` is already set has been reaped at the OS
+    layer even if asyncio has not copied that into ``process.returncode``.
+    """
+
+    if (
+        not isinstance(process, asyncio.subprocess.Process)
+        or process.returncode is not None
+        or process.pid is None
+    ):
+        return False
+    transport = getattr(process, "_transport", None)
+    popen = getattr(transport, "_proc", None)
+    return popen is not None and getattr(popen, "returncode", None) is None
+
+
 def _signal_owned_group_or_process(
     process: asyncio.subprocess.Process,
     process_group: int | None,
     identities: Mapping[int, float],
     signum: int,
 ) -> None:
-    if _signal_owned_group(process_group, identities, signum):
+    trusted = {int(process.pid)} if _live_direct_child_handle(process) else set()
+    if _signal_owned_group(
+        process_group,
+        identities,
+        signum,
+        trusted_pids=trusted,
+    ):
         return
     if process.returncode is not None:
         return
-    created_at = identities.get(process.pid)
-    if created_at is None or process.pid not in _confirmed_owned_processes(
-        {process.pid: created_at}
-    ):
-        return
+    if not trusted:
+        created_at = identities.get(process.pid)
+        if created_at is None or process.pid not in _confirmed_owned_processes(
+            {process.pid: created_at}
+        ):
+            return
     try:
         process.send_signal(signum)
     except ProcessLookupError:
@@ -3665,8 +3781,12 @@ async def _wait_for_owned_exit(
     waiter = asyncio.create_task(process.wait(), name="memory-everos-reap")
     try:
         while time.monotonic() < deadline:
-            if process.returncode is None or _owned_process_identity_is_live(process.pid, identities):
-                _merge_owned_processes(identities, _snapshot_owned_processes(process.pid, process_group))
+            _refresh_owned_process_tree(
+                _SystemProcessHost(),
+                identities,
+                process.pid,
+                process_group,
+            )
             if waiter.done() and not _live_owned_processes(identities):
                 await waiter
                 return True

--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -12,7 +12,6 @@ import math
 import os
 import signal
 import stat
-import subprocess
 import sys
 import time
 from collections import deque
@@ -20,7 +19,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from collections.abc import Awaitable, Callable, Iterable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, Deque, Protocol, TypeVar, runtime_checkable
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -3658,8 +3657,6 @@ def _confirmed_owned_processes(identities: Mapping[int, float]) -> dict[int, flo
 def _group_contains_only_confirmed_owned_processes(
     process_group: int | None,
     identities: Mapping[int, float],
-    *,
-    trusted_pids: Iterable[int] | None = None,
 ) -> bool:
     """Whether a group can be signaled without bypassing PID identity checks."""
 
@@ -3667,10 +3664,8 @@ def _group_contains_only_confirmed_owned_processes(
         return False
     group_members = _snapshot_process_group(process_group)
     confirmed = _confirmed_owned_processes(identities)
-    trusted = set() if trusted_pids is None else set(trusted_pids)
     return bool(group_members) and all(
-        process_id in trusted or confirmed.get(process_id) == created_at
-        for process_id, created_at in group_members.items()
+        confirmed.get(process_id) == created_at for process_id, created_at in group_members.items()
     )
 
 
@@ -3678,25 +3673,18 @@ def _signal_owned_group(
     process_group: int | None,
     identities: Mapping[int, float],
     signum: int,
-    *,
-    trusted_pids: Iterable[int] | None = None,
 ) -> bool:
     """Signal a whole isolated group, but only if every member is confirmed owned.
 
     Returns whether the group signal settled the delivery, so a caller holding a
     direct child handle can fall back to it without widening the blast radius: a
-    group with an unverifiable member is never signaled group-wide. A live
-    spawned Popen child may be treated as confirmed for the direct child only.
+    group with an unverifiable member is never signaled group-wide.
     """
 
     if (
         process_group is None
         or not hasattr(os, "killpg")
-        or not _group_contains_only_confirmed_owned_processes(
-            process_group,
-            identities,
-            trusted_pids=trusted_pids,
-        )
+        or not _group_contains_only_confirmed_owned_processes(process_group, identities)
     ):
         return False
     try:
@@ -3708,47 +3696,21 @@ def _signal_owned_group(
     return True
 
 
-def _live_direct_child_handle(process: asyncio.subprocess.Process) -> bool:
-    """Whether ``process`` is an unreaped child this process actually spawned.
-
-    A constructed ``asyncio.subprocess.Process`` (even one with a fake
-    ``_proc``) is not trusted. Only a live stdlib ``Popen`` whose
-    ``returncode`` is still unset is authoritative for the direct child.
-    """
-
-    if (
-        not isinstance(process, asyncio.subprocess.Process)
-        or process.returncode is not None
-        or process.pid is None
-    ):
-        return False
-    transport = getattr(process, "_transport", None)
-    popen = getattr(transport, "_proc", None)
-    return isinstance(popen, subprocess.Popen) and popen.returncode is None
-
-
 def _signal_owned_group_or_process(
     process: asyncio.subprocess.Process,
     process_group: int | None,
     identities: Mapping[int, float],
     signum: int,
 ) -> None:
-    trusted = {int(process.pid)} if _live_direct_child_handle(process) else set()
-    if _signal_owned_group(
-        process_group,
-        identities,
-        signum,
-        trusted_pids=trusted,
-    ):
+    if _signal_owned_group(process_group, identities, signum):
         return
     if process.returncode is not None:
         return
-    if not trusted:
-        created_at = identities.get(process.pid)
-        if created_at is None or process.pid not in _confirmed_owned_processes(
-            {process.pid: created_at}
-        ):
-            return
+    created_at = identities.get(process.pid)
+    if created_at is None or process.pid not in _confirmed_owned_processes(
+        {process.pid: created_at}
+    ):
+        return
     try:
         process.send_signal(signum)
     except ProcessLookupError:

--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -3149,13 +3149,7 @@ def _classify_recorded_child(
         socket_path=socket_path,
         provider_root=provider_root,
     )
-    live_recorded_stamp = (
-        identity.create_time
-        if has_starttime_ticks
-        else identity.wall_create_time
-        if identity.wall_create_time is not None
-        else identity.create_time
-    )
+    live_recorded_stamp = identity.create_time if has_starttime_ticks else identity.wall_create_time
     getuid = getattr(os, "getuid", None)
     own_uid = getuid() if callable(getuid) else None
     if identity.uid is not None and own_uid is not None and identity.uid != own_uid:

--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -12,6 +12,7 @@ import math
 import os
 import signal
 import stat
+import subprocess
 import sys
 import time
 from collections import deque
@@ -19,7 +20,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from typing import Any, Deque, Protocol, TypeVar, runtime_checkable
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -3657,6 +3658,8 @@ def _confirmed_owned_processes(identities: Mapping[int, float]) -> dict[int, flo
 def _group_contains_only_confirmed_owned_processes(
     process_group: int | None,
     identities: Mapping[int, float],
+    *,
+    trusted_pids: Iterable[int] | None = None,
 ) -> bool:
     """Whether a group can be signaled without bypassing PID identity checks."""
 
@@ -3664,8 +3667,10 @@ def _group_contains_only_confirmed_owned_processes(
         return False
     group_members = _snapshot_process_group(process_group)
     confirmed = _confirmed_owned_processes(identities)
+    trusted = set() if trusted_pids is None else set(trusted_pids)
     return bool(group_members) and all(
-        confirmed.get(process_id) == created_at for process_id, created_at in group_members.items()
+        process_id in trusted or confirmed.get(process_id) == created_at
+        for process_id, created_at in group_members.items()
     )
 
 
@@ -3673,18 +3678,25 @@ def _signal_owned_group(
     process_group: int | None,
     identities: Mapping[int, float],
     signum: int,
+    *,
+    trusted_pids: Iterable[int] | None = None,
 ) -> bool:
     """Signal a whole isolated group, but only if every member is confirmed owned.
 
     Returns whether the group signal settled the delivery, so a caller holding a
     direct child handle can fall back to it without widening the blast radius: a
-    group with an unverifiable member is never signaled group-wide.
+    group with an unverifiable member is never signaled group-wide. A live
+    spawned Popen child may be treated as confirmed for the direct child only.
     """
 
     if (
         process_group is None
         or not hasattr(os, "killpg")
-        or not _group_contains_only_confirmed_owned_processes(process_group, identities)
+        or not _group_contains_only_confirmed_owned_processes(
+            process_group,
+            identities,
+            trusted_pids=trusted_pids,
+        )
     ):
         return False
     try:
@@ -3696,21 +3708,47 @@ def _signal_owned_group(
     return True
 
 
+def _live_direct_child_handle(process: asyncio.subprocess.Process) -> bool:
+    """Whether ``process`` is an unreaped child this process actually spawned.
+
+    A constructed ``asyncio.subprocess.Process`` (even one with a fake
+    ``_proc``) is not trusted. Only a live stdlib ``Popen`` whose
+    ``returncode`` is still unset is authoritative for the direct child.
+    """
+
+    if (
+        not isinstance(process, asyncio.subprocess.Process)
+        or process.returncode is not None
+        or process.pid is None
+    ):
+        return False
+    transport = getattr(process, "_transport", None)
+    popen = getattr(transport, "_proc", None)
+    return isinstance(popen, subprocess.Popen) and popen.returncode is None
+
+
 def _signal_owned_group_or_process(
     process: asyncio.subprocess.Process,
     process_group: int | None,
     identities: Mapping[int, float],
     signum: int,
 ) -> None:
-    if _signal_owned_group(process_group, identities, signum):
+    trusted = {int(process.pid)} if _live_direct_child_handle(process) else set()
+    if _signal_owned_group(
+        process_group,
+        identities,
+        signum,
+        trusted_pids=trusted,
+    ):
         return
     if process.returncode is not None:
         return
-    created_at = identities.get(process.pid)
-    if created_at is None or process.pid not in _confirmed_owned_processes(
-        {process.pid: created_at}
-    ):
-        return
+    if not trusted:
+        created_at = identities.get(process.pid)
+        if created_at is None or process.pid not in _confirmed_owned_processes(
+            {process.pid: created_at}
+        ):
+            return
     try:
         process.send_signal(signum)
     except ProcessLookupError:

--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from collections.abc import Awaitable, Callable, Iterable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, Deque, Protocol, TypeVar, runtime_checkable
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -2651,12 +2651,15 @@ class _ProcessIdentity:
 
     ``create_time`` is the identity stamp from ``_process_creation_stamp``:
     Linux starttime ticks, or ``psutil.Process.create_time()`` elsewhere.
+    ``wall_create_time`` retains the epoch value needed to compare a live Linux
+    process with a legacy record that predates ``starttime_ticks``.
     """
 
     create_time: float | None
     cmdline: tuple[str, ...] | None
     uid: int | None
     environment: Mapping[str, str] | None = None
+    wall_create_time: float | None = None
 
 
 def _uses_linux_starttime_stamp() -> bool:
@@ -2775,6 +2778,7 @@ def _inspect_process_identity(pid: int) -> _ProcessIdentity | None:
             cmdline=None if cmdline is None else tuple(str(value) for value in cmdline),
             uid=_process_real_uid(process),
             environment=_disclosed_process_environment(process),
+            wall_create_time=_disclosed_identity_field(process.create_time),
         )
     except psutil.NoSuchProcess:
         # The process exited between the reads. That is "gone", which retires the
@@ -3073,6 +3077,7 @@ def _legacy_create_time_mismatch_verdict(
     record: object,
     identity: _ProcessIdentity,
     recorded_create_time: float,
+    live_wall_create_time: float | None,
     *,
     socket_path: Path,
     provider_root: Path,
@@ -3088,9 +3093,9 @@ def _legacy_create_time_mismatch_verdict(
     historical recycled-pid ``NOT_OURS`` verdict.
     """
 
-    if identity.create_time is None:
+    if live_wall_create_time is None:
         return _RecordedSidecar.UNVERIFIABLE
-    if abs(identity.create_time - recorded_create_time) > _LEGACY_CREATE_TIME_DRIFT_SECONDS:
+    if abs(live_wall_create_time - recorded_create_time) > _LEGACY_CREATE_TIME_DRIFT_SECONDS:
         return _RecordedSidecar.NOT_OURS
     if identity.cmdline is None:
         return _RecordedSidecar.UNVERIFIABLE
@@ -3139,21 +3144,30 @@ def _classify_recorded_child(
     )
     if identity is None or recorded_create_time is None:
         return _RecordedSidecar.NOT_OURS
+    has_starttime_ticks = _recorded_sidecar_has_starttime_ticks(
+        record,
+        socket_path=socket_path,
+        provider_root=provider_root,
+    )
+    live_recorded_stamp = (
+        identity.create_time
+        if has_starttime_ticks
+        else identity.wall_create_time
+        if identity.wall_create_time is not None
+        else identity.create_time
+    )
     getuid = getattr(os, "getuid", None)
     own_uid = getuid() if callable(getuid) else None
     if identity.uid is not None and own_uid is not None and identity.uid != own_uid:
         return _RecordedSidecar.NOT_OURS
-    if identity.create_time is not None and identity.create_time != recorded_create_time:
-        if _recorded_sidecar_has_starttime_ticks(
-            record,
-            socket_path=socket_path,
-            provider_root=provider_root,
-        ):
+    if live_recorded_stamp is not None and live_recorded_stamp != recorded_create_time:
+        if has_starttime_ticks:
             return _RecordedSidecar.NOT_OURS
         drift_verdict = _legacy_create_time_mismatch_verdict(
             record,
             identity,
             recorded_create_time,
+            live_recorded_stamp,
             socket_path=socket_path,
             provider_root=provider_root,
             role=role,
@@ -3186,7 +3200,7 @@ def _classify_recorded_child(
             or identity.environment.get("AVIBE_MEMORY_CHILD_ROLE") != role.value
         ):
             return _RecordedSidecar.NOT_OURS
-    if identity.create_time is None or identity.cmdline is None:
+    if live_recorded_stamp is None or identity.cmdline is None:
         return _RecordedSidecar.UNVERIFIABLE
     if own_uid is not None and identity.uid is None:
         return _RecordedSidecar.UNVERIFIABLE
@@ -3571,8 +3585,6 @@ def _confirmed_owned_processes(identities: Mapping[int, float]) -> dict[int, flo
 def _group_contains_only_confirmed_owned_processes(
     process_group: int | None,
     identities: Mapping[int, float],
-    *,
-    trusted_pids: Iterable[int] | None = None,
 ) -> bool:
     """Whether a group can be signaled without bypassing PID identity checks."""
 
@@ -3580,10 +3592,8 @@ def _group_contains_only_confirmed_owned_processes(
         return False
     group_members = _snapshot_process_group(process_group)
     confirmed = _confirmed_owned_processes(identities)
-    trusted = set() if trusted_pids is None else set(trusted_pids)
     return bool(group_members) and all(
-        process_id in trusted or confirmed.get(process_id) == created_at
-        for process_id, created_at in group_members.items()
+        confirmed.get(process_id) == created_at for process_id, created_at in group_members.items()
     )
 
 
@@ -3591,26 +3601,18 @@ def _signal_owned_group(
     process_group: int | None,
     identities: Mapping[int, float],
     signum: int,
-    *,
-    trusted_pids: Iterable[int] | None = None,
 ) -> bool:
     """Signal a whole isolated group, but only if every member is confirmed owned.
 
     Returns whether the group signal settled the delivery, so a caller holding a
     direct child handle can fall back to it without widening the blast radius: a
-    group with an unverifiable member is never signaled group-wide. A live
-    direct child this process spawned may be treated as confirmed without a
-    stamp match; every other member stays fail-closed.
+    group with an unverifiable member is never signaled group-wide.
     """
 
     if (
         process_group is None
         or not hasattr(os, "killpg")
-        or not _group_contains_only_confirmed_owned_processes(
-            process_group,
-            identities,
-            trusted_pids=trusted_pids,
-        )
+        or not _group_contains_only_confirmed_owned_processes(process_group, identities)
     ):
         return False
     try:
@@ -3622,46 +3624,21 @@ def _signal_owned_group(
     return True
 
 
-def _live_direct_child_pid(process: asyncio.subprocess.Process) -> int | None:
-    """The pid of an unreaped asyncio child this process spawned, if any.
-
-    ``returncode is None`` on an ``asyncio.subprocess.Process`` means the handle
-    has not been reaped, so the pid cannot have been recycled (the worst case
-    is a zombie). That handle is authoritative for signaling the direct child.
-    """
-
-    if (
-        not isinstance(process, asyncio.subprocess.Process)
-        or process.returncode is not None
-        or process.pid is None
-    ):
-        return None
-    return int(process.pid)
-
-
 def _signal_owned_group_or_process(
     process: asyncio.subprocess.Process,
     process_group: int | None,
     identities: Mapping[int, float],
     signum: int,
 ) -> None:
-    trusted_pid = _live_direct_child_pid(process)
-    trusted = set() if trusted_pid is None else {trusted_pid}
-    if _signal_owned_group(
-        process_group,
-        identities,
-        signum,
-        trusted_pids=trusted,
-    ):
+    if _signal_owned_group(process_group, identities, signum):
         return
     if process.returncode is not None:
         return
-    if trusted_pid is None:
-        created_at = identities.get(process.pid)
-        if created_at is None or process.pid not in _confirmed_owned_processes(
-            {process.pid: created_at}
-        ):
-            return
+    created_at = identities.get(process.pid)
+    if created_at is None or process.pid not in _confirmed_owned_processes(
+        {process.pid: created_at}
+    ):
+        return
     try:
         process.send_signal(signum)
     except ProcessLookupError:

--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from collections.abc import Awaitable, Callable, Iterable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, Deque, Protocol, TypeVar, runtime_checkable
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -3657,8 +3657,6 @@ def _confirmed_owned_processes(identities: Mapping[int, float]) -> dict[int, flo
 def _group_contains_only_confirmed_owned_processes(
     process_group: int | None,
     identities: Mapping[int, float],
-    *,
-    trusted_pids: Iterable[int] | None = None,
 ) -> bool:
     """Whether a group can be signaled without bypassing PID identity checks."""
 
@@ -3666,10 +3664,8 @@ def _group_contains_only_confirmed_owned_processes(
         return False
     group_members = _snapshot_process_group(process_group)
     confirmed = _confirmed_owned_processes(identities)
-    trusted = set() if trusted_pids is None else set(trusted_pids)
     return bool(group_members) and all(
-        process_id in trusted or confirmed.get(process_id) == created_at
-        for process_id, created_at in group_members.items()
+        confirmed.get(process_id) == created_at for process_id, created_at in group_members.items()
     )
 
 
@@ -3677,25 +3673,18 @@ def _signal_owned_group(
     process_group: int | None,
     identities: Mapping[int, float],
     signum: int,
-    *,
-    trusted_pids: Iterable[int] | None = None,
 ) -> bool:
     """Signal a whole isolated group, but only if every member is confirmed owned.
 
     Returns whether the group signal settled the delivery, so a caller holding a
     direct child handle can fall back to it without widening the blast radius: a
-    group with an unverifiable member is never signaled group-wide. A live
-    spawned asyncio child may be treated as confirmed for the direct child only.
+    group with an unverifiable member is never signaled group-wide.
     """
 
     if (
         process_group is None
         or not hasattr(os, "killpg")
-        or not _group_contains_only_confirmed_owned_processes(
-            process_group,
-            identities,
-            trusted_pids=trusted_pids,
-        )
+        or not _group_contains_only_confirmed_owned_processes(process_group, identities)
     ):
         return False
     try:
@@ -3707,48 +3696,21 @@ def _signal_owned_group(
     return True
 
 
-def _live_direct_child_handle(process: asyncio.subprocess.Process) -> bool:
-    """Whether ``process`` is an unreaped asyncio child this process spawned.
-
-    Requires the stdlib Popen the transport still holds. A constructed
-    ``asyncio.subprocess.Process`` with only a fake transport is not trusted,
-    and a Popen whose ``returncode`` is already set has been reaped at the OS
-    layer even if asyncio has not copied that into ``process.returncode``.
-    """
-
-    if (
-        not isinstance(process, asyncio.subprocess.Process)
-        or process.returncode is not None
-        or process.pid is None
-    ):
-        return False
-    transport = getattr(process, "_transport", None)
-    popen = getattr(transport, "_proc", None)
-    return popen is not None and getattr(popen, "returncode", None) is None
-
-
 def _signal_owned_group_or_process(
     process: asyncio.subprocess.Process,
     process_group: int | None,
     identities: Mapping[int, float],
     signum: int,
 ) -> None:
-    trusted = {int(process.pid)} if _live_direct_child_handle(process) else set()
-    if _signal_owned_group(
-        process_group,
-        identities,
-        signum,
-        trusted_pids=trusted,
-    ):
+    if _signal_owned_group(process_group, identities, signum):
         return
     if process.returncode is not None:
         return
-    if not trusted:
-        created_at = identities.get(process.pid)
-        if created_at is None or process.pid not in _confirmed_owned_processes(
-            {process.pid: created_at}
-        ):
-            return
+    created_at = identities.get(process.pid)
+    if created_at is None or process.pid not in _confirmed_owned_processes(
+        {process.pid: created_at}
+    ):
+        return
     try:
         process.send_signal(signum)
     except ProcessLookupError:

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -2848,6 +2848,7 @@ class MemoryRuntime:
                 except Exception:
                     # Retain the supervisor: only its successful stop proves
                     # that no owned child tree remains.
+                    logger.exception("Memory sidecar restart failed")
                     self._runtime_error = "memory_restart_failed"
                     return {"ok": False, "error": self._runtime_error}
                 self._process = None

--- a/core/memory/sync_process.py
+++ b/core/memory/sync_process.py
@@ -773,14 +773,21 @@ def _recorded_sync_time_matches(
         if not _is_identity_stamp(live):
             raise SyncOwnershipError(f"sync {subject} creation time is unavailable")
         return float(live) == float(record[stamp_key])
+    if subject == "parent":
+        # A legacy record can only be read by a later process. The writer is
+        # gone, so exact wall equality is the remaining parent identity; uid
+        # alone would treat a recycled same-uid pid as the original owner.
+        wall = identity.wall_create_time
+        if not _is_identity_stamp(wall):
+            raise SyncOwnershipError(f"sync {subject} creation time is unavailable")
+        return float(wall) == float(record[wall_key])
     if _uses_linux_starttime_stamp():
         wall = identity.wall_create_time
         if not _is_identity_stamp(wall):
             raise SyncOwnershipError(f"sync {subject} creation time is unavailable")
-        # Legacy Linux records stored wall-clock create_time, whose value can
-        # shift arbitrarily after a clock correction. Its presence lets the
-        # caller continue to the exact uid/argv/root/role/nonce checks; only a
-        # stable starttime stamp may decide identity by numeric equality.
+        # Legacy child records still have argv/root/role/nonce to authenticate
+        # after a CLOCK_REALTIME step. Presence of a readable wall time is
+        # enough to continue to those facts.
         return True
     live = identity.stamp
     if not _is_identity_stamp(live):

--- a/core/memory/sync_process.py
+++ b/core/memory/sync_process.py
@@ -24,7 +24,6 @@ import psutil
 
 from config import paths
 from core.memory.process import (
-    _LEGACY_CREATE_TIME_DRIFT_SECONDS,
     _MemoryChildRole,
     _ProcessKind,
     _ProcessIdentity,
@@ -778,8 +777,11 @@ def _recorded_sync_time_matches(
         wall = identity.wall_create_time
         if not _is_identity_stamp(wall):
             raise SyncOwnershipError(f"sync {subject} creation time is unavailable")
-        difference = abs(float(wall) - float(record[wall_key]))
-        return difference <= _LEGACY_CREATE_TIME_DRIFT_SECONDS
+        # Legacy Linux records stored wall-clock create_time, whose value can
+        # shift arbitrarily after a clock correction. Its presence lets the
+        # caller continue to the exact uid/argv/root/role/nonce checks; only a
+        # stable starttime stamp may decide identity by numeric equality.
+        return True
     live = identity.stamp
     if not _is_identity_stamp(live):
         raise SyncOwnershipError(f"sync {subject} creation time is unavailable")

--- a/core/memory/sync_process.py
+++ b/core/memory/sync_process.py
@@ -24,6 +24,7 @@ import psutil
 
 from config import paths
 from core.memory.process import (
+    _LEGACY_CREATE_TIME_DRIFT_SECONDS,
     _MemoryChildRole,
     _ProcessKind,
     _ProcessIdentity,
@@ -31,6 +32,7 @@ from core.memory.process import (
     _ProviderRootBusy,
     _ProviderRootLock,
     _ensure_owner_directory,
+    _is_identity_stamp,
     _provider_rebuild_lock_path,
     _provider_root_coordination_path,
     _provider_roots_match,
@@ -272,13 +274,13 @@ class SyncOwnership:
         parent_identity = self.host.inspect_identity(int(record["parent_pid"]))
         if parent_identity is not None:
             expected_uid = record.get("parent_uid")
-            parent_stamp = getattr(parent_identity, "stamp", getattr(parent_identity, "create_time", None))
-            if parent_stamp is None or (
+            parent_wall = parent_identity.wall_create_time
+            if parent_wall is None or (
                 expected_uid is not None and parent_identity.uid is None
             ):
                 raise SyncOwnershipError("sync parent identity is unavailable")
             if (
-                parent_stamp == float(record["parent_create_time"])
+                parent_wall == float(record["parent_create_time"])
                 and parent_identity.uid == expected_uid
                 and record.get("cleanup_failed") is not True
             ):
@@ -316,6 +318,7 @@ class SyncOwnership:
                 "state": "finalized",
                 "pid": pid,
                 "create_time": created_at,
+                "starttime_ticks": created_at,
                 "process_group": group,
             }
             _validate_child_identity(identity, record, provider_root=self.provider_root)
@@ -345,13 +348,18 @@ class SyncOwnership:
         if foreign:
             raise SyncOwnershipError("sync process group contains unverifiable members")
         identities: dict[int, float] = {}
-        if identity is not None and record.get("create_time") is not None:
-            identities[pid] = float(record["create_time"])
+        if identity is not None and identity.stamp is not None:
+            identities[pid] = float(identity.stamp)
         for member_pid, created_at in claimed.items():
             member = self.host.inspect_identity(member_pid)
             if member is None:
                 continue
-            member_record = {**record, "pid": member_pid, "create_time": created_at}
+            member_record = {
+                **record,
+                "pid": member_pid,
+                "create_time": created_at,
+                "starttime_ticks": created_at,
+            }
             _validate_child_identity(
                 member,
                 member_record,
@@ -495,10 +503,26 @@ class EverOSSyncProcess:
             identity = self._ownership.host.inspect_identity(process.pid)
             if identity is None or group is None:
                 raise SyncOwnershipError("sync child identity could not be observed")
-            _validate_child_identity(identity, {**pending, "pid": process.pid, "create_time": identity.stamp}, provider_root=self.provider_root)
+            _validate_child_identity(
+                identity,
+                {
+                    **pending,
+                    "pid": process.pid,
+                    "create_time": identity.stamp,
+                    "starttime_ticks": identity.stamp,
+                },
+                provider_root=self.provider_root,
+            )
             if identity.stamp is None:
                 raise SyncOwnershipError("sync child creation time is unavailable")
-            finalized = {**pending, "state": "finalized", "pid": process.pid, "create_time": identity.stamp, "process_group": group}
+            finalized = {
+                **pending,
+                "state": "finalized",
+                "pid": process.pid,
+                "create_time": identity.stamp,
+                "starttime_ticks": identity.stamp,
+                "process_group": group,
+            }
             self._ownership.finalize(finalized, nonce=nonce)
             process.send_signal(signal.SIGCONT)
             if spawn_interrupted:
@@ -700,6 +724,10 @@ def _validate_record(record: Mapping[str, Any], *, provider_root: Path) -> None:
         raise SyncOwnershipError("sync parent uid is invalid")
 
 
+def _sync_record_has_starttime_ticks(record: Mapping[str, Any]) -> bool:
+    return _is_identity_stamp(record.get("starttime_ticks"))
+
+
 def _validate_child_identity(
     identity: _ProcessIdentity,
     record: Mapping[str, Any],
@@ -707,12 +735,22 @@ def _validate_child_identity(
     provider_root: Path,
     require_argv: bool = True,
 ) -> None:
-    expected_create = record.get("create_time")
-    if expected_create is not None:
+    if _sync_record_has_starttime_ticks(record):
         if identity.stamp is None:
             raise SyncOwnershipError("sync child creation time is unavailable")
-        if identity.stamp != float(expected_create):
+        if identity.stamp != float(record["starttime_ticks"]):
             raise _SyncIdentityMismatch("sync child creation time does not match")
+    else:
+        expected_create = record.get("create_time")
+        if expected_create is not None:
+            if not _is_identity_stamp(expected_create):
+                raise SyncOwnershipError("sync child creation time is unavailable")
+            wall = identity.wall_create_time
+            if wall is None or not _is_identity_stamp(wall):
+                raise SyncOwnershipError("sync child creation time is unavailable")
+            if wall != float(expected_create):
+                if abs(wall - float(expected_create)) > _LEGACY_CREATE_TIME_DRIFT_SECONDS:
+                    raise _SyncIdentityMismatch("sync child creation time does not match")
     uid = record.get("parent_uid")
     if uid is not None:
         if identity.uid is None:

--- a/core/memory/sync_process.py
+++ b/core/memory/sync_process.py
@@ -33,6 +33,7 @@ from core.memory.process import (
     _ProviderRootLock,
     _ensure_owner_directory,
     _is_identity_stamp,
+    _process_creation_stamp,
     _provider_rebuild_lock_path,
     _provider_root_coordination_path,
     _provider_roots_match,
@@ -43,6 +44,7 @@ from core.memory.process import (
     _finish_cleanup_despite_cancellation,
     _finish_handoff_despite_cancellation,
     _terminate_owned_process_tree,
+    _uses_linux_starttime_stamp,
 )
 
 
@@ -100,14 +102,16 @@ class _ParentIdentity:
     pid: int
     create_time: float
     uid: int | None
+    stamp: float | None = None
 
 
 def _parent_identity() -> _ParentIdentity:
     process = psutil.Process(os.getpid())
     create_time = float(process.create_time())
+    stamp = _process_creation_stamp(process)
     getter = getattr(os, "getuid", None)
     uid = int(getter()) if callable(getter) else None
-    return _ParentIdentity(os.getpid(), create_time, uid)
+    return _ParentIdentity(os.getpid(), create_time, uid, stamp)
 
 
 class SyncOwnership:
@@ -274,13 +278,16 @@ class SyncOwnership:
         parent_identity = self.host.inspect_identity(int(record["parent_pid"]))
         if parent_identity is not None:
             expected_uid = record.get("parent_uid")
-            parent_wall = parent_identity.wall_create_time
-            if parent_wall is None or (
-                expected_uid is not None and parent_identity.uid is None
-            ):
+            if expected_uid is not None and parent_identity.uid is None:
                 raise SyncOwnershipError("sync parent identity is unavailable")
             if (
-                parent_wall == float(record["parent_create_time"])
+                _recorded_sync_time_matches(
+                    parent_identity,
+                    record,
+                    stamp_key="parent_starttime_ticks",
+                    wall_key="parent_create_time",
+                    subject="parent",
+                )
                 and parent_identity.uid == expected_uid
                 and record.get("cleanup_failed") is not True
             ):
@@ -317,8 +324,7 @@ class SyncOwnership:
                 **record,
                 "state": "finalized",
                 "pid": pid,
-                "create_time": created_at,
-                "starttime_ticks": created_at,
+                **_sync_recorded_child_times(identity, captured_stamp=created_at),
                 "process_group": group,
             }
             _validate_child_identity(identity, record, provider_root=self.provider_root)
@@ -357,8 +363,7 @@ class SyncOwnership:
             member_record = {
                 **record,
                 "pid": member_pid,
-                "create_time": created_at,
-                "starttime_ticks": created_at,
+                **_sync_recorded_child_times(member, captured_stamp=created_at),
             }
             _validate_child_identity(
                 member,
@@ -471,6 +476,10 @@ class EverOSSyncProcess:
             "role": SYNC_ROLE,
             "argv": argv,
         }
+        if _uses_linux_starttime_stamp():
+            if not _is_identity_stamp(parent.stamp):
+                return SyncProcessResult.FAILED
+            pending["parent_starttime_ticks"] = parent.stamp
         process: asyncio.subprocess.Process | None = None
         group: int | None = None
         identities: dict[int, float] = {}
@@ -508,8 +517,7 @@ class EverOSSyncProcess:
                 {
                     **pending,
                     "pid": process.pid,
-                    "create_time": identity.stamp,
-                    "starttime_ticks": identity.stamp,
+                    **_sync_recorded_child_times(identity),
                 },
                 provider_root=self.provider_root,
             )
@@ -519,8 +527,7 @@ class EverOSSyncProcess:
                 **pending,
                 "state": "finalized",
                 "pid": process.pid,
-                "create_time": identity.stamp,
-                "starttime_ticks": identity.stamp,
+                **_sync_recorded_child_times(identity),
                 "process_group": group,
             }
             self._ownership.finalize(finalized, nonce=nonce)
@@ -718,14 +725,65 @@ def _validate_record(record: Mapping[str, Any], *, provider_root: Path) -> None:
     parent_uid = record.get("parent_uid")
     if not isinstance(parent_pid, int) or parent_pid <= 1:
         raise SyncOwnershipError("sync parent pid is invalid")
-    if not isinstance(parent_create_time, (int, float)) or isinstance(parent_create_time, bool):
+    if not _is_identity_stamp(parent_create_time):
         raise SyncOwnershipError("sync parent create-time is invalid")
+    if "parent_starttime_ticks" in record and not _is_identity_stamp(
+        record.get("parent_starttime_ticks")
+    ):
+        raise SyncOwnershipError("sync parent start-time is invalid")
+    create_time = record.get("create_time")
+    if create_time is not None and not _is_identity_stamp(create_time):
+        raise SyncOwnershipError("sync child create-time is invalid")
+    if "starttime_ticks" in record and not _is_identity_stamp(record.get("starttime_ticks")):
+        raise SyncOwnershipError("sync child start-time is invalid")
+    if record.get("state") == "finalized" and (
+        "starttime_ticks" not in record and not _is_identity_stamp(create_time)
+    ):
+        raise SyncOwnershipError("sync child creation time is invalid")
     if parent_uid is not None and (not isinstance(parent_uid, int) or isinstance(parent_uid, bool) or parent_uid < 0):
         raise SyncOwnershipError("sync parent uid is invalid")
 
 
-def _sync_record_has_starttime_ticks(record: Mapping[str, Any]) -> bool:
-    return _is_identity_stamp(record.get("starttime_ticks"))
+def _sync_recorded_child_times(
+    identity: _ProcessIdentity,
+    *,
+    captured_stamp: float | None = None,
+) -> dict[str, float | None]:
+    stamp = identity.stamp if captured_stamp is None else captured_stamp
+    if not _is_identity_stamp(stamp):
+        raise SyncOwnershipError("sync child creation time is unavailable")
+    if _uses_linux_starttime_stamp():
+        wall = identity.wall_create_time
+        return {
+            "create_time": float(wall) if _is_identity_stamp(wall) else None,
+            "starttime_ticks": float(stamp),
+        }
+    return {"create_time": float(stamp)}
+
+
+def _recorded_sync_time_matches(
+    identity: _ProcessIdentity,
+    record: Mapping[str, Any],
+    *,
+    stamp_key: str,
+    wall_key: str,
+    subject: str,
+) -> bool:
+    if stamp_key in record:
+        live = identity.stamp
+        if not _is_identity_stamp(live):
+            raise SyncOwnershipError(f"sync {subject} creation time is unavailable")
+        return float(live) == float(record[stamp_key])
+    if _uses_linux_starttime_stamp():
+        wall = identity.wall_create_time
+        if not _is_identity_stamp(wall):
+            raise SyncOwnershipError(f"sync {subject} creation time is unavailable")
+        difference = abs(float(wall) - float(record[wall_key]))
+        return difference <= _LEGACY_CREATE_TIME_DRIFT_SECONDS
+    live = identity.stamp
+    if not _is_identity_stamp(live):
+        raise SyncOwnershipError(f"sync {subject} creation time is unavailable")
+    return float(live) == float(record[wall_key])
 
 
 def _validate_child_identity(
@@ -735,22 +793,14 @@ def _validate_child_identity(
     provider_root: Path,
     require_argv: bool = True,
 ) -> None:
-    if _sync_record_has_starttime_ticks(record):
-        if identity.stamp is None:
-            raise SyncOwnershipError("sync child creation time is unavailable")
-        if identity.stamp != float(record["starttime_ticks"]):
-            raise _SyncIdentityMismatch("sync child creation time does not match")
-    else:
-        expected_create = record.get("create_time")
-        if expected_create is not None:
-            if not _is_identity_stamp(expected_create):
-                raise SyncOwnershipError("sync child creation time is unavailable")
-            wall = identity.wall_create_time
-            if wall is None or not _is_identity_stamp(wall):
-                raise SyncOwnershipError("sync child creation time is unavailable")
-            if wall != float(expected_create):
-                if abs(wall - float(expected_create)) > _LEGACY_CREATE_TIME_DRIFT_SECONDS:
-                    raise _SyncIdentityMismatch("sync child creation time does not match")
+    if not _recorded_sync_time_matches(
+        identity,
+        record,
+        stamp_key="starttime_ticks",
+        wall_key="create_time",
+        subject="child",
+    ):
+        raise _SyncIdentityMismatch("sync child creation time does not match")
     uid = record.get("parent_uid")
     if uid is not None:
         if identity.uid is None:

--- a/core/memory/sync_process.py
+++ b/core/memory/sync_process.py
@@ -272,12 +272,13 @@ class SyncOwnership:
         parent_identity = self.host.inspect_identity(int(record["parent_pid"]))
         if parent_identity is not None:
             expected_uid = record.get("parent_uid")
-            if parent_identity.create_time is None or (
+            parent_stamp = getattr(parent_identity, "stamp", getattr(parent_identity, "create_time", None))
+            if parent_stamp is None or (
                 expected_uid is not None and parent_identity.uid is None
             ):
                 raise SyncOwnershipError("sync parent identity is unavailable")
             if (
-                parent_identity.create_time == float(record["parent_create_time"])
+                parent_stamp == float(record["parent_create_time"])
                 and parent_identity.uid == expected_uid
                 and record.get("cleanup_failed") is not True
             ):
@@ -494,10 +495,10 @@ class EverOSSyncProcess:
             identity = self._ownership.host.inspect_identity(process.pid)
             if identity is None or group is None:
                 raise SyncOwnershipError("sync child identity could not be observed")
-            _validate_child_identity(identity, {**pending, "pid": process.pid, "create_time": identity.create_time}, provider_root=self.provider_root)
-            if identity.create_time is None:
+            _validate_child_identity(identity, {**pending, "pid": process.pid, "create_time": identity.stamp}, provider_root=self.provider_root)
+            if identity.stamp is None:
                 raise SyncOwnershipError("sync child creation time is unavailable")
-            finalized = {**pending, "state": "finalized", "pid": process.pid, "create_time": identity.create_time, "process_group": group}
+            finalized = {**pending, "state": "finalized", "pid": process.pid, "create_time": identity.stamp, "process_group": group}
             self._ownership.finalize(finalized, nonce=nonce)
             process.send_signal(signal.SIGCONT)
             if spawn_interrupted:
@@ -510,7 +511,7 @@ class EverOSSyncProcess:
                     result = SyncProcessResult.TIMED_OUT
                 except asyncio.CancelledError:
                     result = SyncProcessResult.INTERRUPTED
-            identities[process.pid] = float(identity.create_time)
+            identities[process.pid] = float(identity.stamp)
             await self._terminate_owned_sync_tree(
                 process,
                 process_group=group,
@@ -708,9 +709,9 @@ def _validate_child_identity(
 ) -> None:
     expected_create = record.get("create_time")
     if expected_create is not None:
-        if identity.create_time is None:
+        if identity.stamp is None:
             raise SyncOwnershipError("sync child creation time is unavailable")
-        if identity.create_time != float(expected_create):
+        if identity.stamp != float(expected_create):
             raise _SyncIdentityMismatch("sync child creation time does not match")
     uid = record.get("parent_uid")
     if uid is not None:

--- a/tests/test_memory_process.py
+++ b/tests/test_memory_process.py
@@ -867,8 +867,15 @@ async def test_sidecar_stop_reaps_direct_child_after_create_time_clock_step(
         host = _SystemProcessHost()
         process_group = os.getpgid(child.pid)
         identities = host.snapshot_tree(child.pid, process_group)
+        captured_stamp = identities[child.pid]
         original_process = memory_process.psutil.Process
         original_iter = memory_process.psutil.process_iter
+        original_stamp = memory_process._process_creation_stamp
+
+        def _stamp_immune_to_wall_drift(proc: object) -> float:
+            if getattr(proc, "pid", None) == child.pid:
+                return captured_stamp
+            return original_stamp(proc)
 
         class _ShiftedProcess:
             def __init__(self, process_id: int) -> None:
@@ -890,6 +897,7 @@ async def test_sidecar_stop_reaps_direct_child_after_create_time_clock_step(
 
         monkeypatch.setattr(memory_process.psutil, "Process", _ShiftedProcess)
         monkeypatch.setattr(memory_process.psutil, "process_iter", _shifted_iter)
+        monkeypatch.setattr(memory_process, "_process_creation_stamp", _stamp_immune_to_wall_drift)
         process = EverOSProcess(sys.executable, effective_home=tmp_path, settings=_settings())
         await process._terminate_owned_tree(
             child,
@@ -966,6 +974,38 @@ async def test_sidecar_cleanup_never_signals_spawned_pid_after_identity_changes(
             except TimeoutError:
                 child.kill()
                 await child.wait()
+
+
+def test_sidecar_cleanup_reverifies_asyncio_pid_before_signaling(monkeypatch) -> None:
+    signals: list[int] = []
+
+    class _Transport:
+        def get_pid(self) -> int:
+            return _ORPHAN_PID
+
+        def get_returncode(self) -> None:
+            # Models the interval after waitpid() reaped the child but before
+            # asyncio's scheduled process-exited callback updates the transport.
+            return None
+
+        def send_signal(self, signum: int) -> None:
+            signals.append(signum)
+
+    class _Protocol:
+        stdin = None
+        stdout = None
+        stderr = None
+
+    process = asyncio.subprocess.Process(_Transport(), _Protocol(), None)
+    monkeypatch.setattr(memory_process, "_confirmed_owned_processes", lambda _identities: {})
+
+    _SystemProcessHost().signal(
+        {_ORPHAN_PID: _ORPHAN_CREATE_TIME},
+        signal.SIGTERM,
+        process=process,
+    )
+
+    assert signals == []
 
 
 def test_sidecar_cleanup_does_not_group_signal_an_unconfirmed_member(monkeypatch) -> None:
@@ -1153,8 +1193,9 @@ def _orphan_record(process: EverOSProcess, **overrides) -> dict:
 
 
 def _orphan_identity(process: EverOSProcess, **overrides) -> _ProcessIdentity:
+    creation_stamp = overrides.pop("create_time", _ORPHAN_CREATE_TIME)
     fields = {
-        "create_time": _ORPHAN_CREATE_TIME,
+        "create_time": creation_stamp,
         "cmdline": (
             sys.executable,
             "-m",
@@ -1163,6 +1204,7 @@ def _orphan_identity(process: EverOSProcess, **overrides) -> _ProcessIdentity:
             str(process.socket_path),
         ),
         "uid": os.getuid() if hasattr(os, "getuid") else None,
+        "wall_create_time": overrides.pop("wall_create_time", creation_stamp),
     }
     fields.update(overrides)
     return _ProcessIdentity(**fields)
@@ -1252,6 +1294,23 @@ def test_recorded_sidecar_identity_accepts_only_a_provably_owned_orphan(tmp_path
         )
 
 
+def test_inspect_identity_keeps_wall_clock_beside_linux_starttime_ticks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(memory_process, "_uses_linux_starttime_stamp", lambda: True)
+    monkeypatch.setattr(memory_process, "_read_linux_starttime_ticks", lambda _pid: 99.0)
+    monkeypatch.setattr(memory_process.psutil, "Process", _guarded_process_class(uid=4_242))
+
+    identity = memory_process._inspect_process_identity(_ORPHAN_PID)
+
+    assert identity == _ProcessIdentity(
+        create_time=99.0,
+        cmdline=None,
+        uid=4_242,
+        wall_create_time=_ORPHAN_CREATE_TIME,
+    )
+
+
 def test_linux_creation_stamp_reads_starttime_ticks_not_wall_clock(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1266,6 +1325,23 @@ def test_linux_creation_stamp_reads_starttime_ticks_not_wall_clock(
             return _ORPHAN_CREATE_TIME + 48.0
 
     assert memory_process._process_creation_stamp(_Proc()) == ticks
+
+
+def test_linux_process_identity_keeps_wall_time_for_legacy_records(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ticks = 424_242.0
+    guarded = _guarded_process_class(create_time=_ORPHAN_CREATE_TIME, uid=4_242)
+    monkeypatch.setattr(memory_process.psutil, "Process", guarded)
+    monkeypatch.setattr(memory_process, "_uses_linux_starttime_stamp", lambda: True)
+    monkeypatch.setattr(memory_process, "_read_linux_starttime_ticks", lambda _pid: ticks)
+
+    assert memory_process._inspect_process_identity(_ORPHAN_PID) == _ProcessIdentity(
+        create_time=ticks,
+        cmdline=None,
+        uid=4_242,
+        wall_create_time=_ORPHAN_CREATE_TIME,
+    )
 
 
 def test_parse_proc_stat_starttime_handles_spaces_in_comm() -> None:
@@ -1292,19 +1368,21 @@ def test_creation_stamp_falls_back_to_create_time_off_linux(
 def test_legacy_record_accepts_bounded_create_time_drift_when_facts_match(
     tmp_path: Path,
 ) -> None:
+    ticks = 424_242.0
     drifted = _ORPHAN_CREATE_TIME + 48.0
-    host = _FakeProcessHost(live_processes={_ORPHAN_PID: drifted})
+    host = _FakeProcessHost(live_processes={_ORPHAN_PID: ticks})
     process = _orphan_process(tmp_path, host=host)
     host.identities[_ORPHAN_PID] = _orphan_identity(
         process,
-        create_time=drifted,
+        create_time=ticks,
+        wall_create_time=drifted,
         environment={"EVEROS_ROOT": str(process.provider_root)},
     )
     record_path = _write_orphan_record(process, _orphan_record(process))
 
     asyncio.run(process._ownership.reap())
 
-    assert host.signal_calls == [({_ORPHAN_PID: drifted}, signal.SIGTERM, None, None)]
+    assert host.signal_calls == [({_ORPHAN_PID: ticks}, signal.SIGTERM, None, None)]
     assert not record_path.exists()
 
 
@@ -1316,7 +1394,8 @@ def test_legacy_record_rejects_create_time_drift_when_cmdline_mismatches(
         _orphan_record(process),
         _orphan_identity(
             process,
-            create_time=_ORPHAN_CREATE_TIME + 48.0,
+            create_time=424_242.0,
+            wall_create_time=_ORPHAN_CREATE_TIME + 48.0,
             cmdline=(sys.executable, "-m", "http.server"),
             environment={"EVEROS_ROOT": str(process.provider_root)},
         ),
@@ -1333,7 +1412,8 @@ def test_legacy_record_treats_undisclosed_cmdline_as_unverifiable_on_create_time
         _orphan_record(process),
         _orphan_identity(
             process,
-            create_time=_ORPHAN_CREATE_TIME + 48.0,
+            create_time=424_242.0,
+            wall_create_time=_ORPHAN_CREATE_TIME + 48.0,
             cmdline=None,
             environment={"EVEROS_ROOT": str(process.provider_root)},
         ),
@@ -1500,7 +1580,12 @@ def test_process_identity_reports_undisclosed_fields_instead_of_gone(
 
     identity = memory_process._inspect_process_identity(_ORPHAN_PID)
 
-    assert identity == _ProcessIdentity(create_time=_ORPHAN_CREATE_TIME, cmdline=None, uid=4_242)
+    assert identity == _ProcessIdentity(
+        create_time=_ORPHAN_CREATE_TIME,
+        cmdline=None,
+        uid=4_242,
+        wall_create_time=_ORPHAN_CREATE_TIME,
+    )
 
     class _Zombie(guarded):
         def status(self) -> str:
@@ -1530,6 +1615,7 @@ def test_process_identity_reports_undisclosed_fields_instead_of_gone(
         create_time=_ORPHAN_CREATE_TIME,
         cmdline=None,
         uid=None,
+        wall_create_time=_ORPHAN_CREATE_TIME,
     )
 
 
@@ -2922,6 +3008,7 @@ def test_sidecar_and_rebuild_use_one_physical_identity_for_a_symlinked_home(
             "EVEROS_ROOT": str(logical_provider_root),
             "AVIBE_MEMORY_CHILD_ROLE": "sidecar",
         },
+        wall_create_time=_ORPHAN_CREATE_TIME,
     )
     assert _classify_recorded_child(
         legacy_spelling_record,
@@ -4346,8 +4433,9 @@ def _rebuild_record(process: EverOSRebuildProcess, **overrides) -> dict:
 
 
 def _rebuild_identity(process: EverOSRebuildProcess, **overrides) -> _ProcessIdentity:
+    creation_stamp = overrides.pop("create_time", _ORPHAN_CREATE_TIME)
     fields = {
-        "create_time": _ORPHAN_CREATE_TIME,
+        "create_time": creation_stamp,
         "cmdline": (
             sys.executable,
             "-m",
@@ -4361,6 +4449,7 @@ def _rebuild_identity(process: EverOSRebuildProcess, **overrides) -> _ProcessIde
             "EVEROS_ROOT": str(process._provider_root),
             "AVIBE_MEMORY_CHILD_ROLE": "cascade_rebuild",
         },
+        "wall_create_time": overrides.pop("wall_create_time", creation_stamp),
     }
     fields.update(overrides)
     return _ProcessIdentity(**fields)

--- a/tests/test_memory_process.py
+++ b/tests/test_memory_process.py
@@ -1498,11 +1498,11 @@ def test_creation_stamp_falls_back_to_create_time_off_linux(
     assert memory_process._process_creation_stamp(_Proc()) == _ORPHAN_CREATE_TIME
 
 
-def test_legacy_record_accepts_bounded_create_time_drift_when_facts_match(
+def test_legacy_record_accepts_arbitrary_create_time_drift_when_facts_match(
     tmp_path: Path,
 ) -> None:
     ticks = 424_242.0
-    drifted = _ORPHAN_CREATE_TIME + 48.0
+    drifted = _ORPHAN_CREATE_TIME + 86_400.0
     host = _FakeProcessHost(live_processes={_ORPHAN_PID: ticks})
     process = _orphan_process(tmp_path, host=host)
     host.identities[_ORPHAN_PID] = _orphan_identity(
@@ -1528,7 +1528,7 @@ def test_legacy_record_rejects_create_time_drift_when_cmdline_mismatches(
         _orphan_identity(
             process,
             create_time=424_242.0,
-            wall_create_time=_ORPHAN_CREATE_TIME + 48.0,
+            wall_create_time=_ORPHAN_CREATE_TIME + 86_400.0,
             cmdline=(sys.executable, "-m", "http.server"),
             environment={"EVEROS_ROOT": str(process.provider_root)},
         ),
@@ -1546,7 +1546,7 @@ def test_legacy_record_treats_undisclosed_cmdline_as_unverifiable_on_create_time
         _orphan_identity(
             process,
             create_time=424_242.0,
-            wall_create_time=_ORPHAN_CREATE_TIME + 48.0,
+            wall_create_time=_ORPHAN_CREATE_TIME + 86_400.0,
             cmdline=None,
             environment={"EVEROS_ROOT": str(process.provider_root)},
         ),
@@ -1608,12 +1608,12 @@ def test_sidecar_record_omits_wall_create_time_when_undisclosed(
     assert recorded["starttime_ticks"] == 4242.0
 
 
-def test_legacy_linux_ticks_identity_reaps_when_live_wall_drift_is_bounded(
+def test_legacy_linux_ticks_identity_reaps_after_arbitrary_wall_clock_step(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     ticks = 424_242.0
-    drifted_wall = _ORPHAN_CREATE_TIME + 48.0
+    drifted_wall = _ORPHAN_CREATE_TIME + 86_400.0
     helper = {_ORPHAN_GROUP_HELPER_PID: _ORPHAN_CREATE_TIME + 1}
     host = _FakeProcessHost(
         process_groups={_ORPHAN_PID: _ORPHAN_PID},
@@ -1638,7 +1638,7 @@ def test_legacy_linux_ticks_identity_reaps_when_live_wall_drift_is_bounded(
     assert not record_path.exists()
 
 
-def test_legacy_linux_ticks_identity_rejects_live_wall_drift_beyond_bound(
+def test_legacy_linux_ticks_identity_accepts_large_wall_drift_with_exact_facts(
     tmp_path: Path,
 ) -> None:
     process = _orphan_process(tmp_path)
@@ -1647,12 +1647,12 @@ def test_legacy_linux_ticks_identity_rejects_live_wall_drift_beyond_bound(
         _orphan_identity(
             process,
             stamp=424_242.0,
-            wall_create_time=_ORPHAN_CREATE_TIME + 301.0,
+            wall_create_time=_ORPHAN_CREATE_TIME + 7 * 86_400.0,
             environment={"EVEROS_ROOT": str(process.provider_root)},
         ),
         socket_path=process.socket_path,
         provider_root=process.provider_root,
-    ) is _RecordedSidecar.NOT_OURS
+    ) is _RecordedSidecar.OURS
 
 
 def test_new_sidecar_role_record_reaps_with_exact_role_environment(tmp_path: Path) -> None:

--- a/tests/test_memory_process.py
+++ b/tests/test_memory_process.py
@@ -855,7 +855,7 @@ async def test_sidecar_stop_reaps_direct_child_after_create_time_clock_step(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    """A CLOCK_REALTIME step must not block SIGTERM on the handle we own."""
+    """A CLOCK_REALTIME step must not block SIGTERM for a stable child stamp."""
 
     child = await asyncio.create_subprocess_exec(
         sys.executable,
@@ -954,7 +954,13 @@ async def test_sidecar_cleanup_never_signals_spawned_pid_after_identity_changes(
             def send_signal(self, signum: int) -> None:
                 signals.append(("psutil", signum))
 
+        def _reused_stamp(_proc: object) -> float:
+            # Linux identity is starttime ticks, not create_time(). Shift the
+            # stamp itself so this still models a recycled pid on CI.
+            return captured_at + 1.0
+
         monkeypatch.setattr(memory_process.psutil, "Process", _ReusedProcess)
+        monkeypatch.setattr(memory_process, "_process_creation_stamp", _reused_stamp)
         try:
             host.signal(identities, signal.SIGTERM)
             host.signal(
@@ -1006,6 +1012,65 @@ def test_sidecar_cleanup_reverifies_asyncio_pid_before_signaling(monkeypatch) ->
     )
 
     assert signals == []
+
+
+async def test_sidecar_wait_never_discovers_from_a_reused_asyncio_pid(monkeypatch) -> None:
+    identities = {_ORPHAN_PID: _ORPHAN_CREATE_TIME}
+    snapshot_calls: list[tuple[int, int | None]] = []
+
+    class _ReapedChild:
+        pid = _ORPHAN_PID
+        returncode = None
+
+        async def wait(self) -> int:
+            return 0
+
+    def snapshot(pid: int, process_group: int | None) -> dict[int, float]:
+        snapshot_calls.append((pid, process_group))
+        return {
+            _ORPHAN_PID: _ORPHAN_CREATE_TIME + 1,
+            _ORPHAN_DESCENDANT_PID: _ORPHAN_CREATE_TIME + 2,
+        }
+
+    monkeypatch.setattr(memory_process, "_snapshot_owned_processes", snapshot)
+    monkeypatch.setattr(memory_process, "_live_owned_processes", lambda _identities: {})
+
+    assert await memory_process._wait_for_owned_exit(
+        _ReapedChild(),
+        process_group=_ORPHAN_PID,
+        identities=identities,
+        timeout_seconds=0.1,
+    )
+    assert snapshot_calls == []
+    assert identities == {_ORPHAN_PID: _ORPHAN_CREATE_TIME}
+
+
+def test_owned_tree_refresh_reverifies_the_root_after_snapshot() -> None:
+    identities = {_ORPHAN_PID: _ORPHAN_CREATE_TIME}
+
+    class _ReusingHost(_FakeProcessHost):
+        def snapshot_tree(self, pid: int, process_group: int | None) -> dict[int, float]:
+            snapshot = super().snapshot_tree(pid, process_group)
+            self.live_processes[pid] = _ORPHAN_CREATE_TIME + 1
+            return snapshot
+
+    host = _ReusingHost(
+        live_processes=dict(identities),
+        trees={
+            (_ORPHAN_PID, _ORPHAN_PID): {
+                _ORPHAN_PID: _ORPHAN_CREATE_TIME,
+                _ORPHAN_DESCENDANT_PID: _ORPHAN_CREATE_TIME + 2,
+            }
+        },
+    )
+
+    assert not memory_process._refresh_owned_process_tree(
+        host,
+        identities,
+        _ORPHAN_PID,
+        _ORPHAN_PID,
+    )
+    assert identities == {_ORPHAN_PID: _ORPHAN_CREATE_TIME}
 
 
 def test_sidecar_cleanup_does_not_group_signal_an_unconfirmed_member(monkeypatch) -> None:
@@ -1193,9 +1258,9 @@ def _orphan_record(process: EverOSProcess, **overrides) -> dict:
 
 
 def _orphan_identity(process: EverOSProcess, **overrides) -> _ProcessIdentity:
-    creation_stamp = overrides.pop("create_time", _ORPHAN_CREATE_TIME)
+    creation_stamp = overrides.pop("stamp", overrides.pop("create_time", _ORPHAN_CREATE_TIME))
     fields = {
-        "create_time": creation_stamp,
+        "stamp": creation_stamp,
         "cmdline": (
             sys.executable,
             "-m",
@@ -1309,7 +1374,7 @@ def test_inspect_identity_keeps_wall_clock_beside_linux_starttime_ticks(
     identity = memory_process._inspect_process_identity(_ORPHAN_PID)
 
     assert identity == _ProcessIdentity(
-        create_time=99.0,
+        stamp=99.0,
         cmdline=None,
         uid=4_242,
         wall_create_time=_ORPHAN_CREATE_TIME,
@@ -1334,9 +1399,58 @@ def test_linux_creation_stamp_reads_starttime_ticks_not_wall_clock(
 
 def test_parse_proc_stat_starttime_handles_spaces_in_comm() -> None:
     # Field 2 (comm) can contain spaces and parentheses. Field 22 is starttime.
-    after_comm = ["S"] + ["0"] * 18 + ["987654", "1"]
-    stat_text = "42 (python 3.11) " + " ".join(after_comm)
-    assert memory_process._parse_proc_stat_starttime(stat_text) == 987654.0
+    after_comm = [b"S"] + [b"0"] * 18 + [b"987654", b"1"]
+    stat_data = b"42 (python 3.11) " + b" ".join(after_comm)
+    assert memory_process._parse_proc_stat_starttime(stat_data) == 987654.0
+
+
+def test_linux_starttime_reader_accepts_non_utf8_comm(monkeypatch: pytest.MonkeyPatch) -> None:
+    after_comm = [b"S"] + [b"0"] * 18 + [b"987654", b"1"]
+    stat_data = b"42 (worker-\xff) " + b" ".join(after_comm)
+
+    monkeypatch.setattr(Path, "read_bytes", lambda _path: stat_data)
+    monkeypatch.setattr(
+        Path,
+        "read_text",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+        ),
+    )
+
+    assert memory_process._read_linux_starttime_ticks(_ORPHAN_PID) == 987654.0
+
+
+@pytest.mark.parametrize("stamp", [float("nan"), float("inf"), float("-inf"), 10**1000])
+def test_identity_stamps_must_be_finite(stamp: float | int) -> None:
+    assert not memory_process._is_identity_stamp(stamp)
+
+
+def test_legacy_record_rejects_a_nan_creation_stamp(tmp_path: Path) -> None:
+    process = _orphan_process(tmp_path)
+    assert _classify_recorded_sidecar(
+        _orphan_record(process, create_time=float("nan")),
+        _orphan_identity(
+            process,
+            wall_create_time=_ORPHAN_CREATE_TIME + 48.0,
+            environment={"EVEROS_ROOT": str(process.provider_root)},
+        ),
+        socket_path=process.socket_path,
+        provider_root=process.provider_root,
+    ) is _RecordedSidecar.NOT_OURS
+
+
+def test_legacy_record_treats_a_nan_live_creation_stamp_as_unverifiable(tmp_path: Path) -> None:
+    process = _orphan_process(tmp_path)
+    assert _classify_recorded_sidecar(
+        _orphan_record(process),
+        _orphan_identity(
+            process,
+            wall_create_time=float("nan"),
+            environment={"EVEROS_ROOT": str(process.provider_root)},
+        ),
+        socket_path=process.socket_path,
+        provider_root=process.provider_root,
+    ) is _RecordedSidecar.UNVERIFIABLE
 
 
 def test_creation_stamp_falls_back_to_create_time_off_linux(
@@ -1445,6 +1559,76 @@ def test_sidecar_record_writes_starttime_ticks_on_linux(
 
     assert recorded["create_time"] == _ORPHAN_CREATE_TIME
     assert recorded["starttime_ticks"] == 4242.0
+
+
+def test_sidecar_record_omits_wall_create_time_when_undisclosed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(memory_process, "_uses_linux_starttime_stamp", lambda: True)
+    monkeypatch.setattr(memory_process, "_process_wall_create_time", lambda _pid: None)
+    process = _orphan_process(tmp_path)
+    process._ownership.record_path.parent.mkdir(parents=True, exist_ok=True)
+
+    process._ownership.record_launch(_ORPHAN_PID, 4242.0, _ORPHAN_PID)
+    recorded = json.loads(process._ownership.record_path.read_text(encoding="utf-8"))
+
+    assert recorded["create_time"] is None
+    assert recorded["starttime_ticks"] == 4242.0
+
+
+def test_legacy_linux_ticks_identity_reaps_when_live_wall_drift_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    ticks = 424_242.0
+    drifted_wall = _ORPHAN_CREATE_TIME + 48.0
+    helper = {_ORPHAN_GROUP_HELPER_PID: _ORPHAN_CREATE_TIME + 1}
+    monkeypatch.setattr(memory_process, "_process_wall_create_time", lambda _pid: drifted_wall)
+    host = _FakeProcessHost(
+        process_groups={_ORPHAN_PID: _ORPHAN_PID},
+        groups={_ORPHAN_PID: (dict(helper), [])},
+        live_processes={_ORPHAN_PID: ticks, **helper},
+        trees={(_ORPHAN_PID, _ORPHAN_PID): {_ORPHAN_PID: ticks, **helper}},
+    )
+    process = _orphan_process(tmp_path, host=host)
+    host.identities[_ORPHAN_PID] = _orphan_identity(
+        process,
+        stamp=ticks,
+        wall_create_time=None,
+        environment={"EVEROS_ROOT": str(process.provider_root)},
+    )
+    record_path = _write_orphan_record(process, _orphan_record(process))
+
+    asyncio.run(process._ownership.reap())
+
+    signaled = {pid for call in host.signal_calls for pid in call[0]}
+    assert _ORPHAN_PID in signaled
+    assert _ORPHAN_GROUP_HELPER_PID in signaled
+    assert not record_path.exists()
+
+
+def test_legacy_linux_ticks_identity_rejects_live_wall_drift_beyond_bound(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        memory_process,
+        "_process_wall_create_time",
+        lambda _pid: _ORPHAN_CREATE_TIME + 301.0,
+    )
+    process = _orphan_process(tmp_path)
+    assert _classify_recorded_sidecar(
+        _orphan_record(process),
+        _orphan_identity(
+            process,
+            stamp=424_242.0,
+            wall_create_time=None,
+            environment={"EVEROS_ROOT": str(process.provider_root)},
+        ),
+        socket_path=process.socket_path,
+        provider_root=process.provider_root,
+    ) is _RecordedSidecar.NOT_OURS
 
 
 def test_new_sidecar_role_record_reaps_with_exact_role_environment(tmp_path: Path) -> None:
@@ -1569,7 +1753,7 @@ def test_process_identity_reports_undisclosed_fields_instead_of_gone(
     identity = memory_process._inspect_process_identity(_ORPHAN_PID)
 
     assert identity == _ProcessIdentity(
-        create_time=_ORPHAN_CREATE_TIME,
+        stamp=_ORPHAN_CREATE_TIME,
         cmdline=None,
         uid=4_242,
         wall_create_time=_ORPHAN_CREATE_TIME,
@@ -1600,7 +1784,7 @@ def test_process_identity_reports_undisclosed_fields_instead_of_gone(
     monkeypatch.setattr(memory_process.psutil, "Process", _NoUidsPlatform)
 
     assert memory_process._inspect_process_identity(_ORPHAN_PID) == _ProcessIdentity(
-        create_time=_ORPHAN_CREATE_TIME,
+        stamp=_ORPHAN_CREATE_TIME,
         cmdline=None,
         uid=None,
         wall_create_time=_ORPHAN_CREATE_TIME,
@@ -1771,7 +1955,7 @@ def test_sidecar_launch_fails_closed_on_a_live_pid_it_cannot_describe(
         socket_path=short_socket_path,
     )
     host.identities[_ORPHAN_PID] = _ProcessIdentity(
-        create_time=_ORPHAN_CREATE_TIME,
+        stamp=_ORPHAN_CREATE_TIME,
         cmdline=None,
         uid=os.getuid() if hasattr(os, "getuid") else None,
     )
@@ -1811,7 +1995,7 @@ def test_sidecar_launch_proceeds_past_a_recycled_pid_owned_by_another_user(
         socket_path=short_socket_path,
     )
     host.identities[_ORPHAN_PID] = _ProcessIdentity(
-        create_time=_ORPHAN_CREATE_TIME,
+        stamp=_ORPHAN_CREATE_TIME,
         cmdline=None,
         uid=foreign_uid,
     )
@@ -1840,6 +2024,8 @@ def test_sidecar_records_a_verified_launch_identity_privately(tmp_path: Path) ->
     )
     if memory_process._uses_linux_starttime_stamp():
         expected["starttime_ticks"] = _ORPHAN_CREATE_TIME
+        # Fake pid has no wall-clock create_time; do not store ticks there.
+        expected["create_time"] = None
     assert recorded == expected
     assert stat.S_IMODE(process._ownership.record_path.lstat().st_mode) == 0o600
 
@@ -2983,7 +3169,7 @@ def test_sidecar_and_rebuild_use_one_physical_identity_for_a_symlinked_home(
         "python": sys.executable,
     }
     legacy_spelling_identity = _ProcessIdentity(
-        create_time=_ORPHAN_CREATE_TIME,
+        stamp=_ORPHAN_CREATE_TIME,
         cmdline=(
             sys.executable,
             "-m",
@@ -4421,9 +4607,9 @@ def _rebuild_record(process: EverOSRebuildProcess, **overrides) -> dict:
 
 
 def _rebuild_identity(process: EverOSRebuildProcess, **overrides) -> _ProcessIdentity:
-    creation_stamp = overrides.pop("create_time", _ORPHAN_CREATE_TIME)
+    creation_stamp = overrides.pop("stamp", overrides.pop("create_time", _ORPHAN_CREATE_TIME))
     fields = {
-        "create_time": creation_stamp,
+        "stamp": creation_stamp,
         "cmdline": (
             sys.executable,
             "-m",
@@ -4845,7 +5031,7 @@ async def test_rebuild_boot_without_artifact_python_discovers_and_reaps_child(
         process_groups={_ORPHAN_PID: _ORPHAN_PID},
         identities={
             _ORPHAN_PID: _ProcessIdentity(
-                create_time=_ORPHAN_CREATE_TIME,
+                stamp=_ORPHAN_CREATE_TIME,
                 cmdline=(
                     sys.executable,
                     "-m",
@@ -4910,7 +5096,7 @@ async def test_rebuild_boot_discovers_an_orphan_from_the_previous_artifact(
         process_groups={_ORPHAN_PID: _ORPHAN_PID},
         identities={
             _ORPHAN_PID: _ProcessIdentity(
-                create_time=_ORPHAN_CREATE_TIME,
+                stamp=_ORPHAN_CREATE_TIME,
                 cmdline=(
                     str(old_python),
                     "-m",
@@ -5019,7 +5205,7 @@ async def test_rebuild_boot_discovers_exact_survivor_after_reaping_valid_record(
             _ORPHAN_PID: _rebuild_identity(process),
             _ORPHAN_DESCENDANT_PID: _rebuild_identity(
                 process,
-                create_time=_ORPHAN_CREATE_TIME + 1,
+                stamp=_ORPHAN_CREATE_TIME + 1,
             ),
         }
     )
@@ -5274,7 +5460,7 @@ async def test_sidecar_start_refuses_live_cross_home_peer_on_shared_root(
         root_sidecars={_ORPHAN_PID: _ORPHAN_CREATE_TIME},
         identities={
             _ORPHAN_PID: _ProcessIdentity(
-                create_time=_ORPHAN_CREATE_TIME,
+                stamp=_ORPHAN_CREATE_TIME,
                 cmdline=(
                     sys.executable,
                     "-m",

--- a/tests/test_memory_process.py
+++ b/tests/test_memory_process.py
@@ -916,6 +916,37 @@ async def test_sidecar_stop_reaps_direct_child_after_create_time_clock_step(
                 await child.wait()
 
 
+async def test_sidecar_stop_signals_real_child_when_identity_stamp_is_poisoned(
+    tmp_path: Path,
+) -> None:
+    child = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        "import time; time.sleep(60)",
+        start_new_session=True,
+    )
+    try:
+        assert memory_process._live_direct_child_handle(child) is True
+        process_group = os.getpgid(child.pid)
+        identities = {child.pid: _ORPHAN_CREATE_TIME}
+        process = EverOSProcess(sys.executable, effective_home=tmp_path, settings=_settings())
+        await process._terminate_owned_tree(
+            child,
+            process_group=process_group,
+            owned_processes=identities,
+        )
+        assert child.returncode is not None
+        assert not _pid_exists(child.pid)
+    finally:
+        if child.returncode is None:
+            child.terminate()
+            try:
+                await asyncio.wait_for(child.wait(), timeout=3.0)
+            except TimeoutError:
+                child.kill()
+                await child.wait()
+
+
 async def test_sidecar_cleanup_never_signals_spawned_pid_after_identity_changes(monkeypatch, tmp_path: Path) -> None:
     signals: list[tuple[str, int]] = []
 
@@ -1586,7 +1617,6 @@ def test_legacy_linux_ticks_identity_reaps_when_live_wall_drift_is_bounded(
     ticks = 424_242.0
     drifted_wall = _ORPHAN_CREATE_TIME + 48.0
     helper = {_ORPHAN_GROUP_HELPER_PID: _ORPHAN_CREATE_TIME + 1}
-    monkeypatch.setattr(memory_process, "_process_wall_create_time", lambda _pid: drifted_wall)
     host = _FakeProcessHost(
         process_groups={_ORPHAN_PID: _ORPHAN_PID},
         groups={_ORPHAN_PID: (dict(helper), [])},
@@ -1597,7 +1627,7 @@ def test_legacy_linux_ticks_identity_reaps_when_live_wall_drift_is_bounded(
     host.identities[_ORPHAN_PID] = _orphan_identity(
         process,
         stamp=ticks,
-        wall_create_time=None,
+        wall_create_time=drifted_wall,
         environment={"EVEROS_ROOT": str(process.provider_root)},
     )
     record_path = _write_orphan_record(process, _orphan_record(process))
@@ -1611,21 +1641,15 @@ def test_legacy_linux_ticks_identity_reaps_when_live_wall_drift_is_bounded(
 
 
 def test_legacy_linux_ticks_identity_rejects_live_wall_drift_beyond_bound(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    monkeypatch.setattr(
-        memory_process,
-        "_process_wall_create_time",
-        lambda _pid: _ORPHAN_CREATE_TIME + 301.0,
-    )
     process = _orphan_process(tmp_path)
     assert _classify_recorded_sidecar(
         _orphan_record(process),
         _orphan_identity(
             process,
             stamp=424_242.0,
-            wall_create_time=None,
+            wall_create_time=_ORPHAN_CREATE_TIME + 301.0,
             environment={"EVEROS_ROOT": str(process.provider_root)},
         ),
         socket_path=process.socket_path,

--- a/tests/test_memory_process.py
+++ b/tests/test_memory_process.py
@@ -855,7 +855,7 @@ async def test_sidecar_stop_reaps_direct_child_after_create_time_clock_step(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    """A CLOCK_REALTIME step must not block SIGTERM for a stable child stamp."""
+    """A CLOCK_REALTIME step must not block SIGTERM on the handle we spawned."""
 
     child = await asyncio.create_subprocess_exec(
         sys.executable,
@@ -872,9 +872,9 @@ async def test_sidecar_stop_reaps_direct_child_after_create_time_clock_step(
         original_iter = memory_process.psutil.process_iter
         original_stamp = memory_process._process_creation_stamp
 
-        def _stamp_immune_to_wall_drift(proc: object) -> float:
+        def _shifted_stamp(proc: object) -> float:
             if getattr(proc, "pid", None) == child.pid:
-                return captured_stamp
+                return captured_stamp + 48.0
             return original_stamp(proc)
 
         class _ShiftedProcess:
@@ -897,7 +897,12 @@ async def test_sidecar_stop_reaps_direct_child_after_create_time_clock_step(
 
         monkeypatch.setattr(memory_process.psutil, "Process", _ShiftedProcess)
         monkeypatch.setattr(memory_process.psutil, "process_iter", _shifted_iter)
-        monkeypatch.setattr(memory_process, "_process_creation_stamp", _stamp_immune_to_wall_drift)
+        monkeypatch.setattr(memory_process, "_process_creation_stamp", _shifted_stamp)
+        monkeypatch.setattr(
+            memory_process,
+            "_read_linux_starttime_ticks",
+            lambda _pid: captured_stamp + 48.0,
+        )
         process = EverOSProcess(sys.executable, effective_home=tmp_path, settings=_settings())
         await process._terminate_owned_tree(
             child,

--- a/tests/test_memory_process.py
+++ b/tests/test_memory_process.py
@@ -855,7 +855,7 @@ async def test_sidecar_stop_reaps_direct_child_after_create_time_clock_step(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    """A CLOCK_REALTIME step must not block SIGTERM on the handle we spawned."""
+    """A CLOCK_REALTIME step must not block SIGTERM for a stable child stamp."""
 
     child = await asyncio.create_subprocess_exec(
         sys.executable,
@@ -872,9 +872,9 @@ async def test_sidecar_stop_reaps_direct_child_after_create_time_clock_step(
         original_iter = memory_process.psutil.process_iter
         original_stamp = memory_process._process_creation_stamp
 
-        def _shifted_stamp(proc: object) -> float:
+        def _stamp_immune_to_wall_drift(proc: object) -> float:
             if getattr(proc, "pid", None) == child.pid:
-                return captured_stamp + 48.0
+                return captured_stamp
             return original_stamp(proc)
 
         class _ShiftedProcess:
@@ -897,12 +897,7 @@ async def test_sidecar_stop_reaps_direct_child_after_create_time_clock_step(
 
         monkeypatch.setattr(memory_process.psutil, "Process", _ShiftedProcess)
         monkeypatch.setattr(memory_process.psutil, "process_iter", _shifted_iter)
-        monkeypatch.setattr(memory_process, "_process_creation_stamp", _shifted_stamp)
-        monkeypatch.setattr(
-            memory_process,
-            "_read_linux_starttime_ticks",
-            lambda _pid: captured_stamp + 48.0,
-        )
+        monkeypatch.setattr(memory_process, "_process_creation_stamp", _stamp_immune_to_wall_drift)
         process = EverOSProcess(sys.executable, effective_home=tmp_path, settings=_settings())
         await process._terminate_owned_tree(
             child,

--- a/tests/test_memory_process.py
+++ b/tests/test_memory_process.py
@@ -916,9 +916,7 @@ async def test_sidecar_stop_reaps_direct_child_after_create_time_clock_step(
                 await child.wait()
 
 
-async def test_sidecar_stop_signals_real_child_when_identity_stamp_is_poisoned(
-    tmp_path: Path,
-) -> None:
+async def test_sidecar_stop_does_not_signal_real_child_when_identity_stamp_is_poisoned() -> None:
     child = await asyncio.create_subprocess_exec(
         sys.executable,
         "-c",
@@ -926,17 +924,17 @@ async def test_sidecar_stop_signals_real_child_when_identity_stamp_is_poisoned(
         start_new_session=True,
     )
     try:
-        assert memory_process._live_direct_child_handle(child) is True
         process_group = os.getpgid(child.pid)
         identities = {child.pid: _ORPHAN_CREATE_TIME}
-        process = EverOSProcess(sys.executable, effective_home=tmp_path, settings=_settings())
-        await process._terminate_owned_tree(
+        memory_process._signal_owned_group_or_process(
             child,
-            process_group=process_group,
-            owned_processes=identities,
+            process_group,
+            identities,
+            signal.SIGTERM,
         )
-        assert child.returncode is not None
-        assert not _pid_exists(child.pid)
+        await asyncio.sleep(0.05)
+        assert child.returncode is None
+        assert _pid_exists(child.pid)
     finally:
         if child.returncode is None:
             child.terminate()

--- a/tests/test_memory_process.py
+++ b/tests/test_memory_process.py
@@ -1451,8 +1451,11 @@ def test_linux_starttime_reader_accepts_non_utf8_comm(monkeypatch: pytest.Monkey
     assert memory_process._read_linux_starttime_ticks(_ORPHAN_PID) == 987654.0
 
 
-@pytest.mark.parametrize("stamp", [float("nan"), float("inf"), float("-inf"), 10**1000])
-def test_identity_stamps_must_be_finite(stamp: float | int) -> None:
+@pytest.mark.parametrize(
+    "stamp",
+    [-1.0, float("nan"), float("inf"), float("-inf"), 10**1000],
+)
+def test_identity_stamps_must_be_finite_and_non_negative(stamp: float | int) -> None:
     assert not memory_process._is_identity_stamp(stamp)
 
 

--- a/tests/test_memory_process.py
+++ b/tests/test_memory_process.py
@@ -1283,6 +1283,11 @@ def test_recorded_sidecar_identity_accepts_only_a_provably_owned_orphan(tmp_path
         (_orphan_record(process), _orphan_identity(process, create_time=None, cmdline=None, uid=None)),
         # The creation time alone is withheld, so pid reuse cannot be ruled out.
         (_orphan_record(process), _orphan_identity(process, create_time=None)),
+        # Linux starttime ticks cannot be compared with a legacy epoch value.
+        (
+            _orphan_record(process),
+            _orphan_identity(process, create_time=424_242.0, wall_create_time=None),
+        ),
     ]
     for record, identity in unverifiable:
         assert verdict(record, identity) is _RecordedSidecar.UNVERIFIABLE, (record, identity)
@@ -1325,23 +1330,6 @@ def test_linux_creation_stamp_reads_starttime_ticks_not_wall_clock(
             return _ORPHAN_CREATE_TIME + 48.0
 
     assert memory_process._process_creation_stamp(_Proc()) == ticks
-
-
-def test_linux_process_identity_keeps_wall_time_for_legacy_records(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    ticks = 424_242.0
-    guarded = _guarded_process_class(create_time=_ORPHAN_CREATE_TIME, uid=4_242)
-    monkeypatch.setattr(memory_process.psutil, "Process", guarded)
-    monkeypatch.setattr(memory_process, "_uses_linux_starttime_stamp", lambda: True)
-    monkeypatch.setattr(memory_process, "_read_linux_starttime_ticks", lambda _pid: ticks)
-
-    assert memory_process._inspect_process_identity(_ORPHAN_PID) == _ProcessIdentity(
-        create_time=ticks,
-        cmdline=None,
-        uid=4_242,
-        wall_create_time=_ORPHAN_CREATE_TIME,
-    )
 
 
 def test_parse_proc_stat_starttime_handles_spaces_in_comm() -> None:

--- a/tests/test_memory_process.py
+++ b/tests/test_memory_process.py
@@ -760,6 +760,39 @@ def test_sidecar_safety_monitor_ignores_expected_shutdown(tmp_path: Path, caplog
     assert process._process is child
 
 
+def test_sidecar_safety_monitor_logs_the_underlying_exception(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Child:
+        pid = 999_999
+        returncode = None
+
+    process = EverOSProcess(
+        sys.executable,
+        effective_home=tmp_path,
+        settings=_settings(),
+        _host=_FakeProcessHost(),
+    )
+    child = _Child()
+    process._process = child
+    process._desired_running = True
+    process._owned_processes = {child.pid: 11.0}
+
+    def reject_tree(_pid: int) -> dict[int, float]:
+        raise RuntimeError("sidecar ownership changed during monitoring")
+
+    monkeypatch.setattr(process, "_refresh_owned_processes", reject_tree)
+
+    with caplog.at_level(logging.ERROR, logger=memory_process.logger.name):
+        asyncio.run(process._monitor_child(child))
+
+    assert "EverOS sidecar safety monitor rejected the child tree" in caplog.text
+    assert "sidecar ownership changed during monitoring" in caplog.text
+    assert "recorded_stamp=11.0" in caplog.text
+
+
 async def test_sidecar_stop_reaps_a_descendant_that_leaves_the_child_group(tmp_path: Path) -> None:
     child_pid_path = tmp_path / "detached-child.pid"
     script = (
@@ -816,6 +849,63 @@ def test_sidecar_cleanup_skips_a_reused_pid_identity(monkeypatch, tmp_path: Path
     )
 
     assert signals == []
+
+
+async def test_sidecar_stop_reaps_direct_child_after_create_time_clock_step(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """A CLOCK_REALTIME step must not block SIGTERM on the handle we own."""
+
+    child = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        "import time; time.sleep(60)",
+        start_new_session=True,
+    )
+    try:
+        host = _SystemProcessHost()
+        process_group = os.getpgid(child.pid)
+        identities = host.snapshot_tree(child.pid, process_group)
+        original_process = memory_process.psutil.Process
+        original_iter = memory_process.psutil.process_iter
+
+        class _ShiftedProcess:
+            def __init__(self, process_id: int) -> None:
+                self._inner = original_process(process_id)
+                self.pid = process_id
+
+            def create_time(self) -> float:
+                return float(self._inner.create_time()) + 48.0
+
+            def __getattr__(self, name: str):
+                return getattr(self._inner, name)
+
+        def _shifted_iter(*args, **kwargs):
+            for candidate in original_iter(*args, **kwargs):
+                try:
+                    yield _ShiftedProcess(candidate.pid)
+                except (psutil.Error, OSError):
+                    continue
+
+        monkeypatch.setattr(memory_process.psutil, "Process", _ShiftedProcess)
+        monkeypatch.setattr(memory_process.psutil, "process_iter", _shifted_iter)
+        process = EverOSProcess(sys.executable, effective_home=tmp_path, settings=_settings())
+        await process._terminate_owned_tree(
+            child,
+            process_group=process_group,
+            owned_processes=identities,
+        )
+        assert child.returncode is not None
+        assert not _pid_exists(child.pid)
+    finally:
+        if child.returncode is None:
+            child.terminate()
+            try:
+                await asyncio.wait_for(child.wait(), timeout=3.0)
+            except TimeoutError:
+                child.kill()
+                await child.wait()
 
 
 async def test_sidecar_cleanup_never_signals_spawned_pid_after_identity_changes(monkeypatch, tmp_path: Path) -> None:
@@ -1160,6 +1250,133 @@ def test_recorded_sidecar_identity_accepts_only_a_provably_owned_orphan(tmp_path
         assert verdict(_orphan_record(process), _orphan_identity(process, uid=None)) is (
             _RecordedSidecar.UNVERIFIABLE
         )
+
+
+def test_linux_creation_stamp_reads_starttime_ticks_not_wall_clock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ticks = 424_242.0
+    monkeypatch.setattr(memory_process, "_uses_linux_starttime_stamp", lambda: True)
+    monkeypatch.setattr(memory_process, "_read_linux_starttime_ticks", lambda _pid: ticks)
+
+    class _Proc:
+        pid = 99
+
+        def create_time(self) -> float:
+            return _ORPHAN_CREATE_TIME + 48.0
+
+    assert memory_process._process_creation_stamp(_Proc()) == ticks
+
+
+def test_parse_proc_stat_starttime_handles_spaces_in_comm() -> None:
+    # Field 2 (comm) can contain spaces and parentheses. Field 22 is starttime.
+    after_comm = ["S"] + ["0"] * 18 + ["987654", "1"]
+    stat_text = "42 (python 3.11) " + " ".join(after_comm)
+    assert memory_process._parse_proc_stat_starttime(stat_text) == 987654.0
+
+
+def test_creation_stamp_falls_back_to_create_time_off_linux(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(memory_process, "_uses_linux_starttime_stamp", lambda: False)
+
+    class _Proc:
+        pid = 99
+
+        def create_time(self) -> float:
+            return _ORPHAN_CREATE_TIME
+
+    assert memory_process._process_creation_stamp(_Proc()) == _ORPHAN_CREATE_TIME
+
+
+def test_legacy_record_accepts_bounded_create_time_drift_when_facts_match(
+    tmp_path: Path,
+) -> None:
+    drifted = _ORPHAN_CREATE_TIME + 48.0
+    host = _FakeProcessHost(live_processes={_ORPHAN_PID: drifted})
+    process = _orphan_process(tmp_path, host=host)
+    host.identities[_ORPHAN_PID] = _orphan_identity(
+        process,
+        create_time=drifted,
+        environment={"EVEROS_ROOT": str(process.provider_root)},
+    )
+    record_path = _write_orphan_record(process, _orphan_record(process))
+
+    asyncio.run(process._ownership.reap())
+
+    assert host.signal_calls == [({_ORPHAN_PID: drifted}, signal.SIGTERM, None, None)]
+    assert not record_path.exists()
+
+
+def test_legacy_record_rejects_create_time_drift_when_cmdline_mismatches(
+    tmp_path: Path,
+) -> None:
+    process = _orphan_process(tmp_path)
+    assert _classify_recorded_sidecar(
+        _orphan_record(process),
+        _orphan_identity(
+            process,
+            create_time=_ORPHAN_CREATE_TIME + 48.0,
+            cmdline=(sys.executable, "-m", "http.server"),
+            environment={"EVEROS_ROOT": str(process.provider_root)},
+        ),
+        socket_path=process.socket_path,
+        provider_root=process.provider_root,
+    ) is _RecordedSidecar.NOT_OURS
+
+
+def test_legacy_record_treats_undisclosed_cmdline_as_unverifiable_on_create_time_drift(
+    tmp_path: Path,
+) -> None:
+    process = _orphan_process(tmp_path)
+    assert _classify_recorded_sidecar(
+        _orphan_record(process),
+        _orphan_identity(
+            process,
+            create_time=_ORPHAN_CREATE_TIME + 48.0,
+            cmdline=None,
+            environment={"EVEROS_ROOT": str(process.provider_root)},
+        ),
+        socket_path=process.socket_path,
+        provider_root=process.provider_root,
+    ) is _RecordedSidecar.UNVERIFIABLE
+
+
+def test_recorded_sidecar_prefers_starttime_ticks_over_create_time(tmp_path: Path) -> None:
+    process = _orphan_process(tmp_path)
+    record = _orphan_record(process, starttime_ticks=99.0, create_time=_ORPHAN_CREATE_TIME)
+    assert _classify_recorded_sidecar(
+        record,
+        _orphan_identity(process, create_time=99.0),
+        socket_path=process.socket_path,
+        provider_root=process.provider_root,
+    ) is _RecordedSidecar.OURS
+    assert _classify_recorded_sidecar(
+        record,
+        _orphan_identity(process, create_time=_ORPHAN_CREATE_TIME),
+        socket_path=process.socket_path,
+        provider_root=process.provider_root,
+    ) is _RecordedSidecar.NOT_OURS
+
+
+def test_sidecar_record_writes_starttime_ticks_on_linux(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(memory_process, "_uses_linux_starttime_stamp", lambda: True)
+    monkeypatch.setattr(
+        memory_process,
+        "_process_wall_create_time",
+        lambda _pid: _ORPHAN_CREATE_TIME,
+    )
+    process = _orphan_process(tmp_path)
+    process._ownership.record_path.parent.mkdir(parents=True, exist_ok=True)
+
+    process._ownership.record_launch(_ORPHAN_PID, 4242.0, _ORPHAN_PID)
+    recorded = json.loads(process._ownership.record_path.read_text(encoding="utf-8"))
+
+    assert recorded["create_time"] == _ORPHAN_CREATE_TIME
+    assert recorded["starttime_ticks"] == 4242.0
 
 
 def test_new_sidecar_role_record_reaps_with_exact_role_environment(tmp_path: Path) -> None:
@@ -1542,11 +1759,14 @@ def test_sidecar_records_a_verified_launch_identity_privately(tmp_path: Path) ->
     process._ownership.record_launch(_ORPHAN_PID, _ORPHAN_CREATE_TIME, _ORPHAN_PID)
     recorded = json.loads(process._ownership.record_path.read_text(encoding="utf-8"))
 
-    assert recorded == _orphan_record(
+    expected = _orphan_record(
         process,
         role="sidecar",
         python=sys.executable,
     )
+    if memory_process._uses_linux_starttime_stamp():
+        expected["starttime_ticks"] = _ORPHAN_CREATE_TIME
+    assert recorded == expected
     assert stat.S_IMODE(process._ownership.record_path.lstat().st_mode) == 0o600
 
     process._ownership.record_path.unlink()

--- a/tests/test_memory_process.py
+++ b/tests/test_memory_process.py
@@ -986,6 +986,8 @@ def test_sidecar_cleanup_reverifies_asyncio_pid_before_signaling(monkeypatch) ->
     signals: list[int] = []
 
     class _Transport:
+        _proc = SimpleNamespace(returncode=None)
+
         def get_pid(self) -> int:
             return _ORPHAN_PID
 

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -6684,6 +6684,7 @@ async def test_rebuild_settlement_survives_candidate_activation_failure(
 async def test_runtime_restart_stop_failure_retains_old_process_and_paused_claims(
     tmp_path: Path,
     memory_runtime_factory,
+    caplog,
 ) -> None:
     factory = FakeEverOSProcessFactory()
     runtime = memory_runtime_factory(
@@ -6695,10 +6696,13 @@ async def test_runtime_restart_stop_failure_retains_old_process_and_paused_claim
     old = FakeEverOSProcess(stop_failure=RuntimeError("still owned"))
     runtime._process = old
 
-    assert await runtime.restart() == {
-        "ok": False,
-        "error": "memory_restart_failed",
-    }
+    with caplog.at_level(logging.ERROR, logger=memory_runtime.logger.name):
+        assert await runtime.restart() == {
+            "ok": False,
+            "error": "memory_restart_failed",
+        }
+    assert "Memory sidecar restart failed" in caplog.text
+    assert "still owned" in caplog.text
     assert runtime._process is old
     assert factory.created == []
     assert runtime.module._worker._claims_paused is True

--- a/tests/test_memory_sync_process.py
+++ b/tests/test_memory_sync_process.py
@@ -306,7 +306,7 @@ async def test_live_parent_keeps_record_when_identity_stamp_is_linux_ticks(
                 cmdline=("avibe",),
                 uid=uid,
                 environment={},
-                wall_create_time=8.25 + 48.0,
+                wall_create_time=8.25 + 86_400.0,
             )
         }
     )
@@ -344,7 +344,7 @@ async def test_legacy_sync_child_with_wall_clock_record_is_not_removed_as_recycl
                 cmdline=tuple(record["argv"]),
                 uid=uid,
                 environment=environment,
-                wall_create_time=10.5 + 48.0,
+                wall_create_time=10.5 + 86_400.0,
             )
         }
     )
@@ -356,6 +356,43 @@ async def test_legacy_sync_child_with_wall_clock_record_is_not_removed_as_recycl
     assert host.signals
     assert host.signals[0][0] == {451: 424_242.0}
     assert not ownership.path.exists()
+
+
+async def test_legacy_sync_child_with_clock_step_still_rejects_mismatched_facts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(memory_sync_process, "_uses_linux_starttime_stamp", lambda: True)
+    memory_dir = tmp_path / "memory"
+    root = memory_dir / "everos-root"
+    uid = os.getuid() if hasattr(os, "getuid") else None
+    record = _record(root, state="finalized", pid=451)
+    environment = {
+        "EVEROS_ROOT": str(root),
+        "AVIBE_MEMORY_CHILD_ROLE": SYNC_ROLE,
+        SYNC_NONCE_ENV: "a" * 64,
+        SYNC_PARENT_PID_ENV: "99",
+        SYNC_PARENT_CREATE_TIME_ENV: float(8.25).hex(),
+        SYNC_PARENT_UID_ENV: "" if uid is None else str(uid),
+    }
+    host = _Host(
+        {
+            451: _ProcessIdentity(
+                stamp=424_242.0,
+                cmdline=(str(root.parent / "runtime" / "bin" / "python"), "-m", "other"),
+                uid=uid,
+                environment=environment,
+                wall_create_time=10.5 + 86_400.0,
+            )
+        }
+    )
+    ownership = SyncOwnership(sync_record_path(memory_dir), provider_root=root, host=host)
+    ownership.write(record)
+
+    await ownership.reconcile()
+
+    assert not ownership.path.exists()
+    assert host.signals == []
 
 
 async def test_legacy_sync_child_without_wall_time_keeps_record(

--- a/tests/test_memory_sync_process.py
+++ b/tests/test_memory_sync_process.py
@@ -291,7 +291,7 @@ async def test_live_parent_keeps_singleton_sync_record_and_child_untouched(tmp_p
     assert host.signals == []
 
 
-async def test_live_parent_keeps_record_when_identity_stamp_is_linux_ticks(
+async def test_legacy_recycled_parent_pid_does_not_block_cleanup(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -299,7 +299,13 @@ async def test_live_parent_keeps_record_when_identity_stamp_is_linux_ticks(
     memory_dir = tmp_path / "memory"
     root = memory_dir / "everos-root"
     uid = os.getuid() if hasattr(os, "getuid") else None
-    host = _Host(
+
+    class RecycledParentHost(_Host):
+        def recorded_group_members(self, process_group, *, socket_path, provider_root, role=None):
+            del process_group, socket_path, provider_root, role
+            return {}, []
+
+    host = RecycledParentHost(
         {
             99: _ProcessIdentity(
                 stamp=424_242.0,
@@ -313,10 +319,9 @@ async def test_live_parent_keeps_record_when_identity_stamp_is_linux_ticks(
     ownership = SyncOwnership(sync_record_path(memory_dir), provider_root=root, host=host)
     ownership.write(_record(root, state="finalized", pid=451))
 
-    with pytest.raises(SyncOwnershipError, match="live parent"):
-        await ownership.reconcile()
+    await ownership.reconcile()
 
-    assert ownership.path.exists()
+    assert not ownership.path.exists()
     assert host.signals == []
 
 

--- a/tests/test_memory_sync_process.py
+++ b/tests/test_memory_sync_process.py
@@ -245,6 +245,7 @@ async def test_recycled_sync_leader_retires_stale_finalized_record(tmp_path: Pat
     memory_dir = tmp_path / "memory"
     root = memory_dir / "everos-root"
     record = _record(root, state="finalized", pid=451)
+    record["starttime_ticks"] = 10.5
     uid = os.getuid() if hasattr(os, "getuid") else None
     host = _Host(
         {
@@ -276,6 +277,7 @@ async def test_live_parent_keeps_singleton_sync_record_and_child_untouched(tmp_p
                 cmdline=("avibe",),
                 uid=uid,
                 environment={},
+                wall_create_time=8.25,
             )
         }
     )
@@ -283,6 +285,97 @@ async def test_live_parent_keeps_singleton_sync_record_and_child_untouched(tmp_p
     ownership.write(_record(root, state="finalized", pid=451))
 
     with pytest.raises(SyncOwnershipError, match="live parent"):
+        await ownership.reconcile()
+
+    assert ownership.path.exists()
+    assert host.signals == []
+
+
+async def test_live_parent_keeps_record_when_identity_stamp_is_linux_ticks(
+    tmp_path: Path,
+) -> None:
+    memory_dir = tmp_path / "memory"
+    root = memory_dir / "everos-root"
+    uid = os.getuid() if hasattr(os, "getuid") else None
+    host = _Host(
+        {
+            99: _ProcessIdentity(
+                stamp=424_242.0,
+                cmdline=("avibe",),
+                uid=uid,
+                environment={},
+                wall_create_time=8.25,
+            )
+        }
+    )
+    ownership = SyncOwnership(sync_record_path(memory_dir), provider_root=root, host=host)
+    ownership.write(_record(root, state="finalized", pid=451))
+
+    with pytest.raises(SyncOwnershipError, match="live parent"):
+        await ownership.reconcile()
+
+    assert ownership.path.exists()
+    assert host.signals == []
+
+
+async def test_legacy_sync_child_with_wall_clock_record_is_not_removed_as_recycled(
+    tmp_path: Path,
+) -> None:
+    memory_dir = tmp_path / "memory"
+    root = memory_dir / "everos-root"
+    uid = os.getuid() if hasattr(os, "getuid") else None
+    record = _record(root, state="finalized", pid=451)
+    environment = {
+        "EVEROS_ROOT": str(root),
+        "AVIBE_MEMORY_CHILD_ROLE": SYNC_ROLE,
+        SYNC_NONCE_ENV: "a" * 64,
+        SYNC_PARENT_PID_ENV: "99",
+        SYNC_PARENT_CREATE_TIME_ENV: float(8.25).hex(),
+        SYNC_PARENT_UID_ENV: "" if uid is None else str(uid),
+    }
+    host = _Host(
+        {
+            451: _ProcessIdentity(
+                stamp=424_242.0,
+                cmdline=tuple(record["argv"]),
+                uid=uid,
+                environment=environment,
+                wall_create_time=10.5,
+            )
+        }
+    )
+    ownership = SyncOwnership(sync_record_path(memory_dir), provider_root=root, host=host)
+    ownership.write(record)
+
+    await ownership.reconcile()
+
+    assert host.signals
+    assert host.signals[0][0] == {451: 424_242.0}
+    assert not ownership.path.exists()
+
+
+async def test_legacy_sync_child_without_wall_time_keeps_record(
+    tmp_path: Path,
+) -> None:
+    memory_dir = tmp_path / "memory"
+    root = memory_dir / "everos-root"
+    uid = os.getuid() if hasattr(os, "getuid") else None
+    record = _record(root, state="finalized", pid=451)
+    host = _Host(
+        {
+            451: _ProcessIdentity(
+                stamp=424_242.0,
+                cmdline=tuple(record["argv"]),
+                uid=uid,
+                environment={},
+                wall_create_time=None,
+            )
+        }
+    )
+    ownership = SyncOwnership(sync_record_path(memory_dir), provider_root=root, host=host)
+    ownership.write(record)
+
+    with pytest.raises(SyncOwnershipError, match="creation time is unavailable"):
         await ownership.reconcile()
 
     assert ownership.path.exists()
@@ -312,6 +405,7 @@ async def test_retained_failed_cleanup_reconciles_while_its_parent_is_live(
                 cmdline=("avibe",),
                 uid=uid,
                 environment={},
+                wall_create_time=8.25,
             )
         }
     )
@@ -360,6 +454,7 @@ async def test_retained_pending_cleanup_reconciles_while_its_parent_is_live(
                 cmdline=("avibe",),
                 uid=uid,
                 environment={},
+                wall_create_time=8.25,
             )
         }
     )
@@ -414,6 +509,7 @@ async def test_handleless_spawn_failure_marks_discovered_pending_record_retryabl
                 cmdline=("avibe",),
                 uid=uid,
                 environment={},
+                wall_create_time=parent.create_time,
             )
         }
     )
@@ -461,6 +557,7 @@ async def test_handleless_spawn_failure_marks_uncertain_pending_record_retryable
                 cmdline=("avibe",),
                 uid=uid,
                 environment={},
+                wall_create_time=parent.create_time,
             )
         }
     )
@@ -705,6 +802,7 @@ async def test_finalized_sync_reconciliation_cleans_exact_recorded_group(tmp_pat
                 cmdline=tuple(record["argv"]),
                 uid=uid,
                 environment=environment,
+                wall_create_time=10.5,
             )
         }
     )

--- a/tests/test_memory_sync_process.py
+++ b/tests/test_memory_sync_process.py
@@ -44,9 +44,9 @@ class _Host:
         del socket_path, provider_root
         assert role is _MemoryChildRole.CASCADE_SYNC
         return {
-            pid: float(identity.create_time)
+            pid: float(identity.stamp)
             for pid, identity in self.identities.items()
-            if identity.create_time is not None
+            if identity.stamp is not None
         }, []
 
     def signal(self, identities, signum, *, process_group=None, process=None):
@@ -249,7 +249,7 @@ async def test_recycled_sync_leader_retires_stale_finalized_record(tmp_path: Pat
     host = _Host(
         {
             451: _ProcessIdentity(
-                create_time=99.5,
+                stamp=99.5,
                 cmdline=tuple(record["argv"]),
                 uid=uid,
                 environment={},
@@ -272,7 +272,7 @@ async def test_live_parent_keeps_singleton_sync_record_and_child_untouched(tmp_p
     host = _Host(
         {
             99: _ProcessIdentity(
-                create_time=8.25,
+                stamp=8.25,
                 cmdline=("avibe",),
                 uid=uid,
                 environment={},
@@ -308,7 +308,7 @@ async def test_retained_failed_cleanup_reconciles_while_its_parent_is_live(
     host = RetainedCleanupHost(
         {
             99: _ProcessIdentity(
-                create_time=8.25,
+                stamp=8.25,
                 cmdline=("avibe",),
                 uid=uid,
                 environment={},
@@ -356,7 +356,7 @@ async def test_retained_pending_cleanup_reconciles_while_its_parent_is_live(
     host = RetainedPendingHost(
         {
             99: _ProcessIdentity(
-                create_time=8.25,
+                stamp=8.25,
                 cmdline=("avibe",),
                 uid=uid,
                 environment={},
@@ -410,7 +410,7 @@ async def test_handleless_spawn_failure_marks_discovered_pending_record_retryabl
     host = HandlelessSpawnHost(
         {
             parent.pid: _ProcessIdentity(
-                create_time=parent.create_time,
+                stamp=parent.create_time,
                 cmdline=("avibe",),
                 uid=uid,
                 environment={},
@@ -457,7 +457,7 @@ async def test_handleless_spawn_failure_marks_uncertain_pending_record_retryable
     host = UncertainHandlelessSpawnHost(
         {
             parent.pid: _ProcessIdentity(
-                create_time=parent.create_time,
+                stamp=parent.create_time,
                 cmdline=("avibe",),
                 uid=uid,
                 environment={},
@@ -525,7 +525,7 @@ async def test_sync_cleanup_runtime_error_marks_the_finalized_record(
         def inspect_identity(self, pid):
             assert pid == process.pid
             return _ProcessIdentity(
-                create_time=10.5,
+                stamp=10.5,
                 cmdline=(str(python), *SYNC_ARGV),
                 uid=os.getuid() if hasattr(os, "getuid") else None,
                 environment=self.environment,
@@ -701,7 +701,7 @@ async def test_finalized_sync_reconciliation_cleans_exact_recorded_group(tmp_pat
     host = _Host(
         {
             451: _ProcessIdentity(
-                create_time=10.5,
+                stamp=10.5,
                 cmdline=tuple(record["argv"]),
                 uid=uid,
                 environment=environment,
@@ -732,7 +732,7 @@ async def test_gone_leader_with_live_helper_is_swept_before_retirement(tmp_path:
         SYNC_PARENT_UID_ENV: "" if uid is None else str(uid),
     }
     helper = _ProcessIdentity(
-        create_time=11.5,
+        stamp=11.5,
         cmdline=("/runtime/bin/python", "-c", "everos-helper"),
         uid=uid,
         environment=helper_env,
@@ -772,7 +772,7 @@ async def test_orphan_reconciliation_rescans_group_before_retiring_record(
             if self.scans == 1:
                 return {777: 11.5}, []
             self.identities[778] = _ProcessIdentity(
-                create_time=12.5,
+                stamp=12.5,
                 cmdline=("/runtime/bin/python", "-c", "replacement-helper"),
                 uid=uid,
                 environment=helper_env,
@@ -938,7 +938,7 @@ async def test_sync_finalizes_ownership_before_sigcont_and_cleans_group(tmp_path
             assert pid == process.pid
             events.append("validated")
             return _ProcessIdentity(
-                create_time=10.5,
+                stamp=10.5,
                 cmdline=(str(python), *SYNC_ARGV),
                 uid=os.getuid() if hasattr(os, "getuid") else None,
                 environment=self.environment,
@@ -1028,7 +1028,7 @@ async def test_sync_spawn_handoff_finishes_before_honoring_cancellation(tmp_path
         def inspect_identity(self, pid):
             assert pid == process.pid
             return _ProcessIdentity(
-                create_time=10.5,
+                stamp=10.5,
                 cmdline=(str(python), *SYNC_ARGV),
                 uid=os.getuid() if hasattr(os, "getuid") else None,
                 environment=self.environment,
@@ -1066,7 +1066,7 @@ async def test_sync_spawn_handoff_finishes_before_honoring_cancellation(tmp_path
 
 async def test_sync_cleanup_rescans_a_group_after_the_leader_exits(tmp_path: Path) -> None:
     helper = _ProcessIdentity(
-        create_time=11.5,
+        stamp=11.5,
         cmdline=("/runtime/bin/python", *SYNC_ARGV),
         uid=os.getuid() if hasattr(os, "getuid") else None,
         environment={},

--- a/tests/test_memory_sync_process.py
+++ b/tests/test_memory_sync_process.py
@@ -292,8 +292,10 @@ async def test_live_parent_keeps_singleton_sync_record_and_child_untouched(tmp_p
 
 
 async def test_live_parent_keeps_record_when_identity_stamp_is_linux_ticks(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    monkeypatch.setattr(memory_sync_process, "_uses_linux_starttime_stamp", lambda: True)
     memory_dir = tmp_path / "memory"
     root = memory_dir / "everos-root"
     uid = os.getuid() if hasattr(os, "getuid") else None
@@ -304,7 +306,7 @@ async def test_live_parent_keeps_record_when_identity_stamp_is_linux_ticks(
                 cmdline=("avibe",),
                 uid=uid,
                 environment={},
-                wall_create_time=8.25,
+                wall_create_time=8.25 + 48.0,
             )
         }
     )
@@ -319,8 +321,10 @@ async def test_live_parent_keeps_record_when_identity_stamp_is_linux_ticks(
 
 
 async def test_legacy_sync_child_with_wall_clock_record_is_not_removed_as_recycled(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    monkeypatch.setattr(memory_sync_process, "_uses_linux_starttime_stamp", lambda: True)
     memory_dir = tmp_path / "memory"
     root = memory_dir / "everos-root"
     uid = os.getuid() if hasattr(os, "getuid") else None
@@ -340,7 +344,7 @@ async def test_legacy_sync_child_with_wall_clock_record_is_not_removed_as_recycl
                 cmdline=tuple(record["argv"]),
                 uid=uid,
                 environment=environment,
-                wall_create_time=10.5,
+                wall_create_time=10.5 + 48.0,
             )
         }
     )
@@ -355,8 +359,10 @@ async def test_legacy_sync_child_with_wall_clock_record_is_not_removed_as_recycl
 
 
 async def test_legacy_sync_child_without_wall_time_keeps_record(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    monkeypatch.setattr(memory_sync_process, "_uses_linux_starttime_stamp", lambda: True)
     memory_dir = tmp_path / "memory"
     root = memory_dir / "everos-root"
     uid = os.getuid() if hasattr(os, "getuid") else None
@@ -380,6 +386,53 @@ async def test_legacy_sync_child_without_wall_time_keeps_record(
 
     assert ownership.path.exists()
     assert host.signals == []
+
+
+async def test_current_sync_parent_prefers_stable_stamp_over_wall_time(
+    tmp_path: Path,
+) -> None:
+    memory_dir = tmp_path / "memory"
+    root = memory_dir / "everos-root"
+    uid = os.getuid() if hasattr(os, "getuid") else None
+    record = _record(root, state="finalized", pid=451)
+    record["parent_starttime_ticks"] = 424_242.0
+    host = _Host(
+        {
+            99: _ProcessIdentity(
+                stamp=424_242.0,
+                cmdline=("avibe",),
+                uid=uid,
+                environment={},
+                wall_create_time=record["parent_create_time"] + 1_000.0,
+            )
+        }
+    )
+    ownership = SyncOwnership(sync_record_path(memory_dir), provider_root=root, host=host)
+    ownership.write(record)
+
+    with pytest.raises(SyncOwnershipError, match="live parent"):
+        await ownership.reconcile()
+
+    assert ownership.path.exists()
+    assert host.signals == []
+
+
+@pytest.mark.parametrize("field", ["starttime_ticks", "parent_starttime_ticks"])
+async def test_sync_record_rejects_non_finite_stable_stamps(
+    field: str,
+    tmp_path: Path,
+) -> None:
+    memory_dir = tmp_path / "memory"
+    root = memory_dir / "everos-root"
+    record = _record(root, state="finalized", pid=451)
+    record[field] = float("nan")
+    ownership = SyncOwnership(sync_record_path(memory_dir), provider_root=root, host=_Host())
+    ownership.write(record)
+
+    with pytest.raises(SyncOwnershipError, match="start-time is invalid"):
+        await ownership.reconcile()
+
+    assert ownership.path.exists()
 
 
 async def test_retained_failed_cleanup_reconciles_while_its_parent_is_live(
@@ -979,7 +1032,11 @@ def test_sync_environment_has_no_host_source_path(tmp_path: Path) -> None:
     assert all("SOURCE_ROOT" not in key for key in env)
 
 
-async def test_sync_finalizes_ownership_before_sigcont_and_cleans_group(tmp_path: Path) -> None:
+async def test_sync_finalizes_ownership_before_sigcont_and_cleans_group(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(memory_sync_process, "_uses_linux_starttime_stamp", lambda: True)
     python = tmp_path / "runtime" / "bin" / "python"
     python.parent.mkdir(parents=True)
     python.write_bytes(b"python")
@@ -995,6 +1052,9 @@ async def test_sync_finalizes_ownership_before_sigcont_and_cleans_group(tmp_path
             assert signum.name == "SIGCONT"
             record = json.loads(record_path.read_text(encoding="utf-8"))
             assert record["state"] == "finalized"
+            assert record["create_time"] == 1_700_000_010.5
+            assert record["starttime_ticks"] == 10.5
+            assert record["parent_starttime_ticks"] is not None
             events.append("continued")
 
         async def wait(self):
@@ -1040,6 +1100,7 @@ async def test_sync_finalizes_ownership_before_sigcont_and_cleans_group(tmp_path
                 cmdline=(str(python), *SYNC_ARGV),
                 uid=os.getuid() if hasattr(os, "getuid") else None,
                 environment=self.environment,
+                wall_create_time=1_700_000_010.5,
             )
 
         def live(self, identities):

--- a/tests/test_memory_sync_process.py
+++ b/tests/test_memory_sync_process.py
@@ -455,14 +455,16 @@ async def test_current_sync_parent_prefers_stable_stamp_over_wall_time(
 
 
 @pytest.mark.parametrize("field", ["starttime_ticks", "parent_starttime_ticks"])
-async def test_sync_record_rejects_non_finite_stable_stamps(
+@pytest.mark.parametrize("stamp", [-1.0, float("nan")])
+async def test_sync_record_rejects_invalid_stable_stamps(
     field: str,
+    stamp: float,
     tmp_path: Path,
 ) -> None:
     memory_dir = tmp_path / "memory"
     root = memory_dir / "everos-root"
     record = _record(root, state="finalized", pid=451)
-    record[field] = float("nan")
+    record[field] = stamp
     ownership = SyncOwnership(sync_record_path(memory_dir), provider_root=root, host=_Host())
     ownership.write(record)
 


### PR DESCRIPTION
Fixes #1538.

## Capability

Restart engine and sidecar stop can signal and reap the EverOS child after a `CLOCK_REALTIME` step without trusting a recycled PID.

Linux process identity no longer depends on exact `psutil.Process.create_time()` equality. That value is `btime + starttime/CLK_TCK`, so an NTP step, VM clock sync, or laptop sleep moved `btime` and made the supervisor refuse SIGTERM/SIGKILL for a child it still held. The five layers in this change are:

1. Every direct-child, descendant, and process-group signal requires a current finite identity-stamp match; `asyncio.Process.returncode` and its underlying `Popen.returncode` are not treated as ownership evidence.
2. Every later tree snapshot is merged only when the captured root identity matches before and after discovery, so the waitpid-to-asyncio callback window cannot extend ownership from a reused PID.
3. Live identity uses the raw bytes from `/proc/<pid>/stat` starttime ticks on Linux (boot-relative, immune to wall-clock steps and arbitrary non-UTF-8 `comm` bytes) and continues to use `create_time()` on macOS/Windows.
4. New sidecar and sync records retain wall-clock `create_time` and add stable Linux start-time fields. Released records without those fields still load. A legacy sync child treats finite wall time as compatibility disclosure and authenticates with exact uid, argv, provider root, role, and nonce after an arbitrary clock correction. A legacy sync parent has none of those facts, so ownership is exact `wall_create_time == recorded parent_create_time`; a recycled same-uid pid cannot keep the stale record. Malformed, negative, or non-finite values never authorize a signal.
5. `_monitor_child` and `_restart_locked` log the underlying exception, including recorded vs live stamps.

## Evidence

- Unit: `python -m pytest -q tests/test_memory_process.py tests/test_memory_sync_process.py tests/test_memory_runtime.py` (406 passed)
- Unit: clock-step stop still reaps the direct child; Linux stamp reads ignore wall-clock drift and arbitrary `comm` bytes; discovery refuses a root reused before or during a snapshot; the post-waitpid/pre-callback signal path revalidates the PID; invalid persisted and live stamps fail closed; a recycled same-uid parent pid with a different wall create_time does not block cleanup of a legacy record
- Contract: current Linux sidecar and sync records dual-write wall and stable times; released child records retain ownership across arbitrary wall-clock corrections only when all disclosed process facts match; released parent records require exact wall equality
- Scenario IDs: none; no catalog entry for Memory Restart engine / sidecar identity
- Lint: `ruff check core/memory/process.py core/memory/sync_process.py tests/test_memory_process.py tests/test_memory_sync_process.py tests/test_memory_runtime.py`
- Residual manual: Restart engine on the Incus `master` instance that originally reproduced the 48s create_time delta, after this lands. Not run here (no local vibe restart; Incus regression left untouched).

## Known by design

- A legacy sidecar `create_time` mismatch requires a disclosed matching `EVEROS_ROOT` in addition to the exact command and uid; missing deciding facts stay `UNVERIFIABLE`, while contradictions are `NOT_OURS`.
- Legacy sync parent liveness (no `parent_starttime_ticks`) is exact wall-clock equality. The Linux facts-based bypass is child-only, because parent records have no argv/root/role/nonce to authenticate a recycled pid.
- `_merge_owned_processes` keeps the first captured stamp with `setdefault`; `_refresh_owned_process_tree` permits new descendants only while the captured root stamp remains live across the snapshot.