### PR TITLE
fix(storage): ensure the sqlite state once per process, not per request

### DIFF
--- a/storage/importer.py
+++ b/storage/importer.py
@@ -4,6 +4,7 @@ import json
 import logging
 import shutil
 import tempfile
+import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -53,16 +54,47 @@ class MigrationImportReport:
     counts: dict[str, int] = field(default_factory=dict)
 
 
+_ensured_lock = threading.Lock()
+_ensured_targets: dict[tuple[Path, Path], MigrationImportReport] = {}
+
+
+def reset_ensured_sqlite_state() -> None:
+    """Forget which targets this process already ensured.
+
+    Production relies on process lifetime: a target is ensured once and stays
+    ensured. Tests call this around isolated homes so a rebuilt database is
+    migrated again instead of trusting a previous test's result.
+    """
+
+    with _ensured_lock:
+        _ensured_targets.clear()
+
+
 def ensure_sqlite_state(
     *,
     db_path: Path | None = None,
     state_dir: Path | None = None,
     primary_platform: str | None = None,
 ) -> MigrationImportReport:
-    """Create/migrate the SQLite DB and import existing JSON state once."""
+    """Create/migrate the SQLite DB and import existing JSON state once.
+
+    Callers treat this as a cheap precondition and put it in front of ordinary
+    operations, so repeating it must cost nothing. The full body takes a
+    cross-process migration lock and re-runs the whole Alembic upgrade
+    pipeline; running that per request serializes unrelated work machine-wide
+    and turns any transient SQLite contention into a user-visible failure. Once
+    a target is ensured, this process is done with it.
+    """
 
     target_db = (db_path or paths.get_sqlite_state_path()).expanduser().resolve()
     target_state_dir = (state_dir or paths.get_state_dir()).expanduser().resolve()
+    ensured_key = (target_db, target_state_dir)
+    with _ensured_lock:
+        ensured = _ensured_targets.get(ensured_key)
+    # The database file is the evidence; a caller that removed it out from
+    # under us gets a real migration rather than a stale promise.
+    if ensured is not None and target_db.exists():
+        return ensured
     guard_source_checkout_default_state_migration(target_db)
     _ensure_sqlite_target_dirs(
         target_state_dir=target_state_dir,
@@ -134,6 +166,8 @@ def ensure_sqlite_state(
         if report is None:
             raise RuntimeError("SQLite state initialization completed without a report")
         prune_state_backups(target_state_dir / "backups")
+        with _ensured_lock:
+            _ensured_targets[ensured_key] = report
         return report
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -222,15 +222,24 @@ def _seed_sqlite_state_template(
 
 @pytest.fixture(autouse=True)
 def _reset_cached_sqlite_engines():
-    """Keep process-local SQLite engine caches scoped to each isolated test."""
-    try:
-        from storage.db import dispose_cached_sqlite_engines
-    except Exception:
-        yield
-        return
-    dispose_cached_sqlite_engines()
+    """Keep process-local SQLite caches scoped to each isolated test.
+
+    Both caches key on the resolved database path, so a rebuilt home never
+    inherits a previous test's engine or its "already migrated" result.
+    """
+
+    def _reset() -> None:
+        try:
+            from storage.db import dispose_cached_sqlite_engines
+            from storage.importer import reset_ensured_sqlite_state
+        except Exception:
+            return
+        dispose_cached_sqlite_engines()
+        reset_ensured_sqlite_state()
+
+    _reset()
     yield
-    dispose_cached_sqlite_engines()
+    _reset()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -20,8 +20,9 @@ from sqlalchemy.schema import CreateIndex
 from config import paths
 from config.v2_settings import ChannelSettings, RoutingSettings, SettingsState, SettingsStore
 from storage.db import SqliteInvalidationProbe, create_sqlite_engine
-from storage.importer import JSON_IMPORT_MARKER, ensure_sqlite_state
-from storage import message_deliveries, messages_service, migrations
+from storage.importer import JSON_IMPORT_MARKER, ensure_sqlite_state, reset_ensured_sqlite_state
+from storage.lock import MigrationFileLock
+from storage import importer, message_deliveries, messages_service, migrations
 from storage.background import SQLiteBackgroundTaskStore
 from storage.migrations import UnsafeDefaultStateMigrationError, background_tables_ready, run_migrations
 from storage.models import metadata
@@ -5228,6 +5229,11 @@ def test_ensure_sqlite_state_imports_json_once(tmp_path: Path) -> None:
     _write_discovered_chats(state_dir / "discovered_chats.json")
 
     first = ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack")
+    # Drop the process-local "already ensured" result so the second call really
+    # replays the pipeline against the migrated database, the way the next
+    # process to start will. Without the reset this would assert the
+    # short-circuit (covered separately) instead of re-run idempotence.
+    reset_ensured_sqlite_state()
     second = ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack")
 
     assert first.imported is True
@@ -5312,6 +5318,62 @@ def test_ensure_sqlite_state_imports_json_once(tmp_path: Path) -> None:
             "background_runs_imported",
         }
     }
+
+
+def test_ensure_sqlite_state_short_circuits_after_first_success(tmp_path: Path, monkeypatch) -> None:
+    # Callers put ensure_sqlite_state in front of ordinary operations (a login,
+    # a read-only query, a skill delete), so a repeat call must cost nothing.
+    # Re-running the pipeline per request serialized unrelated work on the
+    # cross-process migration lock and turned transient SQLite contention into a
+    # failed login (page: error=oauth_exchange_failed reason=OperationalError).
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = state_dir / "vibe.sqlite"
+
+    first = ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack")
+
+    migrations_run = 0
+    real_run_migrations = importer.run_migrations
+
+    def counting_run_migrations(*args, **kwargs):
+        nonlocal migrations_run
+        migrations_run += 1
+        return real_run_migrations(*args, **kwargs)
+
+    monkeypatch.setattr(importer, "run_migrations", counting_run_migrations)
+
+    # An already-held migration lock is exactly the contention that failed the
+    # login. The repeat call must not queue behind it, so holding it here would
+    # deadlock the test if the short-circuit regressed.
+    with MigrationFileLock(state_dir / "migration.lock", timeout_seconds=1.0):
+        second = ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack")
+
+    assert second is first
+    assert migrations_run == 0
+
+    # The guard is per target, not process-global: a different home still migrates.
+    other_state_dir = tmp_path / "other"
+    other_state_dir.mkdir()
+    other = ensure_sqlite_state(
+        db_path=other_state_dir / "vibe.sqlite",
+        state_dir=other_state_dir,
+        primary_platform="slack",
+    )
+    assert other.db_path != first.db_path
+    assert migrations_run == 1
+
+    # Both homes are migrated now, so nothing on disk distinguishes them any
+    # more -- only the key does. A memo that is not per target would hand the
+    # first home's caller the second home's report, with the wrong db_path and
+    # the wrong counts, and no call would ever notice.
+    assert ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack") is first
+    assert migrations_run == 1
+
+    # A database that disappeared is no longer ensured, whatever we remember.
+    for suffix in ("", "-wal", "-shm"):
+        db_path.with_name(db_path.name + suffix).unlink(missing_ok=True)
+    ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack")
+    assert migrations_run == 2
 
 
 def test_ensure_sqlite_state_collapses_multi_backend_anchor_on_import(tmp_path: Path) -> None:
@@ -5431,6 +5493,11 @@ def test_ensure_sqlite_state_preserves_backend_aliases_without_deprecated_backen
         conn.commit()
 
     first = ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack")
+    # Drop the process-local "already ensured" result so the second call really
+    # replays the pipeline against the migrated database, the way the next
+    # process to start will. Without the reset this would assert the
+    # short-circuit (covered separately) instead of re-run idempotence.
+    reset_ensured_sqlite_state()
     second = ensure_sqlite_state(db_path=db_path, state_dir=state_dir, primary_platform="slack")
 
     with sqlite3.connect(db_path) as conn:


### PR DESCRIPTION
## What changes

`ensure_sqlite_state` is a precondition, and 17 call sites across 15 modules
treat it as a cheap one — `core/services/sessions.py`, `session_fork.py`,
`skills.py`, `show_pages.py`, `show_session_events.py`, `vibe_agents.py`,
`scheduled_tasks.py`, `config/v2_settings.py`, `config/v2_sessions.py`,
`storage/read_only_query.py`, `storage/background.py`,
`storage/remote_access_authorization_service.py`, `vibe/api.py`, `vibe/cli.py`,
`main.py` — all call it in front of ordinary work.

Its body is not cheap. It takes the cross-process migration file lock and
replays the whole Alembic upgrade pipeline. Per request that serializes
unrelated work machine-wide and turns transient SQLite contention into a
user-visible failure: a login died with
`error=oauth_exchange_failed reason=OperationalError`, where the only fault was
that something else held the lock.

A target that has been ensured stays ensured for the life of the process, so
the result is remembered per `(db_path, state_dir)` and returned directly.

Two things the memo deliberately is not:

- **Not trusted on its own.** The database file is the evidence. A caller that
  removed the database out from under us gets a real migration rather than a
  stale promise.
- **Not process-global.** Once two homes are both migrated, nothing on disk
  distinguishes them any more — only the key can. A global memo would hand one
  home's caller the other home's report, with the wrong `db_path` and the wrong
  counts, and no call site would notice.

## What this does not fix

#1561's ledger names this change as "what actually protects the clean
snapshot" under a repeatedly failing migration. That is more than this PR
delivers, and the difference is worth stating rather than inheriting.

There are two problems behind the retry storm:

| | fixed here |
| --- | --- |
| every entry point replays the pipeline on a **healthy** system, contending for the migration lock | yes — this is the observed P1 |
| every entry point retries a **failing** migration, each attempt copying the whole database | no |

Nothing is memoized on failure, so the failing case behaves exactly as it does
on `master`. Its disk cost is already bounded by #1561; what remains is that
attempts after the first copy an already-damaged database and can push the
last clean copy out of a two-slot window.

Memoizing failures would close that, and is deliberately not in this PR: a
`database is locked` and a bad backfill are both "the migration raised", and
remembering the first one poisons the process until restart for a fault that
would have cleared on the next call. That is a distinct behavioural decision
with its own risk, and it should be made on its own evidence — not smuggled in
behind a caching change. Listed as a follow-up.

## Evidence

- `tests/test_sqlite_state_migration.py::test_ensure_sqlite_state_short_circuits_after_first_success`
  states the guarantee as properties rather than call counts: a repeat call
  runs no migration **while another holder owns the migration lock** (if the
  short-circuit regressed, the test would block on that lock and fail rather
  than pass quietly); a second home still migrates; a first home re-ensured
  after that still gets its own report; a database that disappeared is migrated
  again.
- Red-without-fix confirmed by mutation: dropping the short-circuit (1 fail),
  trusting the memo without checking the file (1 fail), making the key
  process-global (1 fail).
- The two existing `ensure_sqlite_state` re-run tests now reset the memo
  explicitly, so they keep asserting pipeline idempotence — what the next
  process to start will do — instead of silently asserting the short-circuit.
- `tests/test_sqlite_state_migration.py` — 119 passed.
- Every test file that references `ensure_sqlite_state` (51 files) — 2962
  passed, 1 pre-existing failure unrelated to this change (see follow-ups).
- `ruff check` clean on changed files.

## Known-by-design ledger

- **The memo is process-local.** What it guards is a per-process cost;
  cross-process coordination is still owned by `MigrationFileLock`. It is also
  not an admission gate: two threads that both miss the memo both proceed, and
  the file lock orders them exactly as it does today.
- **A revision added after a process ensured its target is not picked up
  mid-flight.** That was already true — the process is running the code it
  loaded at startup — and the memo does not change it.

## Follow-ups (not in this PR)

- Stop a repeatedly failing migration from being re-attempted by every entry
  point, per the analysis above. This is the remaining half of #1561's ledger
  entry.
- A cross-process migration lock replacing the process-local `_MIGRATION_LOCK`
  in `storage/migrations.py`, so two processes cannot run `command.upgrade`
  against one SQLite file (#1561 ledger).
- Make `20260725_0037`'s backfill cheap instead of making `0056` guess.
- Non-hermetic tests, unrelated to this change:
  `test_cli_agent_run_schema.py::test_agent_run_async_defaults_callback_from_caller_env`
  reads the ambient Avibe session environment, so it fails when the suite runs
  inside an Avibe agent session and passes in CI;
  `tests/test_wait_for_github_pr_activity.py` and `tests/test_watches.py`
  interfere with each other under the full suite.
