### PR TITLE
fix(storage): only reset initial drift a release cannot have produced

### DIFF
--- a/storage/migrations.py
+++ b/storage/migrations.py
@@ -196,6 +196,17 @@ UNRELEASED_OLD_INITIAL_TABLES = [
     "schema_meta",
     "alembic_version",
 ]
+# The members above that no release could have produced, which is what makes the presence
+# of one evidence of an unreleased build. `scopes` is in INITIAL_TABLES and every stamped
+# database has `alembic_version` -- the check below requires it a few lines earlier -- so
+# testing the full list proved nothing: any database short of INITIAL_TABLES matched, and
+# a released one then had its `scopes` and its stamp dropped out from under it. Derived
+# rather than written out, so a table added to INITIAL_TABLES leaves this correct.
+UNRELEASED_ONLY_INITIAL_TABLES = [
+    table
+    for table in UNRELEASED_OLD_INITIAL_TABLES
+    if table not in INITIAL_TABLES and table != "alembic_version"
+]
 
 
 def alembic_dir() -> Path:
@@ -366,7 +377,7 @@ def _reset_unreleased_initial_schema_drift(db_path: Path) -> None:
         version = conn.execute("select version_num from alembic_version").fetchone()
         if version != (INITIAL_REVISION,):
             return
-        if not any(table in tables for table in UNRELEASED_OLD_INITIAL_TABLES):
+        if not any(table in tables for table in UNRELEASED_ONLY_INITIAL_TABLES):
             return
 
         conn.execute("PRAGMA foreign_keys = OFF")

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 from importlib import import_module
 import hashlib
@@ -6100,3 +6101,79 @@ def test_run_migrations_upgrades_released_0030_to_acl_head(tmp_path: Path) -> No
         )
         assert "resource_access_policies" in tables
         assert "resource_access_groups" in tables
+
+
+def _initial_era_db(db_path: Path, tables: Iterable[str], stamp: str = migrations.INITIAL_REVISION) -> Path:
+    """A database stamped at ``stamp`` carrying ``tables``, each holding one row.
+
+    The tables are placeholders on purpose. What decides whether the reset below fires is
+    which names are present and what the stamp says, so a faithful copy of any particular
+    release's DDL would only make the fixture look more specific than the thing it tests.
+    The rows are there so a drop is visible as lost data rather than as a lost empty shell.
+    """
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("create table alembic_version (version_num varchar(32) not null)")
+        conn.execute("insert into alembic_version (version_num) values (?)", (stamp,))
+        for table in tables:
+            conn.execute(f'create table "{table}" (id text primary key)')
+            conn.execute(f'insert into "{table}" (id) values (?)', (f"row-of-{table}",))
+        conn.commit()
+    return db_path
+
+
+def _surviving_tables(db_path: Path) -> dict[str, int]:
+    with sqlite3.connect(db_path) as conn:
+        names = [
+            str(name)
+            for (name,) in conn.execute(
+                "select name from sqlite_master where type = 'table' and name not like 'sqlite_%'"
+            )
+        ]
+        return {name: conn.execute(f'select count(*) from "{name}"').fetchone()[0] for name in names}
+
+
+@pytest.mark.parametrize("absent", sorted(migrations.INITIAL_TABLES))
+def test_the_initial_drift_reset_never_touches_a_released_database(tmp_path: Path, absent: str) -> None:
+    """A database carrying only released tables is not drift, however incomplete it is.
+
+    The reset only runs at all once INITIAL_TABLES is not a subset of what the database
+    carries, which sounds like a shape no release ships and is not: the initial migration
+    has gained tables since it was first released, so a database from an older release is
+    stamped at INITIAL_REVISION and short of today's set. That is a released database, and
+    the reset dropping `scopes` and the stamp out of it is what made every v2.3-era
+    upgrade abort. The cases come from INITIAL_TABLES itself, so a table added to it later
+    is covered without editing this test, and one absence is the general case because the
+    reset decides once for the database and then drops table by table.
+    """
+
+    present = sorted(migrations.INITIAL_TABLES - {absent})
+    db_path = _initial_era_db(tmp_path / f"without-{absent}.sqlite", present)
+    before = _surviving_tables(db_path)
+
+    migrations._reset_unreleased_initial_schema_drift(db_path)
+
+    assert _surviving_tables(db_path) == before
+
+
+@pytest.mark.parametrize("drifted", migrations.UNRELEASED_ONLY_INITIAL_TABLES)
+def test_the_initial_drift_reset_still_clears_an_unreleased_database(tmp_path: Path, drifted: str) -> None:
+    """Every table the reset treats as evidence of an unreleased build has to be evidence.
+
+    Parametrized over the list the reset reads rather than over a sample of it, so a member
+    that stops firing -- or a list narrowed until nothing does -- fails here instead of
+    leaving a dev database to be upgraded as if it were a released one. Seeded with a
+    released database's tables as well, because the drifted shape carries both and the
+    reset is meant to clear it regardless.
+    """
+
+    db_path = _initial_era_db(
+        tmp_path / f"drifted-{drifted}.sqlite",
+        [*sorted(migrations.INITIAL_TABLES - {"agents"}), drifted],
+    )
+
+    migrations._reset_unreleased_initial_schema_drift(db_path)
+
+    surviving = _surviving_tables(db_path)
+    assert drifted not in surviving
+    assert "alembic_version" not in surviving


### PR DESCRIPTION
## What this changes

`_reset_unreleased_initial_schema_drift` decides whether a database is leftover
drift from an unreleased build and, if so, drops the old-shape tables so the
migration chain can rebuild them. Its gate was:

```python
if not any(table in tables for table in UNRELEASED_OLD_INITIAL_TABLES):
    return
```

`UNRELEASED_OLD_INITIAL_TABLES` contains `alembic_version`, and the same
function requires `alembic_version` to exist four lines earlier. The condition
was therefore always true — the guard never returned. The list also contains
`scopes`, which is a member of `INITIAL_TABLES`, so even reading the list
loosely it named two tables a released database has.

This PR gates on `UNRELEASED_ONLY_INITIAL_TABLES` — the same list minus what
`INITIAL_TABLES` claims and minus the stamp table — derived from those two
sources rather than written out again, so a table added to `INITIAL_TABLES`
later leaves this correct without anyone remembering to come back. The drop
list itself is unchanged.

## Why it matters

The reset only runs at all once `INITIAL_TABLES` is not a subset of what the
database carries. That reads like a shape no release ships, and it is not: the
initial migration `20260501_0001` has gained tables since it was first
released, so a database from an older install is stamped at `INITIAL_REVISION`
and short of today's set. With the gate vacuous, that database was treated as
dev drift — its `scopes` table and its Alembic stamp were dropped, and
`_stamp_existing_initial_schema` then aborted the upgrade:

```
RuntimeError: existing SQLite schema is incomplete; missing initial tables: scopes
```

That is every install from `gh-v2.2.15rc2` through `v2.3.2` (2026-05-14),
13 installable tags sharing one shipped graph. Such a database cannot be
upgraded by any later release.

Surfaced by #1560, whose guard builds a database from every distinct shipped
graph and upgrades it with the code users actually run.

## Blast radius

The change narrows one boolean. It cannot reach a database the reset already
declined, and for a database that really is unreleased drift — one carrying
`session_messages`, `chat_sessions`, `channel_settings`, or any other table no
release produced — the gate still opens and the same tables are still dropped.
The only behavior that changes is on a database carrying none of those, which
is precisely the case that was being damaged.

## Evidence

- **Unit** — two properties in `tests/test_sqlite_state_migration.py`, both
  parametrized off the constants rather than off a sample, so a table added to
  either list is covered without editing a test:
  - `test_the_initial_drift_reset_never_touches_a_released_database` — for each
    released initial table in turn absent, a database carrying the rest comes
    through the reset with every table and every row intact. **Fails 7/7 on the
    old gate**, passes on the new one.
  - `test_the_initial_drift_reset_still_clears_an_unreleased_database` — for
    each member of `UNRELEASED_ONLY_INITIAL_TABLES`, a database carrying it is
    still cleared. This is what stops the fix from being over-narrowed: a list
    trimmed until nothing fires would fail here. Passes on both gates, which is
    the point — the clearing path is unchanged.
- **Suite** — `tests/test_sqlite_state_migration.py`: 118 passed.
- **Acceptance** — #1560's guard, run with this fix applied, builds a database
  from each of the 33 distinct shipped graphs, seeds a row into every table the
  schema accepts one for, and upgrades it through `run_migrations`. Result:

  ```
  migration release guard passed (baseline v3.0.12)
  ```

  Before this fix that run reported `gh-v2.2.15rc2: upgrade aborted with
  RuntimeError: existing SQLite schema is incomplete; missing initial tables:
  scopes`. Every 3.0-era graph is in the same 33 and stays green, so the
  narrowing is proven not to have moved anything for current users.
- **Lint** — `ruff check` clean on both changed files.
- No scenario catalog covers migrations, so no scenario IDs apply.

## Dependencies

None. #1560 is independent — it is the guard that found this, and it stays red
until this merges, at which point its one remaining failure clears.

## Known by design

- **The drop list still contains `scopes` and `alembic_version`.** Only the
  detection is narrowed. Once a database is established as unreleased drift,
  dropping its stamp and its old `scopes` is the intended repair, and changing
  that would alter behavior for the dev databases the function exists for.
- **The fixtures are placeholder tables, not copies of a release's DDL.** What
  decides the reset is which table names are present and what the stamp says;
  reproducing any particular release's column layout would make the fixture
  look more specific than the thing it tests. Each table holds one row so a
  drop shows up as lost data rather than as a lost empty shell.
