### PR TITLE
fix(ui): localize Memory Processing Record repair actions

### DIFF
--- a/ui/src/components/settings/memory/MemoryStatusPanel.i18n.test.tsx
+++ b/ui/src/components/settings/memory/MemoryStatusPanel.i18n.test.tsx
@@ -79,6 +79,35 @@ const renderUnobservedSource = (language: 'en' | 'zh') => {
   );
 };
 
+const renderRepairButton = (language: 'en' | 'zh') => {
+  const i18n = createInstance();
+  void i18n.use(initReactI18next).init({
+    lng: language,
+    fallbackLng: 'en',
+    resources: { en: { translation: en }, zh: { translation: zh } },
+    interpolation: { escapeValue: false },
+  });
+
+  render(
+    <I18nextProvider i18n={i18n}>
+      <MemoryStatusPanel
+        status={null}
+        failures={[]}
+        clearInProgress={null}
+        logSections={null}
+        statusLoading={false}
+        failuresLoading={false}
+        statusError={null}
+        failuresError={null}
+        refreshPending={false}
+        onRefresh={vi.fn()}
+        repairSupported
+        onRepair={vi.fn()}
+      />
+    </I18nextProvider>,
+  );
+};
+
 const renderClearState = (language: 'en' | 'zh', errorCode: string) => {
   const i18n = createInstance();
   void i18n.use(initReactI18next).init({
@@ -161,5 +190,15 @@ describe('MemoryStatusPanel anomaly error localization', () => {
 
     expect(screen.getAllByText(state).length).toBeGreaterThan(0);
     expect(screen.getAllByText(timestamp).length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    ['en', en.memory.processingRecord.repair.action],
+    ['zh', zh.memory.processingRecord.repair.action],
+  ] as const)('localizes the Repair action in %s', (language, action) => {
+    renderRepairButton(language);
+
+    expect(screen.getByRole('button', { name: action })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'memory.processingRecord.repair.action' })).toBeNull();
   });
 });

--- a/ui/src/components/settings/memory/memoryCopyContract.test.ts
+++ b/ui/src/components/settings/memory/memoryCopyContract.test.ts
@@ -220,4 +220,27 @@ describe('Memory UI copy contracts', () => {
       expect(zh.memory.clear.confirmDescription).toContain('Avibe 在本机上管理的记忆数据');
     }
   });
+
+  it.each(['en', 'zh'] as const)('keeps Repair copy on the Processing Record path the UI reads in %s', (language) => {
+    const processingRecord = BUNDLES[language].memory.processingRecord;
+    const repair = processingRecord.repair;
+
+    expect(repair).toEqual({
+      action: language === 'en' ? 'Repair index' : '修复索引',
+      running: language === 'en' ? 'Repairing…' : '正在修复…',
+      confirmTitle: language === 'en' ? 'Repair the Memory index?' : '修复记忆索引？',
+      confirmDescription: language === 'en'
+        ? 'Repair rescans Markdown memory and drains pending work while the live Memory sidecar stays available. Embedding work may use API quota.'
+        : '修复会重新扫描 Markdown 记忆并排空待处理工作，同时保持记忆 sidecar 可用。此过程可能消耗 Embedding API 配额。',
+      confirmLabel: language === 'en' ? 'Repair index' : '修复索引',
+      healthResult: language === 'en' ? 'Health after repair' : '修复后的健康状态',
+      healthy: language === 'en' ? 'Healthy' : '健康',
+      completed: language === 'en' ? 'Memory index repair completed.' : '记忆索引修复完成。',
+      completedWithWarnings: language === 'en'
+        ? 'Memory index repair completed with health warnings.'
+        : '记忆索引修复完成，但健康状态有警告。',
+      failed: language === 'en' ? 'Memory index repair failed.' : '记忆索引修复失败。',
+    });
+    expect('repair' in processingRecord.runtime).toBe(false);
+  });
 });

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -4219,6 +4219,18 @@
       "title": "Processing Record",
       "description": "How the Memory engine is running, how fresh its data is, and any issues it hit while processing.",
       "refresh": "Refresh",
+      "repair": {
+        "action": "Repair index",
+        "running": "Repairing…",
+        "confirmTitle": "Repair the Memory index?",
+        "confirmDescription": "Repair rescans Markdown memory and drains pending work while the live Memory sidecar stays available. Embedding work may use API quota.",
+        "confirmLabel": "Repair index",
+        "healthResult": "Health after repair",
+        "healthy": "Healthy",
+        "completed": "Memory index repair completed.",
+        "completedWithWarnings": "Memory index repair completed with health warnings.",
+        "failed": "Memory index repair failed."
+      },
       "runtime": {
         "title": "Engine status",
         "help": "The Memory engine runs in the background on this machine and turns your messages into memories. This shows how it's doing.",
@@ -4240,18 +4252,6 @@
         "cascade": "Processing queue",
         "cascadeHelp": "Messages wait in a queue and the engine turns them into memories one by one. This shows the queue's progress and failure counts; retryable failures retry automatically, while permanently failed items do not.",
         "cascadeHelpLabel": "About the processing queue",
-        "repair": {
-          "action": "Repair index",
-          "running": "Repairing…",
-          "confirmTitle": "Repair the Memory index?",
-          "confirmDescription": "Repair rescans Markdown memory and drains pending work while the live Memory sidecar stays available. Embedding work may use API quota.",
-          "confirmLabel": "Repair index",
-          "healthResult": "Health after repair",
-          "healthy": "Healthy",
-          "completed": "Memory index repair completed.",
-          "completedWithWarnings": "Memory index repair completed with health warnings.",
-          "failed": "Memory index repair failed."
-        },
         "recorder": "Call log",
         "recorderHelp": "When recording is active, the call log keeps model-call details for troubleshooting. Degraded or off recording may omit new calls.",
         "recorderHelpLabel": "About the call log",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -4219,6 +4219,18 @@
       "title": "处理记录",
       "description": "查看记忆引擎的运行状态、数据更新情况，以及处理中遇到的问题。",
       "refresh": "刷新",
+      "repair": {
+        "action": "修复索引",
+        "running": "正在修复…",
+        "confirmTitle": "修复记忆索引？",
+        "confirmDescription": "修复会重新扫描 Markdown 记忆并排空待处理工作，同时保持记忆 sidecar 可用。此过程可能消耗 Embedding API 配额。",
+        "confirmLabel": "修复索引",
+        "healthResult": "修复后的健康状态",
+        "healthy": "健康",
+        "completed": "记忆索引修复完成。",
+        "completedWithWarnings": "记忆索引修复完成，但健康状态有警告。",
+        "failed": "记忆索引修复失败。"
+      },
       "runtime": {
         "title": "引擎状态",
         "help": "记忆引擎在本机后台运行，负责把你的消息整理成记忆。这里显示它当前的运行情况。",
@@ -4240,18 +4252,6 @@
         "cascade": "处理队列",
         "cascadeHelp": "消息会先进入队列，再由引擎逐条整理成记忆。这里是队列的处理进度和失败统计；可重试的失败会自动重试，永久失败不会。",
         "cascadeHelpLabel": "关于处理队列",
-        "repair": {
-          "action": "修复索引",
-          "running": "正在修复…",
-          "confirmTitle": "修复记忆索引？",
-          "confirmDescription": "修复会重新扫描 Markdown 记忆并排空待处理工作，同时保持记忆 sidecar 可用。此过程可能消耗 Embedding API 配额。",
-          "confirmLabel": "修复索引",
-          "healthResult": "修复后的健康状态",
-          "healthy": "健康",
-          "completed": "记忆索引修复完成。",
-          "completedWithWarnings": "记忆索引修复完成，但健康状态有警告。",
-          "failed": "记忆索引修复失败。"
-        },
         "recorder": "调用记录",
         "recorderHelp": "调用记录正常时会保存模型调用详情，方便排查问题；记录异常或关闭时，新的调用可能不会被记录。",
         "recorderHelpLabel": "关于调用记录",


### PR DESCRIPTION
## Capability
The Memory Processing Record Repair action, confirm dialog, and result toasts now resolve to the existing English and Chinese copy instead of rendering the raw `memory.processingRecord.repair.*` keys.

## Why
The UI already reads `memory.processingRecord.repair.*`, but both locale files nested that copy under `memory.processingRecord.runtime.repair`. i18next therefore fell back to the key itself. A scan of all other `memory.*` UI keys found no additional missing translations; remaining non-memory hits were either i18next plural families or strings that already ship `defaultValue`.

## Evidence
- unit: `memoryCopyContract.test.ts` now asserts the Repair copy lives on the path the UI reads, in both locales
- unit: `MemoryStatusPanel.i18n.test.tsx` renders the Repair button in `en` and `zh` and rejects the raw key
- contract: no schema or API change
- scenario: none; this is locale-path alignment only
- residual manual: confirm the Processing Record Repair button and confirm dialog in the Web UI after merge

## Known-by-design ledger
None.