### PR TITLE
ci(workflows): move remaining node20 action pins to node24

### DIFF
--- a/.github/workflows/build-git.yml
+++ b/.github/workflows/build-git.yml
@@ -448,11 +448,11 @@ jobs:
           - arch: arm64
             platform: linux/arm64
     steps:
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: git-source-patched
 
-      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4
 
       - name: Build and verify static local-only Git
         shell: bash
@@ -582,7 +582,7 @@ jobs:
           - arch: arm64
             runner: macos-15
     steps:
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: git-source-patched
 
@@ -711,7 +711,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           pattern: git-runtime-*
           path: dist

--- a/.github/workflows/build-tmux.yml
+++ b/.github/workflows/build-tmux.yml
@@ -102,7 +102,7 @@ jobs:
     needs: [build-linux, build-macos]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           pattern: tmux-*
           path: dist

--- a/.github/workflows/git-runtime-release-guard.yml
+++ b/.github/workflows/git-runtime-release-guard.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
       - name: Resolve pinned manifest identity
         id: manifest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,14 +66,14 @@ jobs:
           python scripts/prepare_local_show_runtime_manifest.py
           python -m build --wheel
 
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: ui-dist-linux
           path: ui/dist
           if-no-files-found: error
           retention-days: 1
 
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: vibe-wheel-linux
           path: dist/*.whl
@@ -190,12 +190,12 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: ui-dist-linux
           path: ui/dist
 
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: vibe-wheel-linux
           path: dist
@@ -237,7 +237,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: vibe-wheel-linux
           path: dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -181,7 +181,7 @@ jobs:
           npm run build
 
       - name: Download Show Runtime bundles
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           pattern: show-runtime-*
           path: runtime-artifacts
@@ -198,7 +198,7 @@ jobs:
           cp vibe/show_runtime_manifest.json runtime-artifacts/show-runtime-manifest.json
 
       - name: Download Memory Runtime bundles
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           pattern: memory-runtime-*
           path: runtime-artifacts
@@ -409,7 +409,7 @@ jobs:
       id-token: write  # Required for trusted publishing
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: dist
           path: dist/
@@ -442,7 +442,7 @@ jobs:
       id-token: write  # Required for trusted publishing
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/release_ai.yml
+++ b/.github/workflows/release_ai.yml
@@ -157,7 +157,7 @@ jobs:
           npm run build
 
       - name: Download Show Runtime bundles
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           pattern: show-runtime-*
           path: runtime-artifacts
@@ -173,7 +173,7 @@ jobs:
             --output vibe/show_runtime_manifest.json
 
       - name: Download Memory Runtime bundles
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           pattern: memory-runtime-*
           path: runtime-artifacts
@@ -594,7 +594,7 @@ jobs:
           fi
 
       - name: Download release artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: release-dist
           path: dist/


### PR DESCRIPTION
## What changed

Every GitHub Action pin in this repo whose `action.yml` still declared
`runs.using: node20` now points at a node24 release. GitHub force-runs node20
actions on Node 24 today and warns on every job; that warning is scheduled to
become a hard failure.

| File(s) | Action | From | To |
| --- | --- | --- | --- |
| `publish.yml` ×4, `release_ai.yml` ×3, `build-git.yml` ×3, `build-tmux.yml` ×1 | `actions/download-artifact` | v6.0.0 | v8.0.1 |
| `lint.yml` ×3 | `actions/download-artifact` | v5.0.0 | v8.0.1 |
| `lint.yml` ×2 | `actions/upload-artifact` | v5.0.0 | v6.0.0 |
| `git-runtime-release-guard.yml` ×1 | `actions/checkout` | v4.4.0 | v5.1.0 |
| `build-git.yml` ×1 | `docker/setup-qemu-action` | v3.7.0 | v4.2.0 |

18 lines across 6 workflow files. No logic, input, or job-topology changes.

## Why the whole class, not just the warning

The v3.0.11 release run surfaced the deprecation for `download-artifact` only.
Patching that one pin would have left four other node20 pins to re-raise the
same warning on the next run of a different workflow, so the fix is scoped to
the defect class: *any pinned action still declaring node20*.

The warning was also not a stale version comment. `download-artifact` v6.0.0
itself declares `runs.using: node20` — v6 only shipped "preliminary" node24
support — so the comment read `# v6` truthfully while the runner still warned.
Every target was therefore chosen by reading `runs.using` out of `action.yml`
at the candidate SHA, not by trusting a tag name.

## Evidence

- **Post-change audit**: fetched `action.yml` at all 9 distinct pinned SHAs via
  the GitHub API. All report `using: node24`, except
  `pypa/gh-action-pypi-publish` which is `composite`. Zero node20 pins remain.
- **Comment accuracy**: each new SHA resolves to the tag named in its trailing
  comment.
- **Unpinned actions**: none — every `uses:` in `.github/workflows/` is
  SHA-pinned.
- **YAML**: all 8 workflow files parse.
- **Call-site compatibility**: every bumped call site was read back. The
  `download-artifact` sites use only `name` / `path` / `pattern` /
  `merge-multiple`; `checkout` and `setup-qemu-action` are used bare. No input
  was removed or renamed across any of these majors.
- No Python or UI files touched, so no `ruff` / `npm run build` gate applies.

## Behavior changes reviewed

`download-artifact` v6 → v8 is the only bump carrying real behavior changes:

1. `digest-mismatch` now defaults to `error` instead of a warning. Safe and
   security-positive here — a corrupted artifact should stop a release, and
   `publish.yml` already sha256-verifies the runtime archives independently.
2. Responses with a non-zip `Content-Type` are no longer auto-decompressed
   (new `skip-decompress` input). Not reachable: every artifact in this repo is
   a normal zipped Actions artifact.

`upload-artifact` v5 → v6, `checkout` v4 → v5, and `setup-qemu-action` v3 → v4
are pure node24 runtime bumps. `setup-qemu-action` v4 also switched to ESM
internally; its input defaults (`image`, `platforms`, `cache-image`) are
unchanged, and the one call site passes no inputs.

v8.0.1 was chosen over the minimal node24-capable v7.0.0 to match this repo's
convention of tracking current majors and to avoid a second bump shortly after.

## Self-hosted runner risk

Node24 actions require Actions Runner ≥ 2.327.1. The only self-hosted job is
`npm-wrapper` in `lint.yml` (`[self-hosted, Linux, X64, avibe]`). It uses no
`download-artifact`, and its existing `checkout@v5` / `setup-node@v5` steps are
already node24 and passing — runtime evidence those runners support node24.

## Evidence layers

- Unit / contract / scenario: not applicable — CI configuration only.
- Residual manual check: CI on this PR is itself the verification. The intended
  signal is a green run with no "Node.js 20 actions are deprecated" annotation.
  `publish.yml` and the release-guard workflows are not `pull_request`-
  triggered, so their bumped steps are exercised at the next release/schedule
  rather than on this PR.
