### PR TITLE
fix(storage): bound the sqlite rollback window at its creator

### DIFF
--- a/docs/plans/local-data-lifecycle.md
+++ b/docs/plans/local-data-lifecycle.md
@@ -21,9 +21,22 @@ downloads, sources, prebuilt assets, or version directories.
   10 MiB, retaining the newest 5 MiB. This preserves the inode used by live tail
   readers and avoids racing a subprocess that is actively appending output.
 - Before an existing SQLite database advances to another schema revision,
-  create a consistent SQLite online backup. Retain the newest two SQLite
-  migration/repair rollback points and the newest three legacy JSON migration
-  snapshots.
+  create a consistent SQLite online backup, and bound the rollback window in
+  the same call. Creating the copy is unconditional, so the bound has to be
+  too: gating it on the upgrade finishing leaves the window unbounded in the
+  one situation that produces attempt after attempt.
+- Bound the window to the newest two SQLite migration/repair rollback points
+  and the newest three legacy JSON migration snapshots. A rollback point is a
+  distinct database state -- the revisions a copy was stamped with plus a
+  fingerprint of its schema, both read from the copy itself. Two copies of the
+  same state are the same rollback point taken twice, and the newer one holds
+  every write the older one holds, so the window keeps the newest copy of each
+  state, newest state first, and spends any slot left over on the copies that
+  were superseded. On a healthy machine every migration finishes and every copy
+  is a state of its own, which is the newest two. Under a migration that keeps
+  failing partway, every attempt after the first copies the same half-migrated
+  database, so those attempts are one state holding one slot between them and
+  cannot crowd out the snapshot taken before the damage.
 - Prune only strict Avibe formats: self-identifying managed backup directories,
   historical `sqlite-state-migration-*` directories with valid manifests, and
   the exact legacy `vibe-pre-<revision>[-release-head]-repair-<timestamp>` file

--- a/docs/plans/local-data-lifecycle.md
+++ b/docs/plans/local-data-lifecycle.md
@@ -25,25 +25,29 @@ downloads, sources, prebuilt assets, or version directories.
   in the same call. Creating the rollback point is unconditional, so the bound
   has to be too: gating it on the upgrade finishing leaves the window unbounded
   in the one situation that produces attempt after attempt.
-- Take no new copy when the window already holds one stamped with the revisions
-  the database is stamped with now. That is the same rollback point. A
-  migration failing partway is retried by every service entry point that
-  touches the store, and copying the database again on each attempt is what
-  makes the window grow -- and what puts the snapshot taken before the damage
-  at risk, since no rule that inspects the copies can reliably tell it from the
-  ones taken after. A partial upgrade that commits row changes without touching
-  the schema or the revision stamp is identical to the clean database in
-  everything a backup can measure. Not taking the copy keeps the clean snapshot
-  by never producing anything that could displace it.
+- Take the copy unconditionally, and never reuse one already in the window. A
+  copy is a rollback point only if restoring it loses no committed data, and
+  nothing readable from a copy proves that: a migration that commits row
+  changes and then fails moves neither the schema nor the revision stamp, and
+  an operator who restores a copy and keeps serving writes moves the contents
+  under a stamp that never changed. Every rule that recognised a copy as "the
+  same rollback point" was a label standing in for the contents, and each one
+  could be made to agree while the contents differed.
 - Bound the window to the newest two SQLite migration/repair rollback points
   and the newest three legacy JSON migration snapshots, with the copy a call
   has just written protected from that call's own prune. Copies left by a
   machine whose clock ran ahead are dated into the future permanently, so
   ordering alone cannot defend a fresh rollback point.
+- The window bounds disk, and that is all it promises beyond holding the
+  database as it stands at each call. It cannot also promise to keep the last
+  copy taken before a migration started damaging the database: under a
+  migration that keeps failing, the attempts after the first copy an
+  already-damaged database, and no property measurable from those copies
+  distinguishes them from the clean one. That property belongs to not retrying
+  a failed migration once per service entry point, not to retention.
 - Record in each manifest the revisions read back from the copy, not the ones
   the caller reported: another process can advance the database in between, and
-  the next attempt uses the manifest to decide whether the rollback point it
-  needs already exists.
+  an operator choosing a rollback point reads the manifest to do it.
 - Prune only strict Avibe formats: self-identifying managed backup directories,
   historical `sqlite-state-migration-*` directories with valid manifests, and
   the exact legacy `vibe-pre-<revision>[-release-head]-repair-<timestamp>` file

--- a/docs/plans/local-data-lifecycle.md
+++ b/docs/plans/local-data-lifecycle.md
@@ -21,22 +21,29 @@ downloads, sources, prebuilt assets, or version directories.
   10 MiB, retaining the newest 5 MiB. This preserves the inode used by live tail
   readers and avoids racing a subprocess that is actively appending output.
 - Before an existing SQLite database advances to another schema revision,
-  create a consistent SQLite online backup, and bound the rollback window in
-  the same call. Creating the copy is unconditional, so the bound has to be
-  too: gating it on the upgrade finishing leaves the window unbounded in the
-  one situation that produces attempt after attempt.
+  hold a consistent SQLite online backup of it, and bound the rollback window
+  in the same call. Creating the rollback point is unconditional, so the bound
+  has to be too: gating it on the upgrade finishing leaves the window unbounded
+  in the one situation that produces attempt after attempt.
+- Take no new copy when the window already holds one stamped with the revisions
+  the database is stamped with now. That is the same rollback point. A
+  migration failing partway is retried by every service entry point that
+  touches the store, and copying the database again on each attempt is what
+  makes the window grow -- and what puts the snapshot taken before the damage
+  at risk, since no rule that inspects the copies can reliably tell it from the
+  ones taken after. A partial upgrade that commits row changes without touching
+  the schema or the revision stamp is identical to the clean database in
+  everything a backup can measure. Not taking the copy keeps the clean snapshot
+  by never producing anything that could displace it.
 - Bound the window to the newest two SQLite migration/repair rollback points
-  and the newest three legacy JSON migration snapshots. A rollback point is a
-  distinct database state -- the revisions a copy was stamped with plus a
-  fingerprint of its schema, both read from the copy itself. Two copies of the
-  same state are the same rollback point taken twice, and the newer one holds
-  every write the older one holds, so the window keeps the newest copy of each
-  state, newest state first, and spends any slot left over on the copies that
-  were superseded. On a healthy machine every migration finishes and every copy
-  is a state of its own, which is the newest two. Under a migration that keeps
-  failing partway, every attempt after the first copies the same half-migrated
-  database, so those attempts are one state holding one slot between them and
-  cannot crowd out the snapshot taken before the damage.
+  and the newest three legacy JSON migration snapshots, with the copy a call
+  has just written protected from that call's own prune. Copies left by a
+  machine whose clock ran ahead are dated into the future permanently, so
+  ordering alone cannot defend a fresh rollback point.
+- Record in each manifest the revisions read back from the copy, not the ones
+  the caller reported: another process can advance the database in between, and
+  the next attempt uses the manifest to decide whether the rollback point it
+  needs already exists.
 - Prune only strict Avibe formats: self-identifying managed backup directories,
   historical `sqlite-state-migration-*` directories with valid manifests, and
   the exact legacy `vibe-pre-<revision>[-release-head]-repair-<timestamp>` file

--- a/storage/backups.py
+++ b/storage/backups.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import json
 import logging
 import os
@@ -27,6 +28,18 @@ _SQLITE_BACKUP_RE = re.compile(
 _LEGACY_SQLITE_REPAIR_RE = re.compile(
     r"^vibe-pre-(?:live-)?\d{4}(?:-release-head)?-repair-"
     r"(?P<timestamp>\d{8}T\d{6}Z)\.sqlite$"
+)
+
+# The schema move a backup was taken for: (from_revisions, to_revisions).
+_Transition = tuple[tuple[str, ...], tuple[str, ...]]
+
+# A platform or filesystem declining to sync a directory is an answer, not a
+# fault. Anything else -- ENOSPC, EIO -- means the data may not be on the disk,
+# so it must reach the caller instead of being logged and forgotten.
+_UNSUPPORTED_SYNC_ERRNOS = frozenset(
+    getattr(errno, name)
+    for name in ("EACCES", "EPERM", "EINVAL", "EISDIR", "ENOSYS", "ENOTSUP", "EOPNOTSUPP")
+    if hasattr(errno, name)
 )
 
 
@@ -188,7 +201,11 @@ def _remove_candidate(candidate: _BackupCandidate) -> bool:
     return True
 
 
-def _keep_priority(candidates: Iterable[_BackupCandidate]) -> list[_BackupCandidate]:
+def _keep_priority(
+    candidates: Iterable[_BackupCandidate],
+    *,
+    active: _Transition | None = None,
+) -> list[_BackupCandidate]:
     """Order backups by how much a rollback would want them, best first.
 
     Retries of one unfinished migration are attempts at a single rollback point
@@ -200,6 +217,12 @@ def _keep_priority(candidates: Iterable[_BackupCandidate]) -> list[_BackupCandid
     newest-first is the wrong order here: it fills the window with the newest
     two attempts and discards the only clean one.
 
+    `active` is the migration being attempted right now, and its ends outrank
+    everything else because being newest on disk is not the same as being
+    current. A clock corrected backwards, or state carried from a machine that
+    ran ahead, leaves unrelated copies dated later; spending the window on those
+    would evict the snapshot taken before the upgrade that is failing.
+
     Backups that stand alone are their own group, so for a healthy machine --
     where each backup marks a different completed migration -- this stays the
     familiar newest-first.
@@ -209,9 +232,13 @@ def _keep_priority(candidates: Iterable[_BackupCandidate]) -> list[_BackupCandid
     for candidate in candidates:
         groups.setdefault(candidate.group_key, []).append(candidate)
 
+    def rank(group: list[_BackupCandidate]) -> tuple[bool, tuple[datetime, int, str]]:
+        is_active = active is not None and group[0].transition == active
+        return is_active, max(entry.order_key for entry in group)
+
     ranked: list[_BackupCandidate] = []
     superseded: list[_BackupCandidate] = []
-    for group in sorted(groups.values(), key=lambda item: max(entry.order_key for entry in item), reverse=True):
+    for group in sorted(groups.values(), key=rank, reverse=True):
         members = sorted(group, key=lambda item: item.order_key)
         ranked.append(members[-1])
         if len(members) > 1:
@@ -225,19 +252,16 @@ def prune_state_backups(
     *,
     json_retention: int | None = JSON_STATE_BACKUP_RETENTION,
     sqlite_retention: int | None = SQLITE_BACKUP_RETENTION,
-    protect: Path | None = None,
+    active: _Transition | None = None,
 ) -> list[Path]:
     """Keep a bounded rollback window of backups created by Avibe.
 
     Unknown files, symlinks, incomplete backups, and directories without a
     recognized manifest are intentionally left untouched.
 
-    `protect` names a backup that must survive this call. It takes the first
-    slot of its kind rather than an extra one, so the window stays bounded; it
-    exists because timestamp order is not proof of being newest. A clock
-    corrected backwards, or state moved from a machine whose clock ran ahead,
-    leaves future-dated copies that would otherwise rank above a backup taken
-    seconds ago and delete it.
+    `active` names the migration in progress, whose rollback points get the
+    slots first. Callers that are only reclaiming space leave it unset and get
+    the same order by recency.
     """
 
     limits = {
@@ -246,41 +270,53 @@ def prune_state_backups(
         if retention is not None
     }
     candidates = _managed_candidates(backups_dir)
-    protected = protect.expanduser().resolve() if protect is not None else None
     removed: list[Path] = []
     for kind, limit in limits.items():
         matching = [candidate for candidate in candidates if candidate.kind == kind]
-        ranked = _keep_priority(matching)
-        if protected is not None:
-            ranked.sort(key=lambda candidate: candidate.root != protected)
-        keep = {candidate.root for candidate in ranked[:limit]}
+        keep = {candidate.root for candidate in _keep_priority(matching, active=active)[:limit]}
         for candidate in sorted(matching, key=lambda item: item.order_key):
             if candidate.root not in keep and _remove_candidate(candidate):
                 removed.append(candidate.root)
     return removed
 
 
-def _fsync(path: Path) -> None:
-    """Push a file, or a directory's entries, to stable storage.
+def _fsync_file(path: Path) -> None:
+    """Push a file's contents to stable storage.
 
-    Syncing the directory is what makes a rename durable on POSIX, and a backup
-    is worth nothing if a crash can lose it. Windows has no equivalent and
-    refuses to open a directory at all, so a rejection here is the platform's
-    answer rather than a failure to report.
+    A failure here is never tolerable: it says the copy may not survive the
+    crash it was made for, and raising is what stops the caller from deleting
+    the copies it was meant to replace.
     """
 
-    flags = os.O_RDONLY
-    if path.is_dir():
-        flags |= getattr(os, "O_DIRECTORY", 0)
+    fd = os.open(path, os.O_RDONLY)
     try:
-        fd = os.open(path, flags)
-    except OSError:
-        logger.debug("Cannot open %s to fsync it on this platform", path, exc_info=True)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _fsync_directory(path: Path) -> None:
+    """Push a directory's own entries to stable storage, where that is a thing.
+
+    Syncing the directory is how a rename becomes durable on POSIX. Windows has
+    no equivalent and refuses to open a directory at all, and some filesystems
+    reject the call; those refusals are the platform answering. A storage error
+    is not an answer, so it propagates like any other.
+    """
+
+    try:
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    except OSError as error:
+        if error.errno not in _UNSUPPORTED_SYNC_ERRNOS:
+            raise
+        logger.debug("Directory sync is unavailable for %s on this platform", path)
         return
     try:
         os.fsync(fd)
-    except OSError:
-        logger.debug("fsync is unavailable for %s on this platform", path, exc_info=True)
+    except OSError as error:
+        if error.errno not in _UNSUPPORTED_SYNC_ERRNOS:
+            raise
+        logger.debug("Directory sync is unavailable for %s on this filesystem", path)
     finally:
         os.close(fd)
 
@@ -321,9 +357,9 @@ def create_sqlite_migration_backup(
     of their own pruning.
 
     Owning it here also means this call is the only thing that can destroy what
-    it just produced, so it never does: the copy is on stable storage before any
-    older one is deleted, and it is named as protected rather than trusted to
-    rank newest by its own timestamp.
+    it just produced, so it never does: the copy reaches stable storage before
+    any older one is deleted, and the prune is told which migration is in
+    progress rather than left to infer it from timestamps it cannot trust.
     """
 
     source_path = db_path.expanduser().resolve()
@@ -344,7 +380,7 @@ def create_sqlite_migration_backup(
                 if check != ("ok",):
                     raise sqlite3.DatabaseError(f"SQLite backup quick_check failed: {check!r}")
         os.chmod(temp_db, 0o600)
-        _fsync(temp_db)
+        _fsync_file(temp_db)
         temp_db.replace(backup_db)
         manifest = {
             "schema_version": BACKUP_MANIFEST_VERSION,
@@ -357,20 +393,22 @@ def create_sqlite_migration_backup(
         }
         manifest_path = backup_dir / "manifest.json"
         manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
-        _fsync(manifest_path)
-        _fsync(backup_dir)
-        _fsync(target_root)
+        _fsync_file(manifest_path)
+        _fsync_directory(backup_dir)
+        _fsync_directory(target_root)
     except Exception:
         shutil.rmtree(backup_dir, ignore_errors=True)
         raise
 
     # Everything above has to happen before the prune, and each for its own
-    # reason. The fsyncs make the replacement survive a crash first, so the
+    # reason. The fsyncs put the replacement on the disk first, so the
     # filesystem can never persist the deletion of durable copies while losing
-    # the one that replaced them. Being after the try means a failure while
-    # pruning cannot reach the cleanup path and delete the rollback point this
-    # call just made. And it has to follow the manifest write, because a
-    # directory without one is not yet a recognized candidate and would not
-    # count itself against the bound.
-    prune_state_backups(target_root, json_retention=None, protect=backup_dir)
+    # the one that replaced them -- and if a sync reports a storage failure, the
+    # cleanup above runs and nothing is pruned at all. Being after the try means
+    # a failure while pruning cannot reach that cleanup and delete the rollback
+    # point this call just made. And it has to follow the manifest write,
+    # because a directory without one is not yet a recognized candidate: it
+    # would neither count itself against the bound nor be found as the newest
+    # attempt at the migration now in progress.
+    prune_state_backups(target_root, json_retention=None, active=_manifest_transition(manifest))
     return backup_dir

--- a/storage/backups.py
+++ b/storage/backups.py
@@ -47,7 +47,6 @@ class _BackupCandidate:
     kind: str
     timestamp: datetime
     suffix: int
-    revisions: tuple[str, ...] | None = None
 
     @property
     def order_key(self) -> tuple[datetime, int, str]:
@@ -124,23 +123,7 @@ def _directory_candidate(path: Path) -> _BackupCandidate | None:
         kind=kind,
         timestamp=timestamp,
         suffix=int(match.group("suffix") or 0),
-        revisions=_manifest_revisions(manifest),
     )
-
-
-def _manifest_revisions(manifest: dict) -> tuple[str, ...] | None:
-    """The revisions the backup's own copy of the database was stamped with.
-
-    A manifest that does not record them, or records them in a shape this
-    version does not understand, yields `None` -- which never matches anything,
-    so such a backup can never be mistaken for the rollback point a caller is
-    about to look for.
-    """
-
-    value = manifest.get("from_revisions")
-    if not isinstance(value, list):
-        return None
-    return tuple(sorted(str(revision) for revision in value))
 
 
 def _legacy_sqlite_candidate(path: Path) -> _BackupCandidate | None:
@@ -280,8 +263,8 @@ def _stamped_revisions(connection: sqlite3.Connection) -> tuple[str, ...]:
     """The alembic revisions the database behind `connection` is stamped with.
 
     A database with no `alembic_version` table yields the empty tuple, which is
-    a state like any other: it is what an unversioned database is, and two
-    copies of it are the same rollback point.
+    what an unversioned database is. This is recorded, never compared: a stamp
+    names where a database claims to be, not what it holds.
     """
 
     try:
@@ -289,15 +272,6 @@ def _stamped_revisions(connection: sqlite3.Connection) -> tuple[str, ...]:
     except sqlite3.DatabaseError:
         return ()
     return tuple(sorted({str(row[0]) for row in rows}))
-
-
-def _rollback_point_held(backups_dir: Path, revisions: tuple[str, ...]) -> Path | None:
-    """A surviving backup of the database as it is stamped now, if there is one."""
-
-    for candidate in sorted(_managed_candidates(backups_dir), key=lambda item: item.order_key, reverse=True):
-        if candidate.kind == "sqlite" and candidate.revisions == revisions:
-            return candidate.root
-    return None
 
 
 def _unique_backup_dir(backups_dir: Path, *, now: datetime) -> Path:
@@ -334,24 +308,23 @@ def create_sqlite_migration_backup(
     the bound true for callers not yet written, including the ones that opt out
     of their own pruning.
 
-    The copy is skipped entirely when the window already holds one stamped with
-    the revisions the database is stamped with now. That is the same rollback
-    point, and taking it again is what created the problem this function exists
-    to solve: a migration failing partway is retried by every service entry
-    point that touches the store, and the copies pile up faster than any
-    retention rule can sort them out. Not making them is cheaper than deciding
-    which to keep, and safer -- earlier revisions of this code tried to rank the
-    copies by wall-clock adjacency, then by the schema transition each attempt
-    recorded, then by a fingerprint of each copy's schema, and each rule in turn
-    was defeated by something the environment could move or by damage the copy
-    could not show. A migration that commits row changes and then fails leaves a
-    half-migrated database that is byte-comparable to the clean one in every
-    respect a backup can measure. So the clean copy is the one kept, by never
-    being displaced.
+    The copy is unconditional, and the window promises exactly one thing: a
+    restorable copy of the database as it stands at this call. Nothing here
+    tries to recognize a copy it already holds and reuse it. Earlier revisions
+    of this change did, by ranking the copies on wall-clock adjacency, then on
+    the schema transition each attempt recorded, then on a fingerprint of each
+    copy's schema, and finally by skipping the copy when a backup carried the
+    same revision stamp -- and every one of those is a label standing in for the
+    database's contents. Labels can be made to agree while the contents differ:
+    a migration that commits row changes and then fails moves neither schema nor
+    stamp, and an operator who restores a copy and keeps serving writes moves
+    the contents under a stamp that never changed. Reusing a copy on any of
+    those grounds hands back a rollback point missing committed data, which is
+    worse than having none, because it is reported as one.
 
-    A copy that is taken reaches stable storage before any older one is deleted,
-    and is protected from its own prune, so this call can never destroy what it
-    just produced.
+    The copy reaches stable storage before any older one is deleted, and is
+    protected from its own prune, so this call can never destroy what it just
+    produced.
 
     The manifest records the revisions read back from the copy rather than
     anything the caller reported, because between a caller sampling them and
@@ -367,11 +340,6 @@ def create_sqlite_migration_backup(
         # in it counts as durable; a crash that keeps the upgrade but loses this
         # directory leaves no rollback point at all.
         _fsync_directory(target_root.parent)
-
-    with sqlite3.connect(f"{source_path.as_uri()}?mode=ro", uri=True) as probe:
-        held = _rollback_point_held(target_root, _stamped_revisions(probe))
-    if held is not None:
-        return held
 
     backup_dir = _unique_backup_dir(target_root, now=created_at)
     backup_dir.mkdir(mode=0o700)
@@ -415,8 +383,7 @@ def create_sqlite_migration_backup(
     # cleanup above runs and nothing is pruned at all. Being after the try means
     # a failure while pruning cannot reach that cleanup and delete the rollback
     # point this call just made. And it has to follow the manifest write,
-    # because a directory without one is not yet a recognized candidate: it
-    # would neither count itself against the bound nor be findable as the
-    # rollback point that lets the next attempt skip its copy.
+    # because a directory without one is not yet a recognized candidate and
+    # would not count itself against the bound.
     prune_state_backups(target_root, json_retention=None, protect=backup_dir)
     return backup_dir

--- a/storage/backups.py
+++ b/storage/backups.py
@@ -224,9 +224,15 @@ def _fsync_file(path: Path) -> None:
     A failure here is never tolerable: it says the copy may not survive the
     crash it was made for, and raising is what stops the caller from deleting
     the copies it was meant to replace.
+
+    The descriptor is opened for writing because on Windows `os.fsync` reaches
+    `FlushFileBuffers`, which refuses a handle without write access. A
+    read-only descriptor would turn every pre-migration backup on that platform
+    into a failed schema upgrade -- the flush is here to make an upgrade safe,
+    so it must not be the thing that stops one.
     """
 
-    fd = os.open(path, os.O_RDONLY)
+    fd = os.open(path, os.O_RDWR)
     try:
         os.fsync(fd)
     finally:
@@ -334,12 +340,15 @@ def create_sqlite_migration_backup(
     source_path = db_path.expanduser().resolve()
     created_at = now or datetime.now(timezone.utc)
     target_root = (backups_dir or source_path.parent / "backups").expanduser().resolve()
-    if not target_root.exists():
-        target_root.mkdir(parents=True, exist_ok=True)
-        # The entry for the window itself has to be on the disk before anything
-        # in it counts as durable; a crash that keeps the upgrade but loses this
-        # directory leaves no rollback point at all.
-        _fsync_directory(target_root.parent)
+    target_root.mkdir(parents=True, exist_ok=True)
+    # The entry for the window itself has to be on the disk before anything in
+    # it counts as durable; a crash that keeps the upgrade but loses this
+    # directory leaves no rollback point at all. Unconditionally, because the
+    # attempt that created the directory is also the attempt whose sync can
+    # fail: it leaves a root that exists without a durable entry, and every
+    # later attempt that treated an existing root as a synced one would inherit
+    # that silently, for as long as the window lives.
+    _fsync_directory(target_root.parent)
 
     backup_dir = _unique_backup_dir(target_root, now=created_at)
     backup_dir.mkdir(mode=0o700)

--- a/storage/backups.py
+++ b/storage/backups.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import errno
+import hashlib
 import json
 import logging
 import os
@@ -30,9 +31,10 @@ _LEGACY_SQLITE_REPAIR_RE = re.compile(
     r"(?P<timestamp>\d{8}T\d{6}Z)\.sqlite$"
 )
 
-# Where the schema stood when a backup was taken, and where it was headed:
-# (from_revisions, to_revisions).
-_Revisions = tuple[tuple[str, ...], tuple[str, ...]]
+# What a backup's database actually was: the revisions it was stamped with, and
+# a fingerprint of the schema those revisions claim to describe. Two copies are
+# the same rollback point only if they agree on both.
+_State = tuple[tuple[str, ...], str]
 
 # A platform or filesystem declining to sync a directory is an answer, not a
 # fault. Anything else -- ENOSPC, EIO -- means the data may not be on the disk,
@@ -52,7 +54,7 @@ class _BackupCandidate:
     timestamp: datetime
     suffix: int
     sequence: int | None = None
-    revisions: _Revisions | None = None
+    state: _State | None = None
 
     @property
     def order_key(self) -> tuple[bool, int, datetime, int, str]:
@@ -62,8 +64,8 @@ class _BackupCandidate:
         previous writes, so it is the one ordering input nothing outside the
         process can move. Wall-clock time can: an NTP correction, a manual
         change, or state carried from a machine running ahead all reorder
-        timestamps after the fact, and a backup that lands out of order stops
-        being identifiable as the first attempt.
+        timestamps after the fact, and a copy that lands out of order takes the
+        slot of the one that actually holds more of the user's writes.
 
         Backups written before the counter existed have no sequence, and sort
         below every backup that has one -- which is simply true, since the
@@ -143,7 +145,7 @@ def _directory_candidate(path: Path) -> _BackupCandidate | None:
         timestamp=timestamp,
         suffix=int(match.group("suffix") or 0),
         sequence=_manifest_sequence(manifest),
-        revisions=_manifest_revisions(manifest),
+        state=_manifest_state(manifest),
     )
 
 
@@ -152,21 +154,23 @@ def _manifest_sequence(manifest: dict) -> int | None:
     return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
 
 
-def _manifest_revisions(manifest: dict) -> _Revisions | None:
-    """Where the schema stood and where it was headed, when the manifest says.
+def _manifest_state(manifest: dict) -> _State | None:
+    """What the database was, as the manifest recorded it.
 
-    Manifests written before these fields existed simply have none, and a backup
-    with none cannot be linked to its neighbours at all.
+    Both halves are required, because either one alone mistakes a different
+    rollback point for the same one: a partially applied upgrade moves the
+    schema while the revisions stand still, and a data-only migration moves the
+    revisions while the schema stands still.
+
+    Manifests written before the fingerprint existed have no state, and a backup
+    with no state can only be compared to itself.
     """
 
-    from_revisions = manifest.get("from_revisions")
-    to_revisions = manifest.get("to_revisions")
-    if not isinstance(from_revisions, list) or not isinstance(to_revisions, list):
+    revisions = manifest.get("from_revisions")
+    digest = manifest.get("schema_digest")
+    if not isinstance(revisions, list) or not isinstance(digest, str) or not digest:
         return None
-    return (
-        tuple(sorted(str(revision) for revision in from_revisions)),
-        tuple(sorted(str(revision) for revision in to_revisions)),
-    )
+    return tuple(sorted(str(revision) for revision in revisions)), digest
 
 
 def _legacy_sqlite_candidate(path: Path) -> _BackupCandidate | None:
@@ -222,77 +226,48 @@ def _remove_candidate(candidate: _BackupCandidate) -> bool:
     return True
 
 
-def _continues(previous: _BackupCandidate, current: _BackupCandidate) -> bool:
-    """Whether `current` is another attempt at the migration `previous` was for.
-
-    Each manifest records where the schema stood when its backup was taken and
-    where that run was headed. Put two consecutive ones side by side and they
-    answer the only question that matters: had the earlier run finished? If it
-    had, the database would have been sitting at its destination when the next
-    backup was taken. It was not, so the earlier run is still unfinished and
-    these two are attempts at one rollback point.
-
-    Deriving the answer from the pair, rather than reading an identity off
-    either one alone, is what makes it hold while a failing upgrade moves the
-    ground under it. `command.upgrade` walks several revisions, and entering an
-    `autocommit_block` commits the version stamps it has already earned -- so a
-    run that dies inside a later revision leaves the next attempt starting
-    somewhere new. An identity built from the starting point splits one episode
-    in two and throws away its clean first snapshot; an identity built from the
-    destination survives that but not a release upgrade arriving mid-episode,
-    which moves the destination instead. The comparison survives both, because
-    it never asks either backup to name the episode it belongs to.
-
-    A backup with no recorded revisions cannot be linked either way, so it
-    begins an episode of its own.
-    """
-
-    if previous.revisions is None or current.revisions is None:
-        return False
-    return current.revisions[0] != previous.revisions[1]
-
-
-def _episodes(candidates: Iterable[_BackupCandidate]) -> list[list[_BackupCandidate]]:
-    """Split backups into runs of attempts at the same rollback point, oldest first."""
-
-    episodes: list[list[_BackupCandidate]] = []
-    for candidate in sorted(candidates, key=lambda item: item.order_key):
-        if episodes and _continues(episodes[-1][-1], candidate):
-            episodes[-1].append(candidate)
-        else:
-            episodes.append([candidate])
-    return episodes
-
-
 def _keep_priority(candidates: Iterable[_BackupCandidate]) -> list[_BackupCandidate]:
     """Order backups by how much a rollback would want them, best first.
 
-    Retries of one unfinished migration are attempts at a single rollback point
-    rather than one rollback point each, and the two worth keeping are the ends.
-    The first predates any partially applied schema change -- an upgrade can
-    commit part of its work before raising, after which every later copy is of
-    the half-migrated database. The last carries every write made since. Copies
-    in between are worse than both on both counts, which is exactly why plain
-    newest-first is the wrong order here: it fills the window with the newest
-    two attempts and discards the only clean one.
+    Two copies of the same database in the same state are the same rollback
+    point taken twice, and the newer one dominates: it holds every write the
+    older one holds, plus the writes made since. So the window keeps the newest
+    copy of each distinct state, newest state first. That is the whole policy --
+    there is no second rule for it to disagree with.
 
-    The episode holding the newest backup comes first, which is also how the
-    backup being taken right now keeps its slot: it is created with the highest
-    sequence there is, so its episode leads by construction rather than by a
-    second rule saying so.
+    It is what makes a retry storm survivable. An upgrade can commit part of its
+    work and then raise -- a SQLite table rebuild inside an autocommit block
+    that fails a later check is exactly that shape -- and from the next attempt
+    on, every copy is of the half-migrated database. Those retries are all one
+    state, so they hold one slot between them instead of crowding out the
+    snapshot taken before the damage, which is a state nothing else can produce.
 
-    On a healthy machine every migration finishes, so each backup is an episode
-    by itself and this is the familiar newest-first.
+    Reading the state off the database instead of inferring it from the events
+    around the backup is the point. Earlier revisions of this code tried to
+    recognise a run of retries from wall-clock time, and then from the schema
+    transition each attempt recorded; the environment moves both. A clock
+    correction reorders the attempts. `command.upgrade` walks several revisions
+    in one call, and entering an autocommit block commits the version stamps
+    already earned, so the transition an attempt reports is not the one the
+    attempt before it reported. A fingerprint taken from the copy moves only
+    when the database moves -- including backwards, which is what an operator
+    restoring a rollback point does, and why a post-restore snapshot correctly
+    reads as the state it was restored to rather than as one more retry.
+
+    On a healthy machine every migration finishes and every backup is a state of
+    its own, so this is the familiar newest-first. Backups too old to record a
+    state stand alone, for the same reason: nothing about them can be compared.
     """
 
-    ranked: list[_BackupCandidate] = []
+    best: dict[object, _BackupCandidate] = {}
     superseded: list[_BackupCandidate] = []
-    for members in sorted(_episodes(candidates), key=lambda group: group[-1].order_key, reverse=True):
-        ranked.append(members[-1])
-        if len(members) > 1:
-            ranked.append(members[0])
-        superseded.extend(members[1:-1])
-    return ranked + superseded
+    for candidate in sorted(candidates, key=lambda item: item.order_key, reverse=True):
+        key = candidate.state if candidate.state is not None else candidate.root
+        if key in best:
+            superseded.append(candidate)
+        else:
+            best[key] = candidate
+    return list(best.values()) + superseded
 
 
 def prune_state_backups(
@@ -383,6 +358,30 @@ def _next_sequence(backups_dir: Path) -> int:
     ) + 1
 
 
+def _schema_digest(connection: sqlite3.Connection) -> str:
+    """Fingerprint the schema of the database behind `connection`.
+
+    Taken from the copy this call just wrote, so it describes the bytes being
+    preserved rather than anything reported about them. That is what makes it
+    usable as an identity: a partially applied upgrade changes the schema
+    without changing the revision the database is stamped with, and restoring a
+    rollback point changes it back.
+
+    `sqlite_master` is a handful of rows next to a copy of the whole database,
+    so the measurement is free in the only place it is taken.
+    """
+
+    digest = hashlib.sha256()
+    for row in connection.execute(
+        "SELECT type, name, tbl_name, sql FROM sqlite_master ORDER BY type, name, tbl_name"
+    ):
+        for column in row:
+            digest.update(b"\x00" if column is None else str(column).encode("utf-8"))
+            digest.update(b"\x1f")
+        digest.update(b"\x1e")
+    return digest.hexdigest()
+
+
 def _unique_backup_dir(backups_dir: Path, *, now: datetime) -> Path:
     timestamp = now.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     suffixes = [
@@ -422,6 +421,10 @@ def create_sqlite_migration_backup(
     it just produced, so it never does: the copy reaches stable storage before
     any older one is deleted, and it is stamped with the next sequence, which
     puts it ahead of every backup on disk without having to trust a clock.
+
+    The manifest also records what the copy actually is -- the revisions it was
+    stamped with and a fingerprint of its schema -- which is what lets the window
+    tell a fresh rollback point from another copy of one it already holds.
     """
 
     source_path = db_path.expanduser().resolve()
@@ -443,6 +446,7 @@ def create_sqlite_migration_backup(
                 check = destination.execute("PRAGMA quick_check").fetchone()
                 if check != ("ok",):
                     raise sqlite3.DatabaseError(f"SQLite backup quick_check failed: {check!r}")
+                schema_digest = _schema_digest(destination)
         os.chmod(temp_db, 0o600)
         _fsync_file(temp_db)
         temp_db.replace(backup_db)
@@ -453,6 +457,7 @@ def create_sqlite_migration_backup(
             "created_at": created_at.astimezone(timezone.utc).isoformat(),
             "database": "vibe.sqlite",
             "sequence": sequence,
+            "schema_digest": schema_digest,
             "from_revisions": sorted(set(from_revisions)),
             "to_revisions": sorted(set(to_revisions)),
         }
@@ -473,7 +478,7 @@ def create_sqlite_migration_backup(
     # a failure while pruning cannot reach that cleanup and delete the rollback
     # point this call just made. And it has to follow the manifest write,
     # because a directory without one is not yet a recognized candidate: it
-    # would neither count itself against the bound nor carry the sequence that
-    # puts it at the head of the episode in progress.
+    # would neither count itself against the bound nor carry the sequence and
+    # state that decide which copies the bound keeps.
     prune_state_backups(target_root, json_retention=None)
     return backup_dir

--- a/storage/backups.py
+++ b/storage/backups.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import errno
-import hashlib
 import json
 import logging
 import os
@@ -31,11 +30,6 @@ _LEGACY_SQLITE_REPAIR_RE = re.compile(
     r"(?P<timestamp>\d{8}T\d{6}Z)\.sqlite$"
 )
 
-# What a backup's database actually was: the revisions it was stamped with, and
-# a fingerprint of the schema those revisions claim to describe. Two copies are
-# the same rollback point only if they agree on both.
-_State = tuple[tuple[str, ...], str]
-
 # A platform or filesystem declining to sync a directory is an answer, not a
 # fault. Anything else -- ENOSPC, EIO -- means the data may not be on the disk,
 # so it must reach the caller instead of being logged and forgotten.
@@ -53,33 +47,19 @@ class _BackupCandidate:
     kind: str
     timestamp: datetime
     suffix: int
-    sequence: int | None = None
-    state: _State | None = None
+    revisions: tuple[str, ...] | None = None
 
     @property
-    def order_key(self) -> tuple[bool, int, datetime, int, str]:
-        """Creation order, measured by us where possible.
+    def order_key(self) -> tuple[datetime, int, str]:
+        """Creation order, as the backup's own name records it.
 
-        The sequence is a counter this module writes and increments from its own
-        previous writes, so it is the one ordering input nothing outside the
-        process can move. Wall-clock time can: an NTP correction, a manual
-        change, or state carried from a machine running ahead all reorder
-        timestamps after the fact, and a copy that lands out of order takes the
-        slot of the one that actually holds more of the user's writes.
-
-        Backups written before the counter existed have no sequence, and sort
-        below every backup that has one -- which is simply true, since the
-        counter only started being written later. Among themselves the timestamp
-        is the best evidence available.
+        A movable clock can reorder this, and that is tolerable here, because
+        ordering only decides which of the older copies to drop first. The copy
+        a call just made is not defended by outranking them -- it is handed to
+        `prune_state_backups` as protected, which no clock can undo.
         """
 
-        return (
-            self.sequence is not None,
-            self.sequence or 0,
-            self.timestamp,
-            self.suffix,
-            self.root.name,
-        )
+        return (self.timestamp, self.suffix, self.root.name)
 
 
 def _parse_timestamp(value: str) -> datetime | None:
@@ -144,33 +124,23 @@ def _directory_candidate(path: Path) -> _BackupCandidate | None:
         kind=kind,
         timestamp=timestamp,
         suffix=int(match.group("suffix") or 0),
-        sequence=_manifest_sequence(manifest),
-        state=_manifest_state(manifest),
+        revisions=_manifest_revisions(manifest),
     )
 
 
-def _manifest_sequence(manifest: dict) -> int | None:
-    value = manifest.get("sequence")
-    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
+def _manifest_revisions(manifest: dict) -> tuple[str, ...] | None:
+    """The revisions the backup's own copy of the database was stamped with.
 
-
-def _manifest_state(manifest: dict) -> _State | None:
-    """What the database was, as the manifest recorded it.
-
-    Both halves are required, because either one alone mistakes a different
-    rollback point for the same one: a partially applied upgrade moves the
-    schema while the revisions stand still, and a data-only migration moves the
-    revisions while the schema stands still.
-
-    Manifests written before the fingerprint existed have no state, and a backup
-    with no state can only be compared to itself.
+    A manifest that does not record them, or records them in a shape this
+    version does not understand, yields `None` -- which never matches anything,
+    so such a backup can never be mistaken for the rollback point a caller is
+    about to look for.
     """
 
-    revisions = manifest.get("from_revisions")
-    digest = manifest.get("schema_digest")
-    if not isinstance(revisions, list) or not isinstance(digest, str) or not digest:
+    value = manifest.get("from_revisions")
+    if not isinstance(value, list):
         return None
-    return tuple(sorted(str(revision) for revision in revisions)), digest
+    return tuple(sorted(str(revision) for revision in value))
 
 
 def _legacy_sqlite_candidate(path: Path) -> _BackupCandidate | None:
@@ -226,57 +196,21 @@ def _remove_candidate(candidate: _BackupCandidate) -> bool:
     return True
 
 
-def _keep_priority(candidates: Iterable[_BackupCandidate]) -> list[_BackupCandidate]:
-    """Order backups by how much a rollback would want them, best first.
-
-    Two copies of the same database in the same state are the same rollback
-    point taken twice, and the newer one dominates: it holds every write the
-    older one holds, plus the writes made since. So the window keeps the newest
-    copy of each distinct state, newest state first. That is the whole policy --
-    there is no second rule for it to disagree with.
-
-    It is what makes a retry storm survivable. An upgrade can commit part of its
-    work and then raise -- a SQLite table rebuild inside an autocommit block
-    that fails a later check is exactly that shape -- and from the next attempt
-    on, every copy is of the half-migrated database. Those retries are all one
-    state, so they hold one slot between them instead of crowding out the
-    snapshot taken before the damage, which is a state nothing else can produce.
-
-    Reading the state off the database instead of inferring it from the events
-    around the backup is the point. Earlier revisions of this code tried to
-    recognise a run of retries from wall-clock time, and then from the schema
-    transition each attempt recorded; the environment moves both. A clock
-    correction reorders the attempts. `command.upgrade` walks several revisions
-    in one call, and entering an autocommit block commits the version stamps
-    already earned, so the transition an attempt reports is not the one the
-    attempt before it reported. A fingerprint taken from the copy moves only
-    when the database moves -- including backwards, which is what an operator
-    restoring a rollback point does, and why a post-restore snapshot correctly
-    reads as the state it was restored to rather than as one more retry.
-
-    On a healthy machine every migration finishes and every backup is a state of
-    its own, so this is the familiar newest-first. Backups too old to record a
-    state stand alone, for the same reason: nothing about them can be compared.
-    """
-
-    best: dict[object, _BackupCandidate] = {}
-    superseded: list[_BackupCandidate] = []
-    for candidate in sorted(candidates, key=lambda item: item.order_key, reverse=True):
-        key = candidate.state if candidate.state is not None else candidate.root
-        if key in best:
-            superseded.append(candidate)
-        else:
-            best[key] = candidate
-    return list(best.values()) + superseded
-
-
 def prune_state_backups(
     backups_dir: Path,
     *,
     json_retention: int | None = JSON_STATE_BACKUP_RETENTION,
     sqlite_retention: int | None = SQLITE_BACKUP_RETENTION,
+    protect: Path | None = None,
 ) -> list[Path]:
     """Keep a bounded rollback window of backups created by Avibe.
+
+    Newest first, and `protect` -- the backup its caller has just finished
+    writing -- is kept ahead of all of them. Ranking it there rather than
+    trusting it to sort highest is the difference between a bound and a bug: a
+    copy left behind by a machine whose clock ran ahead is dated into the future
+    forever, and every ordering rule that decides the fresh copy's fate by
+    comparing timestamps hands the slot to that stale one instead.
 
     Unknown files, symlinks, incomplete backups, and directories without a
     recognized manifest are intentionally left untouched.
@@ -291,7 +225,10 @@ def prune_state_backups(
     removed: list[Path] = []
     for kind, limit in limits.items():
         matching = [candidate for candidate in candidates if candidate.kind == kind]
-        keep = {candidate.root for candidate in _keep_priority(matching)[:limit]}
+        ordered = sorted(matching, key=lambda item: item.order_key, reverse=True)
+        if protect is not None:
+            ordered.sort(key=lambda item: item.root != protect)
+        keep = {candidate.root for candidate in ordered[:limit]}
         for candidate in sorted(matching, key=lambda item: item.order_key):
             if candidate.root not in keep and _remove_candidate(candidate):
                 removed.append(candidate.root)
@@ -339,47 +276,28 @@ def _fsync_directory(path: Path) -> None:
         os.close(fd)
 
 
-def _next_sequence(backups_dir: Path) -> int:
-    """One past the highest sequence any backup on disk carries.
+def _stamped_revisions(connection: sqlite3.Connection) -> tuple[str, ...]:
+    """The alembic revisions the database behind `connection` is stamped with.
 
-    Counting from what survives rather than from a stored high-water mark is
-    what keeps the counter honest across pruning: the new backup only has to
-    outrank the backups that still exist, and reusing a number whose backup was
-    deleted costs nothing. It cannot collide with a live one by construction.
+    A database with no `alembic_version` table yields the empty tuple, which is
+    a state like any other: it is what an unversioned database is, and two
+    copies of it are the same rollback point.
     """
 
-    return max(
-        (
-            candidate.sequence
-            for candidate in _managed_candidates(backups_dir)
-            if candidate.sequence is not None
-        ),
-        default=0,
-    ) + 1
+    try:
+        rows = connection.execute("select version_num from alembic_version").fetchall()
+    except sqlite3.DatabaseError:
+        return ()
+    return tuple(sorted({str(row[0]) for row in rows}))
 
 
-def _schema_digest(connection: sqlite3.Connection) -> str:
-    """Fingerprint the schema of the database behind `connection`.
+def _rollback_point_held(backups_dir: Path, revisions: tuple[str, ...]) -> Path | None:
+    """A surviving backup of the database as it is stamped now, if there is one."""
 
-    Taken from the copy this call just wrote, so it describes the bytes being
-    preserved rather than anything reported about them. That is what makes it
-    usable as an identity: a partially applied upgrade changes the schema
-    without changing the revision the database is stamped with, and restoring a
-    rollback point changes it back.
-
-    `sqlite_master` is a handful of rows next to a copy of the whole database,
-    so the measurement is free in the only place it is taken.
-    """
-
-    digest = hashlib.sha256()
-    for row in connection.execute(
-        "SELECT type, name, tbl_name, sql FROM sqlite_master ORDER BY type, name, tbl_name"
-    ):
-        for column in row:
-            digest.update(b"\x00" if column is None else str(column).encode("utf-8"))
-            digest.update(b"\x1f")
-        digest.update(b"\x1e")
-    return digest.hexdigest()
+    for candidate in sorted(_managed_candidates(backups_dir), key=lambda item: item.order_key, reverse=True):
+        if candidate.kind == "sqlite" and candidate.revisions == revisions:
+            return candidate.root
+    return None
 
 
 def _unique_backup_dir(backups_dir: Path, *, now: datetime) -> Path:
@@ -402,11 +320,10 @@ def create_sqlite_migration_backup(
     db_path: Path,
     *,
     backups_dir: Path | None = None,
-    from_revisions: Iterable[str] = (),
     to_revisions: Iterable[str] = (),
     now: datetime | None = None,
 ) -> Path:
-    """Add a consistent, self-identifying SQLite backup to a bounded rollback window.
+    """Hold a rollback point for the database as it stands, in a bounded window.
 
     Bounding the window belongs here rather than at the call sites. A backup is
     a rollback point the moment it is durable, so whether the migration that
@@ -417,22 +334,45 @@ def create_sqlite_migration_backup(
     the bound true for callers not yet written, including the ones that opt out
     of their own pruning.
 
-    Owning it here also means this call is the only thing that can destroy what
-    it just produced, so it never does: the copy reaches stable storage before
-    any older one is deleted, and it is stamped with the next sequence, which
-    puts it ahead of every backup on disk without having to trust a clock.
+    The copy is skipped entirely when the window already holds one stamped with
+    the revisions the database is stamped with now. That is the same rollback
+    point, and taking it again is what created the problem this function exists
+    to solve: a migration failing partway is retried by every service entry
+    point that touches the store, and the copies pile up faster than any
+    retention rule can sort them out. Not making them is cheaper than deciding
+    which to keep, and safer -- earlier revisions of this code tried to rank the
+    copies by wall-clock adjacency, then by the schema transition each attempt
+    recorded, then by a fingerprint of each copy's schema, and each rule in turn
+    was defeated by something the environment could move or by damage the copy
+    could not show. A migration that commits row changes and then fails leaves a
+    half-migrated database that is byte-comparable to the clean one in every
+    respect a backup can measure. So the clean copy is the one kept, by never
+    being displaced.
 
-    The manifest also records what the copy actually is -- the revisions it was
-    stamped with and a fingerprint of its schema -- which is what lets the window
-    tell a fresh rollback point from another copy of one it already holds.
+    A copy that is taken reaches stable storage before any older one is deleted,
+    and is protected from its own prune, so this call can never destroy what it
+    just produced.
+
+    The manifest records the revisions read back from the copy rather than
+    anything the caller reported, because between a caller sampling them and
+    this function running, another process can advance the database.
     """
 
     source_path = db_path.expanduser().resolve()
     created_at = now or datetime.now(timezone.utc)
     target_root = (backups_dir or source_path.parent / "backups").expanduser().resolve()
-    target_root.mkdir(parents=True, exist_ok=True)
-    # Read before anything is written, so the count is of finished backups only.
-    sequence = _next_sequence(target_root)
+    if not target_root.exists():
+        target_root.mkdir(parents=True, exist_ok=True)
+        # The entry for the window itself has to be on the disk before anything
+        # in it counts as durable; a crash that keeps the upgrade but loses this
+        # directory leaves no rollback point at all.
+        _fsync_directory(target_root.parent)
+
+    with sqlite3.connect(f"{source_path.as_uri()}?mode=ro", uri=True) as probe:
+        held = _rollback_point_held(target_root, _stamped_revisions(probe))
+    if held is not None:
+        return held
+
     backup_dir = _unique_backup_dir(target_root, now=created_at)
     backup_dir.mkdir(mode=0o700)
     temp_db = backup_dir / "vibe.sqlite.tmp"
@@ -446,7 +386,7 @@ def create_sqlite_migration_backup(
                 check = destination.execute("PRAGMA quick_check").fetchone()
                 if check != ("ok",):
                     raise sqlite3.DatabaseError(f"SQLite backup quick_check failed: {check!r}")
-                schema_digest = _schema_digest(destination)
+                from_revisions = _stamped_revisions(destination)
         os.chmod(temp_db, 0o600)
         _fsync_file(temp_db)
         temp_db.replace(backup_db)
@@ -456,9 +396,7 @@ def create_sqlite_migration_backup(
             "kind": "sqlite-migration",
             "created_at": created_at.astimezone(timezone.utc).isoformat(),
             "database": "vibe.sqlite",
-            "sequence": sequence,
-            "schema_digest": schema_digest,
-            "from_revisions": sorted(set(from_revisions)),
+            "from_revisions": list(from_revisions),
             "to_revisions": sorted(set(to_revisions)),
         }
         manifest_path = backup_dir / "manifest.json"
@@ -478,7 +416,7 @@ def create_sqlite_migration_backup(
     # a failure while pruning cannot reach that cleanup and delete the rollback
     # point this call just made. And it has to follow the manifest write,
     # because a directory without one is not yet a recognized candidate: it
-    # would neither count itself against the bound nor carry the sequence and
-    # state that decide which copies the bound keeps.
-    prune_state_backups(target_root, json_retention=None)
+    # would neither count itself against the bound nor be findable as the
+    # rollback point that lets the next attempt skip its copy.
+    prune_state_backups(target_root, json_retention=None, protect=backup_dir)
     return backup_dir

--- a/storage/backups.py
+++ b/storage/backups.py
@@ -37,10 +37,17 @@ class _BackupCandidate:
     kind: str
     timestamp: datetime
     suffix: int
+    transition: tuple[tuple[str, ...], tuple[str, ...]] | None = None
 
     @property
     def order_key(self) -> tuple[datetime, int, str]:
         return self.timestamp, self.suffix, self.root.name
+
+    @property
+    def group_key(self) -> object:
+        # A backup with no recorded transition cannot be shown to be an attempt
+        # at the same rollback point as any other, so it stands alone.
+        return self.transition or self.root.name
 
 
 def _parse_timestamp(value: str) -> datetime | None:
@@ -105,6 +112,26 @@ def _directory_candidate(path: Path) -> _BackupCandidate | None:
         kind=kind,
         timestamp=timestamp,
         suffix=int(match.group("suffix") or 0),
+        transition=_manifest_transition(manifest),
+    )
+
+
+def _manifest_transition(manifest: dict) -> tuple[tuple[str, ...], tuple[str, ...]] | None:
+    """The schema move a backup was taken for, when the manifest records one.
+
+    A failed upgrade leaves the recorded revisions untouched, so every retry of
+    it reports the same move. That is what makes the move usable as the identity
+    of one rollback point across attempts. Manifests written before these fields
+    existed simply have no transition.
+    """
+
+    from_revisions = manifest.get("from_revisions")
+    to_revisions = manifest.get("to_revisions")
+    if not isinstance(from_revisions, list) or not isinstance(to_revisions, list):
+        return None
+    return (
+        tuple(sorted(str(revision) for revision in from_revisions)),
+        tuple(sorted(str(revision) for revision in to_revisions)),
     )
 
 
@@ -161,16 +188,56 @@ def _remove_candidate(candidate: _BackupCandidate) -> bool:
     return True
 
 
+def _keep_priority(candidates: Iterable[_BackupCandidate]) -> list[_BackupCandidate]:
+    """Order backups by how much a rollback would want them, best first.
+
+    Retries of one unfinished migration are attempts at a single rollback point
+    rather than one rollback point each, and the two worth keeping are the ends.
+    The first predates any partially applied schema change -- an upgrade can
+    commit part of its work before raising, after which every later copy is of
+    the half-migrated database. The last carries every write made since. Copies
+    in between are worse than both on both counts, which is exactly why plain
+    newest-first is the wrong order here: it fills the window with the newest
+    two attempts and discards the only clean one.
+
+    Backups that stand alone are their own group, so for a healthy machine --
+    where each backup marks a different completed migration -- this stays the
+    familiar newest-first.
+    """
+
+    groups: dict[object, list[_BackupCandidate]] = {}
+    for candidate in candidates:
+        groups.setdefault(candidate.group_key, []).append(candidate)
+
+    ranked: list[_BackupCandidate] = []
+    superseded: list[_BackupCandidate] = []
+    for group in sorted(groups.values(), key=lambda item: max(entry.order_key for entry in item), reverse=True):
+        members = sorted(group, key=lambda item: item.order_key)
+        ranked.append(members[-1])
+        if len(members) > 1:
+            ranked.append(members[0])
+        superseded.extend(members[1:-1])
+    return ranked + superseded
+
+
 def prune_state_backups(
     backups_dir: Path,
     *,
     json_retention: int | None = JSON_STATE_BACKUP_RETENTION,
     sqlite_retention: int | None = SQLITE_BACKUP_RETENTION,
+    protect: Path | None = None,
 ) -> list[Path]:
     """Keep a bounded rollback window of backups created by Avibe.
 
     Unknown files, symlinks, incomplete backups, and directories without a
     recognized manifest are intentionally left untouched.
+
+    `protect` names a backup that must survive this call. It takes the first
+    slot of its kind rather than an extra one, so the window stays bounded; it
+    exists because timestamp order is not proof of being newest. A clock
+    corrected backwards, or state moved from a machine whose clock ran ahead,
+    leaves future-dated copies that would otherwise rank above a backup taken
+    seconds ago and delete it.
     """
 
     limits = {
@@ -179,13 +246,43 @@ def prune_state_backups(
         if retention is not None
     }
     candidates = _managed_candidates(backups_dir)
+    protected = protect.expanduser().resolve() if protect is not None else None
     removed: list[Path] = []
     for kind, limit in limits.items():
-        matching = sorted((candidate for candidate in candidates if candidate.kind == kind), key=lambda item: item.order_key)
-        for candidate in matching[: max(0, len(matching) - limit)]:
-            if _remove_candidate(candidate):
+        matching = [candidate for candidate in candidates if candidate.kind == kind]
+        ranked = _keep_priority(matching)
+        if protected is not None:
+            ranked.sort(key=lambda candidate: candidate.root != protected)
+        keep = {candidate.root for candidate in ranked[:limit]}
+        for candidate in sorted(matching, key=lambda item: item.order_key):
+            if candidate.root not in keep and _remove_candidate(candidate):
                 removed.append(candidate.root)
     return removed
+
+
+def _fsync(path: Path) -> None:
+    """Push a file, or a directory's entries, to stable storage.
+
+    Syncing the directory is what makes a rename durable on POSIX, and a backup
+    is worth nothing if a crash can lose it. Windows has no equivalent and
+    refuses to open a directory at all, so a rejection here is the platform's
+    answer rather than a failure to report.
+    """
+
+    flags = os.O_RDONLY
+    if path.is_dir():
+        flags |= getattr(os, "O_DIRECTORY", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        logger.debug("Cannot open %s to fsync it on this platform", path, exc_info=True)
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        logger.debug("fsync is unavailable for %s on this platform", path, exc_info=True)
+    finally:
+        os.close(fd)
 
 
 def _unique_backup_dir(backups_dir: Path, *, now: datetime) -> Path:
@@ -222,6 +319,11 @@ def create_sqlite_migration_backup(
     forever. Owning it at the one function that grows the window is what makes
     the bound true for callers not yet written, including the ones that opt out
     of their own pruning.
+
+    Owning it here also means this call is the only thing that can destroy what
+    it just produced, so it never does: the copy is on stable storage before any
+    older one is deleted, and it is named as protected rather than trusted to
+    rank newest by its own timestamp.
     """
 
     source_path = db_path.expanduser().resolve()
@@ -242,6 +344,7 @@ def create_sqlite_migration_backup(
                 if check != ("ok",):
                     raise sqlite3.DatabaseError(f"SQLite backup quick_check failed: {check!r}")
         os.chmod(temp_db, 0o600)
+        _fsync(temp_db)
         temp_db.replace(backup_db)
         manifest = {
             "schema_version": BACKUP_MANIFEST_VERSION,
@@ -252,16 +355,22 @@ def create_sqlite_migration_backup(
             "from_revisions": sorted(set(from_revisions)),
             "to_revisions": sorted(set(to_revisions)),
         }
-        (backup_dir / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+        manifest_path = backup_dir / "manifest.json"
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+        _fsync(manifest_path)
+        _fsync(backup_dir)
+        _fsync(target_root)
     except Exception:
         shutil.rmtree(backup_dir, ignore_errors=True)
         raise
 
-    # After the try, deliberately: the new backup is durable and complete here,
-    # so a failure while pruning can never reach the cleanup path above and
-    # delete the rollback point this call just made. Pruning also has to follow
-    # the manifest write, because a directory without one is not yet a
-    # recognized candidate and would not count itself against the retention
-    # bound.
-    prune_state_backups(target_root, json_retention=None)
+    # Everything above has to happen before the prune, and each for its own
+    # reason. The fsyncs make the replacement survive a crash first, so the
+    # filesystem can never persist the deletion of durable copies while losing
+    # the one that replaced them. Being after the try means a failure while
+    # pruning cannot reach the cleanup path and delete the rollback point this
+    # call just made. And it has to follow the manifest write, because a
+    # directory without one is not yet a recognized candidate and would not
+    # count itself against the bound.
+    prune_state_backups(target_root, json_retention=None, protect=backup_dir)
     return backup_dir

--- a/storage/backups.py
+++ b/storage/backups.py
@@ -212,7 +212,17 @@ def create_sqlite_migration_backup(
     to_revisions: Iterable[str] = (),
     now: datetime | None = None,
 ) -> Path:
-    """Create a consistent, self-identifying SQLite backup before migration."""
+    """Add a consistent, self-identifying SQLite backup to a bounded rollback window.
+
+    Bounding the window belongs here rather than at the call sites. A backup is
+    a rollback point the moment it is durable, so whether the migration that
+    follows it succeeds says nothing about how many older copies are still
+    worth keeping -- and every caller that pruned on that outcome instead left
+    a failing migration adding one full copy of the database per attempt,
+    forever. Owning it at the one function that grows the window is what makes
+    the bound true for callers not yet written, including the ones that opt out
+    of their own pruning.
+    """
 
     source_path = db_path.expanduser().resolve()
     created_at = now or datetime.now(timezone.utc)
@@ -247,4 +257,11 @@ def create_sqlite_migration_backup(
         shutil.rmtree(backup_dir, ignore_errors=True)
         raise
 
+    # After the try, deliberately: the new backup is durable and complete here,
+    # so a failure while pruning can never reach the cleanup path above and
+    # delete the rollback point this call just made. Pruning also has to follow
+    # the manifest write, because a directory without one is not yet a
+    # recognized candidate and would not count itself against the retention
+    # bound.
+    prune_state_backups(target_root, json_retention=None)
     return backup_dir

--- a/storage/backups.py
+++ b/storage/backups.py
@@ -30,8 +30,9 @@ _LEGACY_SQLITE_REPAIR_RE = re.compile(
     r"(?P<timestamp>\d{8}T\d{6}Z)\.sqlite$"
 )
 
-# The schema move a backup was taken for: (from_revisions, to_revisions).
-_Transition = tuple[tuple[str, ...], tuple[str, ...]]
+# Where the schema stood when a backup was taken, and where it was headed:
+# (from_revisions, to_revisions).
+_Revisions = tuple[tuple[str, ...], tuple[str, ...]]
 
 # A platform or filesystem declining to sync a directory is an answer, not a
 # fault. Anything else -- ENOSPC, EIO -- means the data may not be on the disk,
@@ -50,17 +51,33 @@ class _BackupCandidate:
     kind: str
     timestamp: datetime
     suffix: int
-    transition: tuple[tuple[str, ...], tuple[str, ...]] | None = None
+    sequence: int | None = None
+    revisions: _Revisions | None = None
 
     @property
-    def order_key(self) -> tuple[datetime, int, str]:
-        return self.timestamp, self.suffix, self.root.name
+    def order_key(self) -> tuple[bool, int, datetime, int, str]:
+        """Creation order, measured by us where possible.
 
-    @property
-    def group_key(self) -> object:
-        # A backup with no recorded transition cannot be shown to be an attempt
-        # at the same rollback point as any other, so it stands alone.
-        return self.transition or self.root.name
+        The sequence is a counter this module writes and increments from its own
+        previous writes, so it is the one ordering input nothing outside the
+        process can move. Wall-clock time can: an NTP correction, a manual
+        change, or state carried from a machine running ahead all reorder
+        timestamps after the fact, and a backup that lands out of order stops
+        being identifiable as the first attempt.
+
+        Backups written before the counter existed have no sequence, and sort
+        below every backup that has one -- which is simply true, since the
+        counter only started being written later. Among themselves the timestamp
+        is the best evidence available.
+        """
+
+        return (
+            self.sequence is not None,
+            self.sequence or 0,
+            self.timestamp,
+            self.suffix,
+            self.root.name,
+        )
 
 
 def _parse_timestamp(value: str) -> datetime | None:
@@ -125,17 +142,21 @@ def _directory_candidate(path: Path) -> _BackupCandidate | None:
         kind=kind,
         timestamp=timestamp,
         suffix=int(match.group("suffix") or 0),
-        transition=_manifest_transition(manifest),
+        sequence=_manifest_sequence(manifest),
+        revisions=_manifest_revisions(manifest),
     )
 
 
-def _manifest_transition(manifest: dict) -> tuple[tuple[str, ...], tuple[str, ...]] | None:
-    """The schema move a backup was taken for, when the manifest records one.
+def _manifest_sequence(manifest: dict) -> int | None:
+    value = manifest.get("sequence")
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else None
 
-    A failed upgrade leaves the recorded revisions untouched, so every retry of
-    it reports the same move. That is what makes the move usable as the identity
-    of one rollback point across attempts. Manifests written before these fields
-    existed simply have no transition.
+
+def _manifest_revisions(manifest: dict) -> _Revisions | None:
+    """Where the schema stood and where it was headed, when the manifest says.
+
+    Manifests written before these fields existed simply have none, and a backup
+    with none cannot be linked to its neighbours at all.
     """
 
     from_revisions = manifest.get("from_revisions")
@@ -201,11 +222,49 @@ def _remove_candidate(candidate: _BackupCandidate) -> bool:
     return True
 
 
-def _keep_priority(
-    candidates: Iterable[_BackupCandidate],
-    *,
-    active: _Transition | None = None,
-) -> list[_BackupCandidate]:
+def _continues(previous: _BackupCandidate, current: _BackupCandidate) -> bool:
+    """Whether `current` is another attempt at the migration `previous` was for.
+
+    Each manifest records where the schema stood when its backup was taken and
+    where that run was headed. Put two consecutive ones side by side and they
+    answer the only question that matters: had the earlier run finished? If it
+    had, the database would have been sitting at its destination when the next
+    backup was taken. It was not, so the earlier run is still unfinished and
+    these two are attempts at one rollback point.
+
+    Deriving the answer from the pair, rather than reading an identity off
+    either one alone, is what makes it hold while a failing upgrade moves the
+    ground under it. `command.upgrade` walks several revisions, and entering an
+    `autocommit_block` commits the version stamps it has already earned -- so a
+    run that dies inside a later revision leaves the next attempt starting
+    somewhere new. An identity built from the starting point splits one episode
+    in two and throws away its clean first snapshot; an identity built from the
+    destination survives that but not a release upgrade arriving mid-episode,
+    which moves the destination instead. The comparison survives both, because
+    it never asks either backup to name the episode it belongs to.
+
+    A backup with no recorded revisions cannot be linked either way, so it
+    begins an episode of its own.
+    """
+
+    if previous.revisions is None or current.revisions is None:
+        return False
+    return current.revisions[0] != previous.revisions[1]
+
+
+def _episodes(candidates: Iterable[_BackupCandidate]) -> list[list[_BackupCandidate]]:
+    """Split backups into runs of attempts at the same rollback point, oldest first."""
+
+    episodes: list[list[_BackupCandidate]] = []
+    for candidate in sorted(candidates, key=lambda item: item.order_key):
+        if episodes and _continues(episodes[-1][-1], candidate):
+            episodes[-1].append(candidate)
+        else:
+            episodes.append([candidate])
+    return episodes
+
+
+def _keep_priority(candidates: Iterable[_BackupCandidate]) -> list[_BackupCandidate]:
     """Order backups by how much a rollback would want them, best first.
 
     Retries of one unfinished migration are attempts at a single rollback point
@@ -217,29 +276,18 @@ def _keep_priority(
     newest-first is the wrong order here: it fills the window with the newest
     two attempts and discards the only clean one.
 
-    `active` is the migration being attempted right now, and its ends outrank
-    everything else because being newest on disk is not the same as being
-    current. A clock corrected backwards, or state carried from a machine that
-    ran ahead, leaves unrelated copies dated later; spending the window on those
-    would evict the snapshot taken before the upgrade that is failing.
+    The episode holding the newest backup comes first, which is also how the
+    backup being taken right now keeps its slot: it is created with the highest
+    sequence there is, so its episode leads by construction rather than by a
+    second rule saying so.
 
-    Backups that stand alone are their own group, so for a healthy machine --
-    where each backup marks a different completed migration -- this stays the
-    familiar newest-first.
+    On a healthy machine every migration finishes, so each backup is an episode
+    by itself and this is the familiar newest-first.
     """
-
-    groups: dict[object, list[_BackupCandidate]] = {}
-    for candidate in candidates:
-        groups.setdefault(candidate.group_key, []).append(candidate)
-
-    def rank(group: list[_BackupCandidate]) -> tuple[bool, tuple[datetime, int, str]]:
-        is_active = active is not None and group[0].transition == active
-        return is_active, max(entry.order_key for entry in group)
 
     ranked: list[_BackupCandidate] = []
     superseded: list[_BackupCandidate] = []
-    for group in sorted(groups.values(), key=rank, reverse=True):
-        members = sorted(group, key=lambda item: item.order_key)
+    for members in sorted(_episodes(candidates), key=lambda group: group[-1].order_key, reverse=True):
         ranked.append(members[-1])
         if len(members) > 1:
             ranked.append(members[0])
@@ -252,16 +300,11 @@ def prune_state_backups(
     *,
     json_retention: int | None = JSON_STATE_BACKUP_RETENTION,
     sqlite_retention: int | None = SQLITE_BACKUP_RETENTION,
-    active: _Transition | None = None,
 ) -> list[Path]:
     """Keep a bounded rollback window of backups created by Avibe.
 
     Unknown files, symlinks, incomplete backups, and directories without a
     recognized manifest are intentionally left untouched.
-
-    `active` names the migration in progress, whose rollback points get the
-    slots first. Callers that are only reclaiming space leave it unset and get
-    the same order by recency.
     """
 
     limits = {
@@ -273,7 +316,7 @@ def prune_state_backups(
     removed: list[Path] = []
     for kind, limit in limits.items():
         matching = [candidate for candidate in candidates if candidate.kind == kind]
-        keep = {candidate.root for candidate in _keep_priority(matching, active=active)[:limit]}
+        keep = {candidate.root for candidate in _keep_priority(matching)[:limit]}
         for candidate in sorted(matching, key=lambda item: item.order_key):
             if candidate.root not in keep and _remove_candidate(candidate):
                 removed.append(candidate.root)
@@ -321,6 +364,25 @@ def _fsync_directory(path: Path) -> None:
         os.close(fd)
 
 
+def _next_sequence(backups_dir: Path) -> int:
+    """One past the highest sequence any backup on disk carries.
+
+    Counting from what survives rather than from a stored high-water mark is
+    what keeps the counter honest across pruning: the new backup only has to
+    outrank the backups that still exist, and reusing a number whose backup was
+    deleted costs nothing. It cannot collide with a live one by construction.
+    """
+
+    return max(
+        (
+            candidate.sequence
+            for candidate in _managed_candidates(backups_dir)
+            if candidate.sequence is not None
+        ),
+        default=0,
+    ) + 1
+
+
 def _unique_backup_dir(backups_dir: Path, *, now: datetime) -> Path:
     timestamp = now.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     suffixes = [
@@ -358,14 +420,16 @@ def create_sqlite_migration_backup(
 
     Owning it here also means this call is the only thing that can destroy what
     it just produced, so it never does: the copy reaches stable storage before
-    any older one is deleted, and the prune is told which migration is in
-    progress rather than left to infer it from timestamps it cannot trust.
+    any older one is deleted, and it is stamped with the next sequence, which
+    puts it ahead of every backup on disk without having to trust a clock.
     """
 
     source_path = db_path.expanduser().resolve()
     created_at = now or datetime.now(timezone.utc)
     target_root = (backups_dir or source_path.parent / "backups").expanduser().resolve()
     target_root.mkdir(parents=True, exist_ok=True)
+    # Read before anything is written, so the count is of finished backups only.
+    sequence = _next_sequence(target_root)
     backup_dir = _unique_backup_dir(target_root, now=created_at)
     backup_dir.mkdir(mode=0o700)
     temp_db = backup_dir / "vibe.sqlite.tmp"
@@ -388,6 +452,7 @@ def create_sqlite_migration_backup(
             "kind": "sqlite-migration",
             "created_at": created_at.astimezone(timezone.utc).isoformat(),
             "database": "vibe.sqlite",
+            "sequence": sequence,
             "from_revisions": sorted(set(from_revisions)),
             "to_revisions": sorted(set(to_revisions)),
         }
@@ -408,7 +473,7 @@ def create_sqlite_migration_backup(
     # a failure while pruning cannot reach that cleanup and delete the rollback
     # point this call just made. And it has to follow the manifest write,
     # because a directory without one is not yet a recognized candidate: it
-    # would neither count itself against the bound nor be found as the newest
-    # attempt at the migration now in progress.
-    prune_state_backups(target_root, json_retention=None, active=_manifest_transition(manifest))
+    # would neither count itself against the bound nor carry the sequence that
+    # puts it at the head of the episode in progress.
+    prune_state_backups(target_root, json_retention=None)
     return backup_dir

--- a/storage/migrations.py
+++ b/storage/migrations.py
@@ -234,13 +234,9 @@ def _run_migrations_locked(
     cfg = alembic_config(target_db)
     backup_revisions = _migration_backup_revisions(target_db, cfg, revision)
     if backup_revisions is not None:
-        current_revisions, target_revisions = backup_revisions
-        backup_path = create_sqlite_migration_backup(
-            target_db,
-            from_revisions=current_revisions,
-            to_revisions=target_revisions,
-        )
-        logger.info("Created pre-migration SQLite backup at %s", backup_path)
+        _current_revisions, target_revisions = backup_revisions
+        backup_path = create_sqlite_migration_backup(target_db, to_revisions=target_revisions)
+        logger.info("Pre-migration SQLite rollback point at %s", backup_path)
     _reset_unreleased_initial_schema_drift(target_db)
     _repair_unreleased_head_schema_drift(target_db)
     _stamp_existing_initial_schema(target_db, cfg)

--- a/tests/test_state_backups.py
+++ b/tests/test_state_backups.py
@@ -265,9 +265,9 @@ def test_retry_window_keeps_the_snapshot_taken_before_a_partial_upgrade(monkeypa
     # rebuild inside an autocommit block that fails a later check is exactly
     # that shape. From the next attempt on, every copy is of the half-migrated
     # database, so keeping the newest copies fills the window with damage and
-    # discards the only snapshot that can undo it. What each attempt shares is
-    # the schema move it was taken for, since a failed upgrade leaves the
-    # recorded revisions alone; the window keeps the ends of that move.
+    # discards the only snapshot that can undo it. Consecutive manifests show
+    # the run never reached where it was headed, which is what makes the
+    # attempts one episode; the window keeps its ends.
     state_dir = tmp_path / "state"
     state_dir.mkdir()
     db_path = state_dir / "vibe.sqlite"
@@ -297,10 +297,10 @@ def test_retry_window_keeps_the_snapshot_taken_before_a_partial_upgrade(monkeypa
 def test_future_dated_copies_do_not_outrank_the_migration_in_progress(monkeypatch, tmp_path: Path) -> None:
     # A clock corrected backwards, or state carried from a machine running
     # ahead, leaves unrelated copies dated after everything the current
-    # migration produces. Being newest on disk is not the same as being current:
-    # ranked by timestamp those copies take the window, and both ends of the
-    # failing migration -- the clean snapshot and the latest one -- are lost to
-    # backups that have nothing to do with it.
+    # migration produces. Being newest on disk is not the same as being newest
+    # in creation order: ranked by timestamp those copies take the window, and
+    # both ends of the failing migration -- the clean snapshot and the latest
+    # one -- are lost to backups that have nothing to do with it.
     state_dir = tmp_path / "state"
     state_dir.mkdir()
     db_path = state_dir / "vibe.sqlite"
@@ -326,6 +326,82 @@ def test_future_dated_copies_do_not_outrank_the_migration_in_progress(monkeypatc
     assert any(
         not _table_exists(backups_dir / name / "vibe.sqlite", "half_migrated") for name in surviving
     ), "the snapshot from before the partial upgrade must keep its slot"
+
+
+def _attempt(
+    db_path: Path,
+    backups_dir: Path,
+    *,
+    hour: int,
+    frm: tuple[str, ...],
+    to: tuple[str, ...] = ("20260811_0051",),
+) -> Path:
+    """One migration attempt's backup, at a chosen wall-clock hour."""
+
+    return create_sqlite_migration_backup(
+        db_path,
+        backups_dir=backups_dir,
+        from_revisions=frm,
+        to_revisions=to,
+        now=datetime(2026, 7, 10, hour, 0, tzinfo=timezone.utc),
+    )
+
+
+def test_attempt_order_survives_a_clock_that_moves_backwards(tmp_path: Path) -> None:
+    # A clock correction lands in the middle of a retry storm: the first attempt
+    # is stamped 10:00, the correction drags the next to 05:00, and the third
+    # comes back at 15:00. Sorted by wall-clock time the ends of the episode are
+    # 05:00 and 15:00 -- both taken after the upgrade began committing -- and the
+    # clean 10:00 snapshot is treated as a superseded middle and deleted. Order
+    # has to come from a counter this module writes, not from the clock.
+    db_path = tmp_path / "vibe.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("create table marker (value text)")
+    backups_dir = tmp_path / "backups"
+
+    clean = _attempt(db_path, backups_dir, hour=10, frm=("20260806_0047",))
+    _attempt(db_path, backups_dir, hour=5, frm=("20260809_0049",))
+    latest = _attempt(db_path, backups_dir, hour=15, frm=("20260809_0049",))
+
+    assert _sqlite_backup_roots(backups_dir) == sorted({clean.name, latest.name})
+
+
+def test_one_episode_survives_an_upgrade_that_commits_revisions_before_failing(tmp_path: Path) -> None:
+    # `command.upgrade` walks several revisions in one call, and entering an
+    # autocommit block commits the version stamps already earned. A run that
+    # starts at 0047 can therefore reach 0049 and die inside 0050, leaving the
+    # next attempt starting from 0049 instead. Identifying the episode by where
+    # its attempts started splits it in two and lets the newer, already-damaged
+    # half take the whole window; what actually holds is that no attempt ever
+    # reached where it was headed.
+    db_path = tmp_path / "vibe.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("create table marker (value text)")
+    backups_dir = tmp_path / "backups"
+
+    pristine = _attempt(db_path, backups_dir, hour=1, frm=("20260806_0047",))
+    _attempt(db_path, backups_dir, hour=2, frm=("20260809_0049",))
+    latest = _attempt(db_path, backups_dir, hour=3, frm=("20260809_0049",))
+
+    assert _sqlite_backup_roots(backups_dir) == sorted({pristine.name, latest.name})
+
+
+def test_a_finished_migration_ends_the_episode(tmp_path: Path) -> None:
+    # The other side of the same comparison: when a run does reach its
+    # destination, the next backup starts from there, and that is what marks the
+    # boundary. Two settled migrations are two rollback points rather than one
+    # episode with ends, so the window is the newest two -- never an ancient
+    # snapshot held open by an episode that closed long ago.
+    db_path = tmp_path / "vibe.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("create table marker (value text)")
+    backups_dir = tmp_path / "backups"
+
+    _attempt(db_path, backups_dir, hour=1, frm=("20260806_0047",), to=("20260809_0049",))
+    second = _attempt(db_path, backups_dir, hour=2, frm=("20260809_0049",), to=("20260811_0050",))
+    third = _attempt(db_path, backups_dir, hour=3, frm=("20260811_0050",), to=("20260811_0051",))
+
+    assert _sqlite_backup_roots(backups_dir) == sorted({second.name, third.name})
 
 
 def test_new_backup_reaches_stable_storage_before_older_ones_are_deleted(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_state_backups.py
+++ b/tests/test_state_backups.py
@@ -279,86 +279,66 @@ def test_repeated_migration_failures_keep_the_rollback_window_bounded(monkeypatc
             assert backup.execute("PRAGMA quick_check").fetchone() == ("ok",)
 
 
-def test_retrying_a_failed_migration_does_not_take_another_copy(monkeypatch, tmp_path: Path) -> None:
-    # The retries are all attempts to leave the same revision, so they all want
-    # the same rollback point -- and it already exists after the first one. Not
-    # making the copies is what keeps the clean snapshot: nothing is produced
-    # that could displace it, however long the migration keeps failing.
-    state_dir = tmp_path / "state"
-    state_dir.mkdir()
-    db_path = state_dir / "vibe.sqlite"
-    run_migrations(db_path, revision="20260627_0025")
-    monkeypatch.setattr(
-        "storage.migrations.command.upgrade",
-        _fails_after_committing(db_path, "create table if not exists half_migrated (value text)"),
-    )
-
-    for _ in range(SQLITE_BACKUP_RETENTION + 4):
-        with pytest.raises(RuntimeError, match="upgrade failed after committing"):
-            run_migrations(db_path)
-
-    surviving = _sqlite_backup_roots(state_dir / "backups")
-    assert len(surviving) == 1
-    assert not _table_exists(state_dir / "backups" / surviving[0] / "vibe.sqlite", "half_migrated")
+def _db_contents(path: Path) -> list[tuple[str, list[tuple]]]:
+    with sqlite3.connect(path) as conn:
+        tables = [
+            row[0]
+            for row in conn.execute("select name from sqlite_master where type = 'table' order by name")
+        ]
+        return [(table, conn.execute(f'select * from "{table}"').fetchall()) for table in tables]
 
 
-def test_a_migration_that_only_commits_rows_still_leaves_a_clean_snapshot(
-    monkeypatch, tmp_path: Path
-) -> None:
-    # Not every partial upgrade is visible in the schema. One that commits row
-    # changes and then fails a validation leaves a database whose tables,
-    # indexes and revision stamp are all exactly what they were, so no
-    # fingerprint taken from a copy can tell the damaged database from the clean
-    # one. Any rule that decides which copies to keep by inspecting them is
-    # blind here; not taking the copies is not.
-    state_dir = tmp_path / "state"
-    state_dir.mkdir()
-    db_path = state_dir / "vibe.sqlite"
-    run_migrations(db_path, revision="20260627_0025")
-    with sqlite3.connect(db_path) as conn:
-        conn.execute("create table payload (value text)")
-        conn.execute("insert into payload (value) values ('original')")
-    monkeypatch.setattr(
-        "storage.migrations.command.upgrade",
-        _fails_after_committing(db_path, "update payload set value = 'rewritten'"),
-    )
-
-    for _ in range(SQLITE_BACKUP_RETENTION + 4):
-        with pytest.raises(RuntimeError, match="upgrade failed after committing"):
-            run_migrations(db_path)
-
-    surviving = _sqlite_backup_roots(state_dir / "backups")
-    assert len(surviving) == 1
-    with sqlite3.connect(state_dir / "backups" / surviving[0] / "vibe.sqlite") as backup:
-        assert [row[0] for row in backup.execute("select value from payload")] == ["original"]
-
-
-def test_a_further_revision_reached_takes_its_own_rollback_point(tmp_path: Path) -> None:
-    # The other half of the same rule. When the database really has moved to a
-    # revision the window does not hold, that is a rollback point nothing else
-    # can provide, and it is taken -- so a healthy machine still gets a copy per
-    # migration, and an upgrade that commits some of its stamps before failing
-    # still gets one for each boundary it actually reached.
+def test_every_call_holds_the_database_as_it_stands_at_that_call(tmp_path: Path) -> None:
+    # The one promise the window makes, stated as a property over however the
+    # database moves rather than as a list of the ways it can. That distinction
+    # is the whole history of this change: earlier revisions tried to recognise a
+    # copy already held and reuse it, ranking copies by wall-clock adjacency,
+    # then by the schema transition each attempt recorded, then by a fingerprint
+    # of each copy's schema, then by the revision stamp -- and each rule was
+    # defeated by a movement that leaves every label a backup can compare exactly
+    # as it was. Two of them are exercised below: a migration that commits rows
+    # without touching schema or stamp, and an operator restoring a copy and then
+    # serving writes under a stamp that never moved.
     db_path = tmp_path / "vibe.sqlite"
     backups_dir = tmp_path / "backups"
     _stamp(db_path, "20260806_0047")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("create table payload (value text)")
+        conn.execute("insert into payload (value) values ('original')")
 
-    first = create_sqlite_migration_backup(db_path, backups_dir=backups_dir)
-    again = create_sqlite_migration_backup(db_path, backups_dir=backups_dir)
-    assert again == first
+    taken: list[Path] = []
 
+    def rollback_point() -> Path:
+        backup = create_sqlite_migration_backup(db_path, backups_dir=backups_dir)
+        assert _db_contents(backup / "vibe.sqlite") == _db_contents(db_path)
+        taken.append(backup)
+        return backup
+
+    def write(statement: str) -> None:
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(statement)
+
+    first = rollback_point()
+    write("update payload set value = 'rewritten'")
+    rollback_point()
+    shutil.copy(first / "vibe.sqlite", db_path)
+    write("insert into payload (value) values ('accepted after the restore')")
+    rollback_point()
+    write("create table added (value text)")
+    rollback_point()
     _stamp(db_path, "20260809_0049")
-    advanced = create_sqlite_migration_backup(db_path, backups_dir=backups_dir)
-    assert advanced != first
-    assert _sqlite_backup_roots(backups_dir) == sorted({first.name, advanced.name})
+    rollback_point()
+
+    assert len(set(taken)) == len(taken)
+    assert len(_sqlite_backup_roots(backups_dir)) == SQLITE_BACKUP_RETENTION
 
 
 def test_the_manifest_records_the_revisions_read_from_the_copy(tmp_path: Path) -> None:
     # Callers sample the revisions before handing the work over, and another
     # process can advance the database in between. A manifest describing
     # something other than the copy it sits next to is worse than one that says
-    # nothing: the next attempt uses it to decide whether the rollback point it
-    # needs already exists.
+    # nothing: an operator reading it to choose a rollback point is told the copy
+    # holds a schema it may never have held.
     db_path = tmp_path / "vibe.sqlite"
     backups_dir = tmp_path / "backups"
     _stamp(db_path, "20260811_0050")

--- a/tests/test_state_backups.py
+++ b/tests/test_state_backups.py
@@ -132,7 +132,6 @@ def test_create_sqlite_migration_backup_is_consistent_without_copying_live_sidec
 
         backup_dir = create_sqlite_migration_backup(
             db_path,
-            from_revisions={"old"},
             to_revisions={"new"},
             now=datetime(2026, 7, 10, 3, 0, tzinfo=timezone.utc),
         )
@@ -142,7 +141,7 @@ def test_create_sqlite_migration_backup_is_consistent_without_copying_live_sidec
         manifest = json.loads((backup_dir / "manifest.json").read_text(encoding="utf-8"))
         assert manifest["managed_by"] == "avibe"
         assert manifest["kind"] == "sqlite-migration"
-        assert manifest["from_revisions"] == ["old"]
+        assert manifest["from_revisions"] == []
         assert manifest["to_revisions"] == ["new"]
         # Legacy repair copies are part of the same sqlite window, so adding a
         # backup prunes them to the same bound instead of accumulating beside
@@ -229,14 +228,37 @@ def test_startup_prunes_only_after_migration_backup_succeeds(monkeypatch, tmp_pa
     assert all(path.exists() for path in existing)
 
 
+def _stamp(path: Path, revision: str) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute("create table if not exists alembic_version (version_num varchar(32) not null)")
+        conn.execute("delete from alembic_version")
+        conn.execute("insert into alembic_version (version_num) values (?)", (revision,))
+
+
+def _fails_after_committing(db_path: Path, statement: str):
+    """An upgrade that commits work and then raises.
+
+    The shape a SQLite table rebuild inside an autocommit block leaves when a
+    later check fails: the work is on disk, alembic never stamped, so every
+    entry point that touches the store retries it.
+    """
+
+    def _upgrade(*args, **kwargs):
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(statement)
+        raise RuntimeError("upgrade failed after committing")
+
+    return _upgrade
+
+
 def test_repeated_migration_failures_keep_the_rollback_window_bounded(monkeypatch, tmp_path: Path) -> None:
-    # A migration that fails is retried, and the OAuth callback retries it once
-    # per unauthenticated request. Every attempt copies the whole database, and
-    # pruning used to be gated on the upgrade and the import that follow -- so
-    # the one situation that produces attempts without end was also the one
-    # where nothing ever reclaimed them. Assert the bound itself rather than a
-    # count of attempts: whatever the retry storm does, the window it leaves
-    # behind is the retention bound, and what survives is the newest copies.
+    # A migration that fails is retried, and every service entry point that
+    # touches the store retries it once more. Pruning used to be gated on the
+    # upgrade and the import that follow, so the one situation that produces
+    # attempts without end was also the one where nothing ever reclaimed them.
+    # Assert the bound itself rather than a count of attempts: whatever the
+    # retry storm does, the window it leaves behind is within the retention
+    # bound and every copy in it is restorable.
     state_dir = tmp_path / "state"
     state_dir.mkdir()
     db_path = state_dir / "vibe.sqlite"
@@ -246,246 +268,145 @@ def test_repeated_migration_failures_keep_the_rollback_window_bounded(monkeypatc
         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("migration boom")),
     )
 
-    created: list[str] = []
     for _ in range(SQLITE_BACKUP_RETENTION + 3):
         with pytest.raises(RuntimeError, match="migration boom"):
             ensure_sqlite_state(db_path=db_path, state_dir=state_dir)
-        created.append(max(_sqlite_backup_roots(state_dir / "backups")))
 
     surviving = _sqlite_backup_roots(state_dir / "backups")
-    assert len(surviving) == SQLITE_BACKUP_RETENTION
-    assert surviving == sorted({created[0], created[-1]})
-    # A bounded window is only worth keeping if it is still restorable.
+    assert 0 < len(surviving) <= SQLITE_BACKUP_RETENTION
     for name in surviving:
         with sqlite3.connect(state_dir / "backups" / name / "vibe.sqlite") as backup:
             assert backup.execute("PRAGMA quick_check").fetchone() == ("ok",)
 
 
-def test_retry_window_keeps_the_snapshot_taken_before_a_partial_upgrade(monkeypatch, tmp_path: Path) -> None:
-    # An upgrade can commit part of its work and then raise -- a SQLite table
-    # rebuild inside an autocommit block that fails a later check is exactly
-    # that shape. From the next attempt on, every copy is of the half-migrated
-    # database, so keeping the newest copies fills the window with damage and
-    # discards the only snapshot that can undo it. Consecutive manifests show
-    # the run never reached where it was headed, which is what makes the
-    # attempts one episode; the window keeps its ends.
+def test_retrying_a_failed_migration_does_not_take_another_copy(monkeypatch, tmp_path: Path) -> None:
+    # The retries are all attempts to leave the same revision, so they all want
+    # the same rollback point -- and it already exists after the first one. Not
+    # making the copies is what keeps the clean snapshot: nothing is produced
+    # that could displace it, however long the migration keeps failing.
     state_dir = tmp_path / "state"
     state_dir.mkdir()
     db_path = state_dir / "vibe.sqlite"
     run_migrations(db_path, revision="20260627_0025")
+    monkeypatch.setattr(
+        "storage.migrations.command.upgrade",
+        _fails_after_committing(db_path, "create table if not exists half_migrated (value text)"),
+    )
 
-    def _partially_commit_then_fail(*args, **kwargs):
-        with sqlite3.connect(db_path) as conn:
-            conn.execute("create table if not exists half_migrated (value text)")
-        raise RuntimeError("upgrade failed after committing")
-
-    monkeypatch.setattr("storage.migrations.command.upgrade", _partially_commit_then_fail)
-
-    for _ in range(SQLITE_BACKUP_RETENTION + 2):
+    for _ in range(SQLITE_BACKUP_RETENTION + 4):
         with pytest.raises(RuntimeError, match="upgrade failed after committing"):
             run_migrations(db_path)
 
     surviving = _sqlite_backup_roots(state_dir / "backups")
-    assert len(surviving) == SQLITE_BACKUP_RETENTION
-    intact = [
-        name
-        for name in surviving
-        if not _table_exists(state_dir / "backups" / name / "vibe.sqlite", "half_migrated")
-    ]
-    assert intact, "the snapshot taken before the first partial upgrade must survive the retries"
+    assert len(surviving) == 1
+    assert not _table_exists(state_dir / "backups" / surviving[0] / "vibe.sqlite", "half_migrated")
 
 
-def test_future_dated_copies_do_not_outrank_the_migration_in_progress(monkeypatch, tmp_path: Path) -> None:
-    # A clock corrected backwards, or state carried from a machine running
-    # ahead, leaves unrelated copies dated after everything the current
-    # migration produces. Being newest on disk is not the same as being newest
-    # in creation order: ranked by timestamp those copies take the window, and
-    # both ends of the failing migration -- the clean snapshot and the latest
-    # one -- are lost to backups that have nothing to do with it.
+def test_a_migration_that_only_commits_rows_still_leaves_a_clean_snapshot(
+    monkeypatch, tmp_path: Path
+) -> None:
+    # Not every partial upgrade is visible in the schema. One that commits row
+    # changes and then fails a validation leaves a database whose tables,
+    # indexes and revision stamp are all exactly what they were, so no
+    # fingerprint taken from a copy can tell the damaged database from the clean
+    # one. Any rule that decides which copies to keep by inspecting them is
+    # blind here; not taking the copies is not.
     state_dir = tmp_path / "state"
     state_dir.mkdir()
     db_path = state_dir / "vibe.sqlite"
     run_migrations(db_path, revision="20260627_0025")
-    backups_dir = state_dir / "backups"
-    backups_dir.mkdir()
-    from_the_future = _legacy_sqlite_backup(backups_dir, "vibe-pre-0026-repair-20990101T020000Z.sqlite")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("create table payload (value text)")
+        conn.execute("insert into payload (value) values ('original')")
+    monkeypatch.setattr(
+        "storage.migrations.command.upgrade",
+        _fails_after_committing(db_path, "update payload set value = 'rewritten'"),
+    )
 
-    def _partially_commit_then_fail(*args, **kwargs):
-        with sqlite3.connect(db_path) as conn:
-            conn.execute("create table if not exists half_migrated (value text)")
-        raise RuntimeError("upgrade failed after committing")
-
-    monkeypatch.setattr("storage.migrations.command.upgrade", _partially_commit_then_fail)
-
-    for _ in range(SQLITE_BACKUP_RETENTION + 1):
+    for _ in range(SQLITE_BACKUP_RETENTION + 4):
         with pytest.raises(RuntimeError, match="upgrade failed after committing"):
             run_migrations(db_path)
 
-    surviving = _sqlite_backup_roots(backups_dir)
-    assert len(surviving) == SQLITE_BACKUP_RETENTION
-    assert from_the_future.name not in surviving, "a future timestamp is not a claim on the window"
-    assert any(
-        not _table_exists(backups_dir / name / "vibe.sqlite", "half_migrated") for name in surviving
-    ), "the snapshot from before the partial upgrade must keep its slot"
+    surviving = _sqlite_backup_roots(state_dir / "backups")
+    assert len(surviving) == 1
+    with sqlite3.connect(state_dir / "backups" / surviving[0] / "vibe.sqlite") as backup:
+        assert [row[0] for row in backup.execute("select value from payload")] == ["original"]
 
 
-def _attempt(
-    db_path: Path,
-    backups_dir: Path,
-    *,
-    hour: int,
-    frm: tuple[str, ...] = ("20260806_0047",),
-) -> Path:
-    """One migration attempt's backup, at a chosen wall-clock hour."""
+def test_a_further_revision_reached_takes_its_own_rollback_point(tmp_path: Path) -> None:
+    # The other half of the same rule. When the database really has moved to a
+    # revision the window does not hold, that is a rollback point nothing else
+    # can provide, and it is taken -- so a healthy machine still gets a copy per
+    # migration, and an upgrade that commits some of its stamps before failing
+    # still gets one for each boundary it actually reached.
+    db_path = tmp_path / "vibe.sqlite"
+    backups_dir = tmp_path / "backups"
+    _stamp(db_path, "20260806_0047")
 
-    return create_sqlite_migration_backup(
-        db_path,
-        backups_dir=backups_dir,
-        from_revisions=frm,
-        to_revisions=("20260811_0051",),
-        now=datetime(2026, 7, 10, hour, 0, tzinfo=timezone.utc),
+    first = create_sqlite_migration_backup(db_path, backups_dir=backups_dir)
+    again = create_sqlite_migration_backup(db_path, backups_dir=backups_dir)
+    assert again == first
+
+    _stamp(db_path, "20260809_0049")
+    advanced = create_sqlite_migration_backup(db_path, backups_dir=backups_dir)
+    assert advanced != first
+    assert _sqlite_backup_roots(backups_dir) == sorted({first.name, advanced.name})
+
+
+def test_the_manifest_records_the_revisions_read_from_the_copy(tmp_path: Path) -> None:
+    # Callers sample the revisions before handing the work over, and another
+    # process can advance the database in between. A manifest describing
+    # something other than the copy it sits next to is worse than one that says
+    # nothing: the next attempt uses it to decide whether the rollback point it
+    # needs already exists.
+    db_path = tmp_path / "vibe.sqlite"
+    backups_dir = tmp_path / "backups"
+    _stamp(db_path, "20260811_0050")
+
+    backup_dir = create_sqlite_migration_backup(
+        db_path, backups_dir=backups_dir, to_revisions={"20260811_0051"}
     )
 
-
-def _database(path: Path) -> None:
-    with sqlite3.connect(path) as conn:
-        conn.execute("create table marker (value text)")
-
-
-def _write(path: Path, value: str) -> None:
-    with sqlite3.connect(path) as conn:
-        conn.execute("insert into marker (value) values (?)", (value,))
+    manifest = json.loads((backup_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["from_revisions"] == ["20260811_0050"]
+    assert manifest["to_revisions"] == ["20260811_0051"]
 
 
-def _rows(path: Path) -> list[str]:
-    with sqlite3.connect(path) as conn:
-        return sorted(row[0] for row in conn.execute("select value from marker"))
+def test_the_window_directory_is_durable_before_the_backup_counts(monkeypatch, tmp_path: Path) -> None:
+    # Creating the backup directory also adds an entry to its parent. A crash
+    # that keeps the upgraded database but loses that entry leaves no rollback
+    # point at all, with every fsync this code makes having succeeded.
+    synced: list[Path] = []
+    monkeypatch.setattr(backups, "_fsync_directory", lambda path: synced.append(Path(path)))
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    db_path.parent.mkdir()
+    _stamp(db_path, "20260806_0047")
+
+    create_sqlite_migration_backup(db_path)
+
+    assert db_path.parent in synced
 
 
-def _partially_apply(path: Path) -> None:
-    """The shape an upgrade leaves when it commits work and then raises.
-
-    A table appears; the revision the database is stamped with does not move,
-    because alembic never reached the stamp.
-    """
-
-    with sqlite3.connect(path) as conn:
-        conn.execute("create table if not exists half_migrated (value text)")
-
-
-def test_the_copy_that_keeps_a_state_is_the_one_holding_its_writes(tmp_path: Path) -> None:
-    # Two attempts at the same failing migration are copies of one state, so one
-    # slot covers both -- and it has to be the copy carrying the writes made
-    # since the other. A clock correction landing mid-storm stamps the later
-    # attempt as the earlier of the two, so choosing by wall-clock time keeps the
-    # copy that is missing everything written in between. Order comes from a
-    # counter this module writes instead.
+def test_a_fresh_rollback_point_outlives_copies_dated_after_it(tmp_path: Path) -> None:
+    # A clock corrected backwards, or state carried from a machine running
+    # ahead, leaves unrelated copies dated after everything the current
+    # migration produces -- permanently, since nothing rewrites their names.
+    # Ordering alone therefore cannot defend the copy a call has just made, so
+    # the call protects it explicitly.
     db_path = tmp_path / "vibe.sqlite"
-    _database(db_path)
     backups_dir = tmp_path / "backups"
+    backups_dir.mkdir()
+    _stamp(db_path, "20260806_0047")
+    for index in range(SQLITE_BACKUP_RETENTION + 1):
+        _legacy_sqlite_backup(
+            backups_dir, f"vibe-pre-002{index}-repair-2099010{index + 1}T020000Z.sqlite"
+        )
 
-    _write(db_path, "before")
-    clean = _attempt(db_path, backups_dir, hour=1)
-    _partially_apply(db_path)
-    _attempt(db_path, backups_dir, hour=15)
-    _write(db_path, "after")
-    corrected = _attempt(db_path, backups_dir, hour=5)
+    fresh = create_sqlite_migration_backup(db_path, backups_dir=backups_dir)
 
-    assert _sqlite_backup_roots(backups_dir) == sorted({clean.name, corrected.name})
-    assert _rows(corrected / "vibe.sqlite") == ["after", "before"]
-
-
-def test_a_storm_of_identical_retries_holds_one_slot_between_them(tmp_path: Path) -> None:
-    # Why the window survives a retry storm at all. Every attempt after the
-    # first copies the same half-migrated database, so they are one state and
-    # hold one slot between them however many there are -- which is what leaves
-    # room for the snapshot taken before the damage, a state nothing else can
-    # produce.
-    db_path = tmp_path / "vibe.sqlite"
-    _database(db_path)
-    backups_dir = tmp_path / "backups"
-
-    clean = _attempt(db_path, backups_dir, hour=1)
-    _partially_apply(db_path)
-    for hour in range(2, 10):
-        latest = _attempt(db_path, backups_dir, hour=hour)
-
-    assert _sqlite_backup_roots(backups_dir) == sorted({clean.name, latest.name})
-
-
-def test_restoring_a_rollback_point_makes_it_the_current_state_again(tmp_path: Path) -> None:
-    # An operator restores the clean snapshot, the service comes back up on the
-    # old schema and accepts writes, and the migration fails again. The restored
-    # database is that clean state once more, so the snapshot taken after it is a
-    # newer copy of the same state and supersedes the one restored from. That is
-    # the whole point: it is the only copy that is both clean and holds the
-    # writes made since the restore, and a rollback that landed on the original
-    # would lose every one of them.
-    db_path = tmp_path / "vibe.sqlite"
-    _database(db_path)
-    backups_dir = tmp_path / "backups"
-
-    _write(db_path, "before")
-    restored_from = _attempt(db_path, backups_dir, hour=1)
-    _partially_apply(db_path)
-    _attempt(db_path, backups_dir, hour=2)
-
-    shutil.copy(restored_from / "vibe.sqlite", db_path)
-    _write(db_path, "after restore")
-    restored = _attempt(db_path, backups_dir, hour=3)
-    _partially_apply(db_path)
-    latest = _attempt(db_path, backups_dir, hour=4)
-
-    assert _sqlite_backup_roots(backups_dir) == sorted({restored.name, latest.name})
-    assert _rows(restored / "vibe.sqlite") == ["after restore", "before"]
-
-
-def test_a_duplicated_sequence_cannot_take_a_state_out_of_the_window(
-    monkeypatch, tmp_path: Path
-) -> None:
-    # Sequence allocation reads the highest sequence on disk and adds one, and
-    # two processes can do that at the same moment and both win -- `storage.
-    # migrations` serializes upgrades with a lock that is process-local, so the
-    # UI server and the controller can reach this at once. The collision leaves
-    # ordering within a state falling back on the clock, and a process that
-    # stalled between reserving its directory and copying can publish the
-    # already-damaged database stamped earlier than the clean copy that beat it
-    # there. Identifying a copy by what it is rather than by its place in a run
-    # of attempts is what makes that harmless: the clean snapshot is a state of
-    # its own, and no ordering accident can take its slot.
-    monkeypatch.setattr(backups, "_next_sequence", lambda _root: 1)
-    db_path = tmp_path / "vibe.sqlite"
-    _database(db_path)
-    backups_dir = tmp_path / "backups"
-
-    clean = _attempt(db_path, backups_dir, hour=2)
-    _partially_apply(db_path)
-    _attempt(db_path, backups_dir, hour=1)
-    latest = _attempt(db_path, backups_dir, hour=3)
-
-    assert _sqlite_backup_roots(backups_dir) == sorted({clean.name, latest.name})
-
-
-def test_a_migration_that_moves_only_the_revision_is_a_new_rollback_point(tmp_path: Path) -> None:
-    # Not every migration changes the schema. One that only moves data and
-    # stamps the new revision leaves the DDL identical on both sides of it, and
-    # the two copies are still different rollback points: restoring the wrong
-    # one leaves the database at a revision whose migration has not run against
-    # its data. So the revisions belong in the identity next to the fingerprint,
-    # and neither half stands in for the other.
-    #
-    # Here the data-only migration settles and the next one starts failing. The
-    # snapshot taken before the data moved is the only way back behind it, and
-    # it has to outrank a second copy of the state the retries are stuck in.
-    db_path = tmp_path / "vibe.sqlite"
-    _database(db_path)
-    backups_dir = tmp_path / "backups"
-
-    before = _attempt(db_path, backups_dir, hour=1, frm=("20260806_0047",))
-    _attempt(db_path, backups_dir, hour=2, frm=("20260809_0049",))
-    after = _attempt(db_path, backups_dir, hour=3, frm=("20260809_0049",))
-
-    assert _sqlite_backup_roots(backups_dir) == sorted({before.name, after.name})
+    surviving = _sqlite_backup_roots(backups_dir)
+    assert len(surviving) == SQLITE_BACKUP_RETENTION
+    assert fresh.name in surviving
 
 
 def test_new_backup_reaches_stable_storage_before_older_ones_are_deleted(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_state_backups.py
+++ b/tests/test_state_backups.py
@@ -7,7 +7,12 @@ from pathlib import Path
 
 import pytest
 
-from storage.backups import create_sqlite_migration_backup, prune_state_backups
+from storage.backups import (
+    SQLITE_BACKUP_RETENTION,
+    _JSON_BACKUP_RE,
+    create_sqlite_migration_backup,
+    prune_state_backups,
+)
 from storage.background import SQLiteBackgroundTaskStore
 from storage.importer import _backup_json_state, ensure_sqlite_state
 from storage.migrations import run_migrations
@@ -29,6 +34,21 @@ def _legacy_sqlite_backup(backups_dir: Path, name: str) -> Path:
     path.with_name(path.name + "-wal").write_bytes(b"wal")
     path.with_name(path.name + "-shm").write_bytes(b"shm")
     return path
+
+
+def _sqlite_backup_roots(backups_dir: Path) -> list[str]:
+    """Names in the sqlite rollback window.
+
+    Legacy copies keep -wal/-shm companions beside them, and JSON snapshots are
+    a separate window with its own bound despite the similar name. Derive that
+    exclusion from the module's own pattern rather than restating it here.
+    """
+
+    return sorted(
+        path.name
+        for path in backups_dir.iterdir()
+        if not path.name.endswith(("-wal", "-shm")) and not _JSON_BACKUP_RE.fullmatch(path.name)
+    )
 
 
 def test_prune_state_backups_keeps_bounded_rollbacks_and_unknown_files(tmp_path: Path) -> None:
@@ -114,7 +134,11 @@ def test_create_sqlite_migration_backup_is_consistent_without_copying_live_sidec
         assert manifest["kind"] == "sqlite-migration"
         assert manifest["from_revisions"] == ["old"]
         assert manifest["to_revisions"] == ["new"]
-        assert oldest.exists()
+        # Legacy repair copies are part of the same sqlite window, so adding a
+        # backup prunes them to the same bound instead of accumulating beside
+        # them -- companions included.
+        assert not oldest.exists()
+        assert not oldest.with_name(oldest.name + "-wal").exists()
         assert previous.exists()
         assert not (backup_dir / "vibe.sqlite-wal").exists()
         assert not (backup_dir / "vibe.sqlite-shm").exists()
@@ -195,6 +219,38 @@ def test_startup_prunes_only_after_migration_backup_succeeds(monkeypatch, tmp_pa
     assert all(path.exists() for path in existing)
 
 
+def test_repeated_migration_failures_keep_the_rollback_window_bounded(monkeypatch, tmp_path: Path) -> None:
+    # A migration that fails is retried, and the OAuth callback retries it once
+    # per unauthenticated request. Every attempt copies the whole database, and
+    # pruning used to be gated on the upgrade and the import that follow -- so
+    # the one situation that produces attempts without end was also the one
+    # where nothing ever reclaimed them. Assert the bound itself rather than a
+    # count of attempts: whatever the retry storm does, the window it leaves
+    # behind is the retention bound, and what survives is the newest copies.
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = state_dir / "vibe.sqlite"
+    run_migrations(db_path, revision="20260627_0025")
+    monkeypatch.setattr(
+        "storage.migrations.command.upgrade",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("migration boom")),
+    )
+
+    created: list[Path] = []
+    for _ in range(SQLITE_BACKUP_RETENTION + 3):
+        with pytest.raises(RuntimeError, match="migration boom"):
+            ensure_sqlite_state(db_path=db_path, state_dir=state_dir)
+        created.append(_sqlite_backup_roots(state_dir / "backups")[-1])
+
+    surviving = _sqlite_backup_roots(state_dir / "backups")
+    assert len(surviving) == SQLITE_BACKUP_RETENTION
+    assert surviving == sorted(created[-SQLITE_BACKUP_RETENTION:])
+    # A bounded window is only worth keeping if it is still restorable.
+    for name in surviving:
+        with sqlite3.connect(state_dir / "backups" / name / "vibe.sqlite") as backup:
+            assert backup.execute("PRAGMA quick_check").fetchone() == ("ok",)
+
+
 def test_startup_keeps_json_rollbacks_when_new_snapshot_fails(monkeypatch, tmp_path: Path) -> None:
     state_dir = tmp_path / "state"
     backups_dir = state_dir / "backups"
@@ -252,7 +308,15 @@ def test_startup_keeps_sqlite_rollbacks_when_import_after_upgrade_fails(monkeypa
     with pytest.raises(ValueError, match="invalid import"):
         ensure_sqlite_state(db_path=db_path, state_dir=state_dir)
 
-    assert all(path.exists() for path in existing)
+    # What has to survive a failure is the ability to roll back, not every copy
+    # ever made. Asserting the latter reads as the stronger guarantee and is
+    # what let a repeated failure accumulate one full database per attempt.
+    surviving = _sqlite_backup_roots(backups_dir)
+    assert len(surviving) == SQLITE_BACKUP_RETENTION
+    assert existing[-1].exists(), "the newest pre-existing rollback must be kept"
+    assert any(name.startswith("avibe-sqlite-migration-") for name in surviving), (
+        "the backup taken for this attempt is the rollback point for it"
+    )
 
 
 def test_failed_schema_upgrade_keeps_existing_sqlite_rollbacks(monkeypatch, tmp_path: Path) -> None:
@@ -273,7 +337,14 @@ def test_failed_schema_upgrade_keeps_existing_sqlite_rollbacks(monkeypatch, tmp_
     with pytest.raises(RuntimeError, match="upgrade failed"):
         run_migrations(db_path)
 
-    assert all(path.exists() for path in existing)
+    # Same property as the import-failure case: a rollback point survives the
+    # failure, bounded rather than accumulated.
+    surviving = _sqlite_backup_roots(backups_dir)
+    assert len(surviving) == SQLITE_BACKUP_RETENTION
+    assert existing[-1].exists(), "the newest pre-existing rollback must be kept"
+    assert any(name.startswith("avibe-sqlite-migration-") for name in surviving), (
+        "the backup taken for this attempt is the rollback point for it"
+    )
 
 
 def test_run_migrations_backs_up_only_when_existing_schema_advances(tmp_path: Path) -> None:

--- a/tests/test_state_backups.py
+++ b/tests/test_state_backups.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import errno
 import json
+import shutil
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
@@ -333,8 +334,7 @@ def _attempt(
     backups_dir: Path,
     *,
     hour: int,
-    frm: tuple[str, ...],
-    to: tuple[str, ...] = ("20260811_0051",),
+    frm: tuple[str, ...] = ("20260806_0047",),
 ) -> Path:
     """One migration attempt's backup, at a chosen wall-clock hour."""
 
@@ -342,66 +342,150 @@ def _attempt(
         db_path,
         backups_dir=backups_dir,
         from_revisions=frm,
-        to_revisions=to,
+        to_revisions=("20260811_0051",),
         now=datetime(2026, 7, 10, hour, 0, tzinfo=timezone.utc),
     )
 
 
-def test_attempt_order_survives_a_clock_that_moves_backwards(tmp_path: Path) -> None:
-    # A clock correction lands in the middle of a retry storm: the first attempt
-    # is stamped 10:00, the correction drags the next to 05:00, and the third
-    # comes back at 15:00. Sorted by wall-clock time the ends of the episode are
-    # 05:00 and 15:00 -- both taken after the upgrade began committing -- and the
-    # clean 10:00 snapshot is treated as a superseded middle and deleted. Order
-    # has to come from a counter this module writes, not from the clock.
-    db_path = tmp_path / "vibe.sqlite"
-    with sqlite3.connect(db_path) as conn:
+def _database(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
         conn.execute("create table marker (value text)")
+
+
+def _write(path: Path, value: str) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute("insert into marker (value) values (?)", (value,))
+
+
+def _rows(path: Path) -> list[str]:
+    with sqlite3.connect(path) as conn:
+        return sorted(row[0] for row in conn.execute("select value from marker"))
+
+
+def _partially_apply(path: Path) -> None:
+    """The shape an upgrade leaves when it commits work and then raises.
+
+    A table appears; the revision the database is stamped with does not move,
+    because alembic never reached the stamp.
+    """
+
+    with sqlite3.connect(path) as conn:
+        conn.execute("create table if not exists half_migrated (value text)")
+
+
+def test_the_copy_that_keeps_a_state_is_the_one_holding_its_writes(tmp_path: Path) -> None:
+    # Two attempts at the same failing migration are copies of one state, so one
+    # slot covers both -- and it has to be the copy carrying the writes made
+    # since the other. A clock correction landing mid-storm stamps the later
+    # attempt as the earlier of the two, so choosing by wall-clock time keeps the
+    # copy that is missing everything written in between. Order comes from a
+    # counter this module writes instead.
+    db_path = tmp_path / "vibe.sqlite"
+    _database(db_path)
     backups_dir = tmp_path / "backups"
 
-    clean = _attempt(db_path, backups_dir, hour=10, frm=("20260806_0047",))
-    _attempt(db_path, backups_dir, hour=5, frm=("20260809_0049",))
-    latest = _attempt(db_path, backups_dir, hour=15, frm=("20260809_0049",))
+    _write(db_path, "before")
+    clean = _attempt(db_path, backups_dir, hour=1)
+    _partially_apply(db_path)
+    _attempt(db_path, backups_dir, hour=15)
+    _write(db_path, "after")
+    corrected = _attempt(db_path, backups_dir, hour=5)
+
+    assert _sqlite_backup_roots(backups_dir) == sorted({clean.name, corrected.name})
+    assert _rows(corrected / "vibe.sqlite") == ["after", "before"]
+
+
+def test_a_storm_of_identical_retries_holds_one_slot_between_them(tmp_path: Path) -> None:
+    # Why the window survives a retry storm at all. Every attempt after the
+    # first copies the same half-migrated database, so they are one state and
+    # hold one slot between them however many there are -- which is what leaves
+    # room for the snapshot taken before the damage, a state nothing else can
+    # produce.
+    db_path = tmp_path / "vibe.sqlite"
+    _database(db_path)
+    backups_dir = tmp_path / "backups"
+
+    clean = _attempt(db_path, backups_dir, hour=1)
+    _partially_apply(db_path)
+    for hour in range(2, 10):
+        latest = _attempt(db_path, backups_dir, hour=hour)
 
     assert _sqlite_backup_roots(backups_dir) == sorted({clean.name, latest.name})
 
 
-def test_one_episode_survives_an_upgrade_that_commits_revisions_before_failing(tmp_path: Path) -> None:
-    # `command.upgrade` walks several revisions in one call, and entering an
-    # autocommit block commits the version stamps already earned. A run that
-    # starts at 0047 can therefore reach 0049 and die inside 0050, leaving the
-    # next attempt starting from 0049 instead. Identifying the episode by where
-    # its attempts started splits it in two and lets the newer, already-damaged
-    # half take the whole window; what actually holds is that no attempt ever
-    # reached where it was headed.
+def test_restoring_a_rollback_point_makes_it_the_current_state_again(tmp_path: Path) -> None:
+    # An operator restores the clean snapshot, the service comes back up on the
+    # old schema and accepts writes, and the migration fails again. The restored
+    # database is that clean state once more, so the snapshot taken after it is a
+    # newer copy of the same state and supersedes the one restored from. That is
+    # the whole point: it is the only copy that is both clean and holds the
+    # writes made since the restore, and a rollback that landed on the original
+    # would lose every one of them.
     db_path = tmp_path / "vibe.sqlite"
-    with sqlite3.connect(db_path) as conn:
-        conn.execute("create table marker (value text)")
+    _database(db_path)
     backups_dir = tmp_path / "backups"
 
-    pristine = _attempt(db_path, backups_dir, hour=1, frm=("20260806_0047",))
+    _write(db_path, "before")
+    restored_from = _attempt(db_path, backups_dir, hour=1)
+    _partially_apply(db_path)
+    _attempt(db_path, backups_dir, hour=2)
+
+    shutil.copy(restored_from / "vibe.sqlite", db_path)
+    _write(db_path, "after restore")
+    restored = _attempt(db_path, backups_dir, hour=3)
+    _partially_apply(db_path)
+    latest = _attempt(db_path, backups_dir, hour=4)
+
+    assert _sqlite_backup_roots(backups_dir) == sorted({restored.name, latest.name})
+    assert _rows(restored / "vibe.sqlite") == ["after restore", "before"]
+
+
+def test_a_duplicated_sequence_cannot_take_a_state_out_of_the_window(
+    monkeypatch, tmp_path: Path
+) -> None:
+    # Sequence allocation reads the highest sequence on disk and adds one, and
+    # two processes can do that at the same moment and both win -- `storage.
+    # migrations` serializes upgrades with a lock that is process-local, so the
+    # UI server and the controller can reach this at once. The collision leaves
+    # ordering within a state falling back on the clock, and a process that
+    # stalled between reserving its directory and copying can publish the
+    # already-damaged database stamped earlier than the clean copy that beat it
+    # there. Identifying a copy by what it is rather than by its place in a run
+    # of attempts is what makes that harmless: the clean snapshot is a state of
+    # its own, and no ordering accident can take its slot.
+    monkeypatch.setattr(backups, "_next_sequence", lambda _root: 1)
+    db_path = tmp_path / "vibe.sqlite"
+    _database(db_path)
+    backups_dir = tmp_path / "backups"
+
+    clean = _attempt(db_path, backups_dir, hour=2)
+    _partially_apply(db_path)
+    _attempt(db_path, backups_dir, hour=1)
+    latest = _attempt(db_path, backups_dir, hour=3)
+
+    assert _sqlite_backup_roots(backups_dir) == sorted({clean.name, latest.name})
+
+
+def test_a_migration_that_moves_only_the_revision_is_a_new_rollback_point(tmp_path: Path) -> None:
+    # Not every migration changes the schema. One that only moves data and
+    # stamps the new revision leaves the DDL identical on both sides of it, and
+    # the two copies are still different rollback points: restoring the wrong
+    # one leaves the database at a revision whose migration has not run against
+    # its data. So the revisions belong in the identity next to the fingerprint,
+    # and neither half stands in for the other.
+    #
+    # Here the data-only migration settles and the next one starts failing. The
+    # snapshot taken before the data moved is the only way back behind it, and
+    # it has to outrank a second copy of the state the retries are stuck in.
+    db_path = tmp_path / "vibe.sqlite"
+    _database(db_path)
+    backups_dir = tmp_path / "backups"
+
+    before = _attempt(db_path, backups_dir, hour=1, frm=("20260806_0047",))
     _attempt(db_path, backups_dir, hour=2, frm=("20260809_0049",))
-    latest = _attempt(db_path, backups_dir, hour=3, frm=("20260809_0049",))
+    after = _attempt(db_path, backups_dir, hour=3, frm=("20260809_0049",))
 
-    assert _sqlite_backup_roots(backups_dir) == sorted({pristine.name, latest.name})
-
-
-def test_a_finished_migration_ends_the_episode(tmp_path: Path) -> None:
-    # The other side of the same comparison: when a run does reach its
-    # destination, the next backup starts from there, and that is what marks the
-    # boundary. Two settled migrations are two rollback points rather than one
-    # episode with ends, so the window is the newest two -- never an ancient
-    # snapshot held open by an episode that closed long ago.
-    db_path = tmp_path / "vibe.sqlite"
-    with sqlite3.connect(db_path) as conn:
-        conn.execute("create table marker (value text)")
-    backups_dir = tmp_path / "backups"
-
-    _attempt(db_path, backups_dir, hour=1, frm=("20260806_0047",), to=("20260809_0049",))
-    second = _attempt(db_path, backups_dir, hour=2, frm=("20260809_0049",), to=("20260811_0050",))
-    third = _attempt(db_path, backups_dir, hour=3, frm=("20260811_0050",), to=("20260811_0051",))
-
-    assert _sqlite_backup_roots(backups_dir) == sorted({second.name, third.name})
+    assert _sqlite_backup_roots(backups_dir) == sorted({before.name, after.name})
 
 
 def test_new_backup_reaches_stable_storage_before_older_ones_are_deleted(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_state_backups.py
+++ b/tests/test_state_backups.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import json
 import sqlite3
 from datetime import datetime, timezone
@@ -293,37 +294,38 @@ def test_retry_window_keeps_the_snapshot_taken_before_a_partial_upgrade(monkeypa
     assert intact, "the snapshot taken before the first partial upgrade must survive the retries"
 
 
-def test_new_backup_survives_future_dated_copies_and_outlives_them(tmp_path: Path) -> None:
+def test_future_dated_copies_do_not_outrank_the_migration_in_progress(monkeypatch, tmp_path: Path) -> None:
     # A clock corrected backwards, or state carried from a machine running
-    # ahead, leaves copies dated after the one being taken right now. Ranking by
-    # timestamp alone would call the fresh backup the oldest and delete it, and
-    # create_sqlite_migration_backup would hand back a path to nothing.
+    # ahead, leaves unrelated copies dated after everything the current
+    # migration produces. Being newest on disk is not the same as being current:
+    # ranked by timestamp those copies take the window, and both ends of the
+    # failing migration -- the clean snapshot and the latest one -- are lost to
+    # backups that have nothing to do with it.
     state_dir = tmp_path / "state"
     state_dir.mkdir()
     db_path = state_dir / "vibe.sqlite"
-    with sqlite3.connect(db_path) as writer:
-        writer.execute("create table records (value text not null)")
-        writer.execute("insert into records values ('written today')")
+    run_migrations(db_path, revision="20260627_0025")
     backups_dir = state_dir / "backups"
     backups_dir.mkdir()
-    from_the_future = [
-        _legacy_sqlite_backup(backups_dir, f"vibe-pre-0026-repair-20990{day}01T020000Z.sqlite")
-        for day in (1, 2, 3)
-    ]
+    from_the_future = _legacy_sqlite_backup(backups_dir, "vibe-pre-0026-repair-20990101T020000Z.sqlite")
 
-    backup_dir = create_sqlite_migration_backup(
-        db_path,
-        from_revisions={"old"},
-        to_revisions={"new"},
-        now=datetime(2026, 7, 10, 3, 0, tzinfo=timezone.utc),
-    )
+    def _partially_commit_then_fail(*args, **kwargs):
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("create table if not exists half_migrated (value text)")
+        raise RuntimeError("upgrade failed after committing")
 
-    assert (backup_dir / "vibe.sqlite").is_file()
-    with sqlite3.connect(backup_dir / "vibe.sqlite") as backup:
-        assert backup.execute("select value from records").fetchone() == ("written today",)
-    # Protection takes a slot in the window rather than an extra one.
-    assert len(_sqlite_backup_roots(backups_dir)) == SQLITE_BACKUP_RETENTION
-    assert sum(path.exists() for path in from_the_future) == SQLITE_BACKUP_RETENTION - 1
+    monkeypatch.setattr("storage.migrations.command.upgrade", _partially_commit_then_fail)
+
+    for _ in range(SQLITE_BACKUP_RETENTION + 1):
+        with pytest.raises(RuntimeError, match="upgrade failed after committing"):
+            run_migrations(db_path)
+
+    surviving = _sqlite_backup_roots(backups_dir)
+    assert len(surviving) == SQLITE_BACKUP_RETENTION
+    assert from_the_future.name not in surviving, "a future timestamp is not a claim on the window"
+    assert any(
+        not _table_exists(backups_dir / name / "vibe.sqlite", "half_migrated") for name in surviving
+    ), "the snapshot from before the partial upgrade must keep its slot"
 
 
 def test_new_backup_reaches_stable_storage_before_older_ones_are_deleted(monkeypatch, tmp_path: Path) -> None:
@@ -342,9 +344,10 @@ def test_new_backup_reaches_stable_storage_before_older_ones_are_deleted(monkeyp
         _legacy_sqlite_backup(backups_dir, f"vibe-pre-0026-repair-2026070{day}T020000Z.sqlite")
 
     journal: list[tuple[str, Path]] = []
-    real_fsync = backups._fsync
+    for name in ("_fsync_file", "_fsync_directory"):
+        real = getattr(backups, name)
+        monkeypatch.setattr(backups, name, lambda path, _real=real: (journal.append(("fsync", path)), _real(path))[1])
     real_remove = backups._remove_candidate
-    monkeypatch.setattr(backups, "_fsync", lambda path: (journal.append(("fsync", path)), real_fsync(path))[1])
     monkeypatch.setattr(
         backups,
         "_remove_candidate",
@@ -359,6 +362,37 @@ def test_new_backup_reaches_stable_storage_before_older_ones_are_deleted(monkeyp
     assert backup_dir / "manifest.json" in synced
     assert backup_dir in synced
     assert backup_dir.parent in synced
+
+
+def test_storage_failure_while_flushing_deletes_nothing(monkeypatch, tmp_path: Path) -> None:
+    # A sync that fails because the disk is full or the device errored says the
+    # new copy may not be on it. Swallowing that and pruning anyway deletes
+    # durable rollback points in exchange for one that might not exist after the
+    # next power loss -- the exact trade this window exists to refuse. A
+    # platform that has no directory sync is a different answer and stays quiet.
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = state_dir / "vibe.sqlite"
+    with sqlite3.connect(db_path) as writer:
+        writer.execute("create table records (value text not null)")
+    backups_dir = state_dir / "backups"
+    backups_dir.mkdir()
+    existing = [
+        _legacy_sqlite_backup(backups_dir, f"vibe-pre-0026-repair-2026070{day}T020000Z.sqlite")
+        for day in (7, 8, 9)
+    ]
+
+    def _out_of_space(fd):
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    monkeypatch.setattr(backups.os, "fsync", _out_of_space)
+
+    with pytest.raises(OSError) as failure:
+        create_sqlite_migration_backup(db_path, now=datetime(2026, 7, 10, 3, 0, tzinfo=timezone.utc))
+
+    assert failure.value.errno == errno.ENOSPC
+    assert all(path.exists() for path in existing), "a backup that may not be durable prunes nothing"
+    assert not list(backups_dir.glob("avibe-sqlite-migration-*")), "the incomplete backup is cleaned up"
 
 
 def test_startup_keeps_json_rollbacks_when_new_snapshot_fails(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_state_backups.py
+++ b/tests/test_state_backups.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from storage import backups
 from storage.backups import (
     SQLITE_BACKUP_RETENTION,
     _JSON_BACKUP_RE,
@@ -34,6 +35,13 @@ def _legacy_sqlite_backup(backups_dir: Path, name: str) -> Path:
     path.with_name(path.name + "-wal").write_bytes(b"wal")
     path.with_name(path.name + "-shm").write_bytes(b"shm")
     return path
+
+
+def _table_exists(db_path: Path, table: str) -> bool:
+    with sqlite3.connect(db_path) as conn:
+        return conn.execute(
+            "select 1 from sqlite_master where type = 'table' and name = ?", (table,)
+        ).fetchone() is not None
 
 
 def _sqlite_backup_roots(backups_dir: Path) -> list[str]:
@@ -236,19 +244,121 @@ def test_repeated_migration_failures_keep_the_rollback_window_bounded(monkeypatc
         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("migration boom")),
     )
 
-    created: list[Path] = []
+    created: list[str] = []
     for _ in range(SQLITE_BACKUP_RETENTION + 3):
         with pytest.raises(RuntimeError, match="migration boom"):
             ensure_sqlite_state(db_path=db_path, state_dir=state_dir)
-        created.append(_sqlite_backup_roots(state_dir / "backups")[-1])
+        created.append(max(_sqlite_backup_roots(state_dir / "backups")))
 
     surviving = _sqlite_backup_roots(state_dir / "backups")
     assert len(surviving) == SQLITE_BACKUP_RETENTION
-    assert surviving == sorted(created[-SQLITE_BACKUP_RETENTION:])
+    assert surviving == sorted({created[0], created[-1]})
     # A bounded window is only worth keeping if it is still restorable.
     for name in surviving:
         with sqlite3.connect(state_dir / "backups" / name / "vibe.sqlite") as backup:
             assert backup.execute("PRAGMA quick_check").fetchone() == ("ok",)
+
+
+def test_retry_window_keeps_the_snapshot_taken_before_a_partial_upgrade(monkeypatch, tmp_path: Path) -> None:
+    # An upgrade can commit part of its work and then raise -- a SQLite table
+    # rebuild inside an autocommit block that fails a later check is exactly
+    # that shape. From the next attempt on, every copy is of the half-migrated
+    # database, so keeping the newest copies fills the window with damage and
+    # discards the only snapshot that can undo it. What each attempt shares is
+    # the schema move it was taken for, since a failed upgrade leaves the
+    # recorded revisions alone; the window keeps the ends of that move.
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = state_dir / "vibe.sqlite"
+    run_migrations(db_path, revision="20260627_0025")
+
+    def _partially_commit_then_fail(*args, **kwargs):
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("create table if not exists half_migrated (value text)")
+        raise RuntimeError("upgrade failed after committing")
+
+    monkeypatch.setattr("storage.migrations.command.upgrade", _partially_commit_then_fail)
+
+    for _ in range(SQLITE_BACKUP_RETENTION + 2):
+        with pytest.raises(RuntimeError, match="upgrade failed after committing"):
+            run_migrations(db_path)
+
+    surviving = _sqlite_backup_roots(state_dir / "backups")
+    assert len(surviving) == SQLITE_BACKUP_RETENTION
+    intact = [
+        name
+        for name in surviving
+        if not _table_exists(state_dir / "backups" / name / "vibe.sqlite", "half_migrated")
+    ]
+    assert intact, "the snapshot taken before the first partial upgrade must survive the retries"
+
+
+def test_new_backup_survives_future_dated_copies_and_outlives_them(tmp_path: Path) -> None:
+    # A clock corrected backwards, or state carried from a machine running
+    # ahead, leaves copies dated after the one being taken right now. Ranking by
+    # timestamp alone would call the fresh backup the oldest and delete it, and
+    # create_sqlite_migration_backup would hand back a path to nothing.
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = state_dir / "vibe.sqlite"
+    with sqlite3.connect(db_path) as writer:
+        writer.execute("create table records (value text not null)")
+        writer.execute("insert into records values ('written today')")
+    backups_dir = state_dir / "backups"
+    backups_dir.mkdir()
+    from_the_future = [
+        _legacy_sqlite_backup(backups_dir, f"vibe-pre-0026-repair-20990{day}01T020000Z.sqlite")
+        for day in (1, 2, 3)
+    ]
+
+    backup_dir = create_sqlite_migration_backup(
+        db_path,
+        from_revisions={"old"},
+        to_revisions={"new"},
+        now=datetime(2026, 7, 10, 3, 0, tzinfo=timezone.utc),
+    )
+
+    assert (backup_dir / "vibe.sqlite").is_file()
+    with sqlite3.connect(backup_dir / "vibe.sqlite") as backup:
+        assert backup.execute("select value from records").fetchone() == ("written today",)
+    # Protection takes a slot in the window rather than an extra one.
+    assert len(_sqlite_backup_roots(backups_dir)) == SQLITE_BACKUP_RETENTION
+    assert sum(path.exists() for path in from_the_future) == SQLITE_BACKUP_RETENTION - 1
+
+
+def test_new_backup_reaches_stable_storage_before_older_ones_are_deleted(monkeypatch, tmp_path: Path) -> None:
+    # A backup that replaces durable copies has to be durable first. If the
+    # filesystem is free to persist the deletions while still holding the new
+    # rename and manifest in cache, a power loss here leaves no rollback point
+    # at all -- the one outcome this whole window exists to prevent.
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = state_dir / "vibe.sqlite"
+    with sqlite3.connect(db_path) as writer:
+        writer.execute("create table records (value text not null)")
+    backups_dir = state_dir / "backups"
+    backups_dir.mkdir()
+    for day in (7, 8, 9):
+        _legacy_sqlite_backup(backups_dir, f"vibe-pre-0026-repair-2026070{day}T020000Z.sqlite")
+
+    journal: list[tuple[str, Path]] = []
+    real_fsync = backups._fsync
+    real_remove = backups._remove_candidate
+    monkeypatch.setattr(backups, "_fsync", lambda path: (journal.append(("fsync", path)), real_fsync(path))[1])
+    monkeypatch.setattr(
+        backups,
+        "_remove_candidate",
+        lambda candidate: (journal.append(("remove", candidate.root)), real_remove(candidate))[1],
+    )
+
+    backup_dir = create_sqlite_migration_backup(db_path, now=datetime(2026, 7, 10, 3, 0, tzinfo=timezone.utc))
+
+    removals = [index for index, (action, _) in enumerate(journal) if action == "remove"]
+    assert removals, "the prune must have had something to delete for this ordering to mean anything"
+    synced = {path for action, path in journal[: removals[0]] if action == "fsync"}
+    assert backup_dir / "manifest.json" in synced
+    assert backup_dir in synced
+    assert backup_dir.parent in synced
 
 
 def test_startup_keeps_json_rollbacks_when_new_snapshot_fails(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_state_backups.py
+++ b/tests/test_state_backups.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import errno
 import json
+import os
 import shutil
 import sqlite3
 from datetime import datetime, timezone
@@ -356,15 +357,60 @@ def test_the_window_directory_is_durable_before_the_backup_counts(monkeypatch, t
     # Creating the backup directory also adds an entry to its parent. A crash
     # that keeps the upgraded database but loses that entry leaves no rollback
     # point at all, with every fsync this code makes having succeeded.
+    #
+    # Every attempt syncs, not only the one that created the directory: a
+    # directory whose own entry never reached the disk is indistinguishable from
+    # a durable one, so an attempt that finds the root already there has learned
+    # nothing about it. Skipping the sync then propagates the first attempt's
+    # failure through every later attempt, for as long as the window lives.
     synced: list[Path] = []
     monkeypatch.setattr(backups, "_fsync_directory", lambda path: synced.append(Path(path)))
     db_path = tmp_path / "state" / "vibe.sqlite"
     db_path.parent.mkdir()
     _stamp(db_path, "20260806_0047")
 
+    for _attempt in range(2):
+        synced.clear()
+        create_sqlite_migration_backup(db_path)
+        assert db_path.parent in synced
+
+
+def test_backup_files_are_flushed_through_write_capable_handles(monkeypatch, tmp_path: Path) -> None:
+    # `os.fsync` is not a read-only operation everywhere: on Windows it reaches
+    # `FlushFileBuffers`, which refuses a handle opened without write access. A
+    # read-only descriptor therefore turns every pre-migration backup on that
+    # platform into a failed schema upgrade -- the flush is here to make an
+    # upgrade safe, so it must not be the thing that stops one. Stated over
+    # whatever this code flushes rather than over the call sites it has today.
+    #
+    # Directories are excluded because they are the opposite case: POSIX refuses
+    # to open one for writing, and Windows refuses to open one at all.
+    opened: dict[int, tuple[bool, int]] = {}
+    flushed: list[tuple[bool, int]] = []
+    real_open = os.open
+    real_fsync = os.fsync
+
+    def recording_open(path, flags, *args, **kwargs):
+        fd = real_open(path, flags, *args, **kwargs)
+        opened[fd] = (Path(path).is_dir(), flags)
+        return fd
+
+    def recording_fsync(fd):
+        if fd in opened:
+            flushed.append(opened[fd])
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "open", recording_open)
+    monkeypatch.setattr(os, "fsync", recording_fsync)
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    db_path.parent.mkdir()
+    _stamp(db_path, "20260806_0047")
+
     create_sqlite_migration_backup(db_path)
 
-    assert db_path.parent in synced
+    file_flushes = [flags for is_dir, flags in flushed if not is_dir]
+    assert file_flushes
+    assert all(flags & (os.O_WRONLY | os.O_RDWR) for flags in file_flushes)
 
 
 def test_a_fresh_rollback_point_outlives_copies_dated_after_it(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changes

Pruning of the SQLite rollback window was gated on the upgrade succeeding and
on the legacy JSON import succeeding. Creating a backup is unconditional. So
the one situation that produces attempt after attempt — a migration that fails
partway, every time — was also the one situation in which nothing ever closed
the window. Each retry copied the whole database again and nothing was
reclaimed.

The bound now belongs to the code that creates the copy.
`create_sqlite_migration_backup` prunes in the same call, after its own
manifest is written, so the call cannot delete a copy it has not yet finished
publishing and cannot fail to count itself. Every caller inherits the bound,
including ones not yet written and ones that opt out of their own pruning.

That is the whole behavioural change. What the window promises is one thing:
**every call returns a restorable copy of the database as it stands at that
call**, and the window holding those copies is bounded.

## What this PR tried four times and stopped doing

Bounding the window has a cost the first review round named: under a migration
that keeps failing, the attempts after the first copy an already-damaged
database, and with a fixed bound they can push the last clean copy out.

Four revisions of this PR tried to answer that by recognising which copies were
redundant or superseded. Each rule was defeated:

| recognised by | what defeated it |
| --- | --- |
| wall-clock adjacency between attempts | an NTP or manual clock correction reorders them |
| the schema transition each attempt recorded | `command.upgrade` walks several revisions per call, and entering an autocommit block commits the stamps already earned, so consecutive attempts report different transitions |
| a fingerprint of the copy's `sqlite_master` | a migration that commits row changes and then fails moves neither the schema nor the stamp |
| the revision stamp — skip the copy when the window holds that stamp | an operator who restores a copy and keeps serving writes moves the contents under a stamp that never changed, so the retained copy is missing every write since the restore |

They are four instances of one mistake: **a label standing in for the
database's contents.** A copy is a rollback point only if restoring it loses no
committed data, and no cheap property of a copy proves that. Each successive
rule was harder to collide, never impossible — which per `CLAUDE.md` means none
of them was the terminal rule.

So no copy is ever reused and none is ever judged against another for identity.
The last rule was the most dangerous of the four, because skipping the copy
turns "the window may not hold the clean snapshot" into "the reported rollback
point is missing committed writes".

What survives from those attempts is only what stands on its own: `protect` for
the copy a call has just written, the parent fsync for the window directory,
and reading the manifest's revisions back from the copy.

## Retention and durability

Newest two SQLite rollback points, newest three legacy JSON snapshots, with the
copy a call has just written handed to `prune_state_backups` as `protect`
rather than trusted to sort highest. A copy left behind by a machine whose
clock ran ahead is dated into the future permanently, so no ordering rule can
defend a fresh copy against it; `order_key` only decides which of the *older*
copies to drop first, where a movable clock is tolerable.

The manifest's `from_revisions` is read back from the destination copy, not
taken from the caller: another process can advance the database between a
caller sampling it and the copy being made, and an operator choosing a rollback
point reads that manifest.

The replacement copy reaches stable storage before any older copy is deleted,
and the window's own directory is fsynced into its parent on every attempt, so
a crash cannot keep the upgrade while losing the directory holding the only
rollback point. Every attempt, not only the one that created the directory: a
root left behind by an attempt that failed before its own entry reached the
disk is indistinguishable from a durable one, and deleting such a root is not
available because a concurrent creator may be writing into it.

`_fsync_file` always raises, and opens the descriptor for writing, because
`os.fsync` is only a read-only operation on POSIX -- on Windows it reaches
`FlushFileBuffers`, which refuses a handle without write access, so a read-only
descriptor would turn every pre-migration backup on that platform into a failed
schema upgrade. `_fsync_directory` opens read-only, which is the opposite case,
and tolerates only the errnos that mean "this platform or filesystem does not
implement directory sync"; `ENOSPC` and `EIO` propagate.

## Evidence

- `tests/test_state_backups.py` — 21 tests.
  `test_every_call_holds_the_database_as_it_stands_at_that_call` states the
  window's promise as a property over how the database moves rather than a list
  of cases: it runs the database through a rows-only change, a
  restore-then-write, a schema change and a stamp change, asserting the
  returned copy matches the live database each time. Also: retry storms leave a
  bounded window of restorable copies; a fresh copy outlives future-dated ones;
  the manifest records what the copy carries; the window directory is durable
  before the backup counts, on every attempt; every file this module flushes is
  flushed through a write-capable handle; unknown files, active DB/WAL/SHM,
  symlinks and partial backups are never candidates; the new copy reaches
  stable storage before older ones are deleted.
- Red-without-fix confirmed by mutation: reinstating skip-by-stamp (1 fail),
  dropping `protect` (1 fail), dropping the parent fsync (1 fail), taking the
  caller's revisions for the manifest (2 fail), guarding the parent fsync on
  the root not already existing (1 fail), reverting `_fsync_file` to
  `os.O_RDONLY` (1 fail).
- `tests/test_state_backups.py tests/test_sqlite_state_migration.py
  tests/test_dev_state_migration_guard.py` — 131 passed.
- `ruff check` clean on changed files.

## Known-by-design ledger

- **A migration that keeps failing can push the last clean copy out of the
  window.** The bound is what this PR is for, and the attempts after the first
  copy an already-damaged database. Retention cannot recover the clean one: the
  four defeated rules above are the evidence that nothing measurable from a copy
  distinguishes it. The recoverable version of this problem is upstream — a
  failing migration is retried by every service entry point that touches the
  store — and the fix is memoizing `ensure_sqlite_state`, listed below. Until
  then this is a real regression against `master`'s unbounded window, taken
  deliberately: an unbounded window fills the disk, which is the reported bug.
- **Two processes can still run `command.upgrade` against one SQLite file, and
  the window can then end up holding no copy of the current database.**
  `_MIGRATION_LOCK` (`storage/migrations.py:25`) is a `threading.RLock`, and
  `vibe/ui_server.py` runs in a separate process. `protect` is local to one
  prune invocation, so with two creators in flight and a future-dated copy in
  the other retention slot, each prune ranks its own copy first, the
  future-dated copy second, and the peer's fresh copy out — and both fresh
  copies are deleted. Left as designed, because neither available patch is the
  terminal rule: an ordering rule that demotes future-dated copies closes that
  scenario but is defeated by three concurrent creators at retention 2, and a
  lock around create-and-prune only orders the two prunes, since the second
  creator still legitimately ranks the first's copy out while the first's
  migration is still running. What has to be serialized is the migration —
  `backups.py` does not know when that window closes. That is the same defect
  the sequence-collision thread named, it predates this PR, and a cross-process
  migration lock changes startup behaviour (a stuck holder blocks every entry
  point), needs real-subprocess tests, and is not portable in one shape across
  the platforms `_fsync_directory` already accounts for. It belongs next to the
  `ensure_sqlite_state` follow-up below.
- **`from_revisions` / `to_revisions` stay in the manifest.** Both already ship
  on `master`, and per `AGENTS.md` an on-disk artifact written by a released
  version is a shipped surface. They are recorded for an operator to read; no
  code decides anything by comparing them.

## Follow-ups (not in this PR)

- Memoize `ensure_sqlite_state` — the root cause of the retry storm, and what
  actually protects the clean snapshot.
- Make `20260725_0037`'s backfill cheap instead of making `0056` guess.
- `tests/test_wait_for_github_pr_activity.py` and `tests/test_watches.py`
  interfere under the full suite; they are not hermetic.
