### PR TITLE
fix(memory): consume effective memory LLM source

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -1293,6 +1293,13 @@ def _recover_memory_cloud_section(payload: dict, field_name: Optional[str]) -> b
     cloud.pop(field_name, None)
     if field_name == "runtime_apply_pending":
         cloud["runtime_apply_pending"] = True
+    elif field_name == "memory_llm_source":
+        # A source mismatch means the cached effective LLM cannot be trusted.
+        # Keep the rest of the cloud identity for diagnostics, but fail closed
+        # until the next authoritative status refresh supplies a new pair.
+        capabilities = cloud.get("capabilities")
+        if isinstance(capabilities, dict):
+            capabilities["memory_llm"] = False
     elif field_name == "applied_embedding_identity":
         live_identity = cloud.get("embedding_identity")
         if isinstance(live_identity, str) and live_identity.strip():
@@ -2190,8 +2197,11 @@ class MemoryConfig:
 
     def effective_multimodal_available(self) -> bool:
         if self.cloud_runtime_selected():
-            # Cloud chat is the declared fallback when no dedicated mm slot exists.
-            return self.cloud.runtime_ready() and self.cloud.capabilities.chat
+            # Cloud chat is the declared fallback when no dedicated mm slot exists;
+            # a dedicated multimodal slot remains valid without Chat.
+            return self.cloud.runtime_ready() and (
+                self.cloud.capabilities.multimodal or self.cloud.capabilities.chat
+            )
         return bool(self.processing.multimodal and self.processing.multimodal.complete())
 
 

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -1850,6 +1850,7 @@ _MEMORY_CLOUD_MULTIMODAL_ALIAS = "avibe-cloud-multimodal"
 
 MemoryMode = Literal["platform", "custom"]
 MemoryCloudScope = Literal["organization", "platform"]
+MemoryCloudLlmSource = Literal["dedicated", "chat_fallback"]
 
 
 @dataclass
@@ -1919,16 +1920,26 @@ class MemoryCloudCapabilities:
     chat: bool = False
     embedding: bool = False
     multimodal: bool = False
+    # Older persisted cloud caches did not have the effective Memory LLM
+    # capability. ``None`` keeps that shape distinguishable while the helper
+    # methods treat it as Chat fallback until the next status sync.
+    memory_llm: bool | None = None
 
     def validate(self) -> None:
         if any(
             not isinstance(value, bool)
-            for value in (self.asr, self.chat, self.embedding, self.multimodal)
-        ):
+            for value in (
+                self.asr,
+                self.chat,
+                self.embedding,
+                self.multimodal,
+            )
+        ) or (self.memory_llm is not None and not isinstance(self.memory_llm, bool)):
             raise ValueError("Config 'memory.cloud.capabilities' values must be booleans")
 
     def memory_available(self) -> bool:
-        return self.chat and self.embedding
+        effective_memory_llm = self.chat if self.memory_llm is None else self.memory_llm
+        return effective_memory_llm and self.embedding
 
 
 @dataclass
@@ -1937,6 +1948,7 @@ class MemoryCloudConfig:
 
     scope: MemoryCloudScope | None = None
     capabilities: MemoryCloudCapabilities = field(default_factory=MemoryCloudCapabilities)
+    memory_llm_source: MemoryCloudLlmSource | None = None
     embedding_identity: str | None = None
     revision: int | None = None
     quota_enforced: bool = False
@@ -1952,7 +1964,25 @@ class MemoryCloudConfig:
     def validate(self) -> None:
         if self.scope is not None and self.scope not in get_args(MemoryCloudScope):
             raise ValueError("Config 'memory.cloud.scope' must be 'organization', 'platform', or null")
+        if self.memory_llm_source is not None and self.memory_llm_source not in get_args(
+            MemoryCloudLlmSource
+        ):
+            raise ValueError(
+                "Config 'memory.cloud.memory_llm_source' must be 'dedicated', 'chat_fallback', or null"
+            )
         self.capabilities.validate()
+        if self.memory_llm_source == "dedicated" and self.capabilities.memory_llm is False:
+            raise ValueError(
+                "Config 'memory.cloud.memory_llm_source' dedicated requires memory_llm"
+            )
+        if (
+            self.memory_llm_source == "chat_fallback"
+            and self.capabilities.memory_llm is not None
+            and self.capabilities.memory_llm != self.capabilities.chat
+        ):
+            raise ValueError(
+                "Config 'memory.cloud.memory_llm_source' chat_fallback requires chat"
+            )
         if self.embedding_identity is not None:
             self.embedding_identity = _validate_memory_text(
                 self.embedding_identity,
@@ -2274,7 +2304,9 @@ def memory_config_to_payload(
                 "chat": memory.cloud.capabilities.chat,
                 "embedding": memory.cloud.capabilities.embedding,
                 "multimodal": memory.cloud.capabilities.multimodal,
+                "memory_llm": memory.cloud.capabilities.memory_llm,
             },
+            "memory_llm_source": memory.cloud.memory_llm_source,
             "embedding_identity": memory.cloud.embedding_identity,
             "revision": memory.cloud.revision,
             "quota_enforced": memory.cloud.quota_enforced,

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -528,6 +528,40 @@ def test_memory_cloud_persists_effective_memory_llm_source() -> None:
 
 
 @pytest.mark.parametrize(
+    ("chat", "source"),
+    [(False, "chat_fallback"), (True, "future_source")],
+)
+def test_disk_recovery_of_untrusted_memory_llm_source_disables_cloud_memory(
+    tmp_path,
+    chat: bool,
+    source: str,
+) -> None:
+    config_path = tmp_path / "config.json"
+    cloud = _acknowledged_organization_cloud()
+    cloud["capabilities"]["chat"] = chat
+    cloud["memory_llm_source"] = source
+    payload = _payload(
+        {
+            "enabled": True,
+            "mode": "platform",
+            "processing": _complete_processing(),
+            "cloud": cloud,
+        }
+    )
+
+    with pytest.raises(ValueError, match="memory_llm_source"):
+        V2Config.from_payload(payload)
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = V2Config.load(config_path)
+
+    assert loaded.memory.cloud.memory_llm_source is None
+    assert loaded.memory.cloud.capabilities.memory_llm is False
+    assert loaded.memory.cloud.runtime_ready() is False
+    assert loaded.memory.runtime_source() == "unavailable"
+
+
+@pytest.mark.parametrize(
     ("field", "invalid"),
     [
         ("scope", "unsupported"),

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -483,7 +483,9 @@ def _acknowledged_organization_cloud() -> dict:
             "chat": True,
             "embedding": True,
             "multimodal": False,
+            "memory_llm": True,
         },
+        "memory_llm_source": "chat_fallback",
         "embedding_identity": "emb-org",
         "revision": 4,
         "quota_enforced": False,
@@ -498,10 +500,38 @@ def _acknowledged_organization_cloud() -> dict:
     }
 
 
+def test_memory_cloud_persists_effective_memory_llm_source() -> None:
+    config = V2Config.from_payload(
+        _payload(
+            {
+                "cloud": {
+                    "capabilities": {
+                        "asr": False,
+                        "chat": False,
+                        "embedding": True,
+                        "multimodal": False,
+                        "memory_llm": True,
+                    },
+                    "memory_llm_source": "dedicated",
+                    "embedding_identity": "emb-dedicated",
+                }
+            }
+        )
+    )
+
+    assert config.memory.cloud.memory_llm_source == "dedicated"
+    assert config.memory.cloud.capabilities.memory_available() is True
+
+    payload = config_to_payload(config)
+    assert payload["memory"]["cloud"]["memory_llm_source"] == "dedicated"
+    assert payload["memory"]["cloud"]["capabilities"]["memory_llm"] is True
+
+
 @pytest.mark.parametrize(
     ("field", "invalid"),
     [
         ("scope", "unsupported"),
+        ("memory_llm_source", "unsupported"),
         ("capabilities", []),
         ("embedding_identity", 7),
         ("revision", "four"),

--- a/tests/test_model_service.py
+++ b/tests/test_model_service.py
@@ -32,6 +32,8 @@ def _status(
     *,
     scope: str = "platform",
     chat: bool = True,
+    memory_llm: bool | None = None,
+    memory_llm_source: str = "chat_fallback",
     embedding: bool = True,
     multimodal: bool = False,
     identity: str | None = "emb-v1",
@@ -44,7 +46,9 @@ def _status(
             "chat": chat,
             "embedding": embedding,
             "multimodal": multimodal,
+            "memory_llm": chat if memory_llm is None else memory_llm,
         },
+        "memory_llm_source": memory_llm_source,
         "embedding_identity": identity,
         "quota": {"enforced": False},
         "revision": revision,
@@ -170,6 +174,8 @@ def test_fresh_paired_install_gets_zero_config_cloud_memory_with_write_only_key(
     assert memory.enabled is True
     assert memory.cloud.model_access_key == "mak_first"
     assert memory.cloud.embedding_identity == "emb-v1"
+    assert memory.cloud.memory_llm_source == "chat_fallback"
+    assert memory.cloud.capabilities.memory_llm is True
     assert runtime.llm.base_url == "https://backend.example.test/v1/model"
     assert runtime.llm.model == "avibe-cloud-chat"
     assert runtime.embedding.model == "avibe-cloud-embedding-emb-v1"
@@ -180,6 +186,111 @@ def test_fresh_paired_install_gets_zero_config_cloud_memory_with_write_only_key(
     projected = memory_config_to_payload(memory)
     assert projected["cloud"]["model_access_key"] is None
     assert projected["cloud"]["has_model_access_key"] is True
+
+
+def test_dedicated_memory_llm_can_activate_without_chat_capability() -> None:
+    status = _status(
+        chat=False,
+        memory_llm=True,
+        memory_llm_source="dedicated",
+    )
+
+    parsed = model_service._status_from_payload(status)  # noqa: SLF001
+    assert parsed.memory_available() is True
+
+    activated = _resolved(MemoryConfig(), status, minted=_mint())
+
+    assert activated.enabled is True
+    assert activated.cloud.memory_llm_source == "dedicated"
+    assert activated.cloud.capabilities.memory_llm is True
+    assert activated.runtime_source() == "cloud"
+
+
+def test_chat_fallback_without_chat_capability_is_not_advertised_as_available() -> None:
+    status = _status(
+        chat=False,
+        memory_llm=False,
+        memory_llm_source="chat_fallback",
+    )
+
+    parsed = model_service._status_from_payload(status)  # noqa: SLF001
+    assert parsed.memory_available() is False
+
+    waiting = _resolved(MemoryConfig(), status)
+
+    assert waiting.enabled is False
+    assert waiting.cloud.memory_llm_source == "chat_fallback"
+    assert waiting.cloud.memory_capability_available() is False
+    assert waiting.runtime_source() == "unavailable"
+
+
+def test_dedicated_memory_llm_pause_and_resume_does_not_require_chat() -> None:
+    attached = MemoryConfig(
+        enabled=True,
+        mode="platform",
+        cloud=MemoryCloudConfig(
+            scope="platform",
+            capabilities=MemoryCloudCapabilities(
+                chat=False,
+                embedding=True,
+                memory_llm=True,
+            ),
+            memory_llm_source="dedicated",
+            embedding_identity="emb-v1",
+            applied_embedding_identity="emb-v1",
+            model_access_key="mak_first",
+            proxy_base_url="https://backend.example.test/v1/model",
+            source_instance_id="instance-1",
+        ),
+    )
+
+    paused = _resolved(
+        attached,
+        _status(
+            chat=False,
+            memory_llm=False,
+            memory_llm_source="chat_fallback",
+            embedding=True,
+            identity="emb-v1",
+            revision=2,
+        ),
+    )
+    assert paused.runtime_source() == "unavailable"
+    assert paused.enabled is True
+    assert paused.cloud.memory_llm_source == "chat_fallback"
+
+    resumed = _resolved(
+        paused,
+        _status(
+            chat=False,
+            memory_llm=True,
+            memory_llm_source="dedicated",
+            embedding=True,
+            identity="emb-v1",
+            revision=3,
+        ),
+    )
+    assert resumed.runtime_source() == "cloud"
+    assert resumed.enabled is True
+    assert resumed.cloud.memory_llm_source == "dedicated"
+
+
+@pytest.mark.parametrize(
+    ("memory_llm", "chat", "source"),
+    [
+        (False, True, "dedicated"),
+        (True, False, "chat_fallback"),
+    ],
+)
+def test_memory_llm_source_must_match_effective_capability(
+    memory_llm: bool,
+    chat: bool,
+    source: str,
+) -> None:
+    with pytest.raises(model_service.ModelServiceResolutionError, match="model_service_invalid_response"):
+        model_service._status_from_payload(  # noqa: SLF001
+            _status(chat=chat, memory_llm=memory_llm, memory_llm_source=source)
+        )
 
 
 def test_unpairing_clears_cloud_runtime_and_reconciles_the_running_sidecar(

--- a/tests/test_model_service.py
+++ b/tests/test_model_service.py
@@ -206,6 +206,69 @@ def test_dedicated_memory_llm_can_activate_without_chat_capability() -> None:
     assert activated.runtime_source() == "cloud"
 
 
+def test_dedicated_multimodal_can_be_available_without_chat_capability() -> None:
+    memory = MemoryConfig(
+        enabled=True,
+        mode="platform",
+        cloud=MemoryCloudConfig(
+            scope="platform",
+            capabilities=MemoryCloudCapabilities(
+                chat=False,
+                embedding=True,
+                multimodal=True,
+                memory_llm=True,
+            ),
+            memory_llm_source="dedicated",
+            embedding_identity="emb-v1",
+            applied_embedding_identity="emb-v1",
+            model_access_key="mak_first",
+            proxy_base_url="https://backend.example.test/v1/model",
+            source_instance_id="instance-1",
+        ),
+    )
+
+    assert memory.effective_multimodal_available() is True
+    assert memory.runtime_processing().multimodal is not None
+    assert memory.runtime_processing().multimodal.base_url.endswith("/mm")
+
+
+def test_chat_capability_change_reconciles_attachment_gate_for_dedicated_memory_llm() -> None:
+    current = MemoryConfig(
+        enabled=True,
+        mode="platform",
+        cloud=MemoryCloudConfig(
+            scope="platform",
+            capabilities=MemoryCloudCapabilities(
+                chat=True,
+                embedding=True,
+                memory_llm=True,
+            ),
+            memory_llm_source="dedicated",
+            embedding_identity="emb-v1",
+            applied_embedding_identity="emb-v1",
+            model_access_key="mak_first",
+            proxy_base_url="https://backend.example.test/v1/model",
+            source_instance_id="instance-1",
+        ),
+    )
+    candidate = _resolved(
+        current,
+        _status(
+            chat=False,
+            memory_llm=True,
+            memory_llm_source="dedicated",
+            multimodal=False,
+            identity="emb-v1",
+            revision=2,
+        ),
+    )
+
+    assert current.runtime_source() == candidate.runtime_source() == "cloud"
+    assert current.effective_multimodal_available() is True
+    assert candidate.effective_multimodal_available() is False
+    assert candidate.cloud.runtime_apply_pending is True
+
+
 def test_chat_fallback_without_chat_capability_is_not_advertised_as_available() -> None:
     status = _status(
         chat=False,

--- a/vibe/model_service.py
+++ b/vibe/model_service.py
@@ -186,6 +186,7 @@ def _runtime_state_signature(memory: MemoryConfig) -> tuple[object, ...]:
         memory.recovery_intent,
         memory.runtime_source(),
         memory.runtime_processing(),
+        memory.effective_multimodal_available(),
     )
 
 

--- a/vibe/model_service.py
+++ b/vibe/model_service.py
@@ -15,6 +15,7 @@ import urllib.request
 
 from config.v2_config import (
     MemoryCloudCapabilities,
+    MemoryCloudLlmSource,
     MemoryConfig,
     V2Config,
     memory_config_to_payload,
@@ -39,6 +40,7 @@ class ModelServiceResolutionError(RuntimeError):
 class ModelServiceStatus:
     scope: str
     capabilities: MemoryCloudCapabilities
+    memory_llm_source: MemoryCloudLlmSource
     embedding_identity: str | None
     quota_enforced: bool
     revision: int
@@ -75,6 +77,7 @@ def _status_from_payload(payload: object) -> ModelServiceStatus:
         raise ModelServiceResolutionError("model_service_invalid_response")
     scope = payload.get("mode")
     capabilities = payload.get("capabilities")
+    memory_llm_source = payload.get("memory_llm_source")
     embedding_identity = payload.get("embedding_identity")
     quota = payload.get("quota")
     revision = payload.get("revision")
@@ -82,7 +85,7 @@ def _status_from_payload(payload: object) -> ModelServiceStatus:
         raise ModelServiceResolutionError("model_service_invalid_response")
     if not isinstance(capabilities, Mapping):
         raise ModelServiceResolutionError("model_service_invalid_response")
-    required_capabilities = {"asr", "chat", "embedding", "multimodal"}
+    required_capabilities = {"asr", "chat", "embedding", "multimodal", "memory_llm"}
     if not required_capabilities.issubset(capabilities) or any(
         not isinstance(capabilities.get(name), bool) for name in required_capabilities
     ):
@@ -90,6 +93,12 @@ def _status_from_payload(payload: object) -> ModelServiceStatus:
     if embedding_identity is not None and (not isinstance(embedding_identity, str) or not embedding_identity.strip()):
         raise ModelServiceResolutionError("model_service_invalid_response")
     if bool(capabilities["embedding"]) != bool(embedding_identity):
+        raise ModelServiceResolutionError("model_service_invalid_response")
+    if memory_llm_source not in {"dedicated", "chat_fallback"}:
+        raise ModelServiceResolutionError("model_service_invalid_response")
+    if memory_llm_source == "dedicated" and not capabilities["memory_llm"]:
+        raise ModelServiceResolutionError("model_service_invalid_response")
+    if memory_llm_source == "chat_fallback" and capabilities["memory_llm"] != capabilities["chat"]:
         raise ModelServiceResolutionError("model_service_invalid_response")
     if not isinstance(quota, Mapping) or not isinstance(quota.get("enforced"), bool):
         raise ModelServiceResolutionError("model_service_invalid_response")
@@ -102,7 +111,9 @@ def _status_from_payload(payload: object) -> ModelServiceStatus:
             chat=capabilities["chat"],
             embedding=capabilities["embedding"],
             multimodal=capabilities["multimodal"],
+            memory_llm=capabilities["memory_llm"],
         ),
+        memory_llm_source=memory_llm_source,
         embedding_identity=embedding_identity.strip() if embedding_identity else None,
         quota_enforced=quota["enforced"],
         revision=revision,
@@ -233,6 +244,7 @@ def _resolved_memory(
 
     candidate.cloud.scope = status.scope  # type: ignore[assignment]
     candidate.cloud.capabilities = status.capabilities
+    candidate.cloud.memory_llm_source = status.memory_llm_source
     candidate.cloud.embedding_identity = status.embedding_identity
     candidate.cloud.revision = status.revision
     candidate.cloud.quota_enforced = status.quota_enforced
@@ -329,6 +341,7 @@ def _fenced_cloud_memory(current: MemoryConfig) -> MemoryConfig:
 
     candidate = deepcopy(current)
     candidate.cloud.capabilities = MemoryCloudCapabilities()
+    candidate.cloud.memory_llm_source = None
     candidate.cloud.embedding_identity = None
     candidate.cloud.revision = None
     candidate.cloud.quota_enforced = False


### PR DESCRIPTION
## Summary

Consume the Cloud Model Service `memory_llm` capability and `memory_llm_source` status fields added by backend PR #255.

## Changes

- Treat the effective Memory LLM (`memory_llm`) plus embedding identity as the cloud Memory availability pair.
- Persist `memory_llm_source` (`dedicated` or `chat_fallback`) with the cached cloud status.
- Allow a dedicated Memory LLM to keep Memory available when Chat is disabled.
- Reject inconsistent status payloads so an unavailable Chat slot cannot be advertised as a usable fallback.
- Keep existing sidecar wiring unchanged: cloud Memory still routes through the proxy Chat path.
- Preserve legacy cloud caches that predate the new capability field until the next status refresh.

## Validation

- Memory test suite and model-service tests: 1485 passed, 7 skipped.
- Ruff, pre-commit, and `git diff --check`: passed.

## Contract

Backend contract source: merged [avibe-bot/avibe-backend#255](https://github.com/avibe-bot/avibe-backend/pull/255), merge commit `ce3c6df3d921`.

No merge is requested from this lane; PM owns the merge gate.
