### PR TITLE
fix(cli): report a failed restart with no service as a doctor failure

### DIFF
--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -12,6 +12,19 @@ from vibe import restart_supervisor
 from vibe import runtime
 
 
+@pytest.fixture(autouse=True)
+def _hermetic_service_liveness(monkeypatch):
+    """Answer the liveness probe from the fixture, never from the real machine.
+
+    Recording a restart failure asks whether a service survived it, and the honest
+    answer costs a full process-table scan (~1s) of whatever the developer happens
+    to be running. Default it to "nothing alive", which is what a tmp_path AVIBE_HOME
+    describes; tests that care about the other answer set it themselves.
+    """
+
+    monkeypatch.setattr(runtime, "service_process_running", lambda: False)
+
+
 def _fake_start_runtime(calls, service_pid: int = 222, ui_pid: int = 333):
     calls.append("start_runtime")
     runtime.write_status("running", f"pid={service_pid}", service_pid, ui_pid)
@@ -157,6 +170,38 @@ def test_schedule_restart_marks_status_failed_when_spawn_fails(monkeypatch, tmp_
     assert status["ok"] is False
     assert status["state"] == "failed"
     assert "failed to spawn" in status["error"]
+
+
+@pytest.mark.parametrize("alive", [True, False], ids=["service-survived", "instance-down"])
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        {"ok": False, "state": "failed", "error": "boom"},
+        {"ok": None, "state": "scheduled", "error": None},
+        {"ok": True, "state": "succeeded", "error": None},
+    ],
+    ids=["failed", "in-flight", "succeeded"],
+)
+def test_a_recorded_failure_carries_what_was_alive_when_it_was_written(monkeypatch, tmp_path, outcome, alive):
+    """Only a failure records liveness, and it records what was actually there.
+
+    Whether a failed restart left the instance down depends on which stage failed,
+    and only the moment of failure can tell -- a later reader sees the same empty
+    machine whether the restart killed the service or the user stopped it. The
+    other outcomes make no downtime claim, so they carry no such observation.
+    """
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    monkeypatch.setattr(restart_supervisor.runtime, "service_process_running", lambda: alive)
+
+    restart_supervisor._write_status({"job_id": "job-1", **outcome})
+
+    status = runtime.read_json(runtime.get_restart_status_path())
+    if outcome["ok"] is False:
+        assert status["service_alive"] is alive
+    else:
+        assert "service_alive" not in status
 
 
 def test_restart_job_stops_and_starts_service(monkeypatch, tmp_path):

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -159,7 +159,6 @@ def test_schedule_restart_marks_status_failed_when_spawn_fails(monkeypatch, tmp_
     assert "failed to spawn" in status["error"]
 
 
-@pytest.mark.parametrize("alive", [True, False], ids=["service-survived", "instance-down"])
 @pytest.mark.parametrize(
     "outcome",
     [
@@ -169,31 +168,32 @@ def test_schedule_restart_marks_status_failed_when_spawn_fails(monkeypatch, tmp_
     ],
     ids=["failed", "in-flight", "succeeded"],
 )
-def test_a_recorded_failure_carries_what_was_alive_when_it_was_written(monkeypatch, tmp_path, outcome, alive):
-    """Only a failure records liveness, and it records a lock-verified service.
+def test_a_recorded_outcome_reports_the_job_and_nothing_about_liveness(monkeypatch, tmp_path, outcome):
+    """The record says what the job did. It makes no claim about the machine.
 
-    Whether a failed restart left the instance down depends on which stage failed,
-    and only the moment of failure can tell -- a later reader sees the same empty
-    machine whether the restart killed the service or the user stopped it. The
-    other outcomes make no downtime claim, so they carry no such observation.
-
-    The down case is stated as the wreckage a failed restart actually leaves: a
-    stray process and no lock owner. Anything reading occupancy rather than the
-    lock would call that alive and erase the failure it just recorded.
+    Publishing the outcome must not depend on inspecting the service: the probe
+    can fail on its own -- an unopenable lock file is enough -- and a diagnostic
+    detail is never worth losing the actual restart result over, least of all on
+    the spawn-error path where losing it also strands the `ok: null` marker that
+    makes status report a restart still in flight. So the probes raise here, and
+    every outcome still lands.
     """
 
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
-    monkeypatch.setattr(runtime, "resolve_service_owner_pid", lambda **_kwargs: 4321 if alive else None)
-    monkeypatch.setattr(runtime, "extra_service_process_pids", lambda *_a, **_kw: [] if alive else [7777])
+
+    def fail_probe(*_args, **_kwargs):
+        raise OSError("service.lock cannot be opened")
+
+    monkeypatch.setattr(runtime, "resolve_service_owner_pid", fail_probe)
+    monkeypatch.setattr(runtime, "extra_service_process_pids", fail_probe)
 
     restart_supervisor._write_status({"job_id": "job-1", **outcome})
 
     status = runtime.read_json(runtime.get_restart_status_path())
-    if outcome["ok"] is False:
-        assert status["service_alive"] is alive
-    else:
-        assert "service_alive" not in status
+    assert status["ok"] is outcome["ok"]
+    assert status["state"] == outcome["state"]
+    assert "service_alive" not in status
 
 
 def test_restart_job_stops_and_starts_service(monkeypatch, tmp_path):

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -171,12 +171,17 @@ def test_schedule_restart_marks_status_failed_when_spawn_fails(monkeypatch, tmp_
 def test_a_recorded_outcome_reports_the_job_and_nothing_about_liveness(monkeypatch, tmp_path, outcome):
     """The record says what the job did. It makes no claim about the machine.
 
-    Publishing the outcome must not depend on inspecting the service: the probe
-    can fail on its own -- an unopenable lock file is enough -- and a diagnostic
-    detail is never worth losing the actual restart result over, least of all on
-    the spawn-error path where losing it also strands the `ok: null` marker that
-    makes status report a restart still in flight. So the probes raise here, and
-    every outcome still lands.
+    A fence, not a repair. An earlier revision of this fix had the writer stamp
+    what was alive at write time, and every later reader of that stamp was a way
+    to get a present-tense question wrong from a past-tense answer; doctor now
+    measures liveness when it reports, so the record must stay a statement about
+    the job alone. The liveness probes are stubbed to raise rather than to answer,
+    so a writer that starts consulting them fails here instead of in review --
+    and it names the second cost of consulting them, since a probe can fail on
+    its own (an unopenable lock file is enough) and a diagnostic detail is never
+    worth losing the restart result over, least of all on the spawn-error path
+    where losing it also strands the `ok: null` marker that makes status report a
+    restart still in flight.
     """
 
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -12,19 +12,6 @@ from vibe import restart_supervisor
 from vibe import runtime
 
 
-@pytest.fixture(autouse=True)
-def _hermetic_service_liveness(monkeypatch):
-    """Answer the liveness probe from the fixture, never from the real machine.
-
-    Recording a restart failure asks whether a service survived it, and the honest
-    answer costs a full process-table scan (~1s) of whatever the developer happens
-    to be running. Default it to "nothing alive", which is what a tmp_path AVIBE_HOME
-    describes; tests that care about the other answer set it themselves.
-    """
-
-    monkeypatch.setattr(runtime, "service_process_running", lambda: False)
-
-
 def _fake_start_runtime(calls, service_pid: int = 222, ui_pid: int = 333):
     calls.append("start_runtime")
     runtime.write_status("running", f"pid={service_pid}", service_pid, ui_pid)
@@ -183,17 +170,22 @@ def test_schedule_restart_marks_status_failed_when_spawn_fails(monkeypatch, tmp_
     ids=["failed", "in-flight", "succeeded"],
 )
 def test_a_recorded_failure_carries_what_was_alive_when_it_was_written(monkeypatch, tmp_path, outcome, alive):
-    """Only a failure records liveness, and it records what was actually there.
+    """Only a failure records liveness, and it records a lock-verified service.
 
     Whether a failed restart left the instance down depends on which stage failed,
     and only the moment of failure can tell -- a later reader sees the same empty
     machine whether the restart killed the service or the user stopped it. The
     other outcomes make no downtime claim, so they carry no such observation.
+
+    The down case is stated as the wreckage a failed restart actually leaves: a
+    stray process and no lock owner. Anything reading occupancy rather than the
+    lock would call that alive and erase the failure it just recorded.
     """
 
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
-    monkeypatch.setattr(restart_supervisor.runtime, "service_process_running", lambda: alive)
+    monkeypatch.setattr(runtime, "resolve_service_owner_pid", lambda **_kwargs: 4321 if alive else None)
+    monkeypatch.setattr(runtime, "extra_service_process_pids", lambda *_a, **_kw: [] if alive else [7777])
 
     restart_supervisor._write_status({"job_id": "job-1", **outcome})
 

--- a/tests/test_runtime_service_lock.py
+++ b/tests/test_runtime_service_lock.py
@@ -703,5 +703,42 @@ class RuntimeServiceLockTests(unittest.TestCase):
 
             self.assertFalse(runtime.current_process_owns_service_instance())
 
+    def test_verified_service_running_follows_the_lock_not_the_lock_record(self):
+        """The held lock is the fact; a readable holder pid is not required.
+
+        ``start_service`` refuses on ``lock_available`` alone and does not care
+        whether a holder pid can be read, so the doctor predicate that decides
+        whether an instance has a working service has to agree with it. Corrupting
+        the record while the lock stays held is the state where those two can
+        disagree: it is what a service looks like in the window between taking the
+        lock and writing its record, and answering "no service is running" there
+        would report downtime for a running instance and prescribe a start that
+        cannot succeed.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime_dir = Path(tmpdir) / "runtime"
+            runtime_dir.mkdir(parents=True)
+            lock_path = runtime_dir / "service.lock"
+            pid_path = runtime_dir / "vibe.pid"
+
+            with patch("vibe.runtime.paths.get_runtime_service_lock_path", return_value=lock_path):
+                with patch("vibe.runtime.paths.get_runtime_pid_path", return_value=pid_path):
+                    with patch("vibe.runtime.paths.ensure_data_dirs", return_value=None):
+                        self.assertFalse(runtime.verified_service_running())
+
+                        runtime.acquire_service_instance_lock()
+                        try:
+                            self.assertTrue(runtime.verified_service_running())
+
+                            lock_path.write_text("", encoding="utf-8")
+                            self.assertIsNone(runtime.service_instance_lock_available()[1])
+                            self.assertTrue(runtime.verified_service_running())
+                        finally:
+                            runtime.release_service_instance_lock()
+
+                        self.assertFalse(runtime.verified_service_running())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -1346,6 +1346,105 @@ def test_repair_stale_restart_state_removes_old_marker_without_start_time(monkey
     assert refreshed == [True]
 
 
+def _restart_status_payload(**overrides) -> dict:
+    """Return the status the restart supervisor writes, defaulted to a failure."""
+
+    payload = {
+        "ok": False,
+        "job_id": "0d1f2e3a4b5c",
+        "supervisor_pid": 4242,
+        "supervisor_started_at": 1.0,
+        "state": "failed",
+        "trigger": "auto-update",
+        "delay_seconds": 0.0,
+        "scope": "all",
+        "old_pid": 111,
+        "new_pid": None,
+        "log_path": "/tmp/vibe-restart-0d1f2e3a4b5c.log",
+        "error": "start runtime failed: Config 'model_hub'\n  contains unknown fields",
+        "created_at": "2026-08-11T04:50:31Z",
+        "stage_durations": {"restart_total_seconds": 1.5},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _seed_restart_status(payload: dict, *, age_seconds: float = 0.0) -> Path:
+    paths.ensure_data_dirs()
+    restart_path = runtime.get_restart_status_path()
+    runtime.write_json(restart_path, payload)
+    if age_seconds:
+        stamp = time.time() - age_seconds
+        os.utime(restart_path, (stamp, stamp))
+    return restart_path
+
+
+@pytest.mark.parametrize(
+    "age_seconds",
+    [0.0, cli.DOCTOR_RESTART_RESULT_RETENTION_SECONDS + 60],
+    ids=["fresh", "past-retention"],
+)
+def test_recorded_restart_failure_with_no_service_is_a_doctor_failure(monkeypatch, age_seconds):
+    """A restart that failed and left nothing running is a failure at any age.
+
+    Age is what used to decide the verdict, so both sides of the retention
+    boundary are exercised against the same recorded failure: while the instance
+    is down, neither side may call it healthy nor offer to delete the one record
+    of why it is down.
+    """
+
+    _seed_restart_status(_restart_status_payload(), age_seconds=age_seconds)
+    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda **_kwargs: None)
+
+    items = cli._restart_state_items()
+
+    assert [item["status"] for item in items] == ["fail"]
+    item = items[0]
+    assert item["code"] == "runtime.restart_failed"
+    assert "model_hub" in item["message"]
+    assert "\n" not in item["message"]
+    assert "vibe-restart-0d1f2e3a4b5c.log" in item["message"]
+    assert not item.get("repairable")
+    assert "stale-restart-state" not in item.get("action", "")
+
+
+def test_recorded_restart_failure_with_a_running_service_stays_clearable_history(monkeypatch):
+    """Once something is running again the same record is history, not a failure."""
+
+    _seed_restart_status(
+        _restart_status_payload(),
+        age_seconds=cli.DOCTOR_RESTART_RESULT_RETENTION_SECONDS + 60,
+    )
+    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda **_kwargs: 4321)
+
+    items = cli._restart_state_items()
+
+    assert [item["status"] for item in items] == ["warn"]
+    assert items[0]["repair"]["target"] == "stale-restart-state"
+
+
+def test_restart_state_items_classify_non_failures_without_probing_the_service(monkeypatch):
+    """A record the supervisor did not fail keeps the classification it always had.
+
+    The probe raises instead of returning a pid so this also pins the
+    short-circuit: only a recorded failure may cost doctor a process probe.
+    """
+
+    def fail_probe(*args, **kwargs):
+        raise AssertionError("classifying a non-failure must not probe the service")
+
+    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", fail_probe)
+    succeeded = _restart_status_payload(ok=True, state="succeeded", error=None, new_pid=222)
+
+    _seed_restart_status(succeeded)
+    assert [item["status"] for item in cli._restart_state_items()] == ["pass"]
+
+    _seed_restart_status(succeeded, age_seconds=cli.DOCTOR_RESTART_RESULT_RETENTION_SECONDS + 60)
+    stale = cli._restart_state_items()
+    assert [item["status"] for item in stale] == ["warn"]
+    assert stale[0]["repair"]["target"] == "stale-restart-state"
+
+
 def test_doctor_repair_dry_run_does_not_probe_runtime(monkeypatch):
     def fail_runtime_probe(*args, **kwargs):
         raise AssertionError("dry-run must not touch runtime probes")

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -1403,7 +1403,7 @@ def _seed_restart_status(payload: dict, *, age_seconds: float = 0.0) -> Path:
     return restart_path
 
 
-def _stub_service_liveness(monkeypatch, *, owner_pid=None, starting_pid=None, extra_pids=()):
+def _stub_service_liveness(monkeypatch, *, owner_pid=None, starting_pid=None, extra_pids=(), lock_held=None):
     """Describe a machine state, and let the real predicates read it.
 
     Stubbing ``verified_service_running`` itself would only assert which helper
@@ -1411,15 +1411,23 @@ def _stub_service_liveness(monkeypatch, *, owner_pid=None, starting_pid=None, ex
     ``service_process_running``, so a test can name a machine state -- a lock
     owner, a pid that only reserved itself, a stray process -- and assert the
     verdict the real predicates produce for it.
+
+    ``lock_held`` defaults to whether a lock owner was named, which is the usual
+    case. Pass it True with no ``owner_pid`` for the one state where the two come
+    apart: the lock is held but its record answers no pid, either because the
+    service has not written it yet or because it was corrupted. The lock is what
+    ``start_service`` refuses on, so that state is a running service.
     """
 
     reserved = owner_pid if starting_pid is None else starting_pid
+    holds_lock = owner_pid is not None if lock_held is None else lock_held
 
     def resolve_owner(*, include_starting=False, **_kwargs):
         return reserved if include_starting else owner_pid
 
     monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", resolve_owner)
     monkeypatch.setattr(cli.runtime, "extra_service_process_pids", lambda *_a, **_kw: list(extra_pids))
+    monkeypatch.setattr(cli.runtime, "service_instance_lock_available", lambda: (not holds_lock, owner_pid))
 
 
 @pytest.mark.parametrize(
@@ -1478,6 +1486,13 @@ def test_the_failure_action_only_tells_the_reader_to_run_real_commands(monkeypat
 
     assert "vibe doctor repair duplicate-service-processes" in commands
 
+    # No command twice. `duplicate-service-processes` starts a clean service on
+    # the no-owner path it is prescribed for, so a trailing "then start again"
+    # earns `ServiceAlreadyRunningError` and reads as a recovery that failed --
+    # which is why this asserts the shape rather than that one wording: any
+    # repair that already does what a later step repeats fails here.
+    assert len(commands) == len(set(commands)), f"the action asks for a command twice: {commands}"
+
 
 @pytest.mark.parametrize(
     ("liveness", "expected"),
@@ -1488,6 +1503,7 @@ def test_the_failure_action_only_tells_the_reader_to_run_real_commands(monkeypat
         ({"starting_pid": 5555, "extra_pids": (5555,)}, "fail"),
         ({"owner_pid": 4321}, "warn"),
         ({"owner_pid": 4321, "extra_pids": (7777,)}, "warn"),
+        ({"lock_held": True}, "warn"),
     ],
     ids=[
         "nothing-running",
@@ -1496,6 +1512,7 @@ def test_the_failure_action_only_tells_the_reader_to_run_real_commands(monkeypat
         "half-started-child-both-reserved-and-scanned",
         "lock-owner",
         "lock-owner-beside-a-stray-process",
+        "lock-held-but-its-record-answers-no-pid",
     ],
 )
 def test_a_restart_failure_is_downtime_until_a_lock_verified_service_exists(monkeypatch, liveness, expected):
@@ -1506,6 +1523,12 @@ def test_a_restart_failure_is_downtime_until_a_lock_verified_service_exists(monk
     scan can see, or one child that is both. Reading any of them as a running
     service would suppress the very failure that produced it, so each stays a
     failure until something actually holds the lock.
+
+    The last shape is the one that discriminates the lock from its record. A held
+    lock with no readable holder pid is a service -- caught between acquiring the
+    lock and writing the record, or holding a corrupted one -- and it is exactly
+    what ``start_service`` refuses to start past. Calling it downtime would report
+    a running instance as down and then prescribe a start that cannot succeed.
     """
 
     _seed_restart_status(

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -185,6 +185,44 @@ def test_status_written(tmp_path, monkeypatch):
     assert payload["detail"] == "pid=123"
 
 
+@pytest.mark.parametrize("state", ["running", "starting", "stopped", "error", "degraded"])
+@pytest.mark.parametrize("ok", [False, None, True], ids=["failed", "in-flight", "succeeded"])
+def test_a_running_service_retires_only_a_recorded_restart_failure(tmp_path, monkeypatch, state, ok):
+    """A restart record survives every status write except the one that ends it.
+
+    The failure record claims "this instance is down because a restart failed",
+    and a service reaching running is the only observation that ends that claim
+    -- so every other combination of recorded outcome and written state has to
+    leave the file byte-identical, including a stop, which is the case that would
+    otherwise resurrect an old failure as a fresh diagnosis.
+    """
+
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    runtime.ensure_dirs()
+    restart_path = runtime.get_restart_status_path()
+    payload = {"ok": ok, "state": "failed" if ok is False else "succeeded", "job_id": "job-1"}
+    runtime.write_json(restart_path, payload)
+
+    runtime.write_status(state, detail="pid=123")
+
+    retired = ok is False and state == "running"
+    assert restart_path.exists() is not retired
+    if not retired:
+        assert runtime.read_json(restart_path) == payload
+
+
+def test_write_status_survives_an_unreadable_restart_record(tmp_path, monkeypatch):
+    """Retirement runs inside the status chokepoint, so it cannot fail a write."""
+
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    runtime.ensure_dirs()
+    runtime.get_restart_status_path().write_text("[not a record]", encoding="utf-8")
+
+    runtime.write_status("running", detail="pid=123")
+
+    assert runtime.read_status()["state"] == "running"
+
+
 def test_render_status_includes_restart_status(tmp_path, monkeypatch):
     monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
     runtime.ensure_dirs()
@@ -1379,6 +1417,23 @@ def _seed_restart_status(payload: dict, *, age_seconds: float = 0.0) -> Path:
     return restart_path
 
 
+def _stub_service_liveness(monkeypatch, *, owner_pid=None, starting_pid=None, extra_pids=()):
+    """Pin the two probes ``runtime.service_process_running`` reads.
+
+    Stubbing that predicate itself would only assert which helper doctor calls.
+    Stubbing what it reads describes a machine state instead, and asserts the
+    verdict the real predicate produces for it.
+    """
+
+    reserved = owner_pid if starting_pid is None else starting_pid
+
+    def resolve_owner(*, include_starting=False, **_kwargs):
+        return reserved if include_starting else owner_pid
+
+    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", resolve_owner)
+    monkeypatch.setattr(cli.runtime, "extra_service_process_pids", lambda *_a, **_kw: list(extra_pids))
+
+
 @pytest.mark.parametrize(
     "age_seconds",
     [0.0, cli.DOCTOR_RESTART_RESULT_RETENTION_SECONDS + 60],
@@ -1394,7 +1449,7 @@ def test_recorded_restart_failure_with_no_service_is_a_doctor_failure(monkeypatc
     """
 
     _seed_restart_status(_restart_status_payload(), age_seconds=age_seconds)
-    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda **_kwargs: None)
+    _stub_service_liveness(monkeypatch)
 
     items = cli._restart_state_items()
 
@@ -1408,25 +1463,41 @@ def test_recorded_restart_failure_with_no_service_is_a_doctor_failure(monkeypatc
     assert "stale-restart-state" not in item.get("action", "")
 
 
-def test_recorded_restart_failure_with_a_running_service_stays_clearable_history(monkeypatch):
-    """Once something is running again the same record is history, not a failure."""
+@pytest.mark.parametrize(
+    ("liveness", "expected"),
+    [
+        ({}, "fail"),
+        ({"starting_pid": 5555}, "fail"),
+        ({"owner_pid": 4321}, "warn"),
+        ({"extra_pids": (7777,)}, "warn"),
+    ],
+    ids=["nothing-running", "pid-never-took-the-lock", "lock-owner", "lockless-survivor"],
+)
+def test_recorded_restart_failure_is_a_doctor_failure_exactly_while_nothing_runs(monkeypatch, liveness, expected):
+    """One record, every liveness shape: down is a failure, up is clearable history.
+
+    A pid reserved by a process that never took the lock is still downtime, and a
+    lockless survivor is not -- `vibe start` refuses that one, so telling the user
+    to run it would be wrong. `_service_lifecycle_items` owns reporting it.
+    """
 
     _seed_restart_status(
         _restart_status_payload(),
         age_seconds=cli.DOCTOR_RESTART_RESULT_RETENTION_SECONDS + 60,
     )
-    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda **_kwargs: 4321)
+    _stub_service_liveness(monkeypatch, **liveness)
 
     items = cli._restart_state_items()
 
-    assert [item["status"] for item in items] == ["warn"]
-    assert items[0]["repair"]["target"] == "stale-restart-state"
+    assert [item["status"] for item in items] == [expected]
+    if expected == "warn":
+        assert items[0]["repair"]["target"] == "stale-restart-state"
 
 
 def test_restart_state_items_classify_non_failures_without_probing_the_service(monkeypatch):
     """A record the supervisor did not fail keeps the classification it always had.
 
-    The probe raises instead of returning a pid so this also pins the
+    The probes raise instead of returning a pid so this also pins the
     short-circuit: only a recorded failure may cost doctor a process probe.
     """
 
@@ -1434,6 +1505,7 @@ def test_restart_state_items_classify_non_failures_without_probing_the_service(m
         raise AssertionError("classifying a non-failure must not probe the service")
 
     monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", fail_probe)
+    monkeypatch.setattr(cli.runtime, "extra_service_process_pids", fail_probe)
     succeeded = _restart_status_payload(ok=True, state="succeeded", error=None, new_pid=222)
 
     _seed_restart_status(succeeded)

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -185,19 +185,22 @@ def test_status_written(tmp_path, monkeypatch):
     assert payload["detail"] == "pid=123"
 
 
+@pytest.mark.parametrize("alive", [True, False], ids=["service-alive", "nothing-alive"])
 @pytest.mark.parametrize("state", ["running", "starting", "stopped", "error", "degraded"])
 @pytest.mark.parametrize("ok", [False, None, True], ids=["failed", "in-flight", "succeeded"])
-def test_a_running_service_retires_only_a_recorded_restart_failure(tmp_path, monkeypatch, state, ok):
+def test_an_observed_live_service_retires_only_a_recorded_restart_failure(tmp_path, monkeypatch, state, ok, alive):
     """A restart record survives every status write except the one that ends it.
 
     The failure record claims "this instance is down because a restart failed",
-    and a service reaching running is the only observation that ends that claim
-    -- so every other combination of recorded outcome and written state has to
-    leave the file byte-identical, including a stop, which is the case that would
-    otherwise resurrect an old failure as a fresh diagnosis.
+    and a service being alive is the only observation that ends that claim -- so
+    every other combination of recorded outcome, written state, and liveness has
+    to leave the file byte-identical. Two of those matter in production: the stop
+    that would otherwise resurrect an old failure as a fresh diagnosis, and the
+    ``running`` state a caller copied forward without a service behind it.
     """
 
     monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    monkeypatch.setattr(runtime, "service_process_running", lambda: alive)
     runtime.ensure_dirs()
     restart_path = runtime.get_restart_status_path()
     payload = {"ok": ok, "state": "failed" if ok is False else "succeeded", "job_id": "job-1"}
@@ -205,16 +208,37 @@ def test_a_running_service_retires_only_a_recorded_restart_failure(tmp_path, mon
 
     runtime.write_status(state, detail="pid=123")
 
-    retired = ok is False and state == "running"
+    retired = ok is False and state == "running" and alive
     assert restart_path.exists() is not retired
     if not retired:
         assert runtime.read_json(restart_path) == payload
+
+
+def test_a_copied_running_state_does_not_retire_a_failure(tmp_path, monkeypatch):
+    """The UI reload carries the previous state forward; that is not an observation.
+
+    ``/api/ui/reload`` replaces the UI process and re-writes whatever state string
+    it read, so a service that died between the supervisor's status write and its
+    liveness check would have had its failure record erased by a UI restart.
+    """
+
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    monkeypatch.setattr(runtime, "service_process_running", lambda: False)
+    runtime.ensure_dirs()
+    restart_path = runtime.get_restart_status_path()
+    runtime.write_json(restart_path, {"ok": False, "state": "failed", "job_id": "job-1"})
+    stale = runtime.read_status().get("state", "running")
+
+    runtime.write_status(stale, "carried forward", None, 4321)
+
+    assert restart_path.exists()
 
 
 def test_write_status_survives_an_unreadable_restart_record(tmp_path, monkeypatch):
     """Retirement runs inside the status chokepoint, so it cannot fail a write."""
 
     monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    monkeypatch.setattr(runtime, "service_process_running", lambda: True)
     runtime.ensure_dirs()
     runtime.get_restart_status_path().write_text("[not a record]", encoding="utf-8")
 
@@ -1492,6 +1516,29 @@ def test_recorded_restart_failure_is_a_doctor_failure_exactly_while_nothing_runs
     assert [item["status"] for item in items] == [expected]
     if expected == "warn":
         assert items[0]["repair"]["target"] == "stale-restart-state"
+
+
+@pytest.mark.parametrize(
+    ("service_alive", "expected"),
+    [(True, "warn"), (False, "fail"), (None, "fail")],
+    ids=["failed-with-a-surviving-service", "failed-with-nothing-left", "recorded-before-the-field-existed"],
+)
+def test_a_restart_failure_that_left_a_service_running_never_claims_downtime(monkeypatch, service_alive, expected):
+    """What the supervisor observed at failure time decides whether this is downtime.
+
+    The spawn path fails before anything is stopped, so the old service keeps
+    serving and that record never described downtime -- a deliberate stop months
+    later must not be blamed on it. A record written before the field existed
+    carries no such observation, so it keeps the reading it always had.
+    """
+
+    payload = _restart_status_payload()
+    if service_alive is not None:
+        payload["service_alive"] = service_alive
+    _seed_restart_status(payload, age_seconds=cli.DOCTOR_RESTART_RESULT_RETENTION_SECONDS + 60)
+    _stub_service_liveness(monkeypatch)
+
+    assert [item["status"] for item in cli._restart_state_items()] == [expected]
 
 
 def test_restart_state_items_classify_non_failures_without_probing_the_service(monkeypatch):

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pytest
+import re
 import signal
 import shlex
 import sqlite3
@@ -1448,6 +1449,34 @@ def test_recorded_restart_failure_with_no_service_is_a_doctor_failure(monkeypatc
     assert "vibe-restart-0d1f2e3a4b5c.log" in item["message"]
     assert not item.get("repairable")
     assert "stale-restart-state" not in item.get("action", "")
+
+
+def test_the_failure_action_only_tells_the_reader_to_run_real_commands(monkeypatch):
+    """Every command the action names is one the reader can actually run.
+
+    An action is actionable on its own or not at all. An earlier revision of this
+    told the reader to "apply the extra-service-process repair listed in this
+    report", which is a dependency on what else got rendered: that item is behind
+    `--deep`, and the default run is exactly where a reader of this item lands, so
+    the instruction resolved to nothing. Naming the command instead is the fix, and
+    parsing it here is what keeps the name honest -- a renamed or misspelled repair
+    target fails against the real parser rather than against a user who is already
+    down. Extracted rather than asserted literally, so a command added to this text
+    later is checked too.
+    """
+
+    _seed_restart_status(_restart_status_payload())
+    _stub_service_liveness(monkeypatch)
+
+    action = cli._restart_state_items()[0]["action"]
+    commands = [text for text in re.findall(r"`([^`]+)`", action) if text.startswith("vibe ")]
+    assert commands, f"the action names no runnable command: {action}"
+
+    parser = cli.build_parser()
+    for command in commands:
+        parser.parse_args(shlex.split(command)[1:])
+
+    assert "vibe doctor repair duplicate-service-processes" in commands
 
 
 @pytest.mark.parametrize(

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -300,6 +300,107 @@ def test_write_status_survives_a_restart_record_that_cannot_be_removed(tmp_path,
     assert runtime.read_json(restart_path) == payload
 
 
+@pytest.fixture
+def release_service_lock_after_test():
+    """Release the process-wide lock handle so it cannot leak into another test."""
+
+    try:
+        yield
+    finally:
+        runtime.release_service_instance_lock()
+
+
+def test_a_service_taking_the_lock_retires_a_failure_nobody_reported(
+    tmp_path, monkeypatch, release_service_lock_after_test
+):
+    """Becoming the lock owner retires the failure, with no status write involved.
+
+    This is the start that outlived its supervisor: `wait_for_service_ready` gave
+    up, recorded the failure with nothing alive, and left the child running
+    unwatched, so the child acquires the lock a moment later and no `running`
+    status is ever written for it. The instance recovered; the only thing that
+    knows is the service itself. Left on disk, the record would sit harmless
+    while the service ran and then blame the next deliberate stop for downtime it
+    did not cause.
+
+    Nothing is stubbed here -- a real flock against a redirected home, so the
+    assertion covers the lock path a service actually takes.
+    """
+
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    runtime.ensure_dirs()
+    restart_path = runtime.get_restart_status_path()
+    runtime.write_json(restart_path, {"ok": False, "state": "failed", "job_id": "job-1", "service_alive": False})
+    assert tmp_path in runtime.get_service_lock_path().parents
+
+    runtime.acquire_service_instance_lock()
+
+    assert runtime.verified_service_running()
+    assert not restart_path.exists()
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        None,
+        {"ok": None, "state": "scheduled", "job_id": "job-1"},
+        {"ok": None, "state": "running", "job_id": "job-1"},
+        {"ok": True, "state": "succeeded", "job_id": "job-1"},
+        {"ok": False},
+        "not a record at all",
+    ],
+    ids=["absent", "scheduled", "in-flight", "succeeded", "failure-without-a-job-id", "unreadable"],
+)
+def test_lock_acquisition_only_retires_a_recorded_failure(
+    tmp_path, monkeypatch, release_service_lock_after_test, record
+):
+    """Every shape that is not this call's failure record survives untouched.
+
+    Seeded rather than enumerated as exclusions, so a shape added later is covered
+    without editing this test. The in-flight ones carry the weight: the supervisor
+    spawns the service while its own `ok: null` marker is on disk, so the child
+    retiring it would make `_restart_in_flight()` report no restart running and
+    admit a second supervisor alongside the first. A failure with no `job_id` is a
+    record from before job ids existed and is still this call's to retire -- it is
+    listed here only because the identity guard must match it to itself.
+    """
+
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    runtime.ensure_dirs()
+    restart_path = runtime.get_restart_status_path()
+    if record is not None:
+        restart_path.write_text(json.dumps(record), encoding="utf-8")
+    before = restart_path.read_bytes() if restart_path.exists() else None
+
+    runtime.acquire_service_instance_lock()
+
+    retired = record == {"ok": False}
+    after = restart_path.read_bytes() if restart_path.exists() else None
+    assert after == (None if retired else before)
+
+
+def test_lock_acquisition_survives_a_restart_record_that_cannot_be_removed(
+    tmp_path, monkeypatch, release_service_lock_after_test
+):
+    """A marker that will not delete must not stop the service from starting."""
+
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    runtime.ensure_dirs()
+    restart_path = runtime.get_restart_status_path()
+    payload = {"ok": False, "state": "failed", "job_id": "job-1"}
+    runtime.write_json(restart_path, payload)
+
+    def refuse_unlink(*_args, **_kwargs):
+        raise PermissionError("restart marker is locked")
+
+    monkeypatch.setattr(type(restart_path), "unlink", refuse_unlink)
+
+    runtime.acquire_service_instance_lock()
+
+    assert runtime.service_instance_lock_attached_to_process()
+    assert runtime.read_json(restart_path) == payload
+
+
 def test_render_status_includes_restart_status(tmp_path, monkeypatch):
     monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
     runtime.ensure_dirs()

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -247,6 +247,33 @@ def test_write_status_survives_an_unreadable_restart_record(tmp_path, monkeypatc
     assert runtime.read_status()["state"] == "running"
 
 
+def test_retirement_leaves_a_restart_scheduled_while_it_was_deciding(tmp_path, monkeypatch):
+    """Retirement deletes the record it decided about, not whatever is there now.
+
+    The liveness probe is the slow step, so a restart scheduled during it replaces
+    the file underneath -- staged here by having the probe do the replacing, which
+    puts the interleaving exactly where it can happen. Dropping that new marker
+    would make `_restart_in_flight()` report no restart running and let a second
+    supervisor start alongside the first.
+    """
+
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    runtime.ensure_dirs()
+    restart_path = runtime.get_restart_status_path()
+    runtime.write_json(restart_path, {"ok": False, "state": "failed", "job_id": "old-job"})
+    scheduled = {"ok": None, "state": "scheduled", "job_id": "new-job"}
+
+    def probe_then_reschedule():
+        runtime.write_json(restart_path, scheduled)
+        return True
+
+    monkeypatch.setattr(runtime, "verified_service_running", probe_then_reschedule)
+
+    runtime.write_status("running", detail="pid=123")
+
+    assert runtime.read_json(restart_path) == scheduled
+
+
 def test_write_status_survives_a_restart_record_that_cannot_be_removed(tmp_path, monkeypatch):
     """A marker that will not delete must not fail the service that just started.
 

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -200,7 +200,7 @@ def test_an_observed_live_service_retires_only_a_recorded_restart_failure(tmp_pa
     """
 
     monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
-    monkeypatch.setattr(runtime, "service_process_running", lambda: alive)
+    monkeypatch.setattr(runtime, "verified_service_running", lambda: alive)
     runtime.ensure_dirs()
     restart_path = runtime.get_restart_status_path()
     payload = {"ok": ok, "state": "failed" if ok is False else "succeeded", "job_id": "job-1"}
@@ -223,7 +223,7 @@ def test_a_copied_running_state_does_not_retire_a_failure(tmp_path, monkeypatch)
     """
 
     monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
-    monkeypatch.setattr(runtime, "service_process_running", lambda: False)
+    monkeypatch.setattr(runtime, "verified_service_running", lambda: False)
     runtime.ensure_dirs()
     restart_path = runtime.get_restart_status_path()
     runtime.write_json(restart_path, {"ok": False, "state": "failed", "job_id": "job-1"})
@@ -238,13 +238,39 @@ def test_write_status_survives_an_unreadable_restart_record(tmp_path, monkeypatc
     """Retirement runs inside the status chokepoint, so it cannot fail a write."""
 
     monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
-    monkeypatch.setattr(runtime, "service_process_running", lambda: True)
+    monkeypatch.setattr(runtime, "verified_service_running", lambda: True)
     runtime.ensure_dirs()
     runtime.get_restart_status_path().write_text("[not a record]", encoding="utf-8")
 
     runtime.write_status("running", detail="pid=123")
 
     assert runtime.read_status()["state"] == "running"
+
+
+def test_write_status_survives_a_restart_record_that_cannot_be_removed(tmp_path, monkeypatch):
+    """A marker that will not delete must not fail the service that just started.
+
+    Ownership, a file attribute, or a Windows lock can all refuse the unlink, and
+    this is the write every start path reaches -- so the cleanup is best-effort and
+    the marker simply stays, to be retired by the next successful start.
+    """
+
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
+    monkeypatch.setattr(runtime, "verified_service_running", lambda: True)
+    runtime.ensure_dirs()
+    restart_path = runtime.get_restart_status_path()
+    payload = {"ok": False, "state": "failed", "job_id": "job-1"}
+    runtime.write_json(restart_path, payload)
+
+    def refuse_unlink(*_args, **_kwargs):
+        raise PermissionError("restart marker is locked")
+
+    monkeypatch.setattr(type(restart_path), "unlink", refuse_unlink)
+
+    runtime.write_status("running", detail="pid=123")
+
+    assert runtime.read_status()["state"] == "running"
+    assert runtime.read_json(restart_path) == payload
 
 
 def test_render_status_includes_restart_status(tmp_path, monkeypatch):
@@ -1442,11 +1468,13 @@ def _seed_restart_status(payload: dict, *, age_seconds: float = 0.0) -> Path:
 
 
 def _stub_service_liveness(monkeypatch, *, owner_pid=None, starting_pid=None, extra_pids=()):
-    """Pin the two probes ``runtime.service_process_running`` reads.
+    """Describe a machine state, and let the real predicates read it.
 
-    Stubbing that predicate itself would only assert which helper doctor calls.
-    Stubbing what it reads describes a machine state instead, and asserts the
-    verdict the real predicate produces for it.
+    Stubbing ``verified_service_running`` itself would only assert which helper
+    doctor calls. These are the sources underneath it and underneath the broader
+    ``service_process_running``, so a test can name a machine state -- a lock
+    owner, a pid that only reserved itself, a stray process -- and assert the
+    verdict the real predicates produce for it.
     """
 
     reserved = owner_pid if starting_pid is None else starting_pid
@@ -1492,17 +1520,28 @@ def test_recorded_restart_failure_with_no_service_is_a_doctor_failure(monkeypatc
     [
         ({}, "fail"),
         ({"starting_pid": 5555}, "fail"),
+        ({"extra_pids": (7777,)}, "fail"),
+        ({"starting_pid": 5555, "extra_pids": (5555,)}, "fail"),
         ({"owner_pid": 4321}, "warn"),
-        ({"extra_pids": (7777,)}, "warn"),
+        ({"owner_pid": 4321, "extra_pids": (7777,)}, "warn"),
     ],
-    ids=["nothing-running", "pid-never-took-the-lock", "lock-owner", "lockless-survivor"],
+    ids=[
+        "nothing-running",
+        "pid-reserved-but-never-locked",
+        "stray-process-holding-no-lock",
+        "half-started-child-both-reserved-and-scanned",
+        "lock-owner",
+        "lock-owner-beside-a-stray-process",
+    ],
 )
-def test_recorded_restart_failure_is_a_doctor_failure_exactly_while_nothing_runs(monkeypatch, liveness, expected):
-    """One record, every liveness shape: down is a failure, up is clearable history.
+def test_a_restart_failure_is_downtime_until_a_lock_verified_service_exists(monkeypatch, liveness, expected):
+    """One record against every liveness shape: only the service lock ends downtime.
 
-    A pid reserved by a process that never took the lock is still downtime, and a
-    lockless survivor is not -- `vibe start` refuses that one, so telling the user
-    to run it would be wrong. `_service_lifecycle_items` owns reporting it.
+    The shapes that are not a lock owner are the wreckage a failed restart leaves:
+    a pid that reserved itself and never acquired the lock, a stray process the
+    scan can see, or one child that is both. Reading any of them as a running
+    service would suppress the very failure that produced it, so each stays a
+    failure until something actually holds the lock.
     """
 
     _seed_restart_status(

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -185,22 +185,18 @@ def test_status_written(tmp_path, monkeypatch):
     assert payload["detail"] == "pid=123"
 
 
-@pytest.mark.parametrize("alive", [True, False], ids=["service-alive", "nothing-alive"])
 @pytest.mark.parametrize("state", ["running", "starting", "stopped", "error", "degraded"])
 @pytest.mark.parametrize("ok", [False, None, True], ids=["failed", "in-flight", "succeeded"])
-def test_an_observed_live_service_retires_only_a_recorded_restart_failure(tmp_path, monkeypatch, state, ok, alive):
-    """A restart record survives every status write except the one that ends it.
+def test_a_restart_record_survives_every_status_write(tmp_path, monkeypatch, state, ok):
+    """Nothing about writing runtime status touches the restart record.
 
-    The failure record claims "this instance is down because a restart failed",
-    and a service being alive is the only observation that ends that claim -- so
-    every other combination of recorded outcome, written state, and liveness has
-    to leave the file byte-identical. Two of those matter in production: the stop
-    that would otherwise resurrect an old failure as a fresh diagnosis, and the
-    ``running`` state a caller copied forward without a service behind it.
+    The record is the restart subsystem's own account of its last job, and doctor
+    reads it against live facts rather than against anything a status write
+    remembered. Seeded across every outcome and every state a caller can write, so
+    a status path added later inherits the assertion instead of needing its own.
     """
 
     monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
-    monkeypatch.setattr(runtime, "verified_service_running", lambda: alive)
     runtime.ensure_dirs()
     restart_path = runtime.get_restart_status_path()
     payload = {"ok": ok, "state": "failed" if ok is False else "succeeded", "job_id": "job-1"}
@@ -208,196 +204,7 @@ def test_an_observed_live_service_retires_only_a_recorded_restart_failure(tmp_pa
 
     runtime.write_status(state, detail="pid=123")
 
-    retired = ok is False and state == "running" and alive
-    assert restart_path.exists() is not retired
-    if not retired:
-        assert runtime.read_json(restart_path) == payload
-
-
-def test_a_copied_running_state_does_not_retire_a_failure(tmp_path, monkeypatch):
-    """The UI reload carries the previous state forward; that is not an observation.
-
-    ``/api/ui/reload`` replaces the UI process and re-writes whatever state string
-    it read, so a service that died between the supervisor's status write and its
-    liveness check would have had its failure record erased by a UI restart.
-    """
-
-    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
-    monkeypatch.setattr(runtime, "verified_service_running", lambda: False)
-    runtime.ensure_dirs()
-    restart_path = runtime.get_restart_status_path()
-    runtime.write_json(restart_path, {"ok": False, "state": "failed", "job_id": "job-1"})
-    stale = runtime.read_status().get("state", "running")
-
-    runtime.write_status(stale, "carried forward", None, 4321)
-
-    assert restart_path.exists()
-
-
-def test_write_status_survives_an_unreadable_restart_record(tmp_path, monkeypatch):
-    """Retirement runs inside the status chokepoint, so it cannot fail a write."""
-
-    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
-    monkeypatch.setattr(runtime, "verified_service_running", lambda: True)
-    runtime.ensure_dirs()
-    runtime.get_restart_status_path().write_text("[not a record]", encoding="utf-8")
-
-    runtime.write_status("running", detail="pid=123")
-
-    assert runtime.read_status()["state"] == "running"
-
-
-def test_retirement_leaves_a_restart_scheduled_while_it_was_deciding(tmp_path, monkeypatch):
-    """Retirement deletes the record it decided about, not whatever is there now.
-
-    The liveness probe is the slow step, so a restart scheduled during it replaces
-    the file underneath -- staged here by having the probe do the replacing, which
-    puts the interleaving exactly where it can happen. Dropping that new marker
-    would make `_restart_in_flight()` report no restart running and let a second
-    supervisor start alongside the first.
-    """
-
-    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
-    runtime.ensure_dirs()
-    restart_path = runtime.get_restart_status_path()
-    runtime.write_json(restart_path, {"ok": False, "state": "failed", "job_id": "old-job"})
-    scheduled = {"ok": None, "state": "scheduled", "job_id": "new-job"}
-
-    def probe_then_reschedule():
-        runtime.write_json(restart_path, scheduled)
-        return True
-
-    monkeypatch.setattr(runtime, "verified_service_running", probe_then_reschedule)
-
-    runtime.write_status("running", detail="pid=123")
-
-    assert runtime.read_json(restart_path) == scheduled
-
-
-def test_write_status_survives_a_restart_record_that_cannot_be_removed(tmp_path, monkeypatch):
-    """A marker that will not delete must not fail the service that just started.
-
-    Ownership, a file attribute, or a Windows lock can all refuse the unlink, and
-    this is the write every start path reaches -- so the cleanup is best-effort and
-    the marker simply stays, to be retired by the next successful start.
-    """
-
-    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
-    monkeypatch.setattr(runtime, "verified_service_running", lambda: True)
-    runtime.ensure_dirs()
-    restart_path = runtime.get_restart_status_path()
-    payload = {"ok": False, "state": "failed", "job_id": "job-1"}
-    runtime.write_json(restart_path, payload)
-
-    def refuse_unlink(*_args, **_kwargs):
-        raise PermissionError("restart marker is locked")
-
-    monkeypatch.setattr(type(restart_path), "unlink", refuse_unlink)
-
-    runtime.write_status("running", detail="pid=123")
-
-    assert runtime.read_status()["state"] == "running"
-    assert runtime.read_json(restart_path) == payload
-
-
-@pytest.fixture
-def release_service_lock_after_test():
-    """Release the process-wide lock handle so it cannot leak into another test."""
-
-    try:
-        yield
-    finally:
-        runtime.release_service_instance_lock()
-
-
-def test_a_service_taking_the_lock_retires_a_failure_nobody_reported(
-    tmp_path, monkeypatch, release_service_lock_after_test
-):
-    """Becoming the lock owner retires the failure, with no status write involved.
-
-    This is the start that outlived its supervisor: `wait_for_service_ready` gave
-    up, recorded the failure with nothing alive, and left the child running
-    unwatched, so the child acquires the lock a moment later and no `running`
-    status is ever written for it. The instance recovered; the only thing that
-    knows is the service itself. Left on disk, the record would sit harmless
-    while the service ran and then blame the next deliberate stop for downtime it
-    did not cause.
-
-    Nothing is stubbed here -- a real flock against a redirected home, so the
-    assertion covers the lock path a service actually takes.
-    """
-
-    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
-    runtime.ensure_dirs()
-    restart_path = runtime.get_restart_status_path()
-    runtime.write_json(restart_path, {"ok": False, "state": "failed", "job_id": "job-1", "service_alive": False})
-    assert tmp_path in runtime.get_service_lock_path().parents
-
-    runtime.acquire_service_instance_lock()
-
-    assert runtime.verified_service_running()
-    assert not restart_path.exists()
-
-
-@pytest.mark.parametrize(
-    "record",
-    [
-        None,
-        {"ok": None, "state": "scheduled", "job_id": "job-1"},
-        {"ok": None, "state": "running", "job_id": "job-1"},
-        {"ok": True, "state": "succeeded", "job_id": "job-1"},
-        {"ok": False},
-        "not a record at all",
-    ],
-    ids=["absent", "scheduled", "in-flight", "succeeded", "failure-without-a-job-id", "unreadable"],
-)
-def test_lock_acquisition_only_retires_a_recorded_failure(
-    tmp_path, monkeypatch, release_service_lock_after_test, record
-):
-    """Every shape that is not this call's failure record survives untouched.
-
-    Seeded rather than enumerated as exclusions, so a shape added later is covered
-    without editing this test. The in-flight ones carry the weight: the supervisor
-    spawns the service while its own `ok: null` marker is on disk, so the child
-    retiring it would make `_restart_in_flight()` report no restart running and
-    admit a second supervisor alongside the first. A failure with no `job_id` is a
-    record from before job ids existed and is still this call's to retire -- it is
-    listed here only because the identity guard must match it to itself.
-    """
-
-    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
-    runtime.ensure_dirs()
-    restart_path = runtime.get_restart_status_path()
-    if record is not None:
-        restart_path.write_text(json.dumps(record), encoding="utf-8")
-    before = restart_path.read_bytes() if restart_path.exists() else None
-
-    runtime.acquire_service_instance_lock()
-
-    retired = record == {"ok": False}
-    after = restart_path.read_bytes() if restart_path.exists() else None
-    assert after == (None if retired else before)
-
-
-def test_lock_acquisition_survives_a_restart_record_that_cannot_be_removed(
-    tmp_path, monkeypatch, release_service_lock_after_test
-):
-    """A marker that will not delete must not stop the service from starting."""
-
-    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".vibe_remote")
-    runtime.ensure_dirs()
-    restart_path = runtime.get_restart_status_path()
-    payload = {"ok": False, "state": "failed", "job_id": "job-1"}
-    runtime.write_json(restart_path, payload)
-
-    def refuse_unlink(*_args, **_kwargs):
-        raise PermissionError("restart marker is locked")
-
-    monkeypatch.setattr(type(restart_path), "unlink", refuse_unlink)
-
-    runtime.acquire_service_instance_lock()
-
-    assert runtime.service_instance_lock_attached_to_process()
+    assert runtime.read_status()["state"] == state
     assert runtime.read_json(restart_path) == payload
 
 
@@ -1686,26 +1493,28 @@ def test_a_restart_failure_is_downtime_until_a_lock_verified_service_exists(monk
 
 
 @pytest.mark.parametrize(
-    ("service_alive", "expected"),
-    [(True, "warn"), (False, "fail"), (None, "fail")],
-    ids=["failed-with-a-surviving-service", "failed-with-nothing-left", "recorded-before-the-field-existed"],
+    "extra",
+    [{}, {"service_alive": True}, {"service_alive": False}, {"whatever_a_future_writer_adds": True}],
+    ids=["bare", "claims-a-service-survived", "claims-nothing-survived", "an-unknown-field"],
 )
-def test_a_restart_failure_that_left_a_service_running_never_claims_downtime(monkeypatch, service_alive, expected):
-    """What the supervisor observed at failure time decides whether this is downtime.
+def test_only_live_facts_decide_downtime_not_what_the_record_claims(monkeypatch, extra):
+    """No field in the record can talk doctor out of a verdict about right now.
 
-    The spawn path fails before anything is stopped, so the old service keeps
-    serving and that record never described downtime -- a deliberate stop months
-    later must not be blamed on it. A record written before the field existed
-    carries no such observation, so it keeps the reading it always had.
+    A record is written at failure time and read arbitrarily later, so anything it
+    says about what was alive is a snapshot that may since have been falsified --
+    by a child that took the lock after the supervisor gave up, or by any later
+    start. The rule reads the record for the outcome and the machine for liveness,
+    and nothing else. Seeded with the field a previous revision of this PR wrote,
+    both ways round, so a record produced by any version reaches the same verdict.
     """
 
-    payload = _restart_status_payload()
-    if service_alive is not None:
-        payload["service_alive"] = service_alive
-    _seed_restart_status(payload, age_seconds=cli.DOCTOR_RESTART_RESULT_RETENTION_SECONDS + 60)
+    _seed_restart_status(
+        {**_restart_status_payload(), **extra},
+        age_seconds=cli.DOCTOR_RESTART_RESULT_RETENTION_SECONDS + 60,
+    )
     _stub_service_liveness(monkeypatch)
 
-    assert [item["status"] for item in cli._restart_state_items()] == [expected]
+    assert [item["status"] for item in cli._restart_state_items()] == ["fail"]
 
 
 def test_restart_state_items_classify_non_failures_without_probing_the_service(monkeypatch):

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1210,15 +1210,22 @@ def _restart_state_items() -> list[dict]:
         _add_doctor_item(items, "pass", "No restart metadata is present", code="runtime.restart_state_absent")
         return items
 
-    # `_fail` in the restart supervisor is the only writer of ok=False, and a
-    # failed restart can leave the instance either up or down -- some of its
-    # sites fire after the old service was stopped, one fires precisely because
-    # it would not stop. Rather than enumerate them, observe the result: a
-    # recorded failure with nothing running means this metadata is the record of
-    # why the instance is down. It has to be read before the staleness branch
-    # below, because terminal metadata goes stale after
-    # DOCTOR_RESTART_RESULT_RETENTION_SECONDS, and that branch offers a repair
-    # that deletes the marker -- on a still-down instance, the reason it is down.
+    # A recorded failure explains the current downtime only when no service has
+    # been alive since it was written, which takes an observation at both ends.
+    # At the near end the supervisor records `service_alive`, because a failed
+    # restart leaves the instance up or down depending on which stage failed and
+    # only that moment can tell: the spawn path never stops anything, so the old
+    # service is still serving and this record never described downtime at all.
+    # At the far end a service observed alive retires the record outright (see
+    # `runtime._retire_failed_restart_status`), so a surviving record means
+    # nothing has come up since -- the instance never recovered, rather than
+    # having been stopped deliberately some time later. Records written before
+    # `service_alive` existed carry no such claim and keep the old reading.
+    #
+    # This has to be read before the staleness branch below, because terminal
+    # metadata goes stale after DOCTOR_RESTART_RESULT_RETENTION_SECONDS, and that
+    # branch offers a repair that deletes the marker -- on a still-down instance,
+    # the reason it is down.
     #
     # `service_process_running` is the question being asked, so it is the probe
     # used rather than a liveness rule reassembled here. Both halves of it
@@ -1228,12 +1235,7 @@ def _restart_state_items() -> list[dict]:
     # start` there would send the user into a wall. `_service_lifecycle_items`
     # already owns that state, so this record falls through to history and lets
     # the lifecycle items report it.
-    #
-    # A running service retires the record outright (see
-    # `runtime._retire_failed_restart_status`), so an ok=False record surviving
-    # here means nothing has come up since it was written: the instance never
-    # recovered, rather than having been stopped deliberately some time later.
-    if payload.get("ok") is False and not runtime.service_process_running():
+    if payload.get("ok") is False and payload.get("service_alive") is not True and not runtime.service_process_running():
         _add_doctor_item(
             items,
             "fail",

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1210,32 +1210,43 @@ def _restart_state_items() -> list[dict]:
         _add_doctor_item(items, "pass", "No restart metadata is present", code="runtime.restart_state_absent")
         return items
 
-    # A recorded failure explains the current downtime only when no working
-    # service has existed since it was written, which takes an observation at both
-    # ends. At the near end the supervisor records `service_alive`, because a
-    # failed restart can leave the old service untouched and serving -- the spawn
-    # path never stops anything -- and only that moment can tell. At the far end a
-    # service seen running retires the record outright (see
-    # `runtime._retire_failed_restart_status`), so a surviving record means nothing
-    # has come up since: the instance never recovered, rather than having been
-    # stopped deliberately some time later. Records written before `service_alive`
-    # existed carry no such claim and keep the old reading.
+    # Both clauses are read now, from what is on disk and what is running now.
+    # Nothing here asks what was true at some earlier moment, which is the whole
+    # design: an earlier version of this decided downtime from a liveness snapshot
+    # the supervisor had stamped into the record, and every interleaving between
+    # taking that snapshot and acting on it was a way to get the answer wrong. A
+    # rule with no remembered observation in it has no such window.
+    #
+    # The cost is bounded and in the safe direction. A restart that failed without
+    # stopping the old service -- the spawn path never stops anything -- leaves a
+    # record that outlives its relevance, so after that service is later stopped on
+    # purpose this reports a failure that is history. Both halves of the sentence
+    # are still true, and `vibe start` ends it. Suppressing it instead would mean
+    # trusting a remembered snapshot to stay true, and for a diagnostic the
+    # asymmetry decides it: a stale `fail` is a true statement with a self-clearing
+    # next step, while a wrong `pass` is the eight-day silent outage in #1567
+    # sitting behind a green health check.
+    #
+    # Note what the action must not say, which is the original defect: never offer
+    # the marker-deleting repair here. The reader may be genuinely down, and that
+    # command both destroys the only record of why and makes doctor pass again --
+    # an operator following it would silence their own health check.
     #
     # This has to be read before the staleness branch below, because terminal
     # metadata goes stale after DOCTOR_RESTART_RESULT_RETENTION_SECONDS, and that
     # branch offers a repair that deletes the marker -- on a still-down instance,
     # the reason it is down.
     #
-    # All three of those observations ask `verified_service_running`, never the
-    # broader `service_process_running`. The broad one reports whatever occupies
-    # this data dir, which is the right question for refusing a second start and
-    # the wrong one here: a pid reserved by a process that never acquired the lock
-    # is the wreckage of a failed start, not a recovery, and reading it as one
-    # would suppress the very failure it came from. What that leaves is a stray
-    # process the user is told to `vibe start` past; `_service_lifecycle_items`
-    # owns detecting it and already reports it with its own repair, so the action
-    # below points there rather than reassembling the scan here.
-    if payload.get("ok") is False and payload.get("service_alive") is not True and not runtime.verified_service_running():
+    # Liveness asks `verified_service_running`, never the broader
+    # `service_process_running`. The broad one reports whatever occupies this data
+    # dir, which is the right question for refusing a second start and the wrong
+    # one here: a pid reserved by a process that never acquired the lock is the
+    # wreckage of a failed start, not a recovery, and reading it as one would
+    # suppress the very failure it came from. What that leaves is a stray process
+    # the user is told to `vibe start` past; `_service_lifecycle_items` owns
+    # detecting it and already reports it with its own repair, so the action below
+    # points there rather than reassembling the scan here.
+    if payload.get("ok") is False and not runtime.verified_service_running():
         _add_doctor_item(
             items,
             "fail",

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1210,18 +1210,30 @@ def _restart_state_items() -> list[dict]:
         _add_doctor_item(items, "pass", "No restart metadata is present", code="runtime.restart_state_absent")
         return items
 
-    # `_fail` in the restart supervisor is the only writer of ok=False, and most
-    # of its call sites run after the old service was already stopped. Which
-    # ones leave the instance down is not worth enumerating -- one of them fires
-    # precisely because the old service would not stop -- so observe the result
-    # instead: a recorded failure with no service owner means this metadata is
-    # the record of why the instance is down. It has to be read before the
-    # staleness branch below, because terminal metadata goes stale after
+    # `_fail` in the restart supervisor is the only writer of ok=False, and a
+    # failed restart can leave the instance either up or down -- some of its
+    # sites fire after the old service was stopped, one fires precisely because
+    # it would not stop. Rather than enumerate them, observe the result: a
+    # recorded failure with nothing running means this metadata is the record of
+    # why the instance is down. It has to be read before the staleness branch
+    # below, because terminal metadata goes stale after
     # DOCTOR_RESTART_RESULT_RETENTION_SECONDS, and that branch offers a repair
     # that deletes the marker -- on a still-down instance, the reason it is down.
-    # Once a service is running the same metadata is history, so it falls
-    # through to the ordinary branches and stays clearable.
-    if payload.get("ok") is False and not runtime.resolve_service_owner_pid(include_starting=True):
+    #
+    # `service_process_running` is the question being asked, so it is the probe
+    # used rather than a liveness rule reassembled here. Both halves of it
+    # matter: a pid reserved by a process that never took the lock is not a
+    # recovery, and a surviving lockless daemon is not downtime -- `start_service`
+    # refuses that one with ServiceAlreadyRunningError, so recommending `vibe
+    # start` there would send the user into a wall. `_service_lifecycle_items`
+    # already owns that state, so this record falls through to history and lets
+    # the lifecycle items report it.
+    #
+    # A running service retires the record outright (see
+    # `runtime._retire_failed_restart_status`), so an ok=False record surviving
+    # here means nothing has come up since it was written: the instance never
+    # recovered, rather than having been stopped deliberately some time later.
+    if payload.get("ok") is False and not runtime.service_process_running():
         _add_doctor_item(
             items,
             "fail",

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1243,16 +1243,20 @@ def _restart_state_items() -> list[dict]:
     # one here: a pid reserved by a process that never acquired the lock is the
     # wreckage of a failed start, not a recovery, and reading it as one would
     # suppress the very failure it came from. What that leaves is a stray process
-    # the user is told to `vibe start` past; `_service_lifecycle_items` owns
-    # detecting it and already reports it with its own repair, so the action below
-    # points there rather than reassembling the scan here.
+    # the user is told to `vibe start` past, because `start_service` asks the broad
+    # question and refuses. `_service_lifecycle_items` owns detecting that process,
+    # so this does not reassemble the scan -- but it names the repair rather than
+    # deferring to it, because that item is behind `--deep` and the default run is
+    # exactly where a reader lands. An action is only actionable if it works on its
+    # own; pointing at a sibling item is a dependency on what else got rendered.
     if payload.get("ok") is False and not runtime.verified_service_running():
         _add_doctor_item(
             items,
             "fail",
             f"Last restart failed and no service is running: {_restart_failure_summary(payload)}",
             "Read the restart log named above for the cause, then run `vibe start`. If that reports a "
-            "service already running, apply the extra-service-process repair listed in this report first.",
+            "service already running, the failed restart left a process holding no lock: run "
+            "`vibe doctor repair duplicate-service-processes` to stop it, then start again.",
             code="runtime.restart_failed",
         )
         return items

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1243,12 +1243,20 @@ def _restart_state_items() -> list[dict]:
     # one here: a pid reserved by a process that never acquired the lock is the
     # wreckage of a failed start, not a recovery, and reading it as one would
     # suppress the very failure it came from. What that leaves is a stray process
-    # the user is told to `vibe start` past, because `start_service` asks the broad
-    # question and refuses. `_service_lifecycle_items` owns detecting that process,
-    # so this does not reassemble the scan -- but it names the repair rather than
-    # deferring to it, because that item is behind `--deep` and the default run is
-    # exactly where a reader lands. An action is only actionable if it works on its
-    # own; pointing at a sibling item is a dependency on what else got rendered.
+    # `start_service` refuses to start past, because it asks the broad question --
+    # so the action has to cover it, and `_service_lifecycle_items` cannot be the
+    # one to do that here: its extra-process item is behind `--deep` and the
+    # default run is exactly where a reader of this lands.
+    #
+    # Which is the whole discipline for the text below. Every sentence of procedure
+    # is a claim about control flow this item does not own, and each one is
+    # separately falsifiable: earlier revisions deferred to an item that is not
+    # rendered by default, and then told the reader to start again after a repair
+    # that starts the service itself. So it names the two commands, in order, and
+    # says the one thing the reader cannot see -- that the repair brings the
+    # service up -- because that is what stops them from running start twice and
+    # reading `ServiceAlreadyRunningError` as a failed recovery. Anything beyond
+    # that is a prediction, and the commands report their own outcomes.
     if payload.get("ok") is False and not runtime.verified_service_running():
         _add_doctor_item(
             items,
@@ -1256,7 +1264,7 @@ def _restart_state_items() -> list[dict]:
             f"Last restart failed and no service is running: {_restart_failure_summary(payload)}",
             "Read the restart log named above for the cause, then run `vibe start`. If that reports a "
             "service already running, the failed restart left a process holding no lock: run "
-            "`vibe doctor repair duplicate-service-processes` to stop it, then start again.",
+            "`vibe doctor repair duplicate-service-processes`, which stops it and brings the service up.",
             code="runtime.restart_failed",
         )
         return items

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1210,37 +1210,38 @@ def _restart_state_items() -> list[dict]:
         _add_doctor_item(items, "pass", "No restart metadata is present", code="runtime.restart_state_absent")
         return items
 
-    # A recorded failure explains the current downtime only when no service has
-    # been alive since it was written, which takes an observation at both ends.
-    # At the near end the supervisor records `service_alive`, because a failed
-    # restart leaves the instance up or down depending on which stage failed and
-    # only that moment can tell: the spawn path never stops anything, so the old
-    # service is still serving and this record never described downtime at all.
-    # At the far end a service observed alive retires the record outright (see
-    # `runtime._retire_failed_restart_status`), so a surviving record means
-    # nothing has come up since -- the instance never recovered, rather than
-    # having been stopped deliberately some time later. Records written before
-    # `service_alive` existed carry no such claim and keep the old reading.
+    # A recorded failure explains the current downtime only when no working
+    # service has existed since it was written, which takes an observation at both
+    # ends. At the near end the supervisor records `service_alive`, because a
+    # failed restart can leave the old service untouched and serving -- the spawn
+    # path never stops anything -- and only that moment can tell. At the far end a
+    # service seen running retires the record outright (see
+    # `runtime._retire_failed_restart_status`), so a surviving record means nothing
+    # has come up since: the instance never recovered, rather than having been
+    # stopped deliberately some time later. Records written before `service_alive`
+    # existed carry no such claim and keep the old reading.
     #
     # This has to be read before the staleness branch below, because terminal
     # metadata goes stale after DOCTOR_RESTART_RESULT_RETENTION_SECONDS, and that
     # branch offers a repair that deletes the marker -- on a still-down instance,
     # the reason it is down.
     #
-    # `service_process_running` is the question being asked, so it is the probe
-    # used rather than a liveness rule reassembled here. Both halves of it
-    # matter: a pid reserved by a process that never took the lock is not a
-    # recovery, and a surviving lockless daemon is not downtime -- `start_service`
-    # refuses that one with ServiceAlreadyRunningError, so recommending `vibe
-    # start` there would send the user into a wall. `_service_lifecycle_items`
-    # already owns that state, so this record falls through to history and lets
-    # the lifecycle items report it.
-    if payload.get("ok") is False and payload.get("service_alive") is not True and not runtime.service_process_running():
+    # All three of those observations ask `verified_service_running`, never the
+    # broader `service_process_running`. The broad one reports whatever occupies
+    # this data dir, which is the right question for refusing a second start and
+    # the wrong one here: a pid reserved by a process that never acquired the lock
+    # is the wreckage of a failed start, not a recovery, and reading it as one
+    # would suppress the very failure it came from. What that leaves is a stray
+    # process the user is told to `vibe start` past; `_service_lifecycle_items`
+    # owns detecting it and already reports it with its own repair, so the action
+    # below points there rather than reassembling the scan here.
+    if payload.get("ok") is False and payload.get("service_alive") is not True and not runtime.verified_service_running():
         _add_doctor_item(
             items,
             "fail",
             f"Last restart failed and no service is running: {_restart_failure_summary(payload)}",
-            "Run `vibe start` to bring the service back up, then read the restart log named above for the cause.",
+            "Read the restart log named above for the cause, then run `vibe start`. If that reports a "
+            "service already running, apply the extra-service-process repair listed in this report first.",
             code="runtime.restart_failed",
         )
         return items

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1184,12 +1184,51 @@ def _restart_status_is_stale(payload: dict, path: Path) -> bool:
     return False
 
 
+def _restart_failure_summary(payload: dict) -> str:
+    """Describe a recorded restart failure on the single line doctor prints.
+
+    Why it failed is the entire value of the item, so the recorded error is
+    carried through rather than summarized away, with its whitespace collapsed
+    because the report prints one line per item.
+    """
+
+    pairs = (
+        ("state", payload.get("state") or "unknown"),
+        ("error", " ".join(str(payload.get("error") or "").split())),
+        ("trigger", payload.get("trigger")),
+        ("job_id", payload.get("job_id")),
+        ("log", payload.get("log_path")),
+    )
+    return " ".join(f"{name}={value}" for name, value in pairs if value)
+
+
 def _restart_state_items() -> list[dict]:
     items: list[dict] = []
     restart_path = runtime.get_restart_status_path()
     payload = runtime.read_json(restart_path) or {}
     if not payload:
         _add_doctor_item(items, "pass", "No restart metadata is present", code="runtime.restart_state_absent")
+        return items
+
+    # `_fail` in the restart supervisor is the only writer of ok=False, and most
+    # of its call sites run after the old service was already stopped. Which
+    # ones leave the instance down is not worth enumerating -- one of them fires
+    # precisely because the old service would not stop -- so observe the result
+    # instead: a recorded failure with no service owner means this metadata is
+    # the record of why the instance is down. It has to be read before the
+    # staleness branch below, because terminal metadata goes stale after
+    # DOCTOR_RESTART_RESULT_RETENTION_SECONDS, and that branch offers a repair
+    # that deletes the marker -- on a still-down instance, the reason it is down.
+    # Once a service is running the same metadata is history, so it falls
+    # through to the ordinary branches and stays clearable.
+    if payload.get("ok") is False and not runtime.resolve_service_owner_pid(include_starting=True):
+        _add_doctor_item(
+            items,
+            "fail",
+            f"Last restart failed and no service is running: {_restart_failure_summary(payload)}",
+            "Run `vibe start` to bring the service back up, then read the restart log named above for the cause.",
+            code="runtime.restart_failed",
+        )
         return items
 
     if _restart_status_is_stale(payload, restart_path):

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -89,6 +89,13 @@ def _prune_restart_logs(limit: int = _RESTART_LOG_RETENTION) -> None:
 
 def _write_status(payload: dict) -> None:
     status = {**payload, "updated_at": _now_iso()}
+    if status.get("ok") is False:
+        # A failed restart leaves the instance up or down depending on which
+        # stage failed -- the spawn path never stops anything, the stop-failure
+        # paths leave the old service serving, the start paths leave nothing.
+        # Only this moment can tell the difference, so measure it here instead of
+        # leaving a reader to guess later from a record with no such state in it.
+        status["service_alive"] = runtime.service_process_running()
     path = runtime.get_restart_status_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     runtime.write_json(path, status)

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -90,12 +90,16 @@ def _prune_restart_logs(limit: int = _RESTART_LOG_RETENTION) -> None:
 def _write_status(payload: dict) -> None:
     status = {**payload, "updated_at": _now_iso()}
     if status.get("ok") is False:
-        # A failed restart leaves the instance up or down depending on which
-        # stage failed -- the spawn path never stops anything, the stop-failure
-        # paths leave the old service serving, the start paths leave nothing.
-        # Only this moment can tell the difference, so measure it here instead of
-        # leaving a reader to guess later from a record with no such state in it.
-        status["service_alive"] = runtime.service_process_running()
+        # A failed restart leaves the instance with a working service or without
+        # one depending on which stage failed -- the spawn path never stops
+        # anything, the stop-failure paths leave the old service serving, the
+        # start paths leave nothing. Only this moment can tell the difference, so
+        # measure it here instead of leaving a reader to guess later from a record
+        # with no such state in it. The half-started child this job may have just
+        # left behind is not a service, which is why this asks for a lock-verified
+        # one; the `service pid did not acquire the service lock` failure is that
+        # case exactly, and it is downtime.
+        status["service_alive"] = runtime.verified_service_running()
     path = runtime.get_restart_status_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     runtime.write_json(path, status)

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -89,17 +89,6 @@ def _prune_restart_logs(limit: int = _RESTART_LOG_RETENTION) -> None:
 
 def _write_status(payload: dict) -> None:
     status = {**payload, "updated_at": _now_iso()}
-    if status.get("ok") is False:
-        # A failed restart leaves the instance with a working service or without
-        # one depending on which stage failed -- the spawn path never stops
-        # anything, the stop-failure paths leave the old service serving, the
-        # start paths leave nothing. Only this moment can tell the difference, so
-        # measure it here instead of leaving a reader to guess later from a record
-        # with no such state in it. The half-started child this job may have just
-        # left behind is not a service, which is why this asks for a lock-verified
-        # one; the `service pid did not acquire the service lock` failure is that
-        # case exactly, and it is downtime.
-        status["service_alive"] = runtime.verified_service_running()
     path = runtime.get_restart_status_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     runtime.write_json(path, status)

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -1110,6 +1110,29 @@ def stop_process(pid_path, timeout=5):
     return stopped
 
 
+def _retire_failed_restart_status() -> None:
+    """Drop a recorded restart failure once a service is running again.
+
+    The record exists to say why this instance is down, and nothing else ends
+    that claim: neither ``vibe start`` nor ``vibe stop`` touches the file, so a
+    failure recorded months ago would otherwise become a fresh diagnosis the
+    next time the instance is stopped on purpose. A service reaching "running"
+    is the observation that retires it, whoever started it.
+
+    Only a recorded failure is retired. A restart in progress carries
+    ``ok: None`` and is left alone, because it has not reported an outcome yet
+    and the supervisor writes the running status before it decides the job
+    succeeded; anything else -- absent, succeeded, or too corrupt to read as a
+    record -- was never the claim being ended, and this runs inside the status
+    chokepoint, so it must not turn a damaged file into a failed status write.
+    """
+
+    path = get_restart_status_path()
+    payload = read_json(path)
+    if isinstance(payload, dict) and payload.get("ok") is False:
+        path.unlink(missing_ok=True)
+
+
 def write_status(state, detail=None, service_pid=None, ui_pid=None):
     now_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     # Preserve started_at across consecutive "running" writes so the UI can
@@ -1137,6 +1160,8 @@ def write_status(state, detail=None, service_pid=None, ui_pid=None):
     if started_at:
         payload["started_at"] = started_at
     write_json(paths.get_runtime_status_path(), payload)
+    if state == "running":
+        _retire_failed_restart_status()
 
 
 def read_status():

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -762,6 +762,24 @@ def service_process_running() -> bool:
     return resolve_service_owner_pid(include_starting=False) is not None or bool(extra_service_process_pids())
 
 
+def verified_service_running() -> bool:
+    """Report whether a service holding the service lock is running.
+
+    ``service_process_running`` answers a different question -- whether anything at
+    all occupies this data dir -- and ``start_service`` is right to ask that one,
+    because a half-started child must still block a second start. Deciding whether
+    the instance has a working service needs the narrower fact: a process that
+    reserved the pid and never acquired the lock is not a service, it is a failed
+    start, and a restart record describing that failure must not be demoted to
+    history because the wreckage is still running.
+
+    Cheap by construction. The lock file and pidfile answer this between them, so
+    unlike the broader probe it never scans the process table.
+    """
+
+    return resolve_service_owner_pid(include_starting=False) is not None
+
+
 def _pid_reservation_is_fresh(pid_path: Path, pid: int, *, max_age: float = SERVICE_SLOW_START_TIMEOUT_SECONDS) -> bool:
     try:
         pidfile_mtime = pid_path.stat().st_mtime
@@ -1123,20 +1141,19 @@ def _retire_failed_restart_status() -> None:
     string, and callers copy it: ``/api/ui/reload`` carries the previous state
     forward while it replaces the UI process, so a service that died between the
     supervisor's status write and its liveness check would have its failure
-    record erased by a UI restart. Ask ``service_process_running`` instead -- the
-    state is only the cheap filter that decides whether asking is worth a probe.
+    record erased by a UI restart. Ask instead -- the state is only the cheap
+    filter that decides whether asking is worth it.
 
     Only a recorded failure is retired. A restart in progress carries
     ``ok: None`` and is left alone, because it has not reported an outcome yet
     and the supervisor writes the running status before it decides the job
     succeeded; anything else -- absent, succeeded, or too corrupt to read as a
-    record -- was never the claim being ended, and this runs inside the status
-    chokepoint, so it must not turn a damaged file into a failed status write.
+    record -- was never the claim being ended.
     """
 
     path = get_restart_status_path()
     payload = read_json(path)
-    if isinstance(payload, dict) and payload.get("ok") is False and service_process_running():
+    if isinstance(payload, dict) and payload.get("ok") is False and verified_service_running():
         path.unlink(missing_ok=True)
 
 
@@ -1168,7 +1185,16 @@ def write_status(state, detail=None, service_pid=None, ui_pid=None):
         payload["started_at"] = started_at
     write_json(paths.get_runtime_status_path(), payload)
     if state == "running":
-        _retire_failed_restart_status()
+        # Retiring the marker is cleanup, and this is the write every start path
+        # reaches. An unreadable record, or one that cannot be unlinked because of
+        # ownership, a file attribute, or a Windows lock, must not report the
+        # service that just came up as having failed to start. Leaving the marker
+        # is survivable -- doctor keeps reporting it, and the next successful start
+        # tries again -- so log it and let the status write stand.
+        try:
+            _retire_failed_restart_status()
+        except OSError:
+            logger.warning("Could not retire the recorded restart failure", exc_info=True)
 
 
 def read_status():

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -1111,13 +1111,20 @@ def stop_process(pid_path, timeout=5):
 
 
 def _retire_failed_restart_status() -> None:
-    """Drop a recorded restart failure once a service is running again.
+    """Drop a recorded restart failure once a service is observed running again.
 
     The record exists to say why this instance is down, and nothing else ends
     that claim: neither ``vibe start`` nor ``vibe stop`` touches the file, so a
     failure recorded months ago would otherwise become a fresh diagnosis the
-    next time the instance is stopped on purpose. A service reaching "running"
+    next time the instance is stopped on purpose. A service actually being alive
     is the observation that retires it, whoever started it.
+
+    The ``running`` state that brought us here is not that observation. It is a
+    string, and callers copy it: ``/api/ui/reload`` carries the previous state
+    forward while it replaces the UI process, so a service that died between the
+    supervisor's status write and its liveness check would have its failure
+    record erased by a UI restart. Ask ``service_process_running`` instead -- the
+    state is only the cheap filter that decides whether asking is worth a probe.
 
     Only a recorded failure is retired. A restart in progress carries
     ``ok: None`` and is left alone, because it has not reported an outcome yet
@@ -1129,7 +1136,7 @@ def _retire_failed_restart_status() -> None:
 
     path = get_restart_status_path()
     payload = read_json(path)
-    if isinstance(payload, dict) and payload.get("ok") is False:
+    if isinstance(payload, dict) and payload.get("ok") is False and service_process_running():
         path.unlink(missing_ok=True)
 
 

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -773,11 +773,22 @@ def verified_service_running() -> bool:
     start, and a restart record describing that failure must not be demoted to
     history because the wreckage is still running.
 
-    Cheap by construction. The lock file and pidfile answer this between them, so
-    unlike the broader probe it never scans the process table.
+    The held lock *is* that fact, so this asks for nothing else. Reading the holder
+    pid out of the lock record and requiring it to parse would be strictly weaker
+    than the signal already in hand: the record is written just after the lock is
+    taken, so a service caught in that window -- or one whose record was corrupted
+    -- holds the lock while answering no pid, and calling that "no service" both
+    contradicts the lock and disagrees with ``start_service``, which refuses on
+    ``lock_available`` alone and does not care whether a holder pid could be read.
+    A dead holder cannot keep the lock either, since the kernel drops it when the
+    process goes, so liveness needs no separate check.
+
+    Cheap by construction: one open and one non-blocking lock attempt, and unlike
+    the broader probe it never scans the process table.
     """
 
-    return resolve_service_owner_pid(include_starting=False) is not None
+    lock_available, _holder_pid = service_instance_lock_available()
+    return not lock_available
 
 
 def _pid_reservation_is_fresh(pid_path: Path, pid: int, *, max_age: float = SERVICE_SLOW_START_TIMEOUT_SECONDS) -> bool:

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -276,6 +276,20 @@ def acquire_service_instance_lock() -> None:
         logger.debug("Failed to fsync service instance lock", exc_info=True)
     paths.get_runtime_pid_path().write_text(str(os.getpid()), encoding="utf-8")
     _SERVICE_INSTANCE_LOCK_HANDLE = lock_file
+    # This line is the moment a working service exists, so it is where a recorded
+    # restart failure stops describing the present. Every other observation of
+    # that fact is second-hand: a supervisor writes `running` because it believes
+    # the child came up, and it can be wrong in both directions. It can also
+    # simply never run -- a start that outlives `wait_for_service_ready` leaves
+    # the child alive and unwatched, and the service it becomes is one nobody
+    # reports. Retiring here needs no reporter and no reader.
+    #
+    # Best-effort, for the same reason as in `write_status`: an unremovable or
+    # unreadable marker must not stop the service that just acquired the lock.
+    try:
+        _retire_failed_restart_status()
+    except OSError:
+        logger.warning("Could not retire the recorded restart failure", exc_info=True)
 
 
 def release_service_instance_lock() -> None:
@@ -1136,6 +1150,15 @@ def _retire_failed_restart_status() -> None:
     failure recorded months ago would otherwise become a fresh diagnosis the
     next time the instance is stopped on purpose. A service actually being alive
     is the observation that retires it, whoever started it.
+
+    Two callers reach this, and they are the two ways that fact becomes known.
+    ``acquire_service_instance_lock`` is the authoritative one: it runs inside the
+    service itself, at the instant it becomes the lock owner, so it covers every
+    way a service can come up including the ones no supervisor is still watching.
+    ``write_status`` is opportunistic and covers the other direction -- a service
+    that was already running long before this code shipped, observed by whatever
+    start or refresh path writes its status next, without waiting for a restart.
+    One function owns the decision; those are only the moments worth asking it.
 
     The ``running`` state that brought us here is not that observation. It is a
     string, and callers copy it: ``/api/ui/reload`` carries the previous state

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -276,20 +276,6 @@ def acquire_service_instance_lock() -> None:
         logger.debug("Failed to fsync service instance lock", exc_info=True)
     paths.get_runtime_pid_path().write_text(str(os.getpid()), encoding="utf-8")
     _SERVICE_INSTANCE_LOCK_HANDLE = lock_file
-    # This line is the moment a working service exists, so it is where a recorded
-    # restart failure stops describing the present. Every other observation of
-    # that fact is second-hand: a supervisor writes `running` because it believes
-    # the child came up, and it can be wrong in both directions. It can also
-    # simply never run -- a start that outlives `wait_for_service_ready` leaves
-    # the child alive and unwatched, and the service it becomes is one nobody
-    # reports. Retiring here needs no reporter and no reader.
-    #
-    # Best-effort, for the same reason as in `write_status`: an unremovable or
-    # unreadable marker must not stop the service that just acquired the lock.
-    try:
-        _retire_failed_restart_status()
-    except OSError:
-        logger.warning("Could not retire the recorded restart failure", exc_info=True)
 
 
 def release_service_instance_lock() -> None:
@@ -1142,60 +1128,6 @@ def stop_process(pid_path, timeout=5):
     return stopped
 
 
-def _retire_failed_restart_status() -> None:
-    """Drop a recorded restart failure once a service is observed running again.
-
-    The record exists to say why this instance is down, and nothing else ends
-    that claim: neither ``vibe start`` nor ``vibe stop`` touches the file, so a
-    failure recorded months ago would otherwise become a fresh diagnosis the
-    next time the instance is stopped on purpose. A service actually being alive
-    is the observation that retires it, whoever started it.
-
-    Two callers reach this, and they are the two ways that fact becomes known.
-    ``acquire_service_instance_lock`` is the authoritative one: it runs inside the
-    service itself, at the instant it becomes the lock owner, so it covers every
-    way a service can come up including the ones no supervisor is still watching.
-    ``write_status`` is opportunistic and covers the other direction -- a service
-    that was already running long before this code shipped, observed by whatever
-    start or refresh path writes its status next, without waiting for a restart.
-    One function owns the decision; those are only the moments worth asking it.
-
-    The ``running`` state that brought us here is not that observation. It is a
-    string, and callers copy it: ``/api/ui/reload`` carries the previous state
-    forward while it replaces the UI process, so a service that died between the
-    supervisor's status write and its liveness check would have its failure
-    record erased by a UI restart. Ask instead -- the state is only the cheap
-    filter that decides whether asking is worth it.
-
-    Only a recorded failure is retired. A restart in progress carries
-    ``ok: None`` and is left alone, because it has not reported an outcome yet
-    and the supervisor writes the running status before it decides the job
-    succeeded; anything else -- absent, succeeded, or too corrupt to read as a
-    record -- was never the claim being ended.
-
-    What is deleted is the record this call decided about, not whatever occupies
-    the path by the time it deletes. ``schedule_restart`` seeds a new job by
-    replacing this file atomically, and UI control requests can reach it while a
-    ``running`` status write is in flight, so an unconditional unlink could drop a
-    marker that a restart scheduled in the meantime still needs:
-    ``_restart_in_flight`` reads it, and its absence reads as "no restart running"
-    -- which would let a second supervisor start alongside the first.
-    """
-
-    path = get_restart_status_path()
-    payload = read_json(path)
-    if not (isinstance(payload, dict) and payload.get("ok") is False):
-        return
-    if not verified_service_running():
-        return
-    current = read_json(path)
-    if not isinstance(current, dict) or current.get("ok") is not False:
-        return
-    if current.get("job_id") != payload.get("job_id"):
-        return
-    path.unlink(missing_ok=True)
-
-
 def write_status(state, detail=None, service_pid=None, ui_pid=None):
     now_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     # Preserve started_at across consecutive "running" writes so the UI can
@@ -1223,17 +1155,6 @@ def write_status(state, detail=None, service_pid=None, ui_pid=None):
     if started_at:
         payload["started_at"] = started_at
     write_json(paths.get_runtime_status_path(), payload)
-    if state == "running":
-        # Retiring the marker is cleanup, and this is the write every start path
-        # reaches. An unreadable record, or one that cannot be unlinked because of
-        # ownership, a file attribute, or a Windows lock, must not report the
-        # service that just came up as having failed to start. Leaving the marker
-        # is survivable -- doctor keeps reporting it, and the next successful start
-        # tries again -- so log it and let the status write stand.
-        try:
-            _retire_failed_restart_status()
-        except OSError:
-            logger.warning("Could not retire the recorded restart failure", exc_info=True)
 
 
 def read_status():

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -1149,12 +1149,28 @@ def _retire_failed_restart_status() -> None:
     and the supervisor writes the running status before it decides the job
     succeeded; anything else -- absent, succeeded, or too corrupt to read as a
     record -- was never the claim being ended.
+
+    What is deleted is the record this call decided about, not whatever occupies
+    the path by the time it deletes. ``schedule_restart`` seeds a new job by
+    replacing this file atomically, and UI control requests can reach it while a
+    ``running`` status write is in flight, so an unconditional unlink could drop a
+    marker that a restart scheduled in the meantime still needs:
+    ``_restart_in_flight`` reads it, and its absence reads as "no restart running"
+    -- which would let a second supervisor start alongside the first.
     """
 
     path = get_restart_status_path()
     payload = read_json(path)
-    if isinstance(payload, dict) and payload.get("ok") is False and verified_service_running():
-        path.unlink(missing_ok=True)
+    if not (isinstance(payload, dict) and payload.get("ok") is False):
+        return
+    if not verified_service_running():
+        return
+    current = read_json(path)
+    if not isinstance(current, dict) or current.get("ok") is not False:
+        return
+    if current.get("job_id") != payload.get("job_id"):
+        return
+    path.unlink(missing_ok=True)
 
 
 def write_status(state, detail=None, service_pid=None, ui_pid=None):


### PR DESCRIPTION
## What changes

`vibe doctor` now reports a recorded restart failure that left nothing running as a
**fail**, instead of a pass.

When an auto-upgrade restart fails, `vibe/restart_supervisor.py` writes `ok: false` to
`restart_status.json`. Doctor did not look at the outcome at all; it classified the record
purely by age:

- fresh → `pass` ("Restart metadata is current: state=failed")
- older than `DOCTOR_RESTART_RESULT_RETENTION_SECONDS` → `warn`, whose repair
  (`vibe doctor repair stale-restart-state`) **deletes the marker** — on a still-down
  instance, the only record of why it is down.

Refs #1567.

## The rule

```python
if payload.get("ok") is False and not runtime.verified_service_running():
```

Both clauses are read at the moment of the report, from what is on disk and what is
running now. Nothing in it asks what was true at some earlier moment, and that is the
whole design — see the diagnosis below, where three rounds went to a version that did.

`runtime.verified_service_running()` is the added predicate, and it is one line: **can the
service lock be acquired?** If not, a service holds it.

It is deliberately narrower than the existing `service_process_running()`, which reports
whether anything at all occupies this data dir — the right question for `start_service()`
refusing a second start, the wrong one here. A process that reserved the pid and never
acquired the lock is the wreckage of a failed start, not a recovery. Reading it as one
would suppress the very failure that produced it: the `service pid did not acquire the
service lock` failure leaves exactly that child alive.

It also asks the lock and not the lock's *record*, which is the round-8 fix below. Reading
the holder pid out of the record and requiring it to parse is strictly weaker than the
signal already in hand: the record is written just after the lock is taken, so a service
caught in that window — or holding a corrupted record — answers no pid while holding the
lock. `start_service()` refuses on `lock_available` alone and never asks for a holder pid,
so this now agrees with it. Aliveness needs no separate check either, because the kernel
drops the lock when the holder dies. Cheap by construction: one open and one non-blocking
lock attempt, no pidfile read, no process-table scan — which is why `vibe doctor --fast`
needs no diagnostic depth plumbed into this path.

**Verdict.** `ok is false` and no lock-verified service running ⇒ `fail`, code
`runtime.restart_failed`, with the recorded error, trigger, job id and restart log path on
the item. Because a doctor `fail` drives the process exit code, an external health check
that runs `vibe doctor` now sees this state — `_service_lifecycle_items` reports a free
lock as a `pass`, so nothing else here would.

**What the action must not say.** Never the marker-deleting repair. The reader may be
genuinely down, and that command both destroys the only record of why and makes doctor
pass again, so an operator following it would silence their own health check — the
original defect in #1567. A pre-existing assertion in the suite enforces this, and it
caught me adding exactly that as an escape hatch during this round.

**Accepted cost, stated up front.** A restart that failed *without* stopping the old
service — the spawn path never stops anything — leaves a record that outlives its
relevance, so after that service is later stopped on purpose this reports a failure that
is history. Both halves of the sentence are still true when it prints, and `vibe start`
ends it. Suppressing it instead would mean trusting a remembered liveness snapshot to
still be true when it is read, which is precisely the property that cost this PR three
review rounds. For a diagnostic the asymmetry decides it: a stale `fail` is a true
statement with a self-clearing next step, while a wrong `pass` is the eight-day silent
outage in #1567 sitting behind a green health check.

**The action names its own commands, and predicts nothing else.** A genuine stray lockless
process is real and worth reporting, but detecting it is not this item's job —
`_service_lifecycle_items` owns that. The remedy still has to be *runnable from this item*,
and two revisions got that wrong in the same way: one deferred to "the extra-service-process
repair listed in this report", which is behind `--deep` and so absent from the default run
a reader lands on; the next named the command but appended "then start again", which earns
`ServiceAlreadyRunningError` because that repair reaches `_start_service_after_repair` on
exactly the no-owner path it is prescribed for.

The rule that fell out: every sentence of procedure in a doctor action is a claim about
control flow the item does not own, and each is separately falsifiable. So the text names
the two commands in order and states the single thing the reader cannot see — that the
repair brings the service up — because that is what stops them from starting twice and
reading a successful recovery as a failure. Beyond that, the commands report their own
outcomes.

## Deliberately not in this PR

Issue #1567 names four gaps. Only the doctor misclassification is unambiguously a defect
with one correct fix. The other three each carry a product decision and are left to the
owner rather than decided here:

- no outward alert channel when a restart fails (the record has only two consumers:
  `vibe doctor` and `_restart_in_flight()`)
- no retry, rollback, or version restore after a failed upgrade restart
- `core/update_checker.py` logs `Upgrade successful` and writes the post-update marker
  on `restarting: true`, which is never reconciled against the restart outcome

## Known-by-design ledger

- **Doctor item text is not routed through `vibe/i18n`.** `en.json` holds 697 strings
  across 30 sections and not one of them is a doctor string, while `cli.py` has 86
  `_add_doctor_item` call sites, every one with a hardcoded English message and action.
  Translating item 87 would not produce a localized report — it would produce a single
  translated line inside an otherwise English one. Converting the doctor surface is worth
  doing and is its own change, covering all 86 items and the keys they need.
- **A failed restart that left a service running keeps its record on disk forever.**
  Nothing retires it; see the accepted cost above. It is not downtime, so doctor does not
  fail while that service runs, and the record is the failure's only user-facing trace
  (`vibe status` renders it). `vibe start` overwrites it.
- **Nothing reconciles the record against a later deliberate stop.** By construction:
  every mechanism that could do so has to compare the present against a remembered
  observation, and the three rejected designs below are the ones that looked like they
  could.

## Review-loop diagnosis (circuit breaker)

Tripped three times. Recording all three, because the third one reverses the first two.

**Round 3 — predicate.** Three findings-bearing heads, class = *what counts as a live
service*: `59c8116b2` (the rule hand-rolled at the doctor site), `c634ecfa1` (a status
write and a copied state string used as evidence), `26d9062da` (a half-started lockless
child counted as alive). Root cause: an **occupancy** predicate answering a **recovery**
question. Fixed by giving recovery one owner — `verified_service_running()` — that the
call sites ask. The `--fast` finding on the same head was a second symptom and dissolved
with it.

**Round 5 — owner.** The retirement pass was moved to `acquire_service_instance_lock()`,
the one line where a working service comes into existence, on the grounds that every other
observer of that fact is second-hand.

**Round 8 — second head of the round-7 class, so the breaker tripped.** Two P2s, both on
the action text: the redundant start after a repair that already starts, and a `vibe start`
prescribed into an occupied-but-unverified lock. Same root cause as round 7 — *the remedy
narrates downstream control flow I had not verified* — on a second reviewed head, so I
stopped editing and traced all three call paths first (`_repair_duplicate_service_processes`
at `cli.py:11944`, `_lock_file_pid` at `runtime.py:290`, `start_service`'s lock gate at
`runtime.py:1583`). Both premises held.

Diagnosis: one was a text defect and one was a **predicate** defect wearing text clothes.
`verified_service_running()` demanded a parseable, alive holder pid while `start_service`
refuses on lock availability alone, so a service holding the lock with an unwritten or
corrupted record read as "no service is running" — a false *fail*, and then a prescribed
start that could not succeed. Fixed at the source by asking the lock directly, which is
also a subtraction: the pid read, the parse, and the aliveness check all go. Scope decision
recorded independently per `AGENTS.md`: predicate simplification plus text, no data-model or
contract change, no owner escalation needed — clear, reversible, contract-preserving.

**Round 7 — a genuinely new class**, and the reason the breaker did not trip: the action
text depended on a `--deep`-gated sibling item being rendered. Root cause is
cross-reference, not remembered state, so it is closed by naming the command rather than by
another diagnosis. Recorded here because it is the first finding on this PR that was not a
member of an already-named class.

**Round 6 — subtraction.** Three more P2s, two of them the same class again: an
unsynchronized read-modify-write on `restart_status.json`, where each fix narrows one
interleaving and the reviewer finds the next. Applying the terminal-rule test from
`AGENTS.md` — *if a ruling still has free parameters an adversary can probe, it is not the
terminal rule yet* — the free parameter here is **the interleaving instant itself**, so no
placement of that machinery could be terminal. I would have been buying one round at a
time.

So I stopped patching, took the full inventory by grep, and asked what the machinery was
buying. Only this: suppressing a true report in the accepted-cost case above. Deleting it
makes all six findings from rounds 2–6 inexpressible rather than fixed, and is strictly
better on the legacy path, because no field can be missing when no field is read.

Removed: `service_alive` stamping from `restart_supervisor._write_status` (the supervisor
is now untouched by this PR), `_retire_failed_restart_status` and both its triggers from
`vibe/runtime.py`, and one clause from the doctor gate. Rounds 3 and 5 were not wasted —
`verified_service_running()` is round 3's consolidation and it is the surviving predicate.

**Rejected alternatives**, each of which reintroduces a remembered observation:

- *retain lock-file content past release* — persisted-shape risk, and legacy instances
  give no answer at all
- *compare the record against `runtime_status.json`* — `stopped` is written both by a
  deliberate stop and by refreshers that merely observed nothing running, so it is a state
  string whose writers disagree about its meaning
- *infer recovery from `service.lock` mtime* — doctor's own earlier lock probe can create
  the file on an instance that never had one

## Evidence

- **Unit** — stating invariants rather than case lists:
  - `tests/test_vibe_cli.py`: a recorded failure with no service is a `fail` at any age
    (parametrized across both sides of the retention boundary), carries the recorded cause
    on one line, and never offers to clear the marker
  - one seeded failure against six liveness shapes — nothing running, a pid reserved but
    never locked, a stray process holding no lock, one child that is both reserved and
    visible to the scan, a lock owner, a lock owner beside a stray — asserting `fail` for
    every shape until something holds the lock. It stubs the sources the predicates read,
    not the predicates, so it asserts the verdict the real code produces for a machine
    state; the shapes where occupancy and the lock disagree are what discriminate them.
  - *no field in the record can talk doctor out of a verdict about right now* —
    parametrized over a bare record, `service_alive` both ways round (the field a previous
    revision of this PR wrote), and an unknown field a future writer might add, so a
    record produced by any version reaches the same verdict
  - *a restart record survives every status write* — seeded across every outcome × every
    state a caller can write, so a status path added later inherits the assertion instead
    of needing its own test
  - a non-failure record keeps its existing classification, with both liveness probes
    monkeypatched to raise so the short-circuit is pinned
  - *the action only tells the reader to run real commands* — every backticked `vibe ...`
    command is extracted from the action text and parsed against `cli.build_parser()`, so
    a renamed or misspelled repair target fails there instead of in front of a user who is
    already down. Extracted rather than asserted literally, so a command added to the text
    later is checked too. The same test asserts no command is asked for twice, which is the
    shape of the round-8 finding rather than its wording: any repair that already performs
    what a later step repeats fails there.
  - *the predicate follows the lock, not the lock's record* — `test_runtime_service_lock.py`
    takes a real lock, blanks the record while the lock stays held, and asserts the
    predicate across acquire → corrupt → release. The doctor-level shape table gains a
    seventh row for the same state.
  - Bite-checked on the current head, each against the code it guards: restoring the
    pid-based predicate fails the lock-suite test precisely on the corrupted-record
    assertion and exactly one of the seven shape rows, leaving the other six passing;
    restoring the redundant start fails the duplicate-command assertion; restoring the
    cross-reference text leaves only `vibe start` extractable and fails.
  - `tests/test_restart_supervisor.py`: *a recorded outcome reports the job and nothing
    about liveness* — probes stubbed to raise, every outcome shape still lands, no
    liveness field present. A fence against re-adding what round 6 removed.
  - Verified failing before the change: 3 cells on the parent of the first commit, and 5
    new assertions on the parent of `26d9062d`. Restoring the removed `service_alive`
    clause fails
    `test_only_live_facts_decide_downtime_not_what_the_record_claims[claims-a-service-survived]`.
- **Suite** — `tests/test_vibe_cli.py`, `tests/test_restart_supervisor.py` and
  `tests/test_runtime_service_lock.py` 213 passed; eleven adjacent suites 217 passed
  (`test_dev_state_migration_guard`, `test_service_logging_handlers`,
  `test_macos_session_diagnostics`, `test_ui_server_logs`, `test_ui_server_reload`,
  `test_cli_setup_status`, `test_docker_entrypoint_supervisor`,
  `test_incus_regression_supervisor`, `test_api_runtime_refresh`, `test_upgrade_flow`,
  `test_ui_server_fastapi`).
- **Size** — the whole PR is +431 / −0 across five files, of which 340 are tests and 91 are production code. Round 6 alone was +74 / −344 against the previously reviewed head.
- **Lint** — `ruff check` clean on all changed files.
- **Scenario catalog** — no entry covers doctor runtime items; none added.
- **Residual manual** — none. The change is reachable only through `vibe doctor`, and the
  tests drive it directly against a seeded status file.

## Dependencies

None.
