### PR TITLE
fix(memory): tolerate reasoning-model chat probe responses

### DIFF
--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -64,7 +64,7 @@ PROCESSING_PROBE_MAX_DEADLINE_SECONDS = (
     + PROCESSING_PROBE_DEADLINE_MARGIN_SECONDS
 )
 _PROCESSING_TIMEOUT_SECONDS = PROCESSING_PROBE_REQUEST_TIMEOUT_SECONDS
-_PREFLIGHT_TIMEOUT_SECONDS = 5.0
+_PREFLIGHT_TIMEOUT_SECONDS = 30.0
 _PREFLIGHT_RESPONSE_BYTES = _MAX_RESPONSE_BYTES
 _CHAT_PROBE_MAX_TOKENS = 8
 _CHAT_PROBE_TERMINAL_FINISH_REASONS = frozenset(
@@ -1601,9 +1601,8 @@ def _chat_probe_response_issue(value: Any) -> str | None:
     message = choices[0].get("message")
     if not isinstance(message, dict):
         return "provider_response_missing_message"
-    if "content" not in message:
-        return "provider_response_missing_content"
-    content = message["content"]
+    # Reasoning-model probes may omit content; treat absence like content: null.
+    content = message.get("content")
     if content is not None and not isinstance(content, str):
         return "provider_response_invalid_content"
     if content is None or not content.strip():

--- a/docs/plans/memory-chat-probe-thinking-models.md
+++ b/docs/plans/memory-chat-probe-thinking-models.md
@@ -1,0 +1,106 @@
+# Memory chat probes for reasoning models
+
+Status: approved by owner. This document is the implementation contract for
+one small PR. Update it only if scope changes materially.
+
+## Background
+
+Gemini's OpenAI-compat endpoint
+(`https://generativelanguage.googleapis.com/v1beta/openai`) with current-gen
+thinking models (`gemini-3.5` / `3.6` / `3.7-flash`, and
+`gemini-3-flash-preview`, EverOS's official multimodal default) answers Avibe's
+chat probe (`max_tokens=8`, `temperature=0`) with a 2xx body that has no
+`content` key at all:
+
+```json
+{
+  "choices": [
+    {
+      "finish_reason": "length",
+      "index": 0,
+      "message": {"role": "assistant"}
+    }
+  ],
+  "usage": {"completion_tokens": 0}
+}
+```
+
+Probe latency jitters 0.85–4.78s and occasionally exceeds 5s.
+
+Two Avibe-side failures follow:
+
+1. `_chat_probe_response_issue` in `core/memory/everos.py` rejected a missing
+   `content` key as `provider_response_missing_content`, even though a
+   present-but-empty `content` is already accepted when `role == "assistant"`
+   and `finish_reason` is terminal (`stop`, `length`, `content_filter`,
+   `tool_calls`, `function_call`).
+2. `_PREFLIGHT_TIMEOUT_SECONDS = 5.0` produced intermittent
+   `provider_request_timed_out` on save.
+
+EverOS itself has no such probe. This is Avibe's admission layer only.
+Preflight and periodic health share the same chat-response validator for both
+`llm` and `multimodal` endpoints.
+
+## Goal
+
+Admit reasoning-model OpenAI-compat chat probes that omit `content` when the
+rest of the existing empty-content contract holds, and give save-path preflight
+enough wall-clock budget for observed Gemini jitter.
+
+## Changes
+
+1. **Validator tolerance.** In `_chat_probe_response_issue`, a missing
+   `content` key is treated exactly like `content: null` and falls through to
+   the existing empty-content branch: `role` must be `"assistant"` and
+   `finish_reason` must be a terminal string. All other rejections stay
+   unchanged (missing `choices` / `message`, invalid types, non-terminal or
+   missing `finish_reason`).
+2. **Preflight budget.** `_PREFLIGHT_TIMEOUT_SECONDS` is `30.0` (owner
+   decision). It still bounds both `asyncio.wait_for` per endpoint and
+   `httpx.Timeout(..., connect=2.0)`. `vibe/internal_client.py`
+   `memory_preflight` uses `timeout=None`, so the IPC hop does not cap this.
+   Worst-case save-path preflight is 4 endpoints × 30s.
+3. **Periodic health budget is unchanged.**
+   `PROCESSING_PROBE_REQUEST_TIMEOUT_SECONDS` stays `8.0`.
+
+## Non-goals
+
+- Do not raise `_CHAT_PROBE_MAX_TOKENS` (stays 8).
+- Do not add `reasoning_effort` or any provider-specific request params to
+  probe payloads. Probes stay lowest-common-denominator OpenAI-compat.
+- No config schema change, no UI change, no i18n change, no sidecar / EverOS
+  change.
+- Do not touch `enable_llm_rerank`, agentic recall, or rebuild / recovery
+  behavior.
+
+## Known notes
+
+- **30s preflight is an owner decision**, not a measured minimum. Observed
+  Gemini jitter only needed slightly more than 5s; 30s is the granted
+  headroom, not a claim that probes take that long.
+- **Preflight (30s) / health (8s) asymmetry.** A provider that only answers
+  after more than 8s will pass save preflight and may still flap periodic
+  health. That split is intentional in this PR: health remains a short
+  liveness check.
+- **Admission risk.** A provider that responds but never produces text now
+  passes admission when `role` is `assistant` and `finish_reason` is terminal.
+  Real generation failures surface later in the Processing Record, not at
+  save-path preflight.
+
+## Diagnostic-code shift
+
+A payload that used to fail as `provider_response_missing_content` because the
+`content` key was absent now continues into the empty-content branch. When
+`role == "assistant"` and `finish_reason` is also absent, the reported code is
+now `provider_response_missing_finish_reason`.
+
+## Tests
+
+- Validator unit fixtures for the Gemini thinking shape, the missing-content
+  diagnostic shift, a non-assistant role, and the existing OpenAI
+  `content` / `""` / `null` shapes.
+- Preflight contract tests: stubbed `llm` and `multimodal` endpoints returning
+  the thinking shape pass `EverOSPort.preflight()`.
+- Health: `processing_healthy()` judges the same stub healthy.
+- The preflight constant is pinned at `30.0`; the health probe budget stays
+  `8.0`.

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -13,9 +13,12 @@ import pytest
 
 from core.memory import artifact as memory_artifact
 from core.memory.everos import (
+    PROCESSING_PROBE_REQUEST_TIMEOUT_SECONDS,
     _AGENTIC_ROUND_HEADER,
     _AGENTIC_TIMEOUT_HEADER,
     _ATTACHMENT_ADD_REJECTION_CODES_VALIDATED_EVEROS_VERSION,
+    _PREFLIGHT_TIMEOUT_SECONDS,
+    _chat_probe_response_issue,
     AddAck,
     AddRejected,
     AgenticRecallTelemetry,
@@ -78,6 +81,17 @@ class _FailingResponseStream(httpx.AsyncByteStream):
     async def __aiter__(self):
         raise self._failure_type("response body lost", request=self._request)
         yield b""  # pragma: no cover - keeps this an async generator
+
+
+def _thinking_chat_completion(*, role: str = "assistant", finish_reason: str | None = "length") -> dict:
+    message = {"role": role}
+    choice: dict = {"finish_reason": finish_reason, "index": 0, "message": message}
+    if finish_reason is None:
+        del choice["finish_reason"]
+    return {
+        "choices": [choice],
+        "usage": {"completion_tokens": 0, "prompt_tokens": 1, "total_tokens": 1},
+    }
 
 
 def _health_envelope(recorder) -> dict:
@@ -1489,6 +1503,136 @@ def test_processing_preflight_accepts_truncated_chat_completion_from_resolved_sl
     request_payload = json.loads(requests[0].content)
     assert request_payload["model"] == "client-alias"
     assert request_payload["max_tokens"] == 8
+
+
+def test_preflight_timeout_budget_stays_above_health_probe_budget() -> None:
+    assert _PREFLIGHT_TIMEOUT_SECONDS == 30.0
+    assert PROCESSING_PROBE_REQUEST_TIMEOUT_SECONDS == 8.0
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (_thinking_chat_completion(), None),
+        ({"choices": [{"message": {"content": "OK"}}]}, None),
+        (
+            {
+                "choices": [
+                    {
+                        "finish_reason": "length",
+                        "message": {"role": "assistant", "content": "OK"},
+                    }
+                ]
+            },
+            None,
+        ),
+        (
+            {
+                "choices": [
+                    {
+                        "finish_reason": "length",
+                        "message": {"role": "assistant", "content": ""},
+                    }
+                ]
+            },
+            None,
+        ),
+        (
+            {
+                "choices": [
+                    {
+                        "finish_reason": "length",
+                        "message": {"role": "assistant", "content": None},
+                    }
+                ]
+            },
+            None,
+        ),
+        (
+            _thinking_chat_completion(finish_reason=None),
+            "provider_response_missing_finish_reason",
+        ),
+        (
+            _thinking_chat_completion(role="user"),
+            "provider_response_invalid_role",
+        ),
+        (
+            {"choices": [{"finish_reason": "length", "message": {}}]},
+            "provider_response_invalid_role",
+        ),
+        ({"choices": [{}]}, "provider_response_missing_message"),
+    ],
+)
+def test_chat_probe_validator_accepts_thinking_model_and_openai_shapes(
+    payload: dict, expected: str | None
+) -> None:
+    assert _chat_probe_response_issue(payload) == expected
+
+
+def test_processing_preflight_accepts_thinking_model_chat_completions() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.endswith("/embeddings"):
+            return httpx.Response(200, json={"data": [{"embedding": [0.1]}]})
+        return httpx.Response(200, json=_thinking_chat_completion())
+
+    async def run():
+        return await EverOSPort(
+            Path("/tmp/everos.sock"),
+            llm_base_url="https://llm.example.test/v1",
+            llm_model="chat",
+            llm_api_key="llm-secret",
+            embedding_base_url="https://embed.example.test/v1",
+            embedding_model="embed",
+            embedding_api_key="embedding-secret",
+            multimodal_base_url="https://vision.example.test/v1",
+            multimodal_model="vision-model",
+            multimodal_api_key="vision-secret",
+        ).preflight()
+
+    real_async_client = httpx.AsyncClient
+    with patch("core.memory.everos.httpx.AsyncClient", autospec=True) as client_type:
+        client_type.side_effect = lambda **kwargs: real_async_client(
+            transport=httpx.MockTransport(handler), **kwargs
+        )
+        result = asyncio.run(run())
+
+    assert result.ok is True
+    assert [request.url.path for request in requests] == [
+        "/v1/chat/completions",
+        "/v1/embeddings",
+        "/v1/chat/completions",
+    ]
+
+
+def test_processing_health_accepts_thinking_model_chat_completions() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/embeddings"):
+            return httpx.Response(200, json={"data": [{"embedding": [0.1, 0.2]}]})
+        return httpx.Response(200, json=_thinking_chat_completion())
+
+    async def run() -> bool:
+        return await EverOSPort(
+            Path("/tmp/everos.sock"),
+            llm_base_url="https://llm.example.test/v1",
+            llm_model="chat-model",
+            llm_api_key="llm-secret",
+            embedding_base_url="https://embed.example.test/v1",
+            embedding_model="embedding-model",
+            embedding_api_key="embedding-secret",
+            multimodal_base_url="https://vision.example.test/v1",
+            multimodal_model="vision-model",
+            multimodal_api_key="vision-secret",
+        ).processing_healthy()
+
+    real_async_client = httpx.AsyncClient
+    with patch("core.memory.everos.httpx.AsyncClient", autospec=True) as client_type:
+        client_type.side_effect = lambda **kwargs: real_async_client(
+            transport=httpx.MockTransport(handler), **kwargs
+        )
+        assert asyncio.run(run()) is True
 
 
 def test_processing_preflight_reports_the_rejected_2xx_shape() -> None:


### PR DESCRIPTION
## Capability

Avibe Memory chat-probe admission now accepts OpenAI-compat reasoning-model responses that omit the `content` key, and save-path preflight has a 30s per-endpoint budget so Gemini thinking-model jitter no longer fails admission.

Preflight and periodic health share `_chat_probe_response_issue` for both `llm` and `multimodal`. EverOS itself is unchanged; this is Avibe's admission layer only.

## Behavior deltas

- **Widened accepted probe shape.** A missing `content` key is treated exactly like `content: null`. Admission still requires `role == "assistant"` and a terminal `finish_reason` (`stop`, `length`, `content_filter`, `tool_calls`, `function_call`). Other rejections are unchanged (missing `choices` / `message`, invalid types, non-terminal or missing `finish_reason`).
- **Diagnostic-code shift.** A payload that previously failed as `provider_response_missing_content` because `content` was absent now continues into the empty-content branch. When `role == "assistant"` and `finish_reason` is also absent, the reported code is now `provider_response_missing_finish_reason`.
- **Preflight budget 5s → 30s.** `_PREFLIGHT_TIMEOUT_SECONDS` is 30.0 for both `asyncio.wait_for` and `httpx.Timeout(..., connect=2.0)`. `vibe/internal_client.py` `memory_preflight` uses `timeout=None`, so the IPC hop does not cap this. Worst-case save-path preflight is 4 endpoints × 30s.
- **Periodic health budget is unchanged** (`PROCESSING_PROBE_REQUEST_TIMEOUT_SECONDS = 8.0`). A provider that only answers after >8s will pass save preflight and may flap periodic health.

## Non-goals

- `_CHAT_PROBE_MAX_TOKENS` stays 8.
- No `reasoning_effort` or other provider-specific probe request params.
- No config schema, UI, i18n, sidecar, or EverOS change.
- No change to `enable_llm_rerank`, agentic recall, or rebuild/recovery.

## Evidence layers

- **Unit:** `_chat_probe_response_issue` fixtures for the Gemini thinking shape (missing `content` + `finish_reason: length`), the missing-content diagnostic-code shift, a non-assistant role, and the existing OpenAI `content` / `""` / `null` shapes. Preflight constant pinned at 30.0; health remains 8.0.
- **Contract:** stubbed `llm` and `multimodal` endpoints returning the thinking shape pass `EverOSPort.preflight()`; `processing_healthy()` judges the same stub healthy.
- **Scenario:** none (no catalog entry for this admission helper).
- **Residual manual check:** Incus regression with Gemini endpoints (owner will run).

Plan: `docs/plans/memory-chat-probe-thinking-models.md`.

## Known-by-design ledger

1. **Preflight (30s) / health (8s) asymmetry.** Owner kept the health probe at 8s. A provider that only passes at >8s will pass save preflight but may flap periodic health.
2. **Admission of empty-text terminal completions.** A provider that responds but never produces text now passes admission when `role` is `assistant` and `finish_reason` is terminal. Real generation failures surface later in the Processing Record.
3. **30s is granted headroom, not a measured minimum.** Observed Gemini jitter only needed slightly more than 5s.