### PR TITLE
fix(show): preserve denied-page UX after lease revocation

### DIFF
--- a/tests/scenarios/auth_setup/catalog.yaml
+++ b/tests/scenarios/auth_setup/catalog.yaml
@@ -191,7 +191,7 @@ scenarios:
     backend: web
     test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_organization_remote_session_recovers_and_revokes_without_oauth
   - id: AUTH-SETUP-404
-    name: Verified limited Show Page identity completes local guest admission
+    name: Verified limited Show Page identity admits and denies a revoked guest lease
     status: covered
     kind: happy_path
     layer: scenario

--- a/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
+++ b/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
@@ -41,7 +41,7 @@ from modules.agents.codex.agent import CodexAgent
 from tests.scenario_harness.auth_setup import AuthSetupScenarioHarness, FakeProcess
 from tests.scenario_harness.core import ScenarioExpect, ScenarioRunner, ScenarioStep
 from tests.scenario_harness.show_page_email_access import ShowPageEmailAccessScenarioHarness
-from tests.ui_server_test_helpers import _save_config
+from tests.ui_server_test_helpers import _save_config, remote_session_cookie
 from storage import remote_access_authorization_service
 from tests.scenario_harness.model_hub_native_oauth import (
     HubOAuthScenarioHarness,
@@ -212,6 +212,58 @@ def test_limited_show_identity_closed_loop_installs_guest_lease(monkeypatch, tmp
     )
     assert replay.status_code == 400
     assert replay.get_json()["error"] == "replayed_assertion"
+
+    store = ShowPageStore()
+    try:
+        access = store.get_access(page.session_id)
+        assert access is not None
+        revoked = store.apply_access(
+            page.session_id,
+            expected_revision=access.revision,
+            target_access_mode="limited",
+            target_share_id=page.share_id,
+            target_emails=["someone-else@example.com"],
+        )
+        assert revoked.status == "applied"
+    finally:
+        store.close()
+
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        remote_session_cookie(
+            config,
+            "viewer@example.com",
+            "viewer-1",
+            session_claims={
+                "vibe_instance_id": cloud.instance_id,
+                "vibe_instance_role": "viewer",
+                "vibe_instance_access_source": "show_page_email",
+                "vibe_show_page_id": page.session_id,
+            },
+        ),
+        domain="alex.avibe.bot",
+    )
+    revoked_navigation = client.get(
+        f"/p/{page.share_id}/",
+        base_url="https://alex.avibe.bot",
+        environ_base=remote_peer,
+        headers={
+            "Accept": "text/html",
+            "Sec-Fetch-Mode": "navigate",
+            "Sec-Fetch-Dest": "document",
+        },
+        follow_redirects=False,
+    )
+    assert revoked_navigation.status_code == 403
+    assert "Location" not in revoked_navigation.headers
+    assert "You do not have access to this page" in revoked_navigation.text
+
+    revoked_subresource = client.get(
+        f"/p/{page.share_id}/app.js",
+        base_url="https://alex.avibe.bot",
+        environ_base=remote_peer,
+    )
+    assert revoked_subresource.status_code == 404
 
 
 class _FakeNextTurnRuntime:

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -1374,6 +1374,17 @@ def test_limited_show_guest_is_rechecked_after_access_changes(
         assert "Please contact the page owner" in authenticated_revoked_navigation.text
         assert "Location" not in authenticated_revoked_navigation.headers
 
+        for entry_path in (f"/p/{share_id}/", f"/p/{share_id}/index.html"):
+            non_html_entry = client.get(
+                entry_path,
+                base_url="https://alex.avibe.bot",
+                environ_base=_remote_peer(),
+                headers={"Accept": "application/json"},
+                follow_redirects=False,
+            )
+            assert non_html_entry.status_code == 404
+            assert non_html_entry.get_json() == {"error": "not_found"}
+
         fresh_client = app.test_client()
         fresh_login = fresh_client.get(
             f"/p/{share_id}/",

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -1352,6 +1352,28 @@ def test_limited_show_guest_is_rechecked_after_access_changes(
         )
         assert stale_limited_navigation.status_code == 404
 
+        client.set_cookie(
+            remote_access.SESSION_COOKIE_NAME,
+            remote_session_cookie(
+                config,
+                "viewer@example.com",
+                "viewer-1",
+                role="viewer",
+            ),
+            domain="alex.avibe.bot",
+        )
+        authenticated_revoked_navigation = client.get(
+            f"/p/{share_id}/",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+            headers={"Accept": "text/html"},
+            follow_redirects=False,
+        )
+        assert authenticated_revoked_navigation.status_code == 403
+        assert "You do not have access to this page" in authenticated_revoked_navigation.text
+        assert "Please contact the page owner" in authenticated_revoked_navigation.text
+        assert "Location" not in authenticated_revoked_navigation.headers
+
         fresh_client = app.test_client()
         fresh_login = fresh_client.get(
             f"/p/{share_id}/",

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -12980,6 +12980,22 @@ def _show_public_authenticated_context(config: V2Config | None):
     return context_from_session_payload(session) if session is not None else None
 
 
+def _show_limited_viewer_is_allowed(context: Any, access: Any, page_id: str) -> bool:
+    from core.show_pages import normalize_show_access_email
+
+    allowlisted = False
+    if context.email:
+        try:
+            allowlisted = (
+                access is not None
+                and normalize_show_access_email(context.email)
+                in access.normalized_emails
+            )
+        except (TypeError, ValueError):
+            allowlisted = False
+    return allowlisted or context.can_use_show_page(page_id)
+
+
 async def _show_public_request_author() -> dict[str, str] | None:
     context = await asyncio.to_thread(_show_public_editor_context)
     if context is None:
@@ -14951,14 +14967,44 @@ async def serve_public_show_page(share_id, asset_path):
             # Already-rendered pages are not proactively closed, but every
             # subsequent request must match the current local access record.
             access = store.get_access(page.session_id)
-            if (
-                access is None
-                or page.visibility != "limited"
-                or access.access_mode != "limited"
-                or access.share_id != share_id
-                or lease.normalized_email not in access.normalized_emails
-            ):
-                return _show_limited_not_found_response()
+            lease_is_current = (
+                access is not None
+                and page.visibility == "limited"
+                and access.access_mode == "limited"
+                and access.share_id == share_id
+                and lease.normalized_email in access.normalized_emails
+            )
+            if not lease_is_current:
+                current_limited_binding = (
+                    access is not None
+                    and page.visibility == "limited"
+                    and access.access_mode == "limited"
+                    and access.share_id == share_id
+                )
+                if current_limited_binding:
+                    authenticated_context = await asyncio.to_thread(
+                        _show_public_authenticated_context,
+                        config,
+                    )
+                    if authenticated_context is not None:
+                        if not _show_limited_viewer_is_allowed(
+                            authenticated_context,
+                            access,
+                            page.session_id,
+                        ):
+                            return _show_page_access_denied_response(
+                                include_back_link=(
+                                    authenticated_context.instance_access_source
+                                    != "show_page_email"
+                                )
+                            )
+                        # The current identity may be allowed again, but the
+                        # old lease must not be treated as valid guest access.
+                        limited_guest = False
+                    else:
+                        return _show_limited_not_found_response()
+                else:
+                    return _show_limited_not_found_response()
         if page.visibility == "limited":
             if not limited_guest:
                 if request.method != "GET" or not is_spa_navigation:
@@ -14969,18 +15015,11 @@ async def serve_public_show_page(share_id, asset_path):
                 )
                 if authenticated_context is not None:
                     access = store.get_access(page.session_id)
-                    allowlisted = False
-                    if authenticated_context.email:
-                        try:
-                            allowlisted = (
-                                access is not None
-                                and normalize_show_access_email(authenticated_context.email)
-                                in access.normalized_emails
-                            )
-                        except (TypeError, ValueError):
-                            allowlisted = False
-                    page_scoped = authenticated_context.can_use_show_page(page.session_id)
-                    if not allowlisted and not page_scoped:
+                    if not _show_limited_viewer_is_allowed(
+                        authenticated_context,
+                        access,
+                        page.session_id,
+                    ):
                         return _show_page_access_denied_response(
                             include_back_link=(
                                 authenticated_context.instance_access_source != "show_page_email"

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -12980,7 +12980,13 @@ def _show_public_authenticated_context(config: V2Config | None):
     return context_from_session_payload(session) if session is not None else None
 
 
-def _show_limited_viewer_is_allowed(context: Any, access: Any, page_id: str) -> bool:
+def _show_limited_viewer_is_allowed(
+    context: Any,
+    access: Any,
+    page_id: str,
+    *,
+    allow_page_scoped: bool = True,
+) -> bool:
     from core.show_pages import normalize_show_access_email
 
     allowlisted = False
@@ -12993,7 +12999,7 @@ def _show_limited_viewer_is_allowed(context: Any, access: Any, page_id: str) -> 
             )
         except (TypeError, ValueError):
             allowlisted = False
-    return allowlisted or context.can_use_show_page(page_id)
+    return allowlisted or (allow_page_scoped and context.can_use_show_page(page_id))
 
 
 async def _show_public_request_author() -> dict[str, str] | None:
@@ -14986,11 +14992,12 @@ async def serve_public_show_page(share_id, asset_path):
                         _show_public_authenticated_context,
                         config,
                     )
-                    if authenticated_context is not None:
+                    if authenticated_context is not None and request.method == "GET" and is_spa_navigation:
                         if not _show_limited_viewer_is_allowed(
                             authenticated_context,
                             access,
                             page.session_id,
+                            allow_page_scoped=False,
                         ):
                             return _show_page_access_denied_response(
                                 include_back_link=(

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -14992,7 +14992,12 @@ async def serve_public_show_page(share_id, asset_path):
                         _show_public_authenticated_context,
                         config,
                     )
-                    if authenticated_context is not None and request.method == "GET" and is_spa_navigation:
+                    if (
+                        authenticated_context is not None
+                        and request.method == "GET"
+                        and is_spa_navigation
+                        and _show_page_accepts_html()
+                    ):
                         if not _show_limited_viewer_is_allowed(
                             authenticated_context,
                             access,


### PR DESCRIPTION
When a limited Show email is revoked, an existing browser guest lease is currently classified as anonymous stale access before the active remote session is checked. This keeps anonymous stale leases on the privacy-preserving 404 path, while an authenticated viewer now receives the existing localized 403 access-denied page without OAuth. Re-allowlisted users do not reuse the stale lease and continue through the normal admission flow. Tests: focused Show UI tests (2 passed), Ruff, UI build, diff check.