### PR TITLE
fix(ui): translate remote read-only labels

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2953,6 +2953,8 @@
   "agents": {
     "title": "Agents",
     "subtitle": "{{count}} agents registered across all backends.",
+    "remoteReadOnly": "Read-only",
+    "remoteReadOnlyHint": "This resource is read-only in remote mode.",
     "tabs": {
       "definitions": "Definitions",
       "running": "Runs"
@@ -3237,6 +3239,8 @@
   "skills": {
     "title": "Skills",
     "subtitle": "Manage global and project skills across your agent backends · powered by askill.",
+    "remoteReadOnly": "Read-only",
+    "remoteReadOnlyHint": "Skills are read-only in remote mode.",
     "scopeGlobal": "Global",
     "scopeProject": "Project",
     "searchPlaceholder": "Search installed skills…",
@@ -3811,6 +3815,8 @@
     }
   },
   "vaults": {
+    "remoteReadOnly": "Read-only",
+    "remoteReadOnlyHint": "Vaults are read-only in remote mode.",
     "title": "Vaults",
     "subtitle": "Give your AI agents secrets — their values never enter the context.",
     "add": "Add secret",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2953,6 +2953,8 @@
   "agents": {
     "title": "Agents",
     "subtitle": "已登记 {{count}} 个 Agent。",
+    "remoteReadOnly": "只读",
+    "remoteReadOnlyHint": "远程模式下此资源为只读。",
     "tabs": {
       "definitions": "定义",
       "running": "运行"
@@ -3237,6 +3239,8 @@
   "skills": {
     "title": "技能",
     "subtitle": "跨各 Agent 后端管理全局与项目级技能 · 基于 askill。",
+    "remoteReadOnly": "只读",
+    "remoteReadOnlyHint": "远程模式下技能为只读。",
     "scopeGlobal": "全局",
     "scopeProject": "项目",
     "searchPlaceholder": "搜索已安装技能…",
@@ -3811,6 +3815,8 @@
     }
   },
   "vaults": {
+    "remoteReadOnly": "只读",
+    "remoteReadOnlyHint": "远程模式下 Vaults 为只读。",
     "title": "保险库",
     "subtitle": "为你的 AI Agent 提供密钥，永不进入上下文。",
     "add": "添加密钥",


### PR DESCRIPTION
## Summary
- add English and Chinese translations for remote read-only labels and hints
- cover Agents, Skills, and Vaults pages, which already reference these keys

## Evidence
- Unit: not applicable; locale-only change
- Contract: all `remoteReadOnly` and `remoteReadOnlyHint` call sites audited
- Scenario: not applicable
- Manual: JSON parsing and `git diff --check` passed

## Validation
- `npm run build` attempted; blocked by missing/incompatible local UI dependencies (`vite/client`, `node` types, and `erasableSyntaxOnly`)

## Dependencies
- None
