### PR TITLE
test(storage): guard the migration graph as a release contract

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -167,6 +167,51 @@ jobs:
             exit 1
           fi
 
+  migration-release-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+        with:
+          # The guard reads each release's migration graph straight out of git. The
+          # default shallow checkout fetches no tags, which would leave it with no
+          # shipped graph to compare against.
+          fetch-depth: 0
+
+      # Editable installs require the force-included directory; this job only needs the
+      # migration chain to import.
+      - name: Prepare minimal UI asset placeholder
+        run: |
+          mkdir -p ui/dist
+          printf '%s\n' '<!doctype html><html><body></body></html>' > ui/dist/index.html
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+        with:
+          enable-cache: true
+          save-cache: false
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Install package and test deps
+        run: uv pip install --system -e . --group dev
+
+      - name: Guard the migration graph against every released version
+        run: |
+          set -o pipefail
+          output="$RUNNER_TEMP/migration-release-guard.log"
+          python -m pytest tests/test_migration_release_guard.py -ra | tee "$output"
+          # The release-history properties skip themselves when no tags are reachable so
+          # the sharded unit job stays green on its shallow checkout. This job is the one
+          # that supplies the history, so here a skip means the guard proved nothing.
+          if grep -Eq '(^|[[:space:]])[0-9]+ skipped|SKIPPED' "$output"; then
+            echo "The migration release guard must not skip: this checkout reached no release history."
+            exit 1
+          fi
+
   npm-wrapper:
     runs-on: [self-hosted, Linux, X64, avibe]
     steps:

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -688,6 +688,10 @@ JSON_TYPE_MEMBERS: dict[str, object] = {
 # table it refuses every repeat of must still carry.
 SEED_ROWS = 2
 
+# The step a restored duplicate moves its other columns by. Past every step the seeding used,
+# so a row offered after the references settle cannot land on one offered before them.
+RESTORE_STEP = SEED_ATTEMPTS
+
 
 def representative_value(column: str, declared_type: str) -> object:
     """A value of ``declared_type`` that SQLite will store in ``column``.
@@ -789,6 +793,127 @@ def json_proposals(
     return proposals
 
 
+def moved_row(base: dict[str, object], step: int, *, held: str | None) -> dict[str, object]:
+    """``base`` with every column moved to its ``step`` variant, except ``held``.
+
+    ``held`` is the one column a repeat probe exists to repeat.
+    """
+    return {
+        name: value if name == held else varied(value, step) for name, value in base.items()
+    }
+
+
+def resolve_references(connection: sqlite3.Connection, table: str) -> None:
+    """Point ``table``'s references at values its parents actually hold.
+
+    A reference is the one kind of column a fixture may not simply invent a value for. Every
+    other fabricated value is merely arbitrary, but a fabricated reference is a dangling one,
+    and a dangling reference is a state no release can be in: ``20260806_0047`` rebuilds
+    tables and then runs ``pragma foreign_key_check``, aborting the upgrade if anything
+    dangles. A fixture that manufactures one turns a correct migration red, which is worse
+    than a missed defect because it is indistinguishable from a real catch. That is not
+    hypothetical -- it is what a hundred and two of them did here, and the reason this pass
+    exists rather than a rule about which columns to leave alone.
+
+    Which columns those are is read from the database rather than from the DDL, because the
+    DDL spells a foreign key four different ways and SQLite has already parsed all of them.
+
+    Run after every table is seeded rather than while seeding, which is what makes it
+    ordering-free. A reference needs its parent's row to exist, and the reference graph has
+    cycles -- ``session_turns`` and ``message_deliveries`` each point at the other -- so no
+    seeding order satisfies every reference. Afterwards every parent has rows and the only
+    question left is which of their values to copy. Nothing is asserted here: seeding runs
+    with SQLite's default ``foreign_keys=OFF``, so the rows land regardless and
+    ``dangling_references`` is what reads the result back.
+
+    Copying is necessary because a parent's value is not predictable from its column. The
+    repair in ``insert_seed_row`` moves values until a CHECK is satisfied, so a parent whose
+    key is held to a list of literals ends up holding one of those rather than what
+    ``representative_value`` proposed, and a child that assumed the latter dangles.
+
+    Whether every row may share one parent is the database's answer, not this function's
+    guess: one value for the whole table is offered first, and only if that is refused does
+    each row get its own. Refusal means a unique index covers the column, which is a table
+    like ``scope_settings`` whose primary key *is* its reference -- there, sharing would
+    collapse the fixture to a single row, and one row is the shape five review rounds went
+    into getting away from. Where sharing is accepted it is also preferred, because a
+    reference held still across rows is what the repeat probes proved and what
+    ``seeded_rows_prove_repetition`` reads back.
+    """
+    groups: dict[int, list[tuple[str, str, str | None]]] = {}
+    for row in connection.execute(f'pragma foreign_key_list("{table}")'):
+        groups.setdefault(int(row[0]), []).append((str(row[2]), str(row[3]), row[4] and str(row[4])))
+    for members in groups.values():
+        parent = members[0][0]
+        # An omitted parent column means the parent's primary key, in its declared order.
+        keys = [name for _, _, name in members]
+        if None in keys:
+            keys = [
+                str(column[1])
+                for column in sorted(
+                    (row for row in connection.execute(f'pragma table_info("{parent}")') if row[5]),
+                    key=lambda row: row[5],
+                )
+            ]
+        selected = ", ".join('"{}"'.format(key) for key in keys)
+        held = connection.execute(f'select distinct {selected} from "{parent}"').fetchall()
+        if not held:
+            continue
+        assignments = ", ".join(f'"{name}" = ?' for _, name, _ in members)
+        try:
+            connection.execute(f'update "{table}" set {assignments}', list(held[0]))
+            continue
+        except sqlite3.Error:
+            pass
+        nullable = {
+            str(row[1]): not (row[3] or row[5])
+            for row in connection.execute(f'pragma table_info("{table}")')
+        }
+        blanked = ", ".join(f'"{name}" = null' for _, name, _ in members)
+        rows = [row[0] for row in connection.execute(f'select rowid from "{table}"')]
+        for index, rowid in enumerate(rows):
+            # Offsets so two rows start from different parents; the whole rotation because a
+            # row already holding a later parent's value is in the way of the earlier one.
+            for offset in range(len(held)):
+                try:
+                    connection.execute(
+                        f'update "{table}" set {assignments} where rowid = ?',
+                        [*held[(index + offset) % len(held)], rowid],
+                    )
+                    break
+                except sqlite3.Error:
+                    continue
+            else:
+                # Every parent is taken, which happens when a unique reference has more rows
+                # to point than the parent has rows to point at. A release is in the same
+                # position and answers it the same two ways: the reference is empty where the
+                # column allows it, and the row does not exist where it does not.
+                remove = not all(nullable[name] for _, name, _ in members)
+                if not remove:
+                    try:
+                        connection.execute(f'update "{table}" set {blanked} where rowid = ?', [rowid])
+                    except sqlite3.Error:
+                        remove = True
+                if remove:
+                    connection.execute(f'delete from "{table}" where rowid = ?', [rowid])
+
+
+def dangling_references(connection: sqlite3.Connection) -> str:
+    """Which of the seeded rows point at a parent that is not there, or ``''``.
+
+    The seeding's own check on itself. Every referencing column keeps the value its parent
+    was seeded with, so the references resolve by construction -- but "by construction" is a
+    claim about this code, and ``pragma foreign_key_check`` is the database's answer. They
+    coincided by accident once already: both sides of a reference happened to be handed the
+    same representative value, so nothing dangled while nothing was making sure of it.
+    """
+    violations = connection.execute("pragma foreign_key_check").fetchall()
+    if not violations:
+        return ""
+    tables = sorted({str(row[0]) for row in violations})
+    return f"{len(violations)} row(s) reference a parent that was never seeded, in {', '.join(tables)}"
+
+
 def seeded_rows_prove_repetition(
     connection: sqlite3.Connection, table: str, repeated: Iterable[str]
 ) -> str:
@@ -799,12 +924,18 @@ def seeded_rows_prove_repetition(
     row whose other columns moved, and the repair is free to answer by moving the one column
     that row existed to hold still. The insert is then accepted having proved nothing, and
     reading the column back is the only way to notice.
+
+    The duplicate is counted the way a unique index counts one, which is not the way
+    ``count(distinct c)`` does: SQLite drops NULLs from the latter, so a column NULL in
+    every row but one reads as perfectly distinct and a column NULL in every row reads as
+    empty. Both are rows a unique index would accept and this would have called a repeat.
     """
     for column in repeated:
-        seeded, distinct = connection.execute(
-            f'select count(*), count(distinct "{column}") from "{table}"'
-        ).fetchone()
-        if seeded == distinct:
+        shared = connection.execute(
+            f'select count(*) from (select "{column}" from "{table}" '
+            f'where "{column}" is not null group by "{column}" having count(*) > 1)'
+        ).fetchone()[0]
+        if not shared:
             return f"no two rows share a {column}, though a row repeating it was accepted"
     return ""
 
@@ -846,26 +977,90 @@ def varied(value: object, step: int) -> object:
     return f"{value}-{step}"
 
 
+def restore_repeat(
+    connection: sqlite3.Connection,
+    table: str,
+    ddl: str,
+    offered: list[tuple[str, str]],
+    column: str,
+    references: set[str],
+) -> tuple[str, bool]:
+    """Offer ``table`` one more row repeating ``column``, copied off a row that is still there.
+
+    Reference resolution removes a row when a unique reference has no parent left for it to
+    point at, and the row it removes was carrying some column's only duplicate. The duplicate
+    is not optional: it is what a migration adding a unique index has to meet, and asserting
+    it without it being there is the defect an earlier review round found. So it is offered
+    again here, after the references are settled rather than before, which is what makes the
+    offer survivable.
+
+    The references come from a surviving row instead of being invented, for the reason
+    ``resolve_references`` exists at all, and they are the columns held rather than moved --
+    together with ``column`` itself, which is the point of the row. Everything else moves, so
+    a composite unique index covering the repeated column has something left to separate the
+    two rows by.
+
+    A reference that is itself uniquely indexed cannot be copied, since the row copied from
+    still holds it. Which references those are is not asked but tried: the copy is offered
+    first, and only what the database refuses is offered again with its optional references
+    empty -- a shape released rows already have, so the second offer is a row a release can be
+    in rather than a concession to make the fixture fit. A reference the table demands keeps the
+    copy either way, because the alternative to a shared parent there is no row at all, and
+    then the refusal stands and is reported. ``session_turns`` is that case:
+    ``uq_session_turns_message_written_attempt`` keeps ``initial_delivery_id`` unique among
+    non-terminal turns and the column is NOT NULL, so the table cannot hold more such rows than
+    there are deliveries to point at, and eleven of its columns lose the duplicate they were
+    granted in isolation.
+    """
+    names = [name for name, _ in offered]
+    selected = ", ".join(f'"{name}"' for name in names)
+    survivor = connection.execute(f'select {selected} from "{table}" limit 1').fetchone()
+    if survivor is None:
+        return "no row is left to copy a reference from", True
+    row = {
+        name: value if value is None or name == column or name in references else varied(value, RESTORE_STEP)
+        for name, value in zip(names, survivor)
+    }
+    objection, settled = insert_seed_row(connection, table, ddl, offered, row)
+    if not objection or column in references:
+        return objection, settled
+    optional = {
+        str(info[1])
+        for info in connection.execute(f'pragma table_info("{table}")')
+        if not (info[3] or info[5]) and str(info[1]) in references
+    }
+    emptied = {name: None if name in optional else value for name, value in row.items()}
+    return insert_seed_row(connection, table, ddl, offered, emptied)
+
+
 def insert_seed_row(
     connection: sqlite3.Connection,
     table: str,
     ddl: str,
     required: list[tuple[str, str]],
     values: dict[str, object],
-) -> str:
-    """Insert ``values`` into ``table``, repairing what the schema objects to; ``""`` if it landed.
+) -> tuple[str, bool]:
+    """Insert ``values`` into ``table``, repairing what the schema objects to.
+
+    Returns ``(objection, settled)``. ``objection`` is ``""`` when the row landed, and
+    otherwise the schema's own last words. ``settled`` says whose answer that is, and it is
+    the distinction the caller cannot do without: the database refusing a row is a fact
+    about the schema, while this function running out of attempts with proposals still
+    untried is a fact about this function. Reported as one, a limit in the seeder reads as a
+    property of the release -- which is the failure mode the guard exists to prevent, aimed
+    at itself.
 
     Where a CHECK rejects the row, SQLite names the constraint and the constraint states
     what it wants -- accepted literals, or a JSON shape -- so the repair proposes that and
     asks again. SQLite is the judge throughout: the row is admissible only if the schema
-    accepted it, and the returned message is the schema's own last objection.
+    accepted it, and a refusal is settled once nothing remains to offer.
     """
     if not required:
         try:
             connection.execute(f'insert into "{table}" default values')
         except sqlite3.Error as exc:
-            return str(exc)
-        return ""
+            return str(exc), True
+        return "", True
 
     columns = ", ".join(f'"{column}"' for column, _ in required)
     placeholders = ", ".join("?" for _ in required)
@@ -879,10 +1074,11 @@ def insert_seed_row(
         except sqlite3.Error as exc:
             objection = str(exc)
             # However else SQLite refuses the row, the table is one this cannot seed. Only
-            # a named CHECK carries a repair, so anything else ends here.
+            # a named CHECK carries a repair, so anything else ends here -- settled, because
+            # the refusal is the schema's and there is no next thing to try.
             failure = CHECK_FAILURE.search(objection)
             if failure is None:
-                return objection
+                return objection, True
             expression = check_expression(ddl, failure.group(1))
             untried = [
                 pair
@@ -893,17 +1089,17 @@ def insert_seed_row(
                 if pair not in proposed
             ]
             if not untried:
-                return objection
+                return objection, True
             column, literal = untried[0]
             proposed.add((column, literal))
             values[column] = literal
         else:
-            return ""
-    return objection or f"{SEED_ATTEMPTS} attempts did not produce a row the schema accepts"
+            return "", True
+    return f"{SEED_ATTEMPTS} attempts did not produce a row the schema accepts; last was {objection}", False
 
 
-def seed_representative_rows(db_path: Path) -> dict[str, str]:
-    """Fill every table of the schema ``db_path`` holds; ``{table: objection}`` for what fell short.
+def seed_representative_rows(db_path: Path) -> tuple[dict[str, str], dict[str, str]]:
+    """Fill every table of the schema ``db_path`` holds.
 
     A migration is only as safe as the data it runs over. On an empty database, adding a
     NOT NULL column with no default, tightening a nullable one, backfilling from a column
@@ -914,52 +1110,68 @@ def seed_representative_rows(db_path: Path) -> dict[str, str]:
     The rows are derived from the schema, because the schema is what differs in every
     release and ``pragma table_info`` already knows it; a fixture written per release
     would cover the graphs that existed when it was written and quietly stop at the next
-    one. What gets filled is what every row of that table must hold -- NOT NULL or primary
-    key -- whether or not a default would have supplied it, because a released application
-    writes those columns and a seeder that leans on the defaults instead is measuring the
-    defaults. Leaving the rest NULL is deliberate and the more adversarial choice: a
-    migration that later makes a nullable column NOT NULL has to survive the NULLs a real
-    database has, and the NULL branch is the one a disjunctive CHECK admits.
+    one.
 
-    More than one row, and what the extra rows are for is stated rather than constructed:
-    **a column the schema still lets two rows share has to be shared by two of them.** One
-    row makes every unique index buildable, which is the property most worth testing and the
-    one a single row silently grants; a row that differs everywhere grants it just as
-    silently.
+    Returns ``(short, refused)``, and the split is the whole design. ``short`` is what this
+    seeder failed to do and is a guard failure. ``refused`` is what the database declined and
+    is data: each offer it turned down, mapped to SQLite's own words. Five review rounds went
+    into the difference. Each round named a shape the fixture did not hold -- one row, then
+    unioned distinct groups, then one member per group, then overlapping groups, then columns
+    never made non-NULL -- and each fix widened the fixture and asserted the widening was now
+    complete. It never was, and the reason is structural rather than a missing case: the rows
+    a released database can hold are the schema's satisfiable states, and enumerating those is
+    constraint solving. ``message_deliveries`` settles it by construction -- four CHECKs key
+    twelve columns off ``state``, each state requiring some of them NULL, so **no row of that
+    table has every column non-NULL** and no fixture can be asked for one.
 
-    Which columns those are is asked of the database instead of derived from its schema.
-    Each column gets a row that holds it still and moves every other one, and SQLite either
-    takes it or names the constraint it broke. Moving every other column is not a preference:
-    a differing column can only help a uniqueness constraint accept the row, and the one
-    thing that undoes a difference -- a CHECK holding a column to a list of literals, whose
-    repair puts an accepted one back -- does so whatever else the row does. So this is the
-    likeliest row to be accepted that still repeats the column, and there is no second choice
-    to tune.
+    So the claim stops where the evidence does. What is proved is bounded by the offers this
+    makes, which it controls, not by the value space, which it does not:
 
-    Deriving the answer instead cost three review rounds, each spent on a model of the
-    constraint topology -- one row, unioned members, overlapping groups -- and each fix was
-    another argument that the model was now complete. A partial unique index, an index over
-    an expression, and a CHECK pinning one member of a group to a literal were all still
-    outside it, and this schema ships all three. Offering the row removes the model, and with
-    it the next topology.
+    **every column is offered, and every column the database accepts a repeat of is repeated
+    by two rows that were read back to confirm it.**
 
-    What a refusal means is exactly what it says, and no more: the schema rejected *this*
-    row. For ``uq_constrained_slug`` that is also the schema forbidding the repeat outright,
-    but a partial unique index is conditional -- ``unique (session_id) where state in
-    ('starting', 'active')`` permits a repeated ``session_id`` on a terminal turn -- and
-    reaching the permitted side means giving ``state`` a value whose whole multi-column shape
-    another CHECK then dictates. That is constraint solving, which this deliberately is not,
-    so the column goes uncovered carrying SQLite's message as the reason. The floor below and
-    ``seeded_rows_prove_repetition`` bound what the fixture is allowed to prove instead of
-    the refusal being read as proof of anything.
+    Three offers per table. The maximal row, holding a value in every column, because a
+    nullable column left NULL is a column no migration touching it is tested against. The
+    mandatory row, holding only what NOT NULL and the primary key demand, because the NULL
+    branch is what a released database mostly carries and what a disjunctive CHECK admits.
+    Then one row per column that holds that column still and moves every other one -- moving
+    the rest is not a preference but the likeliest-accepted shape that still repeats the
+    column, since a differing column can only help a uniqueness constraint and the one thing
+    that undoes a difference (a CHECK pinning a column to a literal list, whose repair
+    restores an accepted literal) does so however the row is built.
 
-    What this proves is that the upgrade runs over rows, not over meaningful ones --
-    foreign keys are off, which is SQLite's default and is what lets each table be seeded
-    on its own, so the rows are individually well-formed and collectively inconsistent.
-    A table this cannot fill is returned with the schema's own objection rather than
-    skipped, because a coverage limit the caller cannot see reads as coverage.
+    Then the references are pointed at parents that exist, which is a separate pass because
+    every table has to be seeded before any reference can resolve, and it is what stops the
+    fixture from being a database no release could be in: ``20260806_0047`` aborts the upgrade
+    on a dangling reference, so inventing one turns a correct migration red. Resolution can
+    take rows away -- a demanded, uniquely indexed reference bounds a table by its parent's
+    size -- so the counting and the reading back happen after it, over the fixture the
+    migrations will actually run against, and any duplicate it cost is offered again.
+
+    A refusal means what it says and nothing more: the schema rejected *this* row. Sometimes
+    that is also the schema forbidding the repeat outright, and sometimes it is a partial
+    unique index whose permitted side needs a multi-column state another CHECK dictates.
+    Telling those apart is the constraint solving this is not, so both are reported the same
+    way and neither is read as proof. What that leaves is measured rather than asserted: over
+    every released schema the guard runs, the ledger holds fifty-two entries. One is the
+    maximal row ``message_deliveries`` refuses by construction, above. Of the fifty-one repeat
+    refusals, thirty-six come from a primary key or a total unique index and three from a
+    ``where <column> is not null`` index that a non-NULL repeat check treats as total anyway.
+    The remaining twelve are all one genuinely conditional index,
+    ``uq_session_turns_message_written_attempt``, unique on ``initial_delivery_id`` where the
+    turn is not terminal: one is that column's own repeat, and eleven are other columns of
+    ``session_turns`` whose repeat the table accepted alone and lost once the rest of the
+    fixture was there, because the same index bounds the table at the number of deliveries its
+    rows may point at. Those eleven are the one refusal that is about the whole database rather
+    than one table, and the reason the claim is over what this fixture can hold.
+
+    What this proves is that the upgrade runs over rows whose references resolve, not over
+    meaningful ones -- each table is seeded on its own with foreign keys off, which is
+    SQLite's default, so the rows are individually well-formed and collectively arbitrary.
     """
-    short = {}
+    short: dict[str, str] = {}
+    refused: dict[str, str] = {}
+    accepted: dict[str, tuple[list[str], str, str, list[tuple[str, str]]]] = {}
     with sqlite3.connect(db_path) as connection:
         schema = [
             (str(name), str(ddl))
@@ -969,57 +1181,123 @@ def seed_representative_rows(db_path: Path) -> dict[str, str]:
             if name != ALEMBIC_BOOKKEEPING_TABLE
         ]
         for table, ddl in schema:
-            required = [
-                (str(row[1]), str(row[2]))
+            info = [
+                (str(row[1]), str(row[2]), bool(row[3] or row[5]))
                 for row in connection.execute(f'pragma table_info("{table}")')
-                if row[3] or row[5]
             ]
+            every = [(column, declared) for column, declared, _ in info]
+            mandatory = [(column, declared) for column, declared, required in info if required]
             # The first row is where the repairs happen, so every later row moves the values
-            # the schema has already accepted rather than the ones it rejected.
-            base = {column: representative_value(column, declared) for column, declared in required}
-            objection = insert_seed_row(connection, table, ddl, required, base)
-            excused: dict[str, str] = {}
+            # the schema has already accepted rather than the ones it rejected. Offer every
+            # column first and fall back to what the table demands, because a table whose
+            # CHECKs make some columns mutually exclusive refuses the maximal row by
+            # construction and still has to be seeded.
+            base = {column: representative_value(column, declared) for column, declared in every}
+            objection, settled = insert_seed_row(connection, table, ddl, every, dict(base))
+            offered = every
+            if objection:
+                refused[f"{table}, every column at once"] = objection
+                offered = mandatory
+                base = {column: base[column] for column, _ in mandatory}
+                objection, settled = insert_seed_row(connection, table, ddl, mandatory, base)
+            unsettled = {} if settled else {table: objection}
             repeated: list[str] = []
             # One row per column, holding that column still and moving every other one. The
             # step is the row's, so two of these rows differ from each other wherever they
             # differ from the base row.
-            for step, column in enumerate(() if objection else base, start=1):
-                refusal = insert_seed_row(
+            steps = 0
+            for steps, column in enumerate(() if objection else base, start=1):
+                refusal, decided = insert_seed_row(
+                    connection, table, ddl, offered, moved_row(base, steps, held=column)
+                )
+                if not refusal:
+                    repeated.append(column)
+                elif decided:
+                    refused[f"{table}.{column}"] = refusal
+                else:
+                    unsettled[f"{table}.{column}"] = refusal
+            # Nothing this table holds may repeat, so one more row that differs everywhere --
+            # less than the table was asked for, and all a unique index needs to be buildable
+            # against.
+            if not objection and not repeated:
+                insert_seed_row(
+                    connection, table, ddl, offered, moved_row(base, 1, held=None)
+                )
+            # The shape the maximal row cannot also be. Offered last and one step past the
+            # rows above, so it cannot collide with them on a column they hold still.
+            if not objection and set(offered) != set(mandatory):
+                mandatory_only = {column: base[column] for column, _ in mandatory}
+                refusal, _ = insert_seed_row(
                     connection,
                     table,
                     ddl,
-                    required,
-                    {name: value if name == column else varied(value, step) for name, value in base.items()},
+                    mandatory,
+                    moved_row(mandatory_only, steps + 1, held=None),
                 )
                 if refusal:
-                    excused[column] = refusal
+                    refused[f"{table}, nothing but its mandatory columns"] = refusal
+            short.update(unsettled)
+            accepted[table] = (repeated, objection, ddl, offered)
+        # Reference resolution comes between the seeding and the reading back, because it
+        # rewrites the columns both of them are about: a row counted before it may afterwards
+        # be gone from a unique reference's rotation, and a repeat proved before it may
+        # afterwards have been split apart. What the checks below measure is the fixture the
+        # migrations will actually run against.
+        for _ in range(len(schema)):
+            for table, _ in schema:
+                resolve_references(connection, table)
+            if not connection.execute("pragma foreign_key_check").fetchall():
+                break
+        for table, (repeated, objection, ddl, offered) in accepted.items():
+            # A reference is dropped from the repeat claim rather than proved, because whether
+            # two rows may share one is not this fixture's answer to give: the value belongs to
+            # the parent, and the resolution above hands out as many distinct ones as the
+            # child's unique indexes turn out to require. Composite indexes are why that is not
+            # knowable in advance -- ``resource_access_groups`` is unique on its two reference
+            # columns together with a third, so sharing both at once is refused while sharing
+            # either alone is fine. What the fixture claims for a reference is that it resolves,
+            # and ``dangling_references`` is where that claim is read back.
+            references = {str(row[3]) for row in connection.execute(f'pragma foreign_key_list("{table}")')}
+            claimed = []
+            for column in [name for name in repeated if name not in references]:
+                if not seeded_rows_prove_repetition(connection, table, [column]):
+                    claimed.append(column)
+                    continue
+                refusal, _ = restore_repeat(connection, table, ddl, offered, column, references)
+                if refusal:
+                    # Accepted when the table stood alone and refused now that the rest of the
+                    # fixture is around it, which is the database answering about the whole
+                    # database rather than about one table -- ``session_turns`` may not hold more
+                    # rows than ``message_deliveries`` does, because its reference to one is
+                    # both demanded and unique. So it goes to the ledger with every other
+                    # refusal, and out of the claim, rather than failing the guard: the claim is
+                    # over what this fixture can hold, and this is where that ends.
+                    refused[f"{table}.{column}, once the rest of the fixture is there"] = refusal
                 else:
-                    repeated.append(column)
-            # Nothing this table holds may repeat, so the second row is the one that differs
-            # everywhere -- less than the table was asked for, and all a unique index needs to
-            # be buildable against.
-            if not objection and not repeated:
-                insert_seed_row(
-                    connection, table, ddl, required, {name: varied(value, 1) for name, value in base.items()}
-                )
+                    claimed.append(column)
+            repeated = claimed
             rows = connection.execute(f'select count(*) from "{table}"').fetchone()[0]
             if rows < SEED_ROWS:
-                reason = objection or next(iter(excused.values()), "") or "the schema accepted no more"
-                short[table] = f"{rows} of {SEED_ROWS} rows; {reason}"
+                short[table] = f"{rows} of {SEED_ROWS} rows; {objection or 'the schema accepted no more'}"
                 continue
             unproven = seeded_rows_prove_repetition(connection, table, repeated)
             if unproven:
                 short[table] = unproven
+        dangling = dangling_references(connection)
+        if dangling:
+            short["the seeded database"] = dangling
         connection.commit()
-    return short
+    return short, refused
 
 
-def schema_gap_after_upgrade(tag: str) -> tuple[str | None, dict[str, str]]:
-    """``(gap, short)`` -- why a database built by ``tag``'s graph is not ready, and what it could not carry.
+def schema_gap_after_upgrade(tag: str) -> tuple[str | None, dict[str, str], dict[str, str]]:
+    """``(gap, short, refused)`` -- how a database built by ``tag``'s graph came through the upgrade.
 
-    ``gap`` is ``None`` when the database comes out ready. ``short`` is the tables the
-    upgrade therefore ran over with fewer rows than intended; both are failures, because
-    a property proved over less than its subject is not the property.
+    ``gap`` is ``None`` when the database comes out ready. ``short`` is where the seeding
+    fell short of what it set out to do; both are failures, because a property proved over
+    less than its subject is not the property. ``refused`` is what the schema itself declined
+    to hold and is carried for the report rather than the verdict -- see
+    ``seed_representative_rows`` for why those two cannot be the same list.
 
     What the rows are *for* is the run, not the tally afterwards. Adding a NOT NULL column,
     tightening a nullable one, backfilling from a column being dropped, and building a
@@ -1040,6 +1318,14 @@ def schema_gap_after_upgrade(tag: str) -> tuple[str | None, dict[str, str]]:
     actually run, so a regression in the pre-Alembic repair or stamping path has to fail
     here too, and readiness has to mean what production means by it -- required columns
     included, not merely a full set of table names.
+
+    Readiness is necessary and not sufficient, so the stamp is checked against today's head
+    as well. ``background_tables_ready`` asks whether the tables the product needs are
+    present, which a database can satisfy while stopping short of the graph's end -- a
+    migration that bails out after the last table-creating revision leaves exactly that,
+    and the tail it skipped is where index and constraint changes live. Today's head is read
+    from the working tree's own sources by the same function that reads the released one, so
+    the two stages are held to the same kind of statement about where the chain ends.
 
     Whatever the upgrade raises when it aborts propagates: a crash and a silently
     incomplete schema are the same failure of the same property.
@@ -1064,36 +1350,54 @@ def schema_gap_after_upgrade(tag: str) -> tuple[str | None, dict[str, str]]:
                 f"its head {sorted(shipped_heads)!r}; the released graph was not applied in full"
             )
 
-        short = seed_representative_rows(db_path)
+        short, refused = seed_representative_rows(db_path)
         run_migrations(db_path)
+
+        current_heads = shipped_head_revisions(working_tree_sources())
+        landed = stamped_revision(db_path)
+        if landed is None or landed not in current_heads:
+            raise MigrationGuardError(
+                f"upgrading {tag}'s database with today's graph left it stamped {landed!r} rather "
+                f"than at the current head {sorted(current_heads)!r}; the upgrade stopped early"
+            )
+
         gap = None if background_tables_ready(db_path) else describe_schema_gap(db_path)
-        return gap, short
+        return gap, short, refused
 
 
-def unrepairable_releases() -> dict[str, list[str]]:
-    """``{tag: reasons}`` for every release today's graph cannot bring to head over real rows.
+def unrepairable_releases() -> tuple[dict[str, list[str]], dict[str, str]]:
+    """``({tag: reasons}, refused)`` for every release today's graph runs over real rows.
 
-    A table the seeding could not fill is one of the reasons, not a footnote beside them.
-    The property is that a populated released database survives the upgrade, so a table
-    the run left short is a piece of that property it did not test, and reporting it as
-    anything other than a failure would let the guard read as stronger than its evidence.
+    A limit in the seeding is one of the reasons, not a footnote beside them. The property is
+    that a populated released database survives the upgrade, so anything the run left short is
+    a piece of that property it did not test, and reporting it as less than a failure would
+    let the guard read as stronger than its evidence.
+
+    What the schema itself declined to hold is the other half and is returned separately, to
+    be printed rather than counted. It is the honest boundary of the fixture -- the columns no
+    two rows share and SQLite's reason for each -- and calling it a failure would leave the
+    guard permanently red over primary keys, which is the same as not having one.
     """
     failures: dict[str, list[str]] = {}
+    refused: dict[str, str] = {}
     for tag in released_graphs():
         try:
-            gap, short = schema_gap_after_upgrade(tag)
+            gap, short, declined = schema_gap_after_upgrade(tag)
         except Exception as exc:  # noqa: BLE001 - however the upgrade fails, the verdict is the same
             failures[tag] = [f"upgrade aborted with {type(exc).__name__}: {str(exc).splitlines()[0]}"]
         else:
+            refused.update(declined)
             reasons = [] if gap is None else [f"upgrade left the database not ready: {gap}"]
             reasons += [f"could not seed {table}: {objection}" for table, objection in sorted(short.items())]
             if reasons:
                 failures[tag] = reasons
-    return failures
+    return failures, refused
 
 
-def collect_problems(baseline: str | None = None, *, include_upgrade: bool = True) -> tuple[str, list[str]]:
-    """``(baseline, problems)`` -- every property checked, every violation reported at once.
+def collect_problems(
+    baseline: str | None = None, *, include_upgrade: bool = True
+) -> tuple[str, list[str], dict[str, str]]:
+    """``(baseline, problems, refused)`` -- every property checked, every violation reported at once.
 
     Reporting all of them together rather than stopping at the first is deliberate: a
     graph defect usually shows up in more than one property, and seeing which ones fire
@@ -1102,9 +1406,14 @@ def collect_problems(baseline: str | None = None, *, include_upgrade: bool = Tru
     A limit on what the run could cover is a problem here too, not a note beside them.
     Anything this guard cannot exercise is something it passes without having checked, and
     the two are indistinguishable to whoever reads the exit code.
+
+    ``refused`` is not a problem and is not silence either. It is what the schema declined to
+    hold, printed on every run including a passing one, because the alternative to reporting a
+    boundary is asserting there isn't one.
     """
     baseline = baseline or latest_released_tag()
     problems: list[str] = []
+    refused: dict[str, str] = {}
 
     for tag in releases_with_state_but_no_graph():
         problems.append(
@@ -1126,10 +1435,11 @@ def collect_problems(baseline: str | None = None, *, include_upgrade: bool = Tru
     problems.extend(edited_released_bodies(baseline))
 
     if include_upgrade:
-        for tag, reasons in sorted(unrepairable_releases().items(), key=lambda item: version_key(item[0])):
+        failures, refused = unrepairable_releases()
+        for tag, reasons in sorted(failures.items(), key=lambda item: version_key(item[0])):
             problems.extend(f"{tag}: {reason}" for reason in reasons)
 
-    return baseline, problems
+    return baseline, problems, refused
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -1149,10 +1459,18 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     try:
-        baseline, problems = collect_problems(args.baseline, include_upgrade=not args.skip_upgrade)
+        baseline, problems, refused = collect_problems(args.baseline, include_upgrade=not args.skip_upgrade)
     except MigrationGuardError as exc:
         print(f"migration release guard could not run: {exc}", file=sys.stderr)
         return 2
+
+    # Printed on the way out whatever the verdict is: the columns the fixture holds no repeat
+    # of are the edge of what a pass covers, and a pass that does not say where its edge is
+    # invites being read as covering everything.
+    if refused:
+        print(f"the schema refused a repeat of {len(refused)} column(s), which the upgrade was not proved over:")
+        for target, objection in sorted(refused.items()):
+            print(f"  - {target}: {objection}")
 
     if problems:
         print(f"migration release guard failed (baseline {baseline}):", file=sys.stderr)

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -18,13 +18,17 @@ during autogenerate, so today's runtime can drive an older ``version_locations``
     rechained_revisions()         a released revision keeps its identity and every edge
                                   Alembic orders the graph by
     edited_released_bodies()      a released revision still does what the release ran
-    unrepairable_releases()       a database built by a released graph still comes out
-                                  ready when the upgrade users run upgrades it
+    unrepairable_releases()       a database built by a released graph, carrying rows,
+                                  still comes out ready when the upgrade users run
+                                  upgrades it
 
 Readiness is not this module's opinion. The last property drives ``run_migrations`` and
 asks ``background_tables_ready``, so it covers the repair and stamping that run before
 Alembic does, and it means by "ready" exactly what production means -- required columns
-included, not merely a full set of table names.
+included, not merely a full set of table names. It seeds the released schema first,
+because an empty database is the one case no user is in and is the case under which
+adding a NOT NULL column, tightening a nullable one, and building a unique index all
+succeed unconditionally.
 
 A release here is any installable tag, ``gh-vX.Y.ZrcN`` prereleases included, because a
 database in the field can have been built by one. The first three properties are metadata
@@ -56,7 +60,9 @@ from alembic import command
 from alembic.config import Config
 from alembic.script.base import _only_source_rev_file
 from alembic.util import to_tuple
+from packaging.version import InvalidVersion, Version
 
+from scripts.release_package_version import package_version_from_release_tag
 from storage.migrations import (
     HEAD_ONLY_REQUIRED_COLUMNS,
     HEAD_REQUIRED_COLUMNS,
@@ -101,23 +107,38 @@ def _git(*args: str) -> str:
     return result.stdout
 
 
-RELEASE_TAG = re.compile(r"^(?:gh-)?v(\d+)\.(\d+)\.(\d+)(?:rc(\d+))?$")
+def release_version(tag: str) -> Version | None:
+    """``tag``'s package version, or ``None`` if it is not a release tag.
 
-
-def version_key(tag: str) -> tuple[int, ...]:
-    """Sort key for a release tag, prereleases ordered before the version they lead to.
+    Borrowed rather than restated, the same way ``is_migration_source`` is. The publish
+    workflow turns a tag into a wheel by asking ``package_version_from_release_tag``, so a
+    tag it accepts is a tag that shipped -- and a rule stated separately here could only
+    ever come to disagree with the one that actually decides. Disagreeing in the direction
+    that drops tags is the expensive one: a release the filter does not recognise is
+    absent from every property below, so a migration first shipped in it can be rechained
+    or edited afterwards with nothing to compare against.
 
     ``gh-vX.Y.ZrcN`` prereleases are installable -- AGENTS.md §9 requires a wheel and an
     sdist in their release assets -- so a database in the field can have been built by
-    one, and a graph edited between the prerelease and the release is edited behind those
-    databases. Empty for anything that is not a release tag.
+    one, and PEP 440 already orders them before the release they lead to.
     """
-    match = RELEASE_TAG.match(tag)
-    if match is None:
-        return ()
-    major, minor, patch, candidate = match.groups()
-    ordinal = (0, int(candidate)) if candidate else (1, 0)
-    return (int(major), int(minor), int(patch), *ordinal)
+    try:
+        return Version(package_version_from_release_tag(tag))
+    except (ValueError, InvalidVersion):
+        return None
+
+
+def version_key(tag: str) -> tuple[Version, str]:
+    """Sort key ordering release tags by PEP 440, with the tag itself breaking ties.
+
+    ``vX.Y.Z`` and ``gh-vX.Y.Z`` carry one version between them, so something has to make
+    the order total; the tag string does it, and puts ``v`` last, which is what makes the
+    newest baseline the real release rather than its prerelease.
+    """
+    version = release_version(tag)
+    if version is None:
+        raise MigrationGuardError(f"{tag!r} is not a release tag")
+    return (version, tag)
 
 
 def versions_tree(tag: str) -> str | None:
@@ -145,7 +166,7 @@ def released_tags() -> list[str]:
     anyone is still running it.
     """
     names = _git("tag", "-l", "v*", "-l", "gh-v*").split()
-    candidates = sorted((tag for tag in names if version_key(tag)), key=version_key)
+    candidates = sorted((tag for tag in names if release_version(tag)), key=version_key)
     tags = [tag for tag in candidates if versions_tree(tag)]
     if not tags:
         # A guard that reads "no baseline" as "nothing to compare, therefore fine" passes
@@ -586,8 +607,159 @@ def describe_schema_gap(db_path: Path) -> str:
     return "; ".join(parts) or "the schema is incomplete in a way HEAD_TABLES and the required columns do not name"
 
 
-def schema_gap_after_upgrade(tag: str) -> str | None:
-    """Why a database built by ``tag``'s graph is not ready after today's upgrade, or ``None``.
+# SQLite names the one constraint an insert tripped, which is what makes the repair below
+# a guided search rather than a guess: the database says what it objected to, and the
+# objection itself carries the values it would have accepted.
+CHECK_FAILURE = re.compile(r"CHECK constraint failed: (\w+)")
+
+# Enough attempts to satisfy every constraint a row trips one at a time, and few enough
+# that a table whose constraints cannot be satisfied this way is given up on rather than
+# searched for. Reached only on the tables that refuse the first row at all.
+SEED_ATTEMPTS = 60
+
+
+def representative_value(column: str, declared_type: str) -> object:
+    """A value of ``declared_type`` that SQLite will store in ``column``.
+
+    Typed off the declaration rather than off the column's meaning, because meaning is
+    what no generic seeder can have and what a per-release fixture would have to restate
+    once per shipped graph. The name is consulted only where the declared type leaves the
+    choice open -- every TEXT column would otherwise get the same opaque string -- so a
+    migration that parses a timestamp, an address, or a JSON document gets something
+    parseable rather than ``'x'``.
+    """
+    kind = declared_type.upper()
+    if any(marker in kind for marker in ("INT", "REAL", "NUM", "DOUB", "FLOA", "BOOL")):
+        return 0
+    if "BLOB" in kind:
+        return b""
+    if column.endswith(("_at", "_time")):
+        return "1970-01-01T00:00:00+00:00"
+    if column.endswith("_json"):
+        return "{}"
+    if "email" in column:
+        return "seed@example.invalid"
+    return "x"
+
+
+def check_expression(ddl: str, name: str) -> str:
+    """Constraint ``name``'s expression as ``ddl`` declares it, or ``''`` if it has none."""
+    # SQLite stores the DDL as it was written, so the keywords are whatever case the
+    # migration that created the table happened to use.
+    marker = re.search(rf'CONSTRAINT\s+"?{re.escape(name)}"?\s+CHECK\s*\(', ddl, re.IGNORECASE)
+    if marker is None:
+        return ""
+    depth = 1
+    index = marker.end()
+    for offset in range(index, len(ddl)):
+        if ddl[offset] == "(":
+            depth += 1
+        elif ddl[offset] == ")":
+            depth -= 1
+            if depth == 0:
+                return ddl[index:offset]
+    return ""
+
+
+def check_proposals(expression: str, columns: Iterable[str]) -> list[tuple[str, str]]:
+    """``(column, value)`` pairs ``expression`` itself suggests, for the columns it names.
+
+    A check the row tripped is a check that says what it wants: ``state in ('waiting',
+    ...)`` carries both the column to change and the values it would have accepted. Only
+    columns the expression names are proposed for, because a literal from one constraint
+    written into a column that constraint never mentions is not a repair.
+
+    Reading the expression is a heuristic and is allowed to be wrong. SQLite decides
+    whether the resulting row is admissible, so a bad proposal costs an attempt rather
+    than producing a row the schema would have refused.
+    """
+    literals = re.findall(r"'([^']*)'", expression)
+    named = [column for column in columns if re.search(rf"\b{re.escape(column)}\b", expression)]
+    return [(column, literal) for column in named for literal in literals]
+
+
+def seed_representative_rows(db_path: Path) -> set[str]:
+    """Put one row in every table of the schema ``db_path`` holds; return the ones that refused.
+
+    A migration is only as safe as the data it runs over. On an empty database, adding a
+    NOT NULL column with no default, tightening a nullable one, backfilling from a column
+    being dropped, and building a unique index all succeed unconditionally -- so an
+    upgrade proved on an empty database is proved against the one case no user is in.
+    Seeding first is what makes the property below about the databases users carry.
+
+    The rows are derived from the schema, because the schema is what differs in every
+    release and ``pragma table_info`` already knows it; a fixture written per release
+    would cover the graphs that existed when it was written and quietly stop at the next
+    one. Only what the schema requires is filled -- NOT NULL or primary key, no default.
+    Leaving the rest NULL is deliberate and the more adversarial choice: a migration that
+    later makes a nullable column NOT NULL has to survive the NULLs a real database has.
+
+    Where a CHECK rejects that row, SQLite names the constraint and the constraint names
+    its own accepted values, so the repair proposes those and asks again. SQLite is the
+    judge throughout: a table is seeded only if the schema accepted the row.
+
+    What this proves is that the upgrade runs over rows, not that it runs over meaningful
+    ones -- foreign keys are off, which is SQLite's default and is what lets each table be
+    seeded on its own, so the rows are individually well-formed and collectively
+    inconsistent. Tables whose constraints encode a shape only the writing code knows are
+    returned rather than skipped quietly, so the coverage this leaves out is a number the
+    caller can print instead of an assumption.
+    """
+    refused = set()
+    with sqlite3.connect(db_path) as connection:
+        schema = [
+            (str(name), str(ddl))
+            for name, ddl in connection.execute(
+                "select name, sql from sqlite_master where type = 'table' and name not like 'sqlite_%'"
+            )
+            if name != ALEMBIC_BOOKKEEPING_TABLE
+        ]
+        for table, ddl in schema:
+            required = [
+                (str(row[1]), str(row[2]))
+                for row in connection.execute(f'pragma table_info("{table}")')
+                if (row[3] or row[5]) and row[4] is None
+            ]
+            if not required:
+                connection.execute(f'insert into "{table}" default values')
+                continue
+            columns = ", ".join(f'"{column}"' for column, _ in required)
+            placeholders = ", ".join("?" for _ in required)
+            statement = f'insert into "{table}" ({columns}) values ({placeholders})'
+            values = {column: representative_value(column, declared) for column, declared in required}
+            proposed: set[tuple[str, str]] = set()
+            for _ in range(SEED_ATTEMPTS):
+                try:
+                    connection.execute(statement, [values[column] for column, _ in required])
+                    break
+                except sqlite3.Error as exc:
+                    # However SQLite refuses the row, the table is simply one this cannot
+                    # seed. Only a named CHECK carries a repair, so anything else ends here.
+                    failure = CHECK_FAILURE.search(str(exc))
+                    if failure is None:
+                        break
+                    expression = check_expression(ddl, failure.group(1))
+                    untried = [
+                        pair
+                        for pair in check_proposals(expression, [column for column, _ in required])
+                        if pair not in proposed
+                    ]
+                    if not untried:
+                        break
+                    proposed.add(untried[0])
+                    values[untried[0][0]] = untried[0][1]
+            if connection.execute(f'select count(*) from "{table}"').fetchone()[0] == 0:
+                refused.add(table)
+        connection.commit()
+    return refused
+
+
+def schema_gap_after_upgrade(tag: str) -> tuple[str | None, set[str]]:
+    """``(gap, unseeded)`` -- why a database built by ``tag``'s graph is not ready, and what carried no row.
+
+    ``gap`` is ``None`` when the database comes out ready. ``unseeded`` is the tables the
+    upgrade therefore ran over empty, reported rather than dropped so the coverage this
+    property does not have is a number someone can read.
 
     The second stage runs ``storage.migrations.run_migrations`` rather than Alembic
     directly, and the verdict comes from ``background_tables_ready``. Both are deliberate:
@@ -619,33 +791,49 @@ def schema_gap_after_upgrade(tag: str) -> str | None:
                 f"its head {sorted(shipped_heads)!r}; the released graph was not applied in full"
             )
 
+        unseeded = seed_representative_rows(db_path)
         run_migrations(db_path)
-        return None if background_tables_ready(db_path) else describe_schema_gap(db_path)
+        gap = None if background_tables_ready(db_path) else describe_schema_gap(db_path)
+        return gap, unseeded
 
 
-def unrepairable_releases() -> dict[str, str]:
-    """``{tag: reason}`` for every release whose databases today's graph cannot bring to head."""
+def unrepairable_releases() -> tuple[dict[str, str], set[str]]:
+    """``({tag: reason}, unseeded)`` for every release today's graph cannot bring to head.
+
+    ``unseeded`` is the union across releases: a table no shipped schema would accept a
+    generic row for, and therefore one no release proved its upgrade over rows of.
+    """
     failures = {}
+    unseeded: set[str] = set()
     for tag in released_graphs():
         try:
-            gap = schema_gap_after_upgrade(tag)
+            gap, refused = schema_gap_after_upgrade(tag)
         except Exception as exc:  # noqa: BLE001 - however the upgrade fails, the verdict is the same
             failures[tag] = f"upgrade aborted with {type(exc).__name__}: {str(exc).splitlines()[0]}"
         else:
+            unseeded |= refused
             if gap is not None:
                 failures[tag] = f"upgrade left the database not ready: {gap}"
-    return failures
+    return failures, unseeded
 
 
-def collect_problems(baseline: str | None = None, *, include_upgrade: bool = True) -> tuple[str, list[str]]:
-    """``(baseline, problems)`` -- every property checked, every violation reported at once.
+def collect_problems(
+    baseline: str | None = None, *, include_upgrade: bool = True
+) -> tuple[str, list[str], list[str]]:
+    """``(baseline, problems, notes)`` -- every property checked, every violation reported at once.
 
     Reporting all of them together rather than stopping at the first is deliberate: a
     graph defect usually shows up in more than one property, and seeing which ones fire
     is most of the diagnosis.
+
+    ``notes`` carries what the run could not cover. It is separate from ``problems``
+    because a coverage limit is not a violation, and it is printed rather than dropped
+    because a guard that passes while quietly skipping part of its subject reads as
+    stronger than it is.
     """
     baseline = baseline or latest_released_tag()
     problems: list[str] = []
+    notes: list[str] = []
 
     disagreement = fresh_install_tables() ^ HEAD_TABLES
     if disagreement:
@@ -661,10 +849,16 @@ def collect_problems(baseline: str | None = None, *, include_upgrade: bool = Tru
     problems.extend(edited_released_bodies(baseline))
 
     if include_upgrade:
-        for tag, reason in sorted(unrepairable_releases().items(), key=lambda item: version_key(item[0])):
+        failures, unseeded = unrepairable_releases()
+        for tag, reason in sorted(failures.items(), key=lambda item: version_key(item[0])):
             problems.append(f"{tag}: {reason}")
+        if unseeded:
+            notes.append(
+                "no shipped schema accepted a generic row for these tables, so the upgrade ran "
+                f"over them empty: {', '.join(sorted(unseeded))}"
+            )
 
-    return baseline, problems
+    return baseline, problems, notes
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -684,10 +878,13 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     try:
-        baseline, problems = collect_problems(args.baseline, include_upgrade=not args.skip_upgrade)
+        baseline, problems, notes = collect_problems(args.baseline, include_upgrade=not args.skip_upgrade)
     except MigrationGuardError as exc:
         print(f"migration release guard could not run: {exc}", file=sys.stderr)
         return 2
+
+    for note in notes:
+        print(f"note: {note}", file=sys.stderr)
 
     if problems:
         print(f"migration release guard failed (baseline {baseline}):", file=sys.stderr)

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -15,7 +15,8 @@ during autogenerate, so today's runtime can drive an older ``version_locations``
     fresh_install_tables()        HEAD_TABLES is what a fresh install actually has, so
                                   the property below derives from something measured
     new_slot_collisions()         a change introduces no new duplicated slot number
-    rechained_revisions()         a released revision keeps its identity and its parent
+    rechained_revisions()         a released revision keeps its identity and every edge
+                                  Alembic orders the graph by
     unrepairable_releases()       a database built by a released graph still comes out
                                   ready when the upgrade users run upgrades it
 
@@ -50,6 +51,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from alembic import command
 from alembic.config import Config
+from alembic.util import to_tuple
 
 from storage.migrations import (
     HEAD_ONLY_REQUIRED_COLUMNS,
@@ -211,32 +213,70 @@ class _ComputedMetadata:
 COMPUTED = _ComputedMetadata()
 
 
-def revision_graph(sources: dict[str, str]) -> dict[str, tuple[str, object]]:
-    """``{revision: (filename, down_revision)}``, parsed rather than imported.
+# The module-level names Alembic itself reads out of a migration, mapped to the
+# ``Revision`` constructor arguments they become. Comparing fewer than all of them
+# compares a graph the guard invented rather than the one Alembic builds, and the
+# difference is a hole of exactly the outage's shape: the ordering changes while every
+# comparison here still matches. The mapping is held to that signature by a test, so a
+# field added upstream fails loudly instead of going unwatched.
+GRAPH_FIELDS = {
+    "revision": "revision",
+    "down_revision": "down_revision",
+    "depends_on": "dependencies",
+    "branch_labels": "branch_labels",
+}
+
+GRAPH_EDGES = tuple(field for field in GRAPH_FIELDS if field != "revision")
+
+
+def declared_graph_fields(source: str) -> dict[str, object]:
+    """The graph declarations a migration module makes, in either form Python allows.
+
+    ``revision: str = "..."`` is an ``AnnAssign``, and reading only ``Assign`` does not
+    merely lose the annotation -- it drops the migration out of the graph entirely, so it
+    is compared against nothing and any rechain of it passes.
+
+    Edge values are normalized with Alembic's own ``to_tuple``, exactly as ``Script``
+    does, so the guard's notion of "the same parent" is Alembic's notion and re-spelling
+    a value it already treats as equal is not reported as drift.
+    """
+    declared: dict[str, object] = {}
+    for node in ast.parse(source).body:
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target, value = node.targets[0], node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            target, value = node.target, node.value
+        else:
+            continue
+        if not isinstance(target, ast.Name) or target.id not in GRAPH_FIELDS:
+            continue
+        try:
+            literal = ast.literal_eval(value)
+        except ValueError:
+            declared[target.id] = COMPUTED
+            continue
+        declared[target.id] = literal if target.id == "revision" else to_tuple(literal, default=())
+    return declared
+
+
+def revision_graph(sources: dict[str, str]) -> dict[str, tuple[str, dict[str, object]]]:
+    """``{revision: (filename, {edge_field: value})}``, parsed rather than imported.
 
     Parsing keeps this free of import side effects and lets it read a revision from a
     release whose modules would no longer import against today's code. A computed value
     becomes ``COMPUTED``, which compares unequal to everything; a computed *revision*
     additionally cannot identify its file, so it is keyed by filename and can never be
-    mistaken for a literal revision that happens to render the same way.
+    mistaken for a literal revision that happens to render the same way. An edge a module
+    never declares is ``()``, which is what Alembic defaults it to.
     """
-    graph: dict[str, tuple[str, object]] = {}
+    graph: dict[str, tuple[str, dict[str, object]]] = {}
     for name, source in sources.items():
-        assigned: dict[str, object] = {}
-        for node in ast.parse(source).body:
-            if not isinstance(node, ast.Assign) or len(node.targets) != 1:
-                continue
-            target = node.targets[0]
-            if isinstance(target, ast.Name) and target.id in {"revision", "down_revision"}:
-                try:
-                    assigned[target.id] = ast.literal_eval(node.value)
-                except ValueError:
-                    assigned[target.id] = COMPUTED
-        if "revision" not in assigned:
+        declared = declared_graph_fields(source)
+        if "revision" not in declared:
             continue
-        revision = assigned["revision"]
+        revision = declared["revision"]
         key = f"<computed:{name}>" if revision is COMPUTED else str(revision)
-        graph[key] = (name, assigned.get("down_revision"))
+        graph[key] = (name, {field: declared.get(field, ()) for field in GRAPH_EDGES})
     return graph
 
 
@@ -244,13 +284,13 @@ def unverifiable_sources(sources: dict[str, str]) -> list[str]:
     """Filenames whose revision metadata is computed, and so cannot be compared at all."""
     return sorted(
         name
-        for key, (name, down_revision) in revision_graph(sources).items()
-        if down_revision is COMPUTED or key.startswith("<computed:")
+        for key, (name, edges) in revision_graph(sources).items()
+        if key.startswith("<computed:") or any(value is COMPUTED for value in edges.values())
     )
 
 
 def rechained_revisions(baseline: str | None = None) -> list[str]:
-    """Released revisions whose identity or parent has changed since the baseline release.
+    """Released revisions whose identity or graph edges have changed since the baseline.
 
     This is the property the outage broke. Inserting an ancestor behind a revision the
     field has already passed is invisible to Alembic, which only walks forward, and
@@ -265,16 +305,18 @@ def rechained_revisions(baseline: str | None = None) -> list[str]:
         f"{name} computes its migration metadata, so the guard cannot hold it to {baseline}"
         for name in unverifiable_sources(working_tree)
     ]
-    for revision, (name, down_revision) in sorted(revision_graph(released_sources(baseline)).items()):
+    for revision, (name, shipped) in sorted(revision_graph(released_sources(baseline)).items()):
         if revision not in current:
             problems.append(f"{revision} ({name}) shipped in {baseline} and is no longer in the graph")
-        elif current[revision][1] is COMPUTED:
+            continue
+        edges = current[revision][1]
+        if any(value is COMPUTED for value in edges.values()):
             continue  # already reported above, and reporting it twice describes one defect as two
-        elif current[revision][1] != down_revision:
-            problems.append(
-                f"{revision} ({name}) shipped in {baseline} with down_revision={down_revision!r} "
-                f"and now has {current[revision][1]!r}"
-            )
+        drift = "; ".join(
+            f"{field} {value!r} -> {edges[field]!r}" for field, value in shipped.items() if edges[field] != value
+        )
+        if drift:
+            problems.append(f"{revision} ({name}) no longer matches what {baseline} shipped: {drift}")
     return problems
 
 

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Hold the Alembic migration graph to the shape its releases already shipped.
+
+A released migration graph is a shipped surface. Databases in the field were built by it,
+they record only the revision they reached, and Alembic walks them forward from there and
+never back. So editing a released revision's parentage does not change what those
+databases have already done -- it changes what they will do next, silently, with no error
+at the moment of the edit and no error at the moment of the upgrade.
+
+Four properties, one primitive: the graph as a released tag actually shipped it, read
+straight out of git. Nothing here is a hand-maintained list of known-bad cases, and
+nothing needs an old Python environment -- ``env.py`` reads ``target_metadata`` only
+during autogenerate, so today's runtime can drive an older ``version_locations``.
+
+    fresh_install_tables()        HEAD_TABLES is what a fresh install actually has, so
+                                  the property below derives from something measured
+    new_slot_collisions()         a change introduces no new duplicated slot number
+    rechained_revisions()         a released revision keeps its identity and its parent
+    unrepairable_releases()       a database built by a released graph still reaches the
+                                  full schema when today's graph upgrades it
+
+The first three are metadata only. The fourth builds a database per release and costs
+roughly a fifth of a second each.
+
+Run it directly, or through the ``migration-release-guard`` workflow, which is the job
+that supplies the full tag history this needs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from collections import defaultdict
+from collections.abc import Iterable
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from alembic import command
+from alembic.config import Config
+
+from storage.migrations import HEAD_TABLES, alembic_dir
+
+VERSIONS_PATH = "storage/alembic/versions"
+
+# ``20260806_0047_remove_session_queue_hold.py`` -> slot ``0047``. Two branches choosing
+# the same slot is how the graph forked: the filenames differ, so git merges both without
+# a conflict and the duplicate number is the only trace left.
+SLOT_PATTERN = re.compile(r"^\d{8}_(\d{4})_.*\.py$")
+
+# Alembic's own bookkeeping. It is the one table a database has that no migration
+# declares, so it is the one exclusion when comparing a real database to HEAD_TABLES.
+ALEMBIC_BOOKKEEPING_TABLE = "alembic_version"
+
+
+class MigrationGuardError(RuntimeError):
+    """Raised when the guard cannot reach the release history it exists to compare against."""
+
+
+def _git(*args: str) -> str:
+    result = subprocess.run(["git", *args], capture_output=True, text=True, check=False, cwd=REPO_ROOT)
+    if result.returncode != 0:
+        raise MigrationGuardError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def version_key(tag: str) -> tuple[int, ...]:
+    """Sort key for a ``vX.Y.Z`` tag; empty for anything that is not one."""
+    try:
+        return tuple(int(part) for part in tag.lstrip("v").split("."))
+    except ValueError:
+        return ()
+
+
+def _carries_migrations(tag: str) -> bool:
+    result = subprocess.run(
+        ["git", "cat-file", "-e", f"{tag}:{VERSIONS_PATH}"],
+        capture_output=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    return result.returncode == 0
+
+
+def released_tags() -> list[str]:
+    """Every release tag that shipped a migrations directory, oldest first.
+
+    The window is derived, not chosen. A tag without ``storage/alembic/versions`` never
+    put a migrated database in the field; every tag with one did. A "last N releases"
+    cutoff would instead stop covering a release on a schedule unrelated to whether
+    anyone is still running it.
+    """
+    candidates = sorted((tag for tag in _git("tag", "-l", "v*").split() if version_key(tag)), key=version_key)
+    tags = [tag for tag in candidates if _carries_migrations(tag)]
+    if not tags:
+        # A guard that reads "no baseline" as "nothing to compare, therefore fine" passes
+        # forever while proving nothing. Refuse instead, and name the cause: a shallow
+        # checkout is the way this happens in practice.
+        raise MigrationGuardError(
+            f"no release tag carries {VERSIONS_PATH}, so there is no shipped graph to compare "
+            "against; a shallow checkout without tags produces exactly this (CI needs "
+            "actions/checkout with fetch-depth: 0)"
+        )
+    return tags
+
+
+def latest_released_tag() -> str:
+    """The baseline for the metadata properties: the newest release carrying migrations.
+
+    Comparing against the newest release rather than against all of them is what keeps
+    the guard honest about the past. A splice that has already shipped cannot be
+    un-shipped -- reverting it would break the databases that did apply it -- so demanding
+    that history be clean would leave the guard permanently red and therefore ignored.
+    Each release is instead checked against its predecessor while it is still unreleased,
+    and the invariant chains forward without relitigating anything.
+    """
+    return released_tags()[-1]
+
+
+def released_sources(tag: str) -> dict[str, str]:
+    """``{filename: source}`` for the migration files exactly as ``tag`` shipped them."""
+    names = _git("ls-tree", "--name-only", f"{tag}:{VERSIONS_PATH}").split()
+    return {name: _git("show", f"{tag}:{VERSIONS_PATH}/{name}") for name in names if name.endswith(".py")}
+
+
+def working_tree_sources() -> dict[str, str]:
+    """``{filename: source}`` for the migration files as they are right now."""
+    return {path.name: path.read_text(encoding="utf-8") for path in (REPO_ROOT / VERSIONS_PATH).glob("*.py")}
+
+
+def extract_released_versions(tag: str, destination: Path) -> Path:
+    """Materialise ``tag``'s versions directory under ``destination`` for Alembic to walk."""
+    destination.mkdir(parents=True, exist_ok=True)
+    archive = subprocess.run(
+        ["git", "archive", tag, VERSIONS_PATH],
+        capture_output=True,
+        check=True,
+        cwd=REPO_ROOT,
+    ).stdout
+    subprocess.run(["tar", "-x", "-C", str(destination)], input=archive, check=True)
+    return destination / VERSIONS_PATH
+
+
+def slot_collisions(filenames: Iterable[str]) -> dict[str, set[str]]:
+    """``{slot: filenames}`` for every slot number claimed by more than one file."""
+    slots: dict[str, set[str]] = defaultdict(set)
+    for name in filenames:
+        match = SLOT_PATTERN.match(name)
+        if match:
+            slots[match.group(1)].add(name)
+    return {slot: names for slot, names in slots.items() if len(names) > 1}
+
+
+def new_slot_collisions(baseline: str | None = None) -> dict[str, set[str]]:
+    """Slots that collide now and did not collide in the baseline release.
+
+    The collisions history already contains are in the baseline itself, so they need no
+    allowlist -- and cannot decay into one that outlives the reason it was written.
+    """
+    baseline = baseline or latest_released_tag()
+    shipped = slot_collisions(released_sources(baseline))
+    return {slot: names for slot, names in slot_collisions(working_tree_sources()).items() if slot not in shipped}
+
+
+def revision_graph(sources: dict[str, str]) -> dict[str, tuple[str, object]]:
+    """``{revision: (filename, down_revision)}``, parsed rather than imported.
+
+    Parsing keeps this free of import side effects and lets it read a revision from a
+    release whose modules would no longer import against today's code. A revision that
+    computes either value instead of assigning a literal reads as ``"<computed>"``, which
+    compares unequal to itself and so is reported rather than skipped.
+    """
+    graph: dict[str, tuple[str, object]] = {}
+    for name, source in sources.items():
+        assigned: dict[str, object] = {}
+        for node in ast.parse(source).body:
+            if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+                continue
+            target = node.targets[0]
+            if isinstance(target, ast.Name) and target.id in {"revision", "down_revision"}:
+                try:
+                    assigned[target.id] = ast.literal_eval(node.value)
+                except ValueError:
+                    assigned[target.id] = "<computed>"
+        if "revision" in assigned:
+            graph[str(assigned["revision"])] = (name, assigned.get("down_revision"))
+    return graph
+
+
+def rechained_revisions(baseline: str | None = None) -> list[str]:
+    """Released revisions whose identity or parent has changed since the baseline release.
+
+    This is the property the outage broke. Inserting an ancestor behind a revision the
+    field has already passed is invisible to Alembic, which only walks forward, and
+    invisible to a single-head assertion, which a merge revision satisfies. It is visible
+    here because the shipped parent is read from the release rather than inferred from
+    the graph that replaced it.
+    """
+    baseline = baseline or latest_released_tag()
+    current = revision_graph(working_tree_sources())
+    problems = []
+    for revision, (name, down_revision) in sorted(revision_graph(released_sources(baseline)).items()):
+        if revision not in current:
+            problems.append(f"{revision} ({name}) shipped in {baseline} and is no longer in the graph")
+        elif current[revision][1] != down_revision:
+            problems.append(
+                f"{revision} ({name}) shipped in {baseline} with down_revision={down_revision!r} "
+                f"and now has {current[revision][1]!r}"
+            )
+    return problems
+
+
+def _alembic_config(db_path: Path, versions: Path | None = None) -> Config:
+    config = Config()
+    config.set_main_option("script_location", str(alembic_dir()))
+    if versions is not None:
+        # Without this Alembic splits version_locations on spaces and commas, so a
+        # temporary directory containing either would silently resolve to no location at
+        # all -- and an empty graph upgrades to head without applying anything.
+        config.set_main_option("path_separator", "os")
+        config.set_main_option("version_locations", str(versions))
+    config.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return config
+
+
+def table_names(db_path: Path) -> set[str]:
+    connection = sqlite3.connect(db_path)
+    try:
+        return {str(row[0]) for row in connection.execute("select name from sqlite_master where type = 'table'")}
+    finally:
+        connection.close()
+
+
+def fresh_install_tables() -> set[str]:
+    """The tables a database has after today's graph builds it from empty."""
+    with tempfile.TemporaryDirectory() as workspace:
+        db_path = Path(workspace) / "vibe.sqlite"
+        command.upgrade(_alembic_config(db_path), "head")
+        return table_names(db_path) - {ALEMBIC_BOOKKEEPING_TABLE}
+
+
+def stamped_revision(db_path: Path) -> str | None:
+    connection = sqlite3.connect(db_path)
+    try:
+        rows = connection.execute(f"select version_num from {ALEMBIC_BOOKKEEPING_TABLE}").fetchall()
+    except sqlite3.OperationalError:
+        return None
+    finally:
+        connection.close()
+    return str(rows[0][0]) if len(rows) == 1 else None
+
+
+def missing_tables_after_upgrade(tag: str) -> set[str]:
+    """Tables still absent after a database built by ``tag``'s graph is upgraded by today's.
+
+    Whatever Alembic raises when the upgrade itself aborts propagates: a crash and a
+    silently incomplete schema are the same failure of the same property, and the caller
+    records them the same way.
+    """
+    with tempfile.TemporaryDirectory() as workspace:
+        root = Path(workspace)
+        db_path = root / "vibe.sqlite"
+        released = extract_released_versions(tag, root / "released")
+        command.upgrade(_alembic_config(db_path, released), "head")
+
+        # An Alembic run that resolves ``version_locations`` to nothing reports success
+        # and applies nothing, and an empty database then upgrades cleanly to today's head
+        # -- the guard's own false-negative. Confirm the first upgrade really walked the
+        # released graph before believing anything the second one produces.
+        stamp = stamped_revision(db_path)
+        if stamp is None or stamp not in revision_graph(released_sources(tag)):
+            raise MigrationGuardError(
+                f"upgrading with {tag}'s graph left the database stamped {stamp!r}, which is not "
+                f"one of its revisions; the released graph was not applied"
+            )
+
+        command.upgrade(_alembic_config(db_path), "head")
+        return HEAD_TABLES - table_names(db_path)
+
+
+def unrepairable_releases() -> dict[str, str]:
+    """``{tag: reason}`` for every release whose databases today's graph cannot bring to head."""
+    failures = {}
+    for tag in released_tags():
+        try:
+            missing = missing_tables_after_upgrade(tag)
+        except Exception as exc:  # noqa: BLE001 - however the upgrade fails, the verdict is the same
+            failures[tag] = f"upgrade aborted with {type(exc).__name__}: {str(exc).splitlines()[0]}"
+        else:
+            if missing:
+                failures[tag] = f"upgrade left {len(missing)} table(s) missing: {', '.join(sorted(missing))}"
+    return failures
+
+
+def collect_problems(baseline: str | None = None, *, include_upgrade: bool = True) -> tuple[str, list[str]]:
+    """``(baseline, problems)`` -- every property checked, every violation reported at once.
+
+    Reporting all of them together rather than stopping at the first is deliberate: a
+    graph defect usually shows up in more than one property, and seeing which ones fire
+    is most of the diagnosis.
+    """
+    baseline = baseline or latest_released_tag()
+    problems: list[str] = []
+
+    disagreement = fresh_install_tables() ^ HEAD_TABLES
+    if disagreement:
+        problems.append(
+            "storage.migrations.HEAD_TABLES disagrees with a fresh install on: "
+            f"{', '.join(sorted(disagreement))}"
+        )
+
+    for slot, names in sorted(new_slot_collisions(baseline).items()):
+        problems.append(f"slot {slot} did not collide in {baseline} and now does: {', '.join(sorted(names))}")
+
+    problems.extend(rechained_revisions(baseline))
+
+    if include_upgrade:
+        for tag, reason in sorted(unrepairable_releases().items(), key=lambda item: version_key(item[0])):
+            problems.append(f"{tag}: {reason}")
+
+    return baseline, problems
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Hold the migration graph to the shape its releases shipped.")
+    parser.add_argument(
+        "--baseline",
+        help="release tag to compare metadata against (default: the newest release carrying migrations)",
+    )
+    parser.add_argument(
+        "--skip-upgrade",
+        action="store_true",
+        help="check only the metadata properties, skipping the per-release upgrade",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        baseline, problems = collect_problems(args.baseline, include_upgrade=not args.skip_upgrade)
+    except MigrationGuardError as exc:
+        print(f"migration release guard could not run: {exc}", file=sys.stderr)
+        return 2
+
+    if problems:
+        print(f"migration release guard failed (baseline {baseline}):", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    print(f"migration release guard passed (baseline {baseline})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -7,7 +7,7 @@ never back. So editing a released revision's parentage does not change what thos
 databases have already done -- it changes what they will do next, silently, with no error
 at the moment of the edit and no error at the moment of the upgrade.
 
-Four properties, one primitive: the graph as a released tag actually shipped it, read
+Five properties, one primitive: the graph as a released tag actually shipped it, read
 straight out of git. Nothing here is a hand-maintained list of known-bad cases, and
 nothing needs an old Python environment -- ``env.py`` reads ``target_metadata`` only
 during autogenerate, so today's runtime can drive an older ``version_locations``.
@@ -17,6 +17,7 @@ during autogenerate, so today's runtime can drive an older ``version_locations``
     new_slot_collisions()         a change introduces no new duplicated slot number
     rechained_revisions()         a released revision keeps its identity and every edge
                                   Alembic orders the graph by
+    edited_released_bodies()      a released revision still does what the release ran
     unrepairable_releases()       a database built by a released graph still comes out
                                   ready when the upgrade users run upgrades it
 
@@ -53,6 +54,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from alembic import command
 from alembic.config import Config
+from alembic.script.base import _only_source_rev_file
 from alembic.util import to_tuple
 
 from storage.migrations import (
@@ -78,6 +80,18 @@ ALEMBIC_BOOKKEEPING_TABLE = "alembic_version"
 
 class MigrationGuardError(RuntimeError):
     """Raised when the guard cannot reach the release history it exists to compare against."""
+
+
+def is_migration_source(name: str) -> bool:
+    """Whether Alembic will load ``name`` as a migration, decided by Alembic's own rule.
+
+    Borrowed rather than restated, for the same reason ``GRAPH_FIELDS`` is measured off
+    ``Revision.__init__``: a file Alembic imports is a file this guard must account for,
+    so the two cannot be permitted to disagree about which files those are. Alembic
+    rejects a matching file that declares no ``revision`` outright, so nothing this admits
+    is optional for it either -- which makes it the right denominator for coverage.
+    """
+    return _only_source_rev_file.match(name) is not None
 
 
 def _git(*args: str) -> str:
@@ -340,23 +354,36 @@ def revision_graph(sources: dict[str, str]) -> dict[str, tuple[str, dict[str, ob
 def ungraphable_sources(sources: dict[str, str]) -> dict[str, str]:
     """``{filename: why the guard cannot hold that file to a released graph}``.
 
-    Both reasons are one defect wearing two faces: a key the guard invents has stopped
-    naming exactly one migration. Metadata it cannot read as a literal names nothing, and
-    an identifier two modules declare names two things. Either way the honest answer is
-    "cannot verify", and the one answer that must stay unreachable is "verified unchanged".
+    One defect wearing three faces: a key the guard invents has stopped naming exactly one
+    migration. Metadata it cannot read as a literal names nothing, an identifier two
+    modules declare names two things, and a file declaring no revision at all is never
+    keyed and so was never named by anything. Either way the honest answer is "cannot
+    verify", and the one answer that must stay unreachable is "verified unchanged".
+
+    That third face is why the denominator below is Alembic's file rule and not this
+    module's parse of those files. Asking the parser which files there were to read is
+    self-confirming -- a file it cannot see is absent from its own account of what it saw
+    -- and each earlier version of this function asked exactly that, which is why the same
+    defect kept arriving wearing a new face.
 
     Every caller reading a source tree owes this its output: a tree is compared only
     alongside the reasons parts of it cannot be, or refused outright.
     """
     reasons: dict[str, str] = {}
-    for revision, claims in revision_claims(sources).items():
-        names = [name for name, _ in claims]
-        for name, edges in claims:
+    claims = revision_claims(sources)
+    for revision, claimants in claims.items():
+        names = [name for name, _ in claimants]
+        for name, edges in claimants:
             if revision.startswith("<computed:") or any(value is COMPUTED for value in edges.values()):
                 reasons[name] = "computes its migration metadata"
-            elif len(claims) > 1:
+            elif len(claimants) > 1:
                 others = ", ".join(other for other in names if other != name)
                 reasons[name] = f"declares revision {revision!r}, which {others} also declares"
+
+    keyed = {name for claimants in claims.values() for name, _ in claimants}
+    for name in sources:
+        if name not in keyed and is_migration_source(name):
+            reasons[name] = "declares no module-level revision"
     return reasons
 
 
@@ -432,6 +459,37 @@ def rechained_revisions(baseline: str | None = None) -> list[str]:
         if drift:
             problems.append(f"{revision} ({name}) no longer matches what {baseline} shipped: {drift}")
     return problems
+
+
+def edited_released_bodies(baseline: str | None = None) -> list[str]:
+    """Released migration files whose contents are no longer what the baseline shipped.
+
+    The properties above watch what a migration *declares*; this watches what it *does*.
+    They are one contract seen from two sides -- a released migration is a shipped surface
+    -- and this repository has produced one defect of each shape: the v3.0.11 outage moved
+    a ``down_revision``, and ``20260501_0001`` had its ``upgrade()`` body edited after
+    release. Editing the body is the quieter half. A database stamped at that revision
+    never reruns it, a fresh install runs only the new version, and nothing raises at
+    either moment.
+
+    The upgrade property notices such an edit only when the divergence reaches readiness.
+    An added index, constraint, or backfill leaves both databases ready and permanently
+    different, so it cannot be relied on to notice in general -- and concluding otherwise
+    from the one edit it did catch is how this gap survived a whole design pass.
+
+    No exemption for edits judged harmless. Judging them is the convention this guard
+    exists to replace, and no exemption is needed: restoring the shipped file and adding a
+    new migration carrying the change is always available, and is the only form of the
+    change every database can actually apply.
+    """
+    baseline = baseline or latest_released_tag()
+    current = working_tree_sources()
+    return [
+        f"{name} is no longer what {baseline} shipped; a released migration's body is fixed "
+        "once a database has run it"
+        for name, source in sorted(released_sources(baseline).items())
+        if is_migration_source(name) and name in current and current[name] != source
+    ]
 
 
 def _alembic_config(db_path: Path, versions: Path | None = None) -> Config:
@@ -573,6 +631,7 @@ def collect_problems(baseline: str | None = None, *, include_upgrade: bool = Tru
         problems.append(f"slot {slot} did not collide in {baseline} and now does: {', '.join(sorted(names))}")
 
     problems.extend(rechained_revisions(baseline))
+    problems.extend(edited_released_bodies(baseline))
 
     if include_upgrade:
         for tag, reason in sorted(unrepairable_releases().items(), key=lambda item: version_key(item[0])):

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -25,8 +25,10 @@ asks ``background_tables_ready``, so it covers the repair and stamping that run 
 Alembic does, and it means by "ready" exactly what production means -- required columns
 included, not merely a full set of table names.
 
-The first three are metadata only. The fourth builds a database per release and costs
-roughly a fifth of a second each.
+A release here is any installable tag, ``gh-vX.Y.ZrcN`` prereleases included, because a
+database in the field can have been built by one. The first three properties are metadata
+only; the fourth builds a database per *distinct shipped graph*, which is what makes that
+wider window affordable -- many tags ship byte-identical migrations.
 
 Run it directly, or through the ``migration-release-guard`` workflow, which is the job
 that supplies the full tag history this needs.
@@ -85,22 +87,39 @@ def _git(*args: str) -> str:
     return result.stdout
 
 
+RELEASE_TAG = re.compile(r"^(?:gh-)?v(\d+)\.(\d+)\.(\d+)(?:rc(\d+))?$")
+
+
 def version_key(tag: str) -> tuple[int, ...]:
-    """Sort key for a ``vX.Y.Z`` tag; empty for anything that is not one."""
-    try:
-        return tuple(int(part) for part in tag.lstrip("v").split("."))
-    except ValueError:
+    """Sort key for a release tag, prereleases ordered before the version they lead to.
+
+    ``gh-vX.Y.ZrcN`` prereleases are installable -- AGENTS.md §9 requires a wheel and an
+    sdist in their release assets -- so a database in the field can have been built by
+    one, and a graph edited between the prerelease and the release is edited behind those
+    databases. Empty for anything that is not a release tag.
+    """
+    match = RELEASE_TAG.match(tag)
+    if match is None:
         return ()
+    major, minor, patch, candidate = match.groups()
+    ordinal = (0, int(candidate)) if candidate else (1, 0)
+    return (int(major), int(minor), int(patch), *ordinal)
 
 
-def _carries_migrations(tag: str) -> bool:
+def versions_tree(tag: str) -> str | None:
+    """The git object id of ``tag``'s versions directory, or ``None`` if it shipped none.
+
+    Identity of a shipped graph, straight from git: two tags with the same object id
+    shipped byte-identical migrations and therefore put the same database in the field.
+    """
     result = subprocess.run(
-        ["git", "cat-file", "-e", f"{tag}:{VERSIONS_PATH}"],
+        ["git", "rev-parse", "--verify", "--quiet", f"{tag}^{{}}:{VERSIONS_PATH}"],
         capture_output=True,
         check=False,
+        text=True,
         cwd=REPO_ROOT,
     )
-    return result.returncode == 0
+    return result.stdout.strip() or None
 
 
 def released_tags() -> list[str]:
@@ -111,8 +130,9 @@ def released_tags() -> list[str]:
     cutoff would instead stop covering a release on a schedule unrelated to whether
     anyone is still running it.
     """
-    candidates = sorted((tag for tag in _git("tag", "-l", "v*").split() if version_key(tag)), key=version_key)
-    tags = [tag for tag in candidates if _carries_migrations(tag)]
+    names = _git("tag", "-l", "v*", "-l", "gh-v*").split()
+    candidates = sorted((tag for tag in names if version_key(tag)), key=version_key)
+    tags = [tag for tag in candidates if versions_tree(tag)]
     if not tags:
         # A guard that reads "no baseline" as "nothing to compare, therefore fine" passes
         # forever while proving nothing. Refuse instead, and name the cause: a shallow
@@ -136,6 +156,21 @@ def latest_released_tag() -> str:
     and the invariant chains forward without relitigating anything.
     """
     return released_tags()[-1]
+
+
+def released_graphs() -> list[str]:
+    """One tag per distinct shipped graph, oldest first: the first release that shipped it.
+
+    The unit is a graph, not a tag. What puts a database in the field is a versions
+    directory, so the many prerelease tags that ship a byte-identical one all put the same
+    database there and building it once is building it for all of them. That is what makes
+    covering every installable tag affordable: one ``git rev-parse`` per tag instead of one
+    database per tag, with no release left unexercised.
+    """
+    graphs: dict[str, str] = {}
+    for tag in released_tags():
+        graphs.setdefault(str(versions_tree(tag)), tag)
+    return sorted(graphs.values(), key=version_key)
 
 
 def released_sources(tag: str) -> dict[str, str]:
@@ -259,8 +294,8 @@ def declared_graph_fields(source: str) -> dict[str, object]:
     return declared
 
 
-def revision_graph(sources: dict[str, str]) -> dict[str, tuple[str, dict[str, object]]]:
-    """``{revision: (filename, {edge_field: value})}``, parsed rather than imported.
+def revision_claims(sources: dict[str, str]) -> dict[str, list[tuple[str, dict[str, object]]]]:
+    """Every claim on every revision identifier, contested ones included.
 
     Parsing keeps this free of import side effects and lets it read a revision from a
     release whose modules would no longer import against today's code. A computed value
@@ -268,25 +303,72 @@ def revision_graph(sources: dict[str, str]) -> dict[str, tuple[str, dict[str, ob
     additionally cannot identify its file, so it is keyed by filename and can never be
     mistaken for a literal revision that happens to render the same way. An edge a module
     never declares is ``()``, which is what Alembic defaults it to.
+
+    The identifier is the guard's only handle on "the same migration across two releases",
+    and two modules can declare it at once. Keeping the claimants as a list is what lets a
+    caller report that rather than overwrite one of them: the survivor would otherwise
+    answer for a migration whose body Alembic will skip on any database stamped with the
+    shared identifier.
     """
-    graph: dict[str, tuple[str, dict[str, object]]] = {}
-    for name, source in sources.items():
+    claims: dict[str, list[tuple[str, dict[str, object]]]] = {}
+    for name, source in sorted(sources.items()):
         declared = declared_graph_fields(source)
         if "revision" not in declared:
             continue
         revision = declared["revision"]
         key = f"<computed:{name}>" if revision is COMPUTED else str(revision)
-        graph[key] = (name, {field: declared.get(field, ()) for field in GRAPH_EDGES})
-    return graph
+        edges = {field: declared.get(field, ()) for field in GRAPH_EDGES}
+        claims.setdefault(key, []).append((name, edges))
+    return claims
 
 
-def unverifiable_sources(sources: dict[str, str]) -> list[str]:
-    """Filenames whose revision metadata is computed, and so cannot be compared at all."""
-    return sorted(
-        name
-        for key, (name, edges) in revision_graph(sources).items()
-        if key.startswith("<computed:") or any(value is COMPUTED for value in edges.values())
-    )
+def revision_graph(sources: dict[str, str]) -> dict[str, tuple[str, dict[str, object]]]:
+    """``{revision: (filename, {edge_field: value})}`` for identifiers naming one readable migration.
+
+    A contested or computed identifier names nothing a comparison could be about, so it is
+    absent here and reported by ``ungraphable_sources`` instead. The two functions
+    partition the source tree, which is the whole point: a migration that fell out of both
+    would be one the guard neither checked nor admitted it could not check.
+    """
+    unreadable = ungraphable_sources(sources)
+    return {
+        revision: claims[0]
+        for revision, claims in revision_claims(sources).items()
+        if len(claims) == 1 and claims[0][0] not in unreadable
+    }
+
+
+def ungraphable_sources(sources: dict[str, str]) -> dict[str, str]:
+    """``{filename: why the guard cannot hold that file to a released graph}``.
+
+    Both reasons are one defect wearing two faces: a key the guard invents has stopped
+    naming exactly one migration. Metadata it cannot read as a literal names nothing, and
+    an identifier two modules declare names two things. Either way the honest answer is
+    "cannot verify", and the one answer that must stay unreachable is "verified unchanged"
+    -- so this partitions the source tree with ``revision_graph``: every migration is a
+    node the comparison reaches or a reason it refuses to run, never neither.
+    """
+    reasons: dict[str, str] = {}
+    for revision, claims in revision_claims(sources).items():
+        names = [name for name, _ in claims]
+        for name, edges in claims:
+            if revision.startswith("<computed:") or any(value is COMPUTED for value in edges.values()):
+                reasons[name] = "computes its migration metadata"
+            elif len(claims) > 1:
+                others = ", ".join(other for other in names if other != name)
+                reasons[name] = f"declares revision {revision!r}, which {others} also declares"
+    return reasons
+
+
+def shipped_head_revisions(sources: dict[str, str]) -> set[str]:
+    """The revisions nothing in ``sources`` descends from: where a full upgrade of them ends.
+
+    ``depends_on`` is an ordering constraint rather than a parent link, so only
+    ``down_revision`` decides what is still a head -- the same rule Alembic applies.
+    """
+    graph = revision_graph(sources)
+    parents = {parent for _, edges in graph.values() for parent in edges["down_revision"]}
+    return set(graph) - parents
 
 
 def rechained_revisions(baseline: str | None = None) -> list[str]:
@@ -300,18 +382,21 @@ def rechained_revisions(baseline: str | None = None) -> list[str]:
     """
     baseline = baseline or latest_released_tag()
     working_tree = working_tree_sources()
+    claimed = revision_claims(working_tree)
     current = revision_graph(working_tree)
     problems = [
-        f"{name} computes its migration metadata, so the guard cannot hold it to {baseline}"
-        for name in unverifiable_sources(working_tree)
+        f"{name} {reason}, so the guard cannot hold it to {baseline}"
+        for name, reason in sorted(ungraphable_sources(working_tree).items())
     ]
     for revision, (name, shipped) in sorted(revision_graph(released_sources(baseline)).items()):
         if revision not in current:
+            if revision in claimed:
+                # Still claimed, just not readably: every claimant is named once in the
+                # reasons above, and repeating it here describes one defect as two.
+                continue
             problems.append(f"{revision} ({name}) shipped in {baseline} and is no longer in the graph")
             continue
         edges = current[revision][1]
-        if any(value is COMPUTED for value in edges.values()):
-            continue  # already reported above, and reporting it twice describes one defect as two
         drift = "; ".join(
             f"{field} {value!r} -> {edges[field]!r}" for field, value in shipped.items() if edges[field] != value
         )
@@ -404,17 +489,20 @@ def schema_gap_after_upgrade(tag: str) -> str | None:
         root = Path(workspace)
         db_path = root / "vibe.sqlite"
         released = extract_released_versions(tag, root / "released")
+        # Read from the tag's own files, before Alembic is involved at all. Asking the
+        # resolved graph for its head instead would make this self-confirming: an
+        # extraction or ``version_locations`` that silently resolved to a prefix produces a
+        # smaller graph whose head the run then trivially reaches, and it is exactly that
+        # database -- one the release never put in the field, and one today's graph can
+        # legitimately repair -- whose clean upgrade would be read as evidence.
+        shipped_heads = shipped_head_revisions(released_sources(tag))
         command.upgrade(_alembic_config(db_path, released), "head")
 
-        # An Alembic run that resolves ``version_locations`` to nothing reports success
-        # and applies nothing, and an empty database then upgrades cleanly to today's head
-        # -- the guard's own false-negative. Confirm the first upgrade really walked the
-        # released graph before believing anything the second one produces.
         stamp = stamped_revision(db_path)
-        if stamp is None or stamp not in revision_graph(released_sources(tag)):
+        if stamp is None or stamp not in shipped_heads:
             raise MigrationGuardError(
-                f"upgrading with {tag}'s graph left the database stamped {stamp!r}, which is not "
-                f"one of its revisions; the released graph was not applied"
+                f"upgrading with {tag}'s graph left the database stamped {stamp!r} rather than at "
+                f"its head {sorted(shipped_heads)!r}; the released graph was not applied in full"
             )
 
         run_migrations(db_path)
@@ -424,7 +512,7 @@ def schema_gap_after_upgrade(tag: str) -> str | None:
 def unrepairable_releases() -> dict[str, str]:
     """``{tag: reason}`` for every release whose databases today's graph cannot bring to head."""
     failures = {}
-    for tag in released_tags():
+    for tag in released_graphs():
         try:
             gap = schema_gap_after_upgrade(tag)
         except Exception as exc:  # noqa: BLE001 - however the upgrade fails, the verdict is the same

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -461,8 +461,24 @@ def rechained_revisions(baseline: str | None = None) -> list[str]:
     return problems
 
 
+def released_bodies(sources: dict[str, str]) -> dict[str, tuple[str, str]]:
+    """``{revision: (filename, source)}`` -- what each migration in ``sources`` runs.
+
+    Keyed by revision because that is the key Alembic uses. A filename is not a migration's
+    identity: databases record the revision, ``version_locations`` is scanned rather than
+    enumerated, and renaming a file changes nothing Alembic can observe. Keying bodies by
+    filename would therefore let a rename carry an edit across a release boundary
+    untouched, which is the same mistake as inventing a key for anything else here.
+    """
+    return {
+        revision: (name, sources[name])
+        for revision, (name, _) in revision_graph(sources).items()
+        if is_migration_source(name)
+    }
+
+
 def edited_released_bodies(baseline: str | None = None) -> list[str]:
-    """Released migration files whose contents are no longer what the baseline shipped.
+    """Released revisions whose migration no longer does what the baseline ran.
 
     The properties above watch what a migration *declares*; this watches what it *does*.
     They are one contract seen from two sides -- a released migration is a shipped surface
@@ -477,19 +493,30 @@ def edited_released_bodies(baseline: str | None = None) -> list[str]:
     different, so it cannot be relied on to notice in general -- and concluding otherwise
     from the one edit it did catch is how this gap survived a whole design pass.
 
+    A released revision missing from the working tree is passed over here because
+    ``rechained_revisions`` is what reports it, and from the same two calls: either its
+    file is unreadable or contested, or the revision is gone from the graph outright.
+    Restating it would describe one defect as two. The pair is what must be exhaustive,
+    not either half, and ``collect_problems`` runs both.
+
     No exemption for edits judged harmless. Judging them is the convention this guard
     exists to replace, and no exemption is needed: restoring the shipped file and adding a
     new migration carrying the change is always available, and is the only form of the
     change every database can actually apply.
     """
     baseline = baseline or latest_released_tag()
-    current = working_tree_sources()
-    return [
-        f"{name} is no longer what {baseline} shipped; a released migration's body is fixed "
-        "once a database has run it"
-        for name, source in sorted(released_sources(baseline).items())
-        if is_migration_source(name) and name in current and current[name] != source
-    ]
+    current = released_bodies(working_tree_sources())
+    problems = []
+    for revision, (shipped_name, source) in sorted(released_bodies(released_sources(baseline)).items()):
+        if revision not in current or current[revision][1] == source:
+            continue
+        name = current[revision][0]
+        where = shipped_name if name == shipped_name else f"{shipped_name}, now {name}"
+        problems.append(
+            f"{revision} ({where}) is no longer what {baseline} shipped; a released "
+            "migration's body is fixed once a database has run it"
+        )
+    return problems
 
 
 def _alembic_config(db_path: Path, versions: Path | None = None) -> Config:

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import json
 import re
 import sqlite3
 import subprocess
@@ -650,6 +651,11 @@ CHECK_FAILURE = re.compile(r"CHECK constraint failed: (\w+)")
 # searched for. Reached only on the tables that refuse the first row at all.
 SEED_ATTEMPTS = 60
 
+# Where `varied` records a row's step inside a JSON document. Nothing reads it back; it is
+# there so the document differs while staying a document, and it is namespaced so it cannot
+# collide with a path some CHECK constrains.
+JSON_VARIED_MEMBER = "__seed_step__"
+
 # A CHECK can also require a shape rather than a value. `json_extract(col,'$.p') = 1` and
 # `json_type(col,'$.p') = 'array'` both name the column, the path, and what belongs at it,
 # which is the same three things the plain literal form carries -- so both are read the
@@ -675,10 +681,11 @@ JSON_TYPE_MEMBERS: dict[str, object] = {
     "object": "{}",
 }
 
-# One row proves nothing about uniqueness, and rows that differ everywhere prove just as
-# little: a migration adding `UNIQUE(platform)` cannot fail against a fixture whose
-# platform was never allowed to repeat. So the rows differ only where the schema already
-# demands it, one member of each distinct-group at a time, and the floor is two.
+# The floor, not the target. One row proves nothing about uniqueness, and rows that differ
+# everywhere prove just as little: a migration adding `UNIQUE(platform)` cannot fail against
+# a fixture whose platform was never allowed to repeat. How many rows a table actually gets
+# is the database's answer -- one per column it accepts a repeat of -- so this is only what a
+# table it refuses every repeat of must still carry.
 SEED_ROWS = 2
 
 
@@ -782,50 +789,41 @@ def json_proposals(
     return proposals
 
 
-def distinct_column_groups(connection: sqlite3.Connection, table: str) -> list[tuple[str, ...]]:
-    """The column groups ``table``'s schema requires to be distinct across rows.
+def seeded_rows_prove_repetition(
+    connection: sqlite3.Connection, table: str, repeated: Iterable[str]
+) -> str:
+    """Why ``table``'s stored rows do not repeat every column in ``repeated``, or ``''``.
 
-    Primary key and unique indexes, read from the database rather than from the migration
-    that created them, and kept as groups because a group is what the schema constrains: a
-    composite index demands a distinct *tuple* and says nothing about its members. Union
-    the members into one set of columns and the fixture is built from a stronger rule than
-    the schema states, which costs exactly the case worth testing -- released rows sharing
-    a platform, a kind, a status -- and with it every migration that would add a unique
-    index over one of those columns and fail in the field.
+    Read back out of the database rather than inferred from the code that wrote it, because
+    ``insert_seed_row``'s repair rewrites values: a CHECK spanning two columns can reject a
+    row whose other columns moved, and the repair is free to answer by moving the one column
+    that row existed to hold still. The insert is then accepted having proved nothing, and
+    reading the column back is the only way to notice.
     """
-    groups: list[tuple[str, ...]] = []
-    key = sorted(
-        (int(row[5]), str(row[1])) for row in connection.execute(f'pragma table_info("{table}")') if row[5]
-    )
-    if key:
-        groups.append(tuple(column for _, column in key))
-    for index in connection.execute(f'pragma index_list("{table}")'):
-        if index[2]:
-            members = tuple(
-                str(row[2]) for row in connection.execute(f'pragma index_info("{index[1]}")') if row[2]
-            )
-            if members:
-                groups.append(members)
-    return groups
-
-
-def seed_row_count(groups: Iterable[tuple[str, ...]]) -> int:
-    """How many rows it takes for every member of every group in ``groups`` to repeat once.
-
-    One row per member of the widest group, each varying that member alone, plus the row
-    they all vary from. Every member is then equal in at least two rows -- the base and
-    every row that varied a different member -- while the tuples stay pairwise distinct,
-    which is exactly the distinction a composite unique index draws.
-    """
-    return max(SEED_ROWS, 1 + max((len(group) for group in groups), default=0))
+    for column in repeated:
+        seeded, distinct = connection.execute(
+            f'select count(*), count(distinct "{column}") from "{table}"'
+        ).fetchone()
+        if seeded == distinct:
+            return f"no two rows share a {column}, though a row repeating it was accepted"
+    return ""
 
 
 def varied(value: object, step: int) -> object:
-    """``value`` changed into something of the same type that differs from it and from other steps.
+    """``value`` changed into something of the same kind that differs from it and from other steps.
 
-    Indexed by the row rather than merely different, because a group narrower than the
-    widest one has its members varied on more than one row, and two rows carrying the same
-    replacement would collide on the constraint the variation exists to respect.
+    Indexed by the row rather than merely different, because every row but the base one moves
+    most of its columns, and two rows carrying the same replacement would collide on the
+    constraint the variation exists to respect.
+
+    Same *kind*, not merely same type, and a JSON document is the case that separates the two.
+    ``representative_value`` seeds a ``_json`` column with a document because that is what the
+    application writes there, and appending to the text would leave a string that is still a
+    string and no longer JSON. A migration reading it with ``json_extract`` then fails over
+    data no release ever held -- which is a false alarm, and worse than a missed one, because
+    it is indistinguishable from the failure this guard exists to catch. So a document varies
+    by carrying one more member than it did, and a JSON scalar by its own kind of variation
+    re-encoded, which keeps every branch valid JSON without a list of the shapes it can take.
     """
     if isinstance(value, bool):
         return not value
@@ -835,6 +833,16 @@ def varied(value: object, step: int) -> object:
         return value + float(step)
     if isinstance(value, bytes):
         return value + str(step).encode()
+    try:
+        document = json.loads(value) if isinstance(value, str) else None
+    except ValueError:
+        return f"{value}-{step}"
+    if isinstance(document, dict):
+        return json.dumps({**document, JSON_VARIED_MEMBER: step})
+    if isinstance(document, list):
+        return json.dumps([*document, step])
+    if document is not None:
+        return json.dumps(varied(document, step))
     return f"{value}-{step}"
 
 
@@ -886,8 +894,9 @@ def insert_seed_row(
             ]
             if not untried:
                 return objection
-            proposed.add(untried[0])
-            values[untried[0][0]] = untried[0][1]
+            column, literal = untried[0]
+            proposed.add((column, literal))
+            values[column] = literal
         else:
             return ""
     return objection or f"{SEED_ATTEMPTS} attempts did not produce a row the schema accepts"
@@ -912,14 +921,37 @@ def seed_representative_rows(db_path: Path) -> dict[str, str]:
     migration that later makes a nullable column NOT NULL has to survive the NULLs a real
     database has, and the NULL branch is the one a disjunctive CHECK admits.
 
-    More than one row, and the later ones repeat the first everywhere the schema does not
-    already demand otherwise -- one member of each distinct-group per row, so every other
-    member of that group goes on repeating. One row makes every unique index buildable,
-    which is the property most worth testing and the one a single row silently grants; a
-    row that differs everywhere grants it just as silently for every column a composite
-    index only constrains jointly. Where the schema leaves no room -- a group whose other
-    members a CHECK pins to a single literal -- the difference lands on the one member that
-    can hold it, which is as much repetition as that table is able to have.
+    More than one row, and what the extra rows are for is stated rather than constructed:
+    **a column the schema still lets two rows share has to be shared by two of them.** One
+    row makes every unique index buildable, which is the property most worth testing and the
+    one a single row silently grants; a row that differs everywhere grants it just as
+    silently.
+
+    Which columns those are is asked of the database instead of derived from its schema.
+    Each column gets a row that holds it still and moves every other one, and SQLite either
+    takes it or names the constraint it broke. Moving every other column is not a preference:
+    a differing column can only help a uniqueness constraint accept the row, and the one
+    thing that undoes a difference -- a CHECK holding a column to a list of literals, whose
+    repair puts an accepted one back -- does so whatever else the row does. So this is the
+    likeliest row to be accepted that still repeats the column, and there is no second choice
+    to tune.
+
+    Deriving the answer instead cost three review rounds, each spent on a model of the
+    constraint topology -- one row, unioned members, overlapping groups -- and each fix was
+    another argument that the model was now complete. A partial unique index, an index over
+    an expression, and a CHECK pinning one member of a group to a literal were all still
+    outside it, and this schema ships all three. Offering the row removes the model, and with
+    it the next topology.
+
+    What a refusal means is exactly what it says, and no more: the schema rejected *this*
+    row. For ``uq_constrained_slug`` that is also the schema forbidding the repeat outright,
+    but a partial unique index is conditional -- ``unique (session_id) where state in
+    ('starting', 'active')`` permits a repeated ``session_id`` on a terminal turn -- and
+    reaching the permitted side means giving ``state`` a value whose whole multi-column shape
+    another CHECK then dictates. That is constraint solving, which this deliberately is not,
+    so the column goes uncovered carrying SQLite's message as the reason. The floor below and
+    ``seeded_rows_prove_repetition`` bound what the fixture is allowed to prove instead of
+    the refusal being read as proof of anything.
 
     What this proves is that the upgrade runs over rows, not over meaningful ones --
     foreign keys are off, which is SQLite's default and is what lets each table be seeded
@@ -942,36 +974,42 @@ def seed_representative_rows(db_path: Path) -> dict[str, str]:
                 for row in connection.execute(f'pragma table_info("{table}")')
                 if row[3] or row[5]
             ]
-            groups = distinct_column_groups(connection, table)
-            wanted = seed_row_count(groups)
-            # The first row is where the repairs happen, so every later row varies the
-            # values the schema has already accepted rather than the ones it rejected.
+            # The first row is where the repairs happen, so every later row moves the values
+            # the schema has already accepted rather than the ones it rejected.
             base = {column: representative_value(column, declared) for column, declared in required}
             objection = insert_seed_row(connection, table, ddl, required, base)
-            for row in range(1, wanted):
-                if objection:
-                    break
-                # Which member can carry the difference is the schema's call, not this
-                # loop's: a member a CHECK pins to one literal cannot vary at all, and the
-                # repair inside `insert_seed_row` puts it back, so the row arrives as a
-                # duplicate. SQLite says so, and the next turn offers a different member.
-                for turn in range(max(len(group) for group in groups) if groups else 1):
-                    changing = {group[(row - 1 + turn) % len(group)] for group in groups}
-                    objection = insert_seed_row(
-                        connection,
-                        table,
-                        ddl,
-                        required,
-                        {
-                            column: varied(value, row) if column in changing else value
-                            for column, value in base.items()
-                        },
-                    )
-                    if not objection:
-                        break
+            excused: dict[str, str] = {}
+            repeated: list[str] = []
+            # One row per column, holding that column still and moving every other one. The
+            # step is the row's, so two of these rows differ from each other wherever they
+            # differ from the base row.
+            for step, column in enumerate(() if objection else base, start=1):
+                refusal = insert_seed_row(
+                    connection,
+                    table,
+                    ddl,
+                    required,
+                    {name: value if name == column else varied(value, step) for name, value in base.items()},
+                )
+                if refusal:
+                    excused[column] = refusal
+                else:
+                    repeated.append(column)
+            # Nothing this table holds may repeat, so the second row is the one that differs
+            # everywhere -- less than the table was asked for, and all a unique index needs to
+            # be buildable against.
+            if not objection and not repeated:
+                insert_seed_row(
+                    connection, table, ddl, required, {name: varied(value, 1) for name, value in base.items()}
+                )
             rows = connection.execute(f'select count(*) from "{table}"').fetchone()[0]
-            if rows < wanted:
-                short[table] = f"{rows} of {wanted} rows; {objection or 'the schema accepted no more'}"
+            if rows < SEED_ROWS:
+                reason = objection or next(iter(excused.values()), "") or "the schema accepted no more"
+                short[table] = f"{rows} of {SEED_ROWS} rows; {reason}"
+                continue
+            unproven = seeded_rows_prove_repetition(connection, table, repeated)
+            if unproven:
+                short[table] = unproven
         connection.commit()
     return short
 

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -16,8 +16,13 @@ during autogenerate, so today's runtime can drive an older ``version_locations``
                                   the property below derives from something measured
     new_slot_collisions()         a change introduces no new duplicated slot number
     rechained_revisions()         a released revision keeps its identity and its parent
-    unrepairable_releases()       a database built by a released graph still reaches the
-                                  full schema when today's graph upgrades it
+    unrepairable_releases()       a database built by a released graph still comes out
+                                  ready when the upgrade users run upgrades it
+
+Readiness is not this module's opinion. The last property drives ``run_migrations`` and
+asks ``background_tables_ready``, so it covers the repair and stamping that run before
+Alembic does, and it means by "ready" exactly what production means -- required columns
+included, not merely a full set of table names.
 
 The first three are metadata only. The fourth builds a database per release and costs
 roughly a fifth of a second each.
@@ -46,7 +51,14 @@ if str(REPO_ROOT) not in sys.path:
 from alembic import command
 from alembic.config import Config
 
-from storage.migrations import HEAD_TABLES, alembic_dir
+from storage.migrations import (
+    HEAD_ONLY_REQUIRED_COLUMNS,
+    HEAD_REQUIRED_COLUMNS,
+    HEAD_TABLES,
+    alembic_dir,
+    background_tables_ready,
+    run_migrations,
+)
 
 VERSIONS_PATH = "storage/alembic/versions"
 
@@ -159,23 +171,54 @@ def slot_collisions(filenames: Iterable[str]) -> dict[str, set[str]]:
 
 
 def new_slot_collisions(baseline: str | None = None) -> dict[str, set[str]]:
-    """Slots that collide now and did not collide in the baseline release.
+    """Slots with a claimant the baseline release did not already ship.
 
     The collisions history already contains are in the baseline itself, so they need no
-    allowlist -- and cannot decay into one that outlives the reason it was written.
+    allowlist -- and cannot decay into one that outlives the reason it was written. What
+    the baseline excuses is those exact filenames, though, not the slot number: excusing
+    the number would let a third claimant join an already-duplicated slot unreported,
+    which is the same fork the guard exists to catch.
     """
     baseline = baseline or latest_released_tag()
     shipped = slot_collisions(released_sources(baseline))
-    return {slot: names for slot, names in slot_collisions(working_tree_sources()).items() if slot not in shipped}
+    return {
+        slot: names
+        for slot, names in slot_collisions(working_tree_sources()).items()
+        if names - shipped.get(slot, set())
+    }
+
+
+class _ComputedMetadata:
+    """A ``revision`` or ``down_revision`` the guard could not read as a literal.
+
+    Never equal to anything, including another instance of itself. Two computed
+    expressions are not evidence that a graph is unchanged, they are the absence of
+    evidence, and a sentinel that compared equal would turn "cannot verify" into
+    "verified unchanged" -- silently, and precisely for the revisions least able to
+    afford it.
+    """
+
+    __slots__ = ()
+    __hash__ = object.__hash__
+
+    def __repr__(self) -> str:
+        return "<computed>"
+
+    def __eq__(self, other: object) -> bool:
+        return False
+
+
+COMPUTED = _ComputedMetadata()
 
 
 def revision_graph(sources: dict[str, str]) -> dict[str, tuple[str, object]]:
     """``{revision: (filename, down_revision)}``, parsed rather than imported.
 
     Parsing keeps this free of import side effects and lets it read a revision from a
-    release whose modules would no longer import against today's code. A revision that
-    computes either value instead of assigning a literal reads as ``"<computed>"``, which
-    compares unequal to itself and so is reported rather than skipped.
+    release whose modules would no longer import against today's code. A computed value
+    becomes ``COMPUTED``, which compares unequal to everything; a computed *revision*
+    additionally cannot identify its file, so it is keyed by filename and can never be
+    mistaken for a literal revision that happens to render the same way.
     """
     graph: dict[str, tuple[str, object]] = {}
     for name, source in sources.items():
@@ -188,10 +231,22 @@ def revision_graph(sources: dict[str, str]) -> dict[str, tuple[str, object]]:
                 try:
                     assigned[target.id] = ast.literal_eval(node.value)
                 except ValueError:
-                    assigned[target.id] = "<computed>"
-        if "revision" in assigned:
-            graph[str(assigned["revision"])] = (name, assigned.get("down_revision"))
+                    assigned[target.id] = COMPUTED
+        if "revision" not in assigned:
+            continue
+        revision = assigned["revision"]
+        key = f"<computed:{name}>" if revision is COMPUTED else str(revision)
+        graph[key] = (name, assigned.get("down_revision"))
     return graph
+
+
+def unverifiable_sources(sources: dict[str, str]) -> list[str]:
+    """Filenames whose revision metadata is computed, and so cannot be compared at all."""
+    return sorted(
+        name
+        for key, (name, down_revision) in revision_graph(sources).items()
+        if down_revision is COMPUTED or key.startswith("<computed:")
+    )
 
 
 def rechained_revisions(baseline: str | None = None) -> list[str]:
@@ -204,11 +259,17 @@ def rechained_revisions(baseline: str | None = None) -> list[str]:
     the graph that replaced it.
     """
     baseline = baseline or latest_released_tag()
-    current = revision_graph(working_tree_sources())
-    problems = []
+    working_tree = working_tree_sources()
+    current = revision_graph(working_tree)
+    problems = [
+        f"{name} computes its migration metadata, so the guard cannot hold it to {baseline}"
+        for name in unverifiable_sources(working_tree)
+    ]
     for revision, (name, down_revision) in sorted(revision_graph(released_sources(baseline)).items()):
         if revision not in current:
             problems.append(f"{revision} ({name}) shipped in {baseline} and is no longer in the graph")
+        elif current[revision][1] is COMPUTED:
+            continue  # already reported above, and reporting it twice describes one defect as two
         elif current[revision][1] != down_revision:
             problems.append(
                 f"{revision} ({name}) shipped in {baseline} with down_revision={down_revision!r} "
@@ -239,10 +300,10 @@ def table_names(db_path: Path) -> set[str]:
 
 
 def fresh_install_tables() -> set[str]:
-    """The tables a database has after today's graph builds it from empty."""
+    """The tables a fresh install actually has, built the way production builds one."""
     with tempfile.TemporaryDirectory() as workspace:
         db_path = Path(workspace) / "vibe.sqlite"
-        command.upgrade(_alembic_config(db_path), "head")
+        run_migrations(db_path)
         return table_names(db_path) - {ALEMBIC_BOOKKEEPING_TABLE}
 
 
@@ -257,12 +318,45 @@ def stamped_revision(db_path: Path) -> str | None:
     return str(rows[0][0]) if len(rows) == 1 else None
 
 
-def missing_tables_after_upgrade(tag: str) -> set[str]:
-    """Tables still absent after a database built by ``tag``'s graph is upgraded by today's.
+def describe_schema_gap(db_path: Path) -> str:
+    """Why ``background_tables_ready`` rejected this database, in one line.
 
-    Whatever Alembic raises when the upgrade itself aborts propagates: a crash and a
-    silently incomplete schema are the same failure of the same property, and the caller
-    records them the same way.
+    The verdict is production's; this only reads the same tables and columns back to say
+    what is missing, because "not ready" alone does not tell anyone what to fix.
+    """
+    tables = table_names(db_path)
+    missing_tables = HEAD_TABLES - tables
+    missing_columns = []
+    connection = sqlite3.connect(db_path)
+    try:
+        for table, required in sorted((HEAD_REQUIRED_COLUMNS | HEAD_ONLY_REQUIRED_COLUMNS).items()):
+            if table in missing_tables or table not in tables:
+                continue
+            present = {str(row[1]) for row in connection.execute(f'pragma table_info("{table}")')}
+            missing_columns.extend(f"{table}.{column}" for column in sorted(required - present))
+    finally:
+        connection.close()
+
+    parts = []
+    if missing_tables:
+        parts.append(f"{len(missing_tables)} table(s) missing: {', '.join(sorted(missing_tables))}")
+    if missing_columns:
+        parts.append(f"{len(missing_columns)} column(s) missing: {', '.join(missing_columns)}")
+    return "; ".join(parts) or "the schema is incomplete in a way HEAD_TABLES and the required columns do not name"
+
+
+def schema_gap_after_upgrade(tag: str) -> str | None:
+    """Why a database built by ``tag``'s graph is not ready after today's upgrade, or ``None``.
+
+    The second stage runs ``storage.migrations.run_migrations`` rather than Alembic
+    directly, and the verdict comes from ``background_tables_ready``. Both are deliberate:
+    the property is about the databases users actually carry through the upgrade users
+    actually run, so a regression in the pre-Alembic repair or stamping path has to fail
+    here too, and readiness has to mean what production means by it -- required columns
+    included, not merely a full set of table names.
+
+    Whatever the upgrade raises when it aborts propagates: a crash and a silently
+    incomplete schema are the same failure of the same property.
     """
     with tempfile.TemporaryDirectory() as workspace:
         root = Path(workspace)
@@ -281,8 +375,8 @@ def missing_tables_after_upgrade(tag: str) -> set[str]:
                 f"one of its revisions; the released graph was not applied"
             )
 
-        command.upgrade(_alembic_config(db_path), "head")
-        return HEAD_TABLES - table_names(db_path)
+        run_migrations(db_path)
+        return None if background_tables_ready(db_path) else describe_schema_gap(db_path)
 
 
 def unrepairable_releases() -> dict[str, str]:
@@ -290,12 +384,12 @@ def unrepairable_releases() -> dict[str, str]:
     failures = {}
     for tag in released_tags():
         try:
-            missing = missing_tables_after_upgrade(tag)
+            gap = schema_gap_after_upgrade(tag)
         except Exception as exc:  # noqa: BLE001 - however the upgrade fails, the verdict is the same
             failures[tag] = f"upgrade aborted with {type(exc).__name__}: {str(exc).splitlines()[0]}"
         else:
-            if missing:
-                failures[tag] = f"upgrade left {len(missing)} table(s) missing: {', '.join(sorted(missing))}"
+            if gap is not None:
+                failures[tag] = f"upgrade left the database not ready: {gap}"
     return failures
 
 

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -7,7 +7,7 @@ never back. So editing a released revision's parentage does not change what thos
 databases have already done -- it changes what they will do next, silently, with no error
 at the moment of the edit and no error at the moment of the upgrade.
 
-Five properties, one primitive: the graph as a released tag actually shipped it, read
+Six properties, one primitive: the graph as a released tag actually shipped it, read
 straight out of git. Nothing here is a hand-maintained list of known-bad cases, and
 nothing needs an old Python environment -- ``env.py`` reads ``target_metadata`` only
 during autogenerate, so today's runtime can drive an older ``version_locations``.
@@ -21,14 +21,21 @@ during autogenerate, so today's runtime can drive an older ``version_locations``
     unrepairable_releases()       a database built by a released graph, carrying rows,
                                   still comes out ready when the upgrade users run
                                   upgrades it
+    releases_with_state_but_no   every release that wrote a database is inside the
+    _graph()                      window the property above walks
 
-Readiness is not this module's opinion. The last property drives ``run_migrations`` and
-asks ``background_tables_ready``, so it covers the repair and stamping that run before
-Alembic does, and it means by "ready" exactly what production means -- required columns
-included, not merely a full set of table names. It seeds the released schema first,
-because an empty database is the one case no user is in and is the case under which
-adding a NOT NULL column, tightening a nullable one, and building a unique index all
-succeed unconditionally.
+Readiness is not this module's opinion. ``unrepairable_releases`` drives
+``run_migrations`` and asks ``background_tables_ready``, so it covers the repair and
+stamping that run before Alembic does, and it means by "ready" exactly what production
+means -- required columns included, not merely a full set of table names. It seeds the
+released schema first, because an empty database is the one case no user is in and is
+the case under which adding a NOT NULL column, tightening a nullable one, and building
+a unique index all succeed unconditionally.
+
+Coverage is reported as failure, never as a note. A table the seeder could not fill and
+a release that fell outside the window are both counted with the violations, because a
+property proved over less than its subject is a different, weaker property, and the one
+thing it must not do is read like the stronger one.
 
 A release here is any installable tag, ``gh-vX.Y.ZrcN`` prereleases included, because a
 database in the field can have been built by one. The first three properties are metadata
@@ -73,6 +80,8 @@ from storage.migrations import (
 )
 
 VERSIONS_PATH = "storage/alembic/versions"
+# The package that owns SQLite state. A release without it wrote no database to migrate.
+STATE_PACKAGE_PATH = "storage"
 
 # ``20260806_0047_remove_session_queue_hold.py`` -> slot ``0047``. Two branches choosing
 # the same slot is how the graph forked: the filenames differ, so git merges both without
@@ -141,20 +150,46 @@ def version_key(tag: str) -> tuple[Version, str]:
     return (version, tag)
 
 
-def versions_tree(tag: str) -> str | None:
-    """The git object id of ``tag``'s versions directory, or ``None`` if it shipped none.
-
-    Identity of a shipped graph, straight from git: two tags with the same object id
-    shipped byte-identical migrations and therefore put the same database in the field.
-    """
+def tree_at(tag: str, path: str) -> str | None:
+    """The git object id of ``path`` as ``tag`` shipped it, or ``None`` if it shipped none."""
     result = subprocess.run(
-        ["git", "rev-parse", "--verify", "--quiet", f"{tag}^{{}}:{VERSIONS_PATH}"],
+        ["git", "rev-parse", "--verify", "--quiet", f"{tag}^{{}}:{path}"],
         capture_output=True,
         check=False,
         text=True,
         cwd=REPO_ROOT,
     )
     return result.stdout.strip() or None
+
+
+def versions_tree(tag: str) -> str | None:
+    """The git object id of ``tag``'s versions directory, or ``None`` if it shipped none.
+
+    Identity of a shipped graph, straight from git: two tags with the same object id
+    shipped byte-identical migrations and therefore put the same database in the field.
+    """
+    return tree_at(tag, VERSIONS_PATH)
+
+
+def releases_with_state_but_no_graph() -> list[str]:
+    """Release tags that shipped the SQLite state package without a migration graph.
+
+    ``released_tags`` reads "no versions directory" as "no migrated database in the
+    field", and that is an equation rather than a definition -- so this is the thing that
+    keeps it true instead of assumed. Every release before ``storage/`` existed wrote its
+    state as JSON, which is why ``storage/importer.py`` still carries an importer rather
+    than a migration for it; every release that has ``storage/`` shipped a graph with it.
+    A release shipping one without the other would leave a database in the field that the
+    upgrade property never builds, and it would do so by falling out of the window rather
+    than by failing, which is the failure mode with no symptom. Reported instead.
+    """
+    return [tag for tag in release_tag_names() if tree_at(tag, STATE_PACKAGE_PATH) and not versions_tree(tag)]
+
+
+def release_tag_names() -> list[str]:
+    """Every release tag the publisher can build, oldest first, whether or not it shipped a graph."""
+    names = _git("tag", "-l", "v*", "-l", "gh-v*").split()
+    return sorted((tag for tag in names if release_version(tag)), key=version_key)
 
 
 def released_tags() -> list[str]:
@@ -165,9 +200,7 @@ def released_tags() -> list[str]:
     cutoff would instead stop covering a release on a schedule unrelated to whether
     anyone is still running it.
     """
-    names = _git("tag", "-l", "v*", "-l", "gh-v*").split()
-    candidates = sorted((tag for tag in names if release_version(tag)), key=version_key)
-    tags = [tag for tag in candidates if versions_tree(tag)]
+    tags = [tag for tag in release_tag_names() if versions_tree(tag)]
     if not tags:
         # A guard that reads "no baseline" as "nothing to compare, therefore fine" passes
         # forever while proving nothing. Refuse instead, and name the cause: a shallow
@@ -617,6 +650,37 @@ CHECK_FAILURE = re.compile(r"CHECK constraint failed: (\w+)")
 # searched for. Reached only on the tables that refuse the first row at all.
 SEED_ATTEMPTS = 60
 
+# A CHECK can also require a shape rather than a value. `json_extract(col,'$.p') = 1` and
+# `json_type(col,'$.p') = 'array'` both name the column, the path, and what belongs at it,
+# which is the same three things the plain literal form carries -- so both are read the
+# same way rather than treated as unseedable.
+JSON_REQUIREMENT = re.compile(
+    r"json_(extract|type)\s*\(\s*\"?(\w+)\"?\s*,\s*'([^']*)'\s*\)\s*(?:==|=|is)\s*"
+    r"('[^']*'|-?[0-9]+(?:\.[0-9]+)?)",
+    re.IGNORECASE,
+)
+
+# Every name SQLite's `json_type` can return, against the emptiest document member of that
+# type. A `json_type` clause states the type where the `json_extract` form states the
+# value, so this is the one table that turns the former into the latter; SQLite decides
+# whether the result is admissible either way.
+JSON_TYPE_MEMBERS: dict[str, object] = {
+    "null": None,
+    "true": 1,
+    "false": 0,
+    "integer": 0,
+    "real": 0.0,
+    "text": "",
+    "array": "[]",
+    "object": "{}",
+}
+
+# Two rows, because one proves nothing about uniqueness. A migration that builds a unique
+# index over columns no released schema constrained is exactly the kind that fails in the
+# field and cannot fail against a single row, so the second row repeats the first wherever
+# the schema permits and differs only where it already demands distinctness.
+SEED_ROWS = 2
+
 
 def representative_value(column: str, declared_type: str) -> object:
     """A value of ``declared_type`` that SQLite will store in ``column``.
@@ -678,8 +742,131 @@ def check_proposals(expression: str, columns: Iterable[str]) -> list[tuple[str, 
     return [(column, literal) for column in named for literal in literals]
 
 
-def seed_representative_rows(db_path: Path) -> set[str]:
-    """Put one row in every table of the schema ``db_path`` holds; return the ones that refused.
+def json_proposals(
+    connection: sqlite3.Connection, expression: str, columns: Iterable[str]
+) -> list[tuple[str, str]]:
+    """``(column, document)`` pairs satisfying every JSON-path clause ``expression`` states.
+
+    The document is built by SQLite's own ``json_set`` rather than assembled here, so the
+    path syntax is whatever SQLite accepts and not a second reading of it. All clauses for
+    one column are folded into a single document, because a constraint requiring two paths
+    is not satisfied by a document carrying either one.
+    """
+    wanted = set(columns)
+    required: dict[str, list[tuple[str, str, object]]] = {}
+    for function, column, path, literal in JSON_REQUIREMENT.findall(expression):
+        if column not in wanted:
+            continue
+        if function.lower() == "type":
+            named = literal.strip("'").lower()
+            if named not in JSON_TYPE_MEMBERS:
+                continue
+            member = JSON_TYPE_MEMBERS[named]
+            # A composite has to be spliced in as a document; anything else is a scalar and
+            # would be stored as one whatever `json_set` is handed.
+            term = "json(?)" if named in {"array", "object"} else "?"
+            required.setdefault(column, []).append((path, term, member))
+        elif literal.startswith("'"):
+            required.setdefault(column, []).append((path, "?", literal[1:-1]))
+        else:
+            required.setdefault(column, []).append((path, "?", float(literal) if "." in literal else int(literal)))
+
+    proposals = []
+    for column, clauses in required.items():
+        document = "'{}'"
+        parameters: list[object] = []
+        for path, term, value in clauses:
+            document = f"json_set({document}, ?, {term})"
+            parameters.extend([path, value])
+        proposals.append((column, str(connection.execute(f"select {document}", parameters).fetchone()[0])))
+    return proposals
+
+
+def distinguishing_columns(connection: sqlite3.Connection, table: str) -> set[str]:
+    """The columns of ``table`` the schema already requires to differ between two rows.
+
+    Primary key and unique index members, read from the database rather than from the
+    migration that created them. Everything outside this set may repeat, and the second
+    seeded row repeats it deliberately: a value the released schema never constrained is a
+    value a released database can hold twice.
+    """
+    columns = {str(row[1]) for row in connection.execute(f'pragma table_info("{table}")') if row[5]}
+    for index in connection.execute(f'pragma index_list("{table}")'):
+        if index[2]:
+            columns |= {str(row[2]) for row in connection.execute(f'pragma index_info("{index[1]}")') if row[2]}
+    return columns
+
+
+def varied(value: object) -> object:
+    """``value`` changed into something of the same type that is not equal to it."""
+    if isinstance(value, bool):
+        return not value
+    if isinstance(value, int):
+        return value + 1
+    if isinstance(value, float):
+        return value + 1.0
+    if isinstance(value, bytes):
+        return value + b"2"
+    return f"{value}-2"
+
+
+def insert_seed_row(
+    connection: sqlite3.Connection,
+    table: str,
+    ddl: str,
+    required: list[tuple[str, str]],
+    values: dict[str, object],
+) -> str:
+    """Insert ``values`` into ``table``, repairing what the schema objects to; ``""`` if it landed.
+
+    Where a CHECK rejects the row, SQLite names the constraint and the constraint states
+    what it wants -- accepted literals, or a JSON shape -- so the repair proposes that and
+    asks again. SQLite is the judge throughout: the row is admissible only if the schema
+    accepted it, and the returned message is the schema's own last objection.
+    """
+    if not required:
+        try:
+            connection.execute(f'insert into "{table}" default values')
+        except sqlite3.Error as exc:
+            return str(exc)
+        return ""
+
+    columns = ", ".join(f'"{column}"' for column, _ in required)
+    placeholders = ", ".join("?" for _ in required)
+    statement = f'insert into "{table}" ({columns}) values ({placeholders})'
+    names = [column for column, _ in required]
+    proposed: set[tuple[str, str]] = set()
+    objection = ""
+    for _ in range(SEED_ATTEMPTS):
+        try:
+            connection.execute(statement, [values[column] for column in names])
+        except sqlite3.Error as exc:
+            objection = str(exc)
+            # However else SQLite refuses the row, the table is one this cannot seed. Only
+            # a named CHECK carries a repair, so anything else ends here.
+            failure = CHECK_FAILURE.search(objection)
+            if failure is None:
+                return objection
+            expression = check_expression(ddl, failure.group(1))
+            untried = [
+                pair
+                for pair in [
+                    *check_proposals(expression, names),
+                    *json_proposals(connection, expression, names),
+                ]
+                if pair not in proposed
+            ]
+            if not untried:
+                return objection
+            proposed.add(untried[0])
+            values[untried[0][0]] = untried[0][1]
+        else:
+            return ""
+    return objection or f"{SEED_ATTEMPTS} attempts did not produce a row the schema accepts"
+
+
+def seed_representative_rows(db_path: Path) -> dict[str, str]:
+    """Fill every table of the schema ``db_path`` holds; ``{table: objection}`` for what fell short.
 
     A migration is only as safe as the data it runs over. On an empty database, adding a
     NOT NULL column with no default, tightening a nullable one, backfilling from a column
@@ -690,22 +877,24 @@ def seed_representative_rows(db_path: Path) -> set[str]:
     The rows are derived from the schema, because the schema is what differs in every
     release and ``pragma table_info`` already knows it; a fixture written per release
     would cover the graphs that existed when it was written and quietly stop at the next
-    one. Only what the schema requires is filled -- NOT NULL or primary key, no default.
-    Leaving the rest NULL is deliberate and the more adversarial choice: a migration that
-    later makes a nullable column NOT NULL has to survive the NULLs a real database has.
+    one. What gets filled is what every row of that table must hold -- NOT NULL or primary
+    key -- whether or not a default would have supplied it, because a released application
+    writes those columns and a seeder that leans on the defaults instead is measuring the
+    defaults. Leaving the rest NULL is deliberate and the more adversarial choice: a
+    migration that later makes a nullable column NOT NULL has to survive the NULLs a real
+    database has, and the NULL branch is the one a disjunctive CHECK admits.
 
-    Where a CHECK rejects that row, SQLite names the constraint and the constraint names
-    its own accepted values, so the repair proposes those and asks again. SQLite is the
-    judge throughout: a table is seeded only if the schema accepted the row.
+    ``SEED_ROWS`` rows, not one, and the later ones repeat the first everywhere the schema
+    does not already demand otherwise. One row makes every unique index buildable, which
+    is the property most worth testing and the one a single row silently grants.
 
-    What this proves is that the upgrade runs over rows, not that it runs over meaningful
-    ones -- foreign keys are off, which is SQLite's default and is what lets each table be
-    seeded on its own, so the rows are individually well-formed and collectively
-    inconsistent. Tables whose constraints encode a shape only the writing code knows are
-    returned rather than skipped quietly, so the coverage this leaves out is a number the
-    caller can print instead of an assumption.
+    What this proves is that the upgrade runs over rows, not over meaningful ones --
+    foreign keys are off, which is SQLite's default and is what lets each table be seeded
+    on its own, so the rows are individually well-formed and collectively inconsistent.
+    A table this cannot fill is returned with the schema's own objection rather than
+    skipped, because a coverage limit the caller cannot see reads as coverage.
     """
-    refused = set()
+    short = {}
     with sqlite3.connect(db_path) as connection:
         schema = [
             (str(name), str(ddl))
@@ -718,48 +907,33 @@ def seed_representative_rows(db_path: Path) -> set[str]:
             required = [
                 (str(row[1]), str(row[2]))
                 for row in connection.execute(f'pragma table_info("{table}")')
-                if (row[3] or row[5]) and row[4] is None
+                if row[3] or row[5]
             ]
-            if not required:
-                connection.execute(f'insert into "{table}" default values')
-                continue
-            columns = ", ".join(f'"{column}"' for column, _ in required)
-            placeholders = ", ".join("?" for _ in required)
-            statement = f'insert into "{table}" ({columns}) values ({placeholders})'
+            distinct = distinguishing_columns(connection, table)
             values = {column: representative_value(column, declared) for column, declared in required}
-            proposed: set[tuple[str, str]] = set()
-            for _ in range(SEED_ATTEMPTS):
-                try:
-                    connection.execute(statement, [values[column] for column, _ in required])
+            objection = ""
+            for attempt in range(SEED_ROWS):
+                if attempt:
+                    values = {
+                        column: varied(value) if column in distinct else value
+                        for column, value in values.items()
+                    }
+                objection = insert_seed_row(connection, table, ddl, required, values)
+                if objection:
                     break
-                except sqlite3.Error as exc:
-                    # However SQLite refuses the row, the table is simply one this cannot
-                    # seed. Only a named CHECK carries a repair, so anything else ends here.
-                    failure = CHECK_FAILURE.search(str(exc))
-                    if failure is None:
-                        break
-                    expression = check_expression(ddl, failure.group(1))
-                    untried = [
-                        pair
-                        for pair in check_proposals(expression, [column for column, _ in required])
-                        if pair not in proposed
-                    ]
-                    if not untried:
-                        break
-                    proposed.add(untried[0])
-                    values[untried[0][0]] = untried[0][1]
-            if connection.execute(f'select count(*) from "{table}"').fetchone()[0] == 0:
-                refused.add(table)
+            rows = connection.execute(f'select count(*) from "{table}"').fetchone()[0]
+            if rows < SEED_ROWS:
+                short[table] = f"{rows} of {SEED_ROWS} rows; {objection or 'the schema accepted no more'}"
         connection.commit()
-    return refused
+    return short
 
 
-def schema_gap_after_upgrade(tag: str) -> tuple[str | None, set[str]]:
-    """``(gap, unseeded)`` -- why a database built by ``tag``'s graph is not ready, and what carried no row.
+def schema_gap_after_upgrade(tag: str) -> tuple[str | None, dict[str, str]]:
+    """``(gap, short)`` -- why a database built by ``tag``'s graph is not ready, and what it could not carry.
 
-    ``gap`` is ``None`` when the database comes out ready. ``unseeded`` is the tables the
-    upgrade therefore ran over empty, reported rather than dropped so the coverage this
-    property does not have is a number someone can read.
+    ``gap`` is ``None`` when the database comes out ready. ``short`` is the tables the
+    upgrade therefore ran over with fewer rows than intended; both are failures, because
+    a property proved over less than its subject is not the property.
 
     The second stage runs ``storage.migrations.run_migrations`` rather than Alembic
     directly, and the verdict comes from ``background_tables_ready``. Both are deliberate:
@@ -791,49 +965,53 @@ def schema_gap_after_upgrade(tag: str) -> tuple[str | None, set[str]]:
                 f"its head {sorted(shipped_heads)!r}; the released graph was not applied in full"
             )
 
-        unseeded = seed_representative_rows(db_path)
+        short = seed_representative_rows(db_path)
         run_migrations(db_path)
         gap = None if background_tables_ready(db_path) else describe_schema_gap(db_path)
-        return gap, unseeded
+        return gap, short
 
 
-def unrepairable_releases() -> tuple[dict[str, str], set[str]]:
-    """``({tag: reason}, unseeded)`` for every release today's graph cannot bring to head.
+def unrepairable_releases() -> dict[str, list[str]]:
+    """``{tag: reasons}`` for every release today's graph cannot bring to head over real rows.
 
-    ``unseeded`` is the union across releases: a table no shipped schema would accept a
-    generic row for, and therefore one no release proved its upgrade over rows of.
+    A table the seeding could not fill is one of the reasons, not a footnote beside them.
+    The property is that a populated released database survives the upgrade, so a table
+    the run left short is a piece of that property it did not test, and reporting it as
+    anything other than a failure would let the guard read as stronger than its evidence.
     """
-    failures = {}
-    unseeded: set[str] = set()
+    failures: dict[str, list[str]] = {}
     for tag in released_graphs():
         try:
-            gap, refused = schema_gap_after_upgrade(tag)
+            gap, short = schema_gap_after_upgrade(tag)
         except Exception as exc:  # noqa: BLE001 - however the upgrade fails, the verdict is the same
-            failures[tag] = f"upgrade aborted with {type(exc).__name__}: {str(exc).splitlines()[0]}"
+            failures[tag] = [f"upgrade aborted with {type(exc).__name__}: {str(exc).splitlines()[0]}"]
         else:
-            unseeded |= refused
-            if gap is not None:
-                failures[tag] = f"upgrade left the database not ready: {gap}"
-    return failures, unseeded
+            reasons = [] if gap is None else [f"upgrade left the database not ready: {gap}"]
+            reasons += [f"could not seed {table}: {objection}" for table, objection in sorted(short.items())]
+            if reasons:
+                failures[tag] = reasons
+    return failures
 
 
-def collect_problems(
-    baseline: str | None = None, *, include_upgrade: bool = True
-) -> tuple[str, list[str], list[str]]:
-    """``(baseline, problems, notes)`` -- every property checked, every violation reported at once.
+def collect_problems(baseline: str | None = None, *, include_upgrade: bool = True) -> tuple[str, list[str]]:
+    """``(baseline, problems)`` -- every property checked, every violation reported at once.
 
     Reporting all of them together rather than stopping at the first is deliberate: a
     graph defect usually shows up in more than one property, and seeing which ones fire
     is most of the diagnosis.
 
-    ``notes`` carries what the run could not cover. It is separate from ``problems``
-    because a coverage limit is not a violation, and it is printed rather than dropped
-    because a guard that passes while quietly skipping part of its subject reads as
-    stronger than it is.
+    A limit on what the run could cover is a problem here too, not a note beside them.
+    Anything this guard cannot exercise is something it passes without having checked, and
+    the two are indistinguishable to whoever reads the exit code.
     """
     baseline = baseline or latest_released_tag()
     problems: list[str] = []
-    notes: list[str] = []
+
+    for tag in releases_with_state_but_no_graph():
+        problems.append(
+            f"{tag} shipped {STATE_PACKAGE_PATH} without {VERSIONS_PATH}, so the database it wrote "
+            "falls outside every upgrade property here"
+        )
 
     disagreement = fresh_install_tables() ^ HEAD_TABLES
     if disagreement:
@@ -849,16 +1027,10 @@ def collect_problems(
     problems.extend(edited_released_bodies(baseline))
 
     if include_upgrade:
-        failures, unseeded = unrepairable_releases()
-        for tag, reason in sorted(failures.items(), key=lambda item: version_key(item[0])):
-            problems.append(f"{tag}: {reason}")
-        if unseeded:
-            notes.append(
-                "no shipped schema accepted a generic row for these tables, so the upgrade ran "
-                f"over them empty: {', '.join(sorted(unseeded))}"
-            )
+        for tag, reasons in sorted(unrepairable_releases().items(), key=lambda item: version_key(item[0])):
+            problems.extend(f"{tag}: {reason}" for reason in reasons)
 
-    return baseline, problems, notes
+    return baseline, problems
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -878,13 +1050,10 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     try:
-        baseline, problems, notes = collect_problems(args.baseline, include_upgrade=not args.skip_upgrade)
+        baseline, problems = collect_problems(args.baseline, include_upgrade=not args.skip_upgrade)
     except MigrationGuardError as exc:
         print(f"migration release guard could not run: {exc}", file=sys.stderr)
         return 2
-
-    for note in notes:
-        print(f"note: {note}", file=sys.stderr)
 
     if problems:
         print(f"migration release guard failed (baseline {baseline}):", file=sys.stderr)

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -675,10 +675,10 @@ JSON_TYPE_MEMBERS: dict[str, object] = {
     "object": "{}",
 }
 
-# Two rows, because one proves nothing about uniqueness. A migration that builds a unique
-# index over columns no released schema constrained is exactly the kind that fails in the
-# field and cannot fail against a single row, so the second row repeats the first wherever
-# the schema permits and differs only where it already demands distinctness.
+# One row proves nothing about uniqueness, and rows that differ everywhere prove just as
+# little: a migration adding `UNIQUE(platform)` cannot fail against a fixture whose
+# platform was never allowed to repeat. So the rows differ only where the schema already
+# demands it, one member of each distinct-group at a time, and the floor is two.
 SEED_ROWS = 2
 
 
@@ -782,32 +782,60 @@ def json_proposals(
     return proposals
 
 
-def distinguishing_columns(connection: sqlite3.Connection, table: str) -> set[str]:
-    """The columns of ``table`` the schema already requires to differ between two rows.
+def distinct_column_groups(connection: sqlite3.Connection, table: str) -> list[tuple[str, ...]]:
+    """The column groups ``table``'s schema requires to be distinct across rows.
 
-    Primary key and unique index members, read from the database rather than from the
-    migration that created them. Everything outside this set may repeat, and the second
-    seeded row repeats it deliberately: a value the released schema never constrained is a
-    value a released database can hold twice.
+    Primary key and unique indexes, read from the database rather than from the migration
+    that created them, and kept as groups because a group is what the schema constrains: a
+    composite index demands a distinct *tuple* and says nothing about its members. Union
+    the members into one set of columns and the fixture is built from a stronger rule than
+    the schema states, which costs exactly the case worth testing -- released rows sharing
+    a platform, a kind, a status -- and with it every migration that would add a unique
+    index over one of those columns and fail in the field.
     """
-    columns = {str(row[1]) for row in connection.execute(f'pragma table_info("{table}")') if row[5]}
+    groups: list[tuple[str, ...]] = []
+    key = sorted(
+        (int(row[5]), str(row[1])) for row in connection.execute(f'pragma table_info("{table}")') if row[5]
+    )
+    if key:
+        groups.append(tuple(column for _, column in key))
     for index in connection.execute(f'pragma index_list("{table}")'):
         if index[2]:
-            columns |= {str(row[2]) for row in connection.execute(f'pragma index_info("{index[1]}")') if row[2]}
-    return columns
+            members = tuple(
+                str(row[2]) for row in connection.execute(f'pragma index_info("{index[1]}")') if row[2]
+            )
+            if members:
+                groups.append(members)
+    return groups
 
 
-def varied(value: object) -> object:
-    """``value`` changed into something of the same type that is not equal to it."""
+def seed_row_count(groups: Iterable[tuple[str, ...]]) -> int:
+    """How many rows it takes for every member of every group in ``groups`` to repeat once.
+
+    One row per member of the widest group, each varying that member alone, plus the row
+    they all vary from. Every member is then equal in at least two rows -- the base and
+    every row that varied a different member -- while the tuples stay pairwise distinct,
+    which is exactly the distinction a composite unique index draws.
+    """
+    return max(SEED_ROWS, 1 + max((len(group) for group in groups), default=0))
+
+
+def varied(value: object, step: int) -> object:
+    """``value`` changed into something of the same type that differs from it and from other steps.
+
+    Indexed by the row rather than merely different, because a group narrower than the
+    widest one has its members varied on more than one row, and two rows carrying the same
+    replacement would collide on the constraint the variation exists to respect.
+    """
     if isinstance(value, bool):
         return not value
     if isinstance(value, int):
-        return value + 1
+        return value + step
     if isinstance(value, float):
-        return value + 1.0
+        return value + float(step)
     if isinstance(value, bytes):
-        return value + b"2"
-    return f"{value}-2"
+        return value + str(step).encode()
+    return f"{value}-{step}"
 
 
 def insert_seed_row(
@@ -884,9 +912,14 @@ def seed_representative_rows(db_path: Path) -> dict[str, str]:
     migration that later makes a nullable column NOT NULL has to survive the NULLs a real
     database has, and the NULL branch is the one a disjunctive CHECK admits.
 
-    ``SEED_ROWS`` rows, not one, and the later ones repeat the first everywhere the schema
-    does not already demand otherwise. One row makes every unique index buildable, which
-    is the property most worth testing and the one a single row silently grants.
+    More than one row, and the later ones repeat the first everywhere the schema does not
+    already demand otherwise -- one member of each distinct-group per row, so every other
+    member of that group goes on repeating. One row makes every unique index buildable,
+    which is the property most worth testing and the one a single row silently grants; a
+    row that differs everywhere grants it just as silently for every column a composite
+    index only constrains jointly. Where the schema leaves no room -- a group whose other
+    members a CHECK pins to a single literal -- the difference lands on the one member that
+    can hold it, which is as much repetition as that table is able to have.
 
     What this proves is that the upgrade runs over rows, not over meaningful ones --
     foreign keys are off, which is SQLite's default and is what lets each table be seeded
@@ -909,21 +942,36 @@ def seed_representative_rows(db_path: Path) -> dict[str, str]:
                 for row in connection.execute(f'pragma table_info("{table}")')
                 if row[3] or row[5]
             ]
-            distinct = distinguishing_columns(connection, table)
-            values = {column: representative_value(column, declared) for column, declared in required}
-            objection = ""
-            for attempt in range(SEED_ROWS):
-                if attempt:
-                    values = {
-                        column: varied(value) if column in distinct else value
-                        for column, value in values.items()
-                    }
-                objection = insert_seed_row(connection, table, ddl, required, values)
+            groups = distinct_column_groups(connection, table)
+            wanted = seed_row_count(groups)
+            # The first row is where the repairs happen, so every later row varies the
+            # values the schema has already accepted rather than the ones it rejected.
+            base = {column: representative_value(column, declared) for column, declared in required}
+            objection = insert_seed_row(connection, table, ddl, required, base)
+            for row in range(1, wanted):
                 if objection:
                     break
+                # Which member can carry the difference is the schema's call, not this
+                # loop's: a member a CHECK pins to one literal cannot vary at all, and the
+                # repair inside `insert_seed_row` puts it back, so the row arrives as a
+                # duplicate. SQLite says so, and the next turn offers a different member.
+                for turn in range(max(len(group) for group in groups) if groups else 1):
+                    changing = {group[(row - 1 + turn) % len(group)] for group in groups}
+                    objection = insert_seed_row(
+                        connection,
+                        table,
+                        ddl,
+                        required,
+                        {
+                            column: varied(value, row) if column in changing else value
+                            for column, value in base.items()
+                        },
+                    )
+                    if not objection:
+                        break
             rows = connection.execute(f'select count(*) from "{table}"').fetchone()[0]
-            if rows < SEED_ROWS:
-                short[table] = f"{rows} of {SEED_ROWS} rows; {objection or 'the schema accepted no more'}"
+            if rows < wanted:
+                short[table] = f"{rows} of {wanted} rows; {objection or 'the schema accepted no more'}"
         connection.commit()
     return short
 
@@ -934,6 +982,19 @@ def schema_gap_after_upgrade(tag: str) -> tuple[str | None, dict[str, str]]:
     ``gap`` is ``None`` when the database comes out ready. ``short`` is the tables the
     upgrade therefore ran over with fewer rows than intended; both are failures, because
     a property proved over less than its subject is not the property.
+
+    What the rows are *for* is the run, not the tally afterwards. Adding a NOT NULL column,
+    tightening a nullable one, backfilling from a column being dropped, and building a
+    unique index each fail loudly over data and succeed unconditionally over an empty
+    database, and every one of those failures arrives here as an exception or a schema that
+    came out short. Counting the rows again on the far side would assert something else --
+    that the graph never removes any -- and that is not a property this repository has:
+    ``20260601_0011`` deduplicates sessions to one row per (scope, anchor) by design, and
+    ``20260703_0026`` discards legacy scope-shaped vault grants the new model cannot
+    express. Which removals are intended is a question about one migration's purpose, so it
+    belongs to that migration's own test, where the purpose is known; asking it here would
+    make the guard carry a list of known-good deletions -- the hand-maintained list of cases
+    it exists not to have.
 
     The second stage runs ``storage.migrations.run_migrations`` rather than Alembic
     directly, and the verdict comes from ``background_tables_ready``. Both are deliberate:

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -323,18 +323,17 @@ def revision_claims(sources: dict[str, str]) -> dict[str, list[tuple[str, dict[s
 
 
 def revision_graph(sources: dict[str, str]) -> dict[str, tuple[str, dict[str, object]]]:
-    """``{revision: (filename, {edge_field: value})}`` for identifiers naming one readable migration.
+    """``{revision: (filename, {edge_field: value})}`` for identifiers naming one migration.
 
-    A contested or computed identifier names nothing a comparison could be about, so it is
-    absent here and reported by ``ungraphable_sources`` instead. The two functions
-    partition the source tree, which is the whole point: a migration that fell out of both
-    would be one the guard neither checked nor admitted it could not check.
+    Only a contested identifier is absent, because it cannot be keyed to one migration at
+    all; ``ungraphable_sources`` reports it instead. Metadata that merely cannot be read
+    stays, carrying ``COMPUTED`` values that are unequal to everything -- a comparison
+    involving one reports drift rather than agreement, which is the honest answer where
+    nothing can be read. Dropping it here instead would be silently destructive on a
+    released tree, whose files are the only surviving record of what that release declared.
     """
-    unreadable = ungraphable_sources(sources)
     return {
-        revision: claims[0]
-        for revision, claims in revision_claims(sources).items()
-        if len(claims) == 1 and claims[0][0] not in unreadable
+        revision: claims[0] for revision, claims in revision_claims(sources).items() if len(claims) == 1
     }
 
 
@@ -344,9 +343,10 @@ def ungraphable_sources(sources: dict[str, str]) -> dict[str, str]:
     Both reasons are one defect wearing two faces: a key the guard invents has stopped
     naming exactly one migration. Metadata it cannot read as a literal names nothing, and
     an identifier two modules declare names two things. Either way the honest answer is
-    "cannot verify", and the one answer that must stay unreachable is "verified unchanged"
-    -- so this partitions the source tree with ``revision_graph``: every migration is a
-    node the comparison reaches or a reason it refuses to run, never neither.
+    "cannot verify", and the one answer that must stay unreachable is "verified unchanged".
+
+    Every caller reading a source tree owes this its output: a tree is compared only
+    alongside the reasons parts of it cannot be, or refused outright.
     """
     reasons: dict[str, str] = {}
     for revision, claims in revision_claims(sources).items():
@@ -365,7 +365,18 @@ def shipped_head_revisions(sources: dict[str, str]) -> set[str]:
 
     ``depends_on`` is an ordering constraint rather than a parent link, so only
     ``down_revision`` decides what is still a head -- the same rule Alembic applies.
+
+    Unreadable metadata is refused rather than worked around, because a head is one answer
+    and there is no partial version of it. A parent nobody can resolve leaves the real
+    ancestor looking like a head, so an upgrade that stopped early there would satisfy the
+    assertion this exists to make.
     """
+    unreadable = ungraphable_sources(sources)
+    if unreadable:
+        raise MigrationGuardError(
+            "cannot locate the head of a graph whose metadata is unreadable: "
+            + "; ".join(f"{name} {reason}" for name, reason in sorted(unreadable.items()))
+        )
     graph = revision_graph(sources)
     parents = {parent for _, edges in graph.values() for parent in edges["down_revision"]}
     return set(graph) - parents
@@ -382,19 +393,37 @@ def rechained_revisions(baseline: str | None = None) -> list[str]:
     """
     baseline = baseline or latest_released_tag()
     working_tree = working_tree_sources()
+    shipped_tree = released_sources(baseline)
     claimed = revision_claims(working_tree)
     current = revision_graph(working_tree)
+    # Both trees, because a comparison is only as trustworthy as its less readable side.
+    # A released declaration nobody can read is not one to pass over quietly: those files
+    # are the only surviving record of what the release shipped, so losing one loses the
+    # thing every later revision would have been held to.
+    unreadable_now = ungraphable_sources(working_tree)
+    unreadable_then = ungraphable_sources(shipped_tree)
     problems = [
         f"{name} {reason}, so the guard cannot hold it to {baseline}"
-        for name, reason in sorted(ungraphable_sources(working_tree).items())
+        for name, reason in sorted(unreadable_now.items())
     ]
-    for revision, (name, shipped) in sorted(revision_graph(released_sources(baseline)).items()):
+    problems += [
+        f"{baseline} shipped {name}, which {reason}, so nothing can be held to what it declared"
+        for name, reason in sorted(unreadable_then.items())
+        if name not in unreadable_now
+    ]
+    for revision, (name, shipped) in sorted(revision_graph(shipped_tree).items()):
+        if name in unreadable_then:
+            # The baseline's own declaration is what cannot be read, so there is nothing
+            # to compare against and the reason above is the whole report.
+            continue
         if revision not in current:
             if revision in claimed:
                 # Still claimed, just not readably: every claimant is named once in the
                 # reasons above, and repeating it here describes one defect as two.
                 continue
             problems.append(f"{revision} ({name}) shipped in {baseline} and is no longer in the graph")
+            continue
+        if current[revision][0] in unreadable_now:
             continue
         edges = current[revision][1]
         drift = "; ".join(

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -627,6 +627,15 @@ def test_every_table_the_schema_accepts_rows_for_gets_them(tmp_path):
         connection.execute("create table constrained (id text primary key, slug text not null)")
         connection.execute("create unique index ux_constrained_slug on constrained (slug)")
         connection.execute(
+            "create table paired (platform text not null, native_id text not null, "
+            "label text not null, primary key (platform, native_id))"
+        )
+        connection.execute(
+            "create table pinned (id text primary key, kind text not null "
+            "constraint ck_pinned_kind check (kind in ('only')), ref text not null)"
+        )
+        connection.execute("create unique index ux_pinned_kind_ref on pinned (kind, ref)")
+        connection.execute(
             "create table impossible (id text primary key, shape text not null "
             "constraint ck_impossible_shape check (shape in ('a', 'b') and shape in ('c', 'd')))"
         )
@@ -646,20 +655,31 @@ def test_every_table_the_schema_accepts_rows_for_gets_them(tmp_path):
         doc = connection.execute("select doc from shaped").fetchone()[0]
         slugs = [row[0] for row in connection.execute("select slug from constrained")]
         names = [row[0] for row in connection.execute("select name from plain")]
+        pairs = [tuple(row) for row in connection.execute("select platform, native_id from paired")]
+        pins = [tuple(row) for row in connection.execute("select kind, ref from pinned")]
     finally:
         connection.close()
 
-    assert set(short) == {table for table, count in counted.items() if count < guard.SEED_ROWS}
     assert set(short) == {"impossible"}
     assert "ck_impossible_shape" in short["impossible"]
+    assert all(count >= guard.SEED_ROWS for table, count in counted.items() if table not in short)
     # Every repair came from the constraint that rejected the row before it, not from a guess.
     assert state in {"waiting", "active"}
     assert json.loads(doc) == {"version": 1, "events": []}
-    # The two rows differ exactly where the schema already demands it and nowhere else, so a
+    # The rows differ exactly where the schema already demands it and nowhere else, so a
     # migration adding a unique index over an unconstrained column meets the duplicates a
     # released database is free to hold.
     assert len(set(slugs)) == len(slugs) == guard.SEED_ROWS
     assert len(set(names)) == 1
+    # A composite key constrains the tuple, so each of its columns still has to repeat --
+    # which is only possible over more rows than the group is wide.
+    assert len(set(pairs)) == len(pairs)
+    assert len({platform for platform, _ in pairs}) < len(pairs)
+    assert len({native_id for _, native_id in pairs}) < len(pairs)
+    # Which member of a group can carry the difference is the schema's call: a CHECK pins
+    # `kind` to one literal, so the rows have to differ on `ref` instead of giving up.
+    assert len(set(pins)) == len(pins)
+    assert len({kind for kind, _ in pins}) == 1
 
 
 @requires_release_history
@@ -670,14 +690,20 @@ def test_the_upgrade_property_runs_over_a_database_that_carries_rows(monkeypatch
     behaviour the property is about; counting afterwards would also accept a seeder that
     ran after it, or one whose rows the upgrade had already removed.
     """
-    observed: dict[str, int] = {}
+    observed: dict[str, tuple[int, int]] = {}
     upgrade = guard.run_migrations
 
     def counting(db_path):
         connection = sqlite3.connect(db_path)
         try:
             observed.update(
-                (str(name), connection.execute(f'select count(*) from "{name}"').fetchone()[0])
+                (
+                    str(name),
+                    (
+                        connection.execute(f'select count(*) from "{name}"').fetchone()[0],
+                        guard.seed_row_count(guard.distinct_column_groups(connection, str(name))),
+                    ),
+                )
                 for (name,) in connection.execute(
                     "select name from sqlite_master where type = 'table' and name not like 'sqlite_%'"
                 )
@@ -691,7 +717,7 @@ def test_the_upgrade_property_runs_over_a_database_that_carries_rows(monkeypatch
     _, short = guard.schema_gap_after_upgrade(RELEASE_HISTORY[-1])
 
     assert observed
-    assert {table for table, count in observed.items() if count < guard.SEED_ROWS} == set(short)
+    assert {table for table, (count, wanted) in observed.items() if count < wanted} == set(short)
 
 
 @requires_release_history

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -13,9 +13,11 @@ properties through the CLI with the full history fetched.
 
 from __future__ import annotations
 
+import inspect
 import sqlite3
 
 import pytest
+from alembic.script.revision import Revision
 
 from scripts import migration_release_guard as guard
 from storage.migrations import background_tables_ready
@@ -56,24 +58,29 @@ def _graphs(monkeypatch, shipped: dict[str, str], current: dict[str, str]) -> No
     monkeypatch.setattr(guard, "working_tree_sources", lambda: current)
 
 
-def _revision_file(revision: str, down_revision: str) -> str:
-    return f'"""a migration"""\n\nrevision = "{revision}"\ndown_revision = {down_revision}\n'
+def _revision_file(revision: str, down_revision: str, *, annotated: bool = False, **edges: str) -> str:
+    """A migration module declaring exactly the graph fields it is given."""
+    revision_type, parent_type = (": str", ": str | None") if annotated else ("", "")
+    lines = [f'revision{revision_type} = "{revision}"', f"down_revision{parent_type} = {down_revision}"]
+    lines += [f"{field} = {value}" for field, value in edges.items()]
+    return '"""a migration"""\n\n' + "\n".join(lines) + "\n"
 
 
 # One revision of every shape the real graph contains: a root with no parent, an ordinary
-# linear child, a sibling branch, and a merge whose parent is a tuple. Seeding every shape
-# rather than listing the ones that must not regress means a shape introduced later is
-# covered the moment it joins this table, without editing a single test.
+# linear child declared in the annotated form, a sibling branch carrying a branch label,
+# and a merge with a tuple parent and a dependency edge. Seeding every shape rather than
+# listing the ones that must not regress means a shape introduced later is covered the
+# moment it joins this table, without editing a single test.
 SHIPPED_REVISIONS = (
-    ("20260101_0001", "root", "None"),
-    ("20260102_0002", "linear", '"20260101_0001"'),
-    ("20260103_0003", "branch", '"20260101_0001"'),
-    ("20260104_0004", "merge", '("20260102_0002", "20260103_0003")'),
+    ("20260101_0001", "root", "None", {}),
+    ("20260102_0002", "linear", '"20260101_0001"', {"annotated": True}),
+    ("20260103_0003", "branch", '"20260101_0001"', {"branch_labels": '("side",)'}),
+    ("20260104_0004", "merge", '("20260102_0002", "20260103_0003")', {"depends_on": '"20260103_0003"'}),
 )
 
 SHIPPED_GRAPH = {
-    f"{revision}_{slug}.py": _revision_file(revision, down_revision)
-    for revision, slug, down_revision in SHIPPED_REVISIONS
+    f"{revision}_{slug}.py": _revision_file(revision, down_revision, **edges)
+    for revision, slug, down_revision, edges in SHIPPED_REVISIONS
 }
 
 
@@ -84,15 +91,72 @@ def test_an_unchanged_graph_reports_nothing(monkeypatch):
     assert guard.new_slot_collisions("v0.0.0") == {}
 
 
-@pytest.mark.parametrize(("revision", "slug"), [(revision, slug) for revision, slug, _ in SHIPPED_REVISIONS])
-def test_repointing_any_released_revision_is_reported(monkeypatch, revision, slug):
+@pytest.mark.parametrize(
+    ("revision", "slug", "edges"),
+    [(revision, slug, edges) for revision, slug, _, edges in SHIPPED_REVISIONS],
+)
+def test_repointing_any_released_revision_is_reported(monkeypatch, revision, slug, edges):
     current = dict(SHIPPED_GRAPH)
-    current[f"{revision}_{slug}.py"] = _revision_file(revision, '"20269999_9999"')
+    current[f"{revision}_{slug}.py"] = _revision_file(revision, '"20269999_9999"', **edges)
     _graphs(monkeypatch, SHIPPED_GRAPH, current)
 
     problems = guard.rechained_revisions("v0.0.0")
     assert len(problems) == 1
     assert revision in problems[0]
+
+
+@pytest.mark.parametrize("field", guard.GRAPH_EDGES)
+def test_changing_any_edge_alembic_orders_by_is_reported(monkeypatch, field):
+    """Every field Alembic builds its graph from, not just the parent pointer.
+
+    ``depends_on`` and ``branch_labels`` reorder a graph as surely as ``down_revision``
+    does, and a dependency added behind a revision users are already stamped at is the
+    outage's exact shape: fresh databases traverse it, existing ones record it as
+    satisfied. Parametrizing off ``GRAPH_EDGES`` means a field added to the guard is
+    covered here without editing this test.
+    """
+    declarations = {"down_revision": '"20260101_0001"'} | {field: '"20260103_0003"'}
+    current = dict(SHIPPED_GRAPH)
+    current["20260102_0002_linear.py"] = _revision_file("20260102_0002", annotated=True, **declarations)
+    _graphs(monkeypatch, SHIPPED_GRAPH, current)
+
+    problems = guard.rechained_revisions("v0.0.0")
+
+    assert len(problems) == 1
+    assert field in problems[0]
+
+
+def test_the_compared_fields_are_what_alembic_builds_its_graph_from():
+    """The field list is measured against Alembic, never maintained by hand here.
+
+    A field Alembic orders revisions by and this guard does not read is a hole of exactly
+    the outage's shape -- the graph changes and every comparison still matches. Anchoring
+    to the constructor means a field added upstream fails this test rather than going
+    unwatched for however long it takes someone to notice.
+    """
+    parameters = set(inspect.signature(Revision.__init__).parameters) - {"self"}
+
+    assert set(guard.GRAPH_FIELDS.values()) == parameters
+
+
+@pytest.mark.parametrize(
+    ("shipped", "respelled"),
+    [('"20260101_0001"', '("20260101_0001",)'), ('("20260101_0001",)', '"20260101_0001"')],
+    ids=["scalar-to-tuple", "tuple-to-scalar"],
+)
+def test_a_spelling_alembic_reads_identically_is_not_drift(monkeypatch, shipped, respelled):
+    """Normalization is Alembic's, so the guard agrees with it about what changed.
+
+    A guard that reported a re-spelling would be red for an edit that changes nothing,
+    and a guard people expect to be wrong is one they stop reading.
+    """
+    _graphs(
+        monkeypatch,
+        dict(SHIPPED_GRAPH) | {"20260102_0002_linear.py": _revision_file("20260102_0002", shipped)},
+        dict(SHIPPED_GRAPH) | {"20260102_0002_linear.py": _revision_file("20260102_0002", respelled)},
+    )
+
+    assert guard.rechained_revisions("v0.0.0") == []
 
 
 def test_deleting_a_released_revision_is_reported(monkeypatch):

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -458,7 +458,7 @@ def test_the_real_graph_is_wholly_comparable():
 @pytest.mark.parametrize(("problems", "expected_exit"), [([], 0), (["a released revision was rechained"], 1)])
 def test_the_command_line_exit_code_follows_the_verdict(monkeypatch, capsys, problems, expected_exit):
     """The CLI is how a developer runs this outside CI, so its wiring is part of the guard."""
-    monkeypatch.setattr(guard, "collect_problems", lambda baseline, **kwargs: ("v9.9.9", problems))
+    monkeypatch.setattr(guard, "collect_problems", lambda baseline, **kwargs: ("v9.9.9", problems, {}))
 
     assert guard.main([]) == expected_exit
     for problem in problems:
@@ -565,9 +565,9 @@ def test_a_release_the_property_could_not_cover_is_reported_as_a_failure(monkeyp
     being visible: the run says both "passed" and "did not look", and only one is read.
     """
     monkeypatch.setattr(guard, "released_graphs", lambda: ["v9.9.9"])
-    monkeypatch.setattr(guard, "schema_gap_after_upgrade", lambda tag: (gap, short))
+    monkeypatch.setattr(guard, "schema_gap_after_upgrade", lambda tag: (gap, short, {}))
 
-    reasons = guard.unrepairable_releases().get("v9.9.9", [])
+    reasons = guard.unrepairable_releases()[0].get("v9.9.9", [])
 
     assert len(reasons) == len(expected)
     assert all(fragment in reason for reason, fragment in zip(reasons, expected))
@@ -640,15 +640,38 @@ def test_every_table_the_schema_accepts_rows_for_gets_them(tmp_path):
         )
         connection.execute("create unique index ux_overlapping_ab on overlapping (a, b)")
         connection.execute("create unique index ux_overlapping_bc on overlapping (b, c)")
+        connection.execute("create table nullable (id text primary key, tag text, note text)")
+        connection.execute(
+            "create table exclusive (id text primary key, kind text not null, left_ref text, right_ref text, "
+            "constraint ck_exclusive_shape check ("
+            "(kind = 'left' and left_ref is not null and right_ref is null) or "
+            "(kind = 'right' and right_ref is not null and left_ref is null) or "
+            "(kind = 'none' and left_ref is null and right_ref is null)))"
+        )
         connection.execute(
             "create table impossible (id text primary key, shape text not null "
             "constraint ck_impossible_shape check (shape in ('a', 'b') and shape in ('c', 'd')))"
+        )
+        # A parent whose key a CHECK holds to one literal, so a child cannot guess the value it
+        # ends up with, and two children of it: one whose reference may repeat, and one whose
+        # reference is its own primary key and therefore may not.
+        connection.execute(
+            "create table parented (id text primary key "
+            "constraint ck_parented_id check (id in ('kept')), note text)"
+        )
+        connection.execute(
+            "create table sharing (id text primary key, parent_id text not null references parented (id), "
+            "note text)"
+        )
+        connection.execute(
+            "create table exclusively_owned (parent_id text primary key references parented (id), "
+            "note text)"
         )
         connection.commit()
     finally:
         connection.close()
 
-    short = guard.seed_representative_rows(db_path)
+    short, refused = guard.seed_representative_rows(db_path)
 
     connection = sqlite3.connect(db_path)
     try:
@@ -663,10 +686,15 @@ def test_every_table_the_schema_accepts_rows_for_gets_them(tmp_path):
         pairs = [tuple(row) for row in connection.execute("select platform, native_id from paired")]
         pins = [tuple(row) for row in connection.execute("select kind, ref from pinned")]
         overlaps = [tuple(row) for row in connection.execute("select a, b, c from overlapping")]
+        tags = [row[0] for row in connection.execute("select tag from nullable")]
+        kinds = [tuple(row) for row in connection.execute("select kind, left_ref, right_ref from exclusive")]
+        shared = [row[0] for row in connection.execute("select parent_id from sharing")]
+        owned = [row[0] for row in connection.execute("select parent_id from exclusively_owned")]
+        dangling = connection.execute("pragma foreign_key_check").fetchall()
     finally:
         connection.close()
 
-    assert set(short) == {"impossible"}
+    assert set(short) == {"impossible", "parented", "exclusively_owned"}
     assert "ck_impossible_shape" in short["impossible"]
     assert all(count >= guard.SEED_ROWS for table, count in counted.items() if table not in short)
     # Every repair came from the constraint that rejected the row before it, not from a guess.
@@ -693,6 +721,38 @@ def test_every_table_the_schema_accepts_rows_for_gets_them(tmp_path):
     # other's repeat: every row that holds `ref` still carries `kind = 'only'` and collides.
     assert len(set(pins)) == len(pins)
     assert len({kind for kind, _ in pins}) == 1
+    # A nullable column carries both shapes a release holds. Only the non-NULL one is new: a
+    # migration tightening the column or reading its value is untested against NULLs alone,
+    # and one made non-NULL everywhere is untested against the NULLs it will actually meet.
+    assert None in tags
+    assert [tag for tag in tags if tag is not None]
+    # Some tables have no row with every column non-NULL, and no fixture can be asked for one:
+    # `ck_exclusive_shape` keys `left_ref` and `right_ref` off `kind`, so each state requires
+    # one of them NULL. The table still gets rows, in whichever state the repair reached, and
+    # the columns that leaves NULL are what `refused` exists to say out loud rather than to
+    # pass over. Reaching every state instead is constraint solving, which this is not.
+    assert "exclusive, every column at once" in refused
+    assert "ck_exclusive_shape" in refused["exclusive, every column at once"]
+    assert "exclusive" not in short
+    assert {(left, right) for _, left, right in kinds} == {(None, None)}
+    # Every reference resolves, which is not a nicety: `20260806_0047` rebuilds tables and then
+    # runs this same check, aborting the upgrade if anything dangles, so a fabricated reference
+    # turns a correct migration red. It cannot be resolved by guessing either -- `ck_parented_id`
+    # holds the parent's key to one literal, so only reading back what the parent ended up with
+    # gets it right.
+    assert dangling == []
+    assert set(shared) == {"kept"}
+    # Whether the children may share that parent is the database's answer: `sharing` keeps its
+    # reference in every row, while `exclusively_owned` has it as a primary key and so is bounded
+    # by the one parent row there is. Sharing regardless would collapse it to a single row, and
+    # one row is what this whole fixture exists to stop being.
+    assert owned == ["kept"]
+    assert f"of {guard.SEED_ROWS} rows" in short["exclusively_owned"]
+    # And the bound is reported at both ends rather than only where it bites. `parented` may hold
+    # one row because its key is held to one literal; `exclusively_owned` may hold one because
+    # each of its rows needs a parent of its own. Naming only the child would read as the child's
+    # problem, and naming neither is the shortfall-as-a-note this whole split exists to refuse.
+    assert f"of {guard.SEED_ROWS} rows" in short["parented"]
 
 
 def test_a_repeat_the_rows_do_not_carry_is_a_violation_however_it_got_there():
@@ -740,7 +800,7 @@ def test_the_upgrade_property_runs_over_a_database_that_carries_rows(monkeypatch
         return upgrade(db_path)
 
     monkeypatch.setattr(guard, "run_migrations", counting)
-    _, short = guard.schema_gap_after_upgrade(RELEASE_HISTORY[-1])
+    _, short, _ = guard.schema_gap_after_upgrade(RELEASE_HISTORY[-1])
 
     assert observed
     assert all(count >= guard.SEED_ROWS for table, count in observed.items() if table not in short)
@@ -779,7 +839,7 @@ def test_every_released_database_still_reaches_head():
     replaying the current chain from empty, which produces the schema the current graph
     intends rather than the schema a release actually left behind.
     """
-    assert guard.unrepairable_releases() == {}
+    assert guard.unrepairable_releases()[0] == {}
 
 
 @requires_release_history

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -269,6 +269,7 @@ UNREADABLE_GRAPH = dict(SHIPPED_GRAPH) | {
     ),
     "20260108_0008_duplicate.py": _revision_file("20260102_0002", '"20260101_0001"'),
     "20260109_0009_no_metadata.py": '"""not a migration at all"""\n',
+    "__init__.py": "",
 }
 
 
@@ -287,12 +288,17 @@ def test_every_migration_is_compared_or_reported(sources):
     where dropping a node discards the only surviving record of what that release
     declared. An unreadable node stays in the graph carrying values that compare unequal
     to everything, so it is reached *and* reported.
+
+    The denominator is the point. Every earlier version of this assertion counted the
+    files the guard's own parser had managed to read, which cannot fail: a file it does
+    not see is missing from both the numerator and the denominator at once. Counting the
+    files Alembic will load is a measurement the parser cannot influence, so a migration
+    that becomes invisible to it now fails here instead of passing quietly.
     """
     compared = {name for name, _ in guard.revision_graph(sources).values()}
     reported = set(guard.ungraphable_sources(sources))
-    declares_a_revision = {name for name, source in sources.items() if "revision" in guard.declared_graph_fields(source)}
 
-    assert compared | reported == declares_a_revision
+    assert compared | reported == {name for name in sources if guard.is_migration_source(name)}
 
 
 # Every shape a *released* migration's metadata can take: the readable ones, plus an edge
@@ -326,6 +332,43 @@ def test_no_released_revision_can_be_rewritten_without_a_report(monkeypatch, rev
     problems = guard.rechained_revisions("v0.0.0")
 
     assert [problem for problem in problems if revision in problem or name in problem]
+
+
+@pytest.mark.parametrize(("revision", "slug"), [(revision, slug) for revision, slug, _, _ in SHIPPED_REVISIONS])
+def test_no_released_migration_body_can_change_without_a_report(monkeypatch, revision, slug):
+    """What a released migration *does* is as fixed as what it declares.
+
+    A database stamped at the revision never reruns the edited body and a fresh install
+    runs only the new one, so the two diverge permanently with nothing raised at either
+    moment. The edit here is a comment, which is the weakest case on purpose: an
+    exemption for edits that look harmless would put a human judgement back on the path
+    this guard exists to take it off.
+    """
+    name = f"{revision}_{slug}.py"
+    current = dict(SHIPPED_GRAPH)
+    current[name] += "\n# a later edit\n"
+    _graphs(monkeypatch, SHIPPED_GRAPH, current)
+
+    problems = guard.edited_released_bodies("v0.0.0")
+
+    assert len(problems) == 1
+    assert name in problems[0]
+
+
+def test_support_files_are_not_held_to_the_release(monkeypatch):
+    """Alembic does not load ``__init__.py`` as a migration, so neither does the guard."""
+    shipped = dict(SHIPPED_GRAPH) | {"__init__.py": ""}
+    current = dict(shipped) | {"__init__.py": "# touched\n"}
+    _graphs(monkeypatch, shipped, current)
+
+    assert guard.edited_released_bodies("v0.0.0") == []
+    assert guard.rechained_revisions("v0.0.0") == []
+
+
+@requires_release_history
+def test_no_released_migration_body_has_been_edited():
+    """The claim measured against the graph that actually ships, not a synthetic one."""
+    assert guard.edited_released_bodies() == []
 
 
 def test_an_unreadable_graph_has_its_head_refused_rather_than_guessed():

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -334,8 +334,9 @@ def test_no_released_revision_can_be_rewritten_without_a_report(monkeypatch, rev
     assert [problem for problem in problems if revision in problem or name in problem]
 
 
+@pytest.mark.parametrize("renamed", [False, True], ids=["in-place", "renamed"])
 @pytest.mark.parametrize(("revision", "slug"), [(revision, slug) for revision, slug, _, _ in SHIPPED_REVISIONS])
-def test_no_released_migration_body_can_change_without_a_report(monkeypatch, revision, slug):
+def test_no_released_migration_body_can_change_without_a_report(monkeypatch, revision, slug, renamed):
     """What a released migration *does* is as fixed as what it declares.
 
     A database stamped at the revision never reruns the edited body and a fresh install
@@ -343,16 +344,73 @@ def test_no_released_migration_body_can_change_without_a_report(monkeypatch, rev
     moment. The edit here is a comment, which is the weakest case on purpose: an
     exemption for edits that look harmless would put a human judgement back on the path
     this guard exists to take it off.
+
+    Renaming is the same edit wearing a filename, and both axes are stated together
+    because they are one defect rather than a case and its afterthought. Alembic keys a
+    migration by ``revision`` and scans the directory to find it, so the renamed file runs
+    on every fresh install exactly as the original did -- while a check keyed by filename
+    sees the old name absent and compares nothing.
     """
     name = f"{revision}_{slug}.py"
     current = dict(SHIPPED_GRAPH)
-    current[name] += "\n# a later edit\n"
+    edited = current.pop(name) + "\n# a later edit\n"
+    current[f"{revision}_renamed.py" if renamed else name] = edited
     _graphs(monkeypatch, SHIPPED_GRAPH, current)
 
     problems = guard.edited_released_bodies("v0.0.0")
 
     assert len(problems) == 1
-    assert name in problems[0]
+    assert revision in problems[0]
+
+
+def test_renaming_a_released_migration_without_editing_it_is_not_a_change(monkeypatch):
+    """The boundary the property above draws, stated from the side it must not cross.
+
+    A database records the revision it reached and nothing else, and Alembic finds that
+    revision by scanning ``version_locations`` rather than by name. A rename leaving the
+    body alone is therefore invisible to every database in the field, and reporting it
+    would be the guard enforcing a filename convention of its own -- which is the slot
+    property's subject, not this one's.
+    """
+    revision, slug = SHIPPED_REVISIONS[0][0], SHIPPED_REVISIONS[0][1]
+    current = dict(SHIPPED_GRAPH)
+    current[f"{revision}_moved.py"] = current.pop(f"{revision}_{slug}.py")
+    _graphs(monkeypatch, SHIPPED_GRAPH, current)
+
+    assert guard.edited_released_bodies("v0.0.0") == []
+    assert guard.rechained_revisions("v0.0.0") == []
+
+
+# Every way a released revision can stop running what the release ran, keyed by the shape
+# of the change rather than by which half of the pair happens to catch it.
+RELEASED_REVISION_MUTATIONS = {
+    "edited": lambda sources, name: dict(sources) | {name: sources[name] + "\n# a later edit\n"},
+    "renamed-and-edited": lambda sources, name: {key: value for key, value in sources.items() if key != name}
+    | {"20269999_9999_moved.py": sources[name] + "\n# a later edit\n"},
+    "deleted": lambda sources, name: {key: value for key, value in sources.items() if key != name},
+    "rechained": lambda sources, name: dict(sources) | {name: _revision_file("20260102_0002", '"20269999_9999"')},
+    "made-unreadable": lambda sources, name: dict(sources)
+    | {name: sources[name].replace('"20260102_0002"', "SOME_CONSTANT")},
+    "duplicated": lambda sources, name: dict(sources) | {"20260102_0002_copy.py": sources[name]},
+}
+
+
+@pytest.mark.parametrize(
+    "mutate", list(RELEASED_REVISION_MUTATIONS.values()), ids=list(RELEASED_REVISION_MUTATIONS)
+)
+def test_a_released_revision_is_always_accounted_for(monkeypatch, mutate):
+    """The pair is exhaustive even where neither half is, and that is the claim on record.
+
+    ``rechained_revisions`` watches what a revision declares and ``edited_released_bodies``
+    watches what it does, so each passes over what the other owns -- a revision that is
+    gone, contested, or unreadable has no body to compare, and a body edit under an
+    unchanged declaration produces no drift. Asserting on their union is what makes those
+    hand-offs safe: a case falling out of one half without landing in the other fails here
+    rather than becoming a silently unguarded shape.
+    """
+    _graphs(monkeypatch, SHIPPED_GRAPH, mutate(SHIPPED_GRAPH, "20260102_0002_linear.py"))
+
+    assert guard.rechained_revisions("v0.0.0") + guard.edited_released_bodies("v0.0.0")
 
 
 def test_support_files_are_not_held_to_the_release(monkeypatch):

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -13,9 +13,12 @@ properties through the CLI with the full history fetched.
 
 from __future__ import annotations
 
+import sqlite3
+
 import pytest
 
 from scripts import migration_release_guard as guard
+from storage.migrations import background_tables_ready
 
 pytestmark = pytest.mark.no_sqlite_template
 
@@ -124,15 +127,50 @@ def test_a_slot_the_baseline_already_shared_is_not_reported(monkeypatch):
     assert guard.new_slot_collisions("v0.0.0") == {}
 
 
-def test_a_computed_revision_identifier_is_not_silently_skipped(monkeypatch):
-    """A revision that computes its parent cannot be compared, so it must not read as equal."""
-    current = dict(SHIPPED_GRAPH)
-    current["20260102_0002_linear.py"] = '"""a migration"""\n\nrevision = "20260102_0002"\ndown_revision = ROOT\n'
-    _graphs(monkeypatch, SHIPPED_GRAPH, current)
+def test_a_further_claimant_to_an_already_shared_slot_is_reported(monkeypatch):
+    """What history excuses is the filenames it shipped, not the slot number forever.
+
+    Excusing the number would make an already-duplicated slot a permanent blind spot --
+    the one place a third branch could fork the graph without the guard saying anything.
+    """
+    shipped = dict(SHIPPED_GRAPH)
+    shipped["20260105_0004_second_claim.py"] = _revision_file("20260105_0004", '"20260104_0004"')
+    current = dict(shipped)
+    current["20260106_0004_third_claim.py"] = _revision_file("20260106_0004", '"20260105_0004"')
+    _graphs(monkeypatch, shipped, current)
+
+    assert guard.new_slot_collisions("v0.0.0") == {
+        "0004": {
+            "20260104_0004_merge.py",
+            "20260105_0004_second_claim.py",
+            "20260106_0004_third_claim.py",
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    "shipped_parent",
+    ['"20260101_0001"', "ROOT"],
+    ids=["shipped-a-literal", "shipped-a-computed-expression"],
+)
+def test_computed_revision_metadata_is_reported_rather_than_compared(monkeypatch, shipped_parent):
+    """Metadata the guard cannot read is the absence of evidence, never evidence of equality.
+
+    The second case is the one a normalized ``"<computed>"`` string got wrong: two
+    different computed expressions rendered identically and so compared equal, which read
+    as an unchanged graph precisely where nothing could be verified at all.
+    """
+    shipped = dict(SHIPPED_GRAPH)
+    shipped["20260102_0002_linear.py"] = _revision_file("20260102_0002", shipped_parent)
+    current = dict(shipped)
+    current["20260102_0002_linear.py"] = _revision_file("20260102_0002", "SOME_OTHER_CONSTANT")
+    _graphs(monkeypatch, shipped, current)
 
     problems = guard.rechained_revisions("v0.0.0")
+
     assert len(problems) == 1
-    assert "<computed>" in problems[0]
+    assert "20260102_0002_linear.py" in problems[0]
+    assert "computes its migration metadata" in problems[0]
 
 
 @pytest.mark.parametrize(("problems", "expected_exit"), [([], 0), (["a released revision was rechained"], 1)])
@@ -162,6 +200,28 @@ def test_head_tables_is_what_a_fresh_install_has():
     nobody adds it here, the upgrade property stops asking about it and goes on passing.
     """
     assert guard.fresh_install_tables() == guard.HEAD_TABLES
+
+
+def test_a_complete_set_of_tables_is_not_by_itself_a_complete_schema(tmp_path):
+    """Readiness has to mean what production means by it, columns included.
+
+    An upgrade that creates every table and omits a column leaves a database that starts
+    and then fails on the first query touching it -- indistinguishable from success to
+    anything comparing table names alone.
+    """
+    db_path = tmp_path / "vibe.sqlite"
+    connection = sqlite3.connect(db_path)
+    try:
+        for table in guard.HEAD_TABLES:
+            connection.execute(f'create table "{table}" (placeholder integer)')
+        connection.commit()
+    finally:
+        connection.close()
+
+    assert not background_tables_ready(db_path)
+    gap = guard.describe_schema_gap(db_path)
+    assert "table(s) missing" not in gap
+    assert "column(s) missing" in gap
 
 
 @requires_release_history
@@ -201,7 +261,7 @@ def test_a_released_graph_that_applies_nothing_cannot_pass(monkeypatch):
     )
 
     with pytest.raises(guard.MigrationGuardError):
-        guard.missing_tables_after_upgrade(RELEASE_HISTORY[-1])
+        guard.schema_gap_after_upgrade(RELEASE_HISTORY[-1])
 
 
 @requires_spliced_baseline

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1,0 +1,217 @@
+"""Cover the migration release guard's detection and the properties it asserts.
+
+Two layers. The synthetic tests pin the detection itself, so the guard cannot decay into
+something that passes because it stopped looking. The repository tests are the guard
+running for real: three of them state the invariant the working tree must hold, and one
+runs the guard against the release that preceded the v3.0.11 splice, which is the known
+positive that keeps the other three honest.
+
+Anything reading release history needs tags, which a shallow CI checkout does not have.
+Those tests skip there and the ``migration-release-guard`` workflow runs the same
+properties through the CLI with the full history fetched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts import migration_release_guard as guard
+
+pytestmark = pytest.mark.no_sqlite_template
+
+
+def _release_history() -> list[str]:
+    try:
+        return guard.released_tags()
+    except guard.MigrationGuardError:
+        return []
+
+
+RELEASE_HISTORY = _release_history()
+
+# The last release before the splice shipped. Comparing today's graph against it must
+# still surface the rechain, which is what proves the guard detects the real defect and
+# not merely a synthetic one.
+SPLICED_BASELINE = "v3.0.10"
+SPLICED_REVISION = "20260806_0047"
+
+requires_release_history = pytest.mark.skipif(
+    not RELEASE_HISTORY,
+    reason=(
+        "this checkout has no release tags carrying migrations; the migration-release-guard "
+        "workflow runs these properties with fetch-depth: 0"
+    ),
+)
+requires_spliced_baseline = pytest.mark.skipif(
+    SPLICED_BASELINE not in RELEASE_HISTORY,
+    reason=f"{SPLICED_BASELINE} is not present in this checkout",
+)
+
+
+def _graphs(monkeypatch, shipped: dict[str, str], current: dict[str, str]) -> None:
+    monkeypatch.setattr(guard, "released_sources", lambda tag: shipped)
+    monkeypatch.setattr(guard, "working_tree_sources", lambda: current)
+
+
+def _revision_file(revision: str, down_revision: str) -> str:
+    return f'"""a migration"""\n\nrevision = "{revision}"\ndown_revision = {down_revision}\n'
+
+
+# One revision of every shape the real graph contains: a root with no parent, an ordinary
+# linear child, a sibling branch, and a merge whose parent is a tuple. Seeding every shape
+# rather than listing the ones that must not regress means a shape introduced later is
+# covered the moment it joins this table, without editing a single test.
+SHIPPED_REVISIONS = (
+    ("20260101_0001", "root", "None"),
+    ("20260102_0002", "linear", '"20260101_0001"'),
+    ("20260103_0003", "branch", '"20260101_0001"'),
+    ("20260104_0004", "merge", '("20260102_0002", "20260103_0003")'),
+)
+
+SHIPPED_GRAPH = {
+    f"{revision}_{slug}.py": _revision_file(revision, down_revision)
+    for revision, slug, down_revision in SHIPPED_REVISIONS
+}
+
+
+def test_an_unchanged_graph_reports_nothing(monkeypatch):
+    _graphs(monkeypatch, SHIPPED_GRAPH, dict(SHIPPED_GRAPH))
+
+    assert guard.rechained_revisions("v0.0.0") == []
+    assert guard.new_slot_collisions("v0.0.0") == {}
+
+
+@pytest.mark.parametrize(("revision", "slug"), [(revision, slug) for revision, slug, _ in SHIPPED_REVISIONS])
+def test_repointing_any_released_revision_is_reported(monkeypatch, revision, slug):
+    current = dict(SHIPPED_GRAPH)
+    current[f"{revision}_{slug}.py"] = _revision_file(revision, '"20269999_9999"')
+    _graphs(monkeypatch, SHIPPED_GRAPH, current)
+
+    problems = guard.rechained_revisions("v0.0.0")
+    assert len(problems) == 1
+    assert revision in problems[0]
+
+
+def test_deleting_a_released_revision_is_reported(monkeypatch):
+    current = {name: source for name, source in SHIPPED_GRAPH.items() if "linear" not in name}
+    _graphs(monkeypatch, SHIPPED_GRAPH, current)
+
+    problems = guard.rechained_revisions("v0.0.0")
+    assert len(problems) == 1
+    assert "20260102_0002" in problems[0]
+
+
+def test_a_slot_taken_twice_since_the_baseline_is_reported(monkeypatch):
+    current = dict(SHIPPED_GRAPH)
+    current["20260105_0004_second_claim.py"] = _revision_file("20260105_0004", '"20260104_0004"')
+    _graphs(monkeypatch, SHIPPED_GRAPH, current)
+
+    assert guard.new_slot_collisions("v0.0.0") == {
+        "0004": {"20260104_0004_merge.py", "20260105_0004_second_claim.py"}
+    }
+
+
+def test_a_slot_the_baseline_already_shared_is_not_reported(monkeypatch):
+    """Collisions history already carries stay out of the report, without an allowlist.
+
+    The graph really does contain them. Reporting them would leave the guard permanently
+    red -- and a permanently red guard is one people learn to ignore.
+    """
+    shipped = dict(SHIPPED_GRAPH)
+    shipped["20260105_0004_second_claim.py"] = _revision_file("20260105_0004", '"20260104_0004"')
+    _graphs(monkeypatch, shipped, dict(shipped))
+
+    assert guard.new_slot_collisions("v0.0.0") == {}
+
+
+def test_a_computed_revision_identifier_is_not_silently_skipped(monkeypatch):
+    """A revision that computes its parent cannot be compared, so it must not read as equal."""
+    current = dict(SHIPPED_GRAPH)
+    current["20260102_0002_linear.py"] = '"""a migration"""\n\nrevision = "20260102_0002"\ndown_revision = ROOT\n'
+    _graphs(monkeypatch, SHIPPED_GRAPH, current)
+
+    problems = guard.rechained_revisions("v0.0.0")
+    assert len(problems) == 1
+    assert "<computed>" in problems[0]
+
+
+@pytest.mark.parametrize(("problems", "expected_exit"), [([], 0), (["a released revision was rechained"], 1)])
+def test_the_command_line_exit_code_follows_the_verdict(monkeypatch, capsys, problems, expected_exit):
+    """The CLI is how a developer runs this outside CI, so its wiring is part of the guard."""
+    monkeypatch.setattr(guard, "collect_problems", lambda baseline, **kwargs: ("v9.9.9", problems))
+
+    assert guard.main([]) == expected_exit
+    for problem in problems:
+        assert problem in capsys.readouterr().err
+
+
+def test_the_command_line_refuses_rather_than_passing_without_history(monkeypatch, capsys):
+    def unreachable(*args, **kwargs):
+        raise guard.MigrationGuardError("no release tag carries the migrations directory")
+
+    monkeypatch.setattr(guard, "collect_problems", unreachable)
+
+    assert guard.main([]) == 2
+    assert "could not run" in capsys.readouterr().err
+
+
+def test_head_tables_is_what_a_fresh_install_has():
+    """The derivation source for the upgrade property must itself be measured, not maintained.
+
+    Every other check compares against ``HEAD_TABLES``. If a migration adds a table and
+    nobody adds it here, the upgrade property stops asking about it and goes on passing.
+    """
+    assert guard.fresh_install_tables() == guard.HEAD_TABLES
+
+
+@requires_release_history
+def test_no_slot_is_newly_taken_twice():
+    assert guard.new_slot_collisions() == {}
+
+
+@requires_release_history
+def test_no_released_revision_has_been_rechained():
+    assert guard.rechained_revisions() == []
+
+
+@requires_release_history
+def test_every_released_database_still_reaches_head():
+    """A database built by any released graph must reach the full schema under today's.
+
+    This is the property the v3.0.11 outage violated, and the one no other test in this
+    repository could see: every existing migration test builds its starting database by
+    replaying the current chain from empty, which produces the schema the current graph
+    intends rather than the schema a release actually left behind.
+    """
+    assert guard.unrepairable_releases() == {}
+
+
+@requires_release_history
+def test_a_released_graph_that_applies_nothing_cannot_pass(monkeypatch):
+    """The guard's own false negative, closed.
+
+    An Alembic run whose ``version_locations`` resolves to no revisions reports success
+    and applies nothing, and the empty database it leaves behind then upgrades to today's
+    head with a complete schema -- a pass that proves the opposite of what it claims.
+    """
+    monkeypatch.setattr(
+        guard,
+        "extract_released_versions",
+        lambda tag, destination: (destination.mkdir(parents=True, exist_ok=True), destination)[1],
+    )
+
+    with pytest.raises(guard.MigrationGuardError):
+        guard.missing_tables_after_upgrade(RELEASE_HISTORY[-1])
+
+
+@requires_spliced_baseline
+def test_the_guard_still_detects_the_release_it_was_written_for():
+    """Run against the release before the splice, the guard must report it.
+
+    Without this, every assertion above could pass because the guard stopped detecting
+    anything, and nothing in the suite would notice.
+    """
+    problems = guard.rechained_revisions(SPLICED_BASELINE)
+
+    assert [problem for problem in problems if SPLICED_REVISION in problem]
+    assert guard.new_slot_collisions(SPLICED_BASELINE)

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import inspect
 import sqlite3
+from pathlib import Path
 
 import pytest
 from alembic.script.revision import Revision
@@ -237,6 +238,69 @@ def test_computed_revision_metadata_is_reported_rather_than_compared(monkeypatch
     assert "computes its migration metadata" in problems[0]
 
 
+def test_two_files_claiming_one_revision_are_reported_rather_than_compared(monkeypatch):
+    """Alembic identifies a migration by its revision string, and so must the guard.
+
+    Two files declaring one identifier are indistinguishable to both: a database stamped
+    with it has applied whichever one ran, and Alembic will never run the other's body.
+    The dangerous outcome is not the collision but the silent survivor -- one claimant
+    answering the comparison for a migration whose tables no database has.
+    """
+    current = dict(SHIPPED_GRAPH)
+    current["20260105_0005_impostor.py"] = _revision_file("20260102_0002", '"20260101_0001"')
+    _graphs(monkeypatch, SHIPPED_GRAPH, current)
+
+    problems = guard.rechained_revisions("v0.0.0")
+
+    assert len(problems) == 2
+    assert {"20260102_0002_linear.py", "20260105_0005_impostor.py"} == {problem.split()[0] for problem in problems}
+    assert all("also declares" in problem for problem in problems)
+
+
+# Every way a migration file's declared metadata can be malformed, alongside the well-formed
+# shapes. Seeding the malformed ones rather than listing which failures must be caught is
+# what makes the partition below complete: a new way to be unreadable joins this table and
+# is covered without editing an assertion.
+UNREADABLE_GRAPH = dict(SHIPPED_GRAPH) | {
+    "20260105_0005_computed_revision.py": _revision_file("X", "None").replace('"X"', "SOME_CONSTANT"),
+    "20260106_0006_computed_parent.py": _revision_file("20260106_0006", "SOME_CONSTANT"),
+    "20260107_0007_computed_dependency.py": _revision_file(
+        "20260107_0007", '"20260101_0001"', depends_on="SOME_CONSTANT"
+    ),
+    "20260108_0008_duplicate.py": _revision_file("20260102_0002", '"20260101_0001"'),
+    "20260109_0009_no_metadata.py": '"""not a migration at all"""\n',
+}
+
+
+@pytest.mark.parametrize("sources", [SHIPPED_GRAPH, UNREADABLE_GRAPH], ids=["well-formed", "malformed"])
+def test_every_migration_is_either_compared_or_reported(sources):
+    """The invariant behind every key this guard invents, stated once.
+
+    A key names exactly one migration or it names none. Whatever a file declares, it is
+    either a node the comparison reaches or a reason the comparison refuses to run --
+    never neither, because a file that is neither has been dropped silently and the
+    comparison then passes over a graph missing it. Both known ways to lose one were
+    review findings; asserting the partition instead of those two means the third way
+    fails a test rather than shipping as a hole.
+    """
+    compared = {name for name, _ in guard.revision_graph(sources).values()}
+    reported = set(guard.ungraphable_sources(sources))
+    declares_a_revision = {name for name, source in sources.items() if "revision" in guard.declared_graph_fields(source)}
+
+    assert compared | reported == declares_a_revision
+    assert compared & reported == set()
+
+
+@requires_release_history
+def test_the_real_graph_is_wholly_comparable():
+    """The partition above, run against the graph that actually ships.
+
+    Holding only a synthetic tree to it would leave the possibility that every real
+    migration sits in the reported half, where nothing is ever compared.
+    """
+    assert guard.ungraphable_sources(guard.working_tree_sources()) == {}
+
+
 @pytest.mark.parametrize(("problems", "expected_exit"), [([], 0), (["a released revision was rechained"], 1)])
 def test_the_command_line_exit_code_follows_the_verdict(monkeypatch, capsys, problems, expected_exit):
     """The CLI is how a developer runs this outside CI, so its wiring is part of the guard."""
@@ -288,6 +352,35 @@ def test_a_complete_set_of_tables_is_not_by_itself_a_complete_schema(tmp_path):
     assert "column(s) missing" in gap
 
 
+def test_a_prerelease_sorts_between_the_releases_it_falls_between():
+    """Installable prereleases are releases here, ordered where they actually shipped.
+
+    ``gh-vX.Y.ZrcN`` builds carry a wheel and an sdist, so a database in the field can
+    have been built by one. Sorting them as releases is what makes the newest tag a
+    baseline rather than a guess.
+    """
+    assert (
+        guard.version_key("v3.0.8")
+        < guard.version_key("gh-v3.0.9rc2")
+        < guard.version_key("gh-v3.0.9rc10")
+        < guard.version_key("v3.0.9")
+    )
+
+
+@requires_release_history
+def test_every_installable_tag_is_covered_exactly_once():
+    """Coverage is per shipped graph: nothing skipped, nothing rebuilt.
+
+    The unit has to be the graph rather than the tag, because a graph is what put a
+    database in the field -- and because covering ~95 installable tags one database each
+    would cost minutes to prove what ~30 distinct directories already prove.
+    """
+    covered = guard.released_graphs()
+
+    assert {guard.versions_tree(tag) for tag in covered} == {guard.versions_tree(tag) for tag in guard.released_tags()}
+    assert len({guard.versions_tree(tag) for tag in covered}) == len(covered)
+
+
 @requires_release_history
 def test_no_slot_is_newly_taken_twice():
     assert guard.new_slot_collisions() == {}
@@ -311,18 +404,26 @@ def test_every_released_database_still_reaches_head():
 
 
 @requires_release_history
-def test_a_released_graph_that_applies_nothing_cannot_pass(monkeypatch):
-    """The guard's own false negative, closed.
+@pytest.mark.parametrize("keep", [0, 1], ids=["applies-nothing", "applies-a-prefix"])
+def test_a_database_the_release_never_shipped_cannot_pass(monkeypatch, keep, tmp_path):
+    """The guard's own false negative, closed at the only revision that proves anything.
 
-    An Alembic run whose ``version_locations`` resolves to no revisions reports success
-    and applies nothing, and the empty database it leaves behind then upgrades to today's
-    head with a complete schema -- a pass that proves the opposite of what it claims.
+    An extraction that resolves to no revisions -- or to some prefix of the release --
+    reports success and leaves a database that release never shipped, which then upgrades
+    to today's head with a complete schema: a pass proving the opposite of what it claims.
+    Every intermediate revision is a database today's graph can legitimately repair, so
+    only the released graph's own head is evidence it was applied in full.
     """
-    monkeypatch.setattr(
-        guard,
-        "extract_released_versions",
-        lambda tag, destination: (destination.mkdir(parents=True, exist_ok=True), destination)[1],
-    )
+
+    extract = guard.extract_released_versions
+
+    def truncated(tag: str, destination: Path) -> Path:
+        versions = extract(tag, destination)
+        for path in sorted(versions.glob("*.py"))[keep:]:
+            path.unlink()
+        return versions
+
+    monkeypatch.setattr(guard, "extract_released_versions", truncated)
 
     with pytest.raises(guard.MigrationGuardError):
         guard.schema_gap_after_upgrade(RELEASE_HISTORY[-1])

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -273,22 +273,73 @@ UNREADABLE_GRAPH = dict(SHIPPED_GRAPH) | {
 
 
 @pytest.mark.parametrize("sources", [SHIPPED_GRAPH, UNREADABLE_GRAPH], ids=["well-formed", "malformed"])
-def test_every_migration_is_either_compared_or_reported(sources):
+def test_every_migration_is_compared_or_reported(sources):
     """The invariant behind every key this guard invents, stated once.
 
     A key names exactly one migration or it names none. Whatever a file declares, it is
     either a node the comparison reaches or a reason the comparison refuses to run --
     never neither, because a file that is neither has been dropped silently and the
-    comparison then passes over a graph missing it. Both known ways to lose one were
-    review findings; asserting the partition instead of those two means the third way
-    fails a test rather than shipping as a hole.
+    comparison then passes over a graph missing it.
+
+    Coverage is the property; disjointness is not. Demanding the two halves never overlap
+    is what made ``revision_graph`` drop what it could not read, which is right for the
+    working tree -- the file is reported instead -- and silently wrong for a baseline,
+    where dropping a node discards the only surviving record of what that release
+    declared. An unreadable node stays in the graph carrying values that compare unequal
+    to everything, so it is reached *and* reported.
     """
     compared = {name for name, _ in guard.revision_graph(sources).values()}
     reported = set(guard.ungraphable_sources(sources))
     declares_a_revision = {name for name, source in sources.items() if "revision" in guard.declared_graph_fields(source)}
 
     assert compared | reported == declares_a_revision
-    assert compared & reported == set()
+
+
+# Every shape a *released* migration's metadata can take: the readable ones, plus an edge
+# no reader can resolve. A released revision the guard stops reading is not one it may
+# quietly skip -- it is one whose declared parent nothing records any more, which is
+# strictly worse than a parent that merely changed.
+RELEASED_SHAPES = SHIPPED_REVISIONS + (("20260105_0005", "computed", "SOME_CONSTANT", {}),)
+
+RELEASED_GRAPH = {
+    f"{revision}_{slug}.py": _revision_file(revision, down_revision, **edges)
+    for revision, slug, down_revision, edges in RELEASED_SHAPES
+}
+
+
+@pytest.mark.parametrize(("revision", "slug"), [(revision, slug) for revision, slug, _, _ in RELEASED_SHAPES])
+def test_no_released_revision_can_be_rewritten_without_a_report(monkeypatch, revision, slug):
+    """Whatever a release shipped, rewriting it in the working tree has to be visible.
+
+    Stated per released shape rather than per known bug: the hole this closes was a
+    released node with a computed edge, which the baseline graph dropped while the now
+    readable working-tree node produced no reason of its own, so the rewrite was compared
+    against nothing and reported by nobody. A shape whose baseline handling regresses
+    fails here whatever the mechanism, and a shape added to the table is covered without
+    editing an assertion.
+    """
+    name = f"{revision}_{slug}.py"
+    current = dict(RELEASED_GRAPH)
+    current[name] = _revision_file(revision, '"20269999_9999"')
+    _graphs(monkeypatch, RELEASED_GRAPH, current)
+
+    problems = guard.rechained_revisions("v0.0.0")
+
+    assert [problem for problem in problems if revision in problem or name in problem]
+
+
+def test_an_unreadable_graph_has_its_head_refused_rather_than_guessed():
+    """A head is one answer, and a partial graph corrupts it silently rather than loudly.
+
+    Dropping an unreadable node also drops the parent edge pointing past it, so its
+    ancestor is left looking like a head. The upgrade property asserts a released database
+    ends at a head, so an upgrade that stopped early at that ancestor would satisfy the
+    very assertion the property exists to make.
+    """
+    with pytest.raises(guard.MigrationGuardError):
+        guard.shipped_head_revisions(UNREADABLE_GRAPH)
+
+    assert guard.shipped_head_revisions(SHIPPED_GRAPH) == {"20260104_0004"}
 
 
 @requires_release_history

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -636,6 +636,11 @@ def test_every_table_the_schema_accepts_rows_for_gets_them(tmp_path):
         )
         connection.execute("create unique index ux_pinned_kind_ref on pinned (kind, ref)")
         connection.execute(
+            "create table overlapping (a text not null, b text not null, c text not null, note text)"
+        )
+        connection.execute("create unique index ux_overlapping_ab on overlapping (a, b)")
+        connection.execute("create unique index ux_overlapping_bc on overlapping (b, c)")
+        connection.execute(
             "create table impossible (id text primary key, shape text not null "
             "constraint ck_impossible_shape check (shape in ('a', 'b') and shape in ('c', 'd')))"
         )
@@ -657,6 +662,7 @@ def test_every_table_the_schema_accepts_rows_for_gets_them(tmp_path):
         names = [row[0] for row in connection.execute("select name from plain")]
         pairs = [tuple(row) for row in connection.execute("select platform, native_id from paired")]
         pins = [tuple(row) for row in connection.execute("select kind, ref from pinned")]
+        overlaps = [tuple(row) for row in connection.execute("select a, b, c from overlapping")]
     finally:
         connection.close()
 
@@ -666,20 +672,46 @@ def test_every_table_the_schema_accepts_rows_for_gets_them(tmp_path):
     # Every repair came from the constraint that rejected the row before it, not from a guess.
     assert state in {"waiting", "active"}
     assert json.loads(doc) == {"version": 1, "events": []}
-    # The rows differ exactly where the schema already demands it and nowhere else, so a
-    # migration adding a unique index over an unconstrained column meets the duplicates a
-    # released database is free to hold.
+    # A column repeats unless the schema refuses the row that repeats it, and which of the two
+    # it is stays the database's answer rather than this module's model of the schema. `slug`
+    # and `plain.id` are refused, so those tables fall back to rows differing everywhere;
+    # `plain.name` is free, and a migration adding `unique (name)` meets the duplicate.
     assert len(set(slugs)) == len(slugs) == guard.SEED_ROWS
     assert len(set(names)) == 1
-    # A composite key constrains the tuple, so each of its columns still has to repeat --
-    # which is only possible over more rows than the group is wide.
+    # A composite group constrains the tuple, so each of its members still repeats -- which
+    # takes more rows than the group is wide.
     assert len(set(pairs)) == len(pairs)
     assert len({platform for platform, _ in pairs}) < len(pairs)
     assert len({native_id for _, native_id in pairs}) < len(pairs)
-    # Which member of a group can carry the difference is the schema's call: a CHECK pins
-    # `kind` to one literal, so the rows have to differ on `ref` instead of giving up.
+    # Overlapping groups share a member, and the shared one is what a per-group choice gets
+    # wrong: varying one member of each group leaves `b` distinct in every row, so a later
+    # `unique (b)` migration passes here and fails on a release free to repeat it.
+    assert len({(a, b) for a, b, _ in overlaps}) == len(overlaps)
+    assert len({(b, c) for _, b, c in overlaps}) == len(overlaps)
+    assert all(len({row[member] for row in overlaps}) < len(overlaps) for member in range(3))
+    # A CHECK pinning one member of a group to a single literal is the schema declining the
+    # other's repeat: every row that holds `ref` still carries `kind = 'only'` and collides.
     assert len(set(pins)) == len(pins)
     assert len({kind for kind, _ in pins}) == 1
+
+
+def test_a_repeat_the_rows_do_not_carry_is_a_violation_however_it_got_there():
+    """The claim is read back out of the rows, never inferred from the code that wrote them.
+
+    ``insert_seed_row``'s repair rewrites values to satisfy whatever constraint a row tripped,
+    and it picks the column to rewrite out of that constraint's own text -- so it can pick the
+    one column the row existed to hold still. SQLite then accepts a row that proves nothing,
+    and an accepted insert looks exactly like a successful one until the column is read back.
+    """
+    connection = sqlite3.connect(":memory:")
+    try:
+        connection.execute("create table t (a text not null, b text not null)")
+        connection.executemany("insert into t (a, b) values (?, ?)", [("x", "x"), ("x-1", "x")])
+
+        assert guard.seeded_rows_prove_repetition(connection, "t", ["b"]) == ""
+        assert "a" in guard.seeded_rows_prove_repetition(connection, "t", ["a", "b"])
+    finally:
+        connection.close()
 
 
 @requires_release_history
@@ -690,20 +722,14 @@ def test_the_upgrade_property_runs_over_a_database_that_carries_rows(monkeypatch
     behaviour the property is about; counting afterwards would also accept a seeder that
     ran after it, or one whose rows the upgrade had already removed.
     """
-    observed: dict[str, tuple[int, int]] = {}
+    observed: dict[str, int] = {}
     upgrade = guard.run_migrations
 
     def counting(db_path):
         connection = sqlite3.connect(db_path)
         try:
             observed.update(
-                (
-                    str(name),
-                    (
-                        connection.execute(f'select count(*) from "{name}"').fetchone()[0],
-                        guard.seed_row_count(guard.distinct_column_groups(connection, str(name))),
-                    ),
-                )
+                (str(name), connection.execute(f'select count(*) from "{name}"').fetchone()[0])
                 for (name,) in connection.execute(
                     "select name from sqlite_master where type = 'table' and name not like 'sqlite_%'"
                 )
@@ -717,7 +743,7 @@ def test_the_upgrade_property_runs_over_a_database_that_carries_rows(monkeypatch
     _, short = guard.schema_gap_after_upgrade(RELEASE_HISTORY[-1])
 
     assert observed
-    assert {table for table, (count, wanted) in observed.items() if count < wanted} == set(short)
+    assert all(count >= guard.SEED_ROWS for table, count in observed.items() if table not in short)
 
 
 @requires_release_history

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -21,6 +21,7 @@ import pytest
 from alembic.script.revision import Revision
 
 from scripts import migration_release_guard as guard
+from scripts.release_package_version import package_version_from_release_tag
 from storage.migrations import background_tables_ready
 
 pytestmark = pytest.mark.no_sqlite_template
@@ -456,7 +457,7 @@ def test_the_real_graph_is_wholly_comparable():
 @pytest.mark.parametrize(("problems", "expected_exit"), [([], 0), (["a released revision was rechained"], 1)])
 def test_the_command_line_exit_code_follows_the_verdict(monkeypatch, capsys, problems, expected_exit):
     """The CLI is how a developer runs this outside CI, so its wiring is part of the guard."""
-    monkeypatch.setattr(guard, "collect_problems", lambda baseline, **kwargs: ("v9.9.9", problems))
+    monkeypatch.setattr(guard, "collect_problems", lambda baseline, **kwargs: ("v9.9.9", problems, []))
 
     assert guard.main([]) == expected_exit
     for problem in problems:
@@ -517,6 +518,111 @@ def test_a_prerelease_sorts_between_the_releases_it_falls_between():
         < guard.version_key("gh-v3.0.9rc10")
         < guard.version_key("v3.0.9")
     )
+    # The publisher writes the same version several ways and builds the same wheel from
+    # each, so the guard has to read them as the same release rather than as one release
+    # and some strings it does not recognise.
+    assert guard.release_version("gh-v3.0.9-rc2") == guard.release_version("gh-v3.0.9rc2")
+
+
+@requires_release_history
+def test_no_tag_the_publisher_can_build_falls_outside_the_guard():
+    """The release universe is the publish path's, because that is the one that decides.
+
+    A tag the guard does not recognise is absent from every property here, so a migration
+    first shipped in it can be rechained or edited afterwards with nothing to compare
+    against -- the guard would pass, quietly, over the release it was pointed at.
+
+    The denominator is the repository's own tags run through the publish path's parser,
+    not a list of the forms in use today. Every tag shipped so far happens to be plain
+    ``vX.Y.Z`` or ``gh-vX.Y.ZrcN``, so a filter narrowed back to those would satisfy any
+    test written from today's tags and drop the first release that used another form.
+    """
+    covered = set(guard.released_tags())
+    for tag in guard._git("tag", "-l", "v*", "-l", "gh-v*").split():
+        try:
+            package_version_from_release_tag(tag)
+        except ValueError:
+            continue
+        assert tag in covered or guard.versions_tree(tag) is None, tag
+
+
+def test_every_table_the_schema_accepts_a_row_for_gets_one(tmp_path):
+    """An upgrade proved on an empty database is proved against the one case no user is in.
+
+    Empty is where adding a NOT NULL column, tightening a nullable one, and building a
+    unique index all succeed unconditionally, so it is the state under which a migration
+    that cannot survive real data still passes.
+
+    The claim is a pair, the way the released-revision checks are: a table either carries
+    a row or is named in what the seeder returns. Asserting only that some tables were
+    seeded would pass a seeder that gave up on the awkward ones quietly, and quietly
+    giving up on the awkward ones is the failure that reads most like success.
+    """
+    db_path = tmp_path / "vibe.sqlite"
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute('create table plain (id text primary key, name text not null)')
+        connection.execute(
+            "create table enumerated (id text primary key, state text not null "
+            "constraint ck_enumerated_state check (state in ('waiting', 'active')))"
+        )
+        connection.execute("create table defaulted (id integer primary key, note text default 'n')")
+        connection.execute(
+            "create table impossible (id text primary key, shape text not null "
+            "constraint ck_impossible_shape check (shape in ('a', 'b') and shape in ('c', 'd')))"
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    refused = guard.seed_representative_rows(db_path)
+
+    connection = sqlite3.connect(db_path)
+    try:
+        counted = {
+            str(name): connection.execute(f'select count(*) from "{name}"').fetchone()[0]
+            for (name,) in connection.execute("select name from sqlite_master where type = 'table'")
+        }
+        state = connection.execute("select state from enumerated").fetchone()[0]
+    finally:
+        connection.close()
+
+    assert refused == {table for table, count in counted.items() if count == 0}
+    assert refused == {"impossible"}
+    # The value came from the constraint that rejected the first one, not from a guess.
+    assert state in {"waiting", "active"}
+
+
+@requires_release_history
+def test_the_upgrade_property_runs_over_a_database_that_carries_rows(monkeypatch):
+    """The seeding is only worth anything if the upgrade under test is the thing it precedes.
+
+    Read at the moment ``run_migrations`` is called, because that is the upgrade whose
+    behaviour the property is about; counting afterwards would also accept a seeder that
+    ran after it, or one whose rows the upgrade had already removed.
+    """
+    observed: dict[str, int] = {}
+    upgrade = guard.run_migrations
+
+    def counting(db_path):
+        connection = sqlite3.connect(db_path)
+        try:
+            observed.update(
+                (str(name), connection.execute(f'select count(*) from "{name}"').fetchone()[0])
+                for (name,) in connection.execute(
+                    "select name from sqlite_master where type = 'table' and name not like 'sqlite_%'"
+                )
+                if name != guard.ALEMBIC_BOOKKEEPING_TABLE
+            )
+        finally:
+            connection.close()
+        return upgrade(db_path)
+
+    monkeypatch.setattr(guard, "run_migrations", counting)
+    _, unseeded = guard.schema_gap_after_upgrade(RELEASE_HISTORY[-1])
+
+    assert observed
+    assert {table for table, count in observed.items() if count == 0} == unseeded
 
 
 @requires_release_history
@@ -552,7 +658,7 @@ def test_every_released_database_still_reaches_head():
     replaying the current chain from empty, which produces the schema the current graph
     intends rather than the schema a release actually left behind.
     """
-    assert guard.unrepairable_releases() == {}
+    assert guard.unrepairable_releases()[0] == {}
 
 
 @requires_release_history

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -14,6 +14,7 @@ properties through the CLI with the full history fetched.
 from __future__ import annotations
 
 import inspect
+import json
 import sqlite3
 from pathlib import Path
 
@@ -457,7 +458,7 @@ def test_the_real_graph_is_wholly_comparable():
 @pytest.mark.parametrize(("problems", "expected_exit"), [([], 0), (["a released revision was rechained"], 1)])
 def test_the_command_line_exit_code_follows_the_verdict(monkeypatch, capsys, problems, expected_exit):
     """The CLI is how a developer runs this outside CI, so its wiring is part of the guard."""
-    monkeypatch.setattr(guard, "collect_problems", lambda baseline, **kwargs: ("v9.9.9", problems, []))
+    monkeypatch.setattr(guard, "collect_problems", lambda baseline, **kwargs: ("v9.9.9", problems))
 
     assert guard.main([]) == expected_exit
     for problem in problems:
@@ -546,7 +547,56 @@ def test_no_tag_the_publisher_can_build_falls_outside_the_guard():
         assert tag in covered or guard.versions_tree(tag) is None, tag
 
 
-def test_every_table_the_schema_accepts_a_row_for_gets_one(tmp_path):
+@pytest.mark.parametrize(
+    ("gap", "short", "expected"),
+    [
+        (None, {}, []),
+        (None, {"messages": "0 of 2 rows; CHECK constraint failed: ck_messages_type"}, ["could not seed messages"]),
+        ("1 table(s) missing: scopes", {}, ["upgrade left the database not ready"]),
+    ],
+    ids=["reaches-head-over-rows", "a-table-it-could-not-seed", "a-schema-that-came-out-short"],
+)
+def test_a_release_the_property_could_not_cover_is_reported_as_a_failure(monkeypatch, gap, short, expected):
+    """Coverage the run did not reach is a violation, not a note printed beside them.
+
+    A note blocks nothing, so a guard that downgrades its own gaps into notes goes on
+    reporting success over the part of its subject it never touched. That is the same
+    failure as passing over a release that fell outside the window, and it is worse for
+    being visible: the run says both "passed" and "did not look", and only one is read.
+    """
+    monkeypatch.setattr(guard, "released_graphs", lambda: ["v9.9.9"])
+    monkeypatch.setattr(guard, "schema_gap_after_upgrade", lambda tag: (gap, short))
+
+    reasons = guard.unrepairable_releases().get("v9.9.9", [])
+
+    assert len(reasons) == len(expected)
+    assert all(fragment in reason for reason, fragment in zip(reasons, expected))
+
+
+@requires_release_history
+def test_every_release_that_wrote_a_database_is_inside_the_upgrade_window():
+    """The upgrade property's window is an equation about releases, so it is checked as one.
+
+    ``released_tags`` reads "shipped no versions directory" as "left no migrated database
+    in the field". That is true today because state and the graph arrived together --
+    everything before ``storage/`` persisted JSON, which is why ``storage/importer.py``
+    still carries an importer for it rather than a migration -- but it is an equation, and
+    a release breaking it would leave a database no property here builds while every
+    property here goes on passing. Falling out of a window is the failure with no symptom.
+
+    The second assertion is what keeps the first from being a tautology: the denominator is
+    every tag the publisher can build, which is strictly larger than the tags carrying a
+    graph. Read off the graph-carrying set instead, the property could never be violated
+    and the test would pass forever.
+    """
+    universe = guard.release_tag_names()
+    graphed = guard.released_tags()
+
+    assert guard.releases_with_state_but_no_graph() == []
+    assert set(graphed) < set(universe)
+
+
+def test_every_table_the_schema_accepts_rows_for_gets_them(tmp_path):
     """An upgrade proved on an empty database is proved against the one case no user is in.
 
     Empty is where adding a NOT NULL column, tightening a nullable one, and building a
@@ -554,19 +604,28 @@ def test_every_table_the_schema_accepts_a_row_for_gets_one(tmp_path):
     that cannot survive real data still passes.
 
     The claim is a pair, the way the released-revision checks are: a table either carries
-    a row or is named in what the seeder returns. Asserting only that some tables were
-    seeded would pass a seeder that gave up on the awkward ones quietly, and quietly
-    giving up on the awkward ones is the failure that reads most like success.
+    its rows or is named in what the seeder returns, with the schema's own objection.
+    Asserting only that some tables were seeded would pass a seeder that gave up on the
+    awkward ones quietly, and quietly giving up on the awkward ones is the failure that
+    reads most like success.
     """
     db_path = tmp_path / "vibe.sqlite"
     connection = sqlite3.connect(db_path)
     try:
-        connection.execute('create table plain (id text primary key, name text not null)')
+        connection.execute("create table plain (id text primary key, name text not null)")
         connection.execute(
             "create table enumerated (id text primary key, state text not null "
             "constraint ck_enumerated_state check (state in ('waiting', 'active')))"
         )
         connection.execute("create table defaulted (id integer primary key, note text default 'n')")
+        connection.execute(
+            "create table shaped (id text primary key, doc text not null "
+            "constraint ck_shaped_doc check (json_valid(doc) = 1 "
+            "and json_extract(doc, '$.version') = 1 "
+            "and json_type(doc, '$.events') = 'array'))"
+        )
+        connection.execute("create table constrained (id text primary key, slug text not null)")
+        connection.execute("create unique index ux_constrained_slug on constrained (slug)")
         connection.execute(
             "create table impossible (id text primary key, shape text not null "
             "constraint ck_impossible_shape check (shape in ('a', 'b') and shape in ('c', 'd')))"
@@ -575,7 +634,7 @@ def test_every_table_the_schema_accepts_a_row_for_gets_one(tmp_path):
     finally:
         connection.close()
 
-    refused = guard.seed_representative_rows(db_path)
+    short = guard.seed_representative_rows(db_path)
 
     connection = sqlite3.connect(db_path)
     try:
@@ -584,13 +643,23 @@ def test_every_table_the_schema_accepts_a_row_for_gets_one(tmp_path):
             for (name,) in connection.execute("select name from sqlite_master where type = 'table'")
         }
         state = connection.execute("select state from enumerated").fetchone()[0]
+        doc = connection.execute("select doc from shaped").fetchone()[0]
+        slugs = [row[0] for row in connection.execute("select slug from constrained")]
+        names = [row[0] for row in connection.execute("select name from plain")]
     finally:
         connection.close()
 
-    assert refused == {table for table, count in counted.items() if count == 0}
-    assert refused == {"impossible"}
-    # The value came from the constraint that rejected the first one, not from a guess.
+    assert set(short) == {table for table, count in counted.items() if count < guard.SEED_ROWS}
+    assert set(short) == {"impossible"}
+    assert "ck_impossible_shape" in short["impossible"]
+    # Every repair came from the constraint that rejected the row before it, not from a guess.
     assert state in {"waiting", "active"}
+    assert json.loads(doc) == {"version": 1, "events": []}
+    # The two rows differ exactly where the schema already demands it and nowhere else, so a
+    # migration adding a unique index over an unconstrained column meets the duplicates a
+    # released database is free to hold.
+    assert len(set(slugs)) == len(slugs) == guard.SEED_ROWS
+    assert len(set(names)) == 1
 
 
 @requires_release_history
@@ -619,10 +688,10 @@ def test_the_upgrade_property_runs_over_a_database_that_carries_rows(monkeypatch
         return upgrade(db_path)
 
     monkeypatch.setattr(guard, "run_migrations", counting)
-    _, unseeded = guard.schema_gap_after_upgrade(RELEASE_HISTORY[-1])
+    _, short = guard.schema_gap_after_upgrade(RELEASE_HISTORY[-1])
 
     assert observed
-    assert {table for table, count in observed.items() if count == 0} == unseeded
+    assert {table for table, count in observed.items() if count < guard.SEED_ROWS} == set(short)
 
 
 @requires_release_history
@@ -658,7 +727,7 @@ def test_every_released_database_still_reaches_head():
     replaying the current chain from empty, which produces the schema the current graph
     intends rather than the schema a release actually left behind.
     """
-    assert guard.unrepairable_releases()[0] == {}
+    assert guard.unrepairable_releases() == {}
 
 
 @requires_release_history


### PR DESCRIPTION
## Capability

Turns "a released migration graph must not be edited" from a convention into a mechanical
gate. Adds `scripts/migration_release_guard.py`, its test file, and a
`migration-release-guard` job in `lint.yml`.

Tracking issue: #1555.

## Why nothing caught the v3.0.11 outage

`20260806_0047`'s `down_revision` moved from `20260804_0046` to `20260804_0047`, splicing
a merge and its branch behind a node that had already shipped in v3.0.9. Alembic only
walks forward, so every database at or past that node recorded the branch as applied and
never created its six tables. It stayed dormant until v3.0.11 put
`remote_access_authorizations` on the login path.

Every test layer missed it for one reason: **each one builds its starting database by
replaying the current chain from empty.** A test database "at `20260806_0047`" therefore
has the schema today's graph intends (30 tables, all six present); a real database at the
same revision string has 24 and none. Same revision, different schema. The Incus
regression environment shares the blind spot — `prepare_regression.py` never ships a
database, so `vibe.sqlite` is always built in place by the then-current code. The
single-head assertion in `tests/test_sqlite_state_migration.py` stayed green throughout,
because a merge revision satisfies it.

No path anywhere carried a database written by an older release across an upgrade.

## The six properties

One primitive underneath all of them: the graph as a released tag actually shipped it,
read straight out of git. `env.py` consumes `target_metadata` only during autogenerate, so
today's runtime can drive an older release's `version_locations` without that release's
Python code.

| Property | Catches |
| --- | --- |
| `fresh_install_tables() == HEAD_TABLES` | the derivation source drifting from reality |
| `new_slot_collisions()` | two branches claiming one slot number |
| `rechained_revisions()` | a released revision losing its identity or its parent |
| `edited_released_bodies()` | a released revision's body changing after it shipped |
| `unrepairable_releases()` | **a database built by a released graph not reaching head** |
| `releases_with_state_but_no_graph()` | a release that wrote a database falling outside the window above |

The last is the one that reproduces the outage. It builds a database with a released
graph, then runs `storage.migrations.run_migrations` over it — the same entry point
production calls — and asks `background_tables_ready` for the verdict.

**The unit of coverage is a shipped graph, not a release tag.** A release is any
installable tag: `v*`, and the GitHub-only `gh-vX.Y.ZrcN` prereleases, which AGENTS.md §9
requires to carry a wheel and an sdist and which therefore put databases in the field too.
That is 96 tags carrying migrations — far too many to build a database each. But most
consecutive releases ship byte-identical migrations, so `released_graphs()` keys tags by
the git object id of their versions tree and keeps the first tag that shipped each: **33
distinct graphs**, one `git rev-parse` per tag instead of one database per tag, with no
release left unexercised. About 25 s locally.

`rechained_revisions` and `edited_released_bodies` are the two halves of one contract —
a released migration is a shipped surface, and this repository has produced one defect of
each shape. The v3.0.11 outage moved a `down_revision`; `20260501_0001` had its
`upgrade()` body edited after release. The body half is the quieter one: a database
stamped at that revision never reruns it, a fresh install runs only the new version, and
nothing raises at either moment. The upgrade property notices only when the divergence
reaches readiness, so an added index, constraint, or backfill leaves both databases ready
and permanently different. There is deliberately no exemption for edits judged harmless:
judging them is the convention this guard replaces, and restoring the shipped file plus a
new migration is always available — and is the only form of the change every database can
actually apply.

Design points worth stating, because each is a place this could have been written to pass
while proving nothing:

- **No allowlist.** The metadata properties compare against the *newest* release, so the
  collisions history already carries sit in the baseline and exclude themselves. A splice
  that has already shipped cannot be un-shipped — reverting it would break the databases
  that did apply it — and a guard demanding otherwise would be permanently red, which is
  the same as absent. What the baseline excuses is the exact filenames it shipped, not the
  slot number, so a third claimant to an already-shared slot is still reported.
- **Readiness means what production means by it.** The guard keeps no second opinion: the
  verdict is `background_tables_ready`, so required columns are covered, not merely table
  names, and a definition added there is covered here without editing this file.
  `describe_schema_gap` reads the same tables and columns back only to phrase the message.
- **The head assertion is anchored outside Alembic.** An extraction or `version_locations`
  that resolves to nothing — or to some prefix — reports success and leaves a database the
  release never shipped, which then upgrades cleanly to today's head. Asking the resolved
  `ScriptDirectory` for its head would confirm itself, because a truncated graph's head is
  trivially reached. So the expected head is computed from the tag's own files
  (`shipped_head_revisions(released_sources(tag))`) before Alembic is involved, and the
  database must end there.
- **Every migration is compared or reported, and the count is not the guard's own.** A
  key the guard invents names exactly one migration or it names none: metadata it cannot
  read as a literal names nothing, an identifier two files declare names two things, and a
  file declaring no `revision` was never keyed by anything. All three collapse into
  "verified unchanged", the one answer that must stay unreachable. `revision_claims()`
  keeps every claimant, `ungraphable_sources()` names what cannot be compared and why,
  `revision_graph()` is the remainder.

  The denominator is the load-bearing part. Counting the files the guard's own parser
  managed to read cannot fail — a file it does not see is missing from the numerator and
  the denominator at once — so coverage is measured against Alembic's own rule for what it
  will load (`is_migration_source`, borrowed from `_only_source_rev_file` the way
  `GRAPH_FIELDS` is measured off `Revision.__init__`). A numbered migration that omits or
  misspells `revision` is then reported rather than ignored, which matters because Alembic
  rejects that file outright.

- **Every key is borrowed from whatever already owns it.** The point of failure a guard
  has that its subject does not is a rule it restates: a second copy that can come to
  disagree with the first, and whose disagreement shows up as silence rather than as an
  error. So the release universe is the publish path's — `release_version()` asks
  `package_version_from_release_tag`, the same function that turns a tag into a wheel, then
  orders by PEP 440 — the file rule is `_only_source_rev_file`, the graph identity is git's
  object id, and whether a seeded row is admissible is SQLite's ruling, not a guess this
  code makes. `new_slot_collisions` keying on the filename is the one deliberate exception,
  because the repository's `NNNN` numbering convention is its entire subject.
- **A migration is identified the way Alembic identifies it, everywhere.** Its identity is
  its `revision`: databases record that and nothing else, and Alembic finds it by scanning
  `version_locations` rather than by name. So `released_bodies()` keys bodies by revision,
  which is what makes a rename carrying an edit visible — the declaration is unchanged, so
  `rechained_revisions` has nothing to say about it — and equally what makes a rename with
  identical bytes correctly silent, since no database in the field can observe one.
  `new_slot_collisions` is the single property keyed by filename, because the repository's
  `NNNN` numbering convention is its entire subject.
- **The upgrade is exercised over a database that carries rows, and every column the
  schema still lets two rows share is shared by two of them.** An empty database is the one
  case no user is in, and it is the case under which adding a NOT NULL column, tightening a
  nullable one, and building a unique index all succeed unconditionally. One row per table
  removes only two of those three: a unique index over columns the released schema never
  constrained still builds against a single row, and that is exactly the migration that
  fails in the field. Rows that differ *everywhere* grant the same false pass.

  **Which columns those are is asked of the database, not derived from its schema.** Each
  column gets a row that holds it still and moves every other one, and SQLite either accepts
  it — the repeat is real, and is then read back out of the stored rows rather than inferred
  from the insert having succeeded — or names the constraint it broke, which is recorded
  verbatim as the reason that column went uncovered. Moving every other column is not a
  parameter to tune: a differing column can only help a uniqueness constraint accept the
  row, and the one thing that undoes a difference — a CHECK holding a column to a list of
  literals, whose repair puts an accepted one back — does so whatever else the row does. So
  this is the likeliest row to be accepted that still repeats the column, and there is no
  second choice.

  Each schema is seeded from its own `pragma table_info` rather than from a fixture, filling
  every column every row must hold (NOT NULL or PK) and leaving the rest NULL, which is the
  more adversarial choice and the branch a disjunctive CHECK admits. Defaults are supplied
  rather than relied on: a seeder that leans on them is measuring them. Where a CHECK
  refuses the row, SQLite names the constraint it tripped and the constraint expression
  names what it accepts — the literals it lists, or, through `json_extract` and
  `json_type`, the path and the value or type belonging at it — so the repair is read out
  of the database's own objection and retried. A varied value keeps the original's *kind*,
  not merely its type: appending to a `_json` document would leave a string that is still a
  string and no longer JSON, and a migration reading it with `json_extract` would then fail
  over data no release ever held — a false alarm, which is worse than a missed one because
  it is indistinguishable from a real catch. Nothing here is a free parameter: a row counts
  only if the shipped schema accepted it, and a repeat counts only if the stored rows show
  it.
- **A foreign key is the one column a fixture may not invent a value for.** Seeding each
  table on its own with SQLite's default `foreign_keys=OFF` produced 102 dangling references
  — a state no released database can be in, and one two shipped migrations check for
  explicitly: `20260806_0047` and `20260811_0050` rebuild tables under `PRAGMA
  foreign_keys=OFF` and then `raise` if `pragma foreign_key_check` reports anything. So an
  invented reference turns a correct migration red, which is worse than a missed defect
  because it is indistinguishable from a real catch. `resolve_references` is a separate pass
  after all the seeding, because the reference graph has cycles (`session_turns` ↔
  `message_deliveries`) and no seeding order satisfies every reference. It cannot guess the
  value either: `insert_seed_row`'s CHECK repair moves the parent's key, so the child reads
  back what the parent ended up holding.

  **Whether every row may share one parent is also the database's answer.** One value is
  offered for the whole table — preserving the repeat the probes just proved — and only when
  SQLite refuses does the pass rotate per row, which is what `scope_settings` requires,
  since its reference *is* its primary key. When a uniquely indexed reference runs out of
  parents, the row is emptied where the column allows it and removed where it does not: the
  same two answers a released database gives. Resolution can therefore take a row away, so
  the counting and the repeat read-backs happen after it, over the fixture the migrations
  actually run against, and any duplicate it cost is offered again from a surviving row. A
  reference is dropped from the repeat claim rather than proved — the value belongs to the
  parent, and composite unique indexes (`resource_access_groups` on resource_kind +
  resource_id + group_id) make sharing unpredictable in advance. What the fixture claims for
  a reference is that it resolves, and `pragma foreign_key_check` is where that is read back:
  102 down to 0.
- **A shortfall is a failure; a refusal is data.** The seeder returns two dictionaries and
  the split is the design. `short` is what *it* failed to do — a table below the row floor, a
  repeat it asserted and could not show, a release that shipped a database without a graph —
  and every entry is counted with the violations, because a note blocks nothing and a guard
  that downgrades its own gaps goes on saying both "passed" and "did not look", of which only
  one is read. `refused` is what the *database* declined, mapped to SQLite's own words, and is
  printed on every run rather than counted: calling a primary key a failure would leave the
  guard permanently red, which is the same as absent. The split is also what makes the
  seeder's reading of CHECK expressions safe to be incomplete — a form it cannot read leaves a
  table short, turns the guard red, and gets taught.
- **The window is checked as an equation, not assumed as a definition.** `released_tags()`
  reads "shipped no versions directory" as "left no migrated database in the field". That
  holds today because state and the graph arrived together — everything before `storage/`
  persisted JSON, which is why `storage/importer.py` still carries an importer for it —
  but a release breaking it would fall out of every property here while every property
  here went on passing. `releases_with_state_but_no_graph()` reads the full 145-tag
  publisher universe, not the 96 that carry a graph, so the check cannot be vacuous.
- **The two halves are exhaustive as a pair, and that is what is asserted.**
  `rechained_revisions` watches what a revision declares, `edited_released_bodies` watches
  what it does, and each passes over what the other owns rather than describing one defect
  twice. `test_a_released_revision_is_always_accounted_for` asserts on their union across
  every shape of change — edited, renamed-and-edited, deleted, rechained, made-unreadable,
  duplicated — so a case falling out of one half without landing in the other fails a test
  instead of becoming an unguarded shape.

## Circuit breaker — one class, five heads, and where the claim had to stop

Five consecutive reviewed heads carried a finding of the same class, which `ENGINEERING.md`
says stops the lane. The class, named at the depth it actually sits: **the seeded fixture was
a strict subset of the value space a released database can hold, and the guard asserted the
subset was now the whole.** Each round the reviewer named a shape the fixture did not hold,
and each fix widened it and re-asserted completeness: one row, then the union of every
distinct-group's members, then one member of each group per row, then overlapping groups
sharing a member, then columns no release ever made non-NULL.

The first four rounds were diagnosed as a model of the schema's constraint topology and
fixed by deleting the model — probing the shipped schema instead of reasoning about it found
three topologies already outside it: partial unique indexes (`sqlite_where=`), a unique index
over an expression (`uq_vault_secrets_name_folded on vault_secrets (lower(name))`, whose
member `pragma index_info` reports with a NULL column name and which the old code therefore
dropped silently), and a CHECK pinning one member of a group to a literal. That fix was
right and insufficient, because the fifth head showed the recurrence was not about topology
at all.

**The terminal diagnosis is structural, not a missing case.** The population a released
database can hold is the schema's satisfiable state space, and enumerating that space is
constraint solving. `message_deliveries` settles it by construction rather than by argument:
four CHECKs key roughly twelve columns off `state`, and every state requires some of them
NULL — so *no row of that table has every column non-NULL*, and no fixture can be asked for
one. Any claim of the form "the fixture now holds every shape a release can" is therefore
unprovable, and each round spent one review on rediscovering that.

Scope decision, recorded here and taken at orchestrator level; the change is confined to a
test-only script, is reversible, and preserves the guard's contract, so it did not need an
owner ruling. **Bound the claim by what the fixture controls, not by the value space it does
not.** What is asserted now is one sentence — *every column is offered, and every column the
database accepts a repeat of is repeated by two rows that were read back to confirm it* — and
the two outcomes are separated: the guard fails on its own shortfalls (`short`) and prints
the database's answers (`refused`) every run. Following the project's rule that an
adversarial-input ruling must be anchored to self-measured bounds, this one has no free
parameter left to probe: every value is offered by this code, and every verdict is SQLite's.

A sixth head found a different class, and it is worth separating because it was a false alarm
rather than a gap: the fixture was manufacturing dangling foreign keys, which is a state no
release can be in and one two shipped migrations abort on. See the foreign-key bullet above —
102 dangling references down to 0, verified by `pragma foreign_key_check` inside the seeder
and again in the test.

## Status — green

**Both dependencies have merged.** #1556 cleared v3.0.9 / v3.0.10, and #1566 fixed the
`gh-v2.2.15rc2` defect this PR surfaced. This branch is rebased onto master carrying both,
and the guard now reports `migration release guard passed (baseline v3.0.12)` across all 33
shipped graphs.

That defect stays on the record, because finding it is what this PR is for. A graph shipped
in 13 installable tags, `gh-v2.2.15rc2` through `v2.3.2` (2026-05-14), builds a database
stamped at `INITIAL_REVISION` that lacks `agents` and carries `scopes` — exactly the three
conditions under which `_reset_unreleased_initial_schema_drift` dropped `scopes` as
unreleased dev drift, after which `_stamp_existing_initial_schema` hard-failed. Routing the
second stage through `run_migrations` rather than Alembic directly is what made it visible;
the direct-Alembic path structurally could not see it. Widening the release universe to
prereleases is what dated it correctly — the old `v*`-only query would have blamed
`v2.3.0`, six releases late. The fix shipped as its own PR so the guard and the defect it
found stayed separable.

Deliberately no `xfail` quarantine at any point: a marker that makes the repository green
while a release is genuinely broken is the soft convention this PR exists to replace.

## Evidence

- **Unit** — `tests/test_migration_release_guard.py`, 65 tests. Detection is pinned
  against a synthetic graph seeded with one revision of *every* shape the real graph
  contains (root, linear, sibling branch, tuple-parent merge) and every shape of malformed
  metadata, so a shape added later is covered by joining the table rather than by editing
  a test.
- **Repository** — the same properties run against the real release history, plus
  `test_the_guard_still_detects_the_release_it_was_written_for`, which runs the guard
  against v3.0.10 and requires it to report the splice. Without that, every other
  assertion could pass because the guard had stopped detecting anything.
- **Current result** — 65 passed, 0 failed on a checkout rebased onto master, and
  `migration release guard passed (baseline v3.0.12)` from the CLI. `short` is empty across
  all 33 shipped graphs: every table reached the floor, every repeat the schema accepted is
  present in the stored rows, every reference resolves, and no shipped migration aborted over
  them — so the shipped migrations are data-safe as far as this proves. The head schema's 30
  tables take 411 rows (no table below 3) in 0.09 s. The refusal ledger prints 48 entries for
  the head schema and 52 across all 33 graphs; the taxonomy is in "Known by design" below.
- **CI shape** — verified on a shallow tagless clone (the sharded unit job's checkout): no
  collection error, release-history properties skip. The new job checks out with
  `fetch-depth: 0` and fails on any skip, following the `memory-insight-contract`
  precedent.
- **Lint** — `ruff check` clean on both new files; `lint.yml` parses.
- No scenario catalog covers migrations, so no scenario IDs apply.

## Known by design

- **The release-history properties skip on a shallow checkout.** They run in the sharded
  unit job's checkout, which fetches no tags. Skipping there rather than erroring keeps
  six jobs from turning red for a reason unrelated to what they test; the
  `migration-release-guard` job supplies the history and treats a skip as a failure, so
  the properties cannot go unproven. The CLI never skips — it exits 2 and names the cause.
- **The metadata baseline is the newest release, not every release.** See "No allowlist"
  above. Each release is checked against its predecessor while still unreleased, so the
  invariant chains forward without relitigating shipped history.
- **One database per distinct shipped graph, not per tag.** Tags sharing a versions tree
  put the same database in the field, so building one each would be 96 databases proving
  33 facts. The equivalence is git object identity, and a test requires the covered set to
  cover every installable tag.
- **`git archive` per tag, not a committed fixture database.** Fixture databases are
  themselves built by whatever code committed them, which is the failure mode this guard
  exists to detect.
- **The guard runs the upgrade over rows; it does not count them again afterwards.** The
  rows exist so the migrations execute against data — adding a NOT NULL column, tightening
  a nullable one, backfilling from a column being dropped, building a unique index all
  succeed unconditionally over an empty database and fail loudly over a populated one, and
  every such failure arrives as an exception or a schema that came out short. Re-counting
  on the far side would assert a different property, "the graph never removes a row", and
  this repository does not have it: `20260601_0011` deduplicates sessions to one row per
  (scope, anchor) by design, and `20260703_0026` drops legacy scope-shaped vault grants the
  new model cannot express. There is no self-measured discriminator between an intended
  removal and an accidental one — the dedup migration also rewrites `anchor`, so survivors
  do not match what went missing, and "emptied entirely" has `vault_grants` as a
  counter-example. Which removals are intended is a question about one migration's purpose,
  so it belongs to that migration's own test where the purpose is known (AGENTS.md §1a
  already requires it). Asking it here would make the guard carry a hand-maintained list of
  known-good deletions — the list of cases it exists not to have.
- **The rows are representative, not meaningful.** They prove the upgrade does not abort on
  a populated database and that the result is at head, not that a released graph writes the
  right contents.
- **The seeder reads three CHECK forms, and a fourth would fail the guard rather than
  shrink it.** A membership list, a `json_extract` path equality, and a `json_type` path
  shape are what the shipped schemas state; every table of every shipped graph is seeded
  through them. A CHECK written in some other form would leave its table short, and short
  is a violation, so the guard goes red and the form gets taught. The alternative — the
  seeder deciding for itself that a table it cannot fill does not matter — is the shape
  this bullet used to describe.
- **A refused repeat is recorded, never solved for.** A refusal means exactly what SQLite
  said and no more: the schema rejected *this* row. Sometimes that is also the schema
  forbidding the repeat outright; sometimes it is a partial unique index whose permitted side
  needs a multi-column state another CHECK dictates — `unique (session_id) where state in
  ('starting', 'active')` permits a repeated `session_id` on a terminal turn, and reaching
  that side means giving `state` a value whose whole shape `ck_session_turns_terminal_shape`
  then fixes. Telling the two apart is general constraint solving, which this deliberately is
  not, so both are reported the same way and neither is read as proof. Rotating the repair's
  choice of accepted literal was tried and measured rather than reasoned about: it satisfied
  no partial index at any rotation and cost coverage elsewhere, dropping `session_turns`
  from 9 rows to 5, because a rotation applied to every repair also breaks the repairs that
  were succeeding.
- **What the ledger's ambiguity actually costs is measured, not assumed.** Across all 33
  shipped graphs the ledger holds 52 entries. One is the maximal row `message_deliveries`
  refuses by construction (see the circuit-breaker section). Of the 51 repeat refusals, **36**
  come from a primary key (30) or a total unique index (6) — where the refusal is the schema
  forbidding the repeat, no ambiguity at all — and **3** from a `where <column> is not null`
  partial index, which a non-NULL repeat probe treats as total anyway. The remaining **12**
  are all one genuinely conditional index, `uq_session_turns_message_written_attempt`
  (`unique (initial_delivery_id) where state <> 'terminal' or start_receipt_outcome =
  'accepted'`). So the "this might be solvable" residue is one index on one table, and it is
  named rather than implied. Closing that last residue is tracked as #1577, which
  argues the instrument should be static analysis of the tightening migrations rather than more
  seeding.
- **Eleven repeats are accepted alone and lost once the whole fixture exists, and that is a
  refusal rather than a shortfall.** They are the other 11 of that 12: columns of
  `session_turns` whose repeat the table granted in isolation and could not keep once
  `message_deliveries` was seeded, because `initial_delivery_id` is NOT NULL *and* uniquely
  indexed among non-terminal turns — so the table cannot hold more such rows than there are
  deliveries to point at. That is the database answering about the whole database rather than
  about one table, which is why it goes to the ledger instead of failing the guard: the claim
  is bounded by what this fixture can hold, and this is exactly where that bound sits.
- **A dangling reference is a state no release can be in, so the fixture must not invent
  one.** Two shipped migrations (`20260806_0047`, `20260811_0050`) rebuild tables under
  `PRAGMA foreign_keys=OFF` and then abort on `pragma foreign_key_check`, so a fabricated
  reference produces a red that is indistinguishable from a real catch. `resolve_references`
  runs as its own pass after all seeding — the reference graph has cycles, so no seeding order
  works — and takes every value from what the parent actually stored. It is the reason the
  fixture may lose a row and a repeat, and the reason both are re-measured afterwards rather
  than carried forward from before. Verified at 0 violations, from 102.


