### PR TITLE
fix(memory): retain unverifiable legacy ownership

### DIFF
--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -3168,7 +3168,7 @@ def _legacy_create_time_mismatch_verdict(
         if identity.uid != own_uid:
             return _RecordedSidecar.NOT_OURS
     if identity.environment is None:
-        return _RecordedSidecar.NOT_OURS
+        return _RecordedSidecar.UNVERIFIABLE
     if not _provider_roots_match(identity.environment.get("EVEROS_ROOT"), provider_root):
         return _RecordedSidecar.NOT_OURS
     return None

--- a/tests/test_memory_process.py
+++ b/tests/test_memory_process.py
@@ -1341,8 +1341,6 @@ def test_recorded_sidecar_identity_accepts_only_a_provably_owned_orphan(tmp_path
     not_ours: list[tuple[dict, _ProcessIdentity | None]] = [
         # The process is confirmed gone.
         (_orphan_record(process), None),
-        # The pid was recycled: same number, different process.
-        (_orphan_record(process), _orphan_identity(process, create_time=_ORPHAN_CREATE_TIME + 1)),
         # Not our entrypoint.
         (_orphan_record(process), _orphan_identity(process, cmdline=(sys.executable, "-m", "http.server"))),
         # Our entrypoint name, but serving a different socket.
@@ -1383,6 +1381,12 @@ def test_recorded_sidecar_identity_accepts_only_a_provably_owned_orphan(tmp_path
         (
             _orphan_record(process),
             _orphan_identity(process, create_time=424_242.0, wall_create_time=None),
+        ),
+        # A different legacy wall time can be a clock step. Without the
+        # environment, no disclosed fact proves that the pid was recycled.
+        (
+            _orphan_record(process),
+            _orphan_identity(process, create_time=_ORPHAN_CREATE_TIME + 1),
         ),
     ]
     for record, identity in unverifiable:
@@ -1840,10 +1844,10 @@ def test_sidecar_launch_reaps_a_recorded_orphan_from_a_previous_run(
     assert not record_path.exists()
 
 
-def test_sidecar_launch_never_signals_a_pid_it_cannot_identify(
+def test_sidecar_launch_keeps_legacy_record_when_environment_is_undisclosed(
     tmp_path: Path,
 ) -> None:
-    """A recycled pid retires the record instead of killing its new owner."""
+    """A clock step without environment evidence cannot prove pid reuse."""
 
     host = _FakeProcessHost()
     process = _orphan_process(tmp_path, host=host)
@@ -1853,10 +1857,11 @@ def test_sidecar_launch_never_signals_a_pid_it_cannot_identify(
     )
     record_path = _write_orphan_record(process, _orphan_record(process))
 
-    asyncio.run(process._ownership.reap())
+    with pytest.raises(RuntimeError, match="recorded sidecar identity could not be verified"):
+        asyncio.run(process._ownership.reap())
 
     assert host.signal_calls == []
-    assert not record_path.exists()
+    assert record_path.exists()
 
 
 def test_sidecar_launch_refuses_to_start_beside_an_unreapable_orphan(

--- a/tests/test_memory_sync_process.py
+++ b/tests/test_memory_sync_process.py
@@ -582,11 +582,12 @@ async def test_handleless_spawn_failure_marks_discovered_pending_record_retryabl
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    monkeypatch.setattr(memory_sync_process, "_uses_linux_starttime_stamp", lambda: True)
     python = tmp_path / "runtime" / "bin" / "python"
     python.parent.mkdir(parents=True)
     python.write_bytes(b"python")
     uid = os.getuid() if hasattr(os, "getuid") else None
-    parent = _ParentIdentity(pid=99, create_time=8.25, uid=uid)
+    parent = _ParentIdentity(pid=99, create_time=8.25, uid=uid, stamp=8.25)
 
     class HandlelessSpawnHost(_Host):
         child_is_present = True
@@ -628,11 +629,12 @@ async def test_handleless_spawn_failure_marks_uncertain_pending_record_retryable
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    monkeypatch.setattr(memory_sync_process, "_uses_linux_starttime_stamp", lambda: True)
     python = tmp_path / "runtime" / "bin" / "python"
     python.parent.mkdir(parents=True)
     python.write_bytes(b"python")
     uid = os.getuid() if hasattr(os, "getuid") else None
-    parent = _ParentIdentity(pid=99, create_time=8.25, uid=uid)
+    parent = _ParentIdentity(pid=99, create_time=8.25, uid=uid, stamp=8.25)
 
     class UncertainHandlelessSpawnHost(_Host):
         discovery_is_uncertain = True


### PR DESCRIPTION
## Summary

- preserve a released-format sidecar ownership record when a clock step occurs and the live environment is undisclosed
- treat undisclosed identity evidence as `UNVERIFIABLE`, while retaining `NOT_OURS` for disclosed contradictions
- make handleless sync cleanup tests exercise the Linux stable-parent-stamp path deterministically

Follow-up to the post-merge Codex finding on #1541. Requires #1541, which is already merged.

## Evidence

- Unit: 433 focused process, sync, runtime, and sidecar lifecycle tests passed
- Contract: the existing `OURS` / `NOT_OURS` / `UNVERIFIABLE` ownership classification contract is exercised directly
- Scenario: no catalog scenario applies to this internal recovery path
- Residual manual: no live process signaling probe was run; all signal effects use the existing fake host boundary

## Known-by-design

- None.