### PR TITLE
feat(ui): draw the Model Hub usage tab from the metering ledger

### DIFF
--- a/docs/plans/model-hub-usage-metering.md
+++ b/docs/plans/model-hub-usage-metering.md
@@ -1341,3 +1341,45 @@ IDs, which §4 of the scenario-testing standard has required all along, so a bar
 the standard not being followed rather than a second legitimate convention. Zero test renames.
 Coverage went 20 rows / 1 legend-selected catalog → **22 citations across 22 rows**, and the
 standard now states the property so the next catalog writes citations that pass.
+
+### Stage 2, round 6 (head `aa051476e`) — a new class: a composite npm script swallows filters
+
+One P2 finding, on a line round 5 introduced, and it is **not** class A — it is the first
+appearance of a different class: **a composite npm script forwards `--` arguments only to its
+last command.** No breaker trip; a first appearance is a finding, not a pattern.
+
+```
+"test": "vitest run && npm run validate:catalog"
+npm test -- UsageTab.test.tsx
+  → vitest run && npm run validate:catalog UsageTab.test.tsx
+```
+
+npm appends the arguments to the *end* of the whole string, so the filter landed on the
+validator — which takes no path and ignored it — while vitest ran all 231 files unfiltered.
+Both halves still exited 0, so the failure is silent: the focused run AGENTS.md asks for
+first quietly becomes a four-minute full suite, and the argument that was supposed to narrow
+it is discarded by a command that never wanted it.
+
+The class has exactly one other member in `ui/package.json`, and checking it is what decided
+the fix. `"build": "npm run validate:imports && tsc -b && vite build"` is composite too, but
+its argument-taking command is **last**, so `npm run build -- --mode=x` reaches `vite build`
+by accident rather than by design. A rule of the form "put the arg-taking command last" is a
+rule about command order that nothing enforces and the next composite breaks again.
+
+**So the fix deletes the mechanism instead of wrapping it.** `"test"` returns to
+`vitest run`, and the gate reaches CI as a vitest case: `checkCatalogs()` is exported from
+`validate-scenario-catalog.mjs` with the CLI behind an `import.meta.url` guard, and
+`scenarioCatalog.test.mjs` asserts on it. A test case has no argument to misroute, and
+`npm test` already means "everything that must hold", so the gate needs no second entry
+point in CI to be reached.
+
+Both alternatives the reviewer offered were declined for the same reason. A wrapper script
+that parses `--` and forwards to each command keeps the hazard and adds a layer that hides
+it. A separate unfiltered CI command re-splits "what must hold" across two callers, which is
+how the gate could be forgotten on the next workflow edit — and `build-linux-artifacts`
+already runs `npm test`.
+
+What proved it: `npm test -- UsageTab.test.tsx` now runs 1 file / 14 cases, and the gate case
+fails with the resolver's own message when `MEMORY-LIST-006`'s citation is rotted to a
+nonexistent ID (reverted after checking). Full suite 231 files / 2943 tests, CLI gate 22
+citations across 22 rows, `tsc` clean, `eslint` clean, `npm run build` ✓.

--- a/docs/plans/model-hub-usage-metering.md
+++ b/docs/plans/model-hub-usage-metering.md
@@ -1151,3 +1151,60 @@ reads empty for drawn and undrawn columns alike. The decision behind the floor i
 assertable part and it is asserted where it lives — `usageDayIsMetered` over columns in
 `usageProjection.test.ts` — leaving only the pixel to the residual visual check that this
 tab already carries.
+
+### Stage 2, round 3 (head `d22cb479`) — breaker tripped
+
+Two P2 findings. **F1 repeats head 1's class on a second reviewed head**, so the breaker
+is mechanical: stop patching, diagnose at orchestrator level, record the scope decision.
+
+**The class: a text scan deciding which vitest declarations execute.** Head 1 flagged that
+the catalog accepted a non-executable case; the round-2 fix answered with a hand-written
+JS lexer in `test_model_hub_catalog.py` — comments, string and template literals, a regex
+heuristic. Head 3 then flagged a regex opening after `return`, which the heuristic reads as
+division because it only inspects the previous *character*.
+
+Naming the remaining members is what ends this. Measured against the fixture, the lexer
+accepted a fake declaration in **five** shapes — a regex after a keyword, JSX text, a
+`describe.skip` body, an `if (false)` body, and its own division heuristic — and the
+reviewer had reached one. Two of the four it never reached (`describe.skip`, `if (false)`)
+are ordinary code, not adversarial constructions. The class has no last member by
+construction: telling a regex from division needs the parser's state, and telling a skipped
+or unreachable declaration from a live one needs the run. Every future round buys one more
+patch and leaves the property unproved.
+
+**Scope decision (orchestrator, no owner escalation needed): delete the lexer and ask the
+collector.** `vitest list` answers "does this case run" definitively, and `npm test` — which
+is `vitest run` — already executes in CI's `build-linux-artifacts` job on the same commit,
+so the real collector costs no new job and no new dependency beyond a declared `js-yaml`.
+The action is reversible, contract-preserving (row shape and `path::ID` syntax unchanged),
+and smaller than what it replaces: 219 lines of scanner deleted for 126 lines of resolver
+plus gate.
+
+Duties split so neither side overclaims:
+
+| Question | Owner | Why there |
+| --- | --- | --- |
+| Row shape, cited file exists, ID greppable in it, no `expected_fail` on a UI row | `test_model_hub_catalog.py` | `ast`/text answers these exactly |
+| Does the cited ID name exactly one case vitest **runs** | `ui/scripts/validate-scenario-catalog.mjs` | only the collector knows |
+
+`scenarioCatalog.mjs` holds the resolution rules with no subprocess in them, so they stay
+unit-testable; the gate discovers `tests/scenarios/*/catalog.yaml` rather than listing
+them, reads each catalog's own `status_legend` so the two sides cannot drift into
+disagreeing policies, and throws if `tests/scenarios` is absent — this gate must never
+report "nothing to check" for the one input it exists to read. It collects only the cited
+files (9 rows, 3 files, ~0.3 s), not the whole 231-file suite.
+
+MH-CATALOG-002 moves to `ui/scripts/scenarioCatalog.test.mjs`, seeds one declaration of
+every shape, and asserts the set that resolves *equals* the set the fixture names as
+running — derived from the fixture text, so a shape added later is covered without editing
+the assertion. `it.each` is no longer disqualified on principle: the surviving property is
+"exactly one collected case named for the row", and a 2-row `it.each` fails it by count.
+
+**F2: every non-peak day's figures existed only in a hover `title`.** Keyboard,
+screen-reader, and touch users could reach the endpoints and the peak from the axis and
+nothing else — and `role="img"` on the chart hides the columns from assistive tech by
+design. One `readout(column)` helper now feeds both the tooltip and an `sr-only` list
+rendered as a *sibling* of the image (inside it, it would be hidden with everything else).
+No new i18n key: `byDay.column` is the same wording, so the two readings cannot disagree —
+which is how MH-USAGE-023 asserts it, tooltips against list items rather than against a
+list of days.

--- a/docs/plans/model-hub-usage-metering.md
+++ b/docs/plans/model-hub-usage-metering.md
@@ -1383,3 +1383,84 @@ What proved it: `npm test -- UsageTab.test.tsx` now runs 1 file / 14 cases, and 
 fails with the resolver's own message when `MEMORY-LIST-006`'s citation is rotted to a
 nonexistent ID (reverted after checking). Full suite 231 files / 2943 tests, CLI gate 22
 citations across 22 rows, `tsc` clean, `eslint` clean, `npm run build` ✓.
+
+### Stage 2, round 7 (head `f5991f2a6`) — breaker tripped: a token figure states a number without saying it was measured
+
+One P2 finding, and it is a **class repeat on a second reviewed head** (`5957182` →
+`f5991f2a6`), so the breaker trips mechanically. As the orchestrator in a user-started
+session I recorded the scope decision and continued: the smallest complete action is clear,
+reversible, and changes no contract.
+
+The finding is about the copy round 2 introduced. `byDay.zero` claims 「这个区间的 token 用量
+是 0」 for a window whose upstreams never reported anything, because `usageDayColumns`
+carried `requests` and `tokens` and **dropped `token_reports`** — so no site in the day
+series could ask the coverage question even if its copy wanted to.
+
+**Why this is the same class, and why round 2's closure could not have held.** Round 2 named
+the class *the day series asks tokens a question only requests can answer* and closed it with
+`usageDayIsMetered`. That predicate is about activity, and it is still right about activity.
+What round 2 missed is that a bucket carries **three independent facts, not two**:
+
+| Counter | The question it alone answers |
+| --- | --- |
+| `requests` | did calls happen |
+| `token_reports` | did an upstream say what they cost |
+| `input_tokens + output_tokens` | how much |
+
+A rendered `0` is therefore three different readings — a cost reported as nothing, a cost
+nobody reported, and nothing having run at all — and round 2's projection could distinguish
+only the third. Round 2 also explicitly ruled the stat cards *out* of the class, on the
+evidence that they 「each state a token figure they really do own」. Ownership was the wrong
+test: owning the figure says nothing about whether the figure is a measurement.
+
+**The inventory, which is what makes this a class and not a line.** Every token figure the
+tab states, found by grepping every token expression in `UsageTab.tsx` rather than by
+recalling the panels — **8 members**, one of which round 2's ruling had cleared:
+
+1. the tokens stat card's value
+2. its input/output split note
+3. the cached-input card's note — 「No input tokens in this window」, the same defect one card
+   over: with nothing reported there were no input tokens *we know of*, and an absence of
+   reports is not an absence of usage
+4. the by-model row cell
+5. the by-source row cell
+6. the day bar's tooltip readout
+7. the sr-only day table cell
+8. the peak / no-peak sentence
+
+**The fix is one door plus an enumerable marker.** `useTokenText(counters, value)` is the only
+path from a token count to text, and coverage travels *with* the value rather than being
+checked by the caller, so a new token figure cannot be written without naming the counters it
+came from. `TokenFigure` wraps it in `<span data-usage-token="">`, which is not styling: it is
+what lets a test enumerate every node-shaped token figure on screen and assert they all went
+through the door — completeness by construction, which a per-site test cannot claim. Figures
+interpolated into translated sentences have no element of their own and call `useTokenText`
+directly; their sentence is then the asserted unit.
+
+**Two predicates, deliberately not one.** The first draft was `token_reports > 0` alone, and
+it would have shipped the mirror image of the defect it fixes: a day where nothing ran cost
+nothing, and that zero is measured by *our own* request counter rather than promised by an
+upstream. Blanking it reads an idle day as unknowable. So:
+
+- `usageTokensAreReported` = `token_reports > 0` — an upstream costed something. Used by peak
+  selection and by the claim about what the reports said.
+- `usageTokensAreKnown` = `usageTokensAreReported(c) || c.requests === 0` — the number is a
+  measurement, so printable. Used by the figure door.
+
+Only a day whose tokens were reported can be the busiest one: a day with no report has no
+measured cost to compare, so naming it the peak puts a superlative on a number the report
+never carried. And the no-peak copy becomes four-way with **`reported` ordered before
+`metered`** — a window with any report in it can state what its reports said, and the calls
+that came back without one are the requests card's shortfall to name, not this sentence's.
+
+**The backend premise, verified rather than assumed.** A reported zero really does exist on
+the wire: `extract_protocol_usage` (`core/handlers/model_hub/stream_wire.py:533`) returns a
+non-null report for an explicit all-zero usage block — `_usage_sum` returns `0`, not `None` —
+and `usage.py:464` sets `token_reports = call.requests if usage is not None else 0`. So
+MH-USAGE-025 draws a window that exists, not a hypothetical.
+
+**What proved it, by breaking it.** Rotting `usageTokensAreKnown` to `return true` fails
+MH-USAGE-021 and MH-USAGE-026 and nothing else; swapping the `reported`/`metered` branch order
+fails MH-USAGE-025 and only it. Both restored. Full suite 231 files / 2950 tests, catalog gate
+24 citations across 24 rows, model_hub catalog pytest ✓, `tsc` clean, `eslint` clean,
+`npm run build` ✓.

--- a/docs/plans/model-hub-usage-metering.md
+++ b/docs/plans/model-hub-usage-metering.md
@@ -1208,3 +1208,77 @@ rendered as a *sibling* of the image (inside it, it would be hidden with everyth
 No new i18n key: `byDay.column` is the same wording, so the two readings cannot disagree —
 which is how MH-USAGE-023 asserts it, tooltips against list items rather than against a
 list of days.
+
+### Stage 2, round 4 (head `82c46d5a0`) — breaker tripped again
+
+Two P2 findings, **both class repeats**, so the breaker trips a second time and both
+closures are made at the class owner rather than at the flagged site.
+
+| Class | Heads | What recurs |
+| --- | --- | --- |
+| A | 1, 3, 4 | A row can read `covered` while nothing executable backs it |
+| B | 3, 4 | The report states per-row figures through visual position alone |
+
+**Class A — the gate asked one catalog and passed three in silence.** Round 3's gate
+selected rows through each catalog's own `status_legend`, and `status_legend` maps a status
+to a *description string* in every catalog here but `model_hub`. Reading `test_required`
+off a string yields `undefined`, so `harness_command_task`, `memory_list`, and
+`message_delivery` contributed zero rows — the gate reported a clean 9/9 while three
+catalogs went unasked. That is the same failure the gate exists to prevent, one level up.
+
+The reviewer proposed normalizing the scalar legends. Rejected: inferring `test_required`
+from prose (`'deterministic scenario or contract coverage exists'` → true?) is a heuristic
+over English, the exact species of thing round 3 deleted from the Python side. **A row that
+*cites* a UI file must resolve, whatever its legend looks like** — simpler and strictly
+stronger. A citation is the row's own claim, exists in every catalog, and no legend shape
+can switch it off. Coverage went 9 rows / 1 catalog → 20 rows / 4 catalogs; collection
+still rides `npm test`, 1.7 s.
+
+Three citation shapes now resolve under one rule, because one notion (prefix) is what they
+have in common — a rule per catalog would be a policy each new catalog could contradict:
+
+| Shape | Written as | Resolves against |
+| --- | --- | --- |
+| Catalog ID | `path::MH-USAGE-024` | the case's own name |
+| Readable full name | `path::taskCommandPreview quotes an argv part …` | the full name with `' > '` flattened to `' '` |
+| File only | `path` | the file being collected at all |
+
+Two shapes that resolve to a running case and still prove nothing are rejected explicitly: a
+row citing a **sibling row's ID** (checked against the whole catalog's ID set, including
+pytest-evidenced rows), and a file-only citation whose file collects nothing.
+
+The gate immediately caught a real pre-existing defect it had been unable to see:
+`harness_command_task` **SCT-016** was `covered` on `taskCommandPreview quotes argv the way
+the shell would read it back`, a case name that no longer exists. Re-pointed to the live
+case; the row's claim was true, its citation had rotted.
+
+**Class B — one mechanism for every panel of per-row figures.** Round 3 answered the by-day
+chart with an `sr-only` sentence per day; head 4 flagged the by-source table, whose figures
+were unattributed `<span>`s in a CSS grid. Answering the second panel with a second
+mechanism invites a fifth round, so both panels now carry the same structure.
+
+Why roles and not a native `<table>` for the visible panel: the layout is a CSS grid
+(`--model-hub-usage-columns`) that collapses to one column below 767px, and a `<table>` can
+only stack through a `display` override — overriding `display` is exactly what strips the
+native table semantics it was chosen for. Explicit roles are unaffected by `display` and
+keep both the grid and the structure at every width. The by-day list became an `sr-only`
+native `<table>` (Tailwind's `sr-only` does not touch `display`), so the tab has one answer
+for "figures need row and column association" instead of two.
+
+A figure's column is **its position in its row** — which is what makes the header row an
+answer rather than decoration, in an ARIA table exactly as in a native one — and the cell
+repeats its header as a `md:hidden` label for the width where the header row is `display:none`.
+Between them the two cover both widths, so a per-cell `aria-colindex` restates what position
+already says; it earns its keep only for a row that skips a *middle* column, and the model
+row's empty `lastMetered` cell is the simpler way to not have one. Mutation-checked before
+deciding: dropping `aria-colindex` changed no observable association and no assertion, so it
+went.
+
+MH-USAGE-023 is reframed against the table (its `<li>`s are gone), still deriving every
+expectation from the tooltips so the two readings of a day cannot answer differently.
+MH-USAGE-024 is the class property, asked of *whatever* tables the tab renders: every body
+row has exactly one row header, states as many figures as there are columns (no row ends
+early and shifts the ones before it), and — where the headers can leave the accessibility
+tree — labels every figure with the header at its own position. Four mutations were run
+against it and all four fail: dropping `role="table"`, removing the model row's placeholder
+cell, removing the stacked labels, and reordering `SOURCE_COLUMNS`.

--- a/docs/plans/model-hub-usage-metering.md
+++ b/docs/plans/model-hub-usage-metering.md
@@ -1068,10 +1068,25 @@ own.
 
 **Catalog.** `tests/scenarios/model_hub/test_model_hub_catalog.py` previously
 resolved a row's evidence with `ast.parse`, so the capability's user-visible half
-could not be registered at all. It now resolves a `.ts`/`.tsx` row by slicing the
-named `it(...)` case and requiring the catalog ID inside that case — the same
-per-row greppability the Python docstring rule gives, rather than a per-file
-approximation.
+could not be registered at all. A `.ts`/`.tsx` row now cites its own ID
+(`…/UsageTab.test.tsx::MH-USAGE-018`) and resolves to the single executable
+`it('MH-USAGE-018: …')` declaration that carries it. A vitest case's name is its
+docstring, so that is where the ID belongs — the same per-row greppability the
+Python docstring rule gives, and the evidence is runnable by ID
+(`vitest -t MH-USAGE-018`) rather than only greppable.
+
+The first version of this checker sliced each case's body instead and asked whether
+the ID appeared inside the slice. Two properties are why it was replaced rather than
+patched. Deciding where a case *ends* needs balanced delimiters, and a scan that
+small cannot tell a regex literal from division — so `/Couldn't refresh/i`, ordinary
+in this suite, read as a string opening and the slice swallowed eight sibling cases.
+And its guard against exactly that (re-parse the slice, require one declaration) ran
+the same scan, so the desync agreed with itself and passed. Reading only names
+removes the failure instead of guarding it: a wrong guess can lose a declaration,
+which fails the row loudly, but can never hand a row a neighbour's ID. Verified
+against vitest's own collection over the whole Model Hub UI suite — 873 collected
+cases, every unresolved one a parameterized `it.each` whose name does not exist in
+the source, and nothing resolved that vitest does not run.
 
 **Dead 额度 code removed with the rename.** Copy: `settings.models.usage.monthSpend`,
 `settings.models.usageTab`, and `settings.models.tabs` (a zero-caller duplicate of

--- a/docs/plans/model-hub-usage-metering.md
+++ b/docs/plans/model-hub-usage-metering.md
@@ -1241,7 +1241,7 @@ have in common — a rule per catalog would be a policy each new catalog could c
 | --- | --- | --- |
 | Catalog ID | `path::MH-USAGE-024` | the case's own name |
 | Readable full name | `path::taskCommandPreview quotes an argv part …` | the full name with `' > '` flattened to `' '` |
-| File only | `path` | the file being collected at all |
+| File only | `path` | the file being collected at all — *deleted in round 5, below* |
 
 Two shapes that resolve to a running case and still prove nothing are rejected explicitly: a
 row citing a **sibling row's ID** (checked against the whole catalog's ID set, including
@@ -1282,3 +1282,62 @@ early and shifts the ones before it), and — where the headers can leave the ac
 tree — labels every figure with the header at its own position. Four mutations were run
 against it and all four fail: dropping `role="table"`, removing the model row's placeholder
 cell, removing the stacked labels, and reordering `SOURCE_COLUMNS`.
+
+### Stage 2, round 5 (head `28baeb512`) — class A, fifth appearance
+
+One P2 finding, and it is class A again: **a row can read `covered` while nothing executable
+is tied to *that row*.** Heads 1, 3, 4, 5. Each round's fix was correct about the level it
+was shown and defined the property by what the existing rows happened to say — which is what
+produced the next level.
+
+| Head | What the gate accepted | The question it was actually answering |
+| --- | --- | --- |
+| 1 | a commented-out declaration | does the cited case run |
+| 3 | a regex literal read as division | the same, one layer deeper |
+| 4 | rows selected through `status_legend` | which rows get asked |
+| 5 | a file-only citation | what counts as an answer |
+
+Round 4 accepted the file-only shape **because three legacy rows used it**. The reviewer
+showed why that cannot hold: `MEMORY-LIST-006` and `MEMORY-LIST-007` both cited
+`MemorySearchPanel.test.tsx` and nothing else, so deleting either row's case leaves the other
+row keeping the file collected and *both* rows green. A file runs for reasons that have
+nothing to do with the citing row.
+
+**Terminal rule, with no free parameter left for an adversary to probe:** a citation must
+name a case, and that name must resolve to **exactly one** case the collector observes in the
+cited file — for **every** citation a row makes, not for one key. The shape is deleted rather
+than weakened; there is no ID heuristic bolted onto a bare file.
+
+**The member the reviewer had not reached, which is where the rot was.** `memory_repair`
+states its UI half as `ui_contract: {test, case, inputs}`, so reading `row.test` alone left
+all five of its fully-written citations unasked — the round-4 legend hole again, in a
+different key. Four of the five were dead. `git log -S` traces three to `d6ea9ee0f`
+(#1401, merged 2026-08-14), which deleted 623 lines from `SettingsMemoryPage.test.tsx` and
+368 from `MemoryStatusPanel.test.tsx`; nothing read `ui_contract`, so the false claims sat
+there for five days. Those three `ui_contract` blocks are deleted — `status`,
+`expected_outputs`, and `related_tests` untouched, since only the case-level claim was
+provably false and asserting anything more about another capability's semantics is not mine
+to assert.
+
+`related_tests` and `canonical_tests` stay unread, and that is **the same rule rather than an
+exception to it**: they name a file and no case, so they cannot evidence a row — and they do
+not claim to. "Related" is a pointer.
+
+Two mechanics follow from measurement rather than from taste:
+
+- **Containment, not prefix.** `[MEMORY-LIST-004][MEMORY-LIST-006] browses …` is one case
+  answering two scenarios, each citing it by its own ID, so an ID is not always first. The
+  looseness is bounded by the pre-existing uniqueness count — a name reaching two cases fails
+  for the same reason as one reaching none.
+- **Parameterized cases without emulating printf.** `vitest list` *does* expand `it.each`, so
+  a citation's terms are the template's literal head plus each `inputs` entry, all contained
+  in one collected name. The literal tail is dropped rather than parsed because the count is
+  what decides: for `accepts the declared failure %s with result %s` with
+  `[memory_repair_failed, timed_out]`, one collected case carries all three terms and the
+  other seven carry two.
+
+The three bare-file rows were fixable as citations alone — their cases already carry their
+IDs, which §4 of the scenario-testing standard has required all along, so a bare-file row was
+the standard not being followed rather than a second legitimate convention. Zero test renames.
+Coverage went 20 rows / 1 legend-selected catalog → **22 citations across 22 rows**, and the
+standard now states the property so the next catalog writes citations that pass.

--- a/docs/plans/model-hub-usage-metering.md
+++ b/docs/plans/model-hub-usage-metering.md
@@ -1097,3 +1097,57 @@ keeping them only invites someone to wire it back up. What remains is
 `types.SourceUsage` and the `mockData` 额度 fields: the type mirrors
 `docs/plans/model-hub-contracts/source.schema.json`, which still declares the block,
 and is retired when the contract retires it.
+
+### Stage 2, round 2 (head `5957182`)
+
+Two P2 findings, **no class repeat** — head 1 (`7082c882e`) carried one finding about
+catalog evidence resolved textually, which neither of these touches — so the breaker is
+not tripped and the round is two closures rather than a diagnosis.
+
+**F1: the day series read a missing token report as an idle day.** `token_reports <=
+requests` is a contract, and the gap means *reports that never arrived* — the tab already
+says exactly that for the totals (MH-USAGE-018). The day series then contradicted it: it
+scaled and captioned days by tokens alone, so a window whose upstreams all answered
+without token counts drew every bar at zero and captioned itself
+「没有任何一天有计量数据」 — our own missing evidence reported as the user's idleness.
+
+The finding named the peak/quiet copy. The class — *the day series asks tokens a question
+only requests can answer* — has exactly three members inside `ByDayPanel`: that copy, the
+column height, and the per-column tooltip. So the fix is one predicate, not one call site:
+`UsageDayColumn` carries `requests` alongside `tokens`, `usageDayIsMetered` is the single
+place the series asks whether a day ran, and all three members read it. A no-peak window
+now splits into the two different windows it always was — one nobody used, and one whose
+upstreams never said what it cost (`byDay.quiet` vs `byDay.unreported`).
+
+Ruled *out* of the class on evidence rather than by assumption, by reading
+`core/handlers/model_hub/usage.py`: `usageIsEmpty` gates on `sources.length`, and
+`summary()` builds source rows from the same request-driven rows, so an unreported window
+still has sources and is not empty; the stat cards, `cached.none`, and the chart's
+aria-label each state a token figure they really do own.
+
+**F2: deleting the last Source took the ledger with it.** `directEmpty` was a top-level
+routing fork, so the Frame 09 landing replaced the whole tab shell — including the Usage
+tab. But the ledger outlives the Sources it meters: retention is 62 days and MH-USAGE-017
+exists precisely because a vanished Source keeps its `src_*` id in the report. A user who
+deletes their last source loses the only route to what it cost, and a user reading the
+report when a deletion lands is thrown off the tab mid-read.
+
+One rule replaces the fork: **the Hub always has its two tabs, and `directEmpty` decides
+the body of the `sources` tab.** That is fewer concepts than the alternative (a usage
+affordance inside `DirectHome` plus a route back out of it), and it fixes the mid-read
+eviction for free. MH-USAGE-022 states the property over `Record<ModelsSurfaceKind, …>`,
+so a third landing fails to compile rather than shipping without a route.
+
+**Known-by-design: Frame 09 is drawn without the tab strip.** The frame predates this tab
+and the Usage tab has no frame at all, so the frame's silence is the absence of the
+concept, not a decision about it. What Frame 09 decides is the *body* of the `sources`
+tab, and that is still Frame 09 there — asserted, including that no gateway-overview
+content leaks in beside it.
+
+**Evidence.** MH-USAGE-021 draws a window where every request came back unreported and
+asserts the copy plus each day's readout. The bar geometry itself is not asserted there:
+the floor is `max(2px, …)`, an inline CSS function jsdom's parser drops, so `style.height`
+reads empty for drawn and undrawn columns alike. The decision behind the floor is the
+assertable part and it is asserted where it lives — `usageDayIsMetered` over columns in
+`usageProjection.test.ts` — leaving only the pixel to the residual visual check that this
+tab already carries.

--- a/docs/plans/model-hub-usage-metering.md
+++ b/docs/plans/model-hub-usage-metering.md
@@ -1024,11 +1024,61 @@ verbatim.
 - [x] `ModelHubService.usage_summary` + RPC + `GET /api/models/usage`
 - [x] Contract row, response registry entry, and usage schema
 - [x] Unit and contract coverage
-- [ ] Stage 2: draw the 用量与额度 tab against this data
+- [x] Stage 2: draw the tab against this data, as 用量
 
-## Stage 2 note
+## Stage 2 — what shipped
 
-The tab is currently named 用量与额度 / "Usage and quota". After this stage the
-用量 half is real and the 额度 half is still unobtainable, so the label needs a
-design decision before stage 2 ships — renaming the tab to 用量 is the honest
-option unless a quota source appears.
+**The tab is named 用量 / "Usage".** The label was 用量与额度 / "Usage and quota",
+and the 额度 half has exactly one production writer:
+`core/handlers/model_hub/migration.py` writes `"cycle_used_pct": None`. Every
+non-null value in the repo is a mock or a schema example. So this is not a naming
+preference — a quota reading would be an invention, and the tab is named for what
+it can show. If a quota source ever appears, the label grows back with it.
+
+**Where the data becomes a view.** `usageProjection.ts` owns every derivation the
+tab could get wrong — the trailing local-day window, what a row may display, and
+the densification of a sparse trend — so each one is asserted as a property rather
+than inspected in JSX. `UsageTab.tsx` owns layout and copy and translates nothing
+into numbers. Three properties are worth naming because getting them wrong would
+be a lie rather than a glitch, and each is a catalog row (MH-USAGE-016..020):
+
+- the caption states the `window_days` the server *served*, never the number the
+  control asked for;
+- a `token_reports` shortfall reads as reports that never arrived, never as unused
+  capacity, which the schema forbids in as many words;
+- a model whose label is gone shows no identity at all, because its ledger key is a
+  digest; a gone Source keeps its `src_*` id, which is a string the user has seen.
+
+**The read is the tab's own.** It is deliberately not a member of
+`FIRST_PAINT_REGION_WHITELIST`: the landing decides routing, and a report nobody
+is looking at must not delay it. One effect owns both the open and the window
+change, since a window change is the same read over a different span, and
+`beginRegionRead` keeps the previous figure on screen while the new one lands.
+
+**Geometry.** `design.pen` has no frame for this tab on the local surface, so the
+block adapts `MS/ConfigPanel → cp-usage-body` and otherwise follows the source
+table directly above it — same 18px gutter, 36px head, 11px column labels, 12px
+radius. Importing a second panel's spacing into the middle of this one would read
+as two surfaces stitched together. Two deliberate departures: the day series is a
+column chart because the day count is a window parameter rather than a fixed five,
+and the panels stack because the table carries nested rows. No light-mode branch
+was needed — every ink resolves through a step both light blocks already re-anchor,
+and the chart's two colors are a wash and a `color-mix` accent, which flip on their
+own.
+
+**Catalog.** `tests/scenarios/model_hub/test_model_hub_catalog.py` previously
+resolved a row's evidence with `ast.parse`, so the capability's user-visible half
+could not be registered at all. It now resolves a `.ts`/`.tsx` row by slicing the
+named `it(...)` case and requiring the catalog ID inside that case — the same
+per-row greppability the Python docstring rule gives, rather than a per-file
+approximation.
+
+**Dead 额度 code removed with the rename.** Copy: `settings.models.usage.monthSpend`,
+`settings.models.usageTab`, and `settings.models.tabs` (a zero-caller duplicate of
+`shell.tab`). Formatters: `formatSpend` and `currencySymbol`, which had zero callers
+already on `master` — they render `month_spend_cents`, whose one writer is
+`migration.py`'s `None`, so the amount they format is unobtainable in production and
+keeping them only invites someone to wire it back up. What remains is
+`types.SourceUsage` and the `mockData` 额度 fields: the type mirrors
+`docs/plans/model-hub-contracts/source.schema.json`, which still declares the block,
+and is retired when the contract retires it.

--- a/standards/scenario-testing/STANDARD.md
+++ b/standards/scenario-testing/STANDARD.md
@@ -182,6 +182,17 @@ Every scenario-backed automated test should expose the scenario ID in a searchab
 - test metadata/decorator
 - or a nearby scenario mapping constant
 
+Every citation a row makes must name a **case**, and that name must resolve to
+exactly one case the suite collects in the cited file — in whichever key the row
+states its evidence, `test` and any layer-specific key alike. A citation that
+names only a file is not evidence for the row that makes it: the file stays
+collected for whatever else cites it, so deleting the one case that answered
+this row leaves the row reading `covered` with nothing executable tied to it.
+That is not hypothetical — it is how four dead citations survived a test-file
+rewrite unnoticed for five days. A pointer key such as `related_tests` may name
+bare files precisely because it claims no coverage; anything that does claim
+coverage names its case.
+
 ## 5. Harness Design Rules
 
 ### Preferred Design

--- a/tests/scenarios/INDEX.yaml
+++ b/tests/scenarios/INDEX.yaml
@@ -122,6 +122,7 @@ capabilities:
       - tests/test_opencode_server.py
       - ui/src/components/settings/models/UsageTab.test.tsx
       - ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
+      - ui/scripts/scenarioCatalog.test.mjs
   - id: harness_failure_recovery
     name: Harness per-Session failure recovery
     status: active

--- a/tests/scenarios/INDEX.yaml
+++ b/tests/scenarios/INDEX.yaml
@@ -120,6 +120,8 @@ capabilities:
       - tests/test_model_hub_l3.py
       - tests/test_model_hub_usage.py
       - tests/test_opencode_server.py
+      - ui/src/components/settings/models/UsageTab.test.tsx
+      - ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
   - id: harness_failure_recovery
     name: Harness per-Session failure recovery
     status: active

--- a/tests/scenarios/harness_command_task/catalog.yaml
+++ b/tests/scenarios/harness_command_task/catalog.yaml
@@ -132,7 +132,7 @@ scenarios:
     kind: config
     layer: unit
     backend: shared
-    test: ui/src/components/workbench/harnessLifecycle.test.ts::taskCommandPreview quotes argv the way the shell would read it back
+    test: ui/src/components/workbench/harnessLifecycle.test.ts::taskCommandPreview quotes an argv part that would otherwise lose its boundary
   - id: SCT-017
     name: a fire that produced no exit code clears the one the last fire left
     status: covered

--- a/tests/scenarios/memory_list/catalog.yaml
+++ b/tests/scenarios/memory_list/catalog.yaml
@@ -48,10 +48,10 @@ scenarios:
     status: covered
     kind: happy_path
     layer: contract
-    test: ui/src/components/settings/memory/MemorySearchPanel.test.tsx
+    test: ui/src/components/settings/memory/MemorySearchPanel.test.tsx::[MEMORY-LIST-006]
   - id: MEMORY-LIST-007
     name: Non-empty Search query preserves relevance search behavior
     status: covered
     kind: compatibility
     layer: contract
-    test: ui/src/components/settings/memory/MemorySearchPanel.test.tsx
+    test: ui/src/components/settings/memory/MemorySearchPanel.test.tsx::[MEMORY-LIST-007]

--- a/tests/scenarios/memory_repair/catalog.yaml
+++ b/tests/scenarios/memory_repair/catalog.yaml
@@ -62,9 +62,6 @@ scenarios:
     expected_outputs:
       - A completed-with-warnings response containing the frozen unhealthy projection
       - A follow-up public status read that remains available and reports degraded cascade health
-    ui_contract:
-      test: ui/src/components/settings/SettingsMemoryPage.test.tsx
-      case: renders an unhealthy Repair completion as warnings
     related_tests:
       - tests/test_memory_repair.py::test_repair_runs_sync_beside_live_sidecar_and_projects_health
       - ui/src/components/settings/SettingsMemoryPage.test.tsx
@@ -86,9 +83,6 @@ scenarios:
       - Exactly one internal Repair invocation across both public Repair requests
       - A 409 memory_operation_in_progress response without invoking internal Clear
       - A completed joined response and available follow-up status
-    ui_contract:
-      test: ui/src/components/settings/SettingsMemoryPage.test.tsx
-      case: prevents a second Repair request while the first is pending
     related_tests:
       - tests/test_memory_repair.py::test_repair_is_retained_joined_and_holds_lease_after_caller_cancel
       - ui/src/components/settings/SettingsMemoryPage.test.tsx
@@ -138,9 +132,6 @@ scenarios:
       - repair_available remains exactly false before and after the attempted mutation
       - A 409 memory_runtime_unsupported failure from the public Repair route
       - An available follow-up Memory status result
-    ui_contract:
-      test: ui/src/components/settings/memory/MemoryStatusPanel.test.tsx
-      case: only exposes Repair index when the backend capability is explicitly available
     related_tests:
       - tests/test_ui_memory_routes.py::test_memory_settings_are_direct_loopback_only_and_write_only
       - tests/test_ui_memory_routes.py::test_memory_settings_projects_only_admitted_repair_capability

--- a/tests/scenarios/message_delivery/catalog.yaml
+++ b/tests/scenarios/message_delivery/catalog.yaml
@@ -163,7 +163,7 @@ scenarios:
     status: covered
     kind: regression
     layer: contract
-    test: ui/src/components/workbench/Composer.attachmentRetry.test.tsx
+    test: ui/src/components/workbench/Composer.attachmentRetry.test.tsx::MESSAGE-DELIVERY-025
   - id: MESSAGE-DELIVERY-101
     name: Unresolved fallback-capable delivery fences only later FIFO submissions
     status: covered

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -15,6 +15,9 @@ capability:
     # properties can be observed, so the catalog checker resolves both shapes.
     - ui/src/components/settings/models/UsageTab.test.tsx
     - ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
+    # The gate that resolves those rows against vitest's own collection, and
+    # its own evidence.
+    - ui/scripts/scenarioCatalog.test.mjs
     - tests/scenarios/model_hub/test_model_hub_catalog.py
     - tests/scenarios/model_hub/test_model_hub_configured_route_scenarios.py
     - tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py
@@ -49,7 +52,7 @@ scenarios:
     status: covered
     kind: contract
     layer: unit
-    test: tests/scenarios/model_hub/test_model_hub_catalog.py::test_mh_catalog_002_ui_evidence_resolves_only_to_an_executable_declaration
+    test: ui/scripts/scenarioCatalog.test.mjs::MH-CATALOG-002
   - id: MH-S1-001
     name: Live conditions never change the exact configured hop identity
     status: covered
@@ -261,6 +264,12 @@ scenarios:
     kind: observation
     layer: unit
     test: ui/src/components/settings/models/SettingsModelsPage.render.test.tsx::MH-USAGE-022
+  - id: MH-USAGE-023
+    name: Every day of the window states its figures in text, not only in a pointer tooltip
+    status: covered
+    kind: observation
+    layer: unit
+    test: ui/src/components/settings/models/UsageTab.test.tsx::MH-USAGE-023
   - id: MH-RES-LIVE-001
     name: Live turn retries an eligible backup before streaming starts
     status: covered

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -44,6 +44,12 @@ scenarios:
     kind: contract
     layer: scenario
     test: tests/scenarios/model_hub/test_model_hub_catalog.py::test_mh_catalog_001_scenario_catalog_is_complete_and_executable
+  - id: MH-CATALOG-002
+    name: A UI-evidenced row resolves only to a vitest case that runs under its catalog ID
+    status: covered
+    kind: contract
+    layer: unit
+    test: tests/scenarios/model_hub/test_model_hub_catalog.py::test_mh_catalog_002_ui_evidence_resolves_only_to_an_executable_declaration
   - id: MH-S1-001
     name: Live conditions never change the exact configured hop identity
     status: covered
@@ -218,31 +224,31 @@ scenarios:
     status: covered
     kind: contract
     layer: unit
-    test: ui/src/components/settings/models/UsageTab.test.tsx::names the window the report was served over, not the one asked for
+    test: ui/src/components/settings/models/UsageTab.test.tsx::MH-USAGE-016
   - id: MH-USAGE-017
     name: A vanished model's ledger key never reaches the screen, while a vanished Source stays identifiable
     status: covered
     kind: observation
     layer: unit
-    test: ui/src/components/settings/models/UsageTab.test.tsx::keeps a vanished Source identifiable and a vanished model unnamed
+    test: ui/src/components/settings/models/UsageTab.test.tsx::MH-USAGE-017
   - id: MH-USAGE-018
     name: A token-report shortfall reads as missing reports rather than unused capacity
     status: covered
     kind: contract
     layer: unit
-    test: ui/src/components/settings/models/UsageTab.test.tsx::reads a shortfall as reports that never arrived
+    test: ui/src/components/settings/models/UsageTab.test.tsx::MH-USAGE-018
   - id: MH-USAGE-019
     name: A day the window covered without a metered turn is drawn as idle rather than closed over
     status: covered
     kind: observation
     layer: unit
-    test: ui/src/components/settings/models/UsageTab.test.tsx::plots every day of the window, including the ones that carried nothing
+    test: ui/src/components/settings/models/UsageTab.test.tsx::MH-USAGE-019
   - id: MH-USAGE-020
     name: The usage report is read when its tab is opened, never as part of the routing surface's first paint
     status: covered
     kind: observation
     layer: unit
-    test: ui/src/components/settings/models/SettingsModelsPage.render.test.tsx::leaves the report unread until its tab is opened, then reads the default span
+    test: ui/src/components/settings/models/SettingsModelsPage.render.test.tsx::MH-USAGE-020
   - id: MH-RES-LIVE-001
     name: Live turn retries an eligible backup before streaming starts
     status: covered

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -249,6 +249,18 @@ scenarios:
     kind: observation
     layer: unit
     test: ui/src/components/settings/models/SettingsModelsPage.render.test.tsx::MH-USAGE-020
+  - id: MH-USAGE-021
+    name: A day whose calls carried no token report reads as metered rather than idle
+    status: covered
+    kind: observation
+    layer: unit
+    test: ui/src/components/settings/models/UsageTab.test.tsx::MH-USAGE-021
+  - id: MH-USAGE-022
+    name: The usage report stays reachable from every Model Hub landing, including one with no Source left
+    status: covered
+    kind: observation
+    layer: unit
+    test: ui/src/components/settings/models/SettingsModelsPage.render.test.tsx::MH-USAGE-022
   - id: MH-RES-LIVE-001
     name: Live turn retries an eligible backup before streaming starts
     status: covered

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -11,6 +11,10 @@ capability:
     - tests/test_model_hub_l3.py
     - tests/test_model_hub_usage.py
     - tests/test_opencode_server.py
+    # The user-visible half of metering. A vitest case is the only place these
+    # properties can be observed, so the catalog checker resolves both shapes.
+    - ui/src/components/settings/models/UsageTab.test.tsx
+    - ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
     - tests/scenarios/model_hub/test_model_hub_catalog.py
     - tests/scenarios/model_hub/test_model_hub_configured_route_scenarios.py
     - tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py
@@ -209,6 +213,36 @@ scenarios:
     kind: recovery
     layer: unit
     test: tests/test_model_hub_usage.py::test_a_wedged_ledger_write_cannot_hold_the_process_open
+  - id: MH-USAGE-016
+    name: The usage report names the window the server served, not the one the view asked for
+    status: covered
+    kind: contract
+    layer: unit
+    test: ui/src/components/settings/models/UsageTab.test.tsx::names the window the report was served over, not the one asked for
+  - id: MH-USAGE-017
+    name: A vanished model's ledger key never reaches the screen, while a vanished Source stays identifiable
+    status: covered
+    kind: observation
+    layer: unit
+    test: ui/src/components/settings/models/UsageTab.test.tsx::keeps a vanished Source identifiable and a vanished model unnamed
+  - id: MH-USAGE-018
+    name: A token-report shortfall reads as missing reports rather than unused capacity
+    status: covered
+    kind: contract
+    layer: unit
+    test: ui/src/components/settings/models/UsageTab.test.tsx::reads a shortfall as reports that never arrived
+  - id: MH-USAGE-019
+    name: A day the window covered without a metered turn is drawn as idle rather than closed over
+    status: covered
+    kind: observation
+    layer: unit
+    test: ui/src/components/settings/models/UsageTab.test.tsx::plots every day of the window, including the ones that carried nothing
+  - id: MH-USAGE-020
+    name: The usage report is read when its tab is opened, never as part of the routing surface's first paint
+    status: covered
+    kind: observation
+    layer: unit
+    test: ui/src/components/settings/models/SettingsModelsPage.render.test.tsx::leaves the report unread until its tab is opened, then reads the default span
   - id: MH-RES-LIVE-001
     name: Live turn retries an eligible backup before streaming starts
     status: covered

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -270,6 +270,12 @@ scenarios:
     kind: observation
     layer: unit
     test: ui/src/components/settings/models/UsageTab.test.tsx::MH-USAGE-023
+  - id: MH-USAGE-024
+    name: Every figure in the usage report names the row and the column it answers, not a position on screen
+    status: covered
+    kind: observation
+    layer: unit
+    test: ui/src/components/settings/models/UsageTab.test.tsx::MH-USAGE-024
   - id: MH-RES-LIVE-001
     name: Live turn retries an eligible backup before streaming starts
     status: covered

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -276,6 +276,18 @@ scenarios:
     kind: observation
     layer: unit
     test: ui/src/components/settings/models/UsageTab.test.tsx::MH-USAGE-024
+  - id: MH-USAGE-025
+    name: A window whose upstreams reported zero tokens reads as measured rather than unreported
+    status: covered
+    kind: observation
+    layer: unit
+    test: ui/src/components/settings/models/UsageTab.test.tsx::MH-USAGE-025
+  - id: MH-USAGE-026
+    name: Every token figure the usage report states names the coverage it was measured from
+    status: covered
+    kind: observation
+    layer: unit
+    test: ui/src/components/settings/models/UsageTab.test.tsx::MH-USAGE-026
   - id: MH-RES-LIVE-001
     name: Live turn retries an eligible backup before streaming starts
     status: covered

--- a/tests/scenarios/model_hub/test_model_hub_catalog.py
+++ b/tests/scenarios/model_hub/test_model_hub_catalog.py
@@ -3,14 +3,21 @@
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 
+import pytest
 import yaml
 
 
 SCENARIO_ROOT = Path("tests/scenarios/model_hub")
 PROJECT_INDEX = Path("tests/scenarios/INDEX.yaml")
 CAPABILITY_ID = "model_hub"
+
+#: A vitest case declaration: the bare `it(` call form followed by a name literal.
+#: The lookbehind rejects `xit(` and `suite.it(`, and requiring `(` immediately
+#: after the identifier rejects every modifier form (`it.skip`, `it.each`, …).
+_IT_CALL = re.compile(r"(?<![A-Za-z0-9_$.])it\s*\(\s*(?=['\"`])")
 
 
 def _document(name: str) -> dict:
@@ -38,25 +45,157 @@ def _test_function(path: Path, function_name: str) -> ast.FunctionDef | ast.Asyn
     return function
 
 
-def _vitest_case(path: Path, case_name: str) -> str:
-    """One `it(...)` case's own source.
+def _advance(source: str, index: int) -> int:
+    """Index just past the comment, literal, or regex at `index`; the next character otherwise.
 
-    A user-visible half of this capability is evidenced by a vitest case rather
-    than a pytest function, and it has to be checkable the same way: the row must
-    resolve to a case that exists, and that case must name its catalog ID where a
-    Python test would carry a docstring. Slicing the case out is what makes the ID
-    check per-row instead of per-file, so a second row cannot ride on the first
-    one's ID.
+    This is the whole lexer: everything the scan must not read as code is a comment,
+    a literal, or a regex, and skipping one is always "jump to where it ends".
     """
 
-    source = path.read_text()
-    start = next(
-        (found for quote in ("'", '"') if (found := source.find(f"it({quote}{case_name}{quote}")) != -1),
-        -1,
+    pair = source[index : index + 2]
+    if pair == "//":
+        end = source.find("\n", index)
+        return len(source) if end == -1 else end
+    if pair == "/*":
+        end = source.find("*/", index)
+        return len(source) if end == -1 else end + 2
+    if source[index] in "'\"`":
+        return _skip_literal(source, index)
+    if source[index] == "/" and _opens_regex(source, index):
+        return _skip_regex(source, index)
+    return index + 1
+
+
+def _skip_literal(source: str, index: int) -> int:
+    """Index just past the string or template literal opening at `index`."""
+
+    quote = source[index]
+    index += 1
+    while index < len(source):
+        char = source[index]
+        if char == "\\":
+            index += 2
+        elif char == quote:
+            return index + 1
+        elif quote == "`" and char == "$" and source[index + 1 : index + 2] == "{":
+            # A substitution is code again, so comments and nested literals apply.
+            index = _skip_substitution(source, index + 1)
+        else:
+            index += 1
+    return index
+
+
+def _skip_substitution(source: str, index: int) -> int:
+    """Index just past the balanced `{`…`}` of a template substitution opening at `index`."""
+
+    depth = 0
+    while index < len(source):
+        char = source[index]
+        if char == "{":
+            depth += 1
+            index += 1
+        elif char == "}":
+            depth -= 1
+            index += 1
+            if not depth:
+                return index
+        else:
+            index = _advance(source, index)
+    return index
+
+
+def _opens_regex(source: str, index: int) -> bool:
+    """Whether the `/` at `index` opens a regex rather than dividing.
+
+    Only the previous token can tell the two apart, and the distinction matters
+    because a regex holding an apostrophe — `/Couldn't refresh/i`, ordinary in this
+    suite's assertions — reads as a string opening otherwise. A value can be divided,
+    so a `/` after a name, a number, or a closing `)` / `]` is division; every other
+    position is one where a value has to start.
+    """
+
+    before = source[:index].rstrip()
+    return not before or not (before[-1].isalnum() or before[-1] in "_$)]")
+
+
+def _skip_regex(source: str, index: int) -> int:
+    """Index just past the regex literal opening at `index`.
+
+    A character class is tracked because `/` inside one needs no escape (`/[/]/`),
+    and an unterminated line ends the scan: no regex spans a newline, so a division
+    misread as a regex costs one line rather than the rest of the file.
+    """
+
+    index += 1
+    within_class = False
+    while index < len(source):
+        char = source[index]
+        if char == "\\":
+            index += 2
+        elif char == "\n":
+            return index
+        elif char == "[":
+            within_class = True
+            index += 1
+        elif char == "]":
+            within_class = False
+            index += 1
+        elif char == "/" and not within_class:
+            return index + 1
+        else:
+            index += 1
+    return index
+
+
+def _vitest_case_names(source: str) -> list[str]:
+    """The name of every executable `it('name', …)` declaration, in source order."""
+
+    names: list[str] = []
+    index = 0
+    while index < len(source):
+        match = _IT_CALL.match(source, index)
+        if match is None:
+            index = _advance(source, index)
+            continue
+        end = _skip_literal(source, match.end())
+        names.append(source[match.end() + 1 : end - 1])
+        index = end
+    return names
+
+
+def _vitest_case_name(path: Path, scenario_id: str) -> str:
+    """The full name of the one executable vitest case that carries `scenario_id`.
+
+    A user-visible half of this capability is evidenced by a vitest case rather than
+    a pytest function, and it has to be checkable the same way: the row must resolve
+    to a case that really runs, and that case must state its catalog ID where a
+    Python test would carry a docstring. A vitest case's name *is* its docstring, so
+    that is where the ID goes — which also makes the evidence runnable by ID
+    (`vitest -t MH-USAGE-018`) rather than merely greppable.
+
+    Reading names alone is what keeps this fail-closed. Resolution has to be lexical,
+    because every shape that would fool a text search executes nothing: a
+    commented-out case is not a declaration and neither is a name quoted inside a
+    string. One shape a scan this size cannot decide is a regex literal against
+    division, since that needs the previous token's type rather than its last
+    character. Because a name is all this reads, the worst a wrong guess can do is
+    lose a declaration — the row stops resolving, loudly. It cannot hand a row a
+    neighbour's ID, which is exactly what an earlier version that sliced each case's
+    body got wrong: it bounded the slice by re-running this same scan, so a desync
+    agreed with itself and the row passed on a sibling's ID.
+
+    Only the bare `it(` form resolves, so a modifier this checker cannot verify
+    (`it.skip`, `it.only`, `it.fails`) never counts as evidence, and a parameterized
+    `it.each` — whose names are built at run time — cannot be cited as a row's proof.
+    """
+
+    prefix = f"{scenario_id}:"
+    names = [name for name in _vitest_case_names(path.read_text()) if name.startswith(prefix)]
+    assert len(names) == 1, (
+        f"Catalog points to {len(names)} executable UI cases named `{prefix} …` in {path}, expected exactly one; "
+        "a commented-out, skipped, parameterized, or merely quoted case is not executable evidence"
     )
-    assert start != -1, f"Catalog points to missing UI case {path}::{case_name}"
-    end = source.find("\n  it(", start + 1)
-    return source[start:] if end == -1 else source[start:end]
+    return names[0]
 
 
 def _decorator_names(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
@@ -96,12 +235,14 @@ def test_mh_catalog_001_scenario_catalog_is_complete_and_executable() -> None:
         assert path_text in canonical_tests
         assert path.is_file()
         if path.suffix in {".ts", ".tsx"}:
-            # This checker cannot read a vitest modifier, so a UI-evidenced row may
-            # not claim an expected failure it has no way to prove.
+            # Only the bare `it(` form resolves, so a UI-evidenced row has no way to
+            # declare an expected failure and may not claim one.
             assert not status["expected_fail"], (
                 f"Scenario {scenario['id']} is evidenced by a UI case, which cannot carry an expected failure"
             )
-            evidence = _vitest_case(path, function_name)
+            # A UI row cites its ID, and the case it resolves to is the evidence that
+            # the ID names something vitest runs.
+            evidence = _vitest_case_name(path, function_name)
         else:
             function = _test_function(path, function_name)
             expected_fail = "xfail" in _decorator_names(function)
@@ -109,7 +250,8 @@ def test_mh_catalog_001_scenario_catalog_is_complete_and_executable() -> None:
             evidence = ast.get_docstring(function) or ""
         assert scenario["id"] in evidence, (
             f"Scenario {scenario['id']} is not named inside {test_ref}; "
-            "state the catalog ID in the test docstring so the executable evidence is greppable by ID"
+            "state the catalog ID in the test docstring — for a UI case, in its name — "
+            "so the executable evidence is greppable by ID"
         )
         if scenario["status"] == "partial":
             missing_layer = scenario.get("missing_layer")
@@ -137,3 +279,58 @@ def test_mh_catalog_001_scenario_catalog_is_complete_and_executable() -> None:
         for observation in observations["observations"]
         for scenario_id in observation["affects"]
     )
+
+
+#: Executable, and so citable as evidence.
+_RUNS = "MH-FIXTURE-RUNS"
+#: Present in the file, executed by nothing, and so citable by nothing.
+_DEAD = "MH-FIXTURE-DEAD"
+
+#: One declaration of every shape a `.tsx` file can carry: each is named for whether
+#: vitest runs it, and the assertions read that name rather than a list of cases. A
+#: shape added here is covered by the same two properties without editing them.
+#:
+#: The apostrophe inside a regex literal is what a scan gets wrong by default —
+#: read as a string opening, it swallows every declaration that follows, which is
+#: why a live case sits after it.
+_RESOLVER_FIXTURE = f"""
+describe('resolver fixture', () => {{
+  // it('{_DEAD}-COMMENTED: commented out', () => {{}});
+  /* it('{_DEAD}-BLOCK: commented out in a block', () => {{}}); */
+  it.skip('{_DEAD}-SKIPPED: declared with a modifier', () => {{}});
+  it.each([1, 2])('{_DEAD}-EACH: named at run time %i', () => {{}});
+  it('{_RUNS}-QUOTES: quotes declarations and matches on apostrophes', () => {{
+    expect(label).toBe("it('{_DEAD}-INSTRING: quoted in a string', () => {{}})");
+    expect(hint).toBe(`it('{_DEAD}-INTEMPLATE: quoted in a template', ${{suffix}})`);
+    expect(text).toMatch(/Couldn't refresh, please retry/i);
+    expect(share).toBe(total / count);
+  }});
+  it('{_RUNS}-AFTER: runs after every shape above', () => {{
+    expect(true).toBe(true);
+  }});
+}});
+"""
+
+
+def test_mh_catalog_002_ui_evidence_resolves_only_to_an_executable_declaration(tmp_path: Path) -> None:
+    """MH-CATALOG-002: a UI-evidenced row resolves to the one vitest case that runs under its ID.
+
+    The failure this closes is the one a text search cannot tell apart from evidence:
+    a catalog ID that appears in a `.tsx` file which vitest executes no matching case
+    from, leaving a row `covered` by text alone.
+    """
+
+    path = tmp_path / "fixture.test.tsx"
+    path.write_text(_RESOLVER_FIXTURE)
+    resolved = _vitest_case_names(_RESOLVER_FIXTURE)
+
+    # Nothing dead resolves, and nothing live is missed — a scan that desynced on the
+    # regex above would come up short here rather than resolve past its declaration.
+    assert all(name.startswith(_RUNS) for name in resolved), resolved
+    assert len(resolved) == _RESOLVER_FIXTURE.count(f"'{_RUNS}")
+
+    # A row cites an ID, which resolves to exactly the case that carries it.
+    for name in resolved:
+        assert _vitest_case_name(path, name.split(":")[0]) == name
+    with pytest.raises(AssertionError):
+        _vitest_case_name(path, _DEAD)

--- a/tests/scenarios/model_hub/test_model_hub_catalog.py
+++ b/tests/scenarios/model_hub/test_model_hub_catalog.py
@@ -38,6 +38,27 @@ def _test_function(path: Path, function_name: str) -> ast.FunctionDef | ast.Asyn
     return function
 
 
+def _vitest_case(path: Path, case_name: str) -> str:
+    """One `it(...)` case's own source.
+
+    A user-visible half of this capability is evidenced by a vitest case rather
+    than a pytest function, and it has to be checkable the same way: the row must
+    resolve to a case that exists, and that case must name its catalog ID where a
+    Python test would carry a docstring. Slicing the case out is what makes the ID
+    check per-row instead of per-file, so a second row cannot ride on the first
+    one's ID.
+    """
+
+    source = path.read_text()
+    start = next(
+        (found for quote in ("'", '"') if (found := source.find(f"it({quote}{case_name}{quote}")) != -1),
+        -1,
+    )
+    assert start != -1, f"Catalog points to missing UI case {path}::{case_name}"
+    end = source.find("\n  it(", start + 1)
+    return source[start:] if end == -1 else source[start:end]
+
+
 def _decorator_names(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
     names: set[str] = set()
     for decorator in function.decorator_list:
@@ -74,10 +95,19 @@ def test_mh_catalog_001_scenario_catalog_is_complete_and_executable() -> None:
         path = Path(path_text)
         assert path_text in canonical_tests
         assert path.is_file()
-        function = _test_function(path, function_name)
-        expected_fail = "xfail" in _decorator_names(function)
-        assert expected_fail == status["expected_fail"]
-        assert scenario["id"] in (ast.get_docstring(function) or ""), (
+        if path.suffix in {".ts", ".tsx"}:
+            # This checker cannot read a vitest modifier, so a UI-evidenced row may
+            # not claim an expected failure it has no way to prove.
+            assert not status["expected_fail"], (
+                f"Scenario {scenario['id']} is evidenced by a UI case, which cannot carry an expected failure"
+            )
+            evidence = _vitest_case(path, function_name)
+        else:
+            function = _test_function(path, function_name)
+            expected_fail = "xfail" in _decorator_names(function)
+            assert expected_fail == status["expected_fail"]
+            evidence = ast.get_docstring(function) or ""
+        assert scenario["id"] in evidence, (
             f"Scenario {scenario['id']} is not named inside {test_ref}; "
             "state the catalog ID in the test docstring so the executable evidence is greppable by ID"
         )

--- a/tests/scenarios/model_hub/test_model_hub_catalog.py
+++ b/tests/scenarios/model_hub/test_model_hub_catalog.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import ast
-import re
 from pathlib import Path
 
-import pytest
 import yaml
 
 
@@ -14,10 +12,10 @@ SCENARIO_ROOT = Path("tests/scenarios/model_hub")
 PROJECT_INDEX = Path("tests/scenarios/INDEX.yaml")
 CAPABILITY_ID = "model_hub"
 
-#: A vitest case declaration: the bare `it(` call form followed by a name literal.
-#: The lookbehind rejects `xit(` and `suite.it(`, and requiring `(` immediately
-#: after the identifier rejects every modifier form (`it.skip`, `it.each`, …).
-_IT_CALL = re.compile(r"(?<![A-Za-z0-9_$.])it\s*\(\s*(?=['\"`])")
+#: Suffixes whose evidence is a vitest case rather than a pytest function. Kept in
+#: step with `UI_SUFFIXES` in `ui/scripts/scenarioCatalog.mjs`, which resolves those
+#: rows against vitest's own collection.
+_UI_SUFFIXES = {".ts", ".tsx", ".mts", ".mjs"}
 
 
 def _document(name: str) -> dict:
@@ -43,159 +41,6 @@ def _test_function(path: Path, function_name: str) -> ast.FunctionDef | ast.Asyn
     )
     assert function is not None, f"Catalog points to missing test {path}::{function_name}"
     return function
-
-
-def _advance(source: str, index: int) -> int:
-    """Index just past the comment, literal, or regex at `index`; the next character otherwise.
-
-    This is the whole lexer: everything the scan must not read as code is a comment,
-    a literal, or a regex, and skipping one is always "jump to where it ends".
-    """
-
-    pair = source[index : index + 2]
-    if pair == "//":
-        end = source.find("\n", index)
-        return len(source) if end == -1 else end
-    if pair == "/*":
-        end = source.find("*/", index)
-        return len(source) if end == -1 else end + 2
-    if source[index] in "'\"`":
-        return _skip_literal(source, index)
-    if source[index] == "/" and _opens_regex(source, index):
-        return _skip_regex(source, index)
-    return index + 1
-
-
-def _skip_literal(source: str, index: int) -> int:
-    """Index just past the string or template literal opening at `index`."""
-
-    quote = source[index]
-    index += 1
-    while index < len(source):
-        char = source[index]
-        if char == "\\":
-            index += 2
-        elif char == quote:
-            return index + 1
-        elif quote == "`" and char == "$" and source[index + 1 : index + 2] == "{":
-            # A substitution is code again, so comments and nested literals apply.
-            index = _skip_substitution(source, index + 1)
-        else:
-            index += 1
-    return index
-
-
-def _skip_substitution(source: str, index: int) -> int:
-    """Index just past the balanced `{`…`}` of a template substitution opening at `index`."""
-
-    depth = 0
-    while index < len(source):
-        char = source[index]
-        if char == "{":
-            depth += 1
-            index += 1
-        elif char == "}":
-            depth -= 1
-            index += 1
-            if not depth:
-                return index
-        else:
-            index = _advance(source, index)
-    return index
-
-
-def _opens_regex(source: str, index: int) -> bool:
-    """Whether the `/` at `index` opens a regex rather than dividing.
-
-    Only the previous token can tell the two apart, and the distinction matters
-    because a regex holding an apostrophe — `/Couldn't refresh/i`, ordinary in this
-    suite's assertions — reads as a string opening otherwise. A value can be divided,
-    so a `/` after a name, a number, or a closing `)` / `]` is division; every other
-    position is one where a value has to start.
-    """
-
-    before = source[:index].rstrip()
-    return not before or not (before[-1].isalnum() or before[-1] in "_$)]")
-
-
-def _skip_regex(source: str, index: int) -> int:
-    """Index just past the regex literal opening at `index`.
-
-    A character class is tracked because `/` inside one needs no escape (`/[/]/`),
-    and an unterminated line ends the scan: no regex spans a newline, so a division
-    misread as a regex costs one line rather than the rest of the file.
-    """
-
-    index += 1
-    within_class = False
-    while index < len(source):
-        char = source[index]
-        if char == "\\":
-            index += 2
-        elif char == "\n":
-            return index
-        elif char == "[":
-            within_class = True
-            index += 1
-        elif char == "]":
-            within_class = False
-            index += 1
-        elif char == "/" and not within_class:
-            return index + 1
-        else:
-            index += 1
-    return index
-
-
-def _vitest_case_names(source: str) -> list[str]:
-    """The name of every executable `it('name', …)` declaration, in source order."""
-
-    names: list[str] = []
-    index = 0
-    while index < len(source):
-        match = _IT_CALL.match(source, index)
-        if match is None:
-            index = _advance(source, index)
-            continue
-        end = _skip_literal(source, match.end())
-        names.append(source[match.end() + 1 : end - 1])
-        index = end
-    return names
-
-
-def _vitest_case_name(path: Path, scenario_id: str) -> str:
-    """The full name of the one executable vitest case that carries `scenario_id`.
-
-    A user-visible half of this capability is evidenced by a vitest case rather than
-    a pytest function, and it has to be checkable the same way: the row must resolve
-    to a case that really runs, and that case must state its catalog ID where a
-    Python test would carry a docstring. A vitest case's name *is* its docstring, so
-    that is where the ID goes — which also makes the evidence runnable by ID
-    (`vitest -t MH-USAGE-018`) rather than merely greppable.
-
-    Reading names alone is what keeps this fail-closed. Resolution has to be lexical,
-    because every shape that would fool a text search executes nothing: a
-    commented-out case is not a declaration and neither is a name quoted inside a
-    string. One shape a scan this size cannot decide is a regex literal against
-    division, since that needs the previous token's type rather than its last
-    character. Because a name is all this reads, the worst a wrong guess can do is
-    lose a declaration — the row stops resolving, loudly. It cannot hand a row a
-    neighbour's ID, which is exactly what an earlier version that sliced each case's
-    body got wrong: it bounded the slice by re-running this same scan, so a desync
-    agreed with itself and the row passed on a sibling's ID.
-
-    Only the bare `it(` form resolves, so a modifier this checker cannot verify
-    (`it.skip`, `it.only`, `it.fails`) never counts as evidence, and a parameterized
-    `it.each` — whose names are built at run time — cannot be cited as a row's proof.
-    """
-
-    prefix = f"{scenario_id}:"
-    names = [name for name in _vitest_case_names(path.read_text()) if name.startswith(prefix)]
-    assert len(names) == 1, (
-        f"Catalog points to {len(names)} executable UI cases named `{prefix} …` in {path}, expected exactly one; "
-        "a commented-out, skipped, parameterized, or merely quoted case is not executable evidence"
-    )
-    return names[0]
 
 
 def _decorator_names(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
@@ -234,15 +79,20 @@ def test_mh_catalog_001_scenario_catalog_is_complete_and_executable() -> None:
         path = Path(path_text)
         assert path_text in canonical_tests
         assert path.is_file()
-        if path.suffix in {".ts", ".tsx"}:
-            # Only the bare `it(` form resolves, so a UI-evidenced row has no way to
-            # declare an expected failure and may not claim one.
+        if path.suffix in _UI_SUFFIXES:
+            # An expected failure is declared here with `pytest.mark.xfail`, which a
+            # UI case cannot carry, so a UI-evidenced row may not claim one.
             assert not status["expected_fail"], (
                 f"Scenario {scenario['id']} is evidenced by a UI case, which cannot carry an expected failure"
             )
-            # A UI row cites its ID, and the case it resolves to is the evidence that
-            # the ID names something vitest runs.
-            evidence = _vitest_case_name(path, function_name)
+            # Whether that ID names a case vitest actually *runs* is a question only
+            # vitest answers; `ui/scripts/validate-scenario-catalog.mjs` asks it in
+            # the `npm test` run CI already does over this suite. Approximating it
+            # here would mean re-deciding, from text, which declarations execute —
+            # the answer would be wrong for a skipped, unreachable, or run-time-named
+            # case, and wrong quietly. So this side stops at what it reads exactly:
+            # the file exists and states the ID.
+            evidence = path.read_text()
         else:
             function = _test_function(path, function_name)
             expected_fail = "xfail" in _decorator_names(function)
@@ -279,58 +129,3 @@ def test_mh_catalog_001_scenario_catalog_is_complete_and_executable() -> None:
         for observation in observations["observations"]
         for scenario_id in observation["affects"]
     )
-
-
-#: Executable, and so citable as evidence.
-_RUNS = "MH-FIXTURE-RUNS"
-#: Present in the file, executed by nothing, and so citable by nothing.
-_DEAD = "MH-FIXTURE-DEAD"
-
-#: One declaration of every shape a `.tsx` file can carry: each is named for whether
-#: vitest runs it, and the assertions read that name rather than a list of cases. A
-#: shape added here is covered by the same two properties without editing them.
-#:
-#: The apostrophe inside a regex literal is what a scan gets wrong by default —
-#: read as a string opening, it swallows every declaration that follows, which is
-#: why a live case sits after it.
-_RESOLVER_FIXTURE = f"""
-describe('resolver fixture', () => {{
-  // it('{_DEAD}-COMMENTED: commented out', () => {{}});
-  /* it('{_DEAD}-BLOCK: commented out in a block', () => {{}}); */
-  it.skip('{_DEAD}-SKIPPED: declared with a modifier', () => {{}});
-  it.each([1, 2])('{_DEAD}-EACH: named at run time %i', () => {{}});
-  it('{_RUNS}-QUOTES: quotes declarations and matches on apostrophes', () => {{
-    expect(label).toBe("it('{_DEAD}-INSTRING: quoted in a string', () => {{}})");
-    expect(hint).toBe(`it('{_DEAD}-INTEMPLATE: quoted in a template', ${{suffix}})`);
-    expect(text).toMatch(/Couldn't refresh, please retry/i);
-    expect(share).toBe(total / count);
-  }});
-  it('{_RUNS}-AFTER: runs after every shape above', () => {{
-    expect(true).toBe(true);
-  }});
-}});
-"""
-
-
-def test_mh_catalog_002_ui_evidence_resolves_only_to_an_executable_declaration(tmp_path: Path) -> None:
-    """MH-CATALOG-002: a UI-evidenced row resolves to the one vitest case that runs under its ID.
-
-    The failure this closes is the one a text search cannot tell apart from evidence:
-    a catalog ID that appears in a `.tsx` file which vitest executes no matching case
-    from, leaving a row `covered` by text alone.
-    """
-
-    path = tmp_path / "fixture.test.tsx"
-    path.write_text(_RESOLVER_FIXTURE)
-    resolved = _vitest_case_names(_RESOLVER_FIXTURE)
-
-    # Nothing dead resolves, and nothing live is missed — a scan that desynced on the
-    # regex above would come up short here rather than resolve past its declaration.
-    assert all(name.startswith(_RUNS) for name in resolved), resolved
-    assert len(resolved) == _RESOLVER_FIXTURE.count(f"'{_RUNS}")
-
-    # A row cites an ID, which resolves to exactly the case that carries it.
-    for name in resolved:
-        assert _vitest_case_name(path, name.split(":")[0]) == name
-    with pytest.raises(AssertionError):
-        _vitest_case_name(path, _DEAD)

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -71,6 +71,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "js-yaml": "^4.1.0",
         "jsdom": "^29.1.1",
         "postcss": "^8.5.15",
         "tailwindcss": "^4.1.18",

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,7 +14,7 @@
     "lint:report": "eslint .",
     "lint:baseline": "node scripts/lint-baseline.mjs --update",
     "preview": "vite preview",
-    "test": "vitest run && npm run validate:catalog",
+    "test": "vitest run",
     "test:crypto": "vitest run src/lib/vaultCrypto.test.ts",
     "validate:catalog": "node scripts/validate-scenario-catalog.mjs",
     "validate:theme": "node scripts/validate-theme.mjs"

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,8 +14,9 @@
     "lint:report": "eslint .",
     "lint:baseline": "node scripts/lint-baseline.mjs --update",
     "preview": "vite preview",
-    "test": "vitest run",
+    "test": "vitest run && npm run validate:catalog",
     "test:crypto": "vitest run src/lib/vaultCrypto.test.ts",
+    "validate:catalog": "node scripts/validate-scenario-catalog.mjs",
     "validate:theme": "node scripts/validate-theme.mjs"
   },
   "dependencies": {
@@ -82,6 +83,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "js-yaml": "^4.1.0",
     "jsdom": "^29.1.1",
     "postcss": "^8.5.15",
     "tailwindcss": "^4.1.18",

--- a/ui/scripts/scenarioCatalog.mjs
+++ b/ui/scripts/scenarioCatalog.mjs
@@ -1,0 +1,126 @@
+/**
+ * Resolving a scenario catalog's UI evidence against vitest's own collection.
+ *
+ * A row marked `covered` claims one executable case carries its ID. For a pytest
+ * row `ast.parse` answers that exactly; for a vitest row nothing on the Python
+ * side can, and the scan that tried read a live declaration out of five shapes
+ * that execute nothing — a regex literal after a keyword, JSX text, a
+ * `describe.skip` body, an `if (false)` body, and its own division heuristic.
+ * Those are one class with no last member: telling a regex from division needs
+ * the parser's state, and telling a skipped or unreachable block from a live one
+ * needs the run. So the question goes to the only thing that answers it
+ * definitively, and already runs in CI on the same commit: vitest's collection.
+ *
+ * The gate is `validate-scenario-catalog.mjs`; this module is the part with no
+ * subprocess in it, so the resolution rules are testable without one.
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const UI_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+/** vitest's CLI entry, invoked rather than imported so `list` behaves as it does in CI. */
+const VITEST_BIN = path.join(UI_ROOT, 'node_modules', 'vitest', 'vitest.mjs');
+
+/** Suffixes the catalog may cite as UI evidence — every one a file vitest collects. */
+const UI_SUFFIXES = new Set(['.ts', '.tsx', '.mts', '.mjs']);
+
+/** The file half of a `path::name` catalog reference. */
+const citedPath = (testRef) => testRef.split('::')[0];
+
+export const isUiEvidence = (testRef) => UI_SUFFIXES.has(path.extname(citedPath(testRef)));
+
+/**
+ * Every catalog row whose declared status requires a test and whose test is a UI case.
+ *
+ * Which statuses require one is read from the catalog's own legend, so this side
+ * cannot drift from the Python checker into a second, disagreeing policy.
+ */
+export const uiEvidenceRows = (catalog) => {
+  const legend = catalog.status_legend ?? {};
+  return (catalog.scenarios ?? [])
+    .filter((row) => legend[row.status]?.test_required && typeof row.test === 'string' && isUiEvidence(row.test))
+    .map((row) => {
+      const [file, cited] = row.test.split('::');
+      return { id: row.id, file, cited };
+    });
+};
+
+/** A collected case's own name, without the `describe` path vitest prefixes to it. */
+const caseName = (fullName) => fullName.split(' > ').at(-1);
+
+const sameFile = (collectedFile, file) => {
+  const normalized = collectedFile.replaceAll('\\', '/');
+  return normalized === file || normalized.endsWith(`/${file}`);
+};
+
+/**
+ * What is wrong with these rows, given everything vitest collected — nothing if
+ * each resolves to exactly one collected case named for the row itself.
+ *
+ * Zero is the interesting count: a case that is commented out, skipped, named at
+ * run time by `it.each`, sitting in an unreachable branch, or merely quoted in a
+ * string is absent from a collection, so it cannot stand as a row's evidence.
+ */
+export const resolveUiEvidence = (rows, collected) => {
+  const problems = [];
+  for (const row of rows) {
+    if (row.cited !== row.id) {
+      problems.push(
+        `${row.id} cites \`${row.cited}\` as its evidence; a UI row resolves through a case named for the row itself`,
+      );
+      continue;
+    }
+    const prefix = `${row.id}:`;
+    const matches = collected.filter(
+      (entry) => sameFile(entry.file, row.file) && caseName(entry.name).startsWith(prefix),
+    );
+    if (matches.length !== 1) {
+      problems.push(
+        `${row.id}: vitest collects ${matches.length} cases named \`${prefix} …\` in ${row.file}, expected exactly one — `
+          + 'a commented-out, skipped, parameterized, unreachable or merely quoted case is not executable evidence',
+      );
+    }
+  }
+  return problems;
+};
+
+/**
+ * Every case vitest collects for `files`, as `{ name, file }`.
+ *
+ * `list` collects without running, so this is what the suite would execute rather
+ * than what its source looks like. Filters keep it to the cited files: the gate
+ * only asks about those, and collecting the whole suite twice per `npm test`
+ * would be the slowest possible way to learn the same thing.
+ */
+export const collectCases = ({ root = UI_ROOT, files = [], globals = false } = {}) => {
+  if (!fs.existsSync(VITEST_BIN)) {
+    throw new Error(`vitest is not installed at ${VITEST_BIN}; run \`npm ci\` in ui/ before validating the catalog`);
+  }
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'vitest-list-'));
+  const output = path.join(directory, 'collected.json');
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        VITEST_BIN,
+        'list',
+        `--json=${output}`,
+        '--root',
+        root,
+        '--dir',
+        root,
+        ...(globals ? ['--globals'] : []),
+        ...files,
+      ],
+      { cwd: root, stdio: ['ignore', 'ignore', 'inherit'] },
+    );
+    return JSON.parse(fs.readFileSync(output, 'utf8'));
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+};

--- a/ui/scripts/scenarioCatalog.mjs
+++ b/ui/scripts/scenarioCatalog.mjs
@@ -1,7 +1,7 @@
 /**
  * Resolving a scenario catalog's UI evidence against vitest's own collection.
  *
- * A row marked `covered` claims one executable case carries its ID. For a pytest
+ * A row that cites a test claims one executable case carries it. For a pytest
  * row `ast.parse` answers that exactly; for a vitest row nothing on the Python
  * side can, and the scan that tried read a live declaration out of five shapes
  * that execute nothing — a regex literal after a keyword, JSX text, a
@@ -35,23 +35,38 @@ const citedPath = (testRef) => testRef.split('::')[0];
 export const isUiEvidence = (testRef) => UI_SUFFIXES.has(path.extname(citedPath(testRef)));
 
 /**
- * Every catalog row whose declared status requires a test and whose test is a UI case.
+ * Every catalog row whose evidence is a UI case, whatever its legend looks like.
  *
- * Which statuses require one is read from the catalog's own legend, so this side
- * cannot drift from the Python checker into a second, disagreeing policy.
+ * The row set is the rows that *cite* a UI file, never the rows a legend marks as
+ * needing a test. `status_legend` maps a status to a description string in every
+ * catalog here but one, so reading `test_required` off it selected the rows of
+ * that single catalog and passed the other three in silence — the same failure
+ * this gate exists to prevent, one level up. A citation is the row's own claim,
+ * exists in every catalog, and no legend shape can switch it off.
+ *
+ * `cited` is null for a row that names a file and no case in it.
  */
-export const uiEvidenceRows = (catalog) => {
-  const legend = catalog.status_legend ?? {};
-  return (catalog.scenarios ?? [])
-    .filter((row) => legend[row.status]?.test_required && typeof row.test === 'string' && isUiEvidence(row.test))
+export const uiEvidenceRows = (catalog) =>
+  (catalog.scenarios ?? [])
+    .filter((row) => typeof row.test === 'string' && isUiEvidence(row.test))
     .map((row) => {
-      const [file, cited] = row.test.split('::');
+      const [file, cited = null] = row.test.split('::');
       return { id: row.id, file, cited };
     });
-};
 
 /** A collected case's own name, without the `describe` path vitest prefixes to it. */
 const caseName = (fullName) => fullName.split(' > ').at(-1);
+
+/**
+ * The names a citation may be written against: the case's own, and its full path
+ * with vitest's separator flattened to the space the catalogs write instead.
+ *
+ * Two conventions are in use — a catalog ID that the case name begins with, and
+ * the case's readable full name — and both are a prefix of one of these. One
+ * matching rule covers them because that is what they have in common, rather
+ * than a rule per catalog, which is a policy each new catalog could contradict.
+ */
+const citableNames = (entry) => [caseName(entry.name), entry.name.replaceAll(' > ', ' ')];
 
 const sameFile = (collectedFile, file) => {
   const normalized = collectedFile.replaceAll('\\', '/');
@@ -60,28 +75,40 @@ const sameFile = (collectedFile, file) => {
 
 /**
  * What is wrong with these rows, given everything vitest collected — nothing if
- * each resolves to exactly one collected case named for the row itself.
+ * every citation resolves to a case the suite would execute.
  *
  * Zero is the interesting count: a case that is commented out, skipped, named at
  * run time by `it.each`, sitting in an unreachable branch, or merely quoted in a
  * string is absent from a collection, so it cannot stand as a row's evidence.
+ *
+ * `ids` is the whole catalog's ID set, which is what makes a borrowed citation
+ * legible: a row naming a *sibling row's* ID resolves to a real running case and
+ * still has no evidence of its own.
  */
-export const resolveUiEvidence = (rows, collected) => {
+export const resolveUiEvidence = (rows, collected, ids = new Set(rows.map((row) => row.id))) => {
   const problems = [];
   for (const row of rows) {
-    if (row.cited !== row.id) {
+    const where = row.catalog ? `${row.catalog} ${row.id}` : row.id;
+    const inFile = collected.filter((entry) => sameFile(entry.file, row.file));
+    if (row.cited === null) {
+      // The row cites a file and names no case inside it, so the only claim there
+      // is to check is the one it makes: that vitest executes that file. Which
+      // case carries the row is the catalog's to say, and this one does not say.
+      if (inFile.length === 0) {
+        problems.push(`${where}: vitest collects no case from ${row.file}, so the file it cites is not executable evidence`);
+      }
+      continue;
+    }
+    if (row.cited !== row.id && ids.has(row.cited)) {
       problems.push(
-        `${row.id} cites \`${row.cited}\` as its evidence; a UI row resolves through a case named for the row itself`,
+        `${where} cites \`${row.cited}\`, which is another row's ID; a row resolves through evidence named for itself`,
       );
       continue;
     }
-    const prefix = `${row.id}:`;
-    const matches = collected.filter(
-      (entry) => sameFile(entry.file, row.file) && caseName(entry.name).startsWith(prefix),
-    );
+    const matches = inFile.filter((entry) => citableNames(entry).some((name) => name.startsWith(row.cited)));
     if (matches.length !== 1) {
       problems.push(
-        `${row.id}: vitest collects ${matches.length} cases named \`${prefix} …\` in ${row.file}, expected exactly one — `
+        `${where}: vitest collects ${matches.length} cases named \`${row.cited}…\` in ${row.file}, expected exactly one — `
           + 'a commented-out, skipped, parameterized, unreachable or merely quoted case is not executable evidence',
       );
     }

--- a/ui/scripts/scenarioCatalog.mjs
+++ b/ui/scripts/scenarioCatalog.mjs
@@ -35,24 +35,52 @@ const citedPath = (testRef) => testRef.split('::')[0];
 export const isUiEvidence = (testRef) => UI_SUFFIXES.has(path.extname(citedPath(testRef)));
 
 /**
- * Every catalog row whose evidence is a UI case, whatever its legend looks like.
+ * Every UI citation the catalog's rows make, whatever key it sits in.
  *
- * The row set is the rows that *cite* a UI file, never the rows a legend marks as
- * needing a test. `status_legend` maps a status to a description string in every
- * catalog here but one, so reading `test_required` off it selected the rows of
- * that single catalog and passed the other three in silence — the same failure
- * this gate exists to prevent, one level up. A citation is the row's own claim,
- * exists in every catalog, and no legend shape can switch it off.
+ * Two questions this has been asked wrong twice, and the answer to both is that
+ * the row's own claim decides, never a schema position:
  *
- * `cited` is null for a row that names a file and no case in it.
+ * *Which rows?* The ones that **cite** a UI file — never the ones a legend marks
+ * as needing a test. `status_legend` maps a status to a description string in
+ * every catalog here but one, so reading `test_required` off it selected that
+ * single catalog's rows and passed the other three in silence.
+ *
+ * *Which citations?* Every one, not `test` alone. A row states UI evidence in
+ * two places — `test` names the case that owns the row, and `ui_contract` names
+ * the UI half of a row owned by a pytest scenario — and reading only the first
+ * left five fully-written citations unasked, which is the legend hole again in
+ * another key. It cost four of those five: three named cases #1401 deleted on
+ * 2026-08-14, unnoticed because nothing read them.
+ *
+ * `related_tests` and `canonical_tests` stay unread, and that is the same rule
+ * rather than an exception to it: they name a file and no case, so they cannot
+ * evidence a row, and they do not claim to — "related" is a pointer, not a
+ * coverage claim.
+ *
+ * `cited` is null for a citation that names a file and no case in it, which
+ * `resolveUiEvidence` reports rather than resolves.
  */
 export const uiEvidenceRows = (catalog) =>
-  (catalog.scenarios ?? [])
-    .filter((row) => typeof row.test === 'string' && isUiEvidence(row.test))
-    .map((row) => {
+  (catalog.scenarios ?? []).flatMap((row) => {
+    const citations = [];
+    if (typeof row.test === 'string' && isUiEvidence(row.test)) {
       const [file, cited = null] = row.test.split('::');
-      return { id: row.id, file, cited };
-    });
+      citations.push({ id: row.id, file, cited });
+    }
+    const contract = row.ui_contract;
+    if (contract && typeof contract.test === 'string' && isUiEvidence(contract.test)) {
+      citations.push({
+        id: row.id,
+        file: contract.test,
+        cited: typeof contract.case === 'string' ? contract.case : null,
+        // A parameterized case is named at run time, so the catalog writes the
+        // template and the substitutions it means separately. Both are terms of
+        // one citation; see `citedTerms`.
+        inputs: (contract.inputs ?? []).map(String),
+      });
+    }
+    return citations;
+  });
 
 /** A collected case's own name, without the `describe` path vitest prefixes to it. */
 const caseName = (fullName) => fullName.split(' > ').at(-1);
@@ -61,12 +89,31 @@ const caseName = (fullName) => fullName.split(' > ').at(-1);
  * The names a citation may be written against: the case's own, and its full path
  * with vitest's separator flattened to the space the catalogs write instead.
  *
- * Two conventions are in use — a catalog ID that the case name begins with, and
- * the case's readable full name — and both are a prefix of one of these. One
- * matching rule covers them because that is what they have in common, rather
- * than a rule per catalog, which is a policy each new catalog could contradict.
+ * Two conventions are in use — a catalog ID the case name carries, and the
+ * case's readable full name — and one containment rule covers both, rather than
+ * a rule per catalog, which is a policy each new catalog could contradict.
+ * Containment and not a prefix because an ID is not always first: one case can
+ * carry two scenarios (`[MEMORY-LIST-004][MEMORY-LIST-006] browses …`), and each
+ * of them cites it by its own ID. What bounds the looseness is the count below —
+ * exactly one collected case may match — so a citation loose enough to reach two
+ * cases fails for the same reason as one that reaches none.
  */
 const citableNames = (entry) => [caseName(entry.name), entry.name.replaceAll(' > ', ' ')];
+
+/**
+ * The terms one citation names, all of which the collected name must contain.
+ *
+ * A parameterized case has no name until vitest substitutes its row, so the
+ * catalog writes the template and its `inputs` in separate keys. Taking the
+ * template's literal head plus each input keeps this out of the business of
+ * emulating a format string: `%` opens a substitution, everything before the
+ * first one is literal, and the inputs are what the substitutions were. The
+ * literal tail is dropped rather than parsed, which costs nothing because the
+ * count is what decides — for `accepts the declared failure %s with result %s`
+ * with `[memory_repair_failed, timed_out]`, one collected case carries all
+ * three terms and the other seven carry two.
+ */
+const citedTerms = (row) => [row.cited.split('%')[0], ...(row.inputs ?? [])];
 
 const sameFile = (collectedFile, file) => {
   const normalized = collectedFile.replaceAll('\\', '/');
@@ -74,12 +121,21 @@ const sameFile = (collectedFile, file) => {
 };
 
 /**
- * What is wrong with these rows, given everything vitest collected — nothing if
- * every citation resolves to a case the suite would execute.
+ * What is wrong with these citations, given everything vitest collected — nothing
+ * if each names exactly one case the suite would execute.
  *
- * Zero is the interesting count: a case that is commented out, skipped, named at
- * run time by `it.each`, sitting in an unreachable branch, or merely quoted in a
- * string is absent from a collection, so it cannot stand as a row's evidence.
+ * Zero is the interesting count: a case that is commented out, skipped, sitting
+ * in an unreachable branch, or merely quoted in a string is absent from a
+ * collection, so it cannot stand as a row's evidence.
+ *
+ * A citation must **name a case**, which is the whole rule and the reason there
+ * is no file-only shape left. Accepting a bare file made the gate ask whether the
+ * file runs, and a file runs for reasons that have nothing to do with the citing
+ * row: `MEMORY-LIST-006` and `MEMORY-LIST-007` both named `MemorySearchPanel`
+ * and nothing else, so deleting either one's case left the other keeping the
+ * file collected and both rows green. That is this gate's own failure — a row
+ * reading `covered` with nothing executable tied to *it* — so the file is
+ * reported rather than resolved, and the row states which case carries it.
  *
  * `ids` is the whole catalog's ID set, which is what makes a borrowed citation
  * legible: a row naming a *sibling row's* ID resolves to a real running case and
@@ -89,14 +145,11 @@ export const resolveUiEvidence = (rows, collected, ids = new Set(rows.map((row) 
   const problems = [];
   for (const row of rows) {
     const where = row.catalog ? `${row.catalog} ${row.id}` : row.id;
-    const inFile = collected.filter((entry) => sameFile(entry.file, row.file));
     if (row.cited === null) {
-      // The row cites a file and names no case inside it, so the only claim there
-      // is to check is the one it makes: that vitest executes that file. Which
-      // case carries the row is the catalog's to say, and this one does not say.
-      if (inFile.length === 0) {
-        problems.push(`${where}: vitest collects no case from ${row.file}, so the file it cites is not executable evidence`);
-      }
+      problems.push(
+        `${where} cites ${row.file} and no case in it; a file is evidence for no row in particular — `
+          + 'name the case that carries this one, since any other row citing the same file keeps it collected',
+      );
       continue;
     }
     if (row.cited !== row.id && ids.has(row.cited)) {
@@ -105,11 +158,15 @@ export const resolveUiEvidence = (rows, collected, ids = new Set(rows.map((row) 
       );
       continue;
     }
-    const matches = inFile.filter((entry) => citableNames(entry).some((name) => name.startsWith(row.cited)));
+    const terms = citedTerms(row);
+    const matches = collected
+      .filter((entry) => sameFile(entry.file, row.file))
+      .filter((entry) => citableNames(entry).some((name) => terms.every((term) => name.includes(term))));
     if (matches.length !== 1) {
       problems.push(
-        `${where}: vitest collects ${matches.length} cases named \`${row.cited}…\` in ${row.file}, expected exactly one — `
-          + 'a commented-out, skipped, parameterized, unreachable or merely quoted case is not executable evidence',
+        `${where}: vitest collects ${matches.length} cases named \`${terms.join('` + `')}\` in ${row.file}, expected exactly one — `
+          + 'a commented-out, skipped, unreachable or merely quoted case is not executable evidence, and a name '
+          + 'reaching several cases identifies none of them',
       );
     }
   }

--- a/ui/scripts/scenarioCatalog.test.mjs
+++ b/ui/scripts/scenarioCatalog.test.mjs
@@ -86,6 +86,7 @@ describe('UI evidence resolution', () => {
       { name: 'suite > MH-ROW-B: runs, but in another file', file: '/checkout/other.test.tsx' },
       { name: 'suite > MH-ROW-C: runs', file: `/checkout/${FIXTURE_FILE}` },
       { name: 'suite > MH-ROW-C: runs again', file: `/checkout/${FIXTURE_FILE}` },
+      { name: 'TaskDetail > command task > states the timeout', file: `/checkout/${FIXTURE_FILE}` },
     ];
     const row = (id, extra = {}) => ({ id, cited: id, file: FIXTURE_FILE, ...extra });
 
@@ -94,23 +95,37 @@ describe('UI evidence resolution', () => {
     expect(resolveUiEvidence([row('MH-ROW-B')], collected)).toHaveLength(1);
     expect(resolveUiEvidence([row('MH-ROW-C')], collected)).toHaveLength(1);
     expect(resolveUiEvidence([row('MH-ROW-D')], collected)).toHaveLength(1);
-    // A row may only resolve through a case named for itself, so it cannot pass
-    // by citing a sibling's evidence.
-    expect(resolveUiEvidence([row('MH-ROW-D', { cited: 'MH-ROW-A' })], collected)).toHaveLength(1);
+    // A row may only resolve through evidence named for itself, so it cannot pass
+    // by citing a sibling's — which is a citation that does resolve, to a case
+    // that is another row's answer.
+    const ids = new Set(['MH-ROW-A', 'MH-ROW-D']);
+    expect(resolveUiEvidence([row('MH-ROW-D', { cited: 'MH-ROW-A' })], collected, ids)).toHaveLength(1);
+    // The other convention in the checkout: the case's readable full name, which
+    // the catalogs write with vitest's separator flattened to a space.
+    expect(resolveUiEvidence([row('SCT-018', { cited: 'TaskDetail command task states the timeout' })], collected)).toEqual([]);
+    // A row that names a file and no case in it claims only that the file runs.
+    expect(resolveUiEvidence([row('MH-ROW-E', { cited: null })], collected)).toEqual([]);
+    expect(resolveUiEvidence([row('MH-ROW-E', { cited: null, file: 'absent.test.tsx' })], collected)).toHaveLength(1);
   });
 
-  it('asks about a row only when its declared status requires a test', () => {
-    const catalog = {
-      status_legend: { covered: { test_required: true }, gap: { test_required: false } },
-      scenarios: [
-        { id: 'MH-UI', status: 'covered', test: 'ui/src/a.test.tsx::MH-UI' },
-        { id: 'MH-SCRIPT', status: 'covered', test: 'ui/scripts/a.test.mjs::MH-SCRIPT' },
-        { id: 'MH-PY', status: 'covered', test: 'tests/test_a.py::test_a' },
-        { id: 'MH-GAP', status: 'gap', test: null },
-      ],
-    };
+  it('asks about every row that cites a UI file, whatever its legend looks like', () => {
+    // The legend shape is the hole this closes: `status_legend` is a description
+    // string in every catalog but one, so selecting rows by `test_required` asked
+    // about one catalog and passed the rest without saying so. A citation is the
+    // row's own claim and reads the same in both shapes.
+    const scenarios = [
+      { id: 'MH-UI', status: 'covered', test: 'ui/src/a.test.tsx::MH-UI' },
+      { id: 'MH-SCRIPT', status: 'covered', test: 'ui/scripts/a.test.mjs::MH-SCRIPT' },
+      { id: 'MH-FILE', status: 'covered', test: 'ui/src/b.test.tsx' },
+      { id: 'MH-PY', status: 'covered', test: 'tests/test_a.py::test_a' },
+      { id: 'MH-GAP', status: 'gap', test: null },
+    ];
+    const asked = ['MH-UI', 'MH-SCRIPT', 'MH-FILE'];
 
-    expect(uiEvidenceRows(catalog).map((row) => row.id)).toEqual(['MH-UI', 'MH-SCRIPT']);
+    expect(uiEvidenceRows({ status_legend: { covered: { test_required: true } }, scenarios }).map((row) => row.id)).toEqual(asked);
+    expect(uiEvidenceRows({ status_legend: { covered: 'executable evidence exists' }, scenarios }).map((row) => row.id)).toEqual(asked);
+    expect(uiEvidenceRows({ scenarios }).map((row) => row.id)).toEqual(asked);
+    expect(uiEvidenceRows({ scenarios }).find((row) => row.id === 'MH-FILE').cited).toBe(null);
     expect(isUiEvidence('tests/test_a.py::test_a')).toBe(false);
   });
 });

--- a/ui/scripts/scenarioCatalog.test.mjs
+++ b/ui/scripts/scenarioCatalog.test.mjs
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
 
 import { collectCases, isUiEvidence, resolveUiEvidence, uiEvidenceRows } from './scenarioCatalog.mjs';
+import { checkCatalogs, report } from './validate-scenario-catalog.mjs';
 
 /** Executable, and so citable as evidence. */
 const RUNS = 'MH-FIXTURE-RUNS';
@@ -173,4 +174,27 @@ describe('UI evidence resolution', () => {
     });
     expect(isUiEvidence('tests/test_a.py::test_a')).toBe(false);
   });
+
+  /**
+   * The gate itself, run against the real catalogs rather than a fixture.
+   *
+   * Here and not chained onto `npm test`, because npm appends `--` arguments to
+   * the end of a composite script: `vitest run && npm run validate:catalog` turned
+   * `npm test -- UsageTab.test.tsx` into a full unfiltered suite plus a validator
+   * ignoring a path, which breaks the focused run this repo asks for first. A test
+   * case has no argument to misroute, and `npm test` already means "everything
+   * that must hold".
+   */
+  it(
+    'every UI citation in the checkout names one case this suite collects',
+    () => {
+      const result = checkCatalogs();
+      expect(result.problems, report(result)).toEqual([]);
+      // A checkout whose catalogs cite no UI case at all would pass the line
+      // above while proving nothing, which is the shape of pass this gate exists
+      // to reject.
+      expect(result.rows.length).toBeGreaterThan(0);
+    },
+    60_000,
+  );
 });

--- a/ui/scripts/scenarioCatalog.test.mjs
+++ b/ui/scripts/scenarioCatalog.test.mjs
@@ -1,0 +1,116 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { collectCases, isUiEvidence, resolveUiEvidence, uiEvidenceRows } from './scenarioCatalog.mjs';
+
+/** Executable, and so citable as evidence. */
+const RUNS = 'MH-FIXTURE-RUNS';
+/** Present in the file, executed by nothing, and so citable by nothing. */
+const DEAD = 'MH-FIXTURE-DEAD';
+
+const FIXTURE_FILE = 'probe.test.tsx';
+
+/**
+ * One declaration of every shape a test file can carry, each named for whether
+ * vitest runs it. The assertion below reads those names instead of a list of
+ * cases, so a shape added here is covered without editing it.
+ *
+ * The shapes a source scan got wrong are here: a regex literal opening after a
+ * keyword, a `describe.skip` body, an unreachable branch, and a name quoted
+ * inside a literal. `list` collects by importing, so a shape whose declaration
+ * never executes is absent from the collection for the same reason the suite
+ * never runs it — which is why the one remaining scan-only shape, a name written
+ * as JSX text, needs no seed here: it is not a declaration, and this fixture
+ * cannot resolve the React runtime from a temp directory anyway.
+ */
+const FIXTURE = `
+describe('resolver fixture', () => {
+  // it('${DEAD}-COMMENTED: commented out', () => {});
+  /* it('${DEAD}-BLOCK: commented out in a block', () => {}); */
+  it.skip('${DEAD}-SKIPPED: declared with a modifier', () => {});
+  it.each([1, 2])('${DEAD}-EACH: named at run time %i', () => {});
+  it('${RUNS}-QUOTES: quotes declarations and matches on apostrophes', () => {
+    expect(label).toBe("it('${DEAD}-INSTRING: quoted in a string', () => {})");
+    expect(hint).toBe(\`it('${DEAD}-INTEMPLATE: quoted in a template', \${suffix})\`);
+    expect(pattern(() => { return /it('${DEAD}-REGEX: held in a regex literal', () => {})/ })).toBe(true);
+    expect(text).toMatch(/Couldn't refresh, please retry/i);
+    expect(share).toBe(total / count);
+  });
+  it('${RUNS}-AFTER: runs after every shape above', () => {
+    expect(true).toBe(true);
+  });
+});
+
+describe.skip('skipped suite', () => {
+  it('${DEAD}-INSKIPPEDSUITE: declared inside a skipped suite', () => {});
+});
+
+if (false) {
+  it('${DEAD}-UNREACHABLE: declared in a branch that never runs', () => {});
+}
+`;
+
+const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'mh-scenario-catalog-'));
+fs.writeFileSync(path.join(directory, FIXTURE_FILE), FIXTURE);
+afterAll(() => fs.rmSync(directory, { recursive: true, force: true }));
+
+/** Every ID the fixture mentions, in any shape, deduplicated. */
+const fixtureIds = [...new Set([...FIXTURE.matchAll(/MH-FIXTURE-(?:RUNS|DEAD)-[A-Z]+/g)].map(([id]) => id))];
+
+describe('UI evidence resolution', () => {
+  // The failure this closes is the one a text search cannot tell apart from
+  // evidence: a catalog ID that appears in a `.tsx` file vitest executes no
+  // matching case from, leaving a row `covered` by text alone.
+  it(
+    'MH-CATALOG-002: a UI-evidenced row resolves only to a vitest case that runs under its catalog ID',
+    () => {
+      // `--globals` because the fixture lives outside this package and cannot
+      // resolve `vitest` from there; collection is otherwise the CI call.
+      const collected = collectCases({ root: directory, globals: true });
+      const resolves = (id) => resolveUiEvidence([{ id, cited: id, file: FIXTURE_FILE }], collected).length === 0;
+
+      // The IDs that resolve are exactly the ones the fixture names as running —
+      // not a list of the shapes that must fail, which would pass forever while
+      // the one shape nobody named went on resolving.
+      expect(fixtureIds.filter(resolves).sort()).toEqual(fixtureIds.filter((id) => id.startsWith(RUNS)).sort());
+    },
+    60_000,
+  );
+
+  it('reports a row whose evidence is absent, duplicated, or in another file', () => {
+    const collected = [
+      { name: 'suite > MH-ROW-A: runs', file: `/checkout/${FIXTURE_FILE}` },
+      { name: 'suite > MH-ROW-B: runs, but in another file', file: '/checkout/other.test.tsx' },
+      { name: 'suite > MH-ROW-C: runs', file: `/checkout/${FIXTURE_FILE}` },
+      { name: 'suite > MH-ROW-C: runs again', file: `/checkout/${FIXTURE_FILE}` },
+    ];
+    const row = (id, extra = {}) => ({ id, cited: id, file: FIXTURE_FILE, ...extra });
+
+    expect(resolveUiEvidence([row('MH-ROW-A')], collected)).toEqual([]);
+    // Present in the collection, but not in the file the row points at.
+    expect(resolveUiEvidence([row('MH-ROW-B')], collected)).toHaveLength(1);
+    expect(resolveUiEvidence([row('MH-ROW-C')], collected)).toHaveLength(1);
+    expect(resolveUiEvidence([row('MH-ROW-D')], collected)).toHaveLength(1);
+    // A row may only resolve through a case named for itself, so it cannot pass
+    // by citing a sibling's evidence.
+    expect(resolveUiEvidence([row('MH-ROW-D', { cited: 'MH-ROW-A' })], collected)).toHaveLength(1);
+  });
+
+  it('asks about a row only when its declared status requires a test', () => {
+    const catalog = {
+      status_legend: { covered: { test_required: true }, gap: { test_required: false } },
+      scenarios: [
+        { id: 'MH-UI', status: 'covered', test: 'ui/src/a.test.tsx::MH-UI' },
+        { id: 'MH-SCRIPT', status: 'covered', test: 'ui/scripts/a.test.mjs::MH-SCRIPT' },
+        { id: 'MH-PY', status: 'covered', test: 'tests/test_a.py::test_a' },
+        { id: 'MH-GAP', status: 'gap', test: null },
+      ],
+    };
+
+    expect(uiEvidenceRows(catalog).map((row) => row.id)).toEqual(['MH-UI', 'MH-SCRIPT']);
+    expect(isUiEvidence('tests/test_a.py::test_a')).toBe(false);
+  });
+});

--- a/ui/scripts/scenarioCatalog.test.mjs
+++ b/ui/scripts/scenarioCatalog.test.mjs
@@ -87,6 +87,7 @@ describe('UI evidence resolution', () => {
       { name: 'suite > MH-ROW-C: runs', file: `/checkout/${FIXTURE_FILE}` },
       { name: 'suite > MH-ROW-C: runs again', file: `/checkout/${FIXTURE_FILE}` },
       { name: 'TaskDetail > command task > states the timeout', file: `/checkout/${FIXTURE_FILE}` },
+      { name: 'suite > [MH-ROW-X][MH-ROW-F] one case answering two rows', file: `/checkout/${FIXTURE_FILE}` },
     ];
     const row = (id, extra = {}) => ({ id, cited: id, file: FIXTURE_FILE, ...extra });
 
@@ -103,29 +104,73 @@ describe('UI evidence resolution', () => {
     // The other convention in the checkout: the case's readable full name, which
     // the catalogs write with vitest's separator flattened to a space.
     expect(resolveUiEvidence([row('SCT-018', { cited: 'TaskDetail command task states the timeout' })], collected)).toEqual([]);
-    // A row that names a file and no case in it claims only that the file runs.
-    expect(resolveUiEvidence([row('MH-ROW-E', { cited: null })], collected)).toEqual([]);
-    expect(resolveUiEvidence([row('MH-ROW-E', { cited: null, file: 'absent.test.tsx' })], collected)).toHaveLength(1);
+    // An ID the case name carries without leading with it, which is why the rule
+    // is containment: one case can answer two scenarios, and each of them cites
+    // it by its own ID.
+    expect(resolveUiEvidence([row('MH-ROW-F', { cited: '[MH-ROW-F]' })], collected)).toEqual([]);
+    // A citation naming a file and no case in it is evidence for no row in
+    // particular — whatever else cites the file keeps it collected, so the row
+    // would read `covered` with nothing tied to itself. Reported, not resolved.
+    expect(resolveUiEvidence([row('MH-ROW-E', { cited: null })], collected)).toHaveLength(1);
   });
 
-  it('asks about every row that cites a UI file, whatever its legend looks like', () => {
-    // The legend shape is the hole this closes: `status_legend` is a description
-    // string in every catalog but one, so selecting rows by `test_required` asked
-    // about one catalog and passed the rest without saying so. A citation is the
-    // row's own claim and reads the same in both shapes.
+  it('resolves a parameterized case through the inputs the citation names', () => {
+    // A case named at run time has no name to cite, so the catalog writes the
+    // template and its substitutions in separate keys. Both are terms of one
+    // citation, and the count is still what decides.
+    const collected = [
+      { name: 'parse > accepts the declared failure memory_repair_failed with result failed', file: '/checkout/parse.test.ts' },
+      { name: 'parse > accepts the declared failure memory_repair_failed with result timed_out', file: '/checkout/parse.test.ts' },
+    ];
+    const cited = (inputs) => [{
+      id: 'MEMORY-REPAIR-004',
+      file: 'parse.test.ts',
+      cited: 'accepts the declared failure %s with result %s',
+      inputs,
+    }];
+
+    expect(resolveUiEvidence(cited(['memory_repair_failed', 'timed_out']), collected)).toEqual([]);
+    // The template alone reaches every row of the table, which identifies none of
+    // them — the same failure as reaching no case at all.
+    expect(resolveUiEvidence(cited([]), collected)).toHaveLength(1);
+  });
+
+  it('asks about every UI citation a row makes, whatever key it sits in and whatever its legend looks like', () => {
+    // Two holes of one shape, each found a round apart. The legend: `status_legend`
+    // is a description string in every catalog but one, so selecting rows by
+    // `test_required` asked about that catalog and passed the rest without saying
+    // so. The key: reading `test` alone left every `ui_contract` unasked, and four
+    // of the five in the checkout named a case that no longer existed. A citation
+    // is the row's own claim, so the answer to both is to read them all.
     const scenarios = [
       { id: 'MH-UI', status: 'covered', test: 'ui/src/a.test.tsx::MH-UI' },
       { id: 'MH-SCRIPT', status: 'covered', test: 'ui/scripts/a.test.mjs::MH-SCRIPT' },
       { id: 'MH-FILE', status: 'covered', test: 'ui/src/b.test.tsx' },
       { id: 'MH-PY', status: 'covered', test: 'tests/test_a.py::test_a' },
+      {
+        id: 'MH-CONTRACT',
+        status: 'covered',
+        test: 'tests/test_b.py::test_b',
+        ui_contract: { test: 'ui/src/c.test.tsx', case: 'holds the frozen contract' },
+      },
+      // A pointer, not a claim: it names a file and no case, so it evidences no
+      // row and does not say it does. Unread for the same reason a file-only
+      // citation is rejected, rather than as an exception to it.
+      { id: 'MH-RELATED', status: 'covered', test: 'tests/test_c.py::test_c', related_tests: ['ui/src/d.test.tsx'] },
       { id: 'MH-GAP', status: 'gap', test: null },
     ];
-    const asked = ['MH-UI', 'MH-SCRIPT', 'MH-FILE'];
+    const asked = ['MH-UI', 'MH-SCRIPT', 'MH-FILE', 'MH-CONTRACT'];
+    const rowsOf = (catalog) => uiEvidenceRows({ ...catalog, scenarios });
 
-    expect(uiEvidenceRows({ status_legend: { covered: { test_required: true } }, scenarios }).map((row) => row.id)).toEqual(asked);
-    expect(uiEvidenceRows({ status_legend: { covered: 'executable evidence exists' }, scenarios }).map((row) => row.id)).toEqual(asked);
-    expect(uiEvidenceRows({ scenarios }).map((row) => row.id)).toEqual(asked);
-    expect(uiEvidenceRows({ scenarios }).find((row) => row.id === 'MH-FILE').cited).toBe(null);
+    expect(rowsOf({ status_legend: { covered: { test_required: true } } }).map((row) => row.id)).toEqual(asked);
+    expect(rowsOf({ status_legend: { covered: 'executable evidence exists' } }).map((row) => row.id)).toEqual(asked);
+    expect(rowsOf({}).map((row) => row.id)).toEqual(asked);
+    // The shape the resolver then rejects, and the one it reads a case out of.
+    expect(rowsOf({}).find((row) => row.id === 'MH-FILE').cited).toBe(null);
+    expect(rowsOf({}).find((row) => row.id === 'MH-CONTRACT')).toMatchObject({
+      file: 'ui/src/c.test.tsx',
+      cited: 'holds the frozen contract',
+    });
     expect(isUiEvidence('tests/test_a.py::test_a')).toBe(false);
   });
 });

--- a/ui/scripts/validate-scenario-catalog.mjs
+++ b/ui/scripts/validate-scenario-catalog.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * Gate: every scenario-catalog row evidenced by a UI case resolves to exactly one
+ * case vitest collects, in the file the row cites.
+ *
+ * This runs from `npm test`, which is the UI suite's own CI step, because that is
+ * where the collector lives. The Python catalog checker owns everything it can
+ * answer exactly — the row's shape, its file, and the ID being greppable inside
+ * that file — and defers executability here rather than approximating it.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import yaml from 'js-yaml';
+
+import { collectCases, resolveUiEvidence, uiEvidenceRows } from './scenarioCatalog.mjs';
+
+const UI_ROOT = fileURLToPath(new URL('..', import.meta.url));
+const REPO_ROOT = path.resolve(UI_ROOT, '..');
+const SCENARIO_ROOT = path.join(REPO_ROOT, 'tests', 'scenarios');
+
+/**
+ * Every capability catalog in the checkout.
+ *
+ * Discovered rather than listed: a catalog that starts citing UI evidence is
+ * gated by existing, and no list has to be remembered. A checkout without the
+ * directory at all is a failure, not an empty pass — this gate cannot report
+ * "nothing to check" for the one input it exists to read.
+ */
+const catalogPaths = () => {
+  if (!fs.existsSync(SCENARIO_ROOT)) {
+    throw new Error(`${path.relative(REPO_ROOT, SCENARIO_ROOT)} is missing; run this from a full checkout`);
+  }
+  return fs
+    .readdirSync(SCENARIO_ROOT, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(SCENARIO_ROOT, entry.name, 'catalog.yaml'))
+    .filter((file) => fs.existsSync(file));
+};
+
+const main = () => {
+  const rows = catalogPaths().flatMap((file) => {
+    const catalog = yaml.load(fs.readFileSync(file, 'utf8'));
+    return uiEvidenceRows(catalog).map((row) => ({ ...row, catalog: path.relative(REPO_ROOT, file) }));
+  });
+  if (rows.length === 0) {
+    console.log('scenario catalogs: no rows are evidenced by a UI case');
+    return;
+  }
+
+  const files = [...new Set(rows.map((row) => path.relative(UI_ROOT, path.join(REPO_ROOT, row.file))))];
+  const problems = resolveUiEvidence(rows, collectCases({ files }));
+  if (problems.length > 0) {
+    console.error(`\nUI-evidenced scenario rows that do not resolve to a collected vitest case:\n`);
+    for (const problem of problems) console.error(`  - ${problem}`);
+    console.error('');
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`scenario catalogs: ${rows.length} UI-evidenced rows resolve to a collected vitest case`);
+};
+
+main();

--- a/ui/scripts/validate-scenario-catalog.mjs
+++ b/ui/scripts/validate-scenario-catalog.mjs
@@ -41,17 +41,27 @@ const catalogPaths = () => {
 };
 
 const main = () => {
-  const rows = catalogPaths().flatMap((file) => {
+  const catalogs = catalogPaths().map((file) => {
     const catalog = yaml.load(fs.readFileSync(file, 'utf8'));
-    return uiEvidenceRows(catalog).map((row) => ({ ...row, catalog: path.relative(REPO_ROOT, file) }));
+    const name = path.relative(REPO_ROOT, file);
+    return {
+      // The whole ID set, not just the UI rows': a UI row may borrow the ID of a
+      // row evidenced by pytest, and that is the same empty citation.
+      ids: new Set((catalog.scenarios ?? []).map((row) => row.id)),
+      rows: uiEvidenceRows(catalog).map((row) => ({ ...row, catalog: name })),
+    };
   });
+  const rows = catalogs.flatMap((catalog) => catalog.rows);
   if (rows.length === 0) {
     console.log('scenario catalogs: no rows are evidenced by a UI case');
     return;
   }
 
   const files = [...new Set(rows.map((row) => path.relative(UI_ROOT, path.join(REPO_ROOT, row.file))))];
-  const problems = resolveUiEvidence(rows, collectCases({ files }));
+  // One collection for every catalog: `list` costs a vitest startup, and the
+  // question each row asks is answered by the same collected set.
+  const collected = collectCases({ files });
+  const problems = catalogs.flatMap((catalog) => resolveUiEvidence(catalog.rows, collected, catalog.ids));
   if (problems.length > 0) {
     console.error(`\nUI-evidenced scenario rows that do not resolve to a collected vitest case:\n`);
     for (const problem of problems) console.error(`  - ${problem}`);

--- a/ui/scripts/validate-scenario-catalog.mjs
+++ b/ui/scripts/validate-scenario-catalog.mjs
@@ -3,10 +3,20 @@
  * Gate: every UI citation a scenario catalog makes names exactly one case vitest
  * collects, in the file the citation points at.
  *
- * This runs from `npm test`, which is the UI suite's own CI step, because that is
- * where the collector lives. The Python catalog checker owns everything it can
- * answer exactly — the row's shape, its file, and the ID being greppable inside
- * that file — and defers executability here rather than approximating it.
+ * The check lives here as `checkCatalogs`, and two callers share it: this file's
+ * CLI (`npm run validate:catalog`) and one case in `scenarioCatalog.test.mjs`,
+ * which is how it reaches CI. It was briefly chained onto `npm test` as
+ * `vitest run && npm run validate:catalog` instead, and that is a defect with a
+ * quiet cost: npm appends `--` arguments to the *end* of a composite script, so
+ * `npm test -- UsageTab.test.tsx` became
+ * `vitest run && npm run validate:catalog UsageTab.test.tsx` — vitest ran all 231
+ * files unfiltered and the gate silently ignored a path. Forwarding through a
+ * wrapper would keep the hazard and hide it; a test case has no argument to
+ * misroute, and the suite runner already owns "everything that must hold".
+ *
+ * The Python catalog checker owns everything it can answer exactly — the row's
+ * shape, its file, and the ID being greppable inside that file — and defers
+ * executability here rather than approximating it.
  */
 
 import fs from 'node:fs';
@@ -40,7 +50,14 @@ const catalogPaths = () => {
     .filter((file) => fs.existsSync(file));
 };
 
-const main = () => {
+/**
+ * Every citation in the checkout, and what is wrong with it — `problems` empty
+ * when each names one collected case.
+ *
+ * Returns rather than exits so a test can assert on it: the CLI is one caller of
+ * this check, not its owner.
+ */
+export const checkCatalogs = () => {
   const catalogs = catalogPaths().map((file) => {
     const catalog = yaml.load(fs.readFileSync(file, 'utf8'));
     const name = path.relative(REPO_ROOT, file);
@@ -52,27 +69,39 @@ const main = () => {
     };
   });
   const rows = catalogs.flatMap((catalog) => catalog.rows);
-  if (rows.length === 0) {
-    console.log('scenario catalogs: no row cites a UI case');
-    return;
-  }
+  if (rows.length === 0) return { rows, problems: [] };
 
   const files = [...new Set(rows.map((row) => path.relative(UI_ROOT, path.join(REPO_ROOT, row.file))))];
   // One collection for every catalog: `list` costs a vitest startup, and the
   // question each row asks is answered by the same collected set.
   const collected = collectCases({ files });
-  const problems = catalogs.flatMap((catalog) => resolveUiEvidence(catalog.rows, collected, catalog.ids));
-  if (problems.length > 0) {
-    console.error(`\nScenario-catalog UI citations that do not name a collected vitest case:\n`);
-    for (const problem of problems) console.error(`  - ${problem}`);
-    console.error('');
-    process.exitCode = 1;
-    return;
-  }
-  console.log(
-    `scenario catalogs: ${rows.length} UI citations across `
-      + `${new Set(rows.map((row) => row.id)).size} rows each name one collected vitest case`,
-  );
+  return {
+    rows,
+    problems: catalogs.flatMap((catalog) => resolveUiEvidence(catalog.rows, collected, catalog.ids)),
+  };
 };
 
-main();
+/** How the gate reads for a human, in a terminal or in a CI log. */
+export const report = ({ rows, problems }) => {
+  if (rows.length === 0) return 'scenario catalogs: no row cites a UI case';
+  if (problems.length === 0) {
+    return `scenario catalogs: ${rows.length} UI citations across `
+      + `${new Set(rows.map((row) => row.id)).size} rows each name one collected vitest case`;
+  }
+  return [
+    '\nScenario-catalog UI citations that do not name a collected vitest case:\n',
+    ...problems.map((problem) => `  - ${problem}`),
+    '',
+  ].join('\n');
+};
+
+// Only when run as a command, so importing the check does not execute it.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const result = checkCatalogs();
+  if (result.problems.length > 0) {
+    console.error(report(result));
+    process.exitCode = 1;
+  } else {
+    console.log(report(result));
+  }
+}

--- a/ui/scripts/validate-scenario-catalog.mjs
+++ b/ui/scripts/validate-scenario-catalog.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Gate: every scenario-catalog row evidenced by a UI case resolves to exactly one
- * case vitest collects, in the file the row cites.
+ * Gate: every UI citation a scenario catalog makes names exactly one case vitest
+ * collects, in the file the citation points at.
  *
  * This runs from `npm test`, which is the UI suite's own CI step, because that is
  * where the collector lives. The Python catalog checker owns everything it can
@@ -53,7 +53,7 @@ const main = () => {
   });
   const rows = catalogs.flatMap((catalog) => catalog.rows);
   if (rows.length === 0) {
-    console.log('scenario catalogs: no rows are evidenced by a UI case');
+    console.log('scenario catalogs: no row cites a UI case');
     return;
   }
 
@@ -63,13 +63,16 @@ const main = () => {
   const collected = collectCases({ files });
   const problems = catalogs.flatMap((catalog) => resolveUiEvidence(catalog.rows, collected, catalog.ids));
   if (problems.length > 0) {
-    console.error(`\nUI-evidenced scenario rows that do not resolve to a collected vitest case:\n`);
+    console.error(`\nScenario-catalog UI citations that do not name a collected vitest case:\n`);
     for (const problem of problems) console.error(`  - ${problem}`);
     console.error('');
     process.exitCode = 1;
     return;
   }
-  console.log(`scenario catalogs: ${rows.length} UI-evidenced rows resolve to a collected vitest case`);
+  console.log(
+    `scenario catalogs: ${rows.length} UI citations across `
+      + `${new Set(rows.map((row) => row.id)).size} rows each name one collected vitest case`,
+  );
 };
 
 main();

--- a/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
@@ -12,7 +12,7 @@ import { MANAGE_COMMIT_ACTIONS } from './manage';
 import { modelsApi } from './modelsApi';
 import { SOURCE_MUTATION_REPORT_PROJECTIONS } from './mutationSettlement';
 import { SettingsModelsPage } from './SettingsModelsPage';
-import type { AgentBackend, AgentChain, AgentSupply, RuntimeDependency, Source } from './types';
+import type { AgentBackend, AgentChain, AgentSupply, RuntimeDependency, Source, UsageSummary } from './types';
 
 const directAgent = (backend: AgentBackend): AgentSupply => ({
   backend,
@@ -84,6 +84,25 @@ const takeoverChain: AgentChain = {
   supply_state: 'ok',
 };
 
+const usageSummary: UsageSummary = {
+  window_days: 30,
+  from_day: '2026-07-20',
+  to_day: '2026-08-18',
+  totals: { requests: 12, token_reports: 12, input_tokens: 148230, cached_input_tokens: 96010, output_tokens: 4120 },
+  sources: [{
+    source_id: 'src_retained',
+    label: 'Retained source',
+    last_metered_at: '2026-08-18T03:14:00+00:00',
+    requests: 12,
+    token_reports: 12,
+    input_tokens: 148230,
+    cached_input_tokens: 96010,
+    output_tokens: 4120,
+    models: [{ model_id: 'claude-opus-4-6', label: 'claude-opus-4-6', requests: 12, token_reports: 12, input_tokens: 148230, cached_input_tokens: 96010, output_tokens: 4120 }],
+  }],
+  days: [{ day: '2026-08-18', requests: 12, token_reports: 12, input_tokens: 148230, cached_input_tokens: 96010, output_tokens: 4120 }],
+};
+
 const deferred = <T,>() => {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((done) => {
@@ -101,6 +120,7 @@ const renderPage = (sources: Source[]) => {
   ]);
   vi.spyOn(modelsApi, 'getRuntimeStatus').mockResolvedValue(runtime);
   vi.spyOn(modelsApi, 'listEvents').mockResolvedValue([]);
+  vi.spyOn(modelsApi, 'getUsageSummary').mockResolvedValue(usageSummary);
   return render(
     <ToastProvider>
       <I18nextProvider i18n={i18n}>
@@ -897,5 +917,59 @@ describe('SettingsModelsPage surface branches', () => {
     expect(screen.queryByText(/Now: Replacement source \(takeover\)|当前 Replacement source（接管）/i)).toBeNull();
     expect(screen.queryByText(/^Taken over$|^接管中$/i)).toBeNull();
     expect(screen.getAllByText('—').length).toBeGreaterThan(0);
+  });
+});
+
+// How the usage report is READ. What it says once read is `UsageTab.test.tsx`'s
+// subject; the property here is that the read is the tab's own — off the first
+// paint, live on every open, and spanning whatever the control was left on.
+describe('SettingsModelsPage usage region', () => {
+  const openUsage = () => userEvent.click(screen.getByRole('tab', { name: /^Usage$|^用量$/ }));
+
+  it('leaves the report unread until its tab is opened, then reads the default span', async () => {
+    renderPage([retainedSource]);
+    await screen.findByText('Retained source');
+    const read = vi.mocked(modelsApi.getUsageSummary);
+
+    // MH-USAGE-020. The landing is what decides routing. A report nobody is
+    // looking at may not be part of the read that draws it.
+    expect(read).not.toHaveBeenCalled();
+    await openUsage();
+    await waitFor(() => expect(read).toHaveBeenCalledWith(30));
+  });
+
+  it('re-reads with the span the control was moved to', async () => {
+    renderPage([retainedSource]);
+    await screen.findByText('Retained source');
+    await openUsage();
+    const read = vi.mocked(modelsApi.getUsageSummary);
+    await waitFor(() => expect(read).toHaveBeenCalledTimes(1));
+
+    await userEvent.click(screen.getByRole('radio', { name: /^7d$|^7 天$/ }));
+    await waitFor(() => expect(read).toHaveBeenLastCalledWith(7));
+  });
+
+  it('re-reads on every open, because the figure is live', async () => {
+    renderPage([retainedSource]);
+    await screen.findByText('Retained source');
+    const read = vi.mocked(modelsApi.getUsageSummary);
+    await openUsage();
+    await waitFor(() => expect(read).toHaveBeenCalledTimes(1));
+
+    await userEvent.click(screen.getByRole('tab', { name: /^Sources & gateway$|^来源与网关$/ }));
+    await openUsage();
+    await waitFor(() => expect(read).toHaveBeenCalledTimes(2));
+  });
+
+  it('retries the read the tab failed on, at the same span', async () => {
+    renderPage([retainedSource]);
+    const read = vi.mocked(modelsApi.getUsageSummary);
+    read.mockRejectedValueOnce(new TypeError('usage unread'));
+    await screen.findByText('Retained source');
+    await openUsage();
+
+    await userEvent.click(await screen.findByRole('button', { name: /^Retry$|^重试$/ }));
+    await waitFor(() => expect(read).toHaveBeenCalledTimes(2));
+    expect(read.mock.calls.map(([days]) => days)).toEqual([30, 30]);
   });
 });

--- a/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ToastProvider } from '@/context/ToastProvider';
 import i18n from '@/i18n';
 import { MANAGE_COMMIT_ACTIONS } from './manage';
+import type { ModelsSurfaceKind } from './modelHubSurfaceState';
 import { modelsApi } from './modelsApi';
 import { SOURCE_MUTATION_REPORT_PROJECTIONS } from './mutationSettlement';
 import { SettingsModelsPage } from './SettingsModelsPage';
@@ -183,13 +184,17 @@ describe('SettingsModelsPage surface branches', () => {
     expect(listSources).toHaveBeenCalledTimes(refreshesBeforeCreate + 1);
   });
 
-  it('renders Frame 09 without tabs when every backend is direct and no source exists', async () => {
+  it('renders Frame 09 as the sources tab when every backend is direct and no source exists', async () => {
     renderPage([]);
 
     expect(await screen.findByText(/^Currently: direct$|^当前:直连$/i)).toBeTruthy();
     expect(screen.getAllByRole('button', { name: /^Switch to Gateway$|^切换到网关$/i })).toHaveLength(3);
     expect(screen.getByText(/^Switch to the gateway and you gain three things$|^切换到网关，你会多出三件事$/i)).toBeTruthy();
-    expect(screen.queryByRole('tab')).toBeNull();
+    // Frame 09 is what the `sources` tab shows here — not what the Hub shows
+    // instead of its tabs. It is still Frame 09's body: none of the gateway
+    // overview leaks in beside it.
+    expect(screen.getAllByRole('tab')).toHaveLength(2);
+    expect(screen.queryByText(/^Recent switches$|^最近切换$/i)).toBeNull();
   });
 
   it('renders the no-backend state when every authoritative CLI is absent', async () => {
@@ -925,6 +930,32 @@ describe('SettingsModelsPage surface branches', () => {
 // paint, live on every open, and spanning whatever the control was left on.
 describe('SettingsModelsPage usage region', () => {
   const openUsage = () => userEvent.click(screen.getByRole('tab', { name: /^Usage$|^用量$/ }));
+
+  // The ledger outlives the Sources it metered — 62 days of retention, and a
+  // vanished Source still named by its id — so the route to it cannot be a branch
+  // of currently having one. Deleting the last source may not delete the only way
+  // to read what it cost, and a user reading the report may not be thrown off it
+  // by their own deletion.
+  it('MH-USAGE-022: reaches the report from every landing the Hub can draw', async () => {
+    // Keyed by the landing itself: a `Record<ModelsSurfaceKind, …>` cannot omit
+    // one, so a landing added later fails to compile here rather than quietly
+    // shipping without a route. The loop stays inside one case because a row's
+    // evidence has to be a case the catalog can resolve by name.
+    const landings: Record<ModelsSurfaceKind, Source[]> = {
+      direct_empty: [],
+      gateway: [retainedSource],
+    };
+
+    for (const [landing, sources] of Object.entries(landings)) {
+      cleanup();
+      vi.restoreAllMocks();
+      renderPage(sources);
+
+      await waitFor(() => expect(screen.getAllByRole('tab'), landing).toHaveLength(2));
+      await openUsage();
+      await waitFor(() => expect(vi.mocked(modelsApi.getUsageSummary), landing).toHaveBeenCalledWith(30));
+    }
+  });
 
   it('MH-USAGE-020: leaves the report unread until its tab is opened, then reads the default span', async () => {
     renderPage([retainedSource]);

--- a/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
@@ -926,13 +926,13 @@ describe('SettingsModelsPage surface branches', () => {
 describe('SettingsModelsPage usage region', () => {
   const openUsage = () => userEvent.click(screen.getByRole('tab', { name: /^Usage$|^用量$/ }));
 
-  it('leaves the report unread until its tab is opened, then reads the default span', async () => {
+  it('MH-USAGE-020: leaves the report unread until its tab is opened, then reads the default span', async () => {
     renderPage([retainedSource]);
     await screen.findByText('Retained source');
     const read = vi.mocked(modelsApi.getUsageSummary);
 
-    // MH-USAGE-020. The landing is what decides routing. A report nobody is
-    // looking at may not be part of the read that draws it.
+    // The landing is what decides routing. A report nobody is looking at may
+    // not be part of the read that draws it.
     expect(read).not.toHaveBeenCalled();
     await openUsage();
     await waitFor(() => expect(read).toHaveBeenCalledWith(30));

--- a/ui/src/components/settings/models/SettingsModelsPage.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ArrowLeft, Gauge, Info, LoaderCircle, Route } from 'lucide-react';
+import { ArrowLeft, Gauge, LoaderCircle, Route } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { Badge } from '@/components/ui/badge';
@@ -30,6 +30,7 @@ import {
   releaseSuspendedRouteAttempt,
 } from './suspendedRouteAttempts';
 import { SupplyGraph, SupplyLegend } from './SupplyGraph';
+import { UsageTab } from './UsageTab';
 import './modelHubSurface.css';
 import { agentsWithEcho, createLatestAsyncAuthority, createLatestAsyncAuthorityByKey, createLatestEntityAuthorityByKey, createPendingWrites, mapWithConcurrency } from './asyncLifetime';
 import { createAgentCollectionReadAuthority, createSourceCollectionReadAuthority } from './collectionReadAuthority';
@@ -51,6 +52,7 @@ import {
   foldRegionRead,
   degradedRegion,
   loadingRegion,
+  readRegion,
   readyRegion,
   settleRegionRead,
   unreadRegion,
@@ -60,7 +62,8 @@ import { freshRuntimeProjection, pollRuntimeStatus, runtimeCanAttemptInstall, st
 import { createRouteProjectionReconciler, type RouteProjectionStatus } from './routeProjectionReconciliation';
 import { useSourceMutationReport } from './useSourceMutationReport';
 import { backendVisual } from './vendorMeta';
-import type { AgentBackend, AgentSupply, ResolutionEvent, RuntimeDependency, Source } from './types';
+import { USAGE_DEFAULT_WINDOW_DAYS, type AgentBackend, type AgentSupply, type ResolutionEvent, type RuntimeDependency, type Source, type UsageSummary } from './types';
+import type { UsageWindowOption } from './usageProjection';
 
 const CHAIN_READ_CONCURRENCY = 6;
 const EVENT_PAGE = 20;
@@ -292,6 +295,8 @@ export const SettingsModelsPage: React.FC = () => {
   const [eventsRead, setEventsRead] = React.useState<RegionRead<EventFeed>>(loadingRegion);
   const [loadingEvents, setLoadingEvents] = React.useState(false);
   const [tab, setTab] = React.useState<'sources' | 'usage'>('sources');
+  const [usageRead, setUsageRead] = React.useState<RegionRead<UsageSummary>>(loadingRegion);
+  const [usageWindow, setUsageWindow] = React.useState<UsageWindowOption>(USAGE_DEFAULT_WINDOW_DAYS);
   const [startingRuntime, setStartingRuntime] = React.useState(false);
   const [runtimeRecoveryPending, setRuntimeRecoveryPending] = React.useState(false);
   const [installOpen, setInstallOpen] = React.useState(false);
@@ -516,6 +521,37 @@ export const SettingsModelsPage: React.FC = () => {
         : feedAfterTailRead(emptyFeed, freshEvents, EVENT_PAGE, null));
     });
   }));
+
+  const [usageReadAuthority] = React.useState(() => createLatestAsyncAuthority<RegionRead<UsageSummary>>((incoming) => {
+    if (!aliveRef.current) return;
+    setUsageRead((previous) => settleRegionRead(previous, incoming));
+  }));
+
+  const refreshUsage = React.useCallback(async (days: UsageWindowOption) => {
+    setUsageRead(beginRegionRead);
+    await usageReadAuthority.run(() => readRegion(() => modelsApi.getUsageSummary(days)));
+  }, [usageReadAuthority]);
+
+  /**
+   * The usage report is read lazily, when the tab is opened.
+   *
+   * It is deliberately NOT a first-paint region (see `firstPaintRegions.ts`,
+   * whose whitelist is a policy list of exactly the three reads the landing
+   * cannot be drawn without): a report nobody is looking at must not delay the
+   * surface that decides routing. Re-reading on every open is the point — the
+   * figure is live, and `beginRegionRead` keeps the previous one on screen while
+   * the new one lands, so returning to the tab never flashes empty. A window
+   * change is the same read with a different span, which is why one effect owns
+   * both.
+   */
+  React.useEffect(() => {
+    if (tab !== 'usage') return;
+    void refreshUsage(usageWindow);
+  }, [tab, usageWindow, refreshUsage]);
+
+  const retryUsage = React.useCallback(async () => {
+    await refreshUsage(usageWindow);
+  }, [refreshUsage, usageWindow]);
 
   const refreshEventHead = React.useCallback(async () => {
     setEventsRead(beginRegionRead);
@@ -1121,7 +1157,7 @@ export const SettingsModelsPage: React.FC = () => {
                     </div>
                     <RecentSwitchesCard events={eventsRead} sources={sourcesRead} onRetry={retryEvents} loadingMore={loadingEvents} onLoadMore={loadOlderEvents} />
                     <AdvancedRow />
-                  </div> : <section className="rounded-xl border border-border bg-surface px-5 py-8"><div className="flex items-start gap-3"><Info className="mt-0.5 size-4 text-muted" /><div><h2 className="text-[14px] font-semibold text-foreground">{t('settings.models.usageTab.title')}</h2><p className="mt-1 text-[12px] text-muted">{t('settings.models.usageTab.detail')}</p></div></div></section>}
+                  </div> : <UsageTab usage={usageRead} windowDays={usageWindow} onWindowChange={setUsageWindow} onRetry={retryUsage} />}
                 </div>}
       <SourceMutationReport
         report={sourceMutationReport.report}

--- a/ui/src/components/settings/models/SettingsModelsPage.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.tsx
@@ -1058,10 +1058,19 @@ export const SettingsModelsPage: React.FC = () => {
                 onMutationCommitted={sourceMutationReport.present}
               />
             : <section className="rounded-xl border border-border bg-surface px-5 py-12 text-center text-[12px] text-muted">{t('settings.models.sourceDetail.gone')}</section>
-          : directEmpty ? <DirectHome agents={installedAgents} onSwitch={setAdoptAgent} />
-            : <div className="space-y-[22px]">
+          : <div className="space-y-[22px]">
+                  {/* The tab strip belongs to the Hub, not to the source
+                      inventory. The ledger outlives the Sources it metered — it
+                      retains its window and the report names a deleted Source by
+                      its id — so deleting the last one may not take the only route
+                      to that history with it. Frame 09 is drawn without tabs
+                      because it predates this tab, not because usage stops
+                      existing once the inventory is empty; what the frame decides
+                      is the body of `sources`, which is still Frame 09 there. */}
                   <HubTabs tab={tab} onChange={setTab} />
-                  {tab === 'sources' ? <div className="model-hub-overview">
+                  {tab === 'usage' ? <UsageTab usage={usageRead} windowDays={usageWindow} onWindowChange={setUsageWindow} onRetry={retryUsage} />
+                    : directEmpty ? <DirectHome agents={installedAgents} onSwitch={setAdoptAgent} />
+                    : <div className="model-hub-overview">
                     <div className="model-hub-overview-body">
                       <div ref={overviewRef} className="model-hub-overview-grid relative flex flex-col gap-4">
                         <Popover
@@ -1157,7 +1166,7 @@ export const SettingsModelsPage: React.FC = () => {
                     </div>
                     <RecentSwitchesCard events={eventsRead} sources={sourcesRead} onRetry={retryEvents} loadingMore={loadingEvents} onLoadMore={loadOlderEvents} />
                     <AdvancedRow />
-                  </div> : <UsageTab usage={usageRead} windowDays={usageWindow} onWindowChange={setUsageWindow} onRetry={retryUsage} />}
+                  </div>}
                 </div>}
       <SourceMutationReport
         report={sourceMutationReport.report}

--- a/ui/src/components/settings/models/UsageTab.test.tsx
+++ b/ui/src/components/settings/models/UsageTab.test.tsx
@@ -76,17 +76,17 @@ const draw = (
 afterEach(cleanup);
 
 describe('UsageTab', () => {
-  it('names the window the report was served over, not the one asked for', () => {
-    // MH-USAGE-016. The server clamps `days` to retention and answers with what
-    // it covered. Printing the request back would caption a 62-day report as 7.
+  it('MH-USAGE-016: names the window the report was served over, not the one asked for', () => {
+    // The server clamps `days` to retention and answers with what it covered.
+    // Printing the request back would caption a 62-day report as 7.
     const { container } = draw(readyRegion(summary({ window_days: 62 })), { windowDays: 7 });
     expect(container.textContent).toContain('trailing 62 days');
     expect(container.textContent).not.toContain('trailing 7 days');
   });
 
-  it('keeps a vanished Source identifiable and a vanished model unnamed', () => {
-    // MH-USAGE-017. Asymmetric by contract: `src_*` is a string the user could
-    // have seen elsewhere, a ledger key is a digest nobody typed.
+  it('MH-USAGE-017: keeps a vanished Source identifiable and a vanished model unnamed', () => {
+    // Asymmetric by contract: `src_*` is a string the user could have seen
+    // elsewhere, a ledger key is a digest nobody typed.
     const key = 'claude-opus-4-6-20260514-thinking#9f2c1d';
     const { container } = draw(
       readyRegion(summary({ sources: [source({ label: null, models: [model({ label: null, model_id: key })] })] })),
@@ -98,9 +98,9 @@ describe('UsageTab', () => {
     expect(container.textContent).not.toContain('9f2c1d');
   });
 
-  it('reads a shortfall as reports that never arrived', () => {
-    // MH-USAGE-018. The schema forbids the other reading outright: the gap
-    // between requests and token reports is missing evidence, never spare quota.
+  it('MH-USAGE-018: reads a shortfall as reports that never arrived', () => {
+    // The schema forbids the other reading outright: the gap between requests
+    // and token reports is missing evidence, never spare quota.
     const { container } = draw(readyRegion(summary({ totals: counters({ requests: 12, token_reports: 9 }) })));
     expect(container.textContent).toContain('3 requests came back with no token report');
     expect(container.textContent).not.toContain(en.settings.models.usage.requests.reported);
@@ -118,9 +118,9 @@ describe('UsageTab', () => {
     expect(container.textContent).not.toContain(en.settings.models.usage.byDay.title);
   });
 
-  it('plots every day of the window, including the ones that carried nothing', () => {
-    // MH-USAGE-019. One reported day inside a 30-day span. Drawing `days[]`
-    // directly would close the gap and read as a month of continuous traffic.
+  it('MH-USAGE-019: plots every day of the window, including the ones that carried nothing', () => {
+    // One reported day inside a 30-day span. Drawing `days[]` directly would
+    // close the gap and read as a month of continuous traffic.
     const { container } = draw(readyRegion(summary()));
     expect(container.querySelectorAll('.model-hub-usage-track')).toHaveLength(30);
     expect(screen.getByRole('img', { name: /Metered tokens per day/ })).toBeTruthy();

--- a/ui/src/components/settings/models/UsageTab.test.tsx
+++ b/ui/src/components/settings/models/UsageTab.test.tsx
@@ -157,6 +157,19 @@ describe('UsageTab', () => {
     ]);
   });
 
+  it('MH-USAGE-023: states every day of the window in text, not only in a pointer tooltip', () => {
+    const { container } = draw(readyRegion(summary()));
+    const chart = screen.getByRole('img', { name: /Metered tokens per day/ });
+    const tooltips = [...container.querySelectorAll('.model-hub-usage-track')].map((track) => track.getAttribute('title'));
+
+    // A `title` opens on hover alone, and the chart is one image whose columns
+    // assistive tech never enumerates — so the same readouts have to exist as
+    // text outside it. Asserted against the tooltips rather than against a list
+    // of days: the two readings cannot disagree, whatever the window holds.
+    const items = [...container.querySelectorAll('li')].filter((item) => !chart.contains(item));
+    expect(items.map((item) => item.textContent)).toEqual(tooltips);
+  });
+
   it('keeps the last report on screen while a new one is read, and claims no failure', () => {
     const { container } = draw(degradedRegion(summary(), 'refreshing', false));
     expect(container.textContent).toContain('Contract source');

--- a/ui/src/components/settings/models/UsageTab.test.tsx
+++ b/ui/src/components/settings/models/UsageTab.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+// What the 用量 tab is allowed to SAY about a report. The derivations themselves
+// are `usageProjection.test.ts`'s subject; every assertion here is about a claim
+// the tab could make that the payload does not support — a span it was not
+// served, an identity it cannot render, an empty window drawn as zeroes, or a
+// shortfall presented as spare capacity.
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createInstance } from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import en from '../../../i18n/en.json';
+import { degradedRegion, loadingRegion, readyRegion, unreadRegion, type RegionRead } from './regionRead';
+import type { UsageByModel, UsageBySource, UsageCounters, UsageSummary } from './types';
+import { UsageTab } from './UsageTab';
+
+const i18n = createInstance();
+void i18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  resources: { en: { translation: en } },
+  interpolation: { escapeValue: false },
+});
+
+const counters = (over: Partial<UsageCounters> = {}): UsageCounters => ({
+  requests: 12,
+  token_reports: 12,
+  input_tokens: 148230,
+  cached_input_tokens: 96010,
+  output_tokens: 4120,
+  ...over,
+});
+
+const model = (over: Partial<UsageByModel> = {}): UsageByModel => ({
+  ...counters(),
+  model_id: 'claude-opus-4-6',
+  label: 'claude-opus-4-6',
+  ...over,
+});
+
+const source = (over: Partial<UsageBySource> = {}): UsageBySource => ({
+  ...counters(),
+  source_id: 'src_conform001',
+  label: 'Contract source',
+  last_metered_at: '2026-08-18T03:14:00+00:00',
+  models: [model()],
+  ...over,
+});
+
+const summary = (over: Partial<UsageSummary> = {}): UsageSummary => ({
+  window_days: 30,
+  from_day: '2026-07-20',
+  to_day: '2026-08-18',
+  totals: counters(),
+  sources: [source()],
+  days: [{ ...counters(), day: '2026-08-18' }],
+  ...over,
+});
+
+const draw = (
+  usage: RegionRead<UsageSummary>,
+  over: { windowDays?: 7 | 30 | 60; onWindowChange?: (days: number) => void; onRetry?: () => void } = {},
+) =>
+  render(
+    <I18nextProvider i18n={i18n}>
+      <UsageTab
+        usage={usage}
+        windowDays={over.windowDays ?? 30}
+        onWindowChange={over.onWindowChange ?? (() => {})}
+        onRetry={over.onRetry}
+      />
+    </I18nextProvider>,
+  );
+
+afterEach(cleanup);
+
+describe('UsageTab', () => {
+  it('names the window the report was served over, not the one asked for', () => {
+    // MH-USAGE-016. The server clamps `days` to retention and answers with what
+    // it covered. Printing the request back would caption a 62-day report as 7.
+    const { container } = draw(readyRegion(summary({ window_days: 62 })), { windowDays: 7 });
+    expect(container.textContent).toContain('trailing 62 days');
+    expect(container.textContent).not.toContain('trailing 7 days');
+  });
+
+  it('keeps a vanished Source identifiable and a vanished model unnamed', () => {
+    // MH-USAGE-017. Asymmetric by contract: `src_*` is a string the user could
+    // have seen elsewhere, a ledger key is a digest nobody typed.
+    const key = 'claude-opus-4-6-20260514-thinking#9f2c1d';
+    const { container } = draw(
+      readyRegion(summary({ sources: [source({ label: null, models: [model({ label: null, model_id: key })] })] })),
+    );
+    expect(container.textContent).toContain('src_conform001');
+    expect(container.textContent).toContain(en.settings.models.usage.bySource.goneSource);
+    expect(container.textContent).toContain(en.settings.models.usage.bySource.goneModel);
+    expect(container.textContent).not.toContain(key);
+    expect(container.textContent).not.toContain('9f2c1d');
+  });
+
+  it('reads a shortfall as reports that never arrived', () => {
+    // MH-USAGE-018. The schema forbids the other reading outright: the gap
+    // between requests and token reports is missing evidence, never spare quota.
+    const { container } = draw(readyRegion(summary({ totals: counters({ requests: 12, token_reports: 9 }) })));
+    expect(container.textContent).toContain('3 requests came back with no token report');
+    expect(container.textContent).not.toContain(en.settings.models.usage.requests.reported);
+  });
+
+  it('confirms full reporting when every request carried its tokens', () => {
+    const { container } = draw(readyRegion(summary()));
+    expect(container.textContent).toContain(en.settings.models.usage.requests.reported);
+  });
+
+  it('says nothing was metered instead of drawing a table of zeroes', () => {
+    const { container } = draw(readyRegion(summary({ sources: [], days: [] })));
+    expect(container.textContent).toContain(en.settings.models.usage.empty);
+    expect(container.textContent).not.toContain(en.settings.models.usage.bySource.title);
+    expect(container.textContent).not.toContain(en.settings.models.usage.byDay.title);
+  });
+
+  it('plots every day of the window, including the ones that carried nothing', () => {
+    // MH-USAGE-019. One reported day inside a 30-day span. Drawing `days[]`
+    // directly would close the gap and read as a month of continuous traffic.
+    const { container } = draw(readyRegion(summary()));
+    expect(container.querySelectorAll('.model-hub-usage-track')).toHaveLength(30);
+    expect(screen.getByRole('img', { name: /Metered tokens per day/ })).toBeTruthy();
+  });
+
+  it('keeps the last report on screen while a new one is read, and claims no failure', () => {
+    const { container } = draw(degradedRegion(summary(), 'refreshing', false));
+    expect(container.textContent).toContain('Contract source');
+    expect(container.textContent).not.toContain(en.settings.models.toast.refreshFailed);
+  });
+
+  it('keeps the last report on screen when a refresh fails, under a retry', async () => {
+    // The alternative is an empty state, which would read as "nothing was ever
+    // metered" — a different claim from "the figure could not be refreshed".
+    const onRetry = vi.fn();
+    const { container } = draw(degradedRegion(summary(), 'read_failed', true), { onRetry });
+    expect(container.textContent).toContain('Contract source');
+    expect(container.textContent).toContain(en.settings.models.toast.refreshFailed);
+    await userEvent.click(screen.getByRole('button', { name: en.settings.models.upstream.retry }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers a retry with no report to show when the first read never landed', () => {
+    const { container } = draw(unreadRegion<UsageSummary>());
+    expect(container.textContent).toContain(en.settings.models.toast.refreshFailed);
+    expect(container.textContent).not.toContain(en.settings.models.usage.empty);
+  });
+
+  it('draws no report and no failure while the first read is in flight', () => {
+    const { container } = draw(loadingRegion<UsageSummary>());
+    expect(container.textContent).not.toContain(en.settings.models.toast.refreshFailed);
+    expect(container.textContent).not.toContain(en.settings.models.usage.empty);
+  });
+
+  it('hands its owner a window the contract accepts, as a number', async () => {
+    // The control speaks strings; `days` is a bounded number on the wire.
+    const onWindowChange = vi.fn();
+    draw(readyRegion(summary()), { onWindowChange });
+    await userEvent.click(screen.getByRole('radio', { name: '7d' }));
+    expect(onWindowChange).toHaveBeenCalledWith(7);
+  });
+});

--- a/ui/src/components/settings/models/UsageTab.test.tsx
+++ b/ui/src/components/settings/models/UsageTab.test.tsx
@@ -154,17 +154,91 @@ describe('UsageTab', () => {
 
     expect(container.textContent).toContain(en.settings.models.usage.byDay.unreported);
     expect(container.textContent).not.toContain(en.settings.models.usage.byDay.quiet);
+    expect(container.textContent).not.toContain(en.settings.models.usage.byDay.zero);
     // Every column says what its day carried, so a bar the report could not
     // measure still reads as a day that ran rather than as an unexplained sliver.
     // (Whether it is floored to one is CSS the DOM cannot answer for; the decision
     // behind it is `usageDayIsMetered`, asserted over columns in
     // `usageProjection.test.ts`.)
+    //
+    // The two kinds of day in this window state their tokens differently, which is
+    // the point: a day of uncosted calls has no number to print, while the day
+    // between them ran nothing and so really did cost zero.
     const readouts = [...container.querySelectorAll('.model-hub-usage-track')].map((track) => track.getAttribute('title'));
     expect(readouts).toEqual([
-      'Aug 16, 2026 · 0 tokens · 4 requests',
+      'Aug 16, 2026 · — tokens · 4 requests',
       'Aug 17, 2026 · 0 tokens · 0 requests',
-      'Aug 18, 2026 · 0 tokens · 4 requests',
+      'Aug 18, 2026 · — tokens · 4 requests',
     ]);
+  });
+
+  it('MH-USAGE-025: reads a window whose reports all came back zero as measured, not as missing', () => {
+    // The mirror of MH-USAGE-021, one question over. Every call here WAS costed and
+    // the answer was nothing — an explicit all-zero usage block, which
+    // `extract_protocol_usage` forwards as a report rather than as an absence, so
+    // `token_reports` equals `requests` while every token count is 0. Reading that
+    // as 「no day reported its tokens」 would call a valid upstream answer missing
+    // evidence, and blanking the figures would hide a cost the report does state.
+    const free = counters({ requests: 4, token_reports: 4, input_tokens: 0, cached_input_tokens: 0, output_tokens: 0 });
+    const { container } = draw(readyRegion(summary({
+      from_day: '2026-08-17',
+      to_day: '2026-08-18',
+      window_days: 2,
+      totals: free,
+      sources: [source({ ...free, models: [model(free)] })],
+      days: [{ ...free, day: '2026-08-18' }],
+    })));
+
+    expect(container.textContent).toContain(en.settings.models.usage.byDay.zero);
+    expect(container.textContent).not.toContain(en.settings.models.usage.byDay.unreported);
+    expect(container.textContent).not.toContain(en.settings.models.usage.byDay.quiet);
+    // A measured zero is a number, and the requests card has no shortfall to state
+    // about it either — nothing went unreported.
+    expect(container.textContent).toContain(en.settings.models.usage.requests.reported);
+    expect(container.textContent).not.toContain(en.settings.models.usage.tokens.none);
+    // And the cached card may say what MH-USAGE-026 forbids it to say, because here
+    // it is true: these calls were costed, and the cost included no input.
+    expect(container.textContent).toContain(en.settings.models.usage.cached.none);
+    const tokenFigures = [...container.querySelectorAll('[data-usage-token]')];
+    expect(tokenFigures.length).toBeGreaterThan(0);
+    for (const figure of tokenFigures) expect(figure.textContent).toBe('0');
+  });
+
+  it('MH-USAGE-026: every token figure on screen states its own coverage, whatever states it', () => {
+    // The class MH-USAGE-021 and MH-USAGE-025 are two members of: a token figure
+    // printed without asking whether anything reported it. Asked of every figure the
+    // tab renders rather than of a list of the seven known ones — the marker is
+    // emitted by the single door they all go through, so a card, cell, or column
+    // added later is covered by existing rather than by an edit here.
+    const uncosted = counters({ requests: 6, token_reports: 0, input_tokens: 0, cached_input_tokens: 0, output_tokens: 0 });
+    const { container } = draw(readyRegion(summary({
+      from_day: '2026-08-17',
+      to_day: '2026-08-18',
+      window_days: 2,
+      totals: uncosted,
+      sources: [source({ ...uncosted, models: [model(uncosted)] })],
+      // Both reported days carried calls nobody costed, so no day of this window
+      // may print a token number at all.
+      days: [{ ...uncosted, day: '2026-08-17' }, { ...uncosted, day: '2026-08-18' }],
+    })));
+
+    const tokenFigures = [...container.querySelectorAll('[data-usage-token]')];
+    expect(tokenFigures.length).toBeGreaterThan(0);
+    for (const figure of tokenFigures) expect(figure.textContent).toBe(en.settings.models.usage.blank);
+    // …and the sentences that interpolate a figure instead of holding one say the
+    // same thing, since a tooltip and a note have no element of their own to mark.
+    const readouts = [...container.querySelectorAll('.model-hub-usage-track')].map((track) => track.getAttribute('title'));
+    expect(readouts).toEqual([
+      'Aug 17, 2026 · — tokens · 6 requests',
+      'Aug 18, 2026 · — tokens · 6 requests',
+    ]);
+    // The notes go the same way. The tokens card replaces the input/output split
+    // rather than blanking both halves of it — 「— in · — out」 states a breakdown of
+    // a number nobody gave — and the cached card must not read an absence of reports
+    // as an absence of input.
+    expect(container.textContent).toContain(en.settings.models.usage.tokens.none);
+    expect(container.textContent).not.toContain(' in · ');
+    expect(container.textContent).not.toContain(en.settings.models.usage.cached.none);
   });
 
   it('MH-USAGE-023: states every day of the window in text, not only in a pointer tooltip', () => {

--- a/ui/src/components/settings/models/UsageTab.test.tsx
+++ b/ui/src/components/settings/models/UsageTab.test.tsx
@@ -4,7 +4,7 @@
 // the tab could make that the payload does not support — a span it was not
 // served, an identity it cannot render, an empty window drawn as zeroes, or a
 // shortfall presented as spare capacity.
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createInstance } from 'i18next';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
@@ -72,6 +72,16 @@ const draw = (
       />
     </I18nextProvider>,
   );
+
+/** A table's rows that carry figures — the ones headed by a row rather than by a column. */
+const bodyRows = (table: HTMLElement) =>
+  within(table).getAllByRole('row').filter((row) => within(row).queryAllByRole('rowheader').length > 0);
+
+/**
+ * One row's stated figures, its row header first — which is the order that decides
+ * which column each of them answers.
+ */
+const figures = (row: HTMLElement) => [...within(row).getAllByRole('rowheader'), ...within(row).getAllByRole('cell')];
 
 afterEach(cleanup);
 
@@ -159,15 +169,78 @@ describe('UsageTab', () => {
 
   it('MH-USAGE-023: states every day of the window in text, not only in a pointer tooltip', () => {
     const { container } = draw(readyRegion(summary()));
-    const chart = screen.getByRole('img', { name: /Metered tokens per day/ });
-    const tooltips = [...container.querySelectorAll('.model-hub-usage-track')].map((track) => track.getAttribute('title'));
+    const tooltips = [...container.querySelectorAll('.model-hub-usage-track')].map((track) => track.getAttribute('title') ?? '');
 
     // A `title` opens on hover alone, and the chart is one image whose columns
-    // assistive tech never enumerates — so the same readouts have to exist as
-    // text outside it. Asserted against the tooltips rather than against a list
-    // of days: the two readings cannot disagree, whatever the window holds.
-    const items = [...container.querySelectorAll('li')].filter((item) => !chart.contains(item));
-    expect(items.map((item) => item.textContent)).toEqual(tooltips);
+    // assistive tech never enumerates — so the same three figures have to exist
+    // as cells outside it. Read out of the tooltips rather than out of a list of
+    // days: the two readings of a day cannot disagree, whatever the window holds.
+    const rows = bodyRows(screen.getByRole('table', { name: /Metered tokens and requests per day/ }));
+    expect(rows).toHaveLength(tooltips.length);
+    rows.forEach((row, index) => {
+      const said = tooltips[index].split(' · ');
+      const stated = figures(row).map((figure) => figure.textContent ?? '');
+      expect(stated).toHaveLength(said.length);
+      stated.forEach((text, column) => expect(said[column]).toContain(text));
+    });
+  });
+
+  it('MH-USAGE-024: every figure the report states names the row and the column it answers', () => {
+    // The class this closes: a per-row figure stated by visual position alone,
+    // which no reader who cannot see the layout can recover. Asked of whatever
+    // tables the tab renders rather than of a list of them, so a third panel of
+    // figures is covered by existing instead of by an edit here.
+    const { container } = draw(readyRegion(summary({
+      sources: [
+        source({ models: [model({ model_id: 'claude-opus-4-6', label: 'claude-opus-4-6' })] }),
+        // The ragged shape: a Source with no metering timestamp, over a model that
+        // has none by definition. Both stop before the last column.
+        source({
+          source_id: 'src_probe002',
+          label: 'Probe source',
+          last_metered_at: null,
+          models: [model({ model_id: 'claude-haiku-4-5', label: 'claude-haiku-4-5' })],
+        }),
+      ],
+    })));
+
+    const named: string[] = [];
+    for (const table of screen.getAllByRole('table')) {
+      const headers = within(table).getAllByRole('columnheader');
+      expect(headers.length).toBeGreaterThan(1);
+      // Whether this table's headers can leave the accessibility tree, which is
+      // what decides whether position alone is enough. jsdom loads no stylesheet,
+      // so the class is the only readable statement of it.
+      const stacks = /(^|\s)hidden(\s|$)/.test(headers[0].parentElement?.className ?? '');
+      const rows = bodyRows(table);
+      expect(rows.length).toBeGreaterThan(0);
+      for (const row of rows) {
+        const heads = within(row).getAllByRole('rowheader');
+        expect(heads).toHaveLength(1);
+        named.push(heads[0].textContent ?? '');
+        const stated = figures(row);
+        // A figure answers the column it sits in, so no row may end early: the
+        // model row has no metering timestamp of its own and holds that column
+        // open with an empty cell rather than shifting the ones before it under
+        // the wrong header.
+        expect(stated).toHaveLength(headers.length);
+        stated.forEach((figure, column) => {
+          const label = figure.querySelector('.model-hub-usage-cell-label');
+          // Where the headers go, the cell's own label is the association that
+          // stays — so every figure that states something has to carry one, and it
+          // has to name the column the figure sits in. Two statements about one
+          // cell, which a drifting column order would answer differently.
+          if (stacks && figure !== heads[0] && figure.textContent !== '') expect(label).not.toBeNull();
+          if (label !== null) expect(label.textContent).toBe(headers[column].textContent);
+        });
+      }
+    }
+
+    // …and the rows are the whole report's, not the subset that happens to render:
+    // every Source, every model under it, and every day the chart draws.
+    const days = container.querySelectorAll('.model-hub-usage-track').length;
+    expect(named).toHaveLength(4 + days);
+    expect(named).toEqual(expect.arrayContaining(['Contract source', 'Probe source', 'claude-opus-4-6', 'claude-haiku-4-5']));
   });
 
   it('keeps the last report on screen while a new one is read, and claims no failure', () => {

--- a/ui/src/components/settings/models/UsageTab.test.tsx
+++ b/ui/src/components/settings/models/UsageTab.test.tsx
@@ -126,6 +126,37 @@ describe('UsageTab', () => {
     expect(screen.getByRole('img', { name: /Metered tokens per day/ })).toBeTruthy();
   });
 
+  it('MH-USAGE-021: draws a day of calls whose tokens never came back, and names the window unreported', () => {
+    // Every request in the window answered without a token report, which the
+    // schema permits and the requests card already states as a shortfall. The
+    // series has nothing to scale, so every bar sits on its floor — but the days
+    // ran, and folding them into 「no metered turn」 would report our own missing
+    // evidence as the user's idleness.
+    const unreported = counters({ requests: 4, token_reports: 0, input_tokens: 0, cached_input_tokens: 0, output_tokens: 0 });
+    const { container } = draw(readyRegion(summary({
+      from_day: '2026-08-16',
+      to_day: '2026-08-18',
+      window_days: 3,
+      totals: unreported,
+      sources: [source({ ...unreported, models: [model(unreported)] })],
+      days: [{ ...unreported, day: '2026-08-16' }, { ...unreported, day: '2026-08-18' }],
+    })));
+
+    expect(container.textContent).toContain(en.settings.models.usage.byDay.unreported);
+    expect(container.textContent).not.toContain(en.settings.models.usage.byDay.quiet);
+    // Every column says what its day carried, so a bar the report could not
+    // measure still reads as a day that ran rather than as an unexplained sliver.
+    // (Whether it is floored to one is CSS the DOM cannot answer for; the decision
+    // behind it is `usageDayIsMetered`, asserted over columns in
+    // `usageProjection.test.ts`.)
+    const readouts = [...container.querySelectorAll('.model-hub-usage-track')].map((track) => track.getAttribute('title'));
+    expect(readouts).toEqual([
+      'Aug 16, 2026 · 0 tokens · 4 requests',
+      'Aug 17, 2026 · 0 tokens · 0 requests',
+      'Aug 18, 2026 · 0 tokens · 4 requests',
+    ]);
+  });
+
   it('keeps the last report on screen while a new one is read, and claims no failure', () => {
     const { container } = draw(degradedRegion(summary(), 'refreshing', false));
     expect(container.textContent).toContain('Contract source');

--- a/ui/src/components/settings/models/UsageTab.tsx
+++ b/ui/src/components/settings/models/UsageTab.tsx
@@ -32,6 +32,7 @@ import {
   sourceIdentity,
   usageCachedInputShare,
   usageDayColumns,
+  usageDayIsMetered,
   usageIsEmpty,
   usageReportShortfall,
   usageTotalTokens,
@@ -190,12 +191,17 @@ const BySourcePanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
  * makes the zero-fill legible. A bar of zero height in an empty row is
  * indistinguishable from a missing bar, and the difference — an idle day versus a
  * day the report does not cover — is the whole reason the series is drawn.
+ *
+ * Which day ran is `usageDayIsMetered`'s answer and never a token total: an
+ * upstream can serve a call and report nothing about it, so a window of those has
+ * bars to draw and a peak it cannot name.
  */
 const ByDayPanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
   const { t, i18n } = useTranslation();
   const count = useCount();
   const columns = React.useMemo(() => usageDayColumns(summary), [summary]);
   const peak = columns.reduce<UsageDayColumn | null>((best, column) => (column.tokens > (best?.tokens ?? 0) ? column : best), null);
+  const metered = columns.some(usageDayIsMetered);
   const day = (value: string) => formatLocalDay(value, i18n.language);
   return (
     <section className="model-hub-usage-card overflow-hidden rounded-xl border border-border bg-background">
@@ -212,21 +218,27 @@ const ByDayPanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
             <div
               key={column.day}
               className="model-hub-usage-track flex flex-1 items-end"
-              title={t('settings.models.usage.byDay.column', { day: day(column.day), tokens: count(column.tokens) }) as string}
+              title={t('settings.models.usage.byDay.column', { day: day(column.day), tokens: count(column.tokens), requests: count(column.requests) }) as string}
             >
               {/* A metered day is floored to a visible sliver so the quietest one
-                  still reads as activity; a day with nothing keeps zero height
-                  and shows only the track. */}
-              <div className="model-hub-usage-column w-full" style={{ height: column.tokens > 0 ? `max(2px, ${column.ratio * 100}%)` : 0 }} />
+                  still reads as activity — including one whose tokens never came
+                  back, which is why the floor asks about calls and not about
+                  tokens. Only a day that carried nothing keeps zero height and
+                  shows the track alone. */}
+              <div className="model-hub-usage-column w-full" style={{ height: usageDayIsMetered(column) ? `max(2px, ${column.ratio * 100}%)` : 0 }} />
             </div>
           ))}
         </div>
         <div className="model-hub-usage-axis flex items-baseline justify-between gap-3">
           <span className="truncate">{day(summary.from_day)}</span>
           <span className="model-hub-usage-peak truncate">
-            {peak === null
-              ? t('settings.models.usage.byDay.quiet')
-              : t('settings.models.usage.byDay.peak', { tokens: count(peak.tokens), day: day(peak.day) })}
+            {peak !== null
+              ? t('settings.models.usage.byDay.peak', { tokens: count(peak.tokens), day: day(peak.day) })
+              // No peak is two different windows: one nobody used, and one whose
+              // upstreams never reported what they cost. Only the first is quiet.
+              : metered
+                ? t('settings.models.usage.byDay.unreported')
+                : t('settings.models.usage.byDay.quiet')}
           </span>
           <span className="truncate">{day(summary.to_day)}</span>
         </div>

--- a/ui/src/components/settings/models/UsageTab.tsx
+++ b/ui/src/components/settings/models/UsageTab.tsx
@@ -24,7 +24,7 @@ import { useTranslation } from 'react-i18next';
 import { SegmentedRadio } from '@/components/ui/segmented';
 import { formatCount, formatDayTime, formatPercent } from './format';
 import { foldRegionRead, regionFailed, type RegionRead } from './regionRead';
-import type { UsageByModel, UsageBySource, UsageSummary } from './types';
+import type { UsageByModel, UsageBySource, UsageCounters, UsageSummary } from './types';
 import {
   USAGE_WINDOW_OPTIONS,
   formatLocalDay,
@@ -35,6 +35,8 @@ import {
   usageDayIsMetered,
   usageIsEmpty,
   usageReportShortfall,
+  usageTokensAreKnown,
+  usageTokensAreReported,
   usageTotalTokens,
   type UsageDayColumn,
   type UsageIdentity,
@@ -45,6 +47,44 @@ import {
 const useCount = () => {
   const { i18n } = useTranslation();
   return (value: number) => formatCount(value, i18n.language);
+};
+
+/** Anything a token figure is derived from: a totals bucket, a row, or a day. */
+type TokenCoverage = Pick<UsageCounters, 'requests' | 'token_reports'>;
+
+/**
+ * The one way this tab turns a token count into text.
+ *
+ * A rendered `0` cannot say which of three things it means — a cost reported as
+ * nothing, a cost nobody reported, or nothing having run at all — and every panel
+ * this tab draws states token figures, so wording any single one of them correctly
+ * leaves all the others to be found one review round at a time. The figure asks
+ * its own bucket first: for calls that no upstream ever costed there is no
+ * measurement to print, and the blank marker the cached share and the metering
+ * timestamp already use says exactly that.
+ *
+ * Coverage travels with the value rather than being checked by the caller, so a
+ * new token figure cannot be written without naming the counters it came from.
+ */
+const useTokenText = () => {
+  const { t } = useTranslation();
+  const count = useCount();
+  return (counters: TokenCoverage, value: number) =>
+    usageTokensAreKnown(counters) ? count(value) : (t('settings.models.usage.blank') as string);
+};
+
+/**
+ * A token figure standing on its own, as a cell or a card value.
+ *
+ * `data-usage-token` is not styling: it is what lets a test enumerate every token
+ * figure on screen and assert they all went through the door, which is a claim
+ * about completeness that a per-site test cannot make. A figure interpolated into
+ * a translated sentence has no element of its own and uses `useTokenText`
+ * directly; its sentence is then the asserted unit.
+ */
+const TokenFigure: React.FC<{ counters: TokenCoverage; value: number }> = ({ counters, value }) => {
+  const tokenText = useTokenText();
+  return <span data-usage-token="">{tokenText(counters, value)}</span>;
 };
 
 /**
@@ -101,7 +141,7 @@ const Cell: React.FC<{ column: SourceColumn; children: React.ReactNode }> = ({ c
   );
 };
 
-const StatCard: React.FC<{ label: string; value: string; note: string }> = ({ label, value, note }) => (
+const StatCard: React.FC<{ label: string; value: React.ReactNode; note: string }> = ({ label, value, note }) => (
   <div className="model-hub-usage-stat flex flex-col rounded-xl border border-border bg-background">
     <span className="model-hub-usage-stat-label">{label}</span>
     <span className="model-hub-usage-stat-value font-semibold text-foreground">{value}</span>
@@ -119,8 +159,13 @@ const StatGrid: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
     <div className="grid gap-4 sm:grid-cols-3">
       <StatCard
         label={t('settings.models.usage.tokens.label') as string}
-        value={count(usageTotalTokens(totals))}
-        note={t('settings.models.usage.tokens.detail', { input: count(totals.input_tokens), output: count(totals.output_tokens) }) as string}
+        value={<TokenFigure counters={totals} value={usageTotalTokens(totals)} />}
+        // The input/output split is a reading of the same unreported total, so it
+        // cannot survive on its own once the total is blank: it says what nobody
+        // reported instead.
+        note={(usageTokensAreKnown(totals)
+          ? t('settings.models.usage.tokens.detail', { input: count(totals.input_tokens), output: count(totals.output_tokens) })
+          : t('settings.models.usage.tokens.none')) as string}
       />
       <StatCard
         label={t('settings.models.usage.requests.label') as string}
@@ -134,9 +179,15 @@ const StatGrid: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
       <StatCard
         label={t('settings.models.usage.cached.label') as string}
         value={cachedShare === null ? (t('settings.models.usage.blank') as string) : formatPercent(cachedShare, i18n.language)}
-        note={(cachedShare === null
-          ? t('settings.models.usage.cached.none')
-          : t('settings.models.usage.cached.detail', { cached: count(totals.cached_input_tokens), input: count(totals.input_tokens) })) as string}
+        // 「No input tokens in this window」 is the same defect one card over: with
+        // nothing reported there were no input tokens WE KNOW OF, and an absence of
+        // reports is not an absence of usage. Coverage is asked before the share, so
+        // the card states the missing reports rather than an empty input.
+        note={(!usageTokensAreKnown(totals)
+          ? t('settings.models.usage.tokens.none')
+          : cachedShare === null
+            ? t('settings.models.usage.cached.none')
+            : t('settings.models.usage.cached.detail', { cached: count(totals.cached_input_tokens), input: count(totals.input_tokens) })) as string}
       />
     </div>
   );
@@ -151,7 +202,7 @@ const ModelRow: React.FC<{ model: UsageByModel }> = ({ model }) => {
       <span role="rowheader" className="model-hub-usage-model flex min-w-0 items-baseline">
         <RowIdentity identity={modelIdentity(model)} goneKey="settings.models.usage.bySource.goneModel" />
       </span>
-      <Cell column="tokens">{count(usageTotalTokens(model))}</Cell>
+      <Cell column="tokens"><TokenFigure counters={model} value={usageTotalTokens(model)} /></Cell>
       <Cell column="requests">{count(model.requests)}</Cell>
       <Cell column="cached">
         {share === null ? (t('settings.models.usage.blank') as string) : formatPercent(share, i18n.language)}
@@ -176,7 +227,7 @@ const SourceRows: React.FC<{ source: UsageBySource }> = ({ source }) => {
         <span role="rowheader" className="model-hub-usage-source flex min-w-0 items-baseline font-semibold text-foreground">
           <RowIdentity identity={sourceIdentity(source)} goneKey="settings.models.usage.bySource.goneSource" />
         </span>
-        <Cell column="tokens">{count(usageTotalTokens(source))}</Cell>
+        <Cell column="tokens"><TokenFigure counters={source} value={usageTotalTokens(source)} /></Cell>
         <Cell column="requests">{count(source.requests)}</Cell>
         <Cell column="cached">
           {share === null ? (t('settings.models.usage.blank') as string) : formatPercent(share, i18n.language)}
@@ -227,14 +278,23 @@ const BySourcePanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
  *
  * Which day ran is `usageDayIsMetered`'s answer and never a token total: an
  * upstream can serve a call and report nothing about it, so a window of those has
- * bars to draw and a peak it cannot name.
+ * bars to draw and a peak it cannot name. Whether a day's cost is known at all is
+ * `usageTokensAreReported`'s separate answer — asked of the very same zero.
  */
 const ByDayPanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
   const { t, i18n } = useTranslation();
   const count = useCount();
+  const tokenText = useTokenText();
   const columns = React.useMemo(() => usageDayColumns(summary), [summary]);
-  const peak = columns.reduce<UsageDayColumn | null>((best, column) => (column.tokens > (best?.tokens ?? 0) ? column : best), null);
+  // Only a day whose tokens were reported can be the busiest one. A day with no
+  // report has no measured cost to compare, so naming it the peak would put a
+  // superlative on a number the report never carried.
+  const peak = columns.reduce<UsageDayColumn | null>(
+    (best, column) => (usageTokensAreReported(column) && column.tokens > (best?.tokens ?? 0) ? column : best),
+    null,
+  );
   const metered = columns.some(usageDayIsMetered);
+  const reported = columns.some(usageTokensAreReported);
   const day = (value: string) => formatLocalDay(value, i18n.language);
   // One day's figures as a hover readout. The table below states the same three
   // values in cells, and MH-USAGE-023 derives its expectation from this sentence
@@ -242,7 +302,7 @@ const ByDayPanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
   const readout = (column: UsageDayColumn) =>
     t('settings.models.usage.byDay.column', {
       day: day(column.day),
-      tokens: count(column.tokens),
+      tokens: tokenText(column, column.tokens),
       requests: count(column.requests),
     }) as string;
   return (
@@ -291,7 +351,7 @@ const ByDayPanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
             {columns.map((column) => (
               <tr key={column.day}>
                 <th scope="row">{day(column.day)}</th>
-                <td>{count(column.tokens)}</td>
+                <td><TokenFigure counters={column} value={column.tokens} /></td>
                 <td>{count(column.requests)}</td>
               </tr>
             ))}
@@ -301,12 +361,19 @@ const ByDayPanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
           <span className="truncate">{day(summary.from_day)}</span>
           <span className="model-hub-usage-peak truncate">
             {peak !== null
-              ? t('settings.models.usage.byDay.peak', { tokens: count(peak.tokens), day: day(peak.day) })
-              // No peak is two different windows: one nobody used, and one whose
-              // upstreams never reported what they cost. Only the first is quiet.
-              : metered
-                ? t('settings.models.usage.byDay.unreported')
-                : t('settings.models.usage.byDay.quiet')}
+              ? t('settings.models.usage.byDay.peak', { tokens: tokenText(peak, peak.tokens), day: day(peak.day) })
+              // No peak is three different windows, and the tokens cannot tell them
+              // apart: one nobody used, one whose upstreams never reported what the
+              // calls cost, and one that was measured and really did cost nothing.
+              // Coverage is asked before activity, because a window with any report
+              // in it can state what its reports said — the calls that came back
+              // without one are the requests card's shortfall to name, not this
+              // sentence's.
+              : reported
+                ? t('settings.models.usage.byDay.zero')
+                : metered
+                  ? t('settings.models.usage.byDay.unreported')
+                  : t('settings.models.usage.byDay.quiet')}
           </span>
           <span className="truncate">{day(summary.to_day)}</span>
         </div>

--- a/ui/src/components/settings/models/UsageTab.tsx
+++ b/ui/src/components/settings/models/UsageTab.tsx
@@ -1,0 +1,303 @@
+// 用量 — the metered-token report over a trailing local-day window
+// (`usage-summary.schema.json`).
+//
+// It is a report and only a report: nothing on this tab feeds resolution,
+// admission, or cooldown, and the span it names is the `window_days` the server
+// answered with rather than the number the user asked for. The two are the same
+// for every option offered here, which is a property `usageProjection.test.ts`
+// enforces rather than a coincidence to rely on.
+//
+// The 額度 half the tab label used to promise is absent on purpose. `cycle_used_pct`
+// has exactly one production writer and it writes `None`, so a quota reading would
+// be an invention; the tab is named for what it can actually show.
+//
+// Drawn against `design.pen MS/ConfigPanel → cp-usage-body`. No frame exists for
+// this tab on the local surface, so the geometry follows the source table's own
+// vocabulary — 12px card radius, 18px gutter, 11px column labels — instead of
+// importing a second panel's spacing into the middle of this one. Two deliberate
+// departures from that frame: the day series is a column chart because the day
+// count is a window parameter and not a fixed five, and the panels stack instead
+// of splitting because the table carries nested rows and a trend reads wide.
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { SegmentedRadio } from '@/components/ui/segmented';
+import { formatCount, formatDayTime, formatPercent } from './format';
+import { foldRegionRead, regionFailed, type RegionRead } from './regionRead';
+import type { UsageByModel, UsageBySource, UsageSummary } from './types';
+import {
+  USAGE_WINDOW_OPTIONS,
+  formatLocalDay,
+  modelIdentity,
+  sourceIdentity,
+  usageCachedInputShare,
+  usageDayColumns,
+  usageIsEmpty,
+  usageReportShortfall,
+  usageTotalTokens,
+  type UsageDayColumn,
+  type UsageIdentity,
+  type UsageWindowOption,
+} from './usageProjection';
+
+/** A number that reads against a vendor's own console: grouped, never compacted. */
+const useCount = () => {
+  const { i18n } = useTranslation();
+  return (value: number) => formatCount(value, i18n.language);
+};
+
+/**
+ * A row's own name, or the honest absence of one.
+ *
+ * A Source that has left the inventory keeps its canonical id, so the reader can
+ * still tell which line of the report is which. A model has no displayable
+ * identity at all once its label is gone — its ledger key is a digest — so the
+ * row says so in words instead of printing the key.
+ */
+const RowIdentity: React.FC<{ identity: UsageIdentity; goneKey: string }> = ({ identity, goneKey }) => {
+  const { t } = useTranslation();
+  if (identity.kind === 'label') return <span className="truncate" title={identity.text}>{identity.text}</span>;
+  return (
+    <span className="flex min-w-0 items-baseline gap-1.5">
+      {identity.id !== null && <span className="truncate font-mono" title={identity.id}>{identity.id}</span>}
+      <span className="model-hub-usage-gone shrink-0">{t(goneKey)}</span>
+    </span>
+  );
+};
+
+/**
+ * One measured cell.
+ *
+ * The label is carried on the cell rather than only in the header because the
+ * header is the first thing that goes when the surface narrows — the row keeps
+ * its own labels there, so a stacked cell is still a labelled number instead of
+ * an unattributed one.
+ */
+const Cell: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
+  <span className="model-hub-usage-cell flex items-baseline justify-between gap-2 md:justify-end">
+    <span className="model-hub-usage-cell-label md:hidden">{label}</span>
+    <span className="min-w-0 truncate">{children}</span>
+  </span>
+);
+
+const StatCard: React.FC<{ label: string; value: string; note: string }> = ({ label, value, note }) => (
+  <div className="model-hub-usage-stat flex flex-col rounded-xl border border-border bg-background">
+    <span className="model-hub-usage-stat-label">{label}</span>
+    <span className="model-hub-usage-stat-value font-semibold text-foreground">{value}</span>
+    <span className="model-hub-usage-stat-note">{note}</span>
+  </div>
+);
+
+const StatGrid: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
+  const { t, i18n } = useTranslation();
+  const count = useCount();
+  const totals = summary.totals;
+  const shortfall = usageReportShortfall(totals);
+  const cachedShare = usageCachedInputShare(totals);
+  return (
+    <div className="grid gap-4 sm:grid-cols-3">
+      <StatCard
+        label={t('settings.models.usage.tokens.label') as string}
+        value={count(usageTotalTokens(totals))}
+        note={t('settings.models.usage.tokens.detail', { input: count(totals.input_tokens), output: count(totals.output_tokens) }) as string}
+      />
+      <StatCard
+        label={t('settings.models.usage.requests.label') as string}
+        value={count(totals.requests)}
+        // A shortfall means reports that never arrived, never capacity left
+        // unused, and the copy has to say which of the two it is.
+        note={(shortfall > 0
+          ? t('settings.models.usage.requests.shortfall', { count: shortfall })
+          : t('settings.models.usage.requests.reported')) as string}
+      />
+      <StatCard
+        label={t('settings.models.usage.cached.label') as string}
+        value={cachedShare === null ? (t('settings.models.usage.blank') as string) : formatPercent(cachedShare, i18n.language)}
+        note={(cachedShare === null
+          ? t('settings.models.usage.cached.none')
+          : t('settings.models.usage.cached.detail', { cached: count(totals.cached_input_tokens), input: count(totals.input_tokens) })) as string}
+      />
+    </div>
+  );
+};
+
+const ModelRow: React.FC<{ model: UsageByModel }> = ({ model }) => {
+  const { t, i18n } = useTranslation();
+  const count = useCount();
+  const share = usageCachedInputShare(model);
+  return (
+    <div className="model-hub-usage-row model-hub-usage-row--model grid border-t border-border md:items-center">
+      <span className="model-hub-usage-model flex min-w-0 items-baseline">
+        <RowIdentity identity={modelIdentity(model)} goneKey="settings.models.usage.bySource.goneModel" />
+      </span>
+      <Cell label={t('settings.models.usage.bySource.col.tokens') as string}>{count(usageTotalTokens(model))}</Cell>
+      <Cell label={t('settings.models.usage.bySource.col.requests') as string}>{count(model.requests)}</Cell>
+      <Cell label={t('settings.models.usage.bySource.col.cached') as string}>
+        {share === null ? (t('settings.models.usage.blank') as string) : formatPercent(share, i18n.language)}
+      </Cell>
+      <span className="hidden md:block" />
+    </div>
+  );
+};
+
+const SourceRows: React.FC<{ source: UsageBySource }> = ({ source }) => {
+  const { t, i18n } = useTranslation();
+  const count = useCount();
+  const share = usageCachedInputShare(source);
+  return (
+    <div className="border-b border-border last:border-b-0">
+      <div className="model-hub-usage-row grid md:items-center">
+        <span className="model-hub-usage-source flex min-w-0 items-baseline font-semibold text-foreground">
+          <RowIdentity identity={sourceIdentity(source)} goneKey="settings.models.usage.bySource.goneSource" />
+        </span>
+        <Cell label={t('settings.models.usage.bySource.col.tokens') as string}>{count(usageTotalTokens(source))}</Cell>
+        <Cell label={t('settings.models.usage.bySource.col.requests') as string}>{count(source.requests)}</Cell>
+        <Cell label={t('settings.models.usage.bySource.col.cached') as string}>
+          {share === null ? (t('settings.models.usage.blank') as string) : formatPercent(share, i18n.language)}
+        </Cell>
+        <Cell label={t('settings.models.usage.bySource.col.lastMetered') as string}>
+          {source.last_metered_at === null ? (t('settings.models.usage.blank') as string) : formatDayTime(source.last_metered_at, i18n.language)}
+        </Cell>
+      </div>
+      {source.models.map((model) => <ModelRow key={model.model_id} model={model} />)}
+    </div>
+  );
+};
+
+const BySourcePanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
+  const { t } = useTranslation();
+  return (
+    <section className="model-hub-usage-card overflow-hidden rounded-xl border border-border bg-background">
+      <h3 className="model-hub-usage-card-head model-hub-usage-section-title border-b border-border font-semibold text-foreground">
+        {t('settings.models.usage.bySource.title')}
+      </h3>
+      <div className="model-hub-usage-head hidden border-b border-border font-semibold md:grid">
+        <span className="truncate">{t('settings.models.usage.bySource.col.source')}</span>
+        <span className="flex justify-end truncate">{t('settings.models.usage.bySource.col.tokens')}</span>
+        <span className="flex justify-end truncate">{t('settings.models.usage.bySource.col.requests')}</span>
+        <span className="flex justify-end truncate">{t('settings.models.usage.bySource.col.cached')}</span>
+        <span className="flex justify-end truncate">{t('settings.models.usage.bySource.col.lastMetered')}</span>
+      </div>
+      {summary.sources.map((source) => <SourceRows key={source.source_id} source={source} />)}
+    </section>
+  );
+};
+
+/**
+ * The trend, over every day of the window rather than every day reported.
+ *
+ * `usageDayColumns` is what densifies it; the track behind each column is what
+ * makes the zero-fill legible. A bar of zero height in an empty row is
+ * indistinguishable from a missing bar, and the difference — an idle day versus a
+ * day the report does not cover — is the whole reason the series is drawn.
+ */
+const ByDayPanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
+  const { t, i18n } = useTranslation();
+  const count = useCount();
+  const columns = React.useMemo(() => usageDayColumns(summary), [summary]);
+  const peak = columns.reduce<UsageDayColumn | null>((best, column) => (column.tokens > (best?.tokens ?? 0) ? column : best), null);
+  const day = (value: string) => formatLocalDay(value, i18n.language);
+  return (
+    <section className="model-hub-usage-card overflow-hidden rounded-xl border border-border bg-background">
+      <h3 className="model-hub-usage-card-head model-hub-usage-section-title border-b border-border font-semibold text-foreground">
+        {t('settings.models.usage.byDay.title')}
+      </h3>
+      <div className="model-hub-usage-plot flex flex-col">
+        <div
+          role="img"
+          aria-label={t('settings.models.usage.byDay.chart', { from: day(summary.from_day), to: day(summary.to_day) }) as string}
+          className="model-hub-usage-chart flex items-end"
+        >
+          {columns.map((column) => (
+            <div
+              key={column.day}
+              className="model-hub-usage-track flex flex-1 items-end"
+              title={t('settings.models.usage.byDay.column', { day: day(column.day), tokens: count(column.tokens) }) as string}
+            >
+              {/* A metered day is floored to a visible sliver so the quietest one
+                  still reads as activity; a day with nothing keeps zero height
+                  and shows only the track. */}
+              <div className="model-hub-usage-column w-full" style={{ height: column.tokens > 0 ? `max(2px, ${column.ratio * 100}%)` : 0 }} />
+            </div>
+          ))}
+        </div>
+        <div className="model-hub-usage-axis flex items-baseline justify-between gap-3">
+          <span className="truncate">{day(summary.from_day)}</span>
+          <span className="model-hub-usage-peak truncate">
+            {peak === null
+              ? t('settings.models.usage.byDay.quiet')
+              : t('settings.models.usage.byDay.peak', { tokens: count(peak.tokens), day: day(peak.day) })}
+          </span>
+          <span className="truncate">{day(summary.to_day)}</span>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export const UsageTab: React.FC<{
+  usage: RegionRead<UsageSummary>;
+  /** The window the user asked for. The report answers with what it served. */
+  windowDays: UsageWindowOption;
+  onWindowChange: (days: UsageWindowOption) => void;
+  onRetry?: () => void | Promise<void>;
+}> = ({ usage: usageRead, windowDays, onWindowChange, onRetry }) => {
+  const { t, i18n } = useTranslation();
+  const summary = foldRegionRead<UsageSummary, UsageSummary | null>(usageRead, {
+    loading: () => null,
+    ready: (data) => data,
+    unread: () => null,
+    // A stale report is still the last true one; it stays on screen under the
+    // failure strip rather than being replaced by an empty state that would read
+    // as "nothing was ever metered".
+    degraded: (staleData) => staleData,
+  });
+  const options = React.useMemo(
+    () => USAGE_WINDOW_OPTIONS.map((option) => ({ id: String(option), label: t('settings.models.usage.window.option', { days: option }) as string })),
+    [t],
+  );
+  const pickWindow = (id: string) => {
+    const next = USAGE_WINDOW_OPTIONS.find((option) => String(option) === id);
+    if (next !== undefined) onWindowChange(next);
+  };
+  const day = (value: string) => formatLocalDay(value, i18n.language);
+
+  return (
+    <div className="model-hub-usage">
+      <div className="model-hub-usage-bar flex flex-col gap-3 rounded-xl border border-border bg-surface sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 flex-col gap-1">
+          <h2 className="model-hub-usage-title font-semibold text-foreground">{t('settings.models.usage.title')}</h2>
+          <p className="model-hub-usage-note truncate">
+            {summary === null
+              ? t('settings.models.usage.detail')
+              : t('settings.models.usage.range', { from: day(summary.from_day), to: day(summary.to_day), days: summary.window_days })}
+          </p>
+        </div>
+        <SegmentedRadio
+          value={String(windowDays)}
+          onChange={pickWindow}
+          options={options}
+          ariaLabel={t('settings.models.usage.window.label') as string}
+          className="shrink-0 sm:w-auto"
+        />
+      </div>
+      {regionFailed(usageRead) && (
+        <div className="model-hub-usage-failure flex items-center justify-between gap-3 rounded-xl border border-border bg-background text-destructive-ink">
+          <span>{t('settings.models.toast.refreshFailed')}</span>
+          <button type="button" onClick={() => void onRetry?.()} className="model-hub-action-mint shrink-0 font-semibold">
+            {t('settings.models.upstream.retry')}
+          </button>
+        </div>
+      )}
+      {summary === null
+        ? usageRead.kind === 'loading' && <p className="model-hub-usage-pending text-muted">{t('common.loading')}</p>
+        : usageIsEmpty(summary)
+          ? <p className="model-hub-usage-empty rounded-xl border border-border bg-background text-center text-muted">{t('settings.models.usage.empty')}</p>
+          : <>
+              <StatGrid summary={summary} />
+              <BySourcePanel summary={summary} />
+              <ByDayPanel summary={summary} />
+            </>}
+    </div>
+  );
+};

--- a/ui/src/components/settings/models/UsageTab.tsx
+++ b/ui/src/components/settings/models/UsageTab.tsx
@@ -67,19 +67,39 @@ const RowIdentity: React.FC<{ identity: UsageIdentity; goneKey: string }> = ({ i
 };
 
 /**
- * One measured cell.
+ * The by-source table's columns, in the order the rows state them.
  *
- * The label is carried on the cell rather than only in the header because the
- * header is the first thing that goes when the surface narrows — the row keeps
- * its own labels there, so a stacked cell is still a labelled number instead of
- * an unattributed one.
+ * One list, read by the header row and by every cell's own label, so the two
+ * cannot come to name a column differently.
  */
-const Cell: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
-  <span className="model-hub-usage-cell flex items-baseline justify-between gap-2 md:justify-end">
-    <span className="model-hub-usage-cell-label md:hidden">{label}</span>
-    <span className="min-w-0 truncate">{children}</span>
-  </span>
-);
+const SOURCE_COLUMNS = ['source', 'tokens', 'requests', 'cached', 'lastMetered'] as const;
+
+type SourceColumn = (typeof SOURCE_COLUMNS)[number];
+
+const columnLabel = (column: SourceColumn) => `settings.models.usage.bySource.col.${column}`;
+
+/**
+ * One measured cell, told which column it answers.
+ *
+ * A cell's column is the position it holds in its row, which is what makes the
+ * header row above it an answer and not decoration — so no row may end early: the
+ * model row holds its empty column open below rather than shifting the cells after
+ * it. The label repeats the header on the cell itself because the header is the
+ * first thing that goes when the surface narrows, and a stacked cell has to remain
+ * a labelled number rather than an unattributed one. Between them the two cover
+ * both widths, so a per-cell `aria-colindex` would restate what position already
+ * says; the index earns its keep only for a row that skips a column in the middle,
+ * and holding the place with an empty cell is the simpler way to not have one.
+ */
+const Cell: React.FC<{ column: SourceColumn; children: React.ReactNode }> = ({ column, children }) => {
+  const { t } = useTranslation();
+  return (
+    <span role="cell" className="model-hub-usage-cell flex items-baseline justify-between gap-2 md:justify-end">
+      <span className="model-hub-usage-cell-label md:hidden">{t(columnLabel(column))}</span>
+      <span className="min-w-0 truncate">{children}</span>
+    </span>
+  );
+};
 
 const StatCard: React.FC<{ label: string; value: string; note: string }> = ({ label, value, note }) => (
   <div className="model-hub-usage-stat flex flex-col rounded-xl border border-border bg-background">
@@ -127,16 +147,19 @@ const ModelRow: React.FC<{ model: UsageByModel }> = ({ model }) => {
   const count = useCount();
   const share = usageCachedInputShare(model);
   return (
-    <div className="model-hub-usage-row model-hub-usage-row--model grid border-t border-border md:items-center">
-      <span className="model-hub-usage-model flex min-w-0 items-baseline">
+    <div role="row" className="model-hub-usage-row model-hub-usage-row--model grid border-t border-border md:items-center">
+      <span role="rowheader" className="model-hub-usage-model flex min-w-0 items-baseline">
         <RowIdentity identity={modelIdentity(model)} goneKey="settings.models.usage.bySource.goneModel" />
       </span>
-      <Cell label={t('settings.models.usage.bySource.col.tokens') as string}>{count(usageTotalTokens(model))}</Cell>
-      <Cell label={t('settings.models.usage.bySource.col.requests') as string}>{count(model.requests)}</Cell>
-      <Cell label={t('settings.models.usage.bySource.col.cached') as string}>
+      <Cell column="tokens">{count(usageTotalTokens(model))}</Cell>
+      <Cell column="requests">{count(model.requests)}</Cell>
+      <Cell column="cached">
         {share === null ? (t('settings.models.usage.blank') as string) : formatPercent(share, i18n.language)}
       </Cell>
-      <span className="hidden md:block" />
+      {/* A model has no metering timestamp of its own; the column stays empty
+          rather than repeating the Source's, and holds its place so every cell
+          before it still sits under the header it answers. */}
+      <span role="cell" className="hidden md:block" />
     </div>
   );
 };
@@ -146,17 +169,19 @@ const SourceRows: React.FC<{ source: UsageBySource }> = ({ source }) => {
   const count = useCount();
   const share = usageCachedInputShare(source);
   return (
-    <div className="border-b border-border last:border-b-0">
-      <div className="model-hub-usage-row grid md:items-center">
-        <span className="model-hub-usage-source flex min-w-0 items-baseline font-semibold text-foreground">
+    // A Source and the models under it are one group of rows, which is also what
+    // the border draws: the group is the unit a reader scans, not each line.
+    <div role="rowgroup" className="border-b border-border last:border-b-0">
+      <div role="row" className="model-hub-usage-row grid md:items-center">
+        <span role="rowheader" className="model-hub-usage-source flex min-w-0 items-baseline font-semibold text-foreground">
           <RowIdentity identity={sourceIdentity(source)} goneKey="settings.models.usage.bySource.goneSource" />
         </span>
-        <Cell label={t('settings.models.usage.bySource.col.tokens') as string}>{count(usageTotalTokens(source))}</Cell>
-        <Cell label={t('settings.models.usage.bySource.col.requests') as string}>{count(source.requests)}</Cell>
-        <Cell label={t('settings.models.usage.bySource.col.cached') as string}>
+        <Cell column="tokens">{count(usageTotalTokens(source))}</Cell>
+        <Cell column="requests">{count(source.requests)}</Cell>
+        <Cell column="cached">
           {share === null ? (t('settings.models.usage.blank') as string) : formatPercent(share, i18n.language)}
         </Cell>
-        <Cell label={t('settings.models.usage.bySource.col.lastMetered') as string}>
+        <Cell column="lastMetered">
           {source.last_metered_at === null ? (t('settings.models.usage.blank') as string) : formatDayTime(source.last_metered_at, i18n.language)}
         </Cell>
       </div>
@@ -167,19 +192,27 @@ const SourceRows: React.FC<{ source: UsageBySource }> = ({ source }) => {
 
 const BySourcePanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
   const { t } = useTranslation();
+  const titleId = React.useId();
   return (
     <section className="model-hub-usage-card overflow-hidden rounded-xl border border-border bg-background">
-      <h3 className="model-hub-usage-card-head model-hub-usage-section-title border-b border-border font-semibold text-foreground">
+      <h3 id={titleId} className="model-hub-usage-card-head model-hub-usage-section-title border-b border-border font-semibold text-foreground">
         {t('settings.models.usage.bySource.title')}
       </h3>
-      <div className="model-hub-usage-head hidden border-b border-border font-semibold md:grid">
-        <span className="truncate">{t('settings.models.usage.bySource.col.source')}</span>
-        <span className="flex justify-end truncate">{t('settings.models.usage.bySource.col.tokens')}</span>
-        <span className="flex justify-end truncate">{t('settings.models.usage.bySource.col.requests')}</span>
-        <span className="flex justify-end truncate">{t('settings.models.usage.bySource.col.cached')}</span>
-        <span className="flex justify-end truncate">{t('settings.models.usage.bySource.col.lastMetered')}</span>
+      {/* A table by role rather than by tag. The layout is a CSS grid that stacks
+          into labelled lines on a narrow surface, which a `<table>` can only do
+          through a `display` override — and overriding `display` is exactly what
+          strips a table of the semantics it was chosen for. Explicit roles keep
+          the grid and the structure at every width. */}
+      <div role="table" aria-labelledby={titleId}>
+        <div role="row" className="model-hub-usage-head hidden border-b border-border font-semibold md:grid">
+          {SOURCE_COLUMNS.map((column, index) => (
+            <span key={column} role="columnheader" className={index === 0 ? 'truncate' : 'flex justify-end truncate'}>
+              {t(columnLabel(column))}
+            </span>
+          ))}
+        </div>
+        {summary.sources.map((source) => <SourceRows key={source.source_id} source={source} />)}
       </div>
-      {summary.sources.map((source) => <SourceRows key={source.source_id} source={source} />)}
     </section>
   );
 };
@@ -203,8 +236,9 @@ const ByDayPanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
   const peak = columns.reduce<UsageDayColumn | null>((best, column) => (column.tokens > (best?.tokens ?? 0) ? column : best), null);
   const metered = columns.some(usageDayIsMetered);
   const day = (value: string) => formatLocalDay(value, i18n.language);
-  // One day's figures, in the one wording both the pointer tooltip and the list
-  // below read from — a second phrasing would be a second answer to drift from.
+  // One day's figures as a hover readout. The table below states the same three
+  // values in cells, and MH-USAGE-023 derives its expectation from this sentence
+  // so the two readings of a day cannot answer differently.
   const readout = (column: UsageDayColumn) =>
     t('settings.models.usage.byDay.column', {
       day: day(column.day),
@@ -237,17 +271,32 @@ const ByDayPanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
             </div>
           ))}
         </div>
-        {/* Every day's figures, in text. A pointer tooltip is the one readout a
-            keyboard or screen-reader user cannot open, and `role="img"` above
-            hides the columns from assistive tech by design — so the series is
-            also a list, and the axis stops being the only reachable reading of
-            it. Sibling rather than child: inside the image it would be hidden
-            with everything else. */}
-        <ul className="sr-only">
-          {columns.map((column) => (
-            <li key={column.day}>{readout(column)}</li>
-          ))}
-        </ul>
+        {/* Every day's figures again, as a table. A pointer tooltip is the one
+            readout a keyboard or screen-reader user cannot open, and `role="img"`
+            above hides the columns from assistive tech by design — so the series
+            needs a second reading, in cells rather than one sentence per day,
+            which is the same per-column association the Source table carries.
+            Sibling of the image, never a child: inside it, it would be hidden
+            along with everything else. */}
+        <table className="sr-only">
+          <caption>{t('settings.models.usage.byDay.table', { from: day(summary.from_day), to: day(summary.to_day) })}</caption>
+          <thead>
+            <tr>
+              <th scope="col">{t('settings.models.usage.byDay.col.day')}</th>
+              <th scope="col">{t('settings.models.usage.tokens.label')}</th>
+              <th scope="col">{t('settings.models.usage.requests.label')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {columns.map((column) => (
+              <tr key={column.day}>
+                <th scope="row">{day(column.day)}</th>
+                <td>{count(column.tokens)}</td>
+                <td>{count(column.requests)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
         <div className="model-hub-usage-axis flex items-baseline justify-between gap-3">
           <span className="truncate">{day(summary.from_day)}</span>
           <span className="model-hub-usage-peak truncate">

--- a/ui/src/components/settings/models/UsageTab.tsx
+++ b/ui/src/components/settings/models/UsageTab.tsx
@@ -203,6 +203,14 @@ const ByDayPanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
   const peak = columns.reduce<UsageDayColumn | null>((best, column) => (column.tokens > (best?.tokens ?? 0) ? column : best), null);
   const metered = columns.some(usageDayIsMetered);
   const day = (value: string) => formatLocalDay(value, i18n.language);
+  // One day's figures, in the one wording both the pointer tooltip and the list
+  // below read from — a second phrasing would be a second answer to drift from.
+  const readout = (column: UsageDayColumn) =>
+    t('settings.models.usage.byDay.column', {
+      day: day(column.day),
+      tokens: count(column.tokens),
+      requests: count(column.requests),
+    }) as string;
   return (
     <section className="model-hub-usage-card overflow-hidden rounded-xl border border-border bg-background">
       <h3 className="model-hub-usage-card-head model-hub-usage-section-title border-b border-border font-semibold text-foreground">
@@ -218,7 +226,7 @@ const ByDayPanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
             <div
               key={column.day}
               className="model-hub-usage-track flex flex-1 items-end"
-              title={t('settings.models.usage.byDay.column', { day: day(column.day), tokens: count(column.tokens), requests: count(column.requests) }) as string}
+              title={readout(column)}
             >
               {/* A metered day is floored to a visible sliver so the quietest one
                   still reads as activity — including one whose tokens never came
@@ -229,6 +237,17 @@ const ByDayPanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
             </div>
           ))}
         </div>
+        {/* Every day's figures, in text. A pointer tooltip is the one readout a
+            keyboard or screen-reader user cannot open, and `role="img"` above
+            hides the columns from assistive tech by design — so the series is
+            also a list, and the axis stops being the only reachable reading of
+            it. Sibling rather than child: inside the image it would be hidden
+            with everything else. */}
+        <ul className="sr-only">
+          {columns.map((column) => (
+            <li key={column.day}>{readout(column)}</li>
+          ))}
+        </ul>
         <div className="model-hub-usage-axis flex items-baseline justify-between gap-3">
           <span className="truncate">{day(summary.from_day)}</span>
           <span className="model-hub-usage-peak truncate">

--- a/ui/src/components/settings/models/format.test.ts
+++ b/ui/src/components/settings/models/format.test.ts
@@ -1,54 +1,47 @@
 import { describe, expect, it } from 'vitest';
 
-import { cooldownEtaMinutes, currencySymbol, formatNameList, formatSpend } from './format';
+import { cooldownEtaMinutes, formatCount, formatDayTime, formatNameList, formatPercent } from './format';
 
-describe('currencySymbol', () => {
-  it('falls back to USD when the backend reports no currency', () => {
-    expect(currencySymbol(null)).toBe('$');
-    expect(currencySymbol(undefined)).toBe('$');
-    expect(currencySymbol()).toBe('$');
+describe('formatCount', () => {
+  it('groups so a figure can be read against a vendor console', () => {
+    expect(formatCount(2_968_500, 'en-US')).toBe('2,968,500');
+    expect(formatCount(2_968_500, 'zh-CN')).toBe('2,968,500');
   });
 
-  it('honors an explicitly reported currency', () => {
-    expect(currencySymbol('USD')).toBe('$');
-    expect(currencySymbol('CNY')).toBe('¥');
-    expect(currencySymbol('EUR')).toBe('€');
+  it('leaves a small count ungrouped', () => {
+    expect(formatCount(0, 'en-US')).toBe('0');
+    expect(formatCount(12, 'en-US')).toBe('12');
   });
 
-  it('returns no symbol for a code it cannot map', () => {
-    expect(currencySymbol('JPY')).toBe('');
-  });
-
-  it('agrees with the symbol formatSpend uses, for every currency', () => {
-    for (const currency of [null, undefined, 'USD', 'CNY', 'EUR', 'JPY'] as const) {
-      expect(formatSpend(1240, currency).startsWith(currencySymbol(currency))).toBe(true);
-      const stripped = formatSpend(1240, currency).slice(currencySymbol(currency).length);
-      expect(stripped).toBe('12.4');
-    }
+  // A token count is a count: rounding it up, or rendering a negative one, would
+  // put a claim on screen the ledger never made.
+  it('never renders a fractional or negative count', () => {
+    expect(formatCount(12.9, 'en-US')).toBe('12');
+    expect(formatCount(-5, 'en-US')).toBe('0');
   });
 });
 
-describe('formatSpend', () => {
-  it('falls back to USD when the backend reports no currency', () => {
-    expect(formatSpend(1240, null)).toBe('$12.4');
-    expect(formatSpend(1240, undefined)).toBe('$12.4');
-    expect(formatSpend(1240)).toBe('$12.4');
+describe('formatPercent', () => {
+  it('renders a share as whole percent', () => {
+    expect(formatPercent(0, 'en-US')).toBe('0%');
+    expect(formatPercent(0.647, 'en-US')).toBe('65%');
+    expect(formatPercent(1, 'en-US')).toBe('100%');
+  });
+});
+
+describe('formatDayTime', () => {
+  it('keeps the day and the minute of the instant it was given', () => {
+    // Fixed as an offset-bearing stamp so the assertion is about the formatter
+    // rather than about the machine the test happens to run on.
+    const rendered = formatDayTime('2026-08-18T03:14:00+00:00', 'en-US');
+    const local = new Date('2026-08-18T03:14:00+00:00');
+    expect(rendered).toContain(String(local.getDate()));
+    expect(rendered).toContain(String(local.getMinutes()).padStart(2, '0'));
   });
 
-  it('honors an explicitly reported currency', () => {
-    expect(formatSpend(1240, 'USD')).toBe('$12.4');
-    expect(formatSpend(1240, 'CNY')).toBe('¥12.4');
-    expect(formatSpend(1240, 'EUR')).toBe('€12.4');
-  });
-
-  it('omits the symbol for a currency it cannot map', () => {
-    expect(formatSpend(1240, 'JPY')).toBe('12.4');
-  });
-
-  it('converts cents to one decimal without applying any FX rate', () => {
-    expect(formatSpend(0, null)).toBe('$0.0');
-    expect(formatSpend(5, null)).toBe('$0.1');
-    expect(formatSpend(1234567, null)).toBe('$12345.7');
+  it('renders an unparseable stamp verbatim rather than inventing a time', () => {
+    expect(formatDayTime('never', 'en-US')).toBe('never');
+    expect(formatDayTime('', 'en-US')).toBe('');
   });
 });
 

--- a/ui/src/components/settings/models/format.ts
+++ b/ui/src/components/settings/models/format.ts
@@ -1,24 +1,5 @@
 // Pure formatting helpers for the Model Hub UI (no i18n — callers wrap the
 // returned values in translated templates).
-const CURRENCY_SYMBOL: Record<string, string> = { USD: '$', CNY: '¥', EUR: '€' };
-
-/**
- * Symbol for an ISO 4217 code — the ONLY place a currency symbol is resolved.
- *
- * USD is the fallback because every upstream vendor bills in USD; a CNY default
- * was our own invention. The mapping is kept, so a source that really does report
- * CNY (or EUR) still renders in its own currency. Returns '' for a code we cannot
- * map, so callers can fall back to a currency-free label rather than print a
- * misleading symbol.
- */
-export function currencySymbol(currency?: string | null): string {
-  return CURRENCY_SYMBOL[currency ?? 'USD'] ?? '';
-}
-
-/** Monthly spend as symbol + amount (1 decimal), e.g. "$12.4". */
-export function formatSpend(cents: number, currency?: string | null): string {
-  return `${currencySymbol(currency)}${(cents / 100).toFixed(1)}`;
-}
 
 /**
  * A list of names in the reader's own punctuation — 「A、B、C」 for a Chinese
@@ -32,6 +13,40 @@ export function formatSpend(cents: number, currency?: string | null): string {
  */
 export function formatNameList(names: readonly string[], locale: string): string {
   return new Intl.ListFormat(locale, { style: 'narrow', type: 'conjunction' }).format(names);
+}
+
+/**
+ * A counted quantity in the reader's own grouping — 「2,968,500」.
+ *
+ * Grouped rather than compacted (「3M」) because a usage report is read to be
+ * reconciled against a vendor's own console, and a rounded figure cannot be.
+ * `Intl` is what makes the separator the reader's rather than ours; the value is
+ * floored because a token count is a count, and a fractional one would be a bug
+ * upstream rendered as truth here.
+ */
+export function formatCount(value: number, locale: string): string {
+  return new Intl.NumberFormat(locale).format(Math.max(0, Math.floor(value)));
+}
+
+/** A ratio in [0, 1] as a whole-percent string — 「65%」. */
+export function formatPercent(ratio: number, locale: string): string {
+  return new Intl.NumberFormat(locale, { style: 'percent', maximumFractionDigits: 0 }).format(ratio);
+}
+
+/**
+ * An instant as a short day-and-time in the reader's own zone — 「8/18 03:14」.
+ *
+ * The host zone is the frame on purpose: what this answers is "when did this last
+ * happen to me", and a UTC stamp is a time the reader cannot reconcile against
+ * their own day. The year is dropped because the report this appears in spans at
+ * most a couple of months, so the year is never the ambiguous part; the month is
+ * kept because the day alone is. An unparseable stamp renders verbatim rather
+ * than as an invented time.
+ */
+export function formatDayTime(instant: string, locale: string): string {
+  const ms = Date.parse(instant);
+  if (Number.isNaN(ms)) return instant;
+  return new Intl.DateTimeFormat(locale, { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit' }).format(ms);
 }
 
 /** Whole minutes until a cooldown retry_at (never negative). */

--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -1455,6 +1455,150 @@
   font-weight: 600;
 }
 
+/* 用量 tab.
+ *
+ * design.pen has no frame for this tab on the local surface, so the geometry is
+ * borrowed from the source table above rather than invented: the same 18px
+ * gutter, 36px head, 11px column label, and wash-05 head fill. Importing a
+ * second panel's spacing into the middle of this one would read as two
+ * surfaces stitched together.
+ *
+ * Every ink here resolves through a step the light blocks already re-anchor
+ * (ink-73 / ink-8c / muted-b3), so this block needs no light branch of its own.
+ * The one genuinely new unit is the day chart, and its two colors are a wash and
+ * an accent fill — both of which flip correctly on their own.
+ */
+.model-hub-usage {
+  --model-hub-usage-gap: 16px;
+  --model-hub-usage-bar-padding-y: 13px;
+  --model-hub-usage-bar-padding-x: 18px;
+  --model-hub-usage-padding-x: 18px;
+  --model-hub-usage-head-height: 36px;
+  --model-hub-usage-row-min-height: 46px;
+  --model-hub-usage-row-padding-y: 9px;
+  --model-hub-usage-columns: minmax(0, 1fr) 104px 84px 84px 116px;
+  --model-hub-usage-gutter: 16px;
+  --model-hub-usage-title-size: 13px;
+  --model-hub-usage-section-size: 12px;
+  --model-hub-usage-label-size: 11px;
+  --model-hub-usage-value-size: 20px;
+  --model-hub-usage-cell-size: 12px;
+  --model-hub-usage-note-size: 10.5px;
+  --model-hub-usage-model-indent: 14px;
+  --model-hub-usage-chart-height: 132px;
+  --model-hub-usage-chart-gap: 3px;
+  --model-hub-usage-column-radius: 2px;
+  --model-hub-usage-head-fill: var(--model-hub-wash-05);
+  --model-hub-usage-label-ink: var(--model-hub-ink-73);
+  --model-hub-usage-note-ink: var(--model-hub-muted-b3);
+  --model-hub-usage-model-ink: var(--model-hub-ink-8c);
+  --model-hub-usage-track-fill: var(--model-hub-wash-08);
+  --model-hub-usage-column-fill: color-mix(in srgb, var(--mint) 55%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: var(--model-hub-usage-gap);
+}
+.model-hub-usage-bar {
+  padding: var(--model-hub-usage-bar-padding-y) var(--model-hub-usage-bar-padding-x);
+}
+.model-hub-usage-title { font-size: var(--model-hub-usage-title-size); }
+.model-hub-usage-note {
+  color: var(--model-hub-usage-note-ink);
+  font-size: var(--model-hub-usage-note-size);
+}
+.model-hub-usage-failure {
+  padding: 11px var(--model-hub-usage-padding-x);
+  font-size: var(--model-hub-usage-cell-size);
+}
+.model-hub-usage-pending { font-size: var(--model-hub-usage-title-size); }
+.model-hub-usage-empty {
+  padding: 26px var(--model-hub-usage-padding-x);
+  font-size: var(--model-hub-usage-cell-size);
+}
+.model-hub-usage-stat {
+  padding: 13px var(--model-hub-usage-padding-x) 14px;
+  gap: 5px;
+}
+.model-hub-usage-stat-label {
+  color: var(--model-hub-usage-label-ink);
+  font-size: var(--model-hub-usage-label-size);
+}
+.model-hub-usage-stat-value {
+  font-size: var(--model-hub-usage-value-size);
+  line-height: 1.15;
+  font-variant-numeric: tabular-nums;
+}
+.model-hub-usage-stat-note {
+  color: var(--model-hub-usage-note-ink);
+  font-size: var(--model-hub-usage-note-size);
+}
+.model-hub-usage-card-head {
+  padding: 11px var(--model-hub-usage-padding-x);
+}
+.model-hub-usage-section-title { font-size: var(--model-hub-usage-section-size); }
+/* Grid items stretch by default, which would leave a plain text cell drawing its
+ * glyphs against the top of the box while a flex cell beside it centres them. */
+.model-hub-usage-head {
+  min-height: var(--model-hub-usage-head-height);
+  padding: 0 var(--model-hub-usage-padding-x);
+  grid-template-columns: var(--model-hub-usage-columns);
+  gap: var(--model-hub-usage-gutter);
+  align-items: center;
+  background: var(--model-hub-usage-head-fill);
+  color: var(--model-hub-usage-label-ink);
+  font-size: var(--model-hub-usage-label-size);
+}
+.model-hub-usage-row {
+  min-height: var(--model-hub-usage-row-min-height);
+  padding: var(--model-hub-usage-row-padding-y) var(--model-hub-usage-padding-x);
+  grid-template-columns: var(--model-hub-usage-columns);
+  gap: var(--model-hub-usage-gutter);
+  font-size: var(--model-hub-usage-cell-size);
+}
+.model-hub-usage-row--model {
+  padding-left: calc(var(--model-hub-usage-padding-x) + var(--model-hub-usage-model-indent));
+  color: var(--model-hub-usage-model-ink);
+}
+.model-hub-usage-source,
+.model-hub-usage-model,
+.model-hub-usage-cell { min-width: 0; }
+.model-hub-usage-cell { font-variant-numeric: tabular-nums; }
+.model-hub-usage-cell-label {
+  color: var(--model-hub-usage-label-ink);
+  font-size: var(--model-hub-usage-note-size);
+  font-variant-numeric: normal;
+}
+.model-hub-usage-gone {
+  color: var(--model-hub-usage-note-ink);
+  font-size: var(--model-hub-usage-note-size);
+}
+.model-hub-usage-plot {
+  padding: 16px var(--model-hub-usage-padding-x) 12px;
+  gap: 9px;
+}
+.model-hub-usage-chart {
+  height: var(--model-hub-usage-chart-height);
+  gap: var(--model-hub-usage-chart-gap);
+}
+/* The track is drawn even where the column is not: a bar of zero height in an
+ * empty row cannot be told apart from a day the report never covered, and that
+ * distinction is the reason the series is plotted day by day at all. */
+.model-hub-usage-track {
+  min-width: 0;
+  height: 100%;
+  border-radius: var(--model-hub-usage-column-radius);
+  background: var(--model-hub-usage-track-fill);
+}
+.model-hub-usage-column {
+  border-radius: var(--model-hub-usage-column-radius);
+  background: var(--model-hub-usage-column-fill);
+}
+.model-hub-usage-axis {
+  color: var(--model-hub-usage-note-ink);
+  font-size: var(--model-hub-usage-note-size);
+}
+.model-hub-usage-peak { color: var(--model-hub-usage-label-ink); }
+
 @media (min-width: 1024px) {
   .model-hub-direct-grid {
     grid-template-columns: minmax(0, 1fr) var(--model-hub-direct-benefits-width);
@@ -1468,6 +1612,9 @@
   .model-hub-source-bar { align-items: stretch; }
   .model-hub-source-action { width: auto; flex: 1 1 0; }
   .model-hub-direct-card { min-height: 0; }
+  /* Stacked, each cell carries its own label, so the column gutter becomes a
+   * line gap and 16px of it would read as four separate rows. */
+  .model-hub-usage-row { grid-template-columns: minmax(0, 1fr); gap: 7px; }
 }
 
 @media (min-width: 1024px) {

--- a/ui/src/components/settings/models/modelsApi.ts
+++ b/ui/src/components/settings/models/modelsApi.ts
@@ -33,7 +33,9 @@ import type {
   SourceRepaired,
   SupplyChannel,
   SupplyGap,
+  UsageSummary,
 } from './types';
+import { USAGE_DEFAULT_WINDOW_DAYS } from './types';
 
 /** Add-time Route placement returned by both source-creation paths. */
 export type Adoption = { added_to: AddedTo[]; adopted_by: AdoptedBy[] };
@@ -127,6 +129,10 @@ export type ModelsApi = {
   applyMigration(itemIds: string[]): Promise<MigrationApplyResult>;
   /** `before` is an event id cursor (「查看全部」 pagination). */
   listEvents(limit?: number, before?: string): Promise<ResolutionEvent[]>;
+  /** Metered token report over a trailing local-day window. `days` is a REQUEST:
+   *  the server clamps it to retention and echoes what it served in
+   *  `window_days`, which is the only number a view may display. */
+  getUsageSummary(days?: number): Promise<UsageSummary>;
   getRuntimeStatus(): Promise<RuntimeDependency>;
   /** Start the contract-owned client installation transaction. */
   installRuntime(): Promise<RuntimeDependency>;
@@ -457,6 +463,8 @@ export const modelsApi: ModelsApi = {
     call<{ events: ResolutionEvent[] }>(
       `/api/models/events?limit=${limit}${before ? `&before=${encodeURIComponent(before)}` : ''}`,
     ).then((r) => r.events),
+  getUsageSummary: (days = USAGE_DEFAULT_WINDOW_DAYS) =>
+    call<{ usage: UsageSummary }>(`/api/models/usage?days=${days}`).then((r) => r.usage),
   getRuntimeStatus: () => call<{ runtime?: RuntimeDependency } & RuntimeDependency>('/api/models/runtime/status').then((r) => (r.runtime ?? r) as RuntimeDependency),
   installRuntime: () => call<{ runtime?: RuntimeDependency } & RuntimeDependency>('/api/models/runtime/install', jsonInit('POST')).then((r) => (r.runtime ?? r) as RuntimeDependency),
   startRuntime: () => call<{ runtime?: RuntimeDependency } & RuntimeDependency>('/api/models/runtime/start', jsonInit('POST')).then((r) => (r.runtime ?? r) as RuntimeDependency),

--- a/ui/src/components/settings/models/types.ts
+++ b/ui/src/components/settings/models/types.ts
@@ -66,10 +66,19 @@ export type SourceState = {
   detail_key?: SourceDetailKey | null;
 };
 
+/**
+ * The 額度 block of `source.schema.json`, mirrored so the contract stays typed.
+ *
+ * Nothing renders it: `cycle_used_pct` and `month_spend_cents` have one writer
+ * each (`migration.py`, both `None`), so every value the UI could receive is
+ * absent. The tab that used to promise 額度 reports metered tokens instead — see
+ * `UsageTab.tsx`. Kept as a mirror rather than deleted because the contract file
+ * still declares the fields; drop it when the contract does.
+ */
 export type SourceUsage = {
   cycle_used_pct?: number | null;
   month_spend_cents?: number | null;
-  /** ISO 4217, e.g. USD / CNY. Absent means USD (see formatSpend). */
+  /** ISO 4217, e.g. USD / CNY. Absent means USD. */
   currency?: string | null;
   /** v3, subscription sources only: when the current cycle is projected to run
    *  out at the observed burn rate. null when unknown or not projectable. */
@@ -504,6 +513,79 @@ export type RuntimeDependency = {
     error_key?: 'settings.models.install.fail.detail' | null;
   };
 };
+
+// ── usage-summary.schema.json ───────────────────────────────────────────
+/**
+ * Metered token usage over a trailing local-day window. A REPORT ONLY: the
+ * schema forbids any consumer feeding it back into resolution, admission, or
+ * cooldown, and the UI honours that by never reading it outside the usage tab.
+ *
+ * FIELD names are the schema's exactly, as everywhere in this file. The three
+ * per-dimension TYPE names are `UsageBy*` rather than the schema's `SourceUsage`
+ * / `ModelUsage` / `DayUsage`: `SourceUsage` is already taken above by
+ * source.schema.json's cycle-quota-and-spend projection, which is a different
+ * concept on a different document, and shadowing it would make「用量」ambiguous
+ * in exactly the file that exists to remove ambiguity.
+ */
+export type UsageCounters = {
+  /** Self-measured upstream calls that reached the model. One turn contributes
+   *  more than one when it failed over. Always available. */
+  requests: number;
+  /** Metered calls whose upstream response carried a token report. Never
+   *  greater than `requests`; a shortfall means MISSING REPORTS, not zero
+   *  usage, so no view may present the difference as unused capacity. */
+  token_reports: number;
+  /** Vendor-reported input tokens composed per protocol, cache included. */
+  input_tokens: number;
+  /** Subset of `input_tokens` served from cache. */
+  cached_input_tokens: number;
+  output_tokens: number;
+};
+
+export type UsageByModel = UsageCounters & {
+  /** Ledger key, which for a long identifier is a head plus a digest rather
+   *  than the identifier itself — a string nobody typed. Display `label`,
+   *  never this. `usageProjection.modelIdentity` is the only reader. */
+  model_id: string;
+  /** The model identity this row was metered under, joined from current Source
+   *  config; null once the model is gone. */
+  label: string | null;
+};
+
+export type UsageBySource = UsageCounters & {
+  source_id: string;
+  /** Joined from current Source config; null once the Source is gone. */
+  label: string | null;
+  /** When this Source last had a call metered, served or billed-and-failed. */
+  last_metered_at: string | null;
+  /** Never empty. A model's identity is the (source, model) pair, so this
+   *  nesting is the contract's own answer to a flat model map. */
+  models: UsageByModel[];
+};
+
+export type UsageByDay = UsageCounters & { day: string };
+
+export type UsageSummary = {
+  /** The window the server actually served, after clamping to retention. Views
+   *  render THIS, never the number they asked for. */
+  window_days: number;
+  /** First local day of the window, present even when it carries no turn. */
+  from_day: string;
+  /** Last local day of the window, which is the host's today. */
+  to_day: string;
+  totals: UsageCounters;
+  /** One entry per Source with at least one metered turn, busiest first. */
+  sources: UsageBySource[];
+  /** One entry per local day carrying a metered turn, oldest first — a trend
+   *  series, so a day with no turn is ABSENT rather than reported as zero. */
+  days: UsageByDay[];
+};
+
+/** `window_days` bounds from the schema. The offered options live in
+ *  `usageProjection` and are gated against these. */
+export const USAGE_WINDOW_MIN_DAYS = 1 as const;
+export const USAGE_WINDOW_MAX_DAYS = 62 as const;
+export const USAGE_DEFAULT_WINDOW_DAYS = 30 as const;
 
 // ── API envelope + request shapes (api.md) ──────────────────────────────
 export type ApiOk<T> = { ok: true; contract_version: typeof CONTRACT_VERSION } & T;

--- a/ui/src/components/settings/models/usageProjection.test.ts
+++ b/ui/src/components/settings/models/usageProjection.test.ts
@@ -12,6 +12,8 @@ import {
   usageDayIsMetered,
   usageIsEmpty,
   usageReportShortfall,
+  usageTokensAreKnown,
+  usageTokensAreReported,
   usageTotalTokens,
 } from './usageProjection';
 
@@ -86,6 +88,41 @@ describe('usageReportShortfall', () => {
   });
 });
 
+describe('usageTokensAreReported', () => {
+  // The same rendered zero, three payloads apart. Only `token_reports` says
+  // whether it is a measurement, which is why no caller may read the total.
+  it('separates a reported zero from calls nobody reported', () => {
+    expect(usageTokensAreReported(counters({ requests: 4, token_reports: 4 }))).toBe(true);
+    expect(usageTokensAreReported(counters({ requests: 4, token_reports: 0 }))).toBe(false);
+    expect(usageTokensAreReported(counters())).toBe(false);
+  });
+
+  it('asks about coverage and never about size', () => {
+    expect(usageTokensAreReported(counters({ requests: 1, token_reports: 1, input_tokens: 900_000 }))).toBe(true);
+    expect(usageTokensAreReported(counters({ requests: 1, token_reports: 0, input_tokens: 900_000 }))).toBe(false);
+  });
+});
+
+describe('usageTokensAreKnown', () => {
+  // Wider than reported by exactly one case, and that case is the honest one:
+  // nothing ran, so nothing was spent, and our own request counter is the evidence.
+  // Refusing it would trade an unreported cost read as free for an idle window read
+  // as unknowable.
+  it('prints the zero nothing ran to earn, and refuses the one nobody costed', () => {
+    expect(usageTokensAreKnown(counters({ requests: 0, token_reports: 0 }))).toBe(true);
+    expect(usageTokensAreKnown(counters({ requests: 4, token_reports: 0 }))).toBe(false);
+    expect(usageTokensAreKnown(counters({ requests: 4, token_reports: 4 }))).toBe(true);
+  });
+
+  // A partial report is a real measurement of the calls it covered; the calls it
+  // did not cover are the shortfall's sentence to say, not this figure's.
+  it('treats a partial report as a measurement and leaves the gap to the shortfall', () => {
+    const partial = counters({ requests: 12, token_reports: 9, input_tokens: 400 });
+    expect(usageTokensAreKnown(partial)).toBe(true);
+    expect(usageReportShortfall(partial)).toBe(3);
+  });
+});
+
 describe('usageCachedInputShare', () => {
   it('is the cached share of reported input', () => {
     expect(usageCachedInputShare(counters({ input_tokens: 200, cached_input_tokens: 50 }))).toBe(0.25);
@@ -150,8 +187,13 @@ describe('formatLocalDay', () => {
 
 describe('usageDayColumns', () => {
   // A reported day exists because a call was metered on it, so it carries one
-  // unless the case is about a day that carried several.
-  const day = (value: string, tokens: number, requests = 1) => ({ ...counters({ requests, input_tokens: tokens }), day: value });
+  // unless the case is about a day that carried several. Tokens imply the report
+  // they were summed from — the server only totals what an upstream told it — so
+  // the coverage counter follows the tokens unless a case sets it apart.
+  const day = (value: string, tokens: number, requests = 1, token_reports = tokens > 0 ? requests : 0) => ({
+    ...counters({ requests, token_reports, input_tokens: tokens }),
+    day: value,
+  });
 
   it('spans the whole window and zero-fills the days that carried no turn', () => {
     const columns = usageDayColumns(summary({ from_day: '2026-08-14', to_day: '2026-08-18', days: [day('2026-08-16', 40)] }));
@@ -175,6 +217,25 @@ describe('usageDayColumns', () => {
   it('carries the calls of every reported day through, and gives a filled-in day none', () => {
     const columns = usageDayColumns(summary({ from_day: '2026-08-14', to_day: '2026-08-16', days: [day('2026-08-15', 40, 3)] }));
     expect(columns.map((column) => column.requests)).toEqual([0, 3, 0]);
+  });
+
+  // And so does coverage, for the same reason one step further in: four calls that
+  // were measured at nothing and four whose upstreams said nothing carry identical
+  // tokens and identical requests. Only this counter tells the series apart, so a
+  // column that lost it could not be drawn or described honestly at any zero.
+  it('carries the token reports of every reported day through, and gives a filled-in day none', () => {
+    const columns = usageDayColumns(summary({
+      from_day: '2026-08-14',
+      to_day: '2026-08-16',
+      days: [day('2026-08-14', 0, 4, 4), day('2026-08-16', 0, 4, 0)],
+    }));
+    expect(columns.map((column) => column.tokens)).toEqual([0, 0, 0]);
+    expect(columns.map((column) => column.requests)).toEqual([4, 0, 4]);
+    expect(columns.map((column) => column.token_reports)).toEqual([4, 0, 0]);
+    // Three identical zeroes, three different facts — a measured nothing, a day
+    // nobody used, and a day nobody costed.
+    expect(columns.map(usageTokensAreReported)).toEqual([true, false, false]);
+    expect(columns.map(usageTokensAreKnown)).toEqual([true, true, false]);
   });
 
   // The distinction the whole series exists to draw. A day whose upstreams never

--- a/ui/src/components/settings/models/usageProjection.test.ts
+++ b/ui/src/components/settings/models/usageProjection.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest';
+
+import { USAGE_WINDOW_MAX_DAYS, USAGE_WINDOW_MIN_DAYS, type UsageByModel, type UsageBySource, type UsageCounters, type UsageSummary } from './types';
+import {
+  USAGE_WINDOW_OPTIONS,
+  formatLocalDay,
+  modelIdentity,
+  parseLocalDay,
+  sourceIdentity,
+  usageCachedInputShare,
+  usageDayColumns,
+  usageIsEmpty,
+  usageReportShortfall,
+  usageTotalTokens,
+} from './usageProjection';
+
+const counters = (over: Partial<UsageCounters> = {}): UsageCounters => ({
+  requests: 0,
+  token_reports: 0,
+  input_tokens: 0,
+  cached_input_tokens: 0,
+  output_tokens: 0,
+  ...over,
+});
+
+const model = (over: Partial<UsageByModel> = {}): UsageByModel => ({
+  ...counters(),
+  model_id: 'claude-opus-4-6',
+  label: 'claude-opus-4-6',
+  ...over,
+});
+
+const source = (over: Partial<UsageBySource> = {}): UsageBySource => ({
+  ...counters(),
+  source_id: 'src_conform001',
+  label: 'Contract source',
+  last_metered_at: null,
+  models: [model()],
+  ...over,
+});
+
+const summary = (over: Partial<UsageSummary> = {}): UsageSummary => ({
+  window_days: 30,
+  from_day: '2026-07-20',
+  to_day: '2026-08-18',
+  totals: counters(),
+  sources: [],
+  days: [],
+  ...over,
+});
+
+describe('USAGE_WINDOW_OPTIONS', () => {
+  // The reason this file exists: an option outside the contract bounds is a
+  // number on screen the report never covered.
+  it('offers only windows the contract can serve', () => {
+    expect(USAGE_WINDOW_OPTIONS.length).toBeGreaterThan(0);
+    for (const option of USAGE_WINDOW_OPTIONS) {
+      expect(Number.isInteger(option)).toBe(true);
+      expect(option).toBeGreaterThanOrEqual(USAGE_WINDOW_MIN_DAYS);
+      expect(option).toBeLessThanOrEqual(USAGE_WINDOW_MAX_DAYS);
+    }
+  });
+
+  it('offers each window once, shortest first', () => {
+    const options = [...USAGE_WINDOW_OPTIONS];
+    expect(new Set(options).size).toBe(options.length);
+    expect(options).toEqual([...options].sort((left, right) => left - right));
+  });
+});
+
+describe('usageTotalTokens', () => {
+  it('adds input and output without subtracting the cached subset', () => {
+    expect(usageTotalTokens(counters({ input_tokens: 148_230, cached_input_tokens: 96_010, output_tokens: 4_120 }))).toBe(152_350);
+  });
+});
+
+describe('usageReportShortfall', () => {
+  it('counts the requests that carried no token report', () => {
+    expect(usageReportShortfall(counters({ requests: 12, token_reports: 9 }))).toBe(3);
+    expect(usageReportShortfall(counters({ requests: 12, token_reports: 12 }))).toBe(0);
+  });
+
+  it('never reports a negative shortfall, whatever the payload claims', () => {
+    expect(usageReportShortfall(counters({ requests: 4, token_reports: 9 }))).toBe(0);
+  });
+});
+
+describe('usageCachedInputShare', () => {
+  it('is the cached share of reported input', () => {
+    expect(usageCachedInputShare(counters({ input_tokens: 200, cached_input_tokens: 50 }))).toBe(0.25);
+  });
+
+  it('has no share to report when nothing was input', () => {
+    expect(usageCachedInputShare(counters({ input_tokens: 0, cached_input_tokens: 0 }))).toBeNull();
+    expect(usageCachedInputShare(counters({ input_tokens: 0, cached_input_tokens: 90 }))).toBeNull();
+  });
+
+  it('stays a share even when the payload breaks the subset promise', () => {
+    expect(usageCachedInputShare(counters({ input_tokens: 100, cached_input_tokens: 400 }))).toBe(1);
+    expect(usageCachedInputShare(counters({ input_tokens: 100, cached_input_tokens: -40 }))).toBe(0);
+  });
+});
+
+describe('usageIsEmpty', () => {
+  it('is empty exactly when no Source was metered', () => {
+    expect(usageIsEmpty(summary())).toBe(true);
+    expect(usageIsEmpty(summary({ sources: [source()] }))).toBe(false);
+  });
+});
+
+describe('parseLocalDay', () => {
+  it('accepts a contract LocalDay and rejects anything else', () => {
+    expect(parseLocalDay('2026-08-18')).toBe(Date.UTC(2026, 7, 18));
+    for (const rejected of ['', '2026-8-18', '2026-08-18T00:00:00Z', 'yesterday', '20260818']) {
+      expect(parseLocalDay(rejected)).toBeNull();
+    }
+  });
+
+  // `Date.parse` rolls these forward instead of refusing them, so a day that
+  // survives must read back identical rather than merely parse.
+  it('rejects a day the calendar does not have', () => {
+    for (const rolled of ['2026-02-30', '2026-13-01', '2026-04-31', '2026-00-10', '2026-01-32']) {
+      expect(parseLocalDay(rolled)).toBeNull();
+    }
+  });
+
+  it('round-trips every day of the widest window it will plot', () => {
+    const first = parseLocalDay('2026-01-01');
+    expect(first).not.toBeNull();
+    for (let index = 0; index < USAGE_WINDOW_MAX_DAYS; index += 1) {
+      const day = new Date((first as number) + index * 86_400_000).toISOString().slice(0, 10);
+      expect(parseLocalDay(day)).not.toBeNull();
+    }
+  });
+});
+
+describe('formatLocalDay', () => {
+  it('keeps the labelled day when read back, in either locale', () => {
+    expect(formatLocalDay('2026-08-18', 'en-US')).toContain('18');
+    expect(formatLocalDay('2026-08-18', 'en-US')).toContain('2026');
+    expect(formatLocalDay('2026-08-18', 'zh-CN')).toContain('18');
+    expect(formatLocalDay('2026-08-18', 'zh-CN')).toContain('2026');
+  });
+
+  it('renders an unparseable day verbatim rather than inventing one', () => {
+    expect(formatLocalDay('not-a-day', 'en-US')).toBe('not-a-day');
+  });
+});
+
+describe('usageDayColumns', () => {
+  const day = (value: string, tokens: number) => ({ ...counters({ input_tokens: tokens }), day: value });
+
+  it('spans the whole window and zero-fills the days that carried no turn', () => {
+    const columns = usageDayColumns(summary({ from_day: '2026-08-14', to_day: '2026-08-18', days: [day('2026-08-16', 40)] }));
+    expect(columns.map((column) => column.day)).toEqual(['2026-08-14', '2026-08-15', '2026-08-16', '2026-08-17', '2026-08-18']);
+    expect(columns.map((column) => column.tokens)).toEqual([0, 0, 40, 0, 0]);
+  });
+
+  // The property, not a case list: whatever the reported set is, every reported
+  // day keeps its own tokens and nothing else gains any.
+  it('carries the tokens of every reported day through unchanged', () => {
+    const reported = [day('2026-08-14', 10), day('2026-08-16', 40), day('2026-08-18', 25)];
+    const columns = usageDayColumns(summary({ from_day: '2026-08-14', to_day: '2026-08-18', days: reported }));
+    const byDay = new Map(columns.map((column) => [column.day, column.tokens]));
+    for (const entry of reported) expect(byDay.get(entry.day)).toBe(usageTotalTokens(entry));
+    const total = columns.reduce((sum, column) => sum + column.tokens, 0);
+    expect(total).toBe(reported.reduce((sum, entry) => sum + usageTotalTokens(entry), 0));
+  });
+
+  it('scales every bar against the busiest day on screen', () => {
+    const columns = usageDayColumns(summary({ from_day: '2026-08-17', to_day: '2026-08-18', days: [day('2026-08-17', 25), day('2026-08-18', 100)] }));
+    expect(columns.map((column) => column.ratio)).toEqual([0.25, 1]);
+  });
+
+  it('gives a silent window flat bars rather than a division by zero', () => {
+    const columns = usageDayColumns(summary({ from_day: '2026-08-17', to_day: '2026-08-18' }));
+    expect(columns.map((column) => column.ratio)).toEqual([0, 0]);
+  });
+
+  it('falls back to the reported days when the window bounds are unusable', () => {
+    // Reversed, malformed, and wider than retention all mean the same thing: the
+    // span is not ours to trust, so plot what was actually reported.
+    for (const window of [
+      { from_day: '2026-08-18', to_day: '2026-08-14' },
+      { from_day: 'nope', to_day: '2026-08-18' },
+      { from_day: '2020-01-01', to_day: '2026-08-18' },
+    ]) {
+      const columns = usageDayColumns(summary({ ...window, days: [day('2026-08-16', 40)] }));
+      expect(columns.map((column) => column.day)).toEqual(['2026-08-16']);
+      expect(columns[0].tokens).toBe(40);
+    }
+  });
+
+  it('never plots more columns than the maximum window the contract allows', () => {
+    const columns = usageDayColumns(summary({ from_day: '2026-06-18', to_day: '2026-08-18' }));
+    expect(columns.length).toBeLessThanOrEqual(USAGE_WINDOW_MAX_DAYS);
+  });
+});
+
+describe('usage row identity', () => {
+  it('shows the joined label while there is one', () => {
+    expect(sourceIdentity(source({ label: 'Contract source' }))).toEqual({ kind: 'label', text: 'Contract source' });
+    expect(modelIdentity(model({ label: 'claude-opus-4-6' }))).toEqual({ kind: 'label', text: 'claude-opus-4-6' });
+  });
+
+  it('treats a blank label as no label at all', () => {
+    expect(sourceIdentity(source({ label: '   ' })).kind).toBe('gone');
+    expect(modelIdentity(model({ label: '' })).kind).toBe('gone');
+  });
+
+  it('keeps a gone Source addressable by its canonical id', () => {
+    expect(sourceIdentity(source({ label: null, source_id: 'src_gone' }))).toEqual({ kind: 'gone', id: 'src_gone' });
+  });
+
+  // The contract's rule, as a property: `model_id` is a head plus a digest for
+  // any long identifier, so it is never a string this UI may display.
+  it('never offers the ledger key of a gone model as something to display', () => {
+    for (const key of ['claude-opus-4-6', 'anthropic/claude-opus-4-6-2026#9f2a1c', 'x'.repeat(200)]) {
+      const identity = modelIdentity(model({ label: null, model_id: key }));
+      expect(identity).toEqual({ kind: 'gone', id: null });
+      expect(JSON.stringify(identity)).not.toContain(key);
+    }
+  });
+});

--- a/ui/src/components/settings/models/usageProjection.test.ts
+++ b/ui/src/components/settings/models/usageProjection.test.ts
@@ -9,6 +9,7 @@ import {
   sourceIdentity,
   usageCachedInputShare,
   usageDayColumns,
+  usageDayIsMetered,
   usageIsEmpty,
   usageReportShortfall,
   usageTotalTokens,
@@ -148,7 +149,9 @@ describe('formatLocalDay', () => {
 });
 
 describe('usageDayColumns', () => {
-  const day = (value: string, tokens: number) => ({ ...counters({ input_tokens: tokens }), day: value });
+  // A reported day exists because a call was metered on it, so it carries one
+  // unless the case is about a day that carried several.
+  const day = (value: string, tokens: number, requests = 1) => ({ ...counters({ requests, input_tokens: tokens }), day: value });
 
   it('spans the whole window and zero-fills the days that carried no turn', () => {
     const columns = usageDayColumns(summary({ from_day: '2026-08-14', to_day: '2026-08-18', days: [day('2026-08-16', 40)] }));
@@ -165,6 +168,22 @@ describe('usageDayColumns', () => {
     for (const entry of reported) expect(byDay.get(entry.day)).toBe(usageTotalTokens(entry));
     const total = columns.reduce((sum, column) => sum + column.tokens, 0);
     expect(total).toBe(reported.reduce((sum, entry) => sum + usageTotalTokens(entry), 0));
+  });
+
+  // Both counters travel, because they answer different questions: what a day
+  // cost, and whether it ran at all.
+  it('carries the calls of every reported day through, and gives a filled-in day none', () => {
+    const columns = usageDayColumns(summary({ from_day: '2026-08-14', to_day: '2026-08-16', days: [day('2026-08-15', 40, 3)] }));
+    expect(columns.map((column) => column.requests)).toEqual([0, 3, 0]);
+  });
+
+  // The distinction the whole series exists to draw. A day whose upstreams never
+  // reported their tokens still served the calls the user made, so it is a metered
+  // day with nothing to scale — not an idle one.
+  it('reads a day of calls with no token report as metered rather than idle', () => {
+    const columns = usageDayColumns(summary({ from_day: '2026-08-17', to_day: '2026-08-18', days: [day('2026-08-18', 0, 4)] }));
+    expect(columns.map(usageDayIsMetered)).toEqual([false, true]);
+    expect(columns.map((column) => column.tokens)).toEqual([0, 0]);
   });
 
   it('scales every bar against the busiest day on screen', () => {

--- a/ui/src/components/settings/models/usageProjection.ts
+++ b/ui/src/components/settings/models/usageProjection.ts
@@ -95,10 +95,27 @@ export function usageIsEmpty(summary: UsageSummary): boolean {
 
 export type UsageDayColumn = {
   day: string;
+  /** Calls metered on this day, whether or not their tokens came back. */
+  requests: number;
   tokens: number;
   /** Height against the busiest rendered day, in [0, 1]. */
   ratio: number;
 };
+
+/**
+ * Whether a day carried a metered call at all.
+ *
+ * A day's activity is its request counter, never its token total. An upstream
+ * that answered without a token report still served a call the user made, so a
+ * day of those is a day that ran — and drawing it at zero height, or folding it
+ * into 「没有任何一天有计量数据」, reports our own missing evidence as the user's
+ * idleness. That is the rule the requests card states as a shortfall, applied per
+ * day, and it lives here so the series has one place to ask rather than one
+ * `tokens > 0` per thing it draws.
+ */
+export function usageDayIsMetered(column: UsageDayColumn): boolean {
+  return column.requests > 0;
+}
 
 /**
  * Every day of the window, oldest first, with the days that carried no turn
@@ -116,14 +133,19 @@ export type UsageDayColumn = {
  * span falls back to exactly the days reported — fewer bars, no invention.
  */
 export function usageDayColumns(summary: UsageSummary): UsageDayColumn[] {
-  const tokensByDay = new Map(summary.days.map((day: UsageByDay) => [day.day, usageTotalTokens(day)]));
+  const reportedByDay = new Map(summary.days.map((day: UsageByDay) => [day.day, day]));
   const span = windowSpan(summary.from_day, summary.to_day);
   const days = span ?? summary.days.map((day) => day.day);
-  const counted = days.map((day) => ({ day, tokens: tokensByDay.get(day) ?? 0 }));
+  // Both counters travel, because tokens alone cannot tell a day nobody used
+  // from a day whose upstream never said what it cost.
+  const counted = days.map((day) => {
+    const reported = reportedByDay.get(day);
+    return { day, requests: reported?.requests ?? 0, tokens: reported ? usageTotalTokens(reported) : 0 };
+  });
   // Scaled against the days on screen, not every day reported: a stray row
   // outside the window would otherwise flatten every bar the user can see.
   const peak = counted.reduce((max, column) => Math.max(max, column.tokens), 0);
-  return counted.map(({ day, tokens }) => ({ day, tokens, ratio: peak > 0 ? tokens / peak : 0 }));
+  return counted.map((column) => ({ ...column, ratio: peak > 0 ? column.tokens / peak : 0 }));
 }
 
 const windowSpan = (fromDay: string, toDay: string): string[] | null => {

--- a/ui/src/components/settings/models/usageProjection.ts
+++ b/ui/src/components/settings/models/usageProjection.ts
@@ -1,0 +1,162 @@
+// Pure projections over `usage-summary.schema.json` for the 用量 tab.
+//
+// Everything here is a derivation the tab could get WRONG, kept out of JSX so it
+// can be asserted as a property: what the window spans, what a row is allowed to
+// display, and how a sparse trend becomes a dense one. Layout and copy stay in
+// the component; this module never translates.
+//
+// It owns the trailing local-day window — `YYYY-MM-DD` labels in and out.
+// `localCalendar.ts` answers a different question (is this INSTANT today?) over a
+// different input type, so the two are deliberately not merged: an instant needs
+// a timezone to become a day, and these strings already are days.
+import { USAGE_WINDOW_MAX_DAYS, USAGE_WINDOW_MIN_DAYS, type UsageByDay, type UsageByModel, type UsageBySource, type UsageCounters, type UsageSummary } from './types';
+
+/**
+ * The windows the tab offers.
+ *
+ * Bounded by the schema rather than by the design, which offers 7/30/90: the
+ * server clamps `days` to retention and answers with what it served, so a 「90
+ * 天」 option would put a number on screen the report never covered. The gate is
+ * mechanical — `usageProjection.test.ts` fails if an option leaves the contract
+ * bounds — so the next person to add one cannot reintroduce the lie by hand.
+ */
+export const USAGE_WINDOW_OPTIONS = [7, 30, 60] as const;
+export type UsageWindowOption = (typeof USAGE_WINDOW_OPTIONS)[number];
+
+const DAY_MS = 86_400_000;
+const LOCAL_DAY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const toLocalDay = (ms: number): string => new Date(ms).toISOString().slice(0, 10);
+
+/**
+ * A `LocalDay` as the UTC instant of its midnight, or null when it is not one.
+ *
+ * UTC is the arithmetic frame on purpose. The string is already a local calendar
+ * day, so re-deriving it through the host's zone would let a DST boundary or an
+ * offset change move a labelled day by one; stepping in fixed 86 400 s units and
+ * reading the label straight back cannot.
+ *
+ * The pattern alone does not decide it. `Date.parse` rolls an out-of-range day
+ * FORWARD rather than refusing it — `2026-02-30` becomes March 2 — and a rolled
+ * day silently stops matching the label it was keyed by. Reading the day back out
+ * and requiring it unchanged is a check against our own output, so no calendar
+ * quirk of the host parser can pass through it.
+ */
+export function parseLocalDay(day: string): number | null {
+  if (!LOCAL_DAY_PATTERN.test(day)) return null;
+  const ms = Date.parse(`${day}T00:00:00Z`);
+  return Number.isNaN(ms) || toLocalDay(ms) !== day ? null : ms;
+}
+
+/** A `LocalDay` in the reader's own date order — 「2026年7月20日」/「Jul 20, 2026」.
+ *  Formatted in UTC for the same reason the arithmetic is: the label must survive
+ *  the round trip unshifted. Unparseable input renders verbatim rather than as an
+ *  invented date. */
+export function formatLocalDay(day: string, locale: string): string {
+  const ms = parseLocalDay(day);
+  if (ms === null) return day;
+  return new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeZone: 'UTC' }).format(ms);
+}
+
+/** Tokens the window actually moved. Cache is NOT subtracted: a cached input
+ *  token was still composed into the request, and `cached_input_tokens` is a
+ *  subset of `input_tokens` reported separately so a view can qualify the total
+ *  without double-counting it. */
+export function usageTotalTokens(counters: UsageCounters): number {
+  return counters.input_tokens + counters.output_tokens;
+}
+
+/**
+ * Requests whose upstream response carried no token report.
+ *
+ * The schema guarantees `token_reports <= requests`, and this floors at zero
+ * anyway: both numbers arrive over the wire, and a view that renders 「-3 次未回
+ * 报」 has turned a payload bug into a claim about the user's usage. The honest
+ * reading of a shortfall is missing reports, never unused capacity — which is
+ * why the caller's copy says so.
+ */
+export function usageReportShortfall(counters: UsageCounters): number {
+  return Math.max(0, counters.requests - counters.token_reports);
+}
+
+/** Share of input tokens served from cache, or null when there is no input to
+ *  take a share of. Clamped to [0, 1] because the subset relation is the
+ *  server's promise, not something this view can verify. */
+export function usageCachedInputShare(counters: UsageCounters): number | null {
+  if (counters.input_tokens <= 0) return null;
+  return Math.min(1, Math.max(0, counters.cached_input_tokens / counters.input_tokens));
+}
+
+/** Nothing was metered in the window. `sources` is the gate because it is what
+ *  the table renders, and a Source enters it only once it has a metered turn. */
+export function usageIsEmpty(summary: UsageSummary): boolean {
+  return summary.sources.length === 0;
+}
+
+export type UsageDayColumn = {
+  day: string;
+  tokens: number;
+  /** Height against the busiest rendered day, in [0, 1]. */
+  ratio: number;
+};
+
+/**
+ * Every day of the window, oldest first, with the days that carried no turn
+ * filled in at zero.
+ *
+ * `days[]` is sparse by contract — a quiet day is absent, not reported as zero —
+ * and a chart drawn straight from it would silently close the gaps and read as
+ * continuous traffic. Densifying from `from_day`/`to_day` is what makes an idle
+ * stretch visible as an idle stretch.
+ *
+ * The span comes from the dates rather than from `window_days` so a payload
+ * whose two disagree still plots its real dates, and it is refused outright past
+ * the contract's own maximum: the bound is ours, measured against the schema, so
+ * a `from_day` far in the past cannot ask this for a million columns. A refused
+ * span falls back to exactly the days reported — fewer bars, no invention.
+ */
+export function usageDayColumns(summary: UsageSummary): UsageDayColumn[] {
+  const tokensByDay = new Map(summary.days.map((day: UsageByDay) => [day.day, usageTotalTokens(day)]));
+  const span = windowSpan(summary.from_day, summary.to_day);
+  const days = span ?? summary.days.map((day) => day.day);
+  const counted = days.map((day) => ({ day, tokens: tokensByDay.get(day) ?? 0 }));
+  // Scaled against the days on screen, not every day reported: a stray row
+  // outside the window would otherwise flatten every bar the user can see.
+  const peak = counted.reduce((max, column) => Math.max(max, column.tokens), 0);
+  return counted.map(({ day, tokens }) => ({ day, tokens, ratio: peak > 0 ? tokens / peak : 0 }));
+}
+
+const windowSpan = (fromDay: string, toDay: string): string[] | null => {
+  const from = parseLocalDay(fromDay);
+  const to = parseLocalDay(toDay);
+  if (from === null || to === null || to < from) return null;
+  const length = (to - from) / DAY_MS + 1;
+  if (!Number.isInteger(length) || length < USAGE_WINDOW_MIN_DAYS || length > USAGE_WINDOW_MAX_DAYS) return null;
+  return Array.from({ length }, (_, index) => toLocalDay(from + index * DAY_MS));
+};
+
+/**
+ * What a usage row may put on screen for its own identity.
+ *
+ * `gone` carries an id only where one is safe to show. A Source keeps its
+ * canonical `src_*` id, which is a string the user could have seen elsewhere. A
+ * model's ledger key is a head plus a digest for any long identifier — a string
+ * nobody typed — so a vanished model has NO displayable identity and gets a bare
+ * marker. That asymmetry is the reason both live behind one type instead of two
+ * `label ?? id` expressions in JSX.
+ */
+export type UsageIdentity = { kind: 'label'; text: string } | { kind: 'gone'; id: string | null };
+
+const identify = (label: string | null, fallbackId: string | null): UsageIdentity => {
+  const text = label?.trim();
+  // A blank label is as unrenderable as a missing one, and the schema permits it.
+  return text ? { kind: 'label', text } : { kind: 'gone', id: fallbackId };
+};
+
+export function sourceIdentity(source: UsageBySource): UsageIdentity {
+  return identify(source.label, source.source_id);
+}
+
+export function modelIdentity(model: UsageByModel): UsageIdentity {
+  return identify(model.label, null);
+}

--- a/ui/src/components/settings/models/usageProjection.ts
+++ b/ui/src/components/settings/models/usageProjection.ts
@@ -79,6 +79,36 @@ export function usageReportShortfall(counters: UsageCounters): number {
   return Math.max(0, counters.requests - counters.token_reports);
 }
 
+/**
+ * Whether an upstream said what anything in this bucket cost.
+ *
+ * Three independent facts share one payload, and only one counter answers each:
+ * `requests` says calls happened, `token_reports` says an upstream told us what
+ * they cost, and the token counts say how much. A total of zero is therefore
+ * several different readings, and only this counter can find the one where a cost
+ * was actually reported — which is the only reading allowed to speak for the
+ * report, as a peak or as a claim about what the reports said.
+ */
+export function usageTokensAreReported(counters: Pick<UsageCounters, 'token_reports'>): boolean {
+  return counters.token_reports > 0;
+}
+
+/**
+ * Whether the token counts are a measurement, and so printable as a number.
+ *
+ * Wider than `usageTokensAreReported` by exactly one case, and it is not a
+ * concession: a bucket where nothing ran cost nothing, and that zero is measured
+ * by our own request counter rather than promised by an upstream. Blanking it
+ * would trade the defect this answers — an unreported cost read as free — for its
+ * mirror image, an idle day read as unknowable.
+ *
+ * So the two questions stay apart. Every token figure the tab prints asks this
+ * one; whether the report itself has anything to say about tokens is the other.
+ */
+export function usageTokensAreKnown(counters: Pick<UsageCounters, 'requests' | 'token_reports'>): boolean {
+  return usageTokensAreReported(counters) || counters.requests === 0;
+}
+
 /** Share of input tokens served from cache, or null when there is no input to
  *  take a share of. Clamped to [0, 1] because the subset relation is the
  *  server's promise, not something this view can verify. */
@@ -97,6 +127,8 @@ export type UsageDayColumn = {
   day: string;
   /** Calls metered on this day, whether or not their tokens came back. */
   requests: number;
+  /** Calls whose upstream said what they cost — what makes `tokens` a measurement. */
+  token_reports: number;
   tokens: number;
   /** Height against the busiest rendered day, in [0, 1]. */
   ratio: number;
@@ -136,11 +168,18 @@ export function usageDayColumns(summary: UsageSummary): UsageDayColumn[] {
   const reportedByDay = new Map(summary.days.map((day: UsageByDay) => [day.day, day]));
   const span = windowSpan(summary.from_day, summary.to_day);
   const days = span ?? summary.days.map((day) => day.day);
-  // Both counters travel, because tokens alone cannot tell a day nobody used
-  // from a day whose upstream never said what it cost.
+  // All three counters travel, because tokens alone cannot tell a day nobody
+  // used from a day whose upstream never said what it cost — nor either of those
+  // from a day that really did cost nothing. Dropping `token_reports` here is
+  // what made a rendered 0 ambiguous no matter how carefully the copy was worded.
   const counted = days.map((day) => {
     const reported = reportedByDay.get(day);
-    return { day, requests: reported?.requests ?? 0, tokens: reported ? usageTotalTokens(reported) : 0 };
+    return {
+      day,
+      requests: reported?.requests ?? 0,
+      token_reports: reported?.token_reports ?? 0,
+      tokens: reported ? usageTotalTokens(reported) : 0,
+    };
   });
   // Scaled against the days on screen, not every day reported: a stray row
   // outside the window would otherwise flatten every bar the user can see.

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -979,9 +979,10 @@
         "byDay": {
           "title": "By day",
           "chart": "Metered tokens per day, {{from}} to {{to}}",
-          "column": "{{day}} · {{tokens}} tokens",
+          "column": "{{day}} · {{tokens}} tokens · {{requests}} requests",
           "peak": "Peak {{tokens}} on {{day}}",
-          "quiet": "No day in this window carried a metered turn"
+          "quiet": "No day in this window carried a metered turn",
+          "unreported": "Requests ran, but no day reported its tokens"
         }
       },
       "supplyTooltip": {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -951,7 +951,8 @@
         "blank": "—",
         "tokens": {
           "label": "Tokens",
-          "detail": "{{input}} in · {{output}} out"
+          "detail": "{{input}} in · {{output}} out",
+          "none": "No request in this window reported its tokens"
         },
         "requests": {
           "label": "Requests",
@@ -984,7 +985,8 @@
           "column": "{{day}} · {{tokens}} tokens · {{requests}} requests",
           "peak": "Peak {{tokens}} on {{day}}",
           "quiet": "No day in this window carried a metered turn",
-          "unreported": "Requests ran, but no day reported its tokens"
+          "unreported": "Requests ran, but no day reported its tokens",
+          "zero": "Every day that reported its tokens reported zero"
         }
       },
       "supplyTooltip": {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -979,6 +979,8 @@
         "byDay": {
           "title": "By day",
           "chart": "Metered tokens per day, {{from}} to {{to}}",
+          "table": "Metered tokens and requests per day, {{from}} to {{to}}",
+          "col": { "day": "Day" },
           "column": "{{day}} · {{tokens}} tokens · {{requests}} requests",
           "peak": "Peak {{tokens}} on {{day}}",
           "quiet": "No day in this window carried a metered turn",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -633,10 +633,6 @@
       "subtitle": "See whether each agent model can run now and which source serves it; set a route for one model when needed.",
       "addSource": "Add source",
       "loadError": "Failed to load: {{detail}}",
-      "tabs": {
-        "sources": "Sources & gateway",
-        "usage": "Usage & quota"
-      },
       "sourceKind": {
         "api_key": "API key",
         "subscription": "Subscription"
@@ -659,7 +655,7 @@
         },
         "tab": {
           "hub": "Sources & gateway",
-          "usage": "Usage & quota"
+          "usage": "Usage"
         }
       },
       "direct": {
@@ -817,10 +813,6 @@
         "unavailable": "Supply paused",
         "note": "Route chains are each backend's configured source order."
       },
-      "usageTab": {
-        "title": "Usage and quota",
-        "detail": "Usage appears after a gateway source serves a request."
-      },
       "status": {
         "allHealthy": "All healthy",
         "needsAction_one": "{{count}} model needs attention",
@@ -948,7 +940,49 @@
         "error": "Needs attention"
       },
       "usage": {
-        "monthSpend": "{{amount}} this month"
+        "title": "Usage",
+        "detail": "Metered tokens from the turns the gateway proxied, by local day.",
+        "window": {
+          "label": "Window",
+          "option": "{{days}}d"
+        },
+        "range": "{{from}} – {{to}} · trailing {{days}} days",
+        "empty": "Nothing metered yet. A window fills once a gateway source serves a request.",
+        "blank": "—",
+        "tokens": {
+          "label": "Tokens",
+          "detail": "{{input}} in · {{output}} out"
+        },
+        "requests": {
+          "label": "Requests",
+          "reported": "Every request reported its tokens",
+          "shortfall_one": "{{count}} request came back with no token report",
+          "shortfall_other": "{{count}} requests came back with no token report"
+        },
+        "cached": {
+          "label": "Cached input",
+          "detail": "{{cached}} of {{input}} input tokens",
+          "none": "No input tokens in this window"
+        },
+        "bySource": {
+          "title": "By source",
+          "col": {
+            "source": "Source",
+            "tokens": "Tokens",
+            "requests": "Requests",
+            "cached": "Cached",
+            "lastMetered": "Last metered"
+          },
+          "goneSource": "deleted",
+          "goneModel": "model no longer listed"
+        },
+        "byDay": {
+          "title": "By day",
+          "chart": "Metered tokens per day, {{from}} to {{to}}",
+          "column": "{{day}} · {{tokens}} tokens",
+          "peak": "Peak {{tokens}} on {{day}}",
+          "quiet": "No day in this window carried a metered turn"
+        }
       },
       "supplyTooltip": {
         "label": "Supplies: "

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -979,6 +979,8 @@
         "byDay": {
           "title": "按日",
           "chart": "每日计量 token，{{from}} 至 {{to}}",
+          "table": "每日计量 token 与请求数，{{from}} 至 {{to}}",
+          "col": { "day": "日期" },
           "column": "{{day}} · {{tokens}} tokens · {{requests}} 次请求",
           "peak": "峰值 {{tokens}}，出现在 {{day}}",
           "quiet": "这个区间没有任何一天有计量数据",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -633,10 +633,6 @@
       "subtitle": "按 Agent 查看每个型号现在能否运行、由谁供给；需要时可为单个型号指定路由。",
       "addSource": "添加来源",
       "loadError": "加载失败：{{detail}}",
-      "tabs": {
-        "sources": "来源与网关",
-        "usage": "用量与额度"
-      },
       "sourceKind": {
         "api_key": "API Key",
         "subscription": "订阅"
@@ -659,7 +655,7 @@
         },
         "tab": {
           "hub": "来源与网关",
-          "usage": "用量与额度"
+          "usage": "用量"
         }
       },
       "direct": {
@@ -817,10 +813,6 @@
         "unavailable": "供给已暂停",
         "note": "路由链就是各后端配置的来源顺序。"
       },
-      "usageTab": {
-        "title": "用量与额度",
-        "detail": "网关来源完成请求后，用量会显示在这里。"
-      },
       "status": {
         "allHealthy": "全部正常",
         "needsAction_one": "{{count}} 个模型需要处理",
@@ -948,7 +940,49 @@
         "error": "需要处理"
       },
       "usage": {
-        "monthSpend": "本月 {{amount}}"
+        "title": "用量",
+        "detail": "网关代理的对话所计量的 token，按本地日期汇总。",
+        "window": {
+          "label": "区间",
+          "option": "{{days}} 天"
+        },
+        "range": "{{from}} – {{to}} · 近 {{days}} 天",
+        "empty": "还没有计量数据。网关来源完成请求后，这里就会有内容。",
+        "blank": "—",
+        "tokens": {
+          "label": "Tokens",
+          "detail": "输入 {{input}} · 输出 {{output}}"
+        },
+        "requests": {
+          "label": "请求数",
+          "reported": "每次请求都回报了 token",
+          "shortfall_one": "{{count}} 次请求没有回报 token",
+          "shortfall_other": "{{count}} 次请求没有回报 token"
+        },
+        "cached": {
+          "label": "缓存输入",
+          "detail": "输入 {{input}} 中有 {{cached}} 来自缓存",
+          "none": "这个区间没有输入 token"
+        },
+        "bySource": {
+          "title": "按来源",
+          "col": {
+            "source": "来源",
+            "tokens": "Tokens",
+            "requests": "请求",
+            "cached": "缓存",
+            "lastMetered": "最近计量"
+          },
+          "goneSource": "已删除",
+          "goneModel": "型号已不在列表中"
+        },
+        "byDay": {
+          "title": "按日",
+          "chart": "每日计量 token，{{from}} 至 {{to}}",
+          "column": "{{day}} · {{tokens}} tokens",
+          "peak": "峰值 {{tokens}}，出现在 {{day}}",
+          "quiet": "这个区间没有任何一天有计量数据"
+        }
       },
       "supplyTooltip": {
         "label": "供应："

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -951,7 +951,8 @@
         "blank": "—",
         "tokens": {
           "label": "Tokens",
-          "detail": "输入 {{input}} · 输出 {{output}}"
+          "detail": "输入 {{input}} · 输出 {{output}}",
+          "none": "这个区间没有请求回报 token"
         },
         "requests": {
           "label": "请求数",
@@ -984,7 +985,8 @@
           "column": "{{day}} · {{tokens}} tokens · {{requests}} 次请求",
           "peak": "峰值 {{tokens}}，出现在 {{day}}",
           "quiet": "这个区间没有任何一天有计量数据",
-          "unreported": "有请求，但没有任何一天回报了 token"
+          "unreported": "有请求，但没有任何一天回报了 token",
+          "zero": "有回报 token 的日子，回报的都是 0"
         }
       },
       "supplyTooltip": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -979,9 +979,10 @@
         "byDay": {
           "title": "按日",
           "chart": "每日计量 token，{{from}} 至 {{to}}",
-          "column": "{{day}} · {{tokens}} tokens",
+          "column": "{{day}} · {{tokens}} tokens · {{requests}} 次请求",
           "peak": "峰值 {{tokens}}，出现在 {{day}}",
-          "quiet": "这个区间没有任何一天有计量数据"
+          "quiet": "这个区间没有任何一天有计量数据",
+          "unreported": "有请求，但没有任何一天回报了 token"
         }
       },
       "supplyTooltip": {


### PR DESCRIPTION
## Capability

**Model Hub — metering, user-visible half.** Stage 2 of
`docs/plans/model-hub-usage-metering.md`: the Model Hub gains a tab that reports
what the Stage 1 ledger (#1527) records — requests, token reports, and
input / cached / output tokens, broken down per Source, per model, and per day
over a trailing 7 / 30 / 60-day window.

No backend change. `GET /api/models/usage` shipped in #1527; this PR reads it.

## The tab is named "Usage", not "Usage and quota"

The label promised a 額度 half that cannot exist. `cycle_used_pct` and
`month_spend_cents` have exactly one production writer each —
`core/handlers/model_hub/migration.py` writes both as `None` — and every non-null
value in the repo is a mock or a schema example. A quota reading would therefore be
an invention, so the tab is named for what it can show. If a quota source ever
appears, the label grows back with it.

Removed with the rename: `settings.models.usage.monthSpend`,
`settings.models.usageTab`, `settings.models.tabs` (a zero-caller duplicate of
`shell.tab`), and the `formatSpend` / `currencySymbol` formatters, which already had
zero callers on `master` and format an amount production never populates.
`types.SourceUsage` stays as a mirror of
`docs/plans/model-hub-contracts/source.schema.json`, which still declares the block.

## Structure

- `usageProjection.ts` owns every derivation the tab could get wrong: the trailing
  local-day window, what a row is allowed to display, and densifying a sparse trend.
  Each is asserted as a property rather than inspected in JSX.
- `UsageTab.tsx` owns layout and copy, and turns nothing into numbers.
- The read is deliberately **not** a member of `FIRST_PAINT_REGION_WHITELIST`: the
  landing decides routing, and a report nobody is looking at must not delay it. One
  effect owns both tab-open and window-change, since a window change is the same
  read over a different span, and `beginRegionRead` keeps the previous figure on
  screen while the new one lands.

## Scenario IDs

`tests/scenarios/model_hub/catalog.yaml` — eleven new rows, all `status: covered`:

| ID | Property |
| --- | --- |
| MH-USAGE-016 | The caption states the `window_days` the server **served**, never the number the control asked for. |
| MH-USAGE-017 | A vanished model shows no identity (its ledger key is a digest); a vanished Source keeps its `src_*` id, which is a string the user has seen. |
| MH-USAGE-018 | A `token_reports` shortfall reads as reports that never arrived — never as unused capacity, which the schema forbids in as many words. |
| MH-USAGE-019 | Every day of the window is plotted, including the ones that carried nothing. |
| MH-USAGE-020 | The report is read on tab open, not as part of first paint. |
| MH-USAGE-021 | A day whose calls carried no token report reads as metered, not idle — the same rule MH-USAGE-018 states for the totals, applied per day. |
| MH-USAGE-022 | The report stays reachable from every Model Hub landing, including one with no Source left. |
| MH-USAGE-023 | Every day of the window states its figures in text, not only in a pointer tooltip. |
| MH-USAGE-024 | Every figure the report states names the row and the column it answers, not a position on screen. |
| MH-USAGE-025 | A window whose upstreams reported zero tokens reads as measured, not as unreported. |
| MH-USAGE-026 | Every token figure the report states names the coverage it was measured from — enumerated on screen, not listed in the test. |

## Evidence layers

- **Unit / component (vitest):** `usageProjection.test.ts` (derivations, 29 cases),
  `UsageTab.test.tsx` (16 cases — what the tab may *say* about a report),
  `SettingsModelsPage.render.test.tsx` (+5 cases — *when* the report is read, and
  from *where*). Full UI suite: 231 files / 2950 tests pass — the catalog gate is one of
  them, a case in `scenarioCatalog.test.mjs` rather than a script chained onto `npm test`.
- **Scenario catalog:** MH-USAGE-016..026 registered;
  `tests/scenarios/model_hub/test_model_hub_catalog.py`, `tests/scenarios/INDEX.yaml`,
  and the new `ui/scripts/validate-scenario-catalog.mjs` gate updated. Catalog test
  passes, `ruff check` clean, gate resolves 24 UI citations across 24 rows in every
  catalog that cites UI evidence. `standards/scenario-testing/STANDARD.md` §4 now
  states the citation property.
- **Build gate:** `npm run build` ✓, `tsc --noEmit -p tsconfig.app.json` clean.
- **Contract / scenario (Python):** unchanged — no backend code in this diff.
- **Residual manual check:** visual pass on the rendered tab in both themes;
  `design.pen` has no frame for this tab on the local surface (see below).

## Catalog evidence: the Python checker asks, vitest answers

`test_model_hub_catalog.py` resolved every row's evidence through `ast.parse`, so the
capability's user-visible half could not be registered at all. A UI row now cites its own
ID (`…/UsageTab.test.tsx::MH-USAGE-018`) and resolves to the single `it('MH-USAGE-018: …')`
that carries it — a vitest case's name is its docstring, so that is where the ID goes, and
the evidence becomes runnable by ID (`vitest -t MH-USAGE-018`) rather than only greppable.

Two rounds of review went to the same question — *does that declaration execute?* — first
answered with a text scan, then with a hand-written JS lexer. It is not answerable that
way: telling a regex from division needs the parser's state, and telling a skipped or
unreachable declaration from a live one needs the run. So the question goes to the only
thing that answers it definitively and already runs in CI on the same commit:

| Question | Owner |
| --- | --- |
| Row shape, cited file exists, ID greppable in it, no `expected_fail` on a UI row | `test_model_hub_catalog.py` (`ast`/text answer these exactly) |
| Does each citation name exactly one case vitest **runs** | `ui/scripts/validate-scenario-catalog.mjs`, via `vitest list` |

219 lines of scanner deleted for 126 lines of resolver plus gate. The check is one function,
`checkCatalogs`, with two callers: `npm run validate:catalog` for a standalone run, and one
case in the vitest suite — which is how it reaches CI, since `build-linux-artifacts` already
runs `npm test`. No new CI job, and the only new dependency is `js-yaml`, declared in
`ui/package.json` (already present transitively, so the lockfile resolution is unchanged). The
gate discovers `tests/scenarios/*/catalog.yaml` instead of listing them, fails rather than
passing quietly if `tests/scenarios` is absent, and collects only the cited files (22
citations, 8 files, ~1.7s) instead of the 231-file suite.

An earlier revision chained it as `"test": "vitest run && npm run validate:catalog"`, which is
a defect worth naming because it fails silently: **npm appends `--` arguments to the end of a
composite script**, so `npm test -- UsageTab.test.tsx` became
`vitest run && npm run validate:catalog UsageTab.test.tsx` — vitest ran all 231 files
unfiltered and the validator ignored a path it was never given a use for, breaking the focused
run AGENTS.md asks for first. Forwarding through a wrapper would preserve the hazard behind a
layer that hides it; a test case has no argument to misroute, and `npm test` already means
"everything that must hold", so the composite is deleted rather than repaired. `npm test --
UsageTab.test.tsx` now runs 1 file / 14 cases.

**Which citations it asks about is the row's own claim — never a legend's, and never one
key's.** Two holes of that one shape, found a round apart. First, rows were selected through
each catalog's `status_legend`, which maps a status to a *description string* in every catalog
but `model_hub` — so the gate asked about 9 rows in one catalog and passed the other three in
silence. Then, with that fixed, it still read `row.test` alone, leaving every `ui_contract`
citation unasked. Both are the failure the gate exists to prevent, one level up, so the answer
to both is that a row's own claim decides: **every** UI citation a row makes must resolve,
whatever key it sits in and whatever the legend looks like. (Normalizing the prose legends was
the alternative and is a heuristic over English, the species of thing this gate replaced.)

**A citation must name a case.** A bare file was accepted for one revision because three legacy
rows were written that way, and that cannot hold: `MEMORY-LIST-006` and `MEMORY-LIST-007` both
cited `MemorySearchPanel.test.tsx` and nothing else, so deleting either row's case leaves the
other keeping the file collected and *both* rows green. A file runs for reasons unrelated to
the citing row, so the shape is deleted rather than given an ID heuristic. Two citations that
resolve to a running case and still prove nothing stay rejected by name: a row citing a
**sibling row's** ID, and a name reaching more than one case. `related_tests` and
`canonical_tests` remain unread by the same rule, not as an exception — they name a file and no
case, so they cannot evidence a row and do not claim to.

Matching is containment rather than a prefix because an ID is not always first:
`[MEMORY-LIST-004][MEMORY-LIST-006] browses …` is one case answering two scenarios, each citing
it by its own ID. The pre-existing "exactly one" count is what bounds the looseness. And since
`vitest list` does expand `it.each`, a parameterized citation resolves through the terms it
names — the template's literal head plus each `inputs` entry — with no format-string emulation:
for `accepts the declared failure %s with result %s` with `[memory_repair_failed, timed_out]`,
one collected case carries all three terms and the other seven carry two.

The gate found two real pre-existing defects it had been unable to see. `harness_command_task`
**SCT-016** was `covered` on a case name that no longer exists
(`taskCommandPreview quotes argv the way the shell would read it back`). And four of
`memory_repair`'s five `ui_contract` citations were dead — `git log -S` traces three to
`d6ea9ee0f` (#1401, merged 2026-08-14), which deleted 623 lines from
`SettingsMemoryPage.test.tsx` and 368 from `MemoryStatusPanel.test.tsx`; nothing read
`ui_contract`, so the false claims sat unnoticed for five days. SCT-016 and the three bare-file
rows were re-pointed (their cases already carry their IDs, which the standard has required all
along, so no test was renamed). The three provably-dead `ui_contract` blocks are deleted, with
`status`, `expected_outputs`, and `related_tests` untouched — only the case-level claim was
provably false, and asserting more about another capability's semantics is not this PR's call.

## Every figure names its row and its column

The by-source panel stated per-row figures through position on screen alone, which no reader
who cannot see the layout can recover. Both panels of figures now carry the same structure,
because answering the second one with a second mechanism is how a class earns another round.

The visible panel is a table **by role**, not by tag: its layout is a CSS grid that collapses
to one column below 767px, and a `<table>` can only stack through a `display` override —
which is exactly what strips the native semantics it would have been chosen for. Explicit
roles are unaffected by `display` and keep both the grid and the structure at every width. The
by-day series moved the other way, from round 3's `sr-only` sentence list to an `sr-only`
native `<table>` (Tailwind's `sr-only` does not touch `display`), so the tab has one answer
for this instead of two.

A figure's column is its **position in its row** — what makes the header row an answer rather
than decoration, in an ARIA table exactly as in a native one — and each cell repeats its
header as a `md:hidden` label for the width where that header row is `display:none`. Between
them the two cover both widths, so a per-cell `aria-colindex` would restate what position
already says; it earns its keep only for a row that skips a *middle* column, and the model
row's empty `lastMetered` cell is the simpler way to not have one.

MH-USAGE-024 asks this of *whatever* tables the tab renders rather than of a list of them:
every body row has exactly one row header, states as many figures as there are columns (so no
row ends early and shifts the ones before it under the wrong header), and — where the headers
can leave the accessibility tree — labels every figure with the header at its own position.
Four mutations were run against it and all four fail: dropping `role="table"`, removing the
model row's placeholder cell, removing the stacked labels, and reordering `SOURCE_COLUMNS`.

`MH-CATALOG-002` moves to `ui/scripts/scenarioCatalog.test.mjs`, seeds one declaration of
every shape — commented out, blocked out, `it.skip`, `it.each`, quoted in a string and in a
template, a regex opening after `return`, a `describe.skip` body, an `if (false)` body —
and asserts that the set which resolves **equals** the set the fixture names as running.
Both sides are derived from the fixture text, so a shape added later is covered without
editing the assertion. Beside it, one case per property the resolver owns: which citations get
asked (both keys, either legend shape, `related_tests` unread), what a name may be written
against, and what a parameterized citation resolves through.

## Every token figure names the coverage behind it

A bucket carries **three** independent facts, and each has exactly one counter that can answer
it: `requests` says calls happened, `token_reports` says an upstream said what they cost, and
the token counts say how much. A rendered `0` is therefore three different readings — a cost
reported as nothing, a cost nobody reported, and nothing having run at all — and the tab states
token figures in **eight** places, so wording any one of them correctly leaves the other seven
to be found one review round at a time.

`useTokenText(counters, value)` is now the only path from a token count to text, and coverage
travels *with* the value rather than being checked by the caller, so a new token figure cannot
be written without naming the counters it came from. `TokenFigure` wraps it in
`<span data-usage-token="">`; that marker is not styling, it is what lets MH-USAGE-026
enumerate every token figure on screen and assert they all went through the door — a
completeness claim no per-site test can make. Figures interpolated into translated sentences
have no element of their own and call `useTokenText` directly, so their sentence is the
asserted unit.

Two predicates, deliberately not one:

- `usageTokensAreReported` = `token_reports > 0` — an upstream costed something. Only such a
  day can be the busiest one; naming any other day the peak puts a superlative on a number the
  report never carried.
- `usageTokensAreKnown` = reported **or** `requests === 0` — the number is a measurement, so
  printable. This is the door every figure asks.

The second is wider by exactly one case and that is not a concession: a bucket where nothing
ran cost nothing, and that zero is measured by *our own* request counter. Blanking it would
trade the defect for its mirror image — an idle day read as unknowable. The no-peak copy is
correspondingly four-way, with `reported` ordered ahead of `metered`, because a window holding
any report can state what its reports said; the calls that came back without one are the
requests card's shortfall to name, not that sentence's.

Both new gates were proved executable by breaking the implementation: rotting
`usageTokensAreKnown` to `return true` fails MH-USAGE-021 and MH-USAGE-026 and nothing else,
and swapping the `reported`/`metered` branch order fails MH-USAGE-025 and only it.

## Known by design

- **An idle bucket prints `0`, not the blank marker.** The blank means *nobody told us*, and
  for a bucket with no requests our own counter is the measurement — see the two predicates
  above. MH-USAGE-025's window is the other side of the same rule: reports arrived and said
  zero, so every figure prints `0` and the by-day caption states that the days which reported
  their tokens reported zero.
- **The 額度 cleanup is deliberately partial.** `types.SourceUsage` and the
  `mockData` 額度 fields remain: the type mirrors a contract file that still
  declares the block, and deleting a contract mirror is a contract change, not a
  display change. It retires when the contract does.
- **No first-paint registration.** Absence from `FIRST_PAINT_REGION_WHITELIST` is
  the policy, not an omission — MH-USAGE-020 asserts it.
- **Geometry has no design frame.** `design.pen` has no frame for this tab on the
  local surface, so the block adapts `MS/ConfigPanel → cp-usage-body` and otherwise
  follows the source table directly above it (18px gutter, 36px head, 11px column
  labels, 12px radius). Two deliberate departures: the day series is a column chart
  because the day count is a window parameter rather than a fixed five, and the
  panels stack because the table carries nested rows.
- **No light-mode branch.** Every ink resolves through a step both light blocks
  already re-anchor, and the chart's two colors are a wash plus a `color-mix`
  accent, which flip on their own.
- **Frame 09 is drawn without the tab strip; the Hub keeps it anyway.** The frame
  predates this tab and the Usage tab has no frame at all, so the frame's silence
  is the absence of the concept rather than a decision about it. The ledger
  outlives the Sources it meters — 62 days of retention, and MH-USAGE-017 exists
  because a vanished Source keeps its `src_*` id in the report — so the route to
  it cannot be a branch of currently having a Source. One rule: the Hub always
  draws its two tabs, and `directEmpty` decides the **body** of the `sources`
  tab, which is still Frame 09 there (asserted, including that no
  gateway-overview content leaks in beside it).
- **Exact per-day figures are text and a tooltip, not a tap target.** Each day's
  readout is a pointer `title` plus a row of the `sr-only` by-day table, which is
  what makes it reachable by keyboard and screen reader (MH-USAGE-023). A touch
  user without a screen reader still gets shape, endpoints, and peak rather than
  one day's exact counts; giving them that means tap-to-select on a bar, which is
  an interaction this report does not otherwise have.
- **The by-source panel is a table by role, not a `<table>`.** Overriding
  `display` to stack a native table is what removes its semantics, and this layout
  stacks below 767px. Roles survive `display`; the reasoning is in
  `UsageTab.tsx` beside the `role="table"` wrapper.
- **No per-cell `aria-colindex`.** Position resolves a figure against the header
  row, the `md:hidden` cell label covers the width where that header is
  `display:none`, and MH-USAGE-024 asserts the precondition both rely on — that no
  row ends early. An absolute index would only add something for a row skipping a
  middle column, which the model row's empty cell exists to avoid.
- **MH-USAGE-021 asserts the caption and the per-day readout, not the bar
  height.** The metered-day floor is `max(2px, …)`; jsdom's CSS parser drops an
  unparseable inline function, so `style.height` reads empty for drawn and
  undrawn columns alike. The decision behind the floor is the assertable part and
  is asserted where it lives — `usageDayIsMetered` over columns in
  `usageProjection.test.ts` — leaving the pixel to this PR's residual visual
  check.

