### PR TITLE
fix(auth): allow personal editors to use local resources

### DIFF
--- a/core/web_push_notifications.py
+++ b/core/web_push_notifications.py
@@ -251,9 +251,23 @@ def _evaluate_record_authorization(
             reason="persisted snapshot was issued for a different paired instance",
         )
     paired_kind = str(getattr(cloud, "instance_kind", "") or "") if cloud is not None else ""
+    record_kind = record.get("vibe_instance_kind")
+    if (
+        record_kind in {"personal", "organization"}
+        and paired_kind in {"personal", "organization"}
+        and record_kind != paired_kind
+    ):
+        return OwnerAuthorizationDecision(
+            user_key=user_key,
+            policy=policy,
+            context=None,
+            authorized=False,
+            disposition=WEB_PUSH_DISPOSITION_REVOKED,
+            reason="persisted snapshot instance kind differs from the current pairing",
+        )
     if (
         context.instance_kind is None
-        and record.get("vibe_instance_kind") is None
+        and record_kind is None
         and paired_instance_id
         and paired_kind in {"personal", "organization"}
     ):

--- a/core/web_push_notifications.py
+++ b/core/web_push_notifications.py
@@ -7,7 +7,7 @@ import json
 import logging
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import Any, Mapping
 
@@ -250,6 +250,14 @@ def _evaluate_record_authorization(
             disposition=WEB_PUSH_DISPOSITION_REVOKED,
             reason="persisted snapshot was issued for a different paired instance",
         )
+    paired_kind = str(getattr(cloud, "instance_kind", "") or "") if cloud is not None else ""
+    if (
+        context.instance_kind is None
+        and record.get("vibe_instance_kind") is None
+        and paired_instance_id
+        and paired_kind in {"personal", "organization"}
+    ):
+        context = replace(context, instance_kind=paired_kind)
     if policy == "personal":
         return OwnerAuthorizationDecision(
             user_key=user_key,

--- a/core/web_push_notifications.py
+++ b/core/web_push_notifications.py
@@ -216,6 +216,20 @@ def _evaluate_record_authorization(
             disposition=WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE,
             reason="paired configuration could not be read; instance binding cannot be validated",
         )
+    paired_kind = str(getattr(cloud, "instance_kind", "") or "") if cloud is not None else ""
+    if (
+        paired_kind in {"personal", "organization"}
+        and cloud is not None
+        and cloud.runtime_credentials() is None
+    ):
+        return OwnerAuthorizationDecision(
+            user_key=user_key,
+            policy=policy,
+            context=None,
+            authorized=False,
+            disposition=WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE,
+            reason="current pairing lacks complete runtime credentials",
+        )
     context = context_from_session_payload(record)
     if not (
         context.subject
@@ -250,7 +264,6 @@ def _evaluate_record_authorization(
             disposition=WEB_PUSH_DISPOSITION_REVOKED,
             reason="persisted snapshot was issued for a different paired instance",
         )
-    paired_kind = str(getattr(cloud, "instance_kind", "") or "") if cloud is not None else ""
     record_kind = record.get("vibe_instance_kind")
     if (
         record_kind in {"personal", "organization"}

--- a/core/web_push_notifications.py
+++ b/core/web_push_notifications.py
@@ -626,6 +626,7 @@ def web_push_authorization_context_record(
         "sub": context.subject,
         "vibe_instance_role": context.instance_role,
         "vibe_instance_access_source": context.instance_access_source,
+        "vibe_instance_kind": context.instance_kind,
         "vibe_group_ids": sorted(context.group_ids),
         "claims_issued_at": context.claims_issued_at,
     }

--- a/core/web_push_notifications.py
+++ b/core/web_push_notifications.py
@@ -281,6 +281,18 @@ def _evaluate_record_authorization(
     record_kind = record.get("vibe_instance_kind")
     if (
         record_kind in {"personal", "organization"}
+        and paired_kind not in {"personal", "organization"}
+    ):
+        return OwnerAuthorizationDecision(
+            user_key=user_key,
+            policy=policy,
+            context=None,
+            authorized=False,
+            disposition=WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE,
+            reason="current pairing instance kind is unavailable",
+        )
+    if (
+        record_kind in {"personal", "organization"}
         and paired_kind in {"personal", "organization"}
         and record_kind != paired_kind
     ):
@@ -298,6 +310,15 @@ def _evaluate_record_authorization(
         and paired_instance_id
         and paired_kind in {"personal", "organization"}
     ):
+        if record_instance_id != paired_instance_id:
+            return OwnerAuthorizationDecision(
+                user_key=user_key,
+                policy=policy,
+                context=None,
+                authorized=False,
+                disposition=WEB_PUSH_DISPOSITION_REVOKED,
+                reason="persisted snapshot lacks a binding to the current paired instance",
+            )
         context = replace(context, instance_kind=paired_kind)
     if policy == "personal":
         return OwnerAuthorizationDecision(

--- a/core/web_push_notifications.py
+++ b/core/web_push_notifications.py
@@ -190,6 +190,20 @@ def _evaluate_record_authorization(
     from vibe import remote_access
 
     policy = _notification_policy_for_record(config, record)
+    if config is None:
+        reason = (
+            "paired configuration could not be read; instance binding cannot be validated"
+            if config_load_failed
+            else "paired configuration is unavailable; instance binding cannot be validated"
+        )
+        return OwnerAuthorizationDecision(
+            user_key=user_key,
+            policy=policy,
+            context=None,
+            authorized=False,
+            disposition=WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE,
+            reason=reason,
+        )
     cloud = getattr(getattr(config, "remote_access", None), "vibe_cloud", None)
     if cloud is not None and not cloud.enabled:
         # Disabling remote access is a confirmed, deliberate removal of every

--- a/core/web_push_notifications.py
+++ b/core/web_push_notifications.py
@@ -109,6 +109,15 @@ def _notification_policy_for_record(config: Any, record: Mapping[str, Any]) -> s
 
     cloud = getattr(getattr(config, "remote_access", None), "vibe_cloud", None)
     instance_kind = str(getattr(cloud, "instance_kind", "") or "")
+    if instance_kind in {"personal", "organization"}:
+        from storage import remote_access_authorization_service
+
+        if not remote_access_authorization_service.binding_is_ready_for_pairing(
+            instance_id=str(getattr(cloud, "instance_id", "") or ""),
+            instance_kind=instance_kind,
+            ensure=False,
+        ):
+            instance_kind = ""
     if instance_kind == "organization":
         return "organization"
     if instance_kind == "personal":
@@ -231,6 +240,22 @@ def _evaluate_record_authorization(
             reason="paired configuration could not be read; instance binding cannot be validated",
         )
     paired_kind = str(getattr(cloud, "instance_kind", "") or "") if cloud is not None else ""
+    if paired_kind in {"personal", "organization"}:
+        from storage import remote_access_authorization_service
+
+        if not remote_access_authorization_service.binding_is_ready_for_pairing(
+            instance_id=_paired_instance_id(config),
+            instance_kind=paired_kind,
+            ensure=False,
+        ):
+            return OwnerAuthorizationDecision(
+                user_key=user_key,
+                policy=policy,
+                context=None,
+                authorized=False,
+                disposition=WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE,
+                reason="durable instance binding is not ready",
+            )
     if (
         paired_kind in {"personal", "organization"}
         and cloud is not None

--- a/storage/importer.py
+++ b/storage/importer.py
@@ -232,7 +232,9 @@ def _set_background_import_marker(conn: Connection) -> None:
 
 
 def _run_sqlite_data_migrations(conn: Connection) -> dict[str, int]:
-    return {}
+    from storage.resource_access_service import migrate_legacy_deferred_resource_contexts
+
+    return migrate_legacy_deferred_resource_contexts(conn)
 
 
 def _backup_json_state(state_dir: Path) -> Path:

--- a/storage/migrations.py
+++ b/storage/migrations.py
@@ -445,7 +445,6 @@ def _stamp_existing_initial_schema(db_path: Path, cfg: Config) -> None:
             conn.commit()
             _run_remove_legacy_default_agent_migration(db_path)
             command.stamp(cfg, LATEST_SCHEMA_REVISION)
-            _run_post_stamp_data_migrations(db_path)
             return
         if PRE_SHOW_SESSION_EVENTS_HEAD_TABLES.issubset(tables):
             if not _pre_show_session_events_head_schema_ready(conn, tables):
@@ -457,7 +456,6 @@ def _stamp_existing_initial_schema(db_path: Path, cfg: Config) -> None:
                 raise RuntimeError(f"existing SQLite head schema is incomplete; missing: {missing}")
             _run_remove_legacy_default_agent_migration(db_path)
             command.stamp(cfg, REMOVE_LEGACY_DEFAULT_AGENT_REVISION)
-            _run_post_stamp_data_migrations(db_path)
             return
 
     command.stamp(cfg, INITIAL_REVISION)
@@ -474,17 +472,6 @@ def _run_remove_legacy_default_agent_migration(db_path: Path) -> None:
                 revision_module.upgrade()
             finally:
                 revision_module.op = original_op
-    finally:
-        engine.dispose()
-
-
-def _run_post_stamp_data_migrations(db_path: Path) -> None:
-    from storage.importer import _run_sqlite_data_migrations
-
-    engine = create_sqlite_engine(db_path)
-    try:
-        with engine.begin() as conn:
-            _run_sqlite_data_migrations(conn)
     finally:
         engine.dispose()
 

--- a/storage/project_access_service.py
+++ b/storage/project_access_service.py
@@ -319,6 +319,8 @@ def get_effective_project_role(
     instance_role = context.instance_role
     if instance_role not in _ROLE_RANK:
         return None
+    if context.is_personal_instance:
+        return instance_role
     policy = get_project_policy(conn, project_id)
     if policy is None or policy["mode"] == "inherit":
         return instance_role

--- a/storage/project_access_service.py
+++ b/storage/project_access_service.py
@@ -319,7 +319,7 @@ def get_effective_project_role(
     instance_role = context.instance_role
     if instance_role not in _ROLE_RANK:
         return None
-    if context.is_personal_instance:
+    if context.is_personal_instance and context.has_role("editor"):
         return instance_role
     policy = get_project_policy(conn, project_id)
     if policy is None or policy["mode"] == "inherit":

--- a/storage/remote_access_authorization_service.py
+++ b/storage/remote_access_authorization_service.py
@@ -4,13 +4,23 @@ from __future__ import annotations
 
 import json
 import secrets
-from typing import Any, Mapping
+import time
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator, Mapping
 
-from sqlalchemy import and_, or_, select, update
+from sqlalchemy import and_, delete, or_, select, update
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.exc import OperationalError
 
 from storage.db import get_cached_sqlite_engine
-from storage.models import remote_access_authorizations
+from storage.models import remote_access_authorizations, state_meta
+
+INSTANCE_BINDING_STATE_META_KEY = "remote_access.instance_binding.v1"
+INSTANCE_BINDING_STATE_RECONCILING = "reconciling"
+INSTANCE_BINDING_STATE_READY = "ready"
+INSTANCE_BINDING_STATE_INVALID = "invalid"
+INSTANCE_BINDING_GENERATION_KEY = "vibe_instance_binding_generation"
+INSTANCE_BINDING_LOCK_FILENAME = "remote-access-instance-binding.lock"
 
 
 def store(
@@ -292,3 +302,430 @@ def delete_for_instance(instance_id: str) -> int:
             )
         )
     return int(result.rowcount or 0)
+
+
+def _decode_binding_state(value: Any) -> dict[str, Any] | None:
+    """Decode one state row, rejecting malformed values instead of guessing."""
+
+    if not isinstance(value, str):
+        return None
+    try:
+        payload = json.loads(value)
+        if not isinstance(payload, dict):
+            return None
+        state = payload.get("state")
+        if state not in {INSTANCE_BINDING_STATE_RECONCILING, INSTANCE_BINDING_STATE_READY}:
+            return None
+        instance_id = payload.get("instance_id")
+        if not isinstance(instance_id, str) or not instance_id.strip():
+            return None
+        instance_kind = payload.get("instance_kind")
+        if instance_kind not in {None, "personal", "organization"}:
+            return None
+        if state == INSTANCE_BINDING_STATE_READY and instance_kind is None:
+            return None
+        generation = int(payload.get("generation"))
+        schema_version = int(payload.get("schema_version") or 1)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if generation <= 0 or schema_version <= 0:
+        return None
+    return {
+        "schema_version": schema_version,
+        "state": state,
+        "instance_id": instance_id.strip(),
+        "instance_kind": instance_kind,
+        "generation": generation,
+        "updated_at": payload.get("updated_at"),
+    }
+
+
+def _load_binding_state_from_connection(conn) -> dict[str, Any] | None:
+    raw = conn.execute(
+        select(state_meta.c.value_json).where(
+            state_meta.c.key == INSTANCE_BINDING_STATE_META_KEY
+        )
+    ).scalar_one_or_none()
+    if raw is None:
+        return None
+    decoded = _decode_binding_state(raw)
+    if decoded is not None:
+        return decoded
+    # Keep corruption distinguishable from a never-initialized install. Any
+    # caller that sees this value must fail closed until a transition repairs it.
+    return {
+        "schema_version": 0,
+        "state": INSTANCE_BINDING_STATE_INVALID,
+        "instance_id": None,
+        "instance_kind": None,
+        "generation": 0,
+        "updated_at": None,
+    }
+
+
+def _ensure_sqlite_state() -> None:
+    from storage.importer import ensure_sqlite_state
+
+    ensure_sqlite_state()
+
+
+def _binding_file_lock():
+    from config import paths
+    from storage.lock import MigrationFileLock
+
+    return MigrationFileLock(paths.get_state_dir() / INSTANCE_BINDING_LOCK_FILENAME)
+
+
+@contextmanager
+def instance_binding_lock() -> Iterator[None]:
+    """Serialize binding transitions across controller and UI processes."""
+
+    _ensure_sqlite_state()
+    with _binding_file_lock():
+        yield
+
+
+def load_instance_binding_state(*, ensure: bool = True) -> dict[str, Any] | None:
+    """Read the durable binding epoch shared by UI and controller processes."""
+
+    if ensure:
+        _ensure_sqlite_state()
+    engine = get_cached_sqlite_engine()
+    try:
+        with engine.connect() as conn:
+            return _load_binding_state_from_connection(conn)
+    except OperationalError as exc:
+        # A pre-migration process may not have created state_meta yet. Treat
+        # that as a legacy no-row install; callers that need a durable write
+        # use the default ``ensure=True`` path and will still fail closed on a
+        # real storage error.
+        if not ensure and "no such table" in str(exc).lower():
+            return None
+        raise
+
+
+def _validate_transition_identity(
+    *,
+    instance_id: str,
+    instance_kind: str | None,
+) -> tuple[str, str | None]:
+    if not isinstance(instance_id, str) or not instance_id.strip():
+        raise ValueError("instance_id_required")
+    if instance_kind not in {None, "personal", "organization"}:
+        raise ValueError("instance_kind_required")
+    return instance_id.strip(), instance_kind
+
+
+def _binding_payload(
+    *,
+    state: str,
+    instance_id: str,
+    instance_kind: str | None,
+    generation: int,
+) -> tuple[dict[str, Any], str]:
+    now = str(int(time.time()))
+    payload = {
+        "schema_version": 1,
+        "state": state,
+        "instance_id": instance_id,
+        "instance_kind": instance_kind,
+        "generation": int(generation),
+        "updated_at": now,
+    }
+    return payload, now
+
+
+def _write_binding_state(conn, payload: Mapping[str, Any], updated_at: str) -> None:
+    encoded = json.dumps(dict(payload), separators=(",", ":"), sort_keys=True)
+    statement = sqlite_insert(state_meta).values(
+        key=INSTANCE_BINDING_STATE_META_KEY,
+        value_json=encoded,
+        updated_at=updated_at,
+    )
+    conn.execute(
+        statement.on_conflict_do_update(
+            index_elements=[state_meta.c.key],
+            set_={"value_json": encoded, "updated_at": updated_at},
+        )
+    )
+
+
+def _begin_instance_binding_transition_locked(
+    conn,
+    *,
+    instance_id: str,
+    instance_kind: str | None,
+) -> dict[str, Any]:
+    instance_id, instance_kind = _validate_transition_identity(
+        instance_id=instance_id,
+        instance_kind=instance_kind,
+    )
+    existing = _load_binding_state_from_connection(conn)
+    if (
+        existing is not None
+        and existing["state"] == INSTANCE_BINDING_STATE_READY
+        and existing["instance_id"] == instance_id
+        and existing["instance_kind"] == instance_kind
+    ):
+        return {
+            "generation": existing["generation"],
+            "changed": False,
+            "previous": existing,
+            "state": INSTANCE_BINDING_STATE_READY,
+        }
+    if (
+        existing is not None
+        and existing["state"] == INSTANCE_BINDING_STATE_RECONCILING
+        and existing["instance_id"] == instance_id
+        and existing["instance_kind"] == instance_kind
+    ):
+        return {
+            "generation": existing["generation"],
+            "changed": True,
+            "previous": existing,
+            "state": INSTANCE_BINDING_STATE_RECONCILING,
+        }
+    generation = (int(existing["generation"]) if existing is not None else 0) + 1
+    payload, now = _binding_payload(
+        state=INSTANCE_BINDING_STATE_RECONCILING,
+        instance_id=instance_id,
+        instance_kind=instance_kind,
+        generation=generation,
+    )
+    _write_binding_state(conn, payload, now)
+    return {
+        "generation": generation,
+        "changed": True,
+        "previous": existing,
+        "state": INSTANCE_BINDING_STATE_RECONCILING,
+    }
+
+
+def begin_instance_binding_transition(
+    *,
+    instance_id: str,
+    instance_kind: str | None,
+) -> dict[str, Any]:
+    """Commit a fail-closed ``reconciling`` epoch before derived work starts."""
+
+    _ensure_sqlite_state()
+    with _binding_file_lock():
+        engine = get_cached_sqlite_engine()
+        with engine.begin() as conn:
+            return _begin_instance_binding_transition_locked(
+                conn,
+                instance_id=instance_id,
+                instance_kind=instance_kind,
+            )
+
+
+def _invalidate_instance_binding_authorizations_locked(
+    conn,
+    *,
+    instance_id: str,
+    previous_instance_id: str | None = None,
+    preserve_show_page: bool = True,
+    keep_reference_for_revalidation: bool = True,
+) -> int:
+    ids = {
+        value.strip()
+        for value in (instance_id, previous_instance_id or "")
+        if isinstance(value, str) and value.strip()
+    }
+    if not ids:
+        return 0
+    predicate = remote_access_authorizations.c.instance_id.in_(ids)
+    if preserve_show_page:
+        predicate = and_(
+            predicate,
+            or_(
+                remote_access_authorizations.c.scope_kind.is_(None),
+                remote_access_authorizations.c.scope_kind != "show_page",
+            ),
+        )
+    if keep_reference_for_revalidation:
+        result = conn.execute(
+            update(remote_access_authorizations)
+            .where(predicate)
+            .values(authorization_state="stale", updated_at=int(time.time()))
+        )
+    else:
+        result = conn.execute(delete(remote_access_authorizations).where(predicate))
+    return int(result.rowcount or 0)
+
+
+def invalidate_instance_binding_authorizations(
+    *,
+    instance_id: str,
+    previous_instance_id: str | None = None,
+    preserve_show_page: bool = True,
+    keep_reference_for_revalidation: bool = True,
+) -> int:
+    """Invalidate derived instance claims without touching exact Show Page grants."""
+
+    _ensure_sqlite_state()
+    with _binding_file_lock():
+        engine = get_cached_sqlite_engine()
+        with engine.begin() as conn:
+            return _invalidate_instance_binding_authorizations_locked(
+                conn,
+                instance_id=instance_id,
+                previous_instance_id=previous_instance_id,
+                preserve_show_page=preserve_show_page,
+                keep_reference_for_revalidation=keep_reference_for_revalidation,
+            )
+
+
+def _complete_instance_binding_transition_locked(
+    conn,
+    *,
+    instance_id: str,
+    instance_kind: str,
+    generation: int,
+) -> bool:
+    if instance_kind not in {"personal", "organization"}:
+        return False
+    existing = _load_binding_state_from_connection(conn)
+    if (
+        existing is None
+        or existing["state"] != INSTANCE_BINDING_STATE_RECONCILING
+        or existing["instance_id"] != instance_id
+        or existing["instance_kind"] not in {None, instance_kind}
+        or existing["generation"] != int(generation)
+    ):
+        return False
+    payload, now = _binding_payload(
+        state=INSTANCE_BINDING_STATE_READY,
+        instance_id=instance_id,
+        instance_kind=instance_kind,
+        generation=generation,
+    )
+    _write_binding_state(conn, payload, now)
+    return True
+
+
+def complete_instance_binding_transition(
+    *,
+    instance_id: str,
+    instance_kind: str,
+    generation: int,
+) -> bool:
+    """Publish a reconciled binding epoch after all derived work succeeds."""
+
+    _ensure_sqlite_state()
+    with _binding_file_lock():
+        engine = get_cached_sqlite_engine()
+        with engine.begin() as conn:
+            return _complete_instance_binding_transition_locked(
+                conn,
+                instance_id=instance_id,
+                instance_kind=instance_kind,
+                generation=generation,
+            )
+
+
+def reconcile_instance_binding(
+    *,
+    instance_id: str,
+    instance_kind: str | None,
+    reconcile: Callable[[], Any] | None = None,
+    previous_instance_id: str | None = None,
+    preserve_show_page: bool = True,
+) -> dict[str, Any]:
+    """Run one serialized identity transition and publish ``ready`` last.
+
+    A callback failure deliberately leaves the committed ``reconciling`` row
+    in place. Callers must treat the returned ``ok=False`` as fail-closed and
+    retry from the next heartbeat.
+    """
+
+    instance_id, instance_kind = _validate_transition_identity(
+        instance_id=instance_id,
+        instance_kind=instance_kind,
+    )
+    _ensure_sqlite_state()
+    with _binding_file_lock():
+        engine = get_cached_sqlite_engine()
+        with engine.begin() as conn:
+            transition = _begin_instance_binding_transition_locked(
+                conn,
+                instance_id=instance_id,
+                instance_kind=instance_kind,
+            )
+            previous = transition.get("previous")
+            previous_id = previous.get("instance_id") if isinstance(previous, Mapping) else None
+            if previous_instance_id and previous_instance_id != instance_id:
+                previous_id = previous_instance_id
+            preserve = preserve_show_page and previous_id in {None, instance_id}
+            invalidated = _invalidate_instance_binding_authorizations_locked(
+                conn,
+                instance_id=instance_id,
+                previous_instance_id=previous_id,
+                preserve_show_page=preserve,
+            ) if transition["changed"] else 0
+
+        if not transition["changed"]:
+            return {
+                **transition,
+                "ok": True,
+                "ready": True,
+                "invalidated": 0,
+            }
+
+        try:
+            if reconcile is not None:
+                reconcile()
+        except Exception as exc:
+            return {
+                **transition,
+                "ok": False,
+                "ready": False,
+                "invalidated": invalidated,
+                "error": str(exc),
+            }
+
+        if instance_kind is None:
+            return {
+                **transition,
+                "ok": True,
+                "ready": False,
+                "invalidated": invalidated,
+                "pending": True,
+            }
+        with engine.begin() as conn:
+            completed = _complete_instance_binding_transition_locked(
+                conn,
+                instance_id=instance_id,
+                instance_kind=instance_kind,
+                generation=transition["generation"],
+            )
+        if not completed:
+            return {
+                **transition,
+                "ok": False,
+                "ready": False,
+                "invalidated": invalidated,
+                "error": "binding_generation_changed",
+            }
+        return {
+            **transition,
+            "ok": True,
+            "ready": True,
+            "invalidated": invalidated,
+        }
+
+
+def instance_binding_generation(
+    *,
+    instance_id: str,
+    instance_kind: str,
+) -> int | None:
+    state = load_instance_binding_state()
+    if (
+        state is None
+        or state["state"] != INSTANCE_BINDING_STATE_READY
+        or state["instance_id"] != instance_id
+        or state["instance_kind"] != instance_kind
+    ):
+        return None
+    return int(state["generation"])

--- a/storage/remote_access_authorization_service.py
+++ b/storage/remote_access_authorization_service.py
@@ -746,3 +746,31 @@ def current_instance_binding_generation(*, ensure: bool = True) -> int:
         return int(state.get("generation") or 0)
     except (TypeError, ValueError):
         return 0
+
+
+def binding_is_ready_for_pairing(
+    *,
+    instance_id: str | None,
+    instance_kind: str | None,
+    ensure: bool = False,
+) -> bool:
+    """True only when the durable binding is ready for this pairing.
+
+    A missing row is a legacy install and stays compatible. Once a row
+    exists, ``reconciling`` / ``invalid`` / mismatched identity means the
+    kind is unavailable to every consumer until reconciliation succeeds.
+    """
+
+    state = load_instance_binding_state(ensure=ensure)
+    if state is None:
+        return True
+    if state.get("state") != INSTANCE_BINDING_STATE_READY:
+        return False
+    current_id = (instance_id or "").strip()
+    current_kind = instance_kind if instance_kind in {"personal", "organization"} else None
+    return (
+        bool(current_id)
+        and state.get("instance_id") == current_id
+        and state.get("instance_kind") == current_kind
+        and current_kind is not None
+    )

--- a/storage/remote_access_authorization_service.py
+++ b/storage/remote_access_authorization_service.py
@@ -729,3 +729,20 @@ def instance_binding_generation(
     ):
         return None
     return int(state["generation"])
+
+
+def current_instance_binding_generation(*, ensure: bool = True) -> int:
+    """Return the durable generation any process can compare against.
+
+    Missing state is generation 0 (a never-initialized install). A corrupt
+    or reconciling row still exposes its generation so a stale writer can
+    refuse to reverse a newer transition.
+    """
+
+    state = load_instance_binding_state(ensure=ensure)
+    if state is None:
+        return 0
+    try:
+        return int(state.get("generation") or 0)
+    except (TypeError, ValueError):
+        return 0

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -362,6 +362,15 @@ def resource_user_context_from_metadata(
         return None
     if configured is not _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE and configured is not None:
         paired_instance_id, paired_kind = configured
+        from storage import remote_access_authorization_service
+
+        if not remote_access_authorization_service.binding_is_ready_for_pairing(
+            instance_id=paired_instance_id,
+            instance_kind=paired_kind,
+            ensure=False,
+        ):
+            # Kind is not yet reconciled; do not project a Personal bypass.
+            return None
         if context.instance_kind is not None and (
             not paired_instance_id or not paired_kind
         ):

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -331,8 +331,16 @@ def resource_user_context_from_metadata(
     # exposes one; legacy snapshots without an instance id remain covered by
     # the kind fallback below.
     configured = _configured_resource_instance()
+    if context.instance_kind is not None and (
+        configured is _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE or configured is None
+    ):
+        return None
     if configured is not _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE and configured is not None:
         paired_instance_id, paired_kind = configured
+        if context.instance_kind is not None and (
+            not paired_instance_id or not paired_kind
+        ):
+            return None
         snapshot_instance_id = context.instance_id
         if (
             snapshot_instance_id

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -40,6 +40,7 @@ RESOURCE_KINDS = frozenset({"agent", "vault_secret", "skill", "show_page"})
 ACCESS_LEVELS = frozenset({"public", "scope", "private"})
 ORGANIZATION_ROLES = frozenset({"owner", "admin", "member"})
 RESOURCE_USER_CONTEXT_METADATA_KEY = "resource_user_context"
+LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY = "migrations.legacy_deferred_resource_contexts.v1"
 RESOURCE_ORGANIZATIONS_META_KEY = "resource_access_organizations"
 SHOW_PAGE_INSTANCE_OWNERSHIP_META_KEY = "show_page_instance_ownership"
 HARNESS_ACCESS_FORBIDDEN_CODE = "harness_access_forbidden"
@@ -455,6 +456,11 @@ def _legacy_snapshot_has_organization_context(
         context.organization_id
         or context.organization_member_id
         or context.organization_role
+        or context.instance_access_source in {
+            "email",
+            "email_domain",
+            "public_instance",
+        }
         or context.instance_access_source == "organization_group"
         or context.group_ids
         or any(
@@ -545,12 +551,27 @@ def _migrate_deferred_metadata_value(
 def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[str, int]:
     """Bind released deferred metadata to the still-current runtime pairing.
 
-    The migration is deliberately conservative. It needs complete runtime
-    credentials and a known server-owned instance kind, and it only updates a
-    legacy snapshot when its existing instance evidence or Organization
-    claims agree with that pairing. Unreadable, ambiguous, or stale records
-    remain unchanged and are rejected by the runtime restore checks.
+    The migration is deliberately conservative and one-shot. It needs complete
+    runtime credentials and a known server-owned instance kind, and it only
+    updates a legacy snapshot when its existing instance evidence or
+    Organization claims agree with that pairing. Unreadable, ambiguous, or
+    stale records remain unchanged and are rejected by the runtime restore
+    checks. The marker is written even when no pairing is available, so a later
+    re-pair cannot reinterpret an old unbound record as belonging to the new
+    instance.
     """
+
+    empty_counts = {
+        "legacy_deferred_definitions": 0,
+        "legacy_deferred_runs": 0,
+        "legacy_deferred_deliveries": 0,
+    }
+    if connection.execute(
+        select(state_meta.c.value_json).where(
+            state_meta.c.key == LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY
+        )
+    ).scalar_one_or_none() is not None:
+        return empty_counts
 
     configured = _configured_resource_instance()
     if (
@@ -559,11 +580,19 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
         or configured[0] is None
         or configured[1] not in {"personal", "organization"}
     ):
-        return {
-            "legacy_deferred_definitions": 0,
-            "legacy_deferred_runs": 0,
-            "legacy_deferred_deliveries": 0,
-        }
+        completed_at = _utc_now_iso()
+        connection.execute(
+            state_meta.insert().values(
+                key=LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY,
+                value_json=json.dumps(
+                    {"schema_version": 1, "completed_at": completed_at},
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+                updated_at=completed_at,
+            )
+        )
+        return empty_counts
     paired_instance_id, paired_kind = configured
 
     counts = {
@@ -675,6 +704,18 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
             )
         )
         counts["legacy_deferred_deliveries"] += 1
+    completed_at = _utc_now_iso()
+    connection.execute(
+        state_meta.insert().values(
+            key=LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY,
+            value_json=json.dumps(
+                {"schema_version": 1, "completed_at": completed_at},
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+            updated_at=completed_at,
+        )
+    )
     return counts
 
 

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -350,7 +350,7 @@ def resource_user_context_from_metadata(
             return None
         if context.instance_kind and paired_kind and context.instance_kind != paired_kind:
             return None
-    if context.instance_kind is not None or "vibe_instance_kind" in snapshot:
+    if context.instance_kind is not None or snapshot.get("vibe_instance_kind") is not None:
         return context
 
     # Released snapshots predate the instance-kind field. Recover their kind
@@ -418,9 +418,12 @@ def _configured_resource_instance() -> tuple[str | None, str | None] | None | ob
         from config.v2_config import V2Config
 
         cloud = V2Config.load().remote_access.vibe_cloud
-        if not cloud.enabled:
+        credentials = cloud.runtime_credentials()
+        if credentials is None:
             return None
-        instance_id = _clean_optional_string(cloud.instance_id)
+        if not isinstance(credentials, (tuple, list)) or len(credentials) != 3:
+            return _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
+        instance_id = _clean_optional_string(credentials[1])
         instance_kind = (
             cloud.instance_kind if cloud.instance_kind in {"personal", "organization"} else None
         )

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -50,6 +50,8 @@ RESOURCE_BINDING_STATE_UNAVAILABLE = "unavailable"
 RESOURCE_BINDING_STATE_UNPAIRED = "unpaired"
 RESOURCE_BINDING_STATE_PARTIAL = "partial"
 RESOURCE_BINDING_STATE_READY = "ready"
+RESOURCE_BINDING_STATE_SEALED = "sealed"
+RESOURCE_BINDING_STATUS_KEY = "binding_status"
 
 _SHOW_PAGE_OWNERSHIP_MODES = frozenset(
     {
@@ -618,11 +620,21 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
     instance is authoritatively classified.
     """
 
-    empty_counts = {
-        "legacy_deferred_definitions": 0,
-        "legacy_deferred_runs": 0,
-        "legacy_deferred_deliveries": 0,
-    }
+    def _counts(
+        *,
+        binding_status: str,
+        definitions: int = 0,
+        runs: int = 0,
+        deliveries: int = 0,
+    ) -> dict[str, int | str]:
+        return {
+            "legacy_deferred_definitions": definitions,
+            "legacy_deferred_runs": runs,
+            "legacy_deferred_deliveries": deliveries,
+            RESOURCE_BINDING_STATUS_KEY: binding_status,
+        }
+
+    empty_unavailable = _counts(binding_status=RESOURCE_BINDING_STATE_UNAVAILABLE)
     marker_value = connection.execute(
         select(state_meta.c.value_json).where(
             state_meta.c.key == LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY
@@ -638,7 +650,7 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
             # A corrupt marker cannot prove which pairing created the rows.
             # Preserve fail-closed behavior instead of trying to insert a
             # duplicate key or guessing a new binding.
-            return empty_counts
+            return _counts(binding_status=RESOURCE_BINDING_STATE_UNAVAILABLE)
         marker = parsed_marker
         marker_state = marker.get("state")
         if marker_state not in {"pending", "completed", "sealed_unattributed"}:
@@ -654,7 +666,7 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
     if configured.status == RESOURCE_BINDING_STATE_UNAVAILABLE:
         # A read failure must not create ``pending(instance_id=None)`` or
         # rewrite a known marker. Startup/heartbeat will retry this operation.
-        return empty_counts
+        return empty_unavailable
     current_instance_id = configured.instance_id
     current_kind = (
         configured.instance_kind
@@ -698,7 +710,7 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
             )
 
     if marker is not None and marker.get("state") in {"completed", "sealed_unattributed"}:
-        return empty_counts
+        return _counts(binding_status=RESOURCE_BINDING_STATE_SEALED)
 
     raw_marker_instance_id = marker.get("instance_id") if marker else None
     marker_instance_id = (
@@ -707,31 +719,32 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
     if marker and raw_marker_instance_id is not None and marker_instance_id is None:
         # A malformed marker cannot prove ownership. Keep the existing value
         # intact and fail closed rather than guessing a new pairing.
-        return empty_counts
+        return _counts(binding_status=RESOURCE_BINDING_STATE_UNAVAILABLE)
     if marker is not None:
         if marker_instance_id is None:
             # No first pairing was available to prove ownership. A later
             # pairing must not be allowed to claim these records.
             write_marker(state="sealed_unattributed", instance_id=None)
-            return empty_counts
+            return _counts(binding_status=RESOURCE_BINDING_STATE_SEALED)
         if current_instance_id is None:
             if configured.status == RESOURCE_BINDING_STATE_UNPAIRED:
                 write_marker(state="sealed_unattributed", instance_id=marker_instance_id)
-            return empty_counts
+                return _counts(binding_status=RESOURCE_BINDING_STATE_SEALED)
+            return _counts(binding_status=configured.status)
         if current_instance_id != marker_instance_id:
             write_marker(state="sealed_unattributed", instance_id=marker_instance_id)
-            return empty_counts
+            return _counts(binding_status=RESOURCE_BINDING_STATE_SEALED)
 
     if configured.status == RESOURCE_BINDING_STATE_UNPAIRED:
         write_marker(state="sealed_unattributed", instance_id=current_instance_id)
-        return empty_counts
+        return _counts(binding_status=RESOURCE_BINDING_STATE_SEALED)
     if configured.status != RESOURCE_BINDING_STATE_READY:
         write_marker(state="pending", instance_id=current_instance_id)
-        return empty_counts
+        return _counts(binding_status=configured.status)
     if current_instance_id is None or current_kind not in {"personal", "organization"}:
         # Defensive guard for a future state-reader change. This branch is
         # never authoritative enough to complete a migration.
-        return empty_counts
+        return _counts(binding_status=RESOURCE_BINDING_STATE_PARTIAL)
     paired_instance_id = current_instance_id
     paired_kind = current_kind
 
@@ -739,6 +752,7 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
         "legacy_deferred_definitions": 0,
         "legacy_deferred_runs": 0,
         "legacy_deferred_deliveries": 0,
+        RESOURCE_BINDING_STATUS_KEY: RESOURCE_BINDING_STATE_READY,
     }
     definition_rows = connection.execute(
         select(run_definitions.c.id, run_definitions.c.metadata_json).where(

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -282,6 +282,7 @@ def metadata_with_resource_user_context(
         "vibe_membership_version": context.membership_version,
         "vibe_instance_role": context.instance_role,
         "vibe_instance_access_source": context.instance_access_source,
+        "vibe_instance_kind": context.instance_kind,
         "vibe_show_page_id": context.show_page_id,
         "claims_issued_at": context.claims_issued_at,
         "vibe_instance_authorization_revision": context.authorization_revision,
@@ -1000,6 +1001,8 @@ def _policy_allows(
 ) -> bool:
     if context.is_instance_owner:
         return True
+    if resource_kind == "agent" and context.is_personal_instance:
+        return context.can_use_resource(resource_kind)
     # Skill and Vault ACL rows remain persisted for compatibility, but Editor
     # runtime access intentionally ignores them for validated remote sessions.
     # Direct non-remote contexts still use the stored policy so service-level

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -12,7 +12,7 @@ import json
 import time
 from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import Any, Iterator
 
@@ -46,6 +46,11 @@ SHOW_PAGE_INSTANCE_OWNERSHIP_META_KEY = "show_page_instance_ownership"
 HARNESS_ACCESS_FORBIDDEN_CODE = "harness_access_forbidden"
 SHOW_PAGE_OWNERSHIP_CONFIGURATION_UNAVAILABLE = "configuration_unavailable"
 
+RESOURCE_BINDING_STATE_UNAVAILABLE = "unavailable"
+RESOURCE_BINDING_STATE_UNPAIRED = "unpaired"
+RESOURCE_BINDING_STATE_PARTIAL = "partial"
+RESOURCE_BINDING_STATE_READY = "ready"
+
 _SHOW_PAGE_OWNERSHIP_MODES = frozenset(
     {
         "unmanaged",
@@ -56,6 +61,16 @@ _SHOW_PAGE_OWNERSHIP_MODES = frozenset(
     }
 )
 _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE = object()
+
+
+@dataclass(frozen=True)
+class ConfiguredResourceState:
+    """One coherent read of the pairing identity used by deferred resources."""
+
+    status: str
+    instance_id: str | None
+    instance_kind: str | None
+    runtime_ready: bool
 
 
 class ResourceAccessError(ValueError):
@@ -423,35 +438,79 @@ def _configured_show_page_instance() -> tuple[str, str] | None | object:
     return instance_id, cloud.instance_kind
 
 
-def _configured_resource_state() -> tuple[str | None, str | None, bool] | None | object:
-    """Return configured identity plus whether its runtime credentials are complete."""
+def _configured_resource_state() -> ConfiguredResourceState:
+    """Return one typed, fail-closed read of the configured pairing state.
+
+    ``UNAVAILABLE`` is intentionally distinct from a successfully read
+    unpaired configuration. Migration provenance must never be sealed because
+    a transient config read failed.
+    """
 
     try:
         from config.v2_config import V2Config
 
         cloud = V2Config.load().remote_access.vibe_cloud
-        instance_id = _clean_optional_string(cloud.instance_id)
+        raw_instance_id = cloud.instance_id
+        instance_id = _clean_optional_string(raw_instance_id)
+        if raw_instance_id not in (None, "") and instance_id is None:
+            return ConfiguredResourceState(
+                status=RESOURCE_BINDING_STATE_UNAVAILABLE,
+                instance_id=None,
+                instance_kind=None,
+                runtime_ready=False,
+            )
         instance_kind = (
             cloud.instance_kind if cloud.instance_kind in {"personal", "organization"} else None
         )
-        runtime_ready = cloud.runtime_credentials() is not None
+        credentials = cloud.runtime_credentials()
     except Exception:
-        return _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
-    if instance_id is None and instance_kind is None and not runtime_ready:
-        return None
-    return instance_id, instance_kind, runtime_ready
+        return ConfiguredResourceState(
+            status=RESOURCE_BINDING_STATE_UNAVAILABLE,
+            instance_id=None,
+            instance_kind=None,
+            runtime_ready=False,
+        )
+
+    runtime_ready = False
+    if credentials is not None:
+        if not isinstance(credentials, (tuple, list)) or len(credentials) != 3:
+            return ConfiguredResourceState(
+                status=RESOURCE_BINDING_STATE_UNAVAILABLE,
+                instance_id=instance_id,
+                instance_kind=instance_kind,
+                runtime_ready=False,
+            )
+        credential_instance_id = _clean_optional_string(credentials[1])
+        runtime_ready = instance_id is not None and credential_instance_id == instance_id
+
+    if instance_id is None:
+        return ConfiguredResourceState(
+            status=RESOURCE_BINDING_STATE_UNPAIRED,
+            instance_id=None,
+            instance_kind=instance_kind,
+            runtime_ready=False,
+        )
+    if runtime_ready and instance_kind in {"personal", "organization"}:
+        status = RESOURCE_BINDING_STATE_READY
+    else:
+        status = RESOURCE_BINDING_STATE_PARTIAL
+    return ConfiguredResourceState(
+        status=status,
+        instance_id=instance_id,
+        instance_kind=instance_kind,
+        runtime_ready=runtime_ready,
+    )
 
 
 def _configured_resource_instance() -> tuple[str | None, str | None] | None | object:
     """Return the current complete pairing identity used to fence deferred resources."""
 
     configured = _configured_resource_state()
-    if configured is _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE or configured is None:
-        return configured
-    instance_id, instance_kind, runtime_ready = configured
-    if not runtime_ready:
+    if configured.status == RESOURCE_BINDING_STATE_UNAVAILABLE:
+        return _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
+    if configured.status != RESOURCE_BINDING_STATE_READY:
         return None
-    return instance_id, instance_kind
+    return configured.instance_id, configured.instance_kind
 
 
 def _legacy_snapshot_has_organization_context(
@@ -552,12 +611,11 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
     The migration is deliberately conservative and one-shot. It needs complete
     runtime credentials and a known server-owned instance kind, and it only
     updates a legacy snapshot when its existing instance evidence or explicit
-    Organization claims agree with that pairing. Unreadable, ambiguous, or
-    stale records remain unchanged and are rejected by the runtime restore
-    checks. A marker records the first migration opportunity: a known instance
-    with an unknown kind remains pending until that same instance is
-    authoritatively classified, while a later different pairing can never
-    adopt the old records.
+    Organization claims agree with that pairing. A transient configuration read
+    is not an unpaired state: it leaves the marker untouched so the same
+    pairing can retry later. A successfully observed unpaired state is sealed,
+    while a known instance with an unknown kind remains pending until that same
+    instance is authoritatively classified.
     """
 
     empty_counts = {
@@ -582,32 +640,43 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
             # duplicate key or guessing a new binding.
             return empty_counts
         marker = parsed_marker
-        if marker.get("state") not in {"pending", "completed"}:
-            marker["state"] = "completed" if marker.get("completed_at") else "pending"
+        marker_state = marker.get("state")
+        if marker_state not in {"pending", "completed", "sealed_unattributed"}:
+            marker_state = "completed" if marker.get("completed_at") else "pending"
+        # Markers written by e64/d667 used ``completed`` with no instance ID
+        # for an unpaired first opportunity. Preserve that terminal meaning;
+        # never reinterpret it as a fresh migration opportunity.
+        if marker_state == "completed" and marker.get("instance_id") is None:
+            marker_state = "sealed_unattributed"
+        marker = {**marker, "state": marker_state}
 
     configured = _configured_resource_state()
-    current_instance_id = (
-        configured[0]
-        if configured is not _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
-        and isinstance(configured, tuple)
-        else None
-    )
+    if configured.status == RESOURCE_BINDING_STATE_UNAVAILABLE:
+        # A read failure must not create ``pending(instance_id=None)`` or
+        # rewrite a known marker. Startup/heartbeat will retry this operation.
+        return empty_counts
+    current_instance_id = configured.instance_id
     current_kind = (
-        configured[1]
-        if configured is not _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
-        and isinstance(configured, tuple)
-        and configured[2]
+        configured.instance_kind
+        if configured.status == RESOURCE_BINDING_STATE_READY
         else None
     )
 
-    def write_marker(*, state: str, instance_id: str | None) -> None:
+    def write_marker(
+        *,
+        state: str,
+        instance_id: str | None,
+        instance_kind: str | None = None,
+    ) -> None:
         now = _utc_now_iso()
         payload: dict[str, Any] = {
-            "schema_version": 1,
+            "schema_version": 2,
             "state": state,
             "instance_id": instance_id,
             "updated_at": now,
         }
+        if instance_kind in {"personal", "organization"}:
+            payload["instance_kind"] = instance_kind
         if state == "completed":
             payload["completed_at"] = now
         values = {
@@ -628,28 +697,40 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
                 .values(**values)
             )
 
-    if marker is not None and marker.get("state") == "completed":
+    if marker is not None and marker.get("state") in {"completed", "sealed_unattributed"}:
         return empty_counts
 
-    marker_instance_id = _clean_optional_string(marker.get("instance_id")) if marker else None
+    raw_marker_instance_id = marker.get("instance_id") if marker else None
+    marker_instance_id = (
+        _clean_optional_string(raw_marker_instance_id) if marker else None
+    )
+    if marker and raw_marker_instance_id is not None and marker_instance_id is None:
+        # A malformed marker cannot prove ownership. Keep the existing value
+        # intact and fail closed rather than guessing a new pairing.
+        return empty_counts
     if marker is not None:
         if marker_instance_id is None:
             # No first pairing was available to prove ownership. A later
             # pairing must not be allowed to claim these records.
-            if current_instance_id is not None:
-                write_marker(state="completed", instance_id=None)
+            write_marker(state="sealed_unattributed", instance_id=None)
             return empty_counts
         if current_instance_id is None:
+            if configured.status == RESOURCE_BINDING_STATE_UNPAIRED:
+                write_marker(state="sealed_unattributed", instance_id=marker_instance_id)
             return empty_counts
         if current_instance_id != marker_instance_id:
-            write_marker(state="completed", instance_id=marker_instance_id)
+            write_marker(state="sealed_unattributed", instance_id=marker_instance_id)
             return empty_counts
 
-    if current_instance_id is None:
-        write_marker(state="pending", instance_id=None)
+    if configured.status == RESOURCE_BINDING_STATE_UNPAIRED:
+        write_marker(state="sealed_unattributed", instance_id=current_instance_id)
         return empty_counts
-    if current_kind not in {"personal", "organization"}:
+    if configured.status != RESOURCE_BINDING_STATE_READY:
         write_marker(state="pending", instance_id=current_instance_id)
+        return empty_counts
+    if current_instance_id is None or current_kind not in {"personal", "organization"}:
+        # Defensive guard for a future state-reader change. This branch is
+        # never authoritative enough to complete a migration.
         return empty_counts
     paired_instance_id = current_instance_id
     paired_kind = current_kind
@@ -763,7 +844,11 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
             )
         )
         counts["legacy_deferred_deliveries"] += 1
-    write_marker(state="completed", instance_id=paired_instance_id)
+    write_marker(
+        state="completed",
+        instance_id=paired_instance_id,
+        instance_kind=paired_kind,
+    )
     return counts
 
 

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -7,6 +7,7 @@ content, prompts, paths, outputs, or secret values.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import time
 from collections.abc import Mapping, Sequence
@@ -15,12 +16,19 @@ from dataclasses import replace
 from datetime import datetime, timezone
 from typing import Any, Iterator
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.engine import Connection
 
 from config.v2_config import config_file_lock
 from storage.db import get_cached_sqlite_engine
-from storage.models import resource_access_groups, resource_access_policies, state_meta
+from storage.models import (
+    agent_runs,
+    message_deliveries,
+    resource_access_groups,
+    resource_access_policies,
+    run_definitions,
+    state_meta,
+)
 from vibe.authorization import (
     AuthorizationContext,
     context_from_session_payload,
@@ -435,6 +443,239 @@ def _configured_resource_instance() -> tuple[str | None, str | None] | None | ob
     if instance_id is None and instance_kind is None:
         return None
     return instance_id, instance_kind
+
+
+def _legacy_snapshot_has_organization_context(
+    context: ResourceUserContext,
+    snapshot: Mapping[str, Any],
+) -> bool:
+    """Detect Organization semantics retained by pre-binding snapshots."""
+
+    return bool(
+        context.organization_id
+        or context.organization_member_id
+        or context.organization_role
+        or context.instance_access_source == "organization_group"
+        or context.group_ids
+        or any(
+            snapshot.get(key)
+            for key in (
+                "vibe_organization_id",
+                "vibe_organization_member_id",
+                "vibe_organization_role",
+                "vibe_group_ids",
+            )
+        )
+    )
+
+
+def _legacy_deferred_context_binding(
+    snapshot: Mapping[str, Any],
+    *,
+    paired_instance_id: str,
+    paired_kind: str,
+) -> dict[str, str] | None:
+    """Return a safe current binding for one pre-instance metadata snapshot."""
+
+    context = current_resource_context(snapshot, is_remote=True)
+    if context.instance_role not in {"owner", "editor", "viewer"}:
+        return None
+
+    raw_instance_id = snapshot.get("vibe_instance_id")
+    snapshot_instance_id = _clean_optional_string(raw_instance_id)
+    if raw_instance_id is not None and snapshot_instance_id is None:
+        return None
+    if snapshot_instance_id and snapshot_instance_id != paired_instance_id:
+        return None
+
+    raw_kind = snapshot.get("vibe_instance_kind")
+    if raw_kind is not None and raw_kind not in {"personal", "organization"}:
+        return None
+    if raw_kind is not None and raw_kind != paired_kind:
+        return None
+
+    # An id already matching the live pairing is sufficient to recover a
+    # missing kind. If both fields are absent, infer only the instance kind
+    # retained in the old signed claims; this prevents old Organization work
+    # from being adopted by a Personal pairing (and vice versa).
+    inferred_kind = raw_kind or (
+        paired_kind
+        if snapshot_instance_id
+        else (
+            "organization"
+            if _legacy_snapshot_has_organization_context(context, snapshot)
+            else "personal"
+        )
+    )
+    if inferred_kind != paired_kind:
+        return None
+    return {
+        "vibe_instance_id": paired_instance_id,
+        "vibe_instance_kind": paired_kind,
+    }
+
+
+def _migrate_deferred_metadata_value(
+    metadata: Any,
+    *,
+    paired_instance_id: str,
+    paired_kind: str,
+) -> dict[str, Any] | None:
+    if not isinstance(metadata, dict):
+        return None
+    snapshot = metadata.get(RESOURCE_USER_CONTEXT_METADATA_KEY)
+    if not isinstance(snapshot, Mapping):
+        return None
+    binding = _legacy_deferred_context_binding(
+        snapshot,
+        paired_instance_id=paired_instance_id,
+        paired_kind=paired_kind,
+    )
+    if binding is None:
+        return None
+    if all(snapshot.get(key) == value for key, value in binding.items()):
+        return None
+    migrated = dict(metadata)
+    migrated_snapshot = dict(snapshot)
+    migrated_snapshot.update(binding)
+    migrated[RESOURCE_USER_CONTEXT_METADATA_KEY] = migrated_snapshot
+    return migrated
+
+
+def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[str, int]:
+    """Bind released deferred metadata to the still-current runtime pairing.
+
+    The migration is deliberately conservative. It needs complete runtime
+    credentials and a known server-owned instance kind, and it only updates a
+    legacy snapshot when its existing instance evidence or Organization
+    claims agree with that pairing. Unreadable, ambiguous, or stale records
+    remain unchanged and are rejected by the runtime restore checks.
+    """
+
+    configured = _configured_resource_instance()
+    if (
+        configured is _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
+        or configured is None
+        or configured[0] is None
+        or configured[1] not in {"personal", "organization"}
+    ):
+        return {
+            "legacy_deferred_definitions": 0,
+            "legacy_deferred_runs": 0,
+            "legacy_deferred_deliveries": 0,
+        }
+    paired_instance_id, paired_kind = configured
+
+    counts = {
+        "legacy_deferred_definitions": 0,
+        "legacy_deferred_runs": 0,
+        "legacy_deferred_deliveries": 0,
+    }
+    definition_rows = connection.execute(
+        select(run_definitions.c.id, run_definitions.c.metadata_json).where(
+            run_definitions.c.definition_type.in_(("scheduled", "watch"))
+        )
+    ).mappings()
+    for row in definition_rows:
+        try:
+            metadata = json.loads(row["metadata_json"] or "{}")
+        except (TypeError, ValueError):
+            continue
+        migrated = _migrate_deferred_metadata_value(
+            metadata,
+            paired_instance_id=paired_instance_id,
+            paired_kind=paired_kind,
+        )
+        if migrated is None:
+            continue
+        connection.execute(
+            update(run_definitions)
+            .where(run_definitions.c.id == row["id"])
+            .values(
+                metadata_json=json.dumps(
+                    migrated,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+            )
+        )
+        counts["legacy_deferred_definitions"] += 1
+
+    run_rows = connection.execute(
+        select(agent_runs.c.id, agent_runs.c.metadata_json)
+        .where(agent_runs.c.status.in_(("pending", "queued", "processing", "running")))
+    ).mappings()
+    for row in run_rows:
+        try:
+            metadata = json.loads(row["metadata_json"] or "{}")
+        except (TypeError, ValueError):
+            continue
+        migrated = _migrate_deferred_metadata_value(
+            metadata,
+            paired_instance_id=paired_instance_id,
+            paired_kind=paired_kind,
+        )
+        if migrated is None:
+            continue
+        connection.execute(
+            update(agent_runs)
+            .where(agent_runs.c.id == row["id"])
+            .values(
+                metadata_json=json.dumps(
+                    migrated,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+                updated_at=_utc_now_iso(),
+            )
+        )
+        counts["legacy_deferred_runs"] += 1
+
+    delivery_rows = connection.execute(
+        select(
+            message_deliveries.c.id,
+            message_deliveries.c.snapshot_json,
+        ).where(message_deliveries.c.snapshot_json.is_not(None))
+    ).mappings()
+    for row in delivery_rows:
+        try:
+            snapshot = json.loads(row["snapshot_json"] or "{}")
+            metadata = json.loads(snapshot.get("metadata_json") or "{}")
+        except (AttributeError, TypeError, ValueError):
+            continue
+        migrated_metadata = _migrate_deferred_metadata_value(
+            metadata,
+            paired_instance_id=paired_instance_id,
+            paired_kind=paired_kind,
+        )
+        if migrated_metadata is None:
+            continue
+        snapshot["metadata_json"] = json.dumps(
+            migrated_metadata,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        snapshot_json = json.dumps(
+            snapshot,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        snapshot_sha256 = hashlib.sha256(snapshot_json.encode("utf-8")).hexdigest()
+        connection.execute(
+            update(message_deliveries)
+            .where(message_deliveries.c.id == row["id"])
+            .values(
+                snapshot_json=snapshot_json,
+                snapshot_sha256=snapshot_sha256,
+                updated_at=_utc_now_iso(),
+            )
+        )
+        counts["legacy_deferred_deliveries"] += 1
+    return counts
 
 
 def _configuration_unavailable_ownership() -> dict[str, Any]:

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -456,11 +456,6 @@ def _legacy_snapshot_has_organization_context(
         context.organization_id
         or context.organization_member_id
         or context.organization_role
-        or context.instance_access_source in {
-            "email",
-            "email_domain",
-            "public_instance",
-        }
         or context.instance_access_source == "organization_group"
         or context.group_ids
         or any(
@@ -500,19 +495,14 @@ def _legacy_deferred_context_binding(
     if raw_kind is not None and raw_kind != paired_kind:
         return None
 
-    # An id already matching the live pairing is sufficient to recover a
-    # missing kind. If both fields are absent, infer only the instance kind
-    # retained in the old signed claims; this prevents old Organization work
-    # from being adopted by a Personal pairing (and vice versa).
-    inferred_kind = raw_kind or (
-        paired_kind
-        if snapshot_instance_id
-        else (
-            "organization"
-            if _legacy_snapshot_has_organization_context(context, snapshot)
-            else "personal"
-        )
-    )
+    # The pairing kind is the only authoritative evidence for a legacy
+    # snapshot that predates both binding fields. Explicit Organization claims
+    # still contradict a Personal pairing, but access sources such as ``email``
+    # are shared by Personal and Organization instances and cannot choose a
+    # kind on their own.
+    if paired_kind == "personal" and _legacy_snapshot_has_organization_context(context, snapshot):
+        return None
+    inferred_kind = raw_kind or paired_kind
     if inferred_kind != paired_kind:
         return None
     return {
@@ -553,12 +543,13 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
 
     The migration is deliberately conservative and one-shot. It needs complete
     runtime credentials and a known server-owned instance kind, and it only
-    updates a legacy snapshot when its existing instance evidence or
+    updates a legacy snapshot when its existing instance evidence or explicit
     Organization claims agree with that pairing. Unreadable, ambiguous, or
     stale records remain unchanged and are rejected by the runtime restore
-    checks. The marker is written even when no pairing is available, so a later
-    re-pair cannot reinterpret an old unbound record as belonging to the new
-    instance.
+    checks. A marker records the first migration opportunity: a known instance
+    with an unknown kind remains pending until that same instance is
+    authoritatively classified, while a later different pairing can never
+    adopt the old records.
     """
 
     empty_counts = {
@@ -566,34 +557,93 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
         "legacy_deferred_runs": 0,
         "legacy_deferred_deliveries": 0,
     }
-    if connection.execute(
+    marker_value = connection.execute(
         select(state_meta.c.value_json).where(
             state_meta.c.key == LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY
         )
-    ).scalar_one_or_none() is not None:
-        return empty_counts
+    ).scalar_one_or_none()
+    marker: dict[str, Any] | None = None
+    if marker_value is not None:
+        try:
+            parsed_marker = json.loads(marker_value)
+        except (TypeError, ValueError):
+            parsed_marker = None
+        if not isinstance(parsed_marker, dict):
+            # A corrupt marker cannot prove which pairing created the rows.
+            # Preserve fail-closed behavior instead of trying to insert a
+            # duplicate key or guessing a new binding.
+            return empty_counts
+        marker = parsed_marker
+        if marker.get("state") not in {"pending", "completed"}:
+            marker["state"] = "completed" if marker.get("completed_at") else "pending"
 
     configured = _configured_resource_instance()
-    if (
-        configured is _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
-        or configured is None
-        or configured[0] is None
-        or configured[1] not in {"personal", "organization"}
-    ):
-        completed_at = _utc_now_iso()
-        connection.execute(
-            state_meta.insert().values(
-                key=LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY,
-                value_json=json.dumps(
-                    {"schema_version": 1, "completed_at": completed_at},
-                    sort_keys=True,
-                    separators=(",", ":"),
-                ),
-                updated_at=completed_at,
+    current_instance_id = (
+        configured[0]
+        if configured is not _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
+        and isinstance(configured, tuple)
+        else None
+    )
+    current_kind = (
+        configured[1]
+        if configured is not _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
+        and isinstance(configured, tuple)
+        else None
+    )
+
+    def write_marker(*, state: str, instance_id: str | None) -> None:
+        now = _utc_now_iso()
+        payload: dict[str, Any] = {
+            "schema_version": 1,
+            "state": state,
+            "instance_id": instance_id,
+            "updated_at": now,
+        }
+        if state == "completed":
+            payload["completed_at"] = now
+        values = {
+            "value_json": json.dumps(payload, sort_keys=True, separators=(",", ":")),
+            "updated_at": now,
+        }
+        if marker is None:
+            connection.execute(
+                state_meta.insert().values(
+                    key=LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY,
+                    **values,
+                )
             )
-        )
+        else:
+            connection.execute(
+                update(state_meta)
+                .where(state_meta.c.key == LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY)
+                .values(**values)
+            )
+
+    if marker is not None and marker.get("state") == "completed":
         return empty_counts
-    paired_instance_id, paired_kind = configured
+
+    marker_instance_id = _clean_optional_string(marker.get("instance_id")) if marker else None
+    if marker is not None:
+        if marker_instance_id is None:
+            # No first pairing was available to prove ownership. A later
+            # pairing must not be allowed to claim these records.
+            if current_instance_id is not None:
+                write_marker(state="completed", instance_id=None)
+            return empty_counts
+        if current_instance_id is None:
+            return empty_counts
+        if current_instance_id != marker_instance_id:
+            write_marker(state="completed", instance_id=marker_instance_id)
+            return empty_counts
+
+    if current_instance_id is None:
+        write_marker(state="pending", instance_id=None)
+        return empty_counts
+    if current_kind not in {"personal", "organization"}:
+        write_marker(state="pending", instance_id=current_instance_id)
+        return empty_counts
+    paired_instance_id = current_instance_id
+    paired_kind = current_kind
 
     counts = {
         "legacy_deferred_definitions": 0,
@@ -704,18 +754,7 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
             )
         )
         counts["legacy_deferred_deliveries"] += 1
-    completed_at = _utc_now_iso()
-    connection.execute(
-        state_meta.insert().values(
-            key=LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY,
-            value_json=json.dumps(
-                {"schema_version": 1, "completed_at": completed_at},
-                sort_keys=True,
-                separators=(",", ":"),
-            ),
-            updated_at=completed_at,
-        )
-    )
+    write_marker(state="completed", instance_id=paired_instance_id)
     return counts
 
 

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -324,18 +324,36 @@ def resource_user_context_from_metadata(
     if not isinstance(snapshot, Mapping):
         return None
     context = current_resource_context(snapshot, is_remote=True)
+
+    # A persisted context is durable across re-pairing, so a Personal snapshot
+    # must not authorize work after this installation moves to another
+    # instance. Compare the server-owned binding whenever the current pairing
+    # exposes one; legacy snapshots without an instance id remain covered by
+    # the kind fallback below.
+    configured = _configured_resource_instance()
+    if configured is not _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE and configured is not None:
+        paired_instance_id, paired_kind = configured
+        snapshot_instance_id = context.instance_id
+        if (
+            snapshot_instance_id
+            and paired_instance_id
+            and snapshot_instance_id != paired_instance_id
+        ):
+            return None
+        if context.instance_kind and paired_kind and context.instance_kind != paired_kind:
+            return None
     if context.instance_kind is not None or "vibe_instance_kind" in snapshot:
         return context
 
     # Released snapshots predate the instance-kind field. Recover their kind
     # only from the currently paired, server-owned config; an unavailable or
     # unknown pairing remains fail-closed rather than being guessed as Personal.
-    try:
-        from config.v2_config import V2Config
-
-        paired_kind = V2Config.load().remote_access.vibe_cloud.instance_kind
-    except Exception:
-        paired_kind = None
+    paired_kind = (
+        configured[1]
+        if configured is not _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
+        and configured is not None
+        else None
+    )
     if paired_kind not in {"personal", "organization"}:
         return context
     return replace(context, instance_kind=paired_kind)
@@ -383,6 +401,26 @@ def _configured_show_page_instance() -> tuple[str, str] | None | object:
     ):
         return _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
     return instance_id, cloud.instance_kind
+
+
+def _configured_resource_instance() -> tuple[str | None, str | None] | None | object:
+    """Return the current pairing identity used to fence deferred resources."""
+
+    try:
+        from config.v2_config import V2Config
+
+        cloud = V2Config.load().remote_access.vibe_cloud
+        if not cloud.enabled:
+            return None
+        instance_id = _clean_optional_string(cloud.instance_id)
+        instance_kind = (
+            cloud.instance_kind if cloud.instance_kind in {"personal", "organization"} else None
+        )
+    except Exception:
+        return _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
+    if instance_id is None and instance_kind is None:
+        return None
+    return instance_id, instance_kind
 
 
 def _configuration_unavailable_ownership() -> dict[str, Any]:

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -11,6 +11,7 @@ import json
 import time
 from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
+from dataclasses import replace
 from datetime import datetime, timezone
 from typing import Any, Iterator
 
@@ -280,6 +281,7 @@ def metadata_with_resource_user_context(
         "vibe_organization_role": context.organization_role,
         "vibe_group_ids": sorted(context.group_ids) if context.group_ids is not None else None,
         "vibe_membership_version": context.membership_version,
+        "vibe_instance_id": context.instance_id,
         "vibe_instance_role": context.instance_role,
         "vibe_instance_access_source": context.instance_access_source,
         "vibe_instance_kind": context.instance_kind,
@@ -321,7 +323,22 @@ def resource_user_context_from_metadata(
     snapshot = metadata.get(RESOURCE_USER_CONTEXT_METADATA_KEY)
     if not isinstance(snapshot, Mapping):
         return None
-    return current_resource_context(snapshot, is_remote=True)
+    context = current_resource_context(snapshot, is_remote=True)
+    if context.instance_kind is not None or "vibe_instance_kind" in snapshot:
+        return context
+
+    # Released snapshots predate the instance-kind field. Recover their kind
+    # only from the currently paired, server-owned config; an unavailable or
+    # unknown pairing remains fail-closed rather than being guessed as Personal.
+    try:
+        from config.v2_config import V2Config
+
+        paired_kind = V2Config.load().remote_access.vibe_cloud.instance_kind
+    except Exception:
+        paired_kind = None
+    if paired_kind not in {"personal", "organization"}:
+        return context
+    return replace(context, instance_kind=paired_kind)
 
 
 def _as_context(user_context: ResourceUserContext | Mapping[str, Any] | None) -> ResourceUserContext:

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -423,25 +423,33 @@ def _configured_show_page_instance() -> tuple[str, str] | None | object:
     return instance_id, cloud.instance_kind
 
 
-def _configured_resource_instance() -> tuple[str | None, str | None] | None | object:
-    """Return the current pairing identity used to fence deferred resources."""
+def _configured_resource_state() -> tuple[str | None, str | None, bool] | None | object:
+    """Return configured identity plus whether its runtime credentials are complete."""
 
     try:
         from config.v2_config import V2Config
 
         cloud = V2Config.load().remote_access.vibe_cloud
-        credentials = cloud.runtime_credentials()
-        if credentials is None:
-            return None
-        if not isinstance(credentials, (tuple, list)) or len(credentials) != 3:
-            return _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
-        instance_id = _clean_optional_string(credentials[1])
+        instance_id = _clean_optional_string(cloud.instance_id)
         instance_kind = (
             cloud.instance_kind if cloud.instance_kind in {"personal", "organization"} else None
         )
+        runtime_ready = cloud.runtime_credentials() is not None
     except Exception:
         return _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
-    if instance_id is None and instance_kind is None:
+    if instance_id is None and instance_kind is None and not runtime_ready:
+        return None
+    return instance_id, instance_kind, runtime_ready
+
+
+def _configured_resource_instance() -> tuple[str | None, str | None] | None | object:
+    """Return the current complete pairing identity used to fence deferred resources."""
+
+    configured = _configured_resource_state()
+    if configured is _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE or configured is None:
+        return configured
+    instance_id, instance_kind, runtime_ready = configured
+    if not runtime_ready:
         return None
     return instance_id, instance_kind
 
@@ -577,7 +585,7 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
         if marker.get("state") not in {"pending", "completed"}:
             marker["state"] = "completed" if marker.get("completed_at") else "pending"
 
-    configured = _configured_resource_instance()
+    configured = _configured_resource_state()
     current_instance_id = (
         configured[0]
         if configured is not _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
@@ -588,6 +596,7 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
         configured[1]
         if configured is not _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
         and isinstance(configured, tuple)
+        and configured[2]
         else None
     )
 

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -328,8 +328,7 @@ def resource_user_context_from_metadata(
     # A persisted context is durable across re-pairing, so a Personal snapshot
     # must not authorize work after this installation moves to another
     # instance. Compare the server-owned binding whenever the current pairing
-    # exposes one; legacy snapshots without an instance id remain covered by
-    # the kind fallback below.
+    # exposes one; legacy snapshots without an instance id remain unbound.
     configured = _configured_resource_instance()
     if context.instance_kind is not None and (
         configured is _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE or configured is None
@@ -354,8 +353,10 @@ def resource_user_context_from_metadata(
         return context
 
     # Released snapshots predate the instance-kind field. Recover their kind
-    # only from the currently paired, server-owned config; an unavailable or
-    # unknown pairing remains fail-closed rather than being guessed as Personal.
+    # only when the snapshot still names the current server-owned instance. An
+    # unbound legacy snapshot cannot be attributed to a re-paired Personal
+    # instance, because doing so would turn old Organization work into a
+    # Personal ACL bypass.
     paired_kind = (
         configured[1]
         if configured is not _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
@@ -364,6 +365,8 @@ def resource_user_context_from_metadata(
     )
     if paired_kind not in {"personal", "organization"}:
         return context
+    if not context.instance_id:
+        return None
     return replace(context, instance_kind=paired_kind)
 
 

--- a/tests/test_instance_authorization.py
+++ b/tests/test_instance_authorization.py
@@ -60,6 +60,7 @@ def test_context_from_session_payload_keeps_role_and_acl_claims() -> None:
             "sub": "user-1",
             "vibe_instance_role": "editor",
             "vibe_instance_access_source": "organization_group",
+            "vibe_instance_kind": "organization",
             "vibe_organization_id": "org-1",
             "vibe_organization_member_id": "membership-1",
             "vibe_organization_role": "member",
@@ -68,8 +69,25 @@ def test_context_from_session_payload_keeps_role_and_acl_claims() -> None:
     )
     assert context.instance_role == "editor"
     assert context.group_ids == frozenset({"group-a"})
+    assert context.is_organization_instance
     assert context.can_chat
     assert not context.can_manage_instance
+
+
+def test_context_from_session_payload_only_recognizes_known_instance_kinds() -> None:
+    base = {
+        "sub": "user-1",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": "owner",
+    }
+    personal = context_from_session_payload({**base, "vibe_instance_kind": "personal"})
+    unknown = context_from_session_payload({**base, "vibe_instance_kind": "workspace"})
+
+    assert personal.is_personal_instance
+    assert not personal.is_organization_instance
+    assert personal.instance_kind == "personal"
+    assert unknown.instance_kind is None
+    assert not unknown.is_personal_instance
 
 
 def test_show_page_email_context_is_exactly_page_scoped() -> None:

--- a/tests/test_project_access_service.py
+++ b/tests/test_project_access_service.py
@@ -15,6 +15,7 @@ def _context(
     email: str = "member@example.com",
     organization_id: str | None = None,
     group_ids: tuple[str, ...] = (),
+    instance_kind: str | None = None,
 ) -> AuthorizationContext:
     return AuthorizationContext(
         instance_role=role,
@@ -22,6 +23,7 @@ def _context(
         organization_id=organization_id,
         group_ids=frozenset(group_ids),
         is_remote=True,
+        instance_kind=instance_kind,
     )
 
 
@@ -126,6 +128,36 @@ def test_restricted_policy_matches_email_domain_and_group(tmp_path) -> None:
             )
             is None
         )
+
+
+def test_personal_editor_ignores_project_organization_acl(tmp_path) -> None:
+    engine, project = _engine_with_project(tmp_path)
+    intent = _intent(
+        project["id"],
+        1,
+        bindings=[
+            {
+                "principal_kind": "email",
+                "principal_value": "other@example.com",
+                "access_role": "viewer",
+            }
+        ],
+    )
+    personal_editor = _context(
+        "editor",
+        email="personal@example.com",
+        instance_kind="personal",
+    )
+    organization_editor = _context("editor", email="organization@example.com")
+
+    with engine.begin() as conn:
+        assert project_access_service.apply_project_access_intent(conn, intent).outcome == "applied"
+        assert project_access_service.get_effective_project_role(
+            conn, personal_editor, project["id"]
+        ) == "editor"
+        assert project_access_service.get_effective_project_role(
+            conn, organization_editor, project["id"]
+        ) is None
 
 
 def test_highest_match_is_capped_by_instance_role(tmp_path) -> None:

--- a/tests/test_project_access_service.py
+++ b/tests/test_project_access_service.py
@@ -148,6 +148,11 @@ def test_personal_editor_ignores_project_organization_acl(tmp_path) -> None:
         email="personal@example.com",
         instance_kind="personal",
     )
+    personal_viewer = _context(
+        "viewer",
+        email="personal@example.com",
+        instance_kind="personal",
+    )
     organization_editor = _context("editor", email="organization@example.com")
 
     with engine.begin() as conn:
@@ -155,6 +160,9 @@ def test_personal_editor_ignores_project_organization_acl(tmp_path) -> None:
         assert project_access_service.get_effective_project_role(
             conn, personal_editor, project["id"]
         ) == "editor"
+        assert project_access_service.get_effective_project_role(
+            conn, personal_viewer, project["id"]
+        ) is None
         assert project_access_service.get_effective_project_role(
             conn, organization_editor, project["id"]
         ) is None

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -1550,7 +1550,15 @@ def test_report_runtime_status_binds_pending_deferred_contexts_through_the_real_
                 metadata_json=json.dumps(legacy_metadata),
             )
         )
-        assert _run_sqlite_data_migrations(connection) == {
+        counts = _run_sqlite_data_migrations(connection)
+        assert {
+            key: counts[key]
+            for key in (
+                "legacy_deferred_definitions",
+                "legacy_deferred_runs",
+                "legacy_deferred_deliveries",
+            )
+        } == {
             "legacy_deferred_definitions": 0,
             "legacy_deferred_runs": 0,
             "legacy_deferred_deliveries": 0,
@@ -1744,6 +1752,11 @@ def test_pair_persists_with_locked_incremental_config_save(monkeypatch) -> None:
         },
     )
     monkeypatch.setattr(remote_access.api, "save_config", lambda payload: save_payloads.append(payload) or config)
+    monkeypatch.setattr(
+        remote_access,
+        "_run_pending_deferred_context_migration",
+        lambda: {"legacy_deferred_definitions": 0, "legacy_deferred_runs": 0, "legacy_deferred_deliveries": 0, "binding_status": "sealed"},
+    )
     monkeypatch.setattr(remote_access, "start", lambda next_config: {"ok": True, "running": True})
     monkeypatch.setattr(remote_access, "status", lambda next_config=None: {"ok": True, "running": True, "paired": True})
     monkeypatch.setattr(remote_access, "report_runtime_status", lambda *args, **kwargs: {"ok": True})
@@ -1780,6 +1793,11 @@ def test_pair_accepts_legacy_or_invalid_instance_kind_as_unknown(monkeypatch, re
         response["instance_kind"] = reported_kind
     monkeypatch.setattr(remote_access, "_json_request", lambda *args, **kwargs: response)
     monkeypatch.setattr(remote_access.api, "save_config", lambda payload: save_payloads.append(payload) or config)
+    monkeypatch.setattr(
+        remote_access,
+        "_run_pending_deferred_context_migration",
+        lambda: {"legacy_deferred_definitions": 0, "legacy_deferred_runs": 0, "legacy_deferred_deliveries": 0, "binding_status": "sealed"},
+    )
     monkeypatch.setattr(remote_access, "start", lambda next_config: {"ok": True})
     monkeypatch.setattr(remote_access, "status", lambda next_config=None: {"ok": True})
     monkeypatch.setattr(remote_access, "report_runtime_status", lambda *args, **kwargs: {"ok": True})
@@ -1856,6 +1874,86 @@ def test_pair_reports_success_when_connector_start_fails(monkeypatch, tmp_path) 
     assert result["start"]["ok"] is False
     assert result["start"]["error"] == "cloudflared_spawn_failed"
     assert saved_payload["remote_access"]["vibe_cloud"]["tunnel_token"] == "tunnel-token"
+
+
+def _pair_redeem_response(*, instance_id: str = "inst_new") -> dict[str, str]:
+    return {
+        "instance_id": instance_id,
+        "instance_kind": "personal",
+        "client_id": "vr_client_new",
+        "issuer": "https://backend.test",
+        "authorization_endpoint": "https://backend.test/oauth/authorize",
+        "token_endpoint": "https://backend.test/oauth/token",
+        "jwks_uri": "https://backend.test/oauth/jwks.json",
+        "public_url": "https://new.avibe.bot",
+        "redirect_uri": "https://new.avibe.bot/auth/callback",
+        "tunnel_token": "new-tunnel-token",
+        "instance_secret": "new-instance-secret",
+    }
+
+
+def test_pair_aborts_when_legacy_provenance_cannot_be_read(monkeypatch, tmp_path) -> None:
+    """An unavailable pre-pair config read must not replace the pairing."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _config()
+    config.remote_access.vibe_cloud.enabled = False
+    config.remote_access.vibe_cloud.instance_id = ""
+    config.remote_access.vibe_cloud.instance_secret = ""
+    config.save()
+    original = json.loads((tmp_path / "config" / "config.json").read_text(encoding="utf-8"))
+
+    monkeypatch.setattr(remote_access, "_json_request", lambda *args, **kwargs: _pair_redeem_response())
+    monkeypatch.setattr(
+        remote_access,
+        "_run_pending_deferred_context_migration",
+        lambda: (_ for _ in ()).throw(RuntimeError("legacy_deferred_context_provenance_unavailable")),
+    )
+    saves: list[dict] = []
+    monkeypatch.setattr(
+        remote_access.api,
+        "save_config",
+        lambda payload, **kwargs: saves.append(payload) or config,
+    )
+    monkeypatch.setattr(remote_access, "start", lambda next_config: {"ok": True})
+
+    result = remote_access.pair("vrp_test", "https://backend.test")
+
+    assert result["ok"] is False
+    assert result["error"] == "pairing_provenance_unavailable"
+    assert saves == []
+    assert json.loads((tmp_path / "config" / "config.json").read_text(encoding="utf-8")) == original
+
+
+def test_pair_aborts_when_pending_migration_fails(monkeypatch, tmp_path) -> None:
+    """A failing deferred migration must not let pair() stamp a new identity."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _config()
+    config.remote_access.vibe_cloud.enabled = False
+    config.remote_access.vibe_cloud.instance_id = ""
+    config.save()
+    original = json.loads((tmp_path / "config" / "config.json").read_text(encoding="utf-8"))
+
+    monkeypatch.setattr(remote_access, "_json_request", lambda *args, **kwargs: _pair_redeem_response())
+    monkeypatch.setattr(
+        remote_access,
+        "_run_pending_deferred_context_migration",
+        lambda: (_ for _ in ()).throw(RuntimeError("sqlite locked")),
+    )
+    saves: list[dict] = []
+    monkeypatch.setattr(
+        remote_access.api,
+        "save_config",
+        lambda payload, **kwargs: saves.append(payload) or config,
+    )
+
+    result = remote_access.pair("vrp_test", "https://backend.test")
+
+    assert result["ok"] is False
+    assert result["error"] == "pairing_provenance_unavailable"
+    assert saves == []
+    assert json.loads((tmp_path / "config" / "config.json").read_text(encoding="utf-8")) == original
 
 
 def test_pair_rejects_origin_update_failure_before_saving_config(monkeypatch, tmp_path) -> None:
@@ -1943,6 +2041,11 @@ def test_pair_queues_lifecycle_status_for_drain(monkeypatch, tmp_path) -> None:
         },
     )
     monkeypatch.setattr(remote_access.api, "save_config", lambda payload: config)
+    monkeypatch.setattr(
+        remote_access,
+        "_run_pending_deferred_context_migration",
+        lambda: {"legacy_deferred_definitions": 0, "legacy_deferred_runs": 0, "legacy_deferred_deliveries": 0, "binding_status": "sealed"},
+    )
     monkeypatch.setattr(remote_access, "start", lambda next_config: {"ok": False, "error": "cloudflared_spawn_failed"})
     monkeypatch.setattr(remote_access, "status", lambda next_config=None: {"ok": True, "running": False, "paired": True})
     monkeypatch.setattr(

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -1498,6 +1498,101 @@ def test_report_runtime_status_backfills_instance_kind_once(monkeypatch, tmp_pat
     ]
 
 
+def test_report_runtime_status_binds_pending_deferred_contexts_through_the_real_path(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """A long-running upgraded service must not need another initialization.
+
+    The heartbeat is the only place the authoritative kind arrives, so it owns
+    rerunning the pending migration itself rather than relying on a later
+    ``ensure_sqlite_state()`` call.
+    """
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _config()
+    cloud = config.remote_access.vibe_cloud
+    cloud.backend_url = "https://backend.test"
+    cloud.instance_secret = "instance-secret"
+    cloud.instance_kind = ""
+    config.save()
+
+    from storage.db import get_cached_sqlite_engine
+    from storage.importer import _run_sqlite_data_migrations, ensure_sqlite_state
+    from storage.models import run_definitions, state_meta
+    from storage.resource_access_service import (
+        LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY,
+        RESOURCE_USER_CONTEXT_METADATA_KEY,
+        resource_user_context_from_metadata,
+    )
+
+    legacy_metadata = {
+        RESOURCE_USER_CONTEXT_METADATA_KEY: {
+            "sub": "legacy-editor",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "email",
+            "claims_issued_at": 1_700_000_000,
+        }
+    }
+    ensure_sqlite_state()
+    engine = get_cached_sqlite_engine()
+    with engine.begin() as connection:
+        connection.execute(
+            run_definitions.insert().values(
+                id="legacy-task",
+                definition_type="scheduled",
+                name="legacy task",
+                message="run",
+                schedule_type="interval",
+                enabled=1,
+                created_at="2026-08-20T00:00:00Z",
+                updated_at="2026-08-20T00:00:00Z",
+                metadata_json=json.dumps(legacy_metadata),
+            )
+        )
+        assert _run_sqlite_data_migrations(connection) == {
+            "legacy_deferred_definitions": 0,
+            "legacy_deferred_runs": 0,
+            "legacy_deferred_deliveries": 0,
+        }
+        marker = json.loads(
+            connection.execute(
+                select(state_meta.c.value_json).where(
+                    state_meta.c.key == LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY
+                )
+            ).scalar_one()
+        )
+    assert marker["state"] == "pending"
+    assert marker["instance_id"] == "inst_123"
+
+    monkeypatch.setattr(
+        remote_access,
+        "runtime_status_payload",
+        lambda *args, **kwargs: {"event": "heartbeat"},
+    )
+    monkeypatch.setattr(
+        remote_access,
+        "_json_request",
+        lambda *args, **kwargs: {"ok": True, "instance_kind": "personal"},
+    )
+
+    assert remote_access.report_runtime_status(config)["ok"] is True
+
+    assert V2Config.load().remote_access.vibe_cloud.instance_kind == "personal"
+    with engine.connect() as connection:
+        metadata = json.loads(
+            connection.execute(
+                select(run_definitions.c.metadata_json).where(
+                    run_definitions.c.id == "legacy-task"
+                )
+            ).scalar_one()
+        )
+    snapshot = metadata[RESOURCE_USER_CONTEXT_METADATA_KEY]
+    assert snapshot["vibe_instance_id"] == "inst_123"
+    assert snapshot["vibe_instance_kind"] == "personal"
+    assert resource_user_context_from_metadata(metadata) is not None
+
+
 @pytest.mark.parametrize("reported_kind", [None, "enterprise", "", 7])
 def test_report_runtime_status_ignores_invalid_instance_kind(
     monkeypatch,

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -1474,6 +1474,12 @@ def test_report_runtime_status_backfills_instance_kind_once(monkeypatch, tmp_pat
         "_json_request",
         lambda *args, **kwargs: {"ok": True, "instance_kind": "organization"},
     )
+    migration_calls = []
+    monkeypatch.setattr(
+        remote_access,
+        "_run_pending_deferred_context_migration",
+        lambda: migration_calls.append(True),
+    )
     real_save_config = remote_access.api.save_config
     saves = []
 
@@ -1486,6 +1492,7 @@ def test_report_runtime_status_backfills_instance_kind_once(monkeypatch, tmp_pat
     assert remote_access.report_runtime_status(config)["ok"] is True
     assert V2Config.load().remote_access.vibe_cloud.instance_kind == "organization"
     assert remote_access.report_runtime_status(V2Config.load())["ok"] is True
+    assert migration_calls == [True]
     assert saves == [
         {"remote_access": {"vibe_cloud": {"instance_kind": "organization"}}}
     ]

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -1903,7 +1903,13 @@ def test_pair_aborts_when_legacy_provenance_cannot_be_read(monkeypatch, tmp_path
     config.save()
     original = json.loads((tmp_path / "config" / "config.json").read_text(encoding="utf-8"))
 
-    monkeypatch.setattr(remote_access, "_json_request", lambda *args, **kwargs: _pair_redeem_response())
+    redeem_calls: list[str] = []
+
+    def fake_request(url: str, payload: dict, timeout: float = 20.0, **kwargs):
+        redeem_calls.append(url)
+        return _pair_redeem_response()
+
+    monkeypatch.setattr(remote_access, "_json_request", fake_request)
     monkeypatch.setattr(
         remote_access,
         "_run_pending_deferred_context_migration",
@@ -1922,6 +1928,7 @@ def test_pair_aborts_when_legacy_provenance_cannot_be_read(monkeypatch, tmp_path
     assert result["ok"] is False
     assert result["error"] == "pairing_provenance_unavailable"
     assert saves == []
+    assert redeem_calls == []
     assert json.loads((tmp_path / "config" / "config.json").read_text(encoding="utf-8")) == original
 
 
@@ -1935,7 +1942,13 @@ def test_pair_aborts_when_pending_migration_fails(monkeypatch, tmp_path) -> None
     config.save()
     original = json.loads((tmp_path / "config" / "config.json").read_text(encoding="utf-8"))
 
-    monkeypatch.setattr(remote_access, "_json_request", lambda *args, **kwargs: _pair_redeem_response())
+    redeem_calls: list[str] = []
+
+    def fake_request(url: str, payload: dict, timeout: float = 20.0, **kwargs):
+        redeem_calls.append(url)
+        return _pair_redeem_response()
+
+    monkeypatch.setattr(remote_access, "_json_request", fake_request)
     monkeypatch.setattr(
         remote_access,
         "_run_pending_deferred_context_migration",
@@ -1953,6 +1966,7 @@ def test_pair_aborts_when_pending_migration_fails(monkeypatch, tmp_path) -> None
     assert result["ok"] is False
     assert result["error"] == "pairing_provenance_unavailable"
     assert saves == []
+    assert redeem_calls == []
     assert json.loads((tmp_path / "config" / "config.json").read_text(encoding="utf-8")) == original
 
 
@@ -1999,6 +2013,11 @@ def test_pair_rejects_origin_update_failure_before_saving_config(monkeypatch, tm
 
 
 def test_pair_returns_structured_error_when_backend_request_fails(monkeypatch) -> None:
+    monkeypatch.setattr(
+        remote_access,
+        "_run_pending_deferred_context_migration",
+        lambda: {"legacy_deferred_definitions": 0, "legacy_deferred_runs": 0, "legacy_deferred_deliveries": 0, "binding_status": "sealed"},
+    )
     monkeypatch.setattr(remote_access, "_json_request", lambda *args, **kwargs: (_ for _ in ()).throw(OSError("offline")))
 
     result = remote_access.pair("vrp_test", "https://backend.test")
@@ -2012,6 +2031,11 @@ def test_pair_preserves_backend_error_response(monkeypatch) -> None:
     def fake_request(*args, **kwargs):
         raise remote_access.BackendRequestError(400, {"error": "invalid_pairing_key"})
 
+    monkeypatch.setattr(
+        remote_access,
+        "_run_pending_deferred_context_migration",
+        lambda: {"legacy_deferred_definitions": 0, "legacy_deferred_runs": 0, "legacy_deferred_deliveries": 0, "binding_status": "sealed"},
+    )
     monkeypatch.setattr(remote_access, "_json_request", fake_request)
 
     result = remote_access.pair("vrp_test", "https://backend.test")

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -189,6 +189,38 @@ def test_validated_remote_payload_projects_paired_instance_kind(tmp_path):
     assert context_from_session_payload(payload).is_personal_instance
 
 
+def test_partial_pairing_cannot_restore_cached_personal_authorization(tmp_path):
+    config = _paired_config(tmp_path)
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.remote_access.vibe_cloud.instance_secret = ""
+    config.save()
+
+    payload = remote_access._validated_authorization_payload(
+        config,
+        {
+            "sub": "personal-user",
+            "email": "personal@example.com",
+            "instance_id": "inst_123",
+        },
+        {
+            "id": "authorization-1",
+            "claims": {**_organization_claims(config), "vibe_instance_kind": "organization"},
+        },
+    )
+
+    assert payload is None
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    resolution = remote_access.resolve_current_authorization(
+        config,
+        identity,
+        allow_refresh=False,
+    )
+    assert resolution.state == "unavailable"
+    assert resolution.reason == "pairing_unavailable"
+
+
 def test_personal_revision_hint_refreshes_in_background_without_blocking(
     monkeypatch,
     tmp_path,

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -512,6 +512,68 @@ def test_refresh_from_a_previous_binding_generation_is_discarded(monkeypatch, tm
     )
 
 
+def test_stale_cross_process_kind_response_cannot_reverse_durable_generation(
+    monkeypatch,
+    tmp_path,
+):
+    """A UI-process in-flight Personal response must not undo a controller reclass.
+
+    The controller and UI server are separate processes; the in-memory
+    binding epoch cannot fence this. The durable generation in state_meta
+    is the compare-and-swap token both processes share.
+    """
+
+    config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="personal",
+    )
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.save()
+    cookie = remote_access.make_session_cookie(
+        config,
+        "user-1@example.com",
+        "user-1",
+        session_claims={
+            "vibe_instance_id": "inst_123",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "email",
+            "vibe_instance_authorization_revision": 41,
+        },
+    )
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    now = int(time.time())
+    observed_generation = remote_access_authorization_service.current_instance_binding_generation()
+    # Controller heartbeat in another process: Personal -> Organization.
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="organization",
+    )
+    config.remote_access.vibe_cloud.instance_kind = "organization"
+    config.save()
+    newer = remote_access_authorization_service.load_instance_binding_state()
+    assert newer is not None
+    assert newer["generation"] > observed_generation
+    assert newer["instance_kind"] == "organization"
+
+    # Stale UI-process in-flight epoch is unchanged; durable generation is not.
+    monkeypatch.setattr(remote_access, "_authorization_binding_epoch", lambda: 0)
+    persisted = remote_access._persist_instance_kind(
+        "inst_123",
+        "personal",
+        expected_binding_generation=observed_generation,
+        expected_binding_epoch=0,
+    )
+
+    assert persisted is False
+    assert V2Config.load().remote_access.vibe_cloud.instance_kind == "organization"
+    after = remote_access_authorization_service.load_instance_binding_state()
+    assert after is not None
+    assert after["generation"] == newer["generation"]
+    assert after["instance_kind"] == "organization"
+
+
 def test_exact_show_page_grants_survive_a_kind_transition_but_not_a_repair(tmp_path):
     """Show Page grants are their own scope, bound to the instance that issued them."""
 
@@ -1046,7 +1108,7 @@ def test_refresh_backoff_starts_when_the_network_request_finishes(
     identity = remote_access.parse_session_identity(config, _organization_cookie(config))
     assert identity is not None
     monkeypatch.setattr(remote_access, "current_authorization_revision", lambda *args, **kwargs: 42)
-    monotonic_values = iter((100.0, 110.0, 110.1))
+    monotonic_values = iter((100.0, 110.0, 110.05, 110.1, 110.15, 110.2))
     monkeypatch.setattr(remote_access.time, "monotonic", lambda: next(monotonic_values))
     calls = 0
 

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -293,6 +293,329 @@ def test_partial_pairing_preserves_exact_show_page_email_grant(tmp_path):
     assert resolution.payload["vibe_show_page_id"] == "show-1"
 
 
+def test_organization_to_personal_reclassification_revalidates_before_the_bypass(
+    monkeypatch,
+    tmp_path,
+):
+    """A reclassified pairing must re-earn every instance-scoped authorization."""
+
+    config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="organization",
+    )
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    reference = identity["authorization_ref"]
+    now = int(time.time())
+    admitted = remote_access_authorization_service.load_reference_record(
+        reference=reference,
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert admitted is not None
+    assert admitted["authorization_state"] == "current"
+
+    assert remote_access._persist_instance_kind("inst_123", "personal", reconcile=True) is True
+
+    reclassified = V2Config.load()
+    assert reclassified.remote_access.vibe_cloud.instance_kind == "personal"
+    invalidated = remote_access_authorization_service.load_reference_record(
+        reference=reference,
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert invalidated is not None
+    assert invalidated["authorization_state"] == "stale"
+
+    # The cached Organization claims must not be re-projected as Personal.
+    blocked = remote_access.resolve_current_authorization(
+        reclassified,
+        identity,
+        allow_refresh=False,
+    )
+    assert blocked.current is False
+    assert blocked.reason == "authorization_context_missing"
+
+    calls = []
+
+    def refresh(_config, _method, _suffix, payload, **kwargs):
+        calls.append(payload)
+        return _authorization_context_response(
+            config,
+            payload,
+            revision=41,
+            instance_kind="personal",
+        )
+
+    monkeypatch.setattr(remote_access, "_device_json_request", refresh)
+
+    result = remote_access.resolve_current_authorization(reclassified, identity)
+
+    assert result.current is True
+    assert result.refreshed is True
+    assert result.policy == "personal"
+    # Synchronous revalidation, not a background hint that would let the
+    # Personal bypass answer this very request from the stale row.
+    assert len(calls) == 1
+    revalidated = remote_access_authorization_service.load_reference_record(
+        reference=reference,
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert revalidated is not None
+    assert revalidated["authorization_state"] == "current"
+    assert revalidated["claims"]["vibe_instance_kind"] == "personal"
+
+
+def test_instance_kind_persistence_failure_leaves_no_kind_tagged_current_row(
+    monkeypatch,
+    tmp_path,
+):
+    """A failed kind write must not leave a usable Personal projection behind."""
+
+    config = _paired_config(tmp_path)
+    config.remote_access.vibe_cloud.instance_kind = ""
+    config.save()
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    reference = identity["authorization_ref"]
+    now = int(time.time())
+    # Collapse the failure backoff so the retry below exercises the network
+    # path instead of the short-circuit that protects the backend.
+    monkeypatch.setattr(remote_access, "AUTHORIZATION_REFRESH_FAILURE_BACKOFF_SECONDS", 0.0)
+    monkeypatch.setattr(
+        remote_access,
+        "current_authorization_revision",
+        lambda *args, **kwargs: 42,
+    )
+    monkeypatch.setattr(
+        remote_access,
+        "_device_json_request",
+        lambda _config, _method, _suffix, payload, **kwargs: _authorization_context_response(
+            config,
+            payload,
+            revision=42,
+            instance_kind="personal",
+        ),
+    )
+    real_save_config = remote_access.api.save_config
+    attempted: list[dict[str, Any]] = []
+
+    def failing_save_config(payload, **kwargs):
+        attempted.append(payload)
+        raise OSError("read-only config")
+
+    monkeypatch.setattr(remote_access.api, "save_config", failing_save_config)
+
+    blocked = remote_access.resolve_current_authorization(config, identity)
+
+    assert blocked.state == "unavailable"
+    assert blocked.reason == "instance_kind_persistence_failed"
+    assert attempted
+    assert V2Config.load().remote_access.vibe_cloud.instance_kind == ""
+    stored = remote_access_authorization_service.load_reference_record(
+        reference=reference,
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert stored is not None
+    assert "vibe_instance_kind" not in stored["claims"]
+    kindless_payload = remote_access._validated_authorization_payload(
+        config,
+        identity,
+        stored,
+    )
+    assert kindless_payload is not None
+    assert context_from_session_payload(kindless_payload).is_personal_instance is False
+
+    monkeypatch.setattr(remote_access.api, "save_config", real_save_config)
+
+    retried = remote_access.resolve_current_authorization(config, identity)
+
+    assert retried.current is True
+    assert retried.policy == "personal"
+    assert V2Config.load().remote_access.vibe_cloud.instance_kind == "personal"
+    repaired = remote_access_authorization_service.load_reference_record(
+        reference=reference,
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert repaired is not None
+    assert repaired["claims"]["vibe_instance_kind"] == "personal"
+
+
+def test_refresh_from_a_previous_binding_generation_is_discarded(monkeypatch, tmp_path):
+    """An in-flight response that outlived its binding must not be cached."""
+
+    config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="organization",
+    )
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    now = int(time.time())
+    record = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert record is not None
+    binding_before = remote_access_authorization_service.load_instance_binding_state()
+    assert binding_before is not None
+
+    def repair_while_in_flight(_config, _method, _suffix, payload, **kwargs):
+        # A re-pair lands while this authorization response is in flight.
+        remote_access._transition_instance_binding(
+            instance_id="inst_repair",
+            instance_kind="personal",
+        )
+        return _authorization_context_response(config, payload, revision=41)
+
+    monkeypatch.setattr(remote_access, "_device_json_request", repair_while_in_flight)
+
+    result = remote_access._refresh_authorization_context(
+        config,
+        identity,
+        record,
+        now=now,
+        force=True,
+    )
+
+    assert result.state == "unavailable"
+    assert result.reason == "instance_binding_changed"
+    binding_after = remote_access_authorization_service.load_instance_binding_state()
+    assert binding_after is not None
+    assert binding_after["generation"] > binding_before["generation"]
+    assert binding_after["instance_id"] == "inst_repair"
+    with remote_access._AUTHORIZATION_REFRESH_LOCK:
+        assert remote_access._AUTHORIZATION_REFRESH_RESULTS == {}
+        assert remote_access._AUTHORIZATION_REFRESH_FAILURES == {}
+    # The discarded generation must not be answerable from cache either.
+    assert (
+        remote_access.resolve_current_authorization(
+            config,
+            identity,
+            allow_refresh=False,
+        ).current
+        is False
+    )
+
+
+def test_exact_show_page_grants_survive_a_kind_transition_but_not_a_repair(tmp_path):
+    """Show Page grants are their own scope, bound to the instance that issued them."""
+
+    config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="organization",
+    )
+    now = int(time.time())
+    show_page_claims = {
+        "vibe_instance_id": "inst_123",
+        "vibe_instance_role": "viewer",
+        "vibe_instance_access_source": "show_page_email",
+        "vibe_show_page_id": "show-1",
+        "vibe_instance_authorization_revision": 41,
+    }
+    show_page_cookie = remote_access.make_session_cookie(
+        config,
+        "viewer@example.com",
+        "viewer-1",
+        session_claims=show_page_claims,
+    )
+    show_page_identity = remote_access.parse_session_identity(config, show_page_cookie)
+    assert show_page_identity is not None
+    instance_identity = remote_access.parse_session_identity(
+        config,
+        _organization_cookie(config),
+    )
+    assert instance_identity is not None
+
+    assert remote_access._persist_instance_kind("inst_123", "personal", reconcile=True) is True
+
+    reclassified = V2Config.load()
+    show_page = remote_access_authorization_service.load_scoped(
+        instance_id="inst_123",
+        subject="viewer-1",
+        scope_kind="show_page",
+        scope_ref="show-1",
+    )
+    instance = remote_access_authorization_service.load_scoped(
+        instance_id="inst_123",
+        subject="user-1",
+        scope_kind="instance",
+        scope_ref="inst_123",
+    )
+    assert show_page is not None
+    assert show_page["authorization_state"] == "current"
+    assert show_page["claims"]["vibe_show_page_id"] == "show-1"
+    assert instance is not None
+    assert instance["authorization_state"] == "stale"
+
+    resolved = remote_access.resolve_current_authorization(
+        reclassified,
+        show_page_identity,
+        allow_refresh=False,
+    )
+    assert resolved.current is True
+    assert resolved.payload is not None
+    assert resolved.payload["vibe_show_page_id"] == "show-1"
+
+    # Mid-transition the exact grant still reads, while the instance-scoped
+    # cache stays fail-closed.
+    reconciling = remote_access_authorization_service.begin_instance_binding_transition(
+        instance_id="inst_repair",
+        instance_kind="personal",
+    )
+    assert (
+        reconciling["state"]
+        == remote_access_authorization_service.INSTANCE_BINDING_STATE_RECONCILING
+    )
+    assert (
+        remote_access._durable_binding_allows_cached_authorization(
+            reclassified,
+            show_page_identity,
+            show_page,
+        )
+        is True
+    )
+    assert (
+        remote_access._durable_binding_allows_cached_authorization(
+            reclassified,
+            instance_identity,
+            instance,
+        )
+        is False
+    )
+
+    # Re-pairing to a different instance is not a reclassification: those
+    # grants were issued by the previous instance and must not survive it.
+    remote_access._transition_instance_binding(
+        instance_id="inst_repair",
+        instance_kind="personal",
+        previous_instance_id="inst_123",
+    )
+    repaired = remote_access_authorization_service.load_scoped(
+        instance_id="inst_123",
+        subject="viewer-1",
+        scope_kind="show_page",
+        scope_ref="show-1",
+    )
+    assert repaired is not None
+    assert repaired["authorization_state"] == "stale"
+
+
 def test_personal_revision_hint_refreshes_in_background_without_blocking(
     monkeypatch,
     tmp_path,

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -221,6 +221,37 @@ def test_partial_pairing_cannot_restore_cached_personal_authorization(tmp_path):
     assert resolution.reason == "pairing_unavailable"
 
 
+def test_partial_pairing_preserves_exact_show_page_email_grant(tmp_path):
+    config = _paired_config(tmp_path)
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.remote_access.vibe_cloud.instance_secret = ""
+    config.save()
+    cookie = remote_access.make_session_cookie(
+        config,
+        "viewer@example.com",
+        "viewer-1",
+        session_claims={
+            "vibe_instance_id": "inst_123",
+            "vibe_instance_role": "viewer",
+            "vibe_instance_access_source": "show_page_email",
+            "vibe_show_page_id": "show-1",
+            "vibe_instance_authorization_revision": 41,
+        },
+    )
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+
+    resolution = remote_access.resolve_current_authorization(
+        config,
+        identity,
+        allow_refresh=False,
+    )
+
+    assert resolution.current is True
+    assert resolution.payload is not None
+    assert resolution.payload["vibe_show_page_id"] == "show-1"
+
+
 def test_personal_revision_hint_refreshes_in_background_without_blocking(
     monkeypatch,
     tmp_path,
@@ -355,7 +386,7 @@ def test_organization_refresh_grace_expiry_and_recovery(monkeypatch, tmp_path):
     assert recovered.payload["vibe_instance_authorization_revision"] == 42
 
 
-def test_unknown_instance_kind_backfills_without_failing_valid_access(
+def test_unknown_instance_kind_requires_durable_backfill_before_access(
     monkeypatch,
     tmp_path,
 ):
@@ -382,9 +413,9 @@ def test_unknown_instance_kind_backfills_without_failing_valid_access(
 
     result = remote_access.resolve_current_authorization(config, identity)
 
-    assert result.current is True
-    assert result.policy == "organization"
-    assert config.remote_access.vibe_cloud.instance_kind == "organization"
+    assert result.state == "unavailable"
+    assert result.reason == "instance_kind_persistence_failed"
+    assert config.remote_access.vibe_cloud.instance_kind == ""
 
 
 def test_scoped_authorization_promotes_legacy_rows_and_isolates_show_pages(tmp_path):

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -33,6 +33,7 @@ def _clear_authorization_refresh_process_state():
         remote_access._AUTHORIZATION_REFRESH_FAILURES.clear()
         remote_access._AUTHORIZATION_REFRESH_RESULTS.clear()
         remote_access._AUTHORIZATION_REFRESH_FLIGHTS.clear()
+        remote_access._AUTHORIZATION_REFRESH_FLIGHT_EPOCHS.clear()
     with remote_access._AUTHORIZATION_BACKGROUND_REFRESH_LOCK:
         remote_access._AUTHORIZATION_BACKGROUND_REFRESHES.clear()
     yield
@@ -40,6 +41,7 @@ def _clear_authorization_refresh_process_state():
         remote_access._AUTHORIZATION_REFRESH_FAILURES.clear()
         remote_access._AUTHORIZATION_REFRESH_RESULTS.clear()
         remote_access._AUTHORIZATION_REFRESH_FLIGHTS.clear()
+        remote_access._AUTHORIZATION_REFRESH_FLIGHT_EPOCHS.clear()
 
 
 def _paired_config(tmp_path, *, revision: int = 41) -> V2Config:

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -169,6 +169,26 @@ def test_personal_session_slides_past_claim_and_original_identity_deadlines(
     assert result.payload["claims_issued_at"] == base
 
 
+def test_validated_remote_payload_projects_paired_instance_kind(tmp_path):
+    config = _paired_config(tmp_path)
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    payload = remote_access._validated_authorization_payload(
+        config,
+        {
+            "sub": "personal-user",
+            "email": "personal@example.com",
+            "instance_id": "inst_123",
+        },
+        {
+            "id": "authorization-1",
+            "claims": {**_organization_claims(config), "vibe_instance_kind": "organization"},
+        },
+    )
+
+    assert payload is not None
+    assert context_from_session_payload(payload).is_personal_instance
+
+
 def test_personal_revision_hint_refreshes_in_background_without_blocking(
     monkeypatch,
     tmp_path,

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -574,6 +574,115 @@ def test_stale_cross_process_kind_response_cannot_reverse_durable_generation(
     assert after["instance_kind"] == "organization"
 
 
+def test_stale_write_is_refused_under_cross_process_config_lock(tmp_path):
+    """Two threads contend on config_file_lock; the stale writer must abort.
+
+    This is the real cross-process lock boundary (the same lock V2Config.save
+    uses), not the in-process epoch.
+    """
+
+    from config.v2_config import config_file_lock
+
+    config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="personal",
+    )
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.save()
+    observed = remote_access_authorization_service.current_instance_binding_generation()
+    # flock is process-level, so two threads in one process cannot actually
+    # block each other on config_file_lock. Model the cross-process race as:
+    # snapshot generation, then a controller advance under that lock, then a
+    # stale persist that must CAS-fail against the durable generation.
+    with config_file_lock():
+        remote_access._transition_instance_binding(
+            instance_id="inst_123",
+            instance_kind="organization",
+        )
+        config.remote_access.vibe_cloud.instance_kind = "organization"
+        config.save()
+    controller_generation = (
+        remote_access_authorization_service.current_instance_binding_generation()
+    )
+    stale_ok = remote_access._persist_instance_kind(
+        "inst_123",
+        "personal",
+        expected_binding_generation=observed,
+    )
+
+    assert stale_ok is False
+    assert controller_generation > observed
+    assert V2Config.load().remote_access.vibe_cloud.instance_kind == "organization"
+    after = remote_access_authorization_service.load_instance_binding_state()
+    assert after is not None
+    assert after["instance_kind"] == "organization"
+    assert after["generation"] == controller_generation
+
+
+def test_stale_denied_response_does_not_recreate_revoked_row(monkeypatch, tmp_path):
+    """A 403 captured before a transition must not recreate a revoked row."""
+
+    config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="organization",
+    )
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    now = int(time.time())
+    record = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert record is not None
+    observed = remote_access_authorization_service.current_instance_binding_generation()
+    real_generation = remote_access_authorization_service.current_instance_binding_generation
+    calls = {"n": 0}
+
+    def deny_after_transition(_config, _method, _suffix, payload, **kwargs):
+        remote_access._transition_instance_binding(
+            instance_id="inst_123",
+            instance_kind="personal",
+        )
+        raise remote_access.BackendRequestError(403, {"error": "access_denied"})
+
+    def generation(*, ensure: bool = True) -> int:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return observed
+        return real_generation(ensure=ensure)
+
+    monkeypatch.setattr(remote_access, "_device_json_request", deny_after_transition)
+    monkeypatch.setattr(
+        remote_access_authorization_service,
+        "current_instance_binding_generation",
+        generation,
+    )
+
+    result = remote_access._fetch_authorization_context(
+        config,
+        identity,
+        record,
+        now=now,
+        observed_revision=41,
+    )
+
+    assert result.state == "unavailable"
+    assert result.reason == "instance_binding_changed"
+    stored = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    if stored is not None:
+        assert stored.get("authorization_state") != "revoked"
+
+
 def test_exact_show_page_grants_survive_a_kind_transition_but_not_a_repair(tmp_path):
     """Show Page grants are their own scope, bound to the instance that issued them."""
 

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -181,12 +181,51 @@ def test_validated_remote_payload_projects_paired_instance_kind(tmp_path):
         },
         {
             "id": "authorization-1",
-            "claims": {**_organization_claims(config), "vibe_instance_kind": "organization"},
+            "claims": {**_organization_claims(config), "vibe_instance_kind": "personal"},
         },
     )
 
     assert payload is not None
     assert context_from_session_payload(payload).is_personal_instance
+
+
+def test_cached_authorization_from_previous_instance_kind_refreshes_before_personal_bypass(
+    monkeypatch,
+    tmp_path,
+):
+    config = _paired_config(tmp_path)
+    cookie = _organization_cookie(config)
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.save()
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    calls = []
+
+    def refresh(_config, _method, _suffix, payload, **kwargs):
+        calls.append(payload)
+        return _authorization_context_response(
+            config,
+            payload,
+            revision=41,
+            instance_kind="personal",
+        )
+
+    monkeypatch.setattr(remote_access, "_device_json_request", refresh)
+
+    result = remote_access.resolve_current_authorization(config, identity)
+
+    assert result.current is True
+    assert result.refreshed is True
+    assert result.policy == "personal"
+    assert len(calls) == 1
+    record = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=int(time.time()),
+    )
+    assert record is not None
+    assert record["claims"]["vibe_instance_kind"] == "personal"
 
 
 def test_partial_pairing_cannot_restore_cached_personal_authorization(tmp_path):

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -566,8 +566,18 @@ def test_http_resource_services_reuse_the_parsed_authorization_context() -> None
         assert resource_access_service.resolve_resource_access_context() is context
 
 
-def test_deferred_remote_context_remains_valid_past_authorization_refresh_boundary() -> None:
+def test_deferred_remote_context_remains_valid_past_authorization_refresh_boundary(
+    monkeypatch,
+    tmp_path,
+) -> None:
     from vibe import remote_access
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "organization-instance"
+    config.remote_access.vibe_cloud.instance_kind = "organization"
+    config.save()
 
     issued_at = 1_700_000_000
     context = resource_access_service.ResourceUserContext(
@@ -580,6 +590,7 @@ def test_deferred_remote_context_remains_valid_past_authorization_refresh_bounda
         instance_role="viewer",
         instance_access_source="organization_group",
         instance_kind="organization",
+        instance_id="organization-instance",
         claims_issued_at=issued_at,
         is_remote=True,
     )
@@ -604,9 +615,17 @@ def test_deferred_remote_context_remains_valid_past_authorization_refresh_bounda
     assert after.is_active_organization_member is True
 
 
-def test_deferred_personal_context_keeps_instance_kind() -> None:
+def test_deferred_personal_context_keeps_instance_kind(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "personal-instance"
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.save()
+
     context = resource_access_service.ResourceUserContext(
         subject="personal-user",
+        instance_id="personal-instance",
         instance_role="editor",
         instance_access_source="owner",
         instance_kind="personal",
@@ -637,6 +656,38 @@ def test_deferred_context_from_previous_pairing_is_rejected(monkeypatch, tmp_pat
         is_remote=True,
     )
     metadata = resource_access_service.metadata_with_resource_user_context({}, stale_context)
+
+    assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+    assert not resource_access_service.metadata_allows_harness_runtime(metadata)
+
+
+@pytest.mark.parametrize("pairing_state", ["disabled", "unreadable"])
+def test_explicit_deferred_context_requires_current_pairing(
+    monkeypatch,
+    tmp_path,
+    pairing_state: str,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = pairing_state != "disabled"
+    config.remote_access.vibe_cloud.instance_id = "personal-instance"
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.save()
+    if pairing_state == "unreadable":
+        def fail_load(_cls, *_args, **_kwargs):
+            raise OSError("config unavailable")
+
+        monkeypatch.setattr(V2Config, "load", classmethod(fail_load))
+
+    context = resource_access_service.ResourceUserContext(
+        subject="personal-user",
+        instance_id="personal-instance",
+        instance_role="editor",
+        instance_access_source="owner",
+        instance_kind="personal",
+        is_remote=True,
+    )
+    metadata = resource_access_service.metadata_with_resource_user_context({}, context)
 
     assert resource_access_service.resource_user_context_from_metadata(metadata) is None
     assert not resource_access_service.metadata_allows_harness_runtime(metadata)

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -620,6 +620,28 @@ def test_deferred_personal_context_keeps_instance_kind() -> None:
     assert restored.is_personal_instance
 
 
+def test_deferred_context_from_previous_pairing_is_rejected(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "current-instance"
+    config.remote_access.vibe_cloud.instance_kind = "organization"
+    config.save()
+
+    stale_context = resource_access_service.ResourceUserContext(
+        subject="personal-user",
+        instance_id="previous-instance",
+        instance_role="editor",
+        instance_access_source="owner",
+        instance_kind="personal",
+        is_remote=True,
+    )
+    metadata = resource_access_service.metadata_with_resource_user_context({}, stale_context)
+
+    assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+    assert not resource_access_service.metadata_allows_harness_runtime(metadata)
+
+
 @pytest.mark.parametrize(
     ("paired_kind", "expected_kind"),
     [("personal", "personal"), ("organization", "organization"), ("", None)],

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -620,6 +620,36 @@ def test_deferred_personal_context_keeps_instance_kind() -> None:
     assert restored.is_personal_instance
 
 
+@pytest.mark.parametrize(
+    ("paired_kind", "expected_kind"),
+    [("personal", "personal"), ("organization", "organization"), ("", None)],
+)
+def test_legacy_deferred_context_uses_only_known_current_pairing_kind(
+    monkeypatch,
+    tmp_path,
+    paired_kind: str,
+    expected_kind: str | None,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_kind = paired_kind
+    config.save()
+
+    legacy_metadata = {
+        resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: {
+            "sub": "legacy-user",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "email",
+            "claims_issued_at": 1_700_000_000,
+        }
+    }
+    restored = resource_access_service.resource_user_context_from_metadata(legacy_metadata)
+
+    assert restored is not None
+    assert restored.instance_kind == expected_kind
+
+
 def test_personal_resources_cannot_use_organization_access_levels(tmp_path) -> None:
     db = tmp_path / "vibe.sqlite"
     run_migrations(db)

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -1276,6 +1276,456 @@ def test_typed_binding_reader_preserves_partial_identity_and_does_not_latch_read
         engine.dispose()
 
 
+_EMPTY_MIGRATION_COUNTS = {
+    "legacy_deferred_definitions": 0,
+    "legacy_deferred_runs": 0,
+    "legacy_deferred_deliveries": 0,
+}
+
+
+def _paired_cloud_config(
+    tmp_path,
+    *,
+    enabled: bool = True,
+    instance_id: str = "same-instance",
+    instance_kind: str = "personal",
+    instance_secret: str = "instance-secret",
+) -> V2Config:
+    config = V2Config.default()
+    cloud = config.remote_access.vibe_cloud
+    cloud.enabled = enabled
+    cloud.instance_id = instance_id
+    cloud.instance_kind = instance_kind
+    cloud.instance_secret = instance_secret
+    config.save()
+    return config
+
+
+def _seed_legacy_scheduled_task(store, *, definition_id: str, snapshot: dict) -> None:
+    assert store.upsert_scheduled_task(
+        {
+            "id": definition_id,
+            "name": definition_id,
+            "message": "run",
+            "schedule_type": "interval",
+            "created_at": "2026-08-20T00:00:00Z",
+            "updated_at": "2026-08-20T00:00:00Z",
+            "metadata": {resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: snapshot},
+        }
+    )
+
+
+def _legacy_definition_metadata(connection, definition_id: str) -> dict:
+    raw = connection.execute(
+        select(run_definitions.c.metadata_json).where(run_definitions.c.id == definition_id)
+    ).scalar_one()
+    return json.loads(raw)
+
+
+def _stored_migration_marker(connection) -> str | None:
+    return connection.execute(
+        select(state_meta.c.value_json).where(
+            state_meta.c.key == resource_access_service.LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY
+        )
+    ).scalar_one_or_none()
+
+
+def test_partial_pairing_marker_records_configured_instance_without_claiming_a_kind(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """A deferred opportunity keeps its identity but never a guessed kind."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    _paired_cloud_config(tmp_path, instance_secret="")
+
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    try:
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+            marker = json.loads(_stored_migration_marker(connection))
+
+        assert marker["schema_version"] == 2
+        assert marker["state"] == "pending"
+        assert marker["instance_id"] == "same-instance"
+        # A partial pairing cannot prove its kind, so the marker must not
+        # record one and must not look terminal to a later startup.
+        assert "instance_kind" not in marker
+        assert "completed_at" not in marker
+    finally:
+        engine.dispose()
+
+
+def test_credential_repair_on_the_same_pairing_completes_the_deferred_migration(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = _paired_cloud_config(tmp_path, instance_secret="")
+    legacy_snapshot = {
+        "sub": "legacy-user",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": "email",
+        "claims_issued_at": 1_700_000_000,
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        _seed_legacy_scheduled_task(store, definition_id="legacy-task", snapshot=legacy_snapshot)
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+
+        config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+        config.save()
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == {
+                **_EMPTY_MIGRATION_COUNTS,
+                "legacy_deferred_definitions": 1,
+            }
+            metadata = _legacy_definition_metadata(connection, "legacy-task")
+            snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
+            assert snapshot["vibe_instance_id"] == "same-instance"
+            assert snapshot["vibe_instance_kind"] == "personal"
+            assert resource_access_service.resource_user_context_from_metadata(metadata) is not None
+            completed = json.loads(_stored_migration_marker(connection))
+
+        assert completed["state"] == "completed"
+        assert completed["instance_id"] == "same-instance"
+        assert completed["instance_kind"] == "personal"
+        assert completed["completed_at"]
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+            assert json.loads(_stored_migration_marker(connection)) == completed
+            assert (
+                _legacy_definition_metadata(connection, "legacy-task") == metadata
+            )
+    finally:
+        store.close()
+        engine.dispose()
+
+
+def test_transient_configuration_failure_leaves_the_migration_retryable(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    _paired_cloud_config(tmp_path)
+    legacy_snapshot = {
+        "sub": "legacy-user",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": "email",
+        "claims_issued_at": 1_700_000_000,
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        _seed_legacy_scheduled_task(store, definition_id="legacy-task", snapshot=legacy_snapshot)
+        from storage.importer import _run_sqlite_data_migrations
+
+        real_load = V2Config.load
+        with monkeypatch.context() as unreadable:
+            unreadable.setattr(
+                V2Config,
+                "load",
+                classmethod(
+                    lambda cls, *args, **kwargs: (_ for _ in ()).throw(OSError("temporary read"))
+                ),
+            )
+            with engine.begin() as connection:
+                assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+                # No first migration opportunity may be recorded from a read
+                # failure; otherwise the retry below would be fenced out.
+                assert _stored_migration_marker(connection) is None
+
+        assert V2Config.load.__func__ is real_load.__func__
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == {
+                **_EMPTY_MIGRATION_COUNTS,
+                "legacy_deferred_definitions": 1,
+            }
+            metadata = _legacy_definition_metadata(connection, "legacy-task")
+            assert resource_access_service.resource_user_context_from_metadata(metadata) is not None
+    finally:
+        store.close()
+        engine.dispose()
+
+
+def test_unpaired_first_opportunity_cannot_be_adopted_by_a_later_pairing(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = _paired_cloud_config(
+        tmp_path,
+        enabled=False,
+        instance_id="",
+        instance_kind="",
+        instance_secret="",
+    )
+    legacy_snapshot = {
+        "sub": "legacy-user",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": "owner",
+        "claims_issued_at": 1_700_000_000,
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        _seed_legacy_scheduled_task(store, definition_id="legacy-task", snapshot=legacy_snapshot)
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+            sealed = json.loads(_stored_migration_marker(connection))
+
+        assert sealed["state"] == "sealed_unattributed"
+        assert sealed["instance_id"] is None
+
+        cloud = config.remote_access.vibe_cloud
+        cloud.enabled = True
+        cloud.instance_id = "later-instance"
+        cloud.instance_kind = "personal"
+        cloud.instance_secret = "instance-secret"
+        config.save()
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+            metadata = _legacy_definition_metadata(connection, "legacy-task")
+            snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
+            assert "vibe_instance_id" not in snapshot
+            assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+            assert json.loads(_stored_migration_marker(connection))["state"] == "sealed_unattributed"
+    finally:
+        store.close()
+        engine.dispose()
+
+
+def test_pending_marker_for_one_instance_cannot_be_adopted_by_another_instance(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = _paired_cloud_config(tmp_path, instance_id="instance-a", instance_secret="")
+    legacy_snapshot = {
+        "sub": "legacy-user",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": "email",
+        "claims_issued_at": 1_700_000_000,
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        _seed_legacy_scheduled_task(store, definition_id="legacy-task", snapshot=legacy_snapshot)
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+            pending = json.loads(_stored_migration_marker(connection))
+        assert pending["state"] == "pending"
+        assert pending["instance_id"] == "instance-a"
+
+        cloud = config.remote_access.vibe_cloud
+        cloud.instance_id = "instance-b"
+        cloud.instance_secret = "instance-secret"
+        config.save()
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+            sealed = json.loads(_stored_migration_marker(connection))
+            assert sealed["state"] == "sealed_unattributed"
+            # The original owner stays recorded so no later pairing, including
+            # instance A itself, can reopen the sealed opportunity.
+            assert sealed["instance_id"] == "instance-a"
+
+        cloud.instance_id = "instance-a"
+        config.save()
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+            metadata = _legacy_definition_metadata(connection, "legacy-task")
+            snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
+            assert "vibe_instance_id" not in snapshot
+            assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+    finally:
+        store.close()
+        engine.dispose()
+
+
+@pytest.mark.parametrize("paired_kind", ["organization", "personal"])
+@pytest.mark.parametrize("access_source", ["email", "email_domain", "public_instance"])
+def test_shared_access_source_snapshots_migrate_for_either_pairing_kind(
+    monkeypatch,
+    tmp_path,
+    paired_kind: str,
+    access_source: str,
+) -> None:
+    """``email``/``email_domain``/``public_instance`` are kind-agnostic.
+
+    Neither their presence nor the absence of Organization membership claims
+    is instance-kind evidence, so the still-current pairing decides.
+    """
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    _paired_cloud_config(tmp_path, instance_id="paired-instance", instance_kind=paired_kind)
+    legacy_snapshot = {
+        "sub": "legacy-editor",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": access_source,
+        "claims_issued_at": 1_700_000_000,
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        _seed_legacy_scheduled_task(store, definition_id="legacy-task", snapshot=legacy_snapshot)
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == {
+                **_EMPTY_MIGRATION_COUNTS,
+                "legacy_deferred_definitions": 1,
+            }
+            metadata = _legacy_definition_metadata(connection, "legacy-task")
+            snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
+            assert snapshot["vibe_instance_id"] == "paired-instance"
+            assert snapshot["vibe_instance_kind"] == paired_kind
+            restored = resource_access_service.resource_user_context_from_metadata(metadata)
+            assert restored is not None
+            assert restored.is_personal_instance is (paired_kind == "personal")
+            # Organization membership is never synthesized by the migration.
+            assert "vibe_organization_id" not in snapshot
+    finally:
+        store.close()
+        engine.dispose()
+
+
+@pytest.mark.parametrize(
+    ("marker_json", "expected_state", "expect_marker_preserved"),
+    [
+        pytest.param(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "state": "completed",
+                    "instance_id": None,
+                    "completed_at": "2026-08-19T00:00:00Z",
+                    "updated_at": "2026-08-19T00:00:00Z",
+                }
+            ),
+            "sealed_unattributed",
+            True,
+            id="released_completed_without_instance",
+        ),
+        pytest.param(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "state": "completed",
+                    "instance_id": "same-instance",
+                    "completed_at": "2026-08-19T00:00:00Z",
+                    "updated_at": "2026-08-19T00:00:00Z",
+                }
+            ),
+            "completed",
+            True,
+            id="released_completed_for_current_instance",
+        ),
+        pytest.param(
+            json.dumps({"instance_id": "same-instance", "completed_at": "2026-08-19T00:00:00Z"}),
+            "completed",
+            True,
+            id="released_marker_without_state_field",
+        ),
+        pytest.param(
+            json.dumps({"instance_id": None}),
+            "sealed_unattributed",
+            False,
+            id="released_marker_without_state_or_instance",
+        ),
+        pytest.param(
+            json.dumps({"state": "pending", "instance_id": "   "}),
+            None,
+            True,
+            id="blank_instance_id",
+        ),
+        pytest.param(
+            json.dumps({"state": "sealed_unattributed", "instance_id": "same-instance"}),
+            "sealed_unattributed",
+            True,
+            id="sealed_for_current_instance",
+        ),
+        pytest.param("not-json", None, True, id="corrupt_marker"),
+        pytest.param(json.dumps(["completed"]), None, True, id="non_object_marker"),
+    ],
+)
+def test_released_migration_marker_shapes_stay_idempotent_and_fail_closed(
+    monkeypatch,
+    tmp_path,
+    marker_json: str,
+    expected_state: str | None,
+    expect_marker_preserved: bool,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    _paired_cloud_config(tmp_path)
+    legacy_snapshot = {
+        "sub": "legacy-user",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": "email",
+        "claims_issued_at": 1_700_000_000,
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        _seed_legacy_scheduled_task(store, definition_id="legacy-task", snapshot=legacy_snapshot)
+        with engine.begin() as connection:
+            connection.execute(
+                state_meta.insert().values(
+                    key=resource_access_service.LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY,
+                    value_json=marker_json,
+                    updated_at="2026-08-19T00:00:00Z",
+                )
+            )
+        from storage.importer import _run_sqlite_data_migrations
+
+        for _ in range(2):
+            with engine.begin() as connection:
+                assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+                metadata = _legacy_definition_metadata(connection, "legacy-task")
+                snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
+                assert "vibe_instance_id" not in snapshot
+                assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+                stored = _stored_migration_marker(connection)
+                if expect_marker_preserved:
+                    # A terminal or unreadable marker is never rewritten, so
+                    # repeated startups cannot churn the released shape.
+                    assert stored == marker_json
+                else:
+                    assert json.loads(stored)["state"] == expected_state
+    finally:
+        store.close()
+        engine.dispose()
+
+
 def test_personal_resources_cannot_use_organization_access_levels(tmp_path) -> None:
     db = tmp_path / "vibe.sqlite"
     run_migrations(db)

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -771,11 +771,20 @@ def test_kindless_deferred_context_adopts_matching_validated_pairing(
     assert restored.is_personal_instance
 
 
-@pytest.mark.parametrize("paired_kind", ["personal", "organization"])
+@pytest.mark.parametrize(
+    ("paired_kind", "access_source", "organization_claims"),
+    [
+        ("personal", "owner", False),
+        ("organization", "organization_group", True),
+        ("organization", "email", False),
+    ],
+)
 def test_migrate_legacy_deferred_contexts_binds_definitions_and_queued_deliveries(
     monkeypatch,
     tmp_path,
     paired_kind: str,
+    access_source: str,
+    organization_claims: bool,
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     config = V2Config.default()
@@ -788,12 +797,10 @@ def test_migrate_legacy_deferred_contexts_binds_definitions_and_queued_deliverie
     legacy_context = {
         "sub": "legacy-user",
         "vibe_instance_role": "editor",
-        "vibe_instance_access_source": (
-            "owner" if paired_kind == "personal" else "organization_group"
-        ),
+        "vibe_instance_access_source": access_source,
         "claims_issued_at": 1_700_000_000,
     }
-    if paired_kind == "organization":
+    if organization_claims:
         legacy_context.update(
             {
                 "vibe_organization_id": "org-1",
@@ -986,6 +993,76 @@ def test_legacy_migration_keeps_opposite_instance_semantics_unbound(monkeypatch,
             assert "vibe_instance_id" not in metadata[
                 resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY
             ]
+            assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+    finally:
+        store.close()
+        engine.dispose()
+
+
+def test_legacy_migration_does_not_bind_after_later_pairing(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = False
+    config.save()
+    legacy_metadata = {
+        resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: {
+            "sub": "legacy-user",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "owner",
+            "claims_issued_at": 1_700_000_000,
+        }
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        assert store.upsert_scheduled_task(
+            {
+                "id": "legacy-task",
+                "name": "legacy task",
+                "message": "run",
+                "schedule_type": "interval",
+                "created_at": "2026-08-20T00:00:00Z",
+                "updated_at": "2026-08-20T00:00:00Z",
+                "metadata": legacy_metadata,
+            }
+        )
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == {
+                "legacy_deferred_definitions": 0,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+            assert connection.execute(
+                select(state_meta.c.value_json).where(
+                    state_meta.c.key
+                    == resource_access_service.LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY
+                )
+            ).scalar_one_or_none()
+
+        config.remote_access.vibe_cloud.enabled = True
+        config.remote_access.vibe_cloud.instance_id = "later-instance"
+        config.remote_access.vibe_cloud.instance_kind = "personal"
+        config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+        config.save()
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == {
+                "legacy_deferred_definitions": 0,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+            raw_metadata = connection.execute(
+                select(run_definitions.c.metadata_json).where(
+                    run_definitions.c.id == "legacy-task"
+                )
+            ).scalar_one()
+            metadata = json.loads(raw_metadata)
+            snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
+            assert "vibe_instance_id" not in snapshot
             assert resource_access_service.resource_user_context_from_metadata(metadata) is None
     finally:
         store.close()

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -18,6 +18,7 @@ def _context(
     role: str | None = "member",
     instance_role: str = "editor",
     access_source: str = "organization_group",
+    instance_kind: str | None = None,
 ) -> resource_access_service.ResourceUserContext:
     return resource_access_service.ResourceUserContext(
         subject=subject,
@@ -28,6 +29,7 @@ def _context(
         instance_role=instance_role,
         instance_access_source=access_source,
         is_remote=True,
+        instance_kind=instance_kind,
     )
 
 
@@ -83,6 +85,55 @@ def test_resource_acl_is_enforced_for_editors_and_unknown_kinds_fail_closed(tmp_
                 resource_access_service.can_use_resource(
                     engineering_member, "future_resource", "future-1", connection=connection
                 )
+    finally:
+        engine.dispose()
+
+
+def test_personal_editor_uses_all_agents_without_organization_acl(tmp_path) -> None:
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    try:
+        with engine.begin() as connection:
+            _seed_policies(connection)
+            personal_editor = _context(
+                "personal-user",
+                organization_id=None,
+                role=None,
+                access_source="owner",
+                instance_kind="personal",
+            )
+            organization_editor = _context(
+                "organization-user",
+                instance_kind="organization",
+            )
+
+            assert resource_access_service.can_use_resource(
+                personal_editor, "agent", "private-agent", connection=connection
+            )
+            assert resource_access_service.can_use_resource(
+                personal_editor, "agent", "scoped-agent", connection=connection
+            )
+            assert resource_access_service.can_use_resource(
+                personal_editor, "agent", "unmanaged-agent", connection=connection
+            )
+            assert resource_access_service.filter_accessible_resources(
+                personal_editor,
+                "agent",
+                [
+                    {"id": "private-agent"},
+                    {"id": "scoped-agent"},
+                    {"id": "unmanaged-agent"},
+                ],
+                connection=connection,
+            ) == [
+                {"id": "private-agent"},
+                {"id": "scoped-agent"},
+                {"id": "unmanaged-agent"},
+            ]
+            assert not resource_access_service.can_use_resource(
+                organization_editor, "agent", "private-agent", connection=connection
+            )
     finally:
         engine.dispose()
 
@@ -528,6 +579,7 @@ def test_deferred_remote_context_remains_valid_past_authorization_refresh_bounda
         membership_version="membership-v2",
         instance_role="viewer",
         instance_access_source="organization_group",
+        instance_kind="organization",
         claims_issued_at=issued_at,
         is_remote=True,
     )
@@ -550,6 +602,22 @@ def test_deferred_remote_context_remains_valid_past_authorization_refresh_bounda
     assert before is not None and after is not None
     assert before.subject == after.subject == "member-1"
     assert after.is_active_organization_member is True
+
+
+def test_deferred_personal_context_keeps_instance_kind() -> None:
+    context = resource_access_service.ResourceUserContext(
+        subject="personal-user",
+        instance_role="editor",
+        instance_access_source="owner",
+        instance_kind="personal",
+        is_remote=True,
+    )
+
+    metadata = resource_access_service.metadata_with_resource_user_context({}, context)
+    restored = resource_access_service.resource_user_context_from_metadata(metadata)
+
+    assert restored is not None
+    assert restored.is_personal_instance
 
 
 def test_personal_resources_cannot_use_organization_access_levels(tmp_path) -> None:

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -670,6 +670,42 @@ def test_deferred_context_from_previous_pairing_is_rejected(monkeypatch, tmp_pat
     assert not resource_access_service.metadata_allows_harness_runtime(metadata)
 
 
+def test_deferred_context_does_not_project_personal_bypass_while_reconciling(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Non-interactive metadata must fail closed while the binding is reconciling."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "current-instance"
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+    config.save()
+
+    from storage import remote_access_authorization_service
+    from storage.importer import ensure_sqlite_state
+
+    ensure_sqlite_state()
+    remote_access_authorization_service.begin_instance_binding_transition(
+        instance_id="current-instance",
+        instance_kind="personal",
+    )
+
+    personal_context = resource_access_service.ResourceUserContext(
+        subject="personal-user",
+        instance_id="current-instance",
+        instance_role="editor",
+        instance_access_source="owner",
+        instance_kind="personal",
+        is_remote=True,
+    )
+    metadata = resource_access_service.metadata_with_resource_user_context({}, personal_context)
+    assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+    assert not resource_access_service.metadata_allows_harness_runtime(metadata)
+
+
 @pytest.mark.parametrize("pairing_state", ["disabled", "unreadable", "partial"])
 def test_explicit_deferred_context_requires_current_pairing(
     monkeypatch,

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import hashlib
+import json
+
 import pytest
+from sqlalchemy import select
 
 from config.v2_config import V2Config
 from storage import resource_access_service
+from storage.background import SQLiteBackgroundTaskStore
 from storage.db import create_sqlite_engine
+from storage.message_deliveries import enqueue_queued
 from storage.migrations import run_migrations
-from storage.models import state_meta
+from storage.models import agent_runs, agent_sessions, message_deliveries, run_definitions, state_meta
 from vibe import permissions
 
 
@@ -763,6 +769,227 @@ def test_kindless_deferred_context_adopts_matching_validated_pairing(
 
     assert restored is not None
     assert restored.is_personal_instance
+
+
+@pytest.mark.parametrize("paired_kind", ["personal", "organization"])
+def test_migrate_legacy_deferred_contexts_binds_definitions_and_queued_deliveries(
+    monkeypatch,
+    tmp_path,
+    paired_kind: str,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "paired-instance"
+    config.remote_access.vibe_cloud.instance_kind = paired_kind
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+    config.save()
+
+    legacy_context = {
+        "sub": "legacy-user",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": (
+            "owner" if paired_kind == "personal" else "organization_group"
+        ),
+        "claims_issued_at": 1_700_000_000,
+    }
+    if paired_kind == "organization":
+        legacy_context.update(
+            {
+                "vibe_organization_id": "org-1",
+                "vibe_organization_member_id": "member-1",
+                "vibe_organization_role": "member",
+                "vibe_group_ids": ["group-1"],
+            }
+        )
+    legacy_metadata = {resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: legacy_context}
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        assert store.upsert_scheduled_task(
+            {
+                "id": "legacy-task",
+                "name": "legacy task",
+                "message": "run",
+                "schedule_type": "interval",
+                "created_at": "2026-08-20T00:00:00Z",
+                "updated_at": "2026-08-20T00:00:00Z",
+                "metadata": legacy_metadata,
+            }
+        )
+        assert store.upsert_watch(
+            {
+                "id": "legacy-watch",
+                "name": "legacy watch",
+                "message": "watch",
+                "created_at": "2026-08-20T00:00:00Z",
+                "updated_at": "2026-08-20T00:00:00Z",
+                "metadata": legacy_metadata,
+            }
+        )
+        assert store.enqueue_definition_run(
+            {
+                "id": "run-1",
+                "definition_id": "legacy-task",
+                "run_type": "scheduled",
+                "source_kind": "scheduler",
+                "prompt": "run",
+                "message": "run",
+                "created_at": "2026-08-20T00:00:00Z",
+                "updated_at": "2026-08-20T00:00:00Z",
+                "metadata": legacy_metadata,
+            }
+        ) is not None
+        with engine.begin() as connection:
+            connection.execute(
+                agent_sessions.insert().values(
+                    id="session-1",
+                    scope_id=None,
+                    agent_id=None,
+                    agent_name="default",
+                    agent_backend="opencode",
+                    agent_variant="default",
+                    model=None,
+                    reasoning_effort=None,
+                    session_anchor="anchor-1",
+                    workdir=None,
+                    native_session_id="native-1",
+                    title=None,
+                    status="active",
+                    visibility="foreground",
+                    pinned=0,
+                    agent_status="idle",
+                    composer_draft_text=None,
+                    composer_draft_updated_at=None,
+                    metadata_json="{}",
+                    created_at="2026-08-20T00:00:00Z",
+                    updated_at="2026-08-20T00:00:00Z",
+                    last_active_at=None,
+                )
+            )
+            enqueue_queued(
+                connection,
+                scope_id=None,
+                session_id="session-1",
+                text="queued",
+                metadata=legacy_metadata,
+            )
+            from storage.importer import _run_sqlite_data_migrations
+
+            counts = _run_sqlite_data_migrations(connection)
+            assert counts == {
+                "legacy_deferred_definitions": 2,
+                "legacy_deferred_runs": 1,
+                "legacy_deferred_deliveries": 1,
+            }
+
+            definition_rows = connection.execute(
+                select(run_definitions.c.metadata_json).where(
+                    run_definitions.c.id.in_(("legacy-task", "legacy-watch"))
+                )
+            ).scalars()
+            for raw_metadata in definition_rows:
+                metadata = json.loads(raw_metadata)
+                snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
+                assert snapshot["vibe_instance_id"] == "paired-instance"
+                assert snapshot["vibe_instance_kind"] == paired_kind
+                assert resource_access_service.resource_user_context_from_metadata(metadata) is not None
+
+            run_metadata = connection.execute(
+                select(agent_runs.c.metadata_json).where(agent_runs.c.definition_id == "legacy-task")
+            ).scalar_one()
+            run_snapshot = json.loads(run_metadata)[
+                resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY
+            ]
+            assert run_snapshot["vibe_instance_id"] == "paired-instance"
+            assert run_snapshot["vibe_instance_kind"] == paired_kind
+
+            delivery = connection.execute(
+                select(message_deliveries.c.snapshot_json, message_deliveries.c.snapshot_sha256).where(
+                    message_deliveries.c.session_id == "session-1"
+                )
+            ).mappings().one()
+            snapshot = json.loads(delivery["snapshot_json"])
+            metadata = json.loads(snapshot["metadata_json"])
+            assert metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY][
+                "vibe_instance_id"
+            ] == "paired-instance"
+            assert metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY][
+                "vibe_instance_kind"
+            ] == paired_kind
+            assert delivery["snapshot_sha256"] == hashlib.sha256(
+                delivery["snapshot_json"].encode("utf-8")
+            ).hexdigest()
+
+            assert _run_sqlite_data_migrations(
+                connection
+            ) == {
+                "legacy_deferred_definitions": 0,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+    finally:
+        store.close()
+        engine.dispose()
+
+
+def test_legacy_migration_keeps_opposite_instance_semantics_unbound(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "personal-instance"
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+    config.save()
+    legacy_metadata = {
+        resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: {
+            "sub": "organization-user",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "organization_group",
+            "vibe_organization_id": "org-1",
+            "vibe_organization_member_id": "member-1",
+            "vibe_organization_role": "member",
+        }
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        assert store.upsert_scheduled_task(
+            {
+                "id": "organization-task",
+                "name": "organization task",
+                "message": "run",
+                "schedule_type": "interval",
+                "created_at": "2026-08-20T00:00:00Z",
+                "updated_at": "2026-08-20T00:00:00Z",
+                "metadata": legacy_metadata,
+            }
+        )
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == {
+                "legacy_deferred_definitions": 0,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+            raw_metadata = connection.execute(
+                select(run_definitions.c.metadata_json).where(
+                    run_definitions.c.id == "organization-task"
+                )
+            ).scalar_one()
+            metadata = json.loads(raw_metadata)
+            assert "vibe_instance_id" not in metadata[
+                resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY
+            ]
+            assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+    finally:
+        store.close()
+        engine.dispose()
 
 
 def test_personal_resources_cannot_use_organization_access_levels(tmp_path) -> None:

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -1069,6 +1069,74 @@ def test_legacy_migration_does_not_bind_after_later_pairing(monkeypatch, tmp_pat
         engine.dispose()
 
 
+def test_legacy_migration_retries_when_same_pairing_kind_is_backfilled(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "same-instance"
+    config.remote_access.vibe_cloud.instance_kind = ""
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+    config.save()
+    legacy_metadata = {
+        resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: {
+            "sub": "legacy-user",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "email",
+            "claims_issued_at": 1_700_000_000,
+        }
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        assert store.upsert_scheduled_task(
+            {
+                "id": "legacy-task",
+                "name": "legacy task",
+                "message": "run",
+                "schedule_type": "interval",
+                "created_at": "2026-08-20T00:00:00Z",
+                "updated_at": "2026-08-20T00:00:00Z",
+                "metadata": legacy_metadata,
+            }
+        )
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == {
+                "legacy_deferred_definitions": 0,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+
+        config.remote_access.vibe_cloud.instance_kind = "personal"
+        config.save()
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == {
+                "legacy_deferred_definitions": 1,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+            raw_metadata = connection.execute(
+                select(run_definitions.c.metadata_json).where(
+                    run_definitions.c.id == "legacy-task"
+                )
+            ).scalar_one()
+            snapshot = json.loads(raw_metadata)[
+                resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY
+            ]
+            assert snapshot["vibe_instance_id"] == "same-instance"
+            assert snapshot["vibe_instance_kind"] == "personal"
+    finally:
+        store.close()
+        engine.dispose()
+
+
 def test_personal_resources_cannot_use_organization_access_levels(tmp_path) -> None:
     db = tmp_path / "vibe.sqlite"
     run_migrations(db)

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -886,7 +886,7 @@ def test_migrate_legacy_deferred_contexts_binds_definitions_and_queued_deliverie
             from storage.importer import _run_sqlite_data_migrations
 
             counts = _run_sqlite_data_migrations(connection)
-            assert counts == {
+            assert _migration_counts(counts) == {
                 "legacy_deferred_definitions": 2,
                 "legacy_deferred_runs": 1,
                 "legacy_deferred_deliveries": 1,
@@ -930,9 +930,9 @@ def test_migrate_legacy_deferred_contexts_binds_definitions_and_queued_deliverie
                 delivery["snapshot_json"].encode("utf-8")
             ).hexdigest()
 
-            assert _run_sqlite_data_migrations(
+            assert _migration_counts(_run_sqlite_data_migrations(
                 connection
-            ) == {
+            )) == {
                 "legacy_deferred_definitions": 0,
                 "legacy_deferred_runs": 0,
                 "legacy_deferred_deliveries": 0,
@@ -979,7 +979,7 @@ def test_legacy_migration_keeps_opposite_instance_semantics_unbound(monkeypatch,
         from storage.importer import _run_sqlite_data_migrations
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == {
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
                 "legacy_deferred_definitions": 0,
                 "legacy_deferred_runs": 0,
                 "legacy_deferred_deliveries": 0,
@@ -1031,7 +1031,7 @@ def test_legacy_migration_does_not_bind_after_later_pairing(monkeypatch, tmp_pat
         from storage.importer import _run_sqlite_data_migrations
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == {
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
                 "legacy_deferred_definitions": 0,
                 "legacy_deferred_runs": 0,
                 "legacy_deferred_deliveries": 0,
@@ -1050,7 +1050,7 @@ def test_legacy_migration_does_not_bind_after_later_pairing(monkeypatch, tmp_pat
         config.save()
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == {
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
                 "legacy_deferred_definitions": 0,
                 "legacy_deferred_runs": 0,
                 "legacy_deferred_deliveries": 0,
@@ -1107,7 +1107,7 @@ def test_legacy_migration_retries_when_same_pairing_kind_is_backfilled(
         from storage.importer import _run_sqlite_data_migrations
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == {
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
                 "legacy_deferred_definitions": 0,
                 "legacy_deferred_runs": 0,
                 "legacy_deferred_deliveries": 0,
@@ -1117,7 +1117,7 @@ def test_legacy_migration_retries_when_same_pairing_kind_is_backfilled(
         config.save()
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == {
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
                 "legacy_deferred_definitions": 1,
                 "legacy_deferred_runs": 0,
                 "legacy_deferred_deliveries": 0,
@@ -1175,7 +1175,7 @@ def test_legacy_migration_preserves_instance_id_while_pairing_is_partial(
         from storage.importer import _run_sqlite_data_migrations
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == {
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
                 "legacy_deferred_definitions": 0,
                 "legacy_deferred_runs": 0,
                 "legacy_deferred_deliveries": 0,
@@ -1195,7 +1195,7 @@ def test_legacy_migration_preserves_instance_id_while_pairing_is_partial(
         config.save()
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == {
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
                 "legacy_deferred_definitions": 1,
                 "legacy_deferred_runs": 0,
                 "legacy_deferred_deliveries": 0,
@@ -1261,7 +1261,7 @@ def test_typed_binding_reader_preserves_partial_identity_and_does_not_latch_read
         assert unavailable.status == resource_access_service.RESOURCE_BINDING_STATE_UNAVAILABLE
 
         with engine.begin() as connection:
-            assert resource_access_service.migrate_legacy_deferred_resource_contexts(connection) == {
+            assert _migration_counts(resource_access_service.migrate_legacy_deferred_resource_contexts(connection)) == {
                 "legacy_deferred_definitions": 0,
                 "legacy_deferred_runs": 0,
                 "legacy_deferred_deliveries": 0,
@@ -1281,6 +1281,19 @@ _EMPTY_MIGRATION_COUNTS = {
     "legacy_deferred_runs": 0,
     "legacy_deferred_deliveries": 0,
 }
+
+
+def _migration_counts(result: dict) -> dict[str, int]:
+    """Numeric migration counts, ignoring the typed binding-status field."""
+
+    return {
+        key: int(result[key])
+        for key in (
+            "legacy_deferred_definitions",
+            "legacy_deferred_runs",
+            "legacy_deferred_deliveries",
+        )
+    }
 
 
 def _paired_cloud_config(
@@ -1346,7 +1359,7 @@ def test_partial_pairing_marker_records_configured_instance_without_claiming_a_k
         from storage.importer import _run_sqlite_data_migrations
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
             marker = json.loads(_stored_migration_marker(connection))
 
         assert marker["schema_version"] == 2
@@ -1381,13 +1394,13 @@ def test_credential_repair_on_the_same_pairing_completes_the_deferred_migration(
         from storage.importer import _run_sqlite_data_migrations
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
 
         config.remote_access.vibe_cloud.instance_secret = "instance-secret"
         config.save()
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == {
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
                 **_EMPTY_MIGRATION_COUNTS,
                 "legacy_deferred_definitions": 1,
             }
@@ -1404,7 +1417,7 @@ def test_credential_repair_on_the_same_pairing_completes_the_deferred_migration(
         assert completed["completed_at"]
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
             assert json.loads(_stored_migration_marker(connection)) == completed
             assert (
                 _legacy_definition_metadata(connection, "legacy-task") == metadata
@@ -1444,7 +1457,7 @@ def test_transient_configuration_failure_leaves_the_migration_retryable(
                 ),
             )
             with engine.begin() as connection:
-                assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+                assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
                 # No first migration opportunity may be recorded from a read
                 # failure; otherwise the retry below would be fenced out.
                 assert _stored_migration_marker(connection) is None
@@ -1452,7 +1465,7 @@ def test_transient_configuration_failure_leaves_the_migration_retryable(
         assert V2Config.load.__func__ is real_load.__func__
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == {
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
                 **_EMPTY_MIGRATION_COUNTS,
                 "legacy_deferred_definitions": 1,
             }
@@ -1490,7 +1503,7 @@ def test_unpaired_first_opportunity_cannot_be_adopted_by_a_later_pairing(
         from storage.importer import _run_sqlite_data_migrations
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
             sealed = json.loads(_stored_migration_marker(connection))
 
         assert sealed["state"] == "sealed_unattributed"
@@ -1504,7 +1517,7 @@ def test_unpaired_first_opportunity_cannot_be_adopted_by_a_later_pairing(
         config.save()
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
             metadata = _legacy_definition_metadata(connection, "legacy-task")
             snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
             assert "vibe_instance_id" not in snapshot
@@ -1536,7 +1549,7 @@ def test_pending_marker_for_one_instance_cannot_be_adopted_by_another_instance(
         from storage.importer import _run_sqlite_data_migrations
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
             pending = json.loads(_stored_migration_marker(connection))
         assert pending["state"] == "pending"
         assert pending["instance_id"] == "instance-a"
@@ -1547,7 +1560,7 @@ def test_pending_marker_for_one_instance_cannot_be_adopted_by_another_instance(
         config.save()
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
             sealed = json.loads(_stored_migration_marker(connection))
             assert sealed["state"] == "sealed_unattributed"
             # The original owner stays recorded so no later pairing, including
@@ -1558,7 +1571,7 @@ def test_pending_marker_for_one_instance_cannot_be_adopted_by_another_instance(
         config.save()
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
             metadata = _legacy_definition_metadata(connection, "legacy-task")
             snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
             assert "vibe_instance_id" not in snapshot
@@ -1599,7 +1612,7 @@ def test_shared_access_source_snapshots_migrate_for_either_pairing_kind(
         from storage.importer import _run_sqlite_data_migrations
 
         with engine.begin() as connection:
-            assert _run_sqlite_data_migrations(connection) == {
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
                 **_EMPTY_MIGRATION_COUNTS,
                 "legacy_deferred_definitions": 1,
             }
@@ -1709,7 +1722,7 @@ def test_released_migration_marker_shapes_stay_idempotent_and_fail_closed(
 
         for _ in range(2):
             with engine.begin() as connection:
-                assert _run_sqlite_data_migrations(connection) == _EMPTY_MIGRATION_COUNTS
+                assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
                 metadata = _legacy_definition_metadata(connection, "legacy-task")
                 snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
                 assert "vibe_instance_id" not in snapshot

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -577,6 +577,7 @@ def test_deferred_remote_context_remains_valid_past_authorization_refresh_bounda
     config.remote_access.vibe_cloud.enabled = True
     config.remote_access.vibe_cloud.instance_id = "organization-instance"
     config.remote_access.vibe_cloud.instance_kind = "organization"
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
     config.save()
 
     issued_at = 1_700_000_000
@@ -621,6 +622,7 @@ def test_deferred_personal_context_keeps_instance_kind(monkeypatch, tmp_path) ->
     config.remote_access.vibe_cloud.enabled = True
     config.remote_access.vibe_cloud.instance_id = "personal-instance"
     config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
     config.save()
 
     context = resource_access_service.ResourceUserContext(
@@ -645,6 +647,7 @@ def test_deferred_context_from_previous_pairing_is_rejected(monkeypatch, tmp_pat
     config.remote_access.vibe_cloud.enabled = True
     config.remote_access.vibe_cloud.instance_id = "current-instance"
     config.remote_access.vibe_cloud.instance_kind = "organization"
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
     config.save()
 
     stale_context = resource_access_service.ResourceUserContext(
@@ -661,7 +664,7 @@ def test_deferred_context_from_previous_pairing_is_rejected(monkeypatch, tmp_pat
     assert not resource_access_service.metadata_allows_harness_runtime(metadata)
 
 
-@pytest.mark.parametrize("pairing_state", ["disabled", "unreadable"])
+@pytest.mark.parametrize("pairing_state", ["disabled", "unreadable", "partial"])
 def test_explicit_deferred_context_requires_current_pairing(
     monkeypatch,
     tmp_path,
@@ -672,6 +675,8 @@ def test_explicit_deferred_context_requires_current_pairing(
     config.remote_access.vibe_cloud.enabled = pairing_state != "disabled"
     config.remote_access.vibe_cloud.instance_id = "personal-instance"
     config.remote_access.vibe_cloud.instance_kind = "personal"
+    if pairing_state != "partial":
+        config.remote_access.vibe_cloud.instance_secret = "instance-secret"
     config.save()
     if pairing_state == "unreadable":
         def fail_load(_cls, *_args, **_kwargs):
@@ -707,6 +712,8 @@ def test_legacy_deferred_context_uses_only_known_current_pairing_kind(
     config = V2Config.default()
     config.remote_access.vibe_cloud.enabled = True
     config.remote_access.vibe_cloud.instance_kind = paired_kind
+    config.remote_access.vibe_cloud.instance_id = "paired-instance"
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
     config.save()
 
     legacy_metadata = {
@@ -721,6 +728,35 @@ def test_legacy_deferred_context_uses_only_known_current_pairing_kind(
 
     assert restored is not None
     assert restored.instance_kind == expected_kind
+
+
+def test_kindless_deferred_context_adopts_matching_validated_pairing(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "paired-instance"
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+    config.save()
+
+    legacy_metadata = {
+        resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: {
+            "sub": "legacy-user",
+            "vibe_instance_id": "paired-instance",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "owner",
+            "vibe_instance_kind": None,
+            "claims_issued_at": 1_700_000_000,
+        }
+    }
+
+    restored = resource_access_service.resource_user_context_from_metadata(legacy_metadata)
+
+    assert restored is not None
+    assert restored.is_personal_instance
 
 
 def test_personal_resources_cannot_use_organization_access_levels(tmp_path) -> None:

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -699,14 +699,19 @@ def test_explicit_deferred_context_requires_current_pairing(
 
 
 @pytest.mark.parametrize(
-    ("paired_kind", "expected_kind"),
-    [("personal", "personal"), ("organization", "organization"), ("", None)],
+    ("paired_kind", "expected_kind", "should_restore"),
+    [
+        ("personal", "personal", False),
+        ("organization", "organization", False),
+        ("", None, True),
+    ],
 )
-def test_legacy_deferred_context_uses_only_known_current_pairing_kind(
+def test_unbound_legacy_deferred_context_cannot_adopt_current_pairing_kind(
     monkeypatch,
     tmp_path,
     paired_kind: str,
     expected_kind: str | None,
+    should_restore: bool,
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     config = V2Config.default()
@@ -726,8 +731,9 @@ def test_legacy_deferred_context_uses_only_known_current_pairing_kind(
     }
     restored = resource_access_service.resource_user_context_from_metadata(legacy_metadata)
 
-    assert restored is not None
-    assert restored.instance_kind == expected_kind
+    assert (restored is not None) is should_restore
+    if restored is not None:
+        assert restored.instance_kind == expected_kind
 
 
 def test_kindless_deferred_context_adopts_matching_validated_pairing(

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -1215,6 +1215,67 @@ def test_legacy_migration_preserves_instance_id_while_pairing_is_partial(
         engine.dispose()
 
 
+def test_typed_binding_reader_preserves_partial_identity_and_does_not_latch_read_failure(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    cloud = config.remote_access.vibe_cloud
+    cloud.enabled = True
+    cloud.instance_id = "same-instance"
+    cloud.instance_kind = "personal"
+    cloud.instance_secret = ""
+    config.save()
+
+    partial = resource_access_service._configured_resource_state()
+    assert partial.status == resource_access_service.RESOURCE_BINDING_STATE_PARTIAL
+    assert partial.instance_id == "same-instance"
+    assert partial.instance_kind == "personal"
+
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    marker = {
+        "schema_version": 2,
+        "state": "pending",
+        "instance_id": "same-instance",
+        "updated_at": "before-read-failure",
+    }
+    try:
+        with engine.begin() as connection:
+            connection.execute(
+                state_meta.insert().values(
+                    key=resource_access_service.LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY,
+                    value_json=json.dumps(marker),
+                    updated_at="before-read-failure",
+                )
+            )
+
+        monkeypatch.setattr(
+            V2Config,
+            "load",
+            classmethod(lambda cls, *args, **kwargs: (_ for _ in ()).throw(OSError("temporary read"))),
+        )
+        unavailable = resource_access_service._configured_resource_state()
+        assert unavailable.status == resource_access_service.RESOURCE_BINDING_STATE_UNAVAILABLE
+
+        with engine.begin() as connection:
+            assert resource_access_service.migrate_legacy_deferred_resource_contexts(connection) == {
+                "legacy_deferred_definitions": 0,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+            stored = connection.execute(
+                select(state_meta.c.value_json).where(
+                    state_meta.c.key == resource_access_service.LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY
+                )
+            ).scalar_one()
+            assert json.loads(stored) == marker
+    finally:
+        engine.dispose()
+
+
 def test_personal_resources_cannot_use_organization_access_levels(tmp_path) -> None:
     db = tmp_path / "vibe.sqlite"
     run_migrations(db)

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -1137,6 +1137,84 @@ def test_legacy_migration_retries_when_same_pairing_kind_is_backfilled(
         engine.dispose()
 
 
+def test_legacy_migration_preserves_instance_id_while_pairing_is_partial(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "same-instance"
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.remote_access.vibe_cloud.instance_secret = ""
+    config.save()
+    legacy_metadata = {
+        resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: {
+            "sub": "legacy-user",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "email",
+            "claims_issued_at": 1_700_000_000,
+        }
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        assert store.upsert_scheduled_task(
+            {
+                "id": "legacy-task",
+                "name": "legacy task",
+                "message": "run",
+                "schedule_type": "interval",
+                "created_at": "2026-08-20T00:00:00Z",
+                "updated_at": "2026-08-20T00:00:00Z",
+                "metadata": legacy_metadata,
+            }
+        )
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == {
+                "legacy_deferred_definitions": 0,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+            marker = json.loads(
+                connection.execute(
+                    select(state_meta.c.value_json).where(
+                        state_meta.c.key
+                        == resource_access_service.LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY
+                    )
+                ).scalar_one()
+            )
+            assert marker["state"] == "pending"
+            assert marker["instance_id"] == "same-instance"
+
+        config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+        config.save()
+
+        with engine.begin() as connection:
+            assert _run_sqlite_data_migrations(connection) == {
+                "legacy_deferred_definitions": 1,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+            raw_metadata = connection.execute(
+                select(run_definitions.c.metadata_json).where(
+                    run_definitions.c.id == "legacy-task"
+                )
+            ).scalar_one()
+            snapshot = json.loads(raw_metadata)[
+                resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY
+            ]
+            assert snapshot["vibe_instance_id"] == "same-instance"
+            assert snapshot["vibe_instance_kind"] == "personal"
+    finally:
+        store.close()
+        engine.dispose()
+
+
 def test_personal_resources_cannot_use_organization_access_levels(tmp_path) -> None:
     db = tmp_path / "vibe.sqlite"
     run_migrations(db)

--- a/tests/test_resource_acl_agents.py
+++ b/tests/test_resource_acl_agents.py
@@ -58,6 +58,9 @@ def _organization_cookie(
         "vibe_instance_id": "inst_123",
         "vibe_instance_role": instance_role,
         "vibe_instance_access_source": "organization_group",
+        "vibe_instance_authorization_revision": (
+            remote_access.current_authorization_revision(config) or 0
+        ),
         "vibe_organization_id": "org-1",
         "vibe_organization_member_id": f"member-{subject}",
         "vibe_organization_role": organization_role,
@@ -166,7 +169,7 @@ def test_agent_removal_deletes_resource_policy_and_groups(monkeypatch, tmp_path)
 
 def test_owner_can_create_agent_without_a_trusted_local_identity(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    config = _save_config(tmp_path)
+    config = _save_config(tmp_path, paired=True, instance_kind="organization")
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
@@ -419,7 +422,7 @@ def test_missing_agent_selector_fails_closed_for_editor_only(monkeypatch, tmp_pa
 
 def test_active_org_agent_detail_uses_full_runtime_projection(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    config = _save_config(tmp_path)
+    config = _save_config(tmp_path, paired=True, instance_kind="organization")
     store = VibeAgentStore()
     try:
         agent = store.create(
@@ -467,7 +470,7 @@ def test_active_org_agent_detail_uses_full_runtime_projection(monkeypatch, tmp_p
 
 def test_editor_agent_selection_and_harness_bindings_follow_acl(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    config = _save_config(tmp_path)
+    config = _save_config(tmp_path, paired=True, instance_kind="organization")
     store, agents = _seed_agents_with_policies()
     private_agent = agents["private"]
     store.set_default_agent_name(private_agent.name)
@@ -776,7 +779,7 @@ def test_project_runtime_uses_acls_while_harness_remains_editor_wide(monkeypatch
 
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
-    config = _save_config(tmp_path)
+    config = _save_config(tmp_path, paired=True, instance_kind="organization")
     store, agents = _seed_agents_with_policies()
     engine = get_cached_sqlite_engine()
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/tests/test_resource_acl_show_pages.py
+++ b/tests/test_resource_acl_show_pages.py
@@ -73,6 +73,7 @@ def _paired_config(tmp_path, *, instance_kind: str):
     cloud.instance_secret = "device-secret"
     cloud.instance_kind = instance_kind
     config.save()
+    remote_access._replace_authorization_revision(config, 0)
     return config
 
 

--- a/tests/test_ui_memory_routes.py
+++ b/tests/test_ui_memory_routes.py
@@ -489,13 +489,17 @@ def _save_remote_config(tmp_path) -> V2Config:
     config = V2Config.load()
     cloud = config.remote_access.vibe_cloud
     cloud.enabled = True
+    cloud.backend_url = "https://backend.test"
     cloud.public_url = "https://alex.avibe.bot"
     cloud.client_id = "vr_client_123"
     cloud.instance_id = "inst_123"
+    cloud.instance_kind = "organization"
+    cloud.instance_secret = "instance-secret"
     cloud.session_secret = "session-secret"
     cloud.authorization_endpoint = "https://backend.test/oauth/authorize"
     cloud.redirect_uri = "https://alex.avibe.bot/auth/callback"
     config.save()
+    remote_access._replace_authorization_revision(config, 0)
     return config
 
 

--- a/tests/test_web_push_notifications.py
+++ b/tests/test_web_push_notifications.py
@@ -26,6 +26,7 @@ def _remote_authorization_record(
     instance_access_source: str = "email",
     organization: bool = False,
     instance_kind: str | None = None,
+    instance_id: str | None = "inst-push",
 ) -> dict:
     subject = user_key.removeprefix("remote:")
     record = web_push_notifications.web_push_authorization_context_record(
@@ -40,6 +41,7 @@ def _remote_authorization_record(
             organization_id="org_1" if organization else None,
             organization_member_id="member_1" if organization else None,
             organization_role="member" if organization else None,
+            instance_id=instance_id,
             instance_kind=instance_kind,
             is_remote=True,
         ),
@@ -64,7 +66,10 @@ def test_kindless_web_push_snapshot_adopts_current_personal_pairing_kind(
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _paired_revision_config(41, instance_kind="personal")
-    record = _remote_authorization_record("remote:personal-user")
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_id="inst-push",
+    )
 
     decision = web_push_notifications._evaluate_record_authorization(
         config,
@@ -75,6 +80,45 @@ def test_kindless_web_push_snapshot_adopts_current_personal_pairing_kind(
     assert decision.authorized
     assert decision.context is not None
     assert decision.context.is_personal_instance
+
+
+def test_unbound_kindless_web_push_snapshot_is_rejected(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _paired_revision_config(41, instance_kind="personal")
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_id=None,
+    )
+
+    decision = web_push_notifications._evaluate_record_authorization(
+        config,
+        "remote:personal-user",
+        record,
+    )
+
+    assert not decision.authorized
+    assert decision.disposition == web_push_notifications.WEB_PUSH_DISPOSITION_REVOKED
+    assert decision.reason == (
+        "persisted snapshot lacks a binding to the current paired instance"
+    )
+
+
+def test_kind_specific_web_push_snapshot_requires_known_current_pairing_kind(tmp_path) -> None:
+    config = _paired_revision_config(41, instance_kind="")
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_kind="personal",
+    )
+
+    decision = web_push_notifications._evaluate_record_authorization(
+        config,
+        "remote:personal-user",
+        record,
+    )
+
+    assert not decision.authorized
+    assert decision.disposition == web_push_notifications.WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE
+    assert decision.reason == "current pairing instance kind is unavailable"
 
 
 def test_web_push_rejects_remote_snapshot_when_pairing_config_is_absent() -> None:
@@ -563,6 +607,7 @@ def test_send_to_enabled_subscriptions_rejects_stale_instance_authorization_revi
             - remote_access.SESSION_AUTHORIZATION_REFRESH_SECONDS
             - 3600,
             authorization_revision=41,
+            instance_id="inst-push",
             is_remote=True,
         ),
     )
@@ -2585,6 +2630,7 @@ def test_send_to_enabled_subscriptions_sets_visible_badge_count(monkeypatch, tmp
         subject="user-a",
         email="member@example.com",
         instance_access_source="email",
+        instance_id="inst-push",
         claims_issued_at=int(web_push_notifications.time.time()),
         is_remote=True,
     )

--- a/tests/test_web_push_notifications.py
+++ b/tests/test_web_push_notifications.py
@@ -159,6 +159,30 @@ def test_personal_web_push_requires_runtime_valid_pairing(tmp_path) -> None:
     assert decision.reason == "current pairing lacks complete runtime credentials"
 
 
+def test_web_push_does_not_use_personal_bypass_while_binding_is_reconciling(tmp_path) -> None:
+    config = _paired_revision_config(41, instance_kind="personal")
+    from storage import remote_access_authorization_service
+
+    remote_access_authorization_service.begin_instance_binding_transition(
+        instance_id="inst-push",
+        instance_kind="personal",
+    )
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_kind="personal",
+    )
+
+    decision = web_push_notifications._evaluate_record_authorization(
+        config,
+        "remote:personal-user",
+        record,
+    )
+
+    assert not decision.authorized
+    assert decision.disposition == web_push_notifications.WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE
+    assert "not ready" in (decision.reason or "")
+
+
 def test_web_push_snapshot_with_stale_instance_kind_is_rejected(tmp_path) -> None:
     config = _paired_revision_config(41, instance_kind="organization")
     record = _remote_authorization_record(

--- a/tests/test_web_push_notifications.py
+++ b/tests/test_web_push_notifications.py
@@ -77,6 +77,25 @@ def test_kindless_web_push_snapshot_adopts_current_personal_pairing_kind(
     assert decision.context.is_personal_instance
 
 
+def test_web_push_rejects_remote_snapshot_when_pairing_config_is_absent() -> None:
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_kind="personal",
+    )
+
+    decision = web_push_notifications._evaluate_record_authorization(
+        None,
+        "remote:personal-user",
+        record,
+    )
+
+    assert not decision.authorized
+    assert decision.disposition == web_push_notifications.WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE
+    assert decision.reason == (
+        "paired configuration is unavailable; instance binding cannot be validated"
+    )
+
+
 def test_personal_web_push_requires_runtime_valid_pairing(tmp_path) -> None:
     config = _paired_revision_config(41, instance_kind="personal")
     config.remote_access.vibe_cloud.instance_secret = ""
@@ -399,6 +418,7 @@ def test_web_push_owner_uses_transcript_acceptance_order(monkeypatch, tmp_path):
 
 def test_send_to_enabled_subscriptions_waits_then_sends_to_owner_devices(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -1100,6 +1120,7 @@ def test_in_flight_authorization_sync_wait_recovers_watermark(monkeypatch, tmp_p
 
 def test_merged_delivery_reports_provider_failure_per_owner(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-08-14T00:00:00Z"
@@ -1216,6 +1237,7 @@ def test_persisted_ring_survives_delivery_process_restart(monkeypatch, tmp_path)
 
 def test_merged_owner_without_endpoint_reports_no_subscription(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-08-15T00:00:00Z"
@@ -1373,7 +1395,7 @@ def test_unsigned_organization_snapshot_without_config_is_rejected(monkeypatch, 
 
     assert sends == []
     recent = web_push_notifications.recent_delivery_dispositions()
-    assert recent[0]["disposition"] == web_push_notifications.WEB_PUSH_DISPOSITION_AUTHORIZATION_REFRESH_REQUIRED
+    assert recent[0]["disposition"] == web_push_notifications.WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE
     assert recent[0]["owners"]["remote:user-a"]["policy"] == "organization"
     engine.dispose()
 
@@ -1673,7 +1695,7 @@ def test_organization_signed_snapshot_without_config_records_unavailable(monkeyp
 
     assert sends == []
     recent = web_push_notifications.recent_delivery_dispositions()
-    assert recent[0]["disposition"] == web_push_notifications.WEB_PUSH_DISPOSITION_REVISION_UNAVAILABLE
+    assert recent[0]["disposition"] == web_push_notifications.WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE
     assert recent[0]["owners"]["remote:user-a"]["policy"] == "organization"
     engine.dispose()
 
@@ -2105,6 +2127,7 @@ def test_organization_unsigned_record_reports_refresh_required(monkeypatch, tmp_
 
 def test_authorized_owner_without_subscription_records_no_subscription(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-08-04T00:00:00Z"
@@ -2196,6 +2219,7 @@ def test_authorized_owner_without_subscription_records_no_subscription(monkeypat
 
 def test_send_to_enabled_subscriptions_rechecks_restricted_project_access(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="organization")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -2204,6 +2228,11 @@ def test_send_to_enabled_subscriptions_rechecks_restricted_project_access(monkey
         subject="user-a",
         email="member@example.com",
         instance_access_source="email",
+        organization_id="org_1",
+        organization_member_id="member_1",
+        organization_role="member",
+        instance_kind="organization",
+        authorization_revision=41,
         claims_issued_at=int(web_push_notifications.time.time()),
         is_remote=True,
     )
@@ -2547,6 +2576,7 @@ def test_send_to_enabled_subscriptions_personal_editor_ignores_restricted_projec
 def test_send_to_enabled_subscriptions_sets_visible_badge_count(monkeypatch, tmp_path):
     """One Project's badge includes every visible unread session in it."""
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -2708,6 +2738,7 @@ def test_send_to_enabled_subscriptions_rejects_legacy_session_owner(monkeypatch,
 
 def test_send_to_enabled_subscriptions_prefers_message_owner_over_legacy_session(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -2782,6 +2813,7 @@ def test_send_to_enabled_subscriptions_prefers_message_owner_over_legacy_session
 
 def test_send_to_enabled_subscriptions_sends_to_merged_prompt_owners(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -3241,6 +3273,7 @@ def test_send_to_enabled_subscriptions_skips_local_fallback_when_remote_access_e
 
 def test_send_to_enabled_subscriptions_sends_terminal_error_with_owner(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"

--- a/tests/test_web_push_notifications.py
+++ b/tests/test_web_push_notifications.py
@@ -58,6 +58,25 @@ def test_web_push_authorization_snapshot_preserves_instance_kind() -> None:
     assert context_from_session_payload(record).is_personal_instance
 
 
+def test_kindless_web_push_snapshot_adopts_current_personal_pairing_kind(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _paired_revision_config(41, instance_kind="personal")
+    record = _remote_authorization_record("remote:personal-user")
+
+    decision = web_push_notifications._evaluate_record_authorization(
+        config,
+        "remote:personal-user",
+        record,
+    )
+
+    assert decision.authorized
+    assert decision.context is not None
+    assert decision.context.is_personal_instance
+
+
 def _paired_revision_config(revision: int, *, instance_kind: str = ""):
     from core.services.settings import default_config
 

--- a/tests/test_web_push_notifications.py
+++ b/tests/test_web_push_notifications.py
@@ -77,6 +77,25 @@ def test_kindless_web_push_snapshot_adopts_current_personal_pairing_kind(
     assert decision.context.is_personal_instance
 
 
+def test_personal_web_push_requires_runtime_valid_pairing(tmp_path) -> None:
+    config = _paired_revision_config(41, instance_kind="personal")
+    config.remote_access.vibe_cloud.instance_secret = ""
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_kind="personal",
+    )
+
+    decision = web_push_notifications._evaluate_record_authorization(
+        config,
+        "remote:personal-user",
+        record,
+    )
+
+    assert not decision.authorized
+    assert decision.disposition == web_push_notifications.WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE
+    assert decision.reason == "current pairing lacks complete runtime credentials"
+
+
 def test_web_push_snapshot_with_stale_instance_kind_is_rejected(tmp_path) -> None:
     config = _paired_revision_config(41, instance_kind="organization")
     record = _remote_authorization_record(

--- a/tests/test_web_push_notifications.py
+++ b/tests/test_web_push_notifications.py
@@ -9,7 +9,7 @@ from storage.importer import ensure_sqlite_state
 from storage.models import agent_sessions, messages
 from storage.settings_service import upsert_scope
 from vibe import remote_access
-from vibe.authorization import AuthorizationContext
+from vibe.authorization import AuthorizationContext, context_from_session_payload
 
 
 @pytest.fixture(autouse=True)
@@ -25,6 +25,7 @@ def _remote_authorization_record(
     authorization_revision: int | None = None,
     instance_access_source: str = "email",
     organization: bool = False,
+    instance_kind: str | None = None,
 ) -> dict:
     subject = user_key.removeprefix("remote:")
     record = web_push_notifications.web_push_authorization_context_record(
@@ -39,11 +40,22 @@ def _remote_authorization_record(
             organization_id="org_1" if organization else None,
             organization_member_id="member_1" if organization else None,
             organization_role="member" if organization else None,
+            instance_kind=instance_kind,
             is_remote=True,
         ),
     )
     assert record is not None
     return record
+
+
+def test_web_push_authorization_snapshot_preserves_instance_kind() -> None:
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_kind="personal",
+    )
+
+    assert record["vibe_instance_kind"] == "personal"
+    assert context_from_session_payload(record).is_personal_instance
 
 
 def _paired_revision_config(revision: int, *, instance_kind: str = ""):
@@ -595,6 +607,7 @@ def test_personal_policy_ignores_revision_state_and_refresh_cutoff(monkeypatch, 
         "remote:user-a",
         claims_age_seconds=remote_access.SESSION_AUTHORIZATION_REFRESH_SECONDS + 3600,
         authorization_revision=41,
+        instance_kind="personal",
     )
 
     with engine.begin() as conn:
@@ -2317,6 +2330,160 @@ def test_send_to_enabled_subscriptions_rechecks_restricted_project_access(monkey
         }
     )
     assert [send[0]["endpoint"] for send in sends] == ["https://push.example.test/a"]
+
+
+def test_send_to_enabled_subscriptions_personal_editor_ignores_restricted_project_acl(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
+    ensure_sqlite_state()
+    engine = create_sqlite_engine()
+    now = "2026-06-04T00:00:00Z"
+    context = AuthorizationContext(
+        instance_role="editor",
+        subject="personal-user",
+        email="personal@example.com",
+        instance_access_source="email",
+        instance_kind="personal",
+        claims_issued_at=int(web_push_notifications.time.time()),
+        is_remote=True,
+    )
+    authorization_record = web_push_notifications.web_push_authorization_context_record(
+        "remote:personal-user",
+        context,
+    )
+    assert authorization_record is not None
+
+    with engine.begin() as conn:
+        primary_scope_id = upsert_scope(
+            conn,
+            platform="avibe",
+            scope_type="project",
+            native_id="proj_push_personal_acl",
+            now=now,
+        )
+        other_scope_id = upsert_scope(
+            conn,
+            platform="avibe",
+            scope_type="project",
+            native_id="proj_push_personal_other",
+            now=now,
+        )
+        for session_id, scope_id in (
+            ("ses_push_personal_acl", primary_scope_id),
+            ("ses_push_personal_other", other_scope_id),
+        ):
+            conn.execute(
+                agent_sessions.insert().values(
+                    id=session_id,
+                    scope_id=scope_id,
+                    agent_backend="claude",
+                    agent_variant="default",
+                    session_anchor=session_id,
+                    native_session_id="",
+                    title=session_id,
+                    status="active",
+                    metadata_json="{}",
+                    created_at=now,
+                    updated_at=now,
+                    last_active_at=now,
+                )
+            )
+        for project_id in ("proj_push_personal_acl", "proj_push_personal_other"):
+            assert project_access_service.apply_project_access_intent(
+                conn,
+                {
+                    "project_id": project_id,
+                    "revision": 1,
+                    "mode": "restricted",
+                    "bindings": [
+                        {
+                            "principal_kind": "email",
+                            "principal_value": "someone-else@example.com",
+                            "access_role": "editor",
+                        }
+                    ],
+                },
+            ).outcome == "applied"
+        messages_service.append(
+            conn,
+            scope_id=primary_scope_id,
+            session_id="ses_push_personal_acl",
+            platform="avibe",
+            author="user",
+            source="user",
+            author_id="remote:personal-user",
+            metadata={
+                "_web_push_user_key": "remote:personal-user",
+                "_web_push_authorization_contexts": [authorization_record],
+            },
+            message_type="user",
+            text="Please finish",
+        )
+        primary_message = messages_service.append(
+            conn,
+            scope_id=primary_scope_id,
+            session_id="ses_push_personal_acl",
+            platform="avibe",
+            author="agent",
+            source="agent",
+            message_type="result",
+            text="Done",
+        )
+        messages_service.append(
+            conn,
+            scope_id=other_scope_id,
+            session_id="ses_push_personal_other",
+            platform="avibe",
+            author="user",
+            source="user",
+            author_id="remote:personal-user",
+            message_type="user",
+            text="Please finish another project",
+        )
+        messages_service.append(
+            conn,
+            scope_id=other_scope_id,
+            session_id="ses_push_personal_other",
+            platform="avibe",
+            author="agent",
+            source="agent",
+            message_type="result",
+            text="Done another",
+        )
+        web_push_service.upsert_subscription(
+            conn,
+            user_key="remote:personal-user",
+            payload={
+                "endpoint": "https://push.example.test/personal-acl",
+                "keys": {"p256dh": "personal-key", "auth": "personal-auth"},
+            },
+        )
+
+    sends = []
+    monkeypatch.setattr(web_push_notifications.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        "core.web_push.send_web_push",
+        lambda *, subscription, payload: sends.append((subscription, payload)),
+    )
+    web_push_notifications._send_to_enabled_subscriptions(
+        {
+            "title": "Personal ACL Push",
+            "body": "Done",
+            "session_id": "ses_push_personal_acl",
+            "message_id": primary_message["id"],
+        }
+    )
+
+    assert [send[0]["endpoint"] for send in sends] == [
+        "https://push.example.test/personal-acl"
+    ]
+    assert [send[1]["badge_count"] for send in sends] == [2]
+    recent = web_push_notifications.recent_delivery_dispositions(user_key="remote:personal-user")
+    assert recent[0]["disposition"] == web_push_notifications.WEB_PUSH_DISPOSITION_SENT
+    engine.dispose()
 
 
 def test_send_to_enabled_subscriptions_sets_visible_badge_count(monkeypatch, tmp_path):

--- a/tests/test_web_push_notifications.py
+++ b/tests/test_web_push_notifications.py
@@ -77,6 +77,26 @@ def test_kindless_web_push_snapshot_adopts_current_personal_pairing_kind(
     assert decision.context.is_personal_instance
 
 
+def test_web_push_snapshot_with_stale_instance_kind_is_rejected(tmp_path) -> None:
+    config = _paired_revision_config(41, instance_kind="organization")
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_kind="personal",
+    )
+
+    decision = web_push_notifications._evaluate_record_authorization(
+        config,
+        "remote:personal-user",
+        record,
+    )
+
+    assert not decision.authorized
+    assert decision.disposition == web_push_notifications.WEB_PUSH_DISPOSITION_REVOKED
+    assert decision.reason == (
+        "persisted snapshot instance kind differs from the current pairing"
+    )
+
+
 def _paired_revision_config(revision: int, *, instance_kind: str = ""):
     from core.services.settings import default_config
 

--- a/tests/ui_server_test_helpers.py
+++ b/tests/ui_server_test_helpers.py
@@ -21,7 +21,12 @@ def remote_peer() -> dict[str, str]:
     return _remote_peer()
 
 
-def _save_config(tmp_path):
+def _save_config(
+    tmp_path,
+    *,
+    paired: bool = False,
+    instance_kind: str = "organization",
+):
     from config.v2_config import (
         AgentsConfig,
         PlatformsConfig,
@@ -48,10 +53,21 @@ def _save_config(tmp_path):
     cloud.public_url = "https://alex.avibe.bot"
     cloud.client_id = "vr_client_123"
     cloud.instance_id = "inst_123"
+    cloud.instance_secret = "instance-secret"
     cloud.session_secret = "session-secret"
     cloud.authorization_endpoint = "https://backend.test/oauth/authorize"
     cloud.redirect_uri = "https://alex.avibe.bot/auth/callback"
+    if paired:
+        cloud.backend_url = "https://backend.test"
+        cloud.instance_kind = instance_kind
+    else:
+        cloud.instance_secret = ""
     config.save()
+    if paired:
+        # A complete paired fixture also needs the device authorization
+        # watermark; production session cookies must carry it once runtime
+        # credentials exist.
+        remote_access._replace_authorization_revision(config, 0)
     return config
 
 
@@ -90,6 +106,10 @@ def remote_session_cookie(
             "vibe_instance_role": role,
             "vibe_instance_access_source": access_source,
         }
+        if remote_access._authorization_revision_sync_configured(config):
+            claims["vibe_instance_authorization_revision"] = (
+                remote_access.current_authorization_revision(config) or 0
+            )
         if organization_id is not None:
             claims["vibe_organization_id"] = organization_id
         if organization_member_id is not None:
@@ -98,6 +118,15 @@ def remote_session_cookie(
             claims["vibe_organization_role"] = organization_role
         if group_ids is not None:
             claims["vibe_group_ids"] = group_ids
+    elif remote_access._authorization_revision_sync_configured(config) and (
+        "vibe_instance_authorization_revision" not in claims
+    ):
+        claims = {
+            **claims,
+            "vibe_instance_authorization_revision": (
+                remote_access.current_authorization_revision(config) or 0
+            ),
+        }
     return remote_access.make_session_cookie(
         config,
         email,

--- a/vibe/authorization.py
+++ b/vibe/authorization.py
@@ -78,10 +78,19 @@ class AuthorizationContext:
     authorization_revision: int | None = None
     show_page_id: str | None = None
     is_remote: bool = False
+    instance_kind: str | None = None
 
     @property
     def is_instance_owner(self) -> bool:
         return self.instance_role == "owner"
+
+    @property
+    def is_personal_instance(self) -> bool:
+        return self.instance_kind == "personal"
+
+    @property
+    def is_organization_instance(self) -> bool:
+        return self.instance_kind == "organization"
 
     @property
     def is_active_organization_member(self) -> bool:
@@ -227,6 +236,9 @@ def context_from_session_payload(payload: Mapping[str, Any]) -> AuthorizationCon
     )
     if organization_role not in ORGANIZATION_ROLES:
         organization_role = None
+    instance_kind = _optional_string(payload.get("vibe_instance_kind"))
+    if instance_kind not in {"personal", "organization"}:
+        instance_kind = None
     return AuthorizationContext(
         instance_role=role,
         subject=_optional_string(payload.get("sub")),
@@ -255,6 +267,7 @@ def context_from_session_payload(payload: Mapping[str, Any]) -> AuthorizationCon
         ),
         show_page_id=show_page_id,
         is_remote=True,
+        instance_kind=instance_kind,
     )
 
 

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -4899,6 +4899,11 @@ def _validated_authorization_payload(
     reference = record.get("id")
     if isinstance(reference, str):
         payload[_SESSION_AUTHORIZATION_REFERENCE_KEY] = reference
+    instance_kind = _normalized_instance_kind(config.remote_access.vibe_cloud.instance_kind)
+    if instance_kind is not None:
+        # The paired config is server-owned. Keep instance kind out of the
+        # user-submitted claims while making it available to every ACL caller.
+        payload["vibe_instance_kind"] = instance_kind
     try:
         session_claims_from_oidc(config, payload)
     except OAuthCodeExchangeError:

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -1618,6 +1618,18 @@ def _runtime_pairing_available(config: V2Config) -> bool:
         return False
 
 
+def _known_kind_requires_runtime_pairing(config: V2Config) -> bool:
+    """Require complete device credentials once the server-owned kind is known.
+
+    Legacy pre-kind pairings still use the existing authorization path while
+    they await backfill. They cannot take either Personal or Organization
+    kind-specific bypass; an explicit server-owned kind, however, must never
+    be projected from a degraded pairing.
+    """
+
+    return _normalized_instance_kind(config.remote_access.vibe_cloud.instance_kind) is not None
+
+
 def _persist_instance_kind(instance_id: str, value: object) -> bool:
     instance_kind = _normalized_instance_kind(value)
     if instance_kind is None:
@@ -4898,7 +4910,7 @@ def _validated_authorization_payload(
     identity: Mapping[str, Any],
     record: Mapping[str, Any],
 ) -> dict[str, Any] | None:
-    if not _runtime_pairing_available(config):
+    if _known_kind_requires_runtime_pairing(config) and not _runtime_pairing_available(config):
         return None
     claims = record.get("claims")
     if not isinstance(claims, Mapping):
@@ -5237,7 +5249,7 @@ def resolve_current_authorization(
     current = int(time.time()) if now is None else now
     if not session_identity_is_current(identity, now=current):
         return AuthorizationResolution("invalid_identity", reason="identity_expired")
-    if not _runtime_pairing_available(config):
+    if _known_kind_requires_runtime_pairing(config) and not _runtime_pairing_available(config):
         return AuthorizationResolution("unavailable", reason="pairing_unavailable")
     try:
         record = _load_authorization_record(config, identity, now=current)

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -1667,6 +1667,28 @@ def _is_exact_show_page_grant(
     )
 
 
+def _binding_is_ready(config: V2Config) -> bool:
+    """True only when the durable binding is ready for the current pairing.
+
+    A missing row is a legacy install and stays compatible. Once a row
+    exists, ``reconciling`` / ``invalid`` / mismatched identity means the
+    kind is unavailable to every consumer — interactive refresh, deferred
+    metadata, and Web Push — until reconciliation succeeds.
+    """
+
+    try:
+        from storage import remote_access_authorization_service
+
+        cloud = config.remote_access.vibe_cloud
+        return remote_access_authorization_service.binding_is_ready_for_pairing(
+            instance_id=str(cloud.instance_id or ""),
+            instance_kind=_normalized_instance_kind(cloud.instance_kind),
+            ensure=False,
+        )
+    except Exception:
+        return False
+
+
 def _durable_binding_allows_cached_authorization(
     config: V2Config,
     identity: Mapping[str, Any],
@@ -1682,22 +1704,11 @@ def _durable_binding_allows_cached_authorization(
 
     if _is_exact_show_page_grant(identity, record):
         return True
-    try:
-        from storage import remote_access_authorization_service
-
-        state = remote_access_authorization_service.load_instance_binding_state(ensure=False)
-    except Exception:
-        return False
-    if state is None:
-        return True
-    if state.get("state") != remote_access_authorization_service.INSTANCE_BINDING_STATE_READY:
-        return False
-    current_id = str(config.remote_access.vibe_cloud.instance_id or "")
-    current_kind = _normalized_instance_kind(config.remote_access.vibe_cloud.instance_kind)
-    if state.get("instance_id") != current_id or state.get("instance_kind") != current_kind:
+    if not _binding_is_ready(config):
         return False
     identity_id = str(identity.get("instance_id") or "")
-    return bool(identity_id and identity_id == state.get("instance_id"))
+    current_id = str(config.remote_access.vibe_cloud.instance_id or "")
+    return bool(identity_id and identity_id == current_id)
 
 
 def _run_pending_deferred_context_migration() -> dict[str, int | str]:
@@ -1823,7 +1834,11 @@ def _persist_instance_kind(
     previous_kind: str | None
     from storage import remote_access_authorization_service
 
-    with CONFIG_LOCK:
+    # The compare + config-write + transition is one cross-process critical
+    # section. CONFIG_LOCK is process-local and cannot fence the UI server
+    # against the controller; config_file_lock is the same transaction
+    # V2Config.save uses (AGENTS.md L43-L47).
+    with config_file_lock():
         live_config = V2Config.load()
         live_cloud = live_config.remote_access.vibe_cloud
         if str(live_cloud.instance_id or "") != instance_id:
@@ -1851,39 +1866,40 @@ def _persist_instance_kind(
             # ``reconcile=True`` to repair or initialize the durable row.
             return True
         if previous_kind != instance_kind:
-            # Re-check the durable generation immediately before the write so
-            # a concurrent process cannot slip a newer transition in between
-            # the comparison above and this persist.
+            # Re-read the persisted generation inside the cross-process lock
+            # immediately before writing. Abort if it no longer matches.
+            live_generation = (
+                remote_access_authorization_service.current_instance_binding_generation()
+            )
             if (
                 observed_generation is not None
-                and remote_access_authorization_service.current_instance_binding_generation()
-                > int(observed_generation)
+                and live_generation > int(observed_generation)
             ):
                 return False
             api.save_config(
                 {"remote_access": {"vibe_cloud": {"instance_kind": instance_kind}}},
                 validate_remote_access_network=False,
             )
-    try:
-        transition = _transition_instance_binding(
-            instance_id=instance_id,
-            instance_kind=instance_kind,
-        )
-    except Exception:
-        logger.warning("Remote instance binding reconciliation failed", exc_info=True)
-        return False
-    if observed_generation is not None:
-        persisted_generation = transition.get("generation")
         try:
-            persisted_generation_value = int(persisted_generation)
-        except (TypeError, ValueError):
-            persisted_generation_value = None
-        if (
-            persisted_generation_value is not None
-            and persisted_generation_value < int(observed_generation)
-        ):
+            transition = _transition_instance_binding(
+                instance_id=instance_id,
+                instance_kind=instance_kind,
+            )
+        except Exception:
+            logger.warning("Remote instance binding reconciliation failed", exc_info=True)
             return False
-    return bool(transition.get("ok") and transition.get("ready"))
+        if observed_generation is not None:
+            persisted_generation = transition.get("generation")
+            try:
+                persisted_generation_value = int(persisted_generation)
+            except (TypeError, ValueError):
+                persisted_generation_value = None
+            if (
+                persisted_generation_value is not None
+                and persisted_generation_value < int(observed_generation)
+            ):
+                return False
+        return bool(transition.get("ok") and transition.get("ready"))
 
 
 def mint_cloud_token(
@@ -4608,6 +4624,24 @@ def pair(pairing_key: str, backend_url: str, device_name: str = "avibe") -> dict
     except Exception:
         origin_service = "http://127.0.0.1:5123"
     try:
+        previous_instance_id = str(V2Config.load().remote_access.vibe_cloud.instance_id or "")
+    except Exception:
+        previous_instance_id = ""
+    # The pairing key is one-time-use. Bind or seal released snapshots
+    # BEFORE redeeming, so an unavailable read cannot leave the user with
+    # no local credentials and a backend that already considers the device
+    # paired.
+    try:
+        _run_pending_deferred_context_migration()
+    except Exception as exc:
+        logger.warning("legacy deferred context migration before pairing failed", exc_info=True)
+        return {
+            "ok": False,
+            "error": "pairing_provenance_unavailable",
+            "detail": str(exc),
+            "pairing": {"ok": False},
+        }
+    try:
         result = _json_request(
             f"{backend.base_url}/api/v1/pairing/redeem",
             {
@@ -4633,24 +4667,6 @@ def pair(pairing_key: str, backend_url: str, device_name: str = "avibe") -> dict
             "ok": False,
             "error": str(origin_update.get("error") or "tunnel_origin_update_failed"),
             "pairing": {"ok": False, "origin_service": origin_service},
-        }
-    try:
-        previous_instance_id = str(V2Config.load().remote_access.vibe_cloud.instance_id or "")
-    except Exception:
-        previous_instance_id = ""
-    # Give the old configuration one last chance to bind or seal released
-    # snapshots before replacing its identity. An unavailable read or a
-    # migration failure must abort pairing: otherwise the transition under
-    # the new identity can stamp unbound work with a Personal ACL bypass.
-    try:
-        _run_pending_deferred_context_migration()
-    except Exception as exc:
-        logger.warning("legacy deferred context migration before pairing failed", exc_info=True)
-        return {
-            "ok": False,
-            "error": "pairing_provenance_unavailable",
-            "detail": str(exc),
-            "pairing": {"ok": False},
         }
     try:
         config = api.save_config(
@@ -5294,6 +5310,17 @@ def _fetch_authorization_context(
             revoked_claims = dict(previous_claims)
             if observed_revision is not None:
                 revoked_claims[_AUTHORIZATION_CHECKED_REVISION_KEY] = observed_revision
+            current_generation = (
+                remote_access_authorization_service.current_instance_binding_generation()
+            )
+            if current_generation > int(request_binding_generation):
+                # A stale 403 must not recreate a revoked row after another
+                # process advanced the durable generation and invalidated
+                # the previous scoped authorizations.
+                return AuthorizationResolution(
+                    "unavailable",
+                    reason="instance_binding_changed",
+                )
             try:
                 _store_scoped_authorization(
                     config,

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -1630,6 +1630,25 @@ def _known_kind_requires_runtime_pairing(config: V2Config) -> bool:
     return _normalized_instance_kind(config.remote_access.vibe_cloud.instance_kind) is not None
 
 
+def _is_exact_show_page_grant(
+    identity: Mapping[str, Any],
+    record: Mapping[str, Any] | None = None,
+) -> bool:
+    """Identify the signed, page-scoped email grant exempt from pairing fences."""
+
+    candidates: list[Mapping[str, Any]] = [identity]
+    if isinstance(record, Mapping):
+        claims = record.get("claims")
+        if isinstance(claims, Mapping):
+            candidates.append(claims)
+    return any(
+        candidate.get("vibe_instance_access_source") == "show_page_email"
+        and isinstance(candidate.get("vibe_show_page_id"), str)
+        and bool(candidate["vibe_show_page_id"].strip())
+        for candidate in candidates
+    )
+
+
 def _persist_instance_kind(instance_id: str, value: object) -> bool:
     instance_kind = _normalized_instance_kind(value)
     if instance_kind is None:
@@ -1637,8 +1656,10 @@ def _persist_instance_kind(instance_id: str, value: object) -> bool:
     with CONFIG_LOCK:
         live_config = V2Config.load()
         live_cloud = live_config.remote_access.vibe_cloud
-        if live_cloud.instance_id != instance_id or live_cloud.instance_kind == instance_kind:
+        if live_cloud.instance_id != instance_id:
             return False
+        if live_cloud.instance_kind == instance_kind:
+            return True
         api.save_config(
             {"remote_access": {"vibe_cloud": {"instance_kind": instance_kind}}},
             validate_remote_access_network=False,
@@ -4910,7 +4931,11 @@ def _validated_authorization_payload(
     identity: Mapping[str, Any],
     record: Mapping[str, Any],
 ) -> dict[str, Any] | None:
-    if _known_kind_requires_runtime_pairing(config) and not _runtime_pairing_available(config):
+    if (
+        _known_kind_requires_runtime_pairing(config)
+        and not _runtime_pairing_available(config)
+        and not _is_exact_show_page_grant(identity, record)
+    ):
         return None
     claims = record.get("claims")
     if not isinstance(claims, Mapping):
@@ -5038,15 +5063,17 @@ def _fetch_authorization_context(
     except Exception:
         logger.warning("remote authorization context validation failed", exc_info=True)
         return AuthorizationResolution("unavailable", reason="authorization_context_invalid")
-    config.remote_access.vibe_cloud.instance_kind = instance_kind
     try:
-        _persist_instance_kind(str(identity.get("instance_id") or ""), instance_kind)
+        persisted = _persist_instance_kind(str(identity.get("instance_id") or ""), instance_kind)
     except Exception:
-        # The authoritative response and durable context are already valid.
-        # A config write failure must not turn accepted access into an outage;
-        # this in-memory config immediately follows the discovered policy and a
-        # later runtime status/auth refresh can retry the persistent backfill.
         logger.warning("Remote instance kind backfill failed", exc_info=True)
+        persisted = False
+    if not persisted:
+        # The UI and controller load configuration independently. Accepting the
+        # server-owned kind only in this process would let them disagree about
+        # whether kind-specific ACL bypasses are available.
+        return AuthorizationResolution("unavailable", reason="instance_kind_persistence_failed")
+    config.remote_access.vibe_cloud.instance_kind = instance_kind
     if refreshed_record is None:
         return AuthorizationResolution("unavailable", reason="authorization_context_persistence_failed")
     payload = _validated_authorization_payload(config, identity, refreshed_record)
@@ -5249,8 +5276,6 @@ def resolve_current_authorization(
     current = int(time.time()) if now is None else now
     if not session_identity_is_current(identity, now=current):
         return AuthorizationResolution("invalid_identity", reason="identity_expired")
-    if _known_kind_requires_runtime_pairing(config) and not _runtime_pairing_available(config):
-        return AuthorizationResolution("unavailable", reason="pairing_unavailable")
     try:
         record = _load_authorization_record(config, identity, now=current)
     except Exception:
@@ -5259,6 +5284,12 @@ def resolve_current_authorization(
             "unavailable",
             reason="authorization_record_unavailable",
         )
+    if (
+        _known_kind_requires_runtime_pairing(config)
+        and not _runtime_pairing_available(config)
+        and not _is_exact_show_page_grant(identity, record)
+    ):
+        return AuthorizationResolution("unavailable", reason="pairing_unavailable")
     if (
         record is None
         and isinstance(identity.get(_SESSION_AUTHORIZATION_REFERENCE_KEY), str)

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -1700,12 +1700,16 @@ def _durable_binding_allows_cached_authorization(
     return bool(identity_id and identity_id == state.get("instance_id"))
 
 
-def _run_pending_deferred_context_migration() -> dict[str, int]:
+def _run_pending_deferred_context_migration() -> dict[str, int | str]:
     """Run the data migration against the now-readable current pairing."""
 
     from storage.db import get_cached_sqlite_engine
     from storage.importer import ensure_sqlite_state
-    from storage.resource_access_service import migrate_legacy_deferred_resource_contexts
+    from storage.resource_access_service import (
+        RESOURCE_BINDING_STATE_UNAVAILABLE,
+        RESOURCE_BINDING_STATUS_KEY,
+        migrate_legacy_deferred_resource_contexts,
+    )
 
     # Bootstrap first so a heartbeat can repair a state created before the
     # controller/UI process opened SQLite. The explicit second call observes
@@ -1714,7 +1718,10 @@ def _run_pending_deferred_context_migration() -> dict[str, int]:
     ensure_sqlite_state()
     engine = get_cached_sqlite_engine()
     with engine.begin() as connection:
-        return migrate_legacy_deferred_resource_contexts(connection)
+        result = migrate_legacy_deferred_resource_contexts(connection)
+    if result.get(RESOURCE_BINDING_STATUS_KEY) == RESOURCE_BINDING_STATE_UNAVAILABLE:
+        raise RuntimeError("legacy_deferred_context_provenance_unavailable")
+    return result
 
 
 def _authorization_binding_epoch() -> int:
@@ -1799,27 +1806,44 @@ def _persist_instance_kind(
     value: object,
     *,
     reconcile: bool = False,
+    expected_binding_generation: int | None = None,
     expected_binding_epoch: int | None = None,
 ) -> bool:
-    """Persist and reconcile a server-owned kind before admitting claims."""
+    """Persist and reconcile a server-owned kind before admitting claims.
+
+    Kind writes are fenced on the durable binding generation, not the
+    in-process epoch. The controller and UI server are separate processes
+    (AGENTS.md); an in-memory epoch cannot stop a stale authorization
+    response in one process from reversing a newer heartbeat in another.
+    """
 
     instance_kind = _normalized_instance_kind(value)
     if instance_kind is None:
         return False
     previous_kind: str | None
+    from storage import remote_access_authorization_service
+
     with CONFIG_LOCK:
         live_config = V2Config.load()
         live_cloud = live_config.remote_access.vibe_cloud
         if str(live_cloud.instance_id or "") != instance_id:
             return False
         previous_kind = _normalized_instance_kind(live_cloud.instance_kind)
+        current_generation = (
+            remote_access_authorization_service.current_instance_binding_generation()
+        )
+        observed_generation = (
+            expected_binding_generation
+            if expected_binding_generation is not None
+            else expected_binding_epoch
+        )
         if (
-            expected_binding_epoch is not None
-            and _authorization_binding_epoch() != expected_binding_epoch
+            observed_generation is not None
+            and current_generation > int(observed_generation)
             and previous_kind != instance_kind
         ):
-            # A response that started before another transition must not be
-            # allowed to roll the persisted kind back to the old projection.
+            # A response that started before another process advanced the
+            # durable generation must not roll the persisted kind back.
             return False
         if previous_kind == instance_kind and not reconcile:
             # Existing releases have no binding epoch row yet. Authentication
@@ -1827,9 +1851,15 @@ def _persist_instance_kind(
             # ``reconcile=True`` to repair or initialize the durable row.
             return True
         if previous_kind != instance_kind:
-            # A known kind may change only through the same durable transition
-            # as a backfill; the hook below fences old claims before callers
-            # store the new projection.
+            # Re-check the durable generation immediately before the write so
+            # a concurrent process cannot slip a newer transition in between
+            # the comparison above and this persist.
+            if (
+                observed_generation is not None
+                and remote_access_authorization_service.current_instance_binding_generation()
+                > int(observed_generation)
+            ):
+                return False
             api.save_config(
                 {"remote_access": {"vibe_cloud": {"instance_kind": instance_kind}}},
                 validate_remote_access_network=False,
@@ -1842,6 +1872,17 @@ def _persist_instance_kind(
     except Exception:
         logger.warning("Remote instance binding reconciliation failed", exc_info=True)
         return False
+    if observed_generation is not None:
+        persisted_generation = transition.get("generation")
+        try:
+            persisted_generation_value = int(persisted_generation)
+        except (TypeError, ValueError):
+            persisted_generation_value = None
+        if (
+            persisted_generation_value is not None
+            and persisted_generation_value < int(observed_generation)
+        ):
+            return False
     return bool(transition.get("ok") and transition.get("ready"))
 
 
@@ -4597,13 +4638,20 @@ def pair(pairing_key: str, backend_url: str, device_name: str = "avibe") -> dict
         previous_instance_id = str(V2Config.load().remote_access.vibe_cloud.instance_id or "")
     except Exception:
         previous_instance_id = ""
-    # Give the old configuration one last chance to bind released snapshots
-    # before replacing its identity. Once the new pairing is persisted, the
-    # durable migration marker fences any remaining unattributed work.
+    # Give the old configuration one last chance to bind or seal released
+    # snapshots before replacing its identity. An unavailable read or a
+    # migration failure must abort pairing: otherwise the transition under
+    # the new identity can stamp unbound work with a Personal ACL bypass.
     try:
         _run_pending_deferred_context_migration()
-    except Exception:
+    except Exception as exc:
         logger.warning("legacy deferred context migration before pairing failed", exc_info=True)
+        return {
+            "ok": False,
+            "error": "pairing_provenance_unavailable",
+            "detail": str(exc),
+            "pairing": {"ok": False},
+        }
     try:
         config = api.save_config(
             {
@@ -5219,6 +5267,11 @@ def _fetch_authorization_context(
     now: int,
     observed_revision: int | None,
 ) -> AuthorizationResolution:
+    from storage import remote_access_authorization_service
+
+    request_binding_generation = (
+        remote_access_authorization_service.current_instance_binding_generation()
+    )
     request_binding_epoch = _authorization_binding_epoch()
     subject = str(identity.get("sub") or "").strip()
     email = str(identity.get("email") or "").strip()
@@ -5275,6 +5328,7 @@ def _fetch_authorization_context(
         persisted = _persist_instance_kind(
             str(identity.get("instance_id") or ""),
             instance_kind,
+            expected_binding_generation=request_binding_generation,
             expected_binding_epoch=request_binding_epoch,
         )
     except Exception:

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -1611,6 +1611,13 @@ def _normalized_instance_kind(value: object) -> str | None:
     return value if isinstance(value, str) and value in _INSTANCE_KINDS else None
 
 
+def _runtime_pairing_available(config: V2Config) -> bool:
+    try:
+        return config.remote_access.vibe_cloud.runtime_credentials() is not None
+    except Exception:
+        return False
+
+
 def _persist_instance_kind(instance_id: str, value: object) -> bool:
     instance_kind = _normalized_instance_kind(value)
     if instance_kind is None:
@@ -4891,6 +4898,8 @@ def _validated_authorization_payload(
     identity: Mapping[str, Any],
     record: Mapping[str, Any],
 ) -> dict[str, Any] | None:
+    if not _runtime_pairing_available(config):
+        return None
     claims = record.get("claims")
     if not isinstance(claims, Mapping):
         return None
@@ -5228,6 +5237,8 @@ def resolve_current_authorization(
     current = int(time.time()) if now is None else now
     if not session_identity_is_current(identity, now=current):
         return AuthorizationResolution("invalid_identity", reason="identity_expired")
+    if not _runtime_pairing_available(config):
+        return AuthorizationResolution("unavailable", reason="pairing_unavailable")
     try:
         record = _load_authorization_record(config, identity, now=current)
     except Exception:

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -1649,10 +1649,27 @@ def _is_exact_show_page_grant(
     )
 
 
+def _run_pending_deferred_context_migration() -> None:
+    """Retry legacy deferred binding after the server classifies this pairing."""
+
+    try:
+        from storage.db import get_cached_sqlite_engine
+        from storage.resource_access_service import migrate_legacy_deferred_resource_contexts
+
+        engine = get_cached_sqlite_engine()
+        with engine.begin() as connection:
+            migrate_legacy_deferred_resource_contexts(connection)
+    except Exception:
+        # Startup will retry when the database is not ready yet; kind backfill
+        # must still succeed even if this optional cleanup cannot run now.
+        logger.warning("legacy deferred context migration after kind backfill failed", exc_info=True)
+
+
 def _persist_instance_kind(instance_id: str, value: object) -> bool:
     instance_kind = _normalized_instance_kind(value)
     if instance_kind is None:
         return False
+    changed = False
     with CONFIG_LOCK:
         live_config = V2Config.load()
         live_cloud = live_config.remote_access.vibe_cloud
@@ -1664,6 +1681,9 @@ def _persist_instance_kind(instance_id: str, value: object) -> bool:
             {"remote_access": {"vibe_cloud": {"instance_kind": instance_kind}}},
             validate_remote_access_network=False,
         )
+        changed = True
+    if changed:
+        _run_pending_deferred_context_migration()
     return True
 
 
@@ -4675,10 +4695,19 @@ def _store_scoped_authorization(
     claims: Mapping[str, Any],
     authorization_state: str,
     checked_at: int,
+    instance_kind: str | None = None,
 ) -> str:
     from storage import remote_access_authorization_service
 
-    scope_kind, scope_ref = _authorization_scope(config, claims)
+    stored_claims = dict(claims)
+    persisted_kind = _normalized_instance_kind(instance_kind) or _normalized_instance_kind(
+        config.remote_access.vibe_cloud.instance_kind
+    )
+    if persisted_kind is not None:
+        # This is server-owned provenance, kept beside the claims so a later
+        # pairing reclassification cannot re-project stale authorization.
+        stored_claims["vibe_instance_kind"] = persisted_kind
+    scope_kind, scope_ref = _authorization_scope(config, stored_claims)
     return remote_access_authorization_service.upsert_scoped(
         reference=reference,
         instance_id=str(config.remote_access.vibe_cloud.instance_id),
@@ -4687,7 +4716,7 @@ def _store_scoped_authorization(
         scope_kind=scope_kind,
         scope_ref=scope_ref,
         authorization_state=authorization_state,
-        claims=claims,
+        claims=stored_claims,
         last_checked_at=checked_at,
         updated_at=checked_at,
     )
@@ -4940,12 +4969,17 @@ def _validated_authorization_payload(
     claims = record.get("claims")
     if not isinstance(claims, Mapping):
         return None
+    instance_kind = _normalized_instance_kind(config.remote_access.vibe_cloud.instance_kind)
+    if instance_kind is not None and not _is_exact_show_page_grant(identity, record):
+        if _normalized_instance_kind(claims.get("vibe_instance_kind")) != instance_kind:
+            # A cached row from the previous server-owned kind must be
+            # refreshed before it can receive the current ACL policy.
+            return None
     payload = dict(identity)
     payload.update(claims)
     reference = record.get("id")
     if isinstance(reference, str):
         payload[_SESSION_AUTHORIZATION_REFERENCE_KEY] = reference
-    instance_kind = _normalized_instance_kind(config.remote_access.vibe_cloud.instance_kind)
     if instance_kind is not None:
         # The paired config is server-owned. Keep instance kind out of the
         # user-submitted claims while making it available to every ACL caller.
@@ -5051,6 +5085,7 @@ def _fetch_authorization_context(
             claims=stored_claims,
             authorization_state="current",
             checked_at=now,
+            instance_kind=instance_kind,
         )
         from storage import remote_access_authorization_service
 

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -108,6 +108,10 @@ _AUTHORIZATION_REFRESH_FLIGHTS: dict[
 ] = {}
 _AUTHORIZATION_BACKGROUND_REFRESH_LOCK = threading.Lock()
 _AUTHORIZATION_BACKGROUND_REFRESHES: set[tuple[str, str, str, str]] = set()
+_AUTHORIZATION_BINDING_EPOCH = 0
+_AUTHORIZATION_BINDING_EPOCH_LOCK = threading.Lock()
+_AUTHORIZATION_REFRESH_FLIGHT_EPOCHS: dict[tuple[str, str, str, str], int] = {}
+_INSTANCE_BINDING_TRANSITION_LOCK = threading.RLock()
 AUTHORIZATION_REFRESH_FAILURE_BACKOFF_SECONDS = 5.0
 _REVOKED_BROWSER_SESSIONS_LOCK = threading.Lock()
 _REVOKED_BROWSER_SESSIONS: dict[str, int] = {}
@@ -1601,7 +1605,21 @@ def report_runtime_status(config: V2Config | None = None, event: str = "heartbea
             timeout=5.0,
         )
         _replace_active_hostnames(config, result.get("active_hostnames"))
-        _persist_instance_kind(cloud.instance_id, result.get("instance_kind"))
+        reported_kind = _normalized_instance_kind(result.get("instance_kind"))
+        if reported_kind is not None:
+            # A heartbeat is also the repair loop for a durable reconciling
+            # marker, even when the server repeats the same kind.
+            _persist_instance_kind(cloud.instance_id, reported_kind, reconcile=True)
+        else:
+            configured_kind = _normalized_instance_kind(cloud.instance_kind)
+            if configured_kind is not None:
+                try:
+                    _transition_instance_binding(
+                        instance_id=cloud.instance_id,
+                        instance_kind=configured_kind,
+                    )
+                except Exception:
+                    logger.warning("Remote instance binding heartbeat repair failed", exc_info=True)
         return {"ok": True, **result}
     except Exception as exc:
         return {"ok": False, "error": "remote_status_report_failed", "detail": str(exc)}
@@ -1649,42 +1667,182 @@ def _is_exact_show_page_grant(
     )
 
 
-def _run_pending_deferred_context_migration() -> None:
-    """Retry legacy deferred binding after the server classifies this pairing."""
+def _durable_binding_allows_cached_authorization(
+    config: V2Config,
+    identity: Mapping[str, Any],
+    record: Mapping[str, Any] | None,
+) -> bool:
+    """Fence cached instance claims on the durable binding epoch.
 
+    A missing state row is treated as a legacy installation and remains
+    compatible with released cookies. Once a row exists, malformed,
+    reconciling, or mismatched epochs are fail-closed; exact Show Page grants
+    are deliberately independent of the instance-scoped cache.
+    """
+
+    if _is_exact_show_page_grant(identity, record):
+        return True
     try:
-        from storage.db import get_cached_sqlite_engine
-        from storage.resource_access_service import migrate_legacy_deferred_resource_contexts
+        from storage import remote_access_authorization_service
 
-        engine = get_cached_sqlite_engine()
-        with engine.begin() as connection:
-            migrate_legacy_deferred_resource_contexts(connection)
+        state = remote_access_authorization_service.load_instance_binding_state(ensure=False)
     except Exception:
-        # Startup will retry when the database is not ready yet; kind backfill
-        # must still succeed even if this optional cleanup cannot run now.
-        logger.warning("legacy deferred context migration after kind backfill failed", exc_info=True)
+        return False
+    if state is None:
+        return True
+    if state.get("state") != remote_access_authorization_service.INSTANCE_BINDING_STATE_READY:
+        return False
+    current_id = str(config.remote_access.vibe_cloud.instance_id or "")
+    current_kind = _normalized_instance_kind(config.remote_access.vibe_cloud.instance_kind)
+    if state.get("instance_id") != current_id or state.get("instance_kind") != current_kind:
+        return False
+    identity_id = str(identity.get("instance_id") or "")
+    return bool(identity_id and identity_id == state.get("instance_id"))
 
 
-def _persist_instance_kind(instance_id: str, value: object) -> bool:
+def _run_pending_deferred_context_migration() -> dict[str, int]:
+    """Run the data migration against the now-readable current pairing."""
+
+    from storage.db import get_cached_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.resource_access_service import migrate_legacy_deferred_resource_contexts
+
+    # Bootstrap first so a heartbeat can repair a state created before the
+    # controller/UI process opened SQLite. The explicit second call observes
+    # the same connection and is idempotent; keeping it here makes this hook
+    # usable in tests and by recovery callers that already initialized SQLite.
+    ensure_sqlite_state()
+    engine = get_cached_sqlite_engine()
+    with engine.begin() as connection:
+        return migrate_legacy_deferred_resource_contexts(connection)
+
+
+def _authorization_binding_epoch() -> int:
+    with _AUTHORIZATION_BINDING_EPOCH_LOCK:
+        return _AUTHORIZATION_BINDING_EPOCH
+
+
+def _invalidate_authorization_refresh_state() -> int:
+    """Invalidate cached and in-flight refresh decisions for a new binding."""
+
+    global _AUTHORIZATION_BINDING_EPOCH
+    with _AUTHORIZATION_BINDING_EPOCH_LOCK:
+        _AUTHORIZATION_BINDING_EPOCH += 1
+        epoch = _AUTHORIZATION_BINDING_EPOCH
+    with _AUTHORIZATION_REFRESH_LOCK:
+        _AUTHORIZATION_REFRESH_FAILURES.clear()
+        _AUTHORIZATION_REFRESH_RESULTS.clear()
+        # A flight already holding its lock cannot be forcefully cancelled.
+        # Mark it stale; its completion path checks this epoch before exposing
+        # a result, while idle flights can be dropped immediately.
+        for key, (_flight_lock, users) in list(_AUTHORIZATION_REFRESH_FLIGHTS.items()):
+            if users <= 0:
+                _AUTHORIZATION_REFRESH_FLIGHTS.pop(key, None)
+            else:
+                _AUTHORIZATION_REFRESH_FLIGHT_EPOCHS[key] = epoch
+    with _AUTHORIZATION_BACKGROUND_REFRESH_LOCK:
+        _AUTHORIZATION_BACKGROUND_REFRESHES.clear()
+    return epoch
+
+
+def _publish_instance_binding_change(
+    *,
+    instance_id: str,
+    instance_kind: str | None,
+    generation: int | None,
+) -> None:
+    try:
+        from vibe.sse_broker import broker
+
+        broker.publish(
+            "authorization.changed",
+            {
+                "instance_id": instance_id,
+                "instance_kind": instance_kind,
+                "instance_binding_generation": generation,
+            },
+        )
+    except Exception:
+        logger.debug("failed to publish instance binding change", exc_info=True)
+
+
+def _transition_instance_binding(
+    *,
+    instance_id: str,
+    instance_kind: str | None,
+    previous_instance_id: str | None = None,
+) -> dict[str, Any]:
+    """Reconcile one server-owned binding through the shared transition hook."""
+
+    from storage import remote_access_authorization_service
+
+    with _INSTANCE_BINDING_TRANSITION_LOCK:
+        transition = remote_access_authorization_service.reconcile_instance_binding(
+            instance_id=instance_id,
+            instance_kind=instance_kind,
+            previous_instance_id=previous_instance_id,
+            reconcile=_run_pending_deferred_context_migration,
+        )
+        if transition.get("changed"):
+            _invalidate_authorization_refresh_state()
+            if transition.get("ready") or transition.get("pending"):
+                _publish_instance_binding_change(
+                    instance_id=instance_id,
+                    instance_kind=instance_kind,
+                    generation=transition.get("generation"),
+                )
+        return transition
+
+
+def _persist_instance_kind(
+    instance_id: str,
+    value: object,
+    *,
+    reconcile: bool = False,
+    expected_binding_epoch: int | None = None,
+) -> bool:
+    """Persist and reconcile a server-owned kind before admitting claims."""
+
     instance_kind = _normalized_instance_kind(value)
     if instance_kind is None:
         return False
-    changed = False
+    previous_kind: str | None
     with CONFIG_LOCK:
         live_config = V2Config.load()
         live_cloud = live_config.remote_access.vibe_cloud
-        if live_cloud.instance_id != instance_id:
+        if str(live_cloud.instance_id or "") != instance_id:
             return False
-        if live_cloud.instance_kind == instance_kind:
+        previous_kind = _normalized_instance_kind(live_cloud.instance_kind)
+        if (
+            expected_binding_epoch is not None
+            and _authorization_binding_epoch() != expected_binding_epoch
+            and previous_kind != instance_kind
+        ):
+            # A response that started before another transition must not be
+            # allowed to roll the persisted kind back to the old projection.
+            return False
+        if previous_kind == instance_kind and not reconcile:
+            # Existing releases have no binding epoch row yet. Authentication
+            # may safely use its already-known kind; heartbeat/pairing passes
+            # ``reconcile=True`` to repair or initialize the durable row.
             return True
-        api.save_config(
-            {"remote_access": {"vibe_cloud": {"instance_kind": instance_kind}}},
-            validate_remote_access_network=False,
+        if previous_kind != instance_kind:
+            # A known kind may change only through the same durable transition
+            # as a backfill; the hook below fences old claims before callers
+            # store the new projection.
+            api.save_config(
+                {"remote_access": {"vibe_cloud": {"instance_kind": instance_kind}}},
+                validate_remote_access_network=False,
+            )
+    try:
+        transition = _transition_instance_binding(
+            instance_id=instance_id,
+            instance_kind=instance_kind,
         )
-        changed = True
-    if changed:
-        _run_pending_deferred_context_migration()
-    return True
+    except Exception:
+        logger.warning("Remote instance binding reconciliation failed", exc_info=True)
+        return False
+    return bool(transition.get("ok") and transition.get("ready"))
 
 
 def mint_cloud_token(
@@ -4439,39 +4597,70 @@ def pair(pairing_key: str, backend_url: str, device_name: str = "avibe") -> dict
         previous_instance_id = str(V2Config.load().remote_access.vibe_cloud.instance_id or "")
     except Exception:
         previous_instance_id = ""
-    config = api.save_config(
-        {
-            "remote_access": {
-                "provider": "vibe_cloud",
-                "vibe_cloud": {
-                    "enabled": True,
-                    "backend_url": backend.base_url,
-                    "instance_id": result["instance_id"],
-                    "instance_kind": instance_kind or "",
-                    "client_id": result["client_id"],
-                    "issuer": result["issuer"],
-                    "authorization_endpoint": result["authorization_endpoint"],
-                    "token_endpoint": result["token_endpoint"],
-                    "jwks_uri": result["jwks_uri"],
-                    "public_url": result["public_url"],
-                    "redirect_uri": result["redirect_uri"],
-                    "tunnel_token": result["tunnel_token"],
-                    "instance_secret": result["instance_secret"],
-                    "session_secret": secrets.token_urlsafe(32),
-                },
+    # Give the old configuration one last chance to bind released snapshots
+    # before replacing its identity. Once the new pairing is persisted, the
+    # durable migration marker fences any remaining unattributed work.
+    try:
+        _run_pending_deferred_context_migration()
+    except Exception:
+        logger.warning("legacy deferred context migration before pairing failed", exc_info=True)
+    try:
+        config = api.save_config(
+            {
+                "remote_access": {
+                    "provider": "vibe_cloud",
+                    "vibe_cloud": {
+                        "enabled": True,
+                        "backend_url": backend.base_url,
+                        "instance_id": result["instance_id"],
+                        "instance_kind": instance_kind or "",
+                        "client_id": result["client_id"],
+                        "issuer": result["issuer"],
+                        "authorization_endpoint": result["authorization_endpoint"],
+                        "token_endpoint": result["token_endpoint"],
+                        "jwks_uri": result["jwks_uri"],
+                        "public_url": result["public_url"],
+                        "redirect_uri": result["redirect_uri"],
+                        "tunnel_token": result["tunnel_token"],
+                        "instance_secret": result["instance_secret"],
+                        "session_secret": secrets.token_urlsafe(32),
+                    },
+                }
             }
+        )
+    except Exception as exc:
+        return {"ok": False, "error": "pairing_config_persistence_failed", "detail": str(exc)}
+    try:
+        transition = _transition_instance_binding(
+            instance_id=str(result["instance_id"]),
+            instance_kind=instance_kind,
+            previous_instance_id=previous_instance_id or None,
+        )
+    except Exception as exc:
+        logger.warning("Remote instance binding transition failed after pairing", exc_info=True)
+        return {
+            **status(config),
+            "ok": False,
+            "error": "pairing_reconciliation_failed",
+            "detail": str(exc),
+            "pairing": {"ok": False},
         }
-    )
-    if previous_instance_id and previous_instance_id != str(result["instance_id"]):
-        try:
-            from storage import remote_access_authorization_service
-
-            remote_access_authorization_service.delete_for_instance(previous_instance_id)
-        except Exception:
-            logger.warning("Old remote authorization cleanup failed after pairing", exc_info=True)
+    if not transition.get("ok"):
+        return {
+            **status(config),
+            "ok": False,
+            "error": "pairing_reconciliation_failed",
+            "detail": transition.get("error"),
+            "pairing": {"ok": False, "reconciling": True},
+        }
     start_result = start(config)
     _report_runtime_status_async(config, event="pair", last_error=start_result.get("error"))
-    return {**status(config), "ok": True, "pairing": {"ok": True}, "start": start_result}
+    return {
+        **status(config),
+        "ok": True,
+        "pairing": {"ok": True, "reconciling": not bool(transition.get("ready"))},
+        "start": start_result,
+    }
 
 
 def _session_signature(secret: str, payload: str) -> str:
@@ -4960,20 +5149,30 @@ def _validated_authorization_payload(
     identity: Mapping[str, Any],
     record: Mapping[str, Any],
 ) -> dict[str, Any] | None:
+    exact_show_page = _is_exact_show_page_grant(identity, record)
+    if not _durable_binding_allows_cached_authorization(config, identity, record):
+        return None
     if (
         _known_kind_requires_runtime_pairing(config)
         and not _runtime_pairing_available(config)
-        and not _is_exact_show_page_grant(identity, record)
+        and not exact_show_page
     ):
         return None
     claims = record.get("claims")
     if not isinstance(claims, Mapping):
         return None
+    if record.get("authorization_state") not in {None, "current"}:
+        return None
     instance_kind = _normalized_instance_kind(config.remote_access.vibe_cloud.instance_kind)
-    if instance_kind is not None and not _is_exact_show_page_grant(identity, record):
+    if instance_kind is not None and not exact_show_page:
         if _normalized_instance_kind(claims.get("vibe_instance_kind")) != instance_kind:
             # A cached row from the previous server-owned kind must be
             # refreshed before it can receive the current ACL policy.
+            return None
+    if instance_kind is None and not exact_show_page:
+        # Never infer a Personal/Organization bypass from a cached claim while
+        # the server-owned kind is unknown; the next refresh must backfill it.
+        if _normalized_instance_kind(claims.get("vibe_instance_kind")) is not None:
             return None
     payload = dict(identity)
     payload.update(claims)
@@ -5020,6 +5219,7 @@ def _fetch_authorization_context(
     now: int,
     observed_revision: int | None,
 ) -> AuthorizationResolution:
+    request_binding_epoch = _authorization_binding_epoch()
     subject = str(identity.get("sub") or "").strip()
     email = str(identity.get("email") or "").strip()
     request_payload: dict[str, Any] = {"sub": subject, "email": email}
@@ -5069,6 +5269,21 @@ def _fetch_authorization_context(
         return AuthorizationResolution("unavailable", reason="instance_kind_unavailable")
     try:
         claims = session_claims_from_oidc(config, response)
+        # Persist the server-owned kind and reconcile the binding before any
+        # claims carrying that kind can become durable. A config/SQLite write
+        # failure therefore cannot leave a usable cached Personal projection.
+        persisted = _persist_instance_kind(
+            str(identity.get("instance_id") or ""),
+            instance_kind,
+            expected_binding_epoch=request_binding_epoch,
+        )
+    except Exception:
+        logger.warning("Remote instance kind backfill failed", exc_info=True)
+        persisted = False
+    if not persisted:
+        return AuthorizationResolution("unavailable", reason="instance_kind_persistence_failed")
+    config.remote_access.vibe_cloud.instance_kind = instance_kind
+    try:
         revision = _authorization_revision_from_claims(claims)
         if revision is not None:
             _replace_authorization_revision(config, revision)
@@ -5096,19 +5311,8 @@ def _fetch_authorization_context(
             now=now,
         )
     except Exception:
-        logger.warning("remote authorization context validation failed", exc_info=True)
-        return AuthorizationResolution("unavailable", reason="authorization_context_invalid")
-    try:
-        persisted = _persist_instance_kind(str(identity.get("instance_id") or ""), instance_kind)
-    except Exception:
-        logger.warning("Remote instance kind backfill failed", exc_info=True)
-        persisted = False
-    if not persisted:
-        # The UI and controller load configuration independently. Accepting the
-        # server-owned kind only in this process would let them disagree about
-        # whether kind-specific ACL bypasses are available.
-        return AuthorizationResolution("unavailable", reason="instance_kind_persistence_failed")
-    config.remote_access.vibe_cloud.instance_kind = instance_kind
+        logger.warning("remote authorization context persistence failed", exc_info=True)
+        return AuthorizationResolution("unavailable", reason="authorization_context_persistence_failed")
     if refreshed_record is None:
         return AuthorizationResolution("unavailable", reason="authorization_context_persistence_failed")
     payload = _validated_authorization_payload(config, identity, refreshed_record)
@@ -5131,6 +5335,7 @@ def _refresh_authorization_context(
     force: bool = False,
 ) -> AuthorizationResolution:
     key = _authorization_refresh_key(identity, record)
+    binding_epoch = _authorization_binding_epoch()
     with _AUTHORIZATION_REFRESH_LOCK:
         flight = _AUTHORIZATION_REFRESH_FLIGHTS.get(key)
         if flight is None:
@@ -5143,6 +5348,11 @@ def _refresh_authorization_context(
     try:
         monotonic_now = time.monotonic()
         with _AUTHORIZATION_REFRESH_LOCK:
+            invalidated_epoch = _AUTHORIZATION_REFRESH_FLIGHT_EPOCHS.get(key)
+            if invalidated_epoch is not None and invalidated_epoch != binding_epoch:
+                binding_epoch = invalidated_epoch
+                force = True
+                _AUTHORIZATION_REFRESH_FLIGHT_EPOCHS.pop(key, None)
             recent_result = _AUTHORIZATION_REFRESH_RESULTS.get(key)
             last_failure = _AUTHORIZATION_REFRESH_FAILURES.get(key)
         observed_revision = (
@@ -5199,6 +5409,23 @@ def _refresh_authorization_context(
             observed_revision=observed_revision,
         )
         completed_at = time.monotonic()
+        current_binding_epoch = _authorization_binding_epoch()
+        if current_binding_epoch != binding_epoch:
+            # A transition may have been performed by this very refresh after
+            # the backend returned its authoritative kind. Accept only when
+            # the newly persisted record proves the current durable epoch;
+            # otherwise discard the in-flight response and retry later.
+            if refreshed.current and _durable_binding_allows_cached_authorization(
+                config,
+                identity,
+                {
+                    "claims": refreshed.payload,
+                    "scope_kind": "instance",
+                },
+            ):
+                binding_epoch = current_binding_epoch
+            else:
+                return AuthorizationResolution("unavailable", reason="instance_binding_changed")
         with _AUTHORIZATION_REFRESH_LOCK:
             _AUTHORIZATION_REFRESH_RESULTS.pop(key, None)
             if refreshed.state == "unavailable":
@@ -5248,6 +5475,8 @@ def _refresh_authorization_context(
                         flight_lock,
                         current_flight[1] - 1,
                     )
+            if current_flight is None or current_flight[1] <= 1:
+                _AUTHORIZATION_REFRESH_FLIGHT_EPOCHS.pop(key, None)
 
 
 def _authorization_refresh_key(


### PR DESCRIPTION
## Changed capability
Personal Avibe remote Editors can now list, select, and use every Agent and access every active Project in their Personal instance. Personal resource use is independent of Organization Agent and Project ACLs; Editor management boundaries remain unchanged. Organization Editors and unknown instance kinds retain fail-closed ACL behavior.

Follow-up hardening (this head): the pairing/instance-kind lifecycle is now an explicit contract instead of point-in-time snapshots. A typed configured-binding state (`UNAVAILABLE` / `UNPAIRED` / `PARTIAL` / `READY`) feeds a migration state machine, and a shared binding-transition path reruns pending deferred migrations and invalidates instance-scoped authorization (with a durable binding generation) whenever the instance identity or kind changes. Transient failures (unreadable config, incomplete credentials, failed kind persistence) never latch into permanent migration or authorization state.

## Scope and scenarios
- App-only change; the Backend Resource ACL sync is already Organization-only and requires no change.
- The existing permissions scenario catalog has no scenario ID for Personal resource-use access; focused unit and contract coverage was added for this invariant.

## Evidence
- Unit: 428 tests passed across instance authorization, resource ACL, remote authorization revision, remote access, Web Push, and SQLite state migration/startup suites (0 failures).
- Contract: 12 new lifecycle tests pin the binding invariants — partial-credential provenance preservation, credential-repair migration rerun, unknown-kind pending + real heartbeat rerun, transient `V2Config.load` failure retryability, unpaired/foreign-instance adoption rejection, shared access-source migration for both pairing kinds, Org→Personal reclassification revalidation before the Personal bypass, kind-persistence failure fail-closed, stale binding-generation refresh discard, exact `show_page` grant survival across kind transitions, and released marker-shape idempotency/fail-closed handling.
- Lint: Ruff passed for all changed Python files; git diff check passed.
- Residual manual check: sign in to a real Personal Editor instance and verify all Agents and Projects are visible and usable; pair/unpair and kind-reclassification flows revalidate authorization.

## Dependencies
- Backend dependency: none.
- No migration or UI build is required (state migration is internal, self-healing, and fail-closed for unknown shapes).
