### PR TITLE
feat(memory): admit EverOS rerank providers

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -1917,6 +1917,10 @@ _MEMORY_CLOUD_MULTIMODAL_ALIAS = "avibe-cloud-multimodal"
 MemoryMode = Literal["platform", "custom"]
 MemoryCloudScope = Literal["organization", "platform"]
 MemoryCloudLlmSource = Literal["dedicated", "chat_fallback"]
+MemoryRerankProvider = Literal["deepinfra", "vllm", "dashscope"]
+MEMORY_RERANK_PROVIDERS = frozenset(get_args(MemoryRerankProvider))
+DEFAULT_MEMORY_RERANK_PROVIDER: MemoryRerankProvider = "deepinfra"
+DASHSCOPE_RERANK_MODEL = "gte-rerank-v2"
 
 
 @dataclass
@@ -1926,6 +1930,7 @@ class MemoryEndpointConfig:
     base_url: Optional[str] = None
     model: Optional[str] = None
     api_key: Optional[str] = field(default=None, repr=False)
+    provider: Optional[str] = None
 
     def validate(self, *, name: str) -> None:
         self.base_url = _validate_memory_url(
@@ -1941,9 +1946,31 @@ class MemoryEndpointConfig:
             self.api_key,
             path=f"memory.processing.{name}.api_key",
         )
+        if name != "rerank":
+            self.provider = None
+            return
+        if not any((self.base_url, self.model, self.api_key)):
+            self.provider = None
+            return
+        provider = (self.provider or "").strip() or DEFAULT_MEMORY_RERANK_PROVIDER
+        if provider not in MEMORY_RERANK_PROVIDERS:
+            raise ValueError(
+                "Memory rerank endpoint provider must be deepinfra, vllm, or dashscope"
+            )
+        if provider == "dashscope" and self.model != DASHSCOPE_RERANK_MODEL:
+            raise ValueError(
+                "Memory DashScope rerank endpoint model must be gte-rerank-v2"
+            )
+        self.provider = provider
 
     def complete(self) -> bool:
         return bool(self.base_url and self.model and self.api_key)
+
+    def rerank_provider(self) -> MemoryRerankProvider:
+        provider = (self.provider or "").strip()
+        if provider in MEMORY_RERANK_PROVIDERS:
+            return provider
+        return DEFAULT_MEMORY_RERANK_PROVIDER
 
 
 @dataclass
@@ -1958,7 +1985,13 @@ class MemoryProcessingConfig:
         self.embedding.validate(name="embedding")
         if self.rerank is not None:
             self.rerank.validate(name="rerank")
-            if not any((self.rerank.base_url, self.rerank.model, self.rerank.api_key)):
+            if not any(
+                (
+                    self.rerank.base_url,
+                    self.rerank.model,
+                    self.rerank.api_key,
+                )
+            ):
                 self.rerank = None
             elif not self.rerank.complete():
                 raise ValueError(
@@ -2345,21 +2378,31 @@ def memory_config_to_payload(
 ) -> dict:
     """Project Memory config without ever returning a reusable API key."""
 
-    def endpoint_payload(endpoint: MemoryEndpointConfig) -> dict:
+    def endpoint_payload(
+        endpoint: MemoryEndpointConfig,
+        *,
+        include_provider: bool = False,
+    ) -> dict:
         key = endpoint.api_key
-        return {
+        payload = {
             "base_url": endpoint.base_url,
             "model": endpoint.model,
             "api_key": key if include_secrets else None,
             "has_api_key": bool(key),
         }
+        if include_provider:
+            payload["provider"] = endpoint.rerank_provider()
+        return payload
 
     processing = {
         "llm": endpoint_payload(memory.processing.llm),
         "embedding": endpoint_payload(memory.processing.embedding),
     }
     if memory.processing.rerank is not None:
-        processing["rerank"] = endpoint_payload(memory.processing.rerank)
+        processing["rerank"] = endpoint_payload(
+            memory.processing.rerank,
+            include_provider=True,
+        )
     if memory.processing.multimodal is not None:
         processing["multimodal"] = endpoint_payload(memory.processing.multimodal)
     payload = {

--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -78,6 +78,10 @@ _PREFLIGHT_IMAGE_DATA_URI = (
 )
 MULTIMODAL_EXPLICIT_ENV = "AVIBE_MEMORY_MULTIMODAL_EXPLICIT"
 _PROFILE_QUERY = "profile"
+MemoryRerankProvider = Literal["deepinfra", "vllm", "dashscope"]
+DEFAULT_MEMORY_RERANK_PROVIDER: MemoryRerankProvider = "deepinfra"
+DASHSCOPE_RERANK_PATH = "api/v1/services/rerank/text-rerank/text-rerank"
+
 _MAX_LIST_PAGE_SIZE = 20
 _EVEROS_EXACT_SORT_WINDOW = 20_000
 _MAX_PROFILE_TIMESTAMP_MS = 4_102_444_800_000
@@ -260,6 +264,7 @@ class EverOSPort:
         rerank_base_url: str | None = None,
         rerank_model: str | None = None,
         rerank_api_key: str | None = None,
+        rerank_provider: str | None = None,
         multimodal_base_url: str | None = None,
         multimodal_model: str | None = None,
         multimodal_api_key: str | None = None,
@@ -280,6 +285,7 @@ class EverOSPort:
         self._rerank_base_url = _normalized_endpoint_url(rerank_base_url)
         self._rerank_model = _optional_string(rerank_model)
         self._rerank_api_key = _optional_string(rerank_api_key)
+        self._rerank_provider = _normalized_rerank_provider(rerank_provider)
         self._multimodal_base_url = _normalized_endpoint_url(multimodal_base_url)
         self._multimodal_model = _optional_string(multimodal_model)
         self._multimodal_api_key = _optional_string(multimodal_api_key)
@@ -647,15 +653,7 @@ class EverOSPort:
                 ),
             ]
             if self._rerank_configured():
-                probes.append(
-                    _ProcessingProbeSpec(
-                        base_url=self._rerank_base_url,
-                        api_key=self._rerank_api_key,
-                        path=self._rerank_model or "",
-                        payload={"queries": ["OK"], "documents": ["OK"]},
-                        validator=_valid_rerank_probe_response,
-                    )
-                )
+                probes.append(self._rerank_probe_spec())
             if self._multimodal_configured():
                 probes.append(
                     _ProcessingProbeSpec(
@@ -699,14 +697,15 @@ class EverOSPort:
             }, _valid_embedding_probe_response),
         ]
         if self._rerank_configured():
+            probe = self._rerank_probe_spec()
             checks.append(
                 (
                     "rerank",
-                    self._rerank_base_url,
-                    self._rerank_api_key,
-                    self._rerank_model or "",
-                    {"queries": ["OK"], "documents": ["OK"]},
-                    _valid_rerank_probe_response,
+                    probe.base_url,
+                    probe.api_key,
+                    probe.path,
+                    probe.payload,
+                    probe.validator,
                 )
             )
         if self._multimodal_configured():
@@ -772,6 +771,14 @@ class EverOSPort:
 
     def _rerank_configured(self) -> bool:
         return all((self._rerank_base_url, self._rerank_model, self._rerank_api_key))
+
+    def _rerank_probe_spec(self) -> _ProcessingProbeSpec:
+        return _rerank_probe_spec(
+            base_url=self._rerank_base_url,
+            api_key=self._rerank_api_key,
+            model=self._rerank_model,
+            provider=self._rerank_provider,
+        )
 
     def _multimodal_configured(self) -> bool:
         return all(
@@ -1640,6 +1647,10 @@ def _valid_embedding_probe_response(value: Any) -> bool:
 
 
 def _valid_rerank_probe_response(value: Any) -> bool:
+    return _valid_deepinfra_rerank_probe_response(value)
+
+
+def _valid_deepinfra_rerank_probe_response(value: Any) -> bool:
     if not isinstance(value, dict):
         return False
     scores = value.get("scores")
@@ -1651,6 +1662,61 @@ def _valid_rerank_probe_response(value: Any) -> bool:
         and isinstance(scores[0][0], (int, float))
         and not isinstance(scores[0][0], bool)
         and math.isfinite(scores[0][0])
+    )
+
+
+def _valid_ranked_results_probe_response(
+    value: Any,
+    *,
+    results_key: tuple[str, ...] = ("results",),
+) -> bool:
+    current: Any = value
+    for key in results_key:
+        if not isinstance(current, dict):
+            return False
+        current = current.get(key)
+    if not isinstance(current, list) or len(current) != 1 or not isinstance(current[0], dict):
+        return False
+    score = current[0].get("relevance_score")
+    return isinstance(score, (int, float)) and not isinstance(score, bool) and math.isfinite(score)
+
+
+def _rerank_probe_spec(
+    *,
+    base_url: str | None,
+    api_key: str | None,
+    model: str | None,
+    provider: MemoryRerankProvider,
+) -> _ProcessingProbeSpec:
+    if provider == "vllm":
+        return _ProcessingProbeSpec(
+            base_url=base_url,
+            api_key=api_key,
+            path="rerank",
+            payload={"model": model, "query": "OK", "documents": ["OK"]},
+            validator=_valid_ranked_results_probe_response,
+        )
+    if provider == "dashscope":
+        return _ProcessingProbeSpec(
+            base_url=base_url,
+            api_key=api_key,
+            path=DASHSCOPE_RERANK_PATH,
+            payload={
+                "model": model,
+                "input": {"query": "OK", "documents": ["OK"]},
+                "parameters": {"return_documents": False, "top_n": 1},
+            },
+            validator=lambda value: _valid_ranked_results_probe_response(
+                value,
+                results_key=("output", "results"),
+            ),
+        )
+    return _ProcessingProbeSpec(
+        base_url=base_url,
+        api_key=api_key,
+        path=model or "",
+        payload={"queries": ["OK"], "documents": ["OK"]},
+        validator=_valid_deepinfra_rerank_probe_response,
     )
 
 
@@ -1865,6 +1931,13 @@ def _safe_health_token(value: object, *, max_bytes: int, allow_dot: bool = False
 def _normalized_endpoint_url(value: str | None) -> str | None:
     normalized = _optional_string(value)
     return normalized.rstrip("/") if normalized else None
+
+
+def _normalized_rerank_provider(value: str | None) -> MemoryRerankProvider:
+    provider = _optional_string(value)
+    if provider in {"deepinfra", "vllm", "dashscope"}:
+        return provider
+    return DEFAULT_MEMORY_RERANK_PROVIDER
 
 
 def _positive_timeout(value: object, fallback: float) -> float:

--- a/core/memory/process.py
+++ b/core/memory/process.py
@@ -146,6 +146,7 @@ class EverOSProcessSettings:
     rerank_base_url: str | None = None
     rerank_model: str | None = None
     rerank_api_key: str | None = field(default=None, repr=False)
+    rerank_provider: str | None = None
     multimodal_base_url: str | None = None
     multimodal_model: str | None = None
     multimodal_api_key: str | None = field(default=None, repr=False)
@@ -2571,6 +2572,17 @@ def _memory_child_environment(
         "EVEROS_RERANK__BASE_URL": settings.rerank_base_url,
         "EVEROS_RERANK__MODEL": settings.rerank_model,
         "EVEROS_RERANK__API_KEY": settings.rerank_api_key,
+        "EVEROS_RERANK__PROVIDER": (
+            (settings.rerank_provider or "deepinfra")
+            if all(
+                (
+                    settings.rerank_base_url,
+                    settings.rerank_model,
+                    settings.rerank_api_key,
+                )
+            )
+            else None
+        ),
     }
     env.update({key: value for key, value in optional.items() if value is not None})
     if all(

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -2558,6 +2558,9 @@ class MemoryRuntime:
             rerank_base_url=(processing.rerank.base_url if processing.rerank else None),
             rerank_model=(processing.rerank.model if processing.rerank else None),
             rerank_api_key=(processing.rerank.api_key if processing.rerank else None),
+            rerank_provider=(
+                processing.rerank.rerank_provider() if processing.rerank else None
+            ),
             multimodal_base_url=(
                 processing.multimodal.base_url
                 if processing.multimodal
@@ -3822,6 +3825,7 @@ def _provider_kwargs(config: MemoryConfig) -> dict[str, str | None]:
         "rerank_base_url": rerank.base_url if rerank else None,
         "rerank_model": rerank.model if rerank else None,
         "rerank_api_key": rerank.api_key if rerank else None,
+        "rerank_provider": rerank.rerank_provider() if rerank else None,
         "multimodal_base_url": multimodal.base_url if multimodal else None,
         "multimodal_model": multimodal.model if multimodal else None,
         "multimodal_api_key": multimodal.api_key if multimodal else None,

--- a/core/memory/sidecar.py
+++ b/core/memory/sidecar.py
@@ -617,6 +617,7 @@ def _processing_healthy_from_child_environment() -> bool:
         rerank_base_url=os.environ.get("EVEROS_RERANK__BASE_URL"),
         rerank_model=os.environ.get("EVEROS_RERANK__MODEL"),
         rerank_api_key=os.environ.get("EVEROS_RERANK__API_KEY"),
+        rerank_provider=os.environ.get("EVEROS_RERANK__PROVIDER"),
         **multimodal_kwargs,
     )
     return asyncio.run(provider.processing_healthy())

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -55,12 +55,15 @@ non-empty query switches the same tab back to relevance-ordered search.
 
 ## Optional reranking endpoint
 
-The third processing endpoint in **Settings > Memory** is optional. Configure
-its Base URL, model, and API key together to let the pinned Memory runtime use
-its reranking capability; changing a configured endpoint is admitted by the
-same bounded preflight before it is saved. Leave all three fields empty to keep
-the standard Memory search tier. Removing the saved reranking endpoint clears
-all three values and does not rebuild the embedding index.
+The third processing endpoint in **Settings > Memory** is optional. Choose one
+EverOS rerank provider (`deepinfra`, `vllm`, or `dashscope`) and configure that
+provider's Base URL, model, and API key together. Changing a configured
+endpoint is admitted by a provider-specific bounded preflight before it is
+saved. Older configs without `provider` keep the DeepInfra probe and sidecar
+protocol. Leave the rerank fields empty to keep the standard Memory search
+tier. Removing the saved reranking endpoint clears the provider and the three
+endpoint values and does not rebuild the embedding index. DashScope currently
+accepts only `gte-rerank-v2` at `https://dashscope.aliyuncs.com`.
 
 ## Processing Record
 

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -304,11 +304,13 @@ def test_memory_rerank_round_trips_without_projecting_its_key(tmp_path) -> None:
     stored = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
     projected = config_to_payload(config)["memory"]["processing"]["rerank"]
     assert stored["memory"]["processing"]["rerank"]["api_key"] == "rerank-secret"
+    assert stored["memory"]["processing"]["rerank"]["provider"] == "deepinfra"
     assert projected == {
         "base_url": "https://rerank.example.test/v1/inference",
         "model": "rerank-model",
         "api_key": None,
         "has_api_key": True,
+        "provider": "deepinfra",
     }
 
 
@@ -335,6 +337,50 @@ def test_memory_multimodal_round_trips_without_projecting_its_key(tmp_path) -> N
         "api_key": None,
         "has_api_key": True,
     }
+
+
+def test_memory_rerank_persists_explicit_provider(tmp_path) -> None:
+    processing = _complete_processing()
+    processing["rerank"] = {
+        "provider": "dashscope",
+        "base_url": "https://dashscope.aliyuncs.com",
+        "model": "gte-rerank-v2",
+        "api_key": "rerank-secret",
+    }
+    config = V2Config.from_payload(
+        _payload({"enabled": True, "processing": processing})
+    )
+    config.save(tmp_path / "config.json")
+
+    stored = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
+    loaded = V2Config.load(tmp_path / "config.json")
+    assert stored["memory"]["processing"]["rerank"]["provider"] == "dashscope"
+    assert loaded.memory.processing.rerank.rerank_provider() == "dashscope"
+    assert loaded.memory.processing.rerank.model == "gte-rerank-v2"
+
+
+def test_memory_rerank_rejects_unknown_provider() -> None:
+    processing = _complete_processing()
+    processing["rerank"] = {
+        "provider": "cohere",
+        "base_url": "https://rerank.example.test/v1/inference",
+        "model": "rerank-model",
+        "api_key": "rerank-secret",
+    }
+    with pytest.raises(ValueError, match="provider must be deepinfra, vllm, or dashscope"):
+        V2Config.from_payload(_payload({"enabled": False, "processing": processing}))
+
+
+def test_memory_rerank_rejects_unsupported_dashscope_model() -> None:
+    processing = _complete_processing()
+    processing["rerank"] = {
+        "provider": "dashscope",
+        "base_url": "https://dashscope.aliyuncs.com",
+        "model": "qwen3-vl-rerank",
+        "api_key": "rerank-secret",
+    }
+    with pytest.raises(ValueError, match="gte-rerank-v2"):
+        V2Config.from_payload(_payload({"enabled": False, "processing": processing}))
 
 
 @pytest.mark.parametrize("missing", ["base_url", "model", "api_key"])

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -1794,6 +1794,95 @@ def test_processing_preflight_probes_configured_rerank_endpoint() -> None:
     assert "model" not in recorded[-1]["request"]
 
 
+def test_processing_preflight_probes_vllm_rerank_endpoint() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.endswith("/chat/completions"):
+            return httpx.Response(200, json={"choices": [{"message": {"content": "OK"}}]})
+        if request.url.path.endswith("/embeddings"):
+            return httpx.Response(200, json={"data": [{"embedding": [0.1]}]})
+        return httpx.Response(200, json={"results": [{"index": 0, "relevance_score": 0.9}]})
+
+    async def run():
+        return await EverOSPort(
+            Path("/tmp/everos.sock"),
+            llm_base_url="https://llm.example.test/v1",
+            llm_model="chat",
+            llm_api_key="llm-secret",
+            embedding_base_url="https://embed.example.test/v1",
+            embedding_model="embed",
+            embedding_api_key="embedding-secret",
+            rerank_base_url="http://localhost:8000/v1",
+            rerank_model="Qwen/Qwen3-Reranker-4B",
+            rerank_api_key="rerank-secret",
+            rerank_provider="vllm",
+        ).preflight()
+
+    real_async_client = httpx.AsyncClient
+    with patch("core.memory.everos.httpx.AsyncClient", autospec=True) as client_type:
+        client_type.side_effect = lambda **kwargs: real_async_client(
+            transport=httpx.MockTransport(handler), **kwargs
+        )
+        result = asyncio.run(run())
+
+    assert result.ok is True
+    assert [request.url.path for request in requests][-1] == "/v1/rerank"
+    assert json.loads(requests[-1].content) == {
+        "model": "Qwen/Qwen3-Reranker-4B",
+        "query": "OK",
+        "documents": ["OK"],
+    }
+
+
+def test_processing_preflight_probes_dashscope_rerank_endpoint() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.endswith("/chat/completions"):
+            return httpx.Response(200, json={"choices": [{"message": {"content": "OK"}}]})
+        if request.url.path.endswith("/embeddings"):
+            return httpx.Response(200, json={"data": [{"embedding": [0.1]}]})
+        return httpx.Response(
+            200,
+            json={"output": {"results": [{"index": 0, "relevance_score": 0.9}]}},
+        )
+
+    async def run():
+        return await EverOSPort(
+            Path("/tmp/everos.sock"),
+            llm_base_url="https://llm.example.test/v1",
+            llm_model="chat",
+            llm_api_key="llm-secret",
+            embedding_base_url="https://embed.example.test/v1",
+            embedding_model="embed",
+            embedding_api_key="embedding-secret",
+            rerank_base_url="https://dashscope.aliyuncs.com",
+            rerank_model="gte-rerank-v2",
+            rerank_api_key="rerank-secret",
+            rerank_provider="dashscope",
+        ).preflight()
+
+    real_async_client = httpx.AsyncClient
+    with patch("core.memory.everos.httpx.AsyncClient", autospec=True) as client_type:
+        client_type.side_effect = lambda **kwargs: real_async_client(
+            transport=httpx.MockTransport(handler), **kwargs
+        )
+        result = asyncio.run(run())
+
+    assert result.ok is True
+    assert [request.url.path for request in requests][-1] == (
+        "/api/v1/services/rerank/text-rerank/text-rerank"
+    )
+    assert json.loads(requests[-1].content) == {
+        "model": "gte-rerank-v2",
+        "input": {"query": "OK", "documents": ["OK"]},
+        "parameters": {"return_documents": False, "top_n": 1},
+    }
+
+
 def test_processing_preflight_probes_configured_multimodal_endpoint() -> None:
     """MEMORY-IM-ATTACH-001: opt-in is admitted with synthetic image data only."""
 

--- a/tests/test_memory_process.py
+++ b/tests/test_memory_process.py
@@ -459,8 +459,31 @@ def test_configured_rerank_stays_env_only_when_env_overrides_toml(tmp_path: Path
     assert environment["EVEROS_RERANK__BASE_URL"] == settings.rerank_base_url
     assert environment["EVEROS_RERANK__MODEL"] == settings.rerank_model
     assert environment["EVEROS_RERANK__API_KEY"] == "rerank-secret"
+    assert environment["EVEROS_RERANK__PROVIDER"] == "deepinfra"
     assert parsed["rerank"] == {"model": "", "base_url": ""}
     assert "rerank-secret" not in generated
+
+
+def test_configured_rerank_provider_is_injected_into_child_env(tmp_path: Path) -> None:
+    settings = replace(
+        _settings(),
+        timezone="UTC",
+        rerank_base_url="https://dashscope.aliyuncs.com",
+        rerank_model="gte-rerank-v2",
+        rerank_api_key="rerank-secret",
+        rerank_provider="dashscope",
+    )
+    process = EverOSProcess(
+        sys.executable,
+        effective_home=tmp_path,
+        settings=settings,
+    )
+    process._prepare_owned_directories()
+    process._write_generated_config()
+
+    environment = process._child_environment()
+    assert environment["EVEROS_RERANK__PROVIDER"] == "dashscope"
+    assert environment["EVEROS_RERANK__MODEL"] == "gte-rerank-v2"
 
 
 def test_sidecar_child_home_preparation_hardens_every_created_directory(

--- a/tests/test_memory_sidecar.py
+++ b/tests/test_memory_sidecar.py
@@ -736,6 +736,7 @@ def test_processing_probe_builds_the_adapter_from_child_environment_only(monkeyp
         "rerank_base_url": "https://rerank.example.test/v1/inference",
         "rerank_model": "rerank-model",
         "rerank_api_key": "rerank-secret",
+        "rerank_provider": None,
         "multimodal_base_url": "https://vision.example.test/v1",
         "multimodal_model": "vision-model",
         "multimodal_api_key": "vision-secret",

--- a/tests/test_ui_memory_routes.py
+++ b/tests/test_ui_memory_routes.py
@@ -124,6 +124,7 @@ def test_memory_settings_patch_accepts_optional_complete_rerank_endpoint() -> No
         "https://rerank.example.test/v1/inference",
         "rerank-model",
         "rerank-secret",
+        "deepinfra",
     )
 
 

--- a/ui/src/components/settings/memory/MemorySettingsPanel.test.tsx
+++ b/ui/src/components/settings/memory/MemorySettingsPanel.test.tsx
@@ -358,8 +358,10 @@ describe('MemorySettingsPanel', () => {
 
     expect(screen.queryByText('memory.settings.multimodalTitle')).toBeNull();
     expect(screen.queryByText('memory.settings.disclosureAttachment')).toBeNull();
-    expect(screen.getAllByPlaceholderText('memory.settings.baseUrlPlaceholder')).toHaveLength(3);
-    expect(screen.getAllByPlaceholderText('memory.settings.modelPlaceholder')).toHaveLength(3);
+    expect(screen.getAllByPlaceholderText('memory.settings.baseUrlPlaceholder')).toHaveLength(2);
+    expect(screen.getAllByPlaceholderText('memory.settings.modelPlaceholder')).toHaveLength(2);
+    expect(screen.getByPlaceholderText('https://api.deepinfra.com/v1/inference')).not.toBeNull();
+    expect(screen.getByPlaceholderText('Qwen/Qwen3-Reranker-4B')).not.toBeNull();
   });
 
   it('renders optional multimodal configuration once IM capture is available', () => {
@@ -378,10 +380,12 @@ describe('MemorySettingsPanel', () => {
     );
 
     expect(screen.getByText('memory.settings.rerankTitle')).not.toBeNull();
+    expect(screen.getByLabelText('memory.settings.rerankProvider')).not.toBeNull();
     expect(screen.getByText('memory.settings.multimodalTitle')).not.toBeNull();
     expect(screen.getByText('memory.settings.disclosureAttachment')).not.toBeNull();
-    expect(screen.getAllByPlaceholderText('memory.settings.baseUrlPlaceholder')).toHaveLength(4);
-    expect(screen.getAllByPlaceholderText('memory.settings.modelPlaceholder')).toHaveLength(4);
+    expect(screen.getAllByPlaceholderText('memory.settings.baseUrlPlaceholder')).toHaveLength(3);
+    expect(screen.getAllByPlaceholderText('memory.settings.modelPlaceholder')).toHaveLength(3);
+    expect(screen.getByPlaceholderText('https://api.deepinfra.com/v1/inference')).not.toBeNull();
   });
 
   it('submits a complete multimodal endpoint as the IM attachment opt-in', async () => {
@@ -410,8 +414,8 @@ describe('MemorySettingsPanel', () => {
     const baseUrls = screen.getAllByPlaceholderText('memory.settings.baseUrlPlaceholder');
     const models = screen.getAllByPlaceholderText('memory.settings.modelPlaceholder');
     const keys = screen.getAllByPlaceholderText('memory.settings.apiKeyPlaceholder');
-    await user.type(baseUrls[3], 'https://vision.example.test/v1');
-    await user.type(models[3], 'vision-model');
+    await user.type(baseUrls[2], 'https://vision.example.test/v1');
+    await user.type(models[2], 'vision-model');
     await user.type(keys[3], 'vision-secret');
     await user.click(screen.getByRole('button', { name: 'memory.settings.save' }));
 

--- a/ui/src/components/settings/memory/MemorySettingsPanel.tsx
+++ b/ui/src/components/settings/memory/MemorySettingsPanel.tsx
@@ -19,19 +19,28 @@ import { ConfirmDialog } from '../../ui/confirm-dialog';
 import { InfoHint } from '../../ui/info-hint';
 import { Input } from '../../ui/input';
 import { Label } from '../../ui/label';
+import { Select } from '../../ui/select';
 import { Switch } from '../../ui/switch';
 import { useApi } from '../../../context/ApiContext';
 import type {
   MemoryEndpointConfig,
   MemoryMaintenance,
+  MemoryRerankProvider,
   MemorySettings,
   MemorySettingsPatch,
   MemorySettingsResult,
 } from '../../../context/ApiContext';
 import { useToast } from '../../../context/ToastContext';
-import { buildEndpointPatch, draftFromConfig } from '../../../lib/memorySettings';
-import type { EndpointDraft } from '../../../lib/memorySettings';
 import { isMemoryOk, memoryErrorMessage } from '../../../lib/memoryRead';
+import {
+  DASHSCOPE_RERANK_MODEL,
+  DEFAULT_MEMORY_RERANK_PROVIDER,
+  MEMORY_RERANK_PROVIDERS,
+  buildEndpointPatch,
+  draftFromConfig,
+  normalizeRerankProvider,
+} from '../../../lib/memorySettings';
+import type { EndpointDraft } from '../../../lib/memorySettings';
 
 type MemorySettingsOk = Extract<MemorySettingsResult, { status: 'ok' }>;
 
@@ -40,6 +49,21 @@ const EMPTY_ENDPOINT: MemoryEndpointConfig = {
   model: null,
   api_key: null,
   has_api_key: false,
+};
+
+const RERANK_FIELD_HINTS: Record<MemoryRerankProvider, { baseUrl: string; model: string }> = {
+  deepinfra: {
+    baseUrl: 'https://api.deepinfra.com/v1/inference',
+    model: 'Qwen/Qwen3-Reranker-4B',
+  },
+  vllm: {
+    baseUrl: 'http://localhost:8000/v1',
+    model: 'Qwen/Qwen3-Reranker-4B',
+  },
+  dashscope: {
+    baseUrl: 'https://dashscope.aliyuncs.com',
+    model: DASHSCOPE_RERANK_MODEL,
+  },
 };
 
 const EndpointFields: React.FC<{
@@ -53,6 +77,7 @@ const EndpointFields: React.FC<{
   identityHint?: string;
   canClearKey: boolean;
   clearKeyLabel?: string;
+  showProvider?: boolean;
 }> = ({
   title,
   help,
@@ -64,9 +89,12 @@ const EndpointFields: React.FC<{
   identityHint,
   canClearKey,
   clearKeyLabel,
+  showProvider = false,
 }) => {
   const { t } = useTranslation();
   const clearLabel = clearKeyLabel ?? t('memory.settings.clearKeyLabel');
+  const provider = showProvider ? normalizeRerankProvider(draft.provider) : DEFAULT_MEMORY_RERANK_PROVIDER;
+  const hints = showProvider ? RERANK_FIELD_HINTS[provider] : null;
   return (
     <div className="flex flex-col gap-3 rounded-xl border border-border bg-surface p-4">
       <div className="flex items-center gap-2">
@@ -79,13 +107,38 @@ const EndpointFields: React.FC<{
         )}
       </div>
       {identityHint ? <p className="text-[11.5px] leading-snug text-muted">{identityHint}</p> : null}
+      {showProvider ? (
+        <div className="flex flex-col gap-1.5">
+          <Label className="text-[12px] text-muted">{t('memory.settings.rerankProvider')}</Label>
+          <Select
+            value={provider}
+            disabled={disabled}
+            aria-label={t('memory.settings.rerankProvider')}
+            onChange={(event) => {
+              const nextProvider = normalizeRerankProvider(event.target.value);
+              const nextModel = nextProvider === 'dashscope'
+                ? DASHSCOPE_RERANK_MODEL
+                : draft.model === DASHSCOPE_RERANK_MODEL
+                  ? ''
+                  : draft.model;
+              onChange({ ...draft, provider: nextProvider, model: nextModel });
+            }}
+          >
+            {MEMORY_RERANK_PROVIDERS.map((value) => (
+              <option key={value} value={value}>
+                {t(`memory.settings.rerankProviders.${value}`)}
+              </option>
+            ))}
+          </Select>
+        </div>
+      ) : null}
       <div className="grid gap-3 sm:grid-cols-2">
         <div className="flex flex-col gap-1.5">
           <Label className="text-[12px] text-muted">{t('memory.settings.baseUrl')}</Label>
           <Input
             value={draft.baseUrl}
             disabled={disabled}
-            placeholder={t('memory.settings.baseUrlPlaceholder')}
+            placeholder={hints?.baseUrl ?? t('memory.settings.baseUrlPlaceholder')}
             onChange={(e) => onChange({ ...draft, baseUrl: e.target.value })}
             className="text-[13px]"
           />
@@ -94,8 +147,8 @@ const EndpointFields: React.FC<{
           <Label className="text-[12px] text-muted">{t('memory.settings.model')}</Label>
           <Input
             value={draft.model}
-            disabled={disabled}
-            placeholder={t('memory.settings.modelPlaceholder')}
+            disabled={disabled || provider === 'dashscope'}
+            placeholder={hints?.model ?? t('memory.settings.modelPlaceholder')}
             onChange={(e) => onChange({ ...draft, model: e.target.value })}
             className="text-[13px]"
           />
@@ -566,6 +619,7 @@ export const MemorySettingsPanel: React.FC<{
             identityHint={t('memory.settings.rerankIdentityHint')}
             canClearKey
             clearKeyLabel={t('memory.settings.rerankClearLabel')}
+            showProvider
           />
 
           {settings.im_attachment_capture_available === true ? (

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -1836,6 +1836,8 @@ export type DependenciesResult = { ok: boolean; deps: DependencyItem[] };
 
 // Memory plugin contract: docs/plans/memory-plugin-system.md.
 // Keys are write-only: GET never returns a usable `api_key`, only `has_api_key`.
+export type MemoryRerankProvider = 'deepinfra' | 'vllm' | 'dashscope';
+
 export type MemoryEndpointConfig = {
   base_url: string | null;
   model: string | null;
@@ -1843,6 +1845,7 @@ export type MemoryEndpointConfig = {
   // Typed as `null` so no caller can read a saved key back off the response.
   api_key: null;
   has_api_key: boolean;
+  provider?: MemoryRerankProvider | null;
 };
 
 export type MemoryProcessingConfig = {
@@ -1875,6 +1878,7 @@ export type MemoryEndpointPatch = {
   base_url?: string | null;
   model?: string | null;
   api_key?: string | null;
+  provider?: MemoryRerankProvider | null;
 };
 
 export type MemorySettingsPatch = {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -4569,9 +4569,15 @@
       "embeddingHelp": "Memory uses this model to index memories so you can search them. Changing the embedding endpoint or model requires rebuilding the index.",
       "embeddingHelpLabel": "About the embedding model",
       "rerankTitle": "Reranking model (optional)",
-      "rerankHelp": "Memory uses this model to score search results for advanced recall. Enter a reranking base URL, model name, and API key to enable it.",
+      "rerankHelp": "Memory uses this model to score search results for advanced recall. Choose the EverOS rerank provider, then enter that provider's base URL, model name, and API key.",
       "rerankHelpLabel": "About the reranking model",
       "rerankClearLabel": "Remove reranking endpoint",
+      "rerankProvider": "Rerank provider",
+      "rerankProviders": {
+        "deepinfra": "DeepInfra",
+        "vllm": "vLLM / OpenAI-compatible",
+        "dashscope": "DashScope"
+      },
       "multimodalTitle": "IM attachment processing model (optional)",
       "multimodalHelp": "When fully configured, eligible attachments from bound direct messages are sent to this OpenAI-compatible vision endpoint for Memory capture.",
       "multimodalHelpLabel": "About IM attachment processing",
@@ -4621,7 +4627,7 @@
       "rebuildCompleted": "Memory index rebuild completed.",
       "rebuildFailed": "Memory index rebuild failed.",
       "embeddingIdentityHint": "Changing the embedding endpoint or model rebuilds the local index. Your memories are kept.",
-      "rerankIdentityHint": "Leave all three fields empty to keep the standard Memory search tier.",
+      "rerankIdentityHint": "Leave the rerank fields empty to keep the standard Memory search tier. DashScope currently accepts only gte-rerank-v2.",
       "multimodalIdentityHint": "A complete base URL, model, and API key is the opt-in. Leave all three empty to keep IM attachment capture off."
     },
     "clear": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -4569,9 +4569,15 @@
       "embeddingHelp": "记忆功能用这个模型为记忆建立索引，让你可以搜索记忆。更改向量模型接口地址或模型后需要重建索引。",
       "embeddingHelpLabel": "关于向量模型",
       "rerankTitle": "重排序模型（可选）",
-      "rerankHelp": "记忆功能用这个模型为高级召回结果评分。填写重排序接口地址、模型名称和 API Key 后即可启用。",
+      "rerankHelp": "记忆功能用这个模型为高级召回结果评分。先选择 EverOS 支持的重排序服务商，再填写该服务商对应的接口地址、模型名称和 API Key。",
       "rerankHelpLabel": "关于重排序模型",
       "rerankClearLabel": "移除重排序端点",
+      "rerankProvider": "重排序服务商",
+      "rerankProviders": {
+        "deepinfra": "DeepInfra",
+        "vllm": "vLLM / OpenAI 兼容",
+        "dashscope": "DashScope"
+      },
       "multimodalTitle": "IM 附件处理模型（可选）",
       "multimodalHelp": "完整配置后，已绑定私聊中的合规附件会发送到这个兼容 OpenAI 格式的视觉模型端点，用于记忆捕获。",
       "multimodalHelpLabel": "关于 IM 附件处理",
@@ -4621,7 +4627,7 @@
       "rebuildCompleted": "记忆索引重建完成。",
       "rebuildFailed": "记忆索引重建失败。",
       "embeddingIdentityHint": "更改向量模型接口地址或模型会重建本地索引，已有记忆不会丢失。",
-      "rerankIdentityHint": "三个字段全部留空时，记忆功能会继续使用标准搜索层级。",
+      "rerankIdentityHint": "重排序字段全部留空时，记忆功能会继续使用标准搜索层级。DashScope 目前只支持 gte-rerank-v2。",
       "multimodalIdentityHint": "完整填写接口地址、模型和 API Key 即表示选择启用；三个字段全部留空时，IM 附件捕获保持关闭。"
     },
     "clear": {

--- a/ui/src/lib/memorySettings.test.ts
+++ b/ui/src/lib/memorySettings.test.ts
@@ -97,4 +97,30 @@ describe('buildEndpointPatch', () => {
       true,
     )).toEqual({ api_key: null, base_url: null, model: null });
   });
+
+  it('includes an explicit rerank provider when it differs from the saved endpoint', () => {
+    expect(buildEndpointPatch(
+      {
+        baseUrl: 'https://dashscope.aliyuncs.com',
+        model: 'gte-rerank-v2',
+        apiKey: 'rerank-secret',
+        clearKey: false,
+        provider: 'dashscope',
+      },
+      {
+        base_url: null,
+        model: null,
+        api_key: null,
+        has_api_key: false,
+      },
+      true,
+      false,
+      true,
+    )).toEqual({
+      base_url: 'https://dashscope.aliyuncs.com',
+      model: 'gte-rerank-v2',
+      api_key: 'rerank-secret',
+      provider: 'dashscope',
+    });
+  });
 });

--- a/ui/src/lib/memorySettings.ts
+++ b/ui/src/lib/memorySettings.ts
@@ -1,12 +1,31 @@
 import type {
   MemoryEndpointConfig,
   MemoryEndpointPatch,
+  MemoryRerankProvider,
   MemorySettingsResult,
 } from '../context/ApiContext';
 import { isMemoryOk } from './memoryRead';
 
 
-export type EndpointDraft = { baseUrl: string; model: string; apiKey: string; clearKey: boolean };
+export const MEMORY_RERANK_PROVIDERS = ['deepinfra', 'vllm', 'dashscope'] as const;
+export const DEFAULT_MEMORY_RERANK_PROVIDER: MemoryRerankProvider = 'deepinfra';
+export const DASHSCOPE_RERANK_MODEL = 'gte-rerank-v2';
+
+export type EndpointDraft = {
+  baseUrl: string;
+  model: string;
+  apiKey: string;
+  clearKey: boolean;
+  provider?: MemoryRerankProvider;
+};
+
+export const normalizeRerankProvider = (
+  value: string | null | undefined,
+): MemoryRerankProvider => (
+  MEMORY_RERANK_PROVIDERS.includes(value as MemoryRerankProvider)
+    ? value as MemoryRerankProvider
+    : DEFAULT_MEMORY_RERANK_PROVIDER
+);
 export type MemorySetupStage = 'loading' | 'runtime-required' | 'setup' | 'manage';
 
 export function memorySetupStage(runtimeInstalled: boolean | null, enabled: boolean | null): MemorySetupStage {
@@ -28,6 +47,7 @@ export const draftFromConfig = (config: MemoryEndpointConfig): EndpointDraft => 
   model: config.model ?? '',
   apiKey: '',
   clearKey: false,
+  provider: normalizeRerankProvider(config.provider),
 });
 
 // `allowClear` gates the explicit `api_key: null` clear. `identityLocked` protects
@@ -52,6 +72,13 @@ export function buildEndpointPatch(
       patch.model = model;
       changed = true;
     }
+    if (draft.provider !== undefined) {
+      const provider = normalizeRerankProvider(draft.provider);
+      if (provider !== normalizeRerankProvider(original.provider)) {
+        patch.provider = provider;
+        changed = true;
+      }
+    }
   }
   const trimmedKey = draft.apiKey.trim();
   if (trimmedKey) {
@@ -62,6 +89,9 @@ export function buildEndpointPatch(
     if (clearEndpoint) {
       patch.base_url = null;
       patch.model = null;
+      if (original.provider != null) {
+        patch.provider = null;
+      }
     }
     changed = true;
   }

--- a/vibe/ui_memory_routes.py
+++ b/vibe/ui_memory_routes.py
@@ -258,7 +258,10 @@ def _memory_settings_patch(current: V2Config, patch_payload: object) -> tuple[di
             endpoint_patch = processing_patch.get(endpoint)
             if endpoint_patch is None:
                 continue
-            if not isinstance(endpoint_patch, dict) or not set(endpoint_patch).issubset({"base_url", "model", "api_key"}):
+            allowed = {"base_url", "model", "api_key"}
+            if endpoint == "rerank":
+                allowed.add("provider")
+            if not isinstance(endpoint_patch, dict) or not set(endpoint_patch).issubset(allowed):
                 raise ValueError("invalid_memory_patch")
             target["processing"].setdefault(
                 endpoint,
@@ -269,11 +272,14 @@ def _memory_settings_patch(current: V2Config, patch_payload: object) -> tuple[di
                 and set(endpoint_patch) == {"api_key"}
                 and endpoint_patch["api_key"] in {None, ""}
             ):
-                target["processing"][endpoint] = {
+                cleared = {
                     "base_url": None,
                     "model": None,
                     "api_key": None,
                 }
+                if endpoint == "rerank":
+                    cleared["provider"] = None
+                target["processing"][endpoint] = cleared
 
     explicit_required_key_clear = any(
         endpoint_patch.get("api_key") in {None, ""}
@@ -306,11 +312,18 @@ def _memory_embedding_configuration_changed(current: V2Config, candidate: V2Conf
 def _memory_rerank_configuration_changed(current: V2Config, candidate: V2Config) -> bool:
     """Return whether the optional reranking provider configuration changed."""
 
-    def endpoint_values(config: V2Config) -> tuple[str | None, str | None, str | None]:
+    def endpoint_values(
+        config: V2Config,
+    ) -> tuple[str | None, str | None, str | None, str | None]:
         endpoint = config.memory.processing.rerank
         if endpoint is None:
-            return (None, None, None)
-        return (endpoint.base_url, endpoint.model, endpoint.api_key)
+            return (None, None, None, None)
+        return (
+            endpoint.base_url,
+            endpoint.model,
+            endpoint.api_key,
+            endpoint.rerank_provider(),
+        )
 
     return endpoint_values(current) != endpoint_values(candidate)
 
@@ -376,7 +389,7 @@ def _memory_factory_reset_repair_patch(patch_payload: object) -> bool:
     return all(
         isinstance(endpoint, dict)
         and bool(endpoint)
-        and set(endpoint).issubset({"base_url", "model", "api_key"})
+        and set(endpoint).issubset({"base_url", "model", "api_key", "provider"})
         for endpoint in processing.values()
     )
 


### PR DESCRIPTION
## Summary

Memory rerank now matches EverOS 1.2.3's three providers instead of assuming DeepInfra.

DashScope `qwen3-vl-rerank` 404s because Avibe preflighted `POST {base_url}/{model}` on the OpenAI-compatible URL. That path does not exist, and EverOS's DashScope branch only accepts `gte-rerank-v2`.

This change:

- persists `memory.processing.rerank.provider` (`deepinfra` | `vllm` | `dashscope`)
- probes each provider with its real request path and body
- injects `EVEROS_RERANK__PROVIDER` into the sidecar
- adds a Settings selector with provider-specific URL/model hints
- keeps missing `provider` as DeepInfra so older saved configs stay valid

DashScope still accepts only `gte-rerank-v2`. `qwen3-vl-rerank` remains an EverOS gap.

## Evidence

- unit: config load/save, provider validation, DashScope model gate
- contract: DeepInfra / vLLM / DashScope preflight request shapes; sidecar env injection
- UI: settings selector and patch construction
- residual manual: save DashScope `gte-rerank-v2` against a live key after merge

## Known-by-design

- Cloud Memory still does not expose a rerank slot.
- EverOS DashScope rerank remains `gte-rerank-v2` only.