### PR TITLE
fix(storage): restore a usable default for delivery_history_json

### DIFF
--- a/storage/alembic/versions/20260819_0057_delivery_history_default.py
+++ b/storage/alembic/versions/20260819_0057_delivery_history_default.py
@@ -1,0 +1,103 @@
+"""restore a usable default for message_deliveries.delivery_history_json
+
+Revision ID: 20260819_0057
+Revises: 20260819_0056
+Create Date: 2026-08-19
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260819_0057"
+down_revision = "20260819_0056"
+branch_labels = None
+depends_on = None
+
+_TABLE = "message_deliveries"
+_COLUMN = "delivery_history_json"
+
+# 20260801_0044 declared this default as the Python string '{"version":1,"events":[]}'.
+# That string compiles correctly on its own -- the column shipped usable. 20260811_0050
+# then rebuilt the table through ``op.batch_alter_table`` to replace a check
+# constraint. Batch mode reflects the existing table, reflection hands a server default
+# back as a ``TextClause``, and compiling a ``TextClause`` treats ``:1`` as a bind
+# parameter: the emitted DDL became DEFAULT '{"version"NULL,"events":[]}'. Every
+# database that crossed 0050 stores that, and it is not valid JSON, so
+# ck_message_deliveries_history_json rejects any insert that omits the column -- the
+# one thing a defaulted column exists to allow.
+#
+# The repair is not merely the correct literal: re-emitting a literal keeps the column
+# one rebuild away from the same corruption. ``json_object()`` carries no colon at all,
+# so it survives any number of reflect-and-recompile cycles while evaluating to the
+# same bytes the application writes.
+_FIXED_DEFAULT = "(json_object('version', 1, 'events', json_array()))"
+
+# What 0050 left behind, restored verbatim on downgrade. Undoing this migration means
+# putting back the shape the previous revision actually shipped; quietly leaving the
+# corrected default would make 0057 irreversible and hide where the fix came from.
+# Reintroducing it is inert -- every write path supplies the column explicitly, which
+# is why the defect stayed latent -- and no released code reads the default at all.
+_CORRUPTED_DEFAULT = "'{\"version\"NULL,\"events\":[]}'"
+
+# 0050 rebuilt this table the same way and is released, so its helper cannot be shared
+# from here without editing a shipped body. session_turns references
+# message_deliveries, and batch mode rebuilds by copy-drop-rename, so the rebuild runs
+# with foreign keys off and is verified before the connection re-enables them.
+_FK_NAMING_CONVENTION = {"fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s"}
+
+
+def _set_default(expression: str) -> None:
+    with op.batch_alter_table(_TABLE, naming_convention=_FK_NAMING_CONVENTION) as batch:
+        batch.alter_column(
+            _COLUMN,
+            existing_type=sa.Text(),
+            existing_nullable=False,
+            server_default=sa.text(expression),
+        )
+
+
+def _survey(bind) -> tuple[int, int]:
+    """Row count and dangling-reference count this migration must not change."""
+    rows = bind.exec_driver_sql(f"select count(*) from {_TABLE}").scalar_one()
+    dangling = len(bind.exec_driver_sql(f"PRAGMA foreign_key_check({_TABLE})").fetchall())
+    return rows, dangling
+
+
+def _rebuild(expression: str) -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "sqlite":
+        _set_default(expression)
+        return
+    with op.get_context().autocommit_block():
+        # Batch mode rebuilds by copy-drop-rename, and four tables reference this one,
+        # so the drop needs foreign keys off. What that suspends has to be re-checked
+        # afterwards -- but against what this migration is answerable for, not against
+        # an absolute. A database may already hold a dangling reference (SQLite
+        # enforces none unless the connection asks), and refusing to upgrade over
+        # damage predating this revision would pin the install below head for a reason
+        # the migration did not cause. So both bounds come from measuring the same
+        # table before and after: rows cannot be lost, and no reference this rebuild
+        # touched may come loose. Row preservation is what covers the four referring
+        # tables -- their references can only break if a row stops existing.
+        bind.exec_driver_sql("PRAGMA foreign_keys=OFF")
+        try:
+            before = _survey(bind)
+            _set_default(expression)
+            after = _survey(bind)
+        finally:
+            bind.exec_driver_sql("PRAGMA foreign_keys=ON")
+        if after != before:
+            raise RuntimeError(
+                f"delivery history default rebuild altered {_TABLE}: "
+                f"(rows, dangling refs) {before} -> {after}"
+            )
+
+
+def upgrade() -> None:
+    _rebuild(_FIXED_DEFAULT)
+
+
+def downgrade() -> None:
+    _rebuild(_CORRUPTED_DEFAULT)

--- a/storage/models.py
+++ b/storage/models.py
@@ -779,7 +779,17 @@ message_deliveries = Table(
     Column("current_receipt_outcome", String, nullable=True),
     Column("current_receipt_json", Text, nullable=False, server_default="{}"),
     Column("current_attempt_opened_at", String, nullable=True),
-    Column("delivery_history_json", Text, nullable=False, server_default='{"version":1,"events":[]}'),
+    Column(
+        "delivery_history_json",
+        Text,
+        nullable=False,
+        # Declared as an expression rather than a JSON literal on purpose: a literal
+        # default containing ``:1`` is re-read as a bind parameter every time a table
+        # rebuild reflects and recompiles it, which is how 20260811_0050 turned this
+        # default into invalid JSON. json_object() has no colon to lose. See
+        # 20260819_0057.
+        server_default=text("(json_object('version', 1, 'events', json_array()))"),
+    ),
     Column("version", Integer, nullable=False, server_default="1"),
     Column("submitted_at", String, nullable=False),
     Column("updated_at", String, nullable=False),

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import pytest
 from alembic import command
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
 from alembic.script import ScriptDirectory
 from sqlalchemy.dialects.sqlite import dialect as sqlite_dialect
 from sqlalchemy.exc import IntegrityError
@@ -33,7 +35,14 @@ from vibe.message_types import build_partial_index_predicate
 pytestmark = pytest.mark.no_sqlite_template
 
 
-HEAD_REVISION = "20260819_0056"
+HEAD_REVISION = "20260819_0057"
+# ``storage.models`` builds a bare ``MetaData()``, so its foreign keys are unnamed and
+# Alembic cannot re-emit them when batch mode recreates a table. Every migration that
+# rebuilds one therefore passes this convention; the rebuild simulated below has to pass
+# the same one to reproduce what those migrations actually do.
+_MIGRATION_FK_NAMING_CONVENTION = {
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s"
+}
 MESSAGE_PARTIAL_INDEX_PREDICATES = {
     "ix_messages_inbox_activity": (
         "session_id is not null and type in "
@@ -742,11 +751,15 @@ def test_repair_restores_branch_indexes_whose_tables_survived(tmp_path: Path) ->
 
 
 def test_replaying_the_branch_over_a_healthy_database_changes_nothing(tmp_path: Path) -> None:
-    # The repair replays unconditionally, so every database that reaches head replays
-    # the branch over a schema that already has it -- including the backfill in
+    # The repair replays unconditionally, so every database that reaches it replays the
+    # branch over a schema that already has it -- including the backfill in
     # 20260725_0037, which writes rows rather than DDL. That is only safe while every
     # replayed revision is a no-op against what it finds, so pin exactly that: same
     # schema, and a row the backfill would otherwise duplicate or overwrite left alone.
+    #
+    # Upgrade to the repair itself rather than to head. The subject here is the replay,
+    # and a later revision is free to change the schema deliberately -- as 20260819_0057
+    # does -- which would otherwise read as the replay having damaged something.
     db_path = _upgraded_db(tmp_path / "healthy.sqlite", "20260817_0055")
     with sqlite3.connect(db_path) as conn:
         conn.execute(
@@ -760,7 +773,7 @@ def test_replaying_the_branch_over_a_healthy_database_changes_nothing(tmp_path: 
         conn.commit()
     before = _schema_of(db_path)
 
-    command.upgrade(migrations.alembic_config(db_path), "head")
+    command.upgrade(migrations.alembic_config(db_path), _REPAIR_REVISION)
 
     assert _schema_of(db_path) == before
     with sqlite3.connect(db_path) as conn:
@@ -768,7 +781,7 @@ def test_replaying_the_branch_over_a_healthy_database_changes_nothing(tmp_path: 
             "select token, session_id, created_at from media_object_references"
         ).fetchall() == [("tok", "ses", "original")]
         assert conn.execute("select version_num from alembic_version").fetchall() == [
-            (HEAD_REVISION,)
+            (_REPAIR_REVISION,)
         ]
 
 
@@ -948,6 +961,305 @@ def test_session_queue_hold_removal_is_schema_complete_and_reversible(
             "from agent_sessions where id='ses_queue_hold'"
         ).fetchone()
     assert restored == ("open", 1, None)
+
+
+def _column_defaults(conn: sqlite3.Connection) -> dict[tuple[str, str], str]:
+    """Every stored column default in the database, keyed by (table, column)."""
+    tables = [
+        row[0]
+        for row in conn.execute(
+            "select name from sqlite_master where type = 'table' and name not like 'sqlite_%'"
+        )
+    ]
+    return {
+        (table, row[1]): row[4]
+        for table in tables
+        for row in conn.execute(f"pragma table_info('{table}')")
+        if row[4] is not None
+    }
+
+
+def _rebuild_every_table(db_path: Path) -> None:
+    """Run the no-op batch rebuild Alembic performs for a SQLite table alteration.
+
+    This leaves the database only good enough to read column defaults back from: batch
+    mode cannot reflect an expression-based index, so rebuilding every table drops the
+    partial and expression indexes this schema uses. Do not reuse it to assert anything
+    about indexes.
+    """
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.connect() as conn:
+            conn.exec_driver_sql("PRAGMA foreign_keys=OFF")
+            operations = Operations(MigrationContext.configure(conn))
+            tables = [
+                row[0]
+                for row in conn.exec_driver_sql(
+                    "select name from sqlite_master where type = 'table' "
+                    "and name not like 'sqlite_%' and name <> 'alembic_version'"
+                )
+            ]
+            for table in tables:
+                with operations.batch_alter_table(
+                    table,
+                    recreate="always",
+                    naming_convention=_MIGRATION_FK_NAMING_CONVENTION,
+                ):
+                    pass
+            conn.commit()
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.parametrize("schema", ["declared", "migrated"])
+def test_no_table_rebuild_can_corrupt_a_column_default(tmp_path: Path, schema: str) -> None:
+    """A table rebuild must preserve every column default, in every table.
+
+    Alembic alters a SQLite column by reflecting the table and recreating it, and
+    reflection hands a server default back as a ``TextClause``. Recompiling one
+    re-reads ``:name`` as a bind parameter, so a default containing a colon is
+    rewritten -- that is how ``20260811_0050`` silently turned
+    ``message_deliveries.delivery_history_json`` into invalid JSON while replacing
+    an unrelated check constraint.
+
+    Asserting over every default in the schema is what makes this durable: the
+    property holds for defaults nobody has written yet, so a colon-bearing default
+    added to any table fails here when it is declared rather than one unrelated
+    rebuild later. Both the declared schema and the migrated one are checked
+    because they are separately authored and can disagree.
+    """
+    db_path = tmp_path / "vibe.sqlite"
+    if schema == "declared":
+        engine = create_sqlite_engine(db_path)
+        try:
+            metadata.create_all(engine)
+        finally:
+            engine.dispose()
+    else:
+        run_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        before = _column_defaults(conn)
+    assert before, "expected the schema under test to declare column defaults"
+
+    _rebuild_every_table(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        after = _column_defaults(conn)
+    drifted = {
+        key: (before.get(key), after.get(key))
+        for key in before.keys() | after.keys()
+        if before.get(key) != after.get(key)
+    }
+    assert drifted == {}
+
+
+def test_head_column_defaults_satisfy_their_own_table_constraints(tmp_path: Path) -> None:
+    """A defaulted column must accept an insert that omits it.
+
+    The whole point of a server default is that a writer may leave the column out,
+    so a default the table's own constraints reject is a broken column. This is the
+    reachable half of the ``delivery_history_json`` defect: the corrupted default was
+    not valid JSON, and ``ck_message_deliveries_history_json`` refused every insert
+    that relied on it.
+    """
+    db_path = tmp_path / "vibe.sqlite"
+    run_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        _insert_scope(conn, "scope_defaults")
+        _insert_agent_session(
+            conn,
+            row_id="ses_defaults",
+            scope_id="scope_defaults",
+            anchor="defaults",
+            workdir=None,
+            backend="codex",
+            native="native-defaults",
+            last_active="now",
+        )
+        conn.execute(
+            "insert into message_deliveries ("
+            "id, session_id, priority, state, snapshot_sha256, dispatch_sha256, "
+            "submitted_at, updated_at"
+            ") values ('md_defaults', 'ses_defaults', 'p1', 'queued', 'h', 'h', 'now', 'now')"
+        )
+        stored = conn.execute(
+            "select delivery_history_json from message_deliveries where id = 'md_defaults'"
+        ).fetchone()[0]
+        conn.commit()
+
+    assert json.loads(stored) == {"version": 1, "events": []}
+
+
+def test_delivery_history_default_repair_preserves_rows_and_reverses(tmp_path: Path) -> None:
+    """0057 changes that one default and nothing else, over data and back.
+
+    The repair rebuilds a table four others reference, so the rows that already
+    exist are the thing at risk. One row of each shape a real database can hold is
+    seeded -- a reference-clean row, and one whose parent is missing, because SQLite
+    enforces foreign keys only when a connection asks it to and ``20260819_0056``
+    exists to repair databases that are already damaged. Refusing to upgrade over
+    pre-existing damage would pin such an install below head for a reason this
+    revision did not cause.
+    """
+    db_path = tmp_path / "vibe.sqlite"
+    run_migrations(db_path, revision="20260819_0056")
+
+    history = json.dumps({"version": 1, "events": [{"kind": "queued"}]})
+    with sqlite3.connect(db_path) as conn:
+        _insert_scope(conn, "scope_history")
+        _insert_agent_session(
+            conn,
+            row_id="ses_history",
+            scope_id="scope_history",
+            anchor="history",
+            workdir=None,
+            backend="codex",
+            native="native-history",
+            last_active="now",
+        )
+        for row_id, session_id in (("md_clean", "ses_history"), ("md_orphan", "ses_missing")):
+            conn.execute(
+                "insert into message_deliveries ("
+                "id, session_id, priority, state, snapshot_sha256, dispatch_sha256, "
+                "submitted_at, updated_at, delivery_history_json"
+                ") values (?, ?, 'p1', 'queued', 'h', 'h', 'now', 'now', ?)",
+                (row_id, session_id, history),
+            )
+        conn.commit()
+        seeded = _schema_fingerprint(conn)
+        rows_before = _delivery_rows(conn)
+
+    # The check the corrupted default violates is the reason this repair exists, so
+    # prove the fingerprint actually captured it: a comparison over a set that silently
+    # came out empty would hold no matter what the rebuild did.
+    assert "ck_message_deliveries_history_json" in " ".join(
+        seeded["constraints"]["message_deliveries"]
+    )
+
+    run_migrations(db_path)
+    with sqlite3.connect(db_path) as conn:
+        upgraded = _schema_fingerprint(conn)
+        assert _delivery_rows(conn) == rows_before
+        assert conn.execute("select version_num from alembic_version").fetchone() == (
+            HEAD_REVISION,
+        )
+    # Only that one column's default may differ -- every other column, constraint,
+    # index, and table in the database is untouched.
+    assert _fingerprint_difference(seeded, upgraded) == {
+        ("message_deliveries", "delivery_history_json")
+    }
+
+    command.downgrade(migrations.alembic_config(db_path), "20260819_0056")
+    with sqlite3.connect(db_path) as conn:
+        assert _schema_fingerprint(conn) == seeded
+        assert _delivery_rows(conn) == rows_before
+
+
+def _delivery_rows(conn: sqlite3.Connection) -> list[tuple[object, ...]]:
+    return conn.execute(
+        "select id, session_id, delivery_history_json from message_deliveries order by id"
+    ).fetchall()
+
+
+def _schema_fingerprint(conn: sqlite3.Connection) -> dict[str, object]:
+    """Column shapes, table constraints, indexes, and foreign keys, whole database.
+
+    Constraints are compared as sets rather than as DDL text because a batch rebuild
+    re-emits them in reflection order, which is not the order they were written in.
+    """
+    tables = sorted(
+        row[0]
+        for row in conn.execute(
+            "select name from sqlite_master where type = 'table' and name not like 'sqlite_%'"
+        )
+    )
+    columns = {
+        (table, row[1]): tuple(row[2:6])
+        for table in tables
+        for row in conn.execute(f"pragma table_info('{table}')")
+    }
+    constraints = {
+        table: {
+            re.sub(r"\s+", " ", item)
+            for item in _split_table_constraints(
+                conn.execute(
+                    "select sql from sqlite_master where type = 'table' and name = ?",
+                    (table,),
+                ).fetchone()[0]
+            )
+        }
+        for table in tables
+    }
+    others = {
+        (row[0], row[1]): re.sub(r"\s+", " ", row[2] or "")
+        for row in conn.execute(
+            "select type, name, sql from sqlite_master "
+            "where type <> 'table' and name not like 'sqlite_%'"
+        )
+    }
+    foreign_keys = {
+        table: sorted(tuple(row[2:]) for row in conn.execute(f"pragma foreign_key_list('{table}')"))
+        for table in tables
+    }
+    return {
+        "columns": columns,
+        "constraints": constraints,
+        "others": others,
+        "foreign_keys": foreign_keys,
+    }
+
+
+_TABLE_CONSTRAINT_KEYWORDS = ("constraint", "check", "foreign", "primary", "unique")
+
+
+def _split_table_constraints(sql: str) -> list[str]:
+    """Table-level constraints declared in a CREATE TABLE body.
+
+    Column definitions are deliberately dropped: ``pragma table_info`` reports column
+    shape exactly, so parsing it out of the DDL text again would only add a second,
+    weaker reading of the same fact. A plain ``split(",")`` also cannot do this --
+    ``check (state in ('a','b'))`` puts commas inside parentheses and a default like
+    ``'{"a":1,"b":2}'`` puts one inside a string literal -- so both are tracked.
+    """
+    body = sql[sql.index("(") + 1 : sql.rindex(")")]
+    items: list[str] = []
+    depth = 0
+    quoted = False
+    current: list[str] = []
+    for char in body:
+        if char == "'":
+            # SQLite escapes a quote by doubling it, which this toggle handles: the
+            # second quote of '' re-enters the literal.
+            quoted = not quoted
+        elif not quoted and char == "(":
+            depth += 1
+        elif not quoted and char == ")":
+            depth -= 1
+        if char == "," and depth == 0 and not quoted:
+            items.append("".join(current).strip())
+            current = []
+        else:
+            current.append(char)
+    items.append("".join(current).strip())
+    return [
+        item
+        for item in items
+        if item.split(" ", 1)[0].lower() in _TABLE_CONSTRAINT_KEYWORDS
+    ]
+
+
+def _fingerprint_difference(
+    before: dict[str, object], after: dict[str, object]
+) -> set[tuple[str, str]]:
+    """(table, column) pairs whose shape changed; raises if anything else did."""
+    for key in ("constraints", "others", "foreign_keys"):
+        assert before[key] == after[key], f"{key} changed"
+    before_columns = before["columns"]
+    after_columns = after["columns"]
+    assert before_columns.keys() == after_columns.keys()
+    return {key for key in before_columns if before_columns[key] != after_columns[key]}
 
 
 def test_scoped_native_message_identity_upgrade_and_safe_downgrade(


### PR DESCRIPTION
## What changed

`message_deliveries.delivery_history_json` has a server default that is not valid JSON, so the table's own `ck_message_deliveries_history_json` rejects any insert that omits the column. This restores a usable default and makes the corruption mechanism unable to recur.

## Root cause

`20260801_0044` declared the default as the Python string `'{"version":1,"events":[]}'`. That compiles correctly — the column shipped usable.

`20260811_0050` then rebuilt the table with `op.batch_alter_table` to replace an unrelated check constraint. Batch mode reflects the existing table; reflection hands a server default back as a `TextClause`; and recompiling a `TextClause` treats `:1` as a **bind parameter**. The emitted DDL became:

```
DEFAULT '{"version"NULL,"events":[]}'
```

Measured revision by revision:

| revision | stored default |
| --- | --- |
| `20260801_0044` | `'{"version":1,"events":[]}'` |
| `20260809_0049` | `'{"version":1,"events":[]}'` |
| `20260811_0050` | `'{"version"NULL,"events":[]}'` |
| `master` head | `'{"version"NULL,"events":[]}'` |

Every database that crossed `0050` stores the corrupted form. The reachable failure on a `0056` database:

```
insert into message_deliveries (id, session_id, priority, state, snapshot_sha256,
  dispatch_sha256, submitted_at, updated_at) values (...)
-> IntegrityError: CHECK constraint failed: ck_message_deliveries_history_json
```

The defect is latent in production only because `storage/message_deliveries.py` always writes the column explicitly.

## The fix

`20260819_0057` sets the default to `json_object('version', 1, 'events', json_array())` rather than re-emitting the correct literal. A literal would leave the column one rebuild away from the same corruption; an expression carries no colon at all, so it survives any number of reflect-and-recompile cycles while evaluating to the byte-identical `{"version":1,"events":[]}` the application writes. `storage/models.py` is changed to declare the same expression.

Scope was bounded by measurement, not assumption: across the entire head schema exactly one live default contains a colon and exactly one is corrupted — this column. The *mechanism*, however, threatens any colon-bearing default added to any rebuilt table later, which is what the regression targets.

## Evidence layers

**Unit / migration** — `tests/test_sqlite_state_migration.py`:

- `test_no_table_rebuild_can_corrupt_a_column_default[declared|migrated]` — the property: **every** column default in the schema survives a table rebuild unchanged. Complete by construction over every table and every default, with no allowlist, so a colon-bearing default added later fails when it is declared rather than one unrelated rebuild afterwards. Declared and migrated schemas are checked separately because they are separately authored.
- `test_head_column_defaults_satisfy_their_own_table_constraints` — a defaulted column must accept an insert that omits it. This is the reachable half of the defect.
- `test_delivery_history_default_repair_preserves_rows_and_reverses` — seeds one row of each shape a real database holds, asserts the rows are unchanged, asserts only that one column's shape differs across the whole database (every other column, table constraint, index, and foreign key compared), then downgrades and asserts the `0056` schema and rows are restored exactly.

**Mutation-tested** — the assertions were verified to fail on master's shape, not merely to pass on the fix:

| mutation | result |
| --- | --- |
| restore master's plain-string model default | `test_no_table_rebuild_can_corrupt_a_column_default[declared]` FAILS, reproducing `'{"version"NULL,"events":[]}'` exactly |
| make `0057.upgrade()` a no-op | admissibility and repair tests both FAIL |

**Full file** — `tests/test_sqlite_state_migration.py` 123 passed; `test_delivery_state_matrix.py`, `test_message_delivery_authority.py`, `test_session_delivery_fsm.py` 206 passed. `ruff 0.4.9 check --config=pyproject.toml` clean on all changed files.

**Residual manual checks** — none. No regression-environment verification: the change is schema-only and the defect is unreachable through any released write path.

## Known by design

- **Downgrade restores the corrupted default byte-for-byte.** Undoing this revision means putting back the shape `0056` actually shipped. Silently leaving the corrected default would make `0057` irreversible and hide where the fix came from. Reintroducing it is inert — every write path supplies the column explicitly, and no released code reads the default.
- **The rebuild guard is a self-measured delta, not an absolute.** `PRAGMA foreign_key_check` with no argument scans the whole database, so an absolute "zero violations" assertion would abort the upgrade over damage predating this revision — pinning the install below head for a reason this migration did not cause, which is the exact failure mode `20260819_0056` exists to repair. Both bounds are therefore measured against the same table before and after: rows cannot be lost, and no reference this rebuild touched may come loose. Row preservation is what covers the four referring tables — their references can only break if a row stops existing. The test seeds a deliberately dangling row to prove the upgrade tolerates pre-existing damage.
- **The FK naming convention is duplicated into the test.** `storage.models` builds a bare `MetaData()`, so foreign keys are unnamed and batch mode needs the convention passed explicitly. Three migrations already carry their own copy; two are released, so consolidating into one owner would mean editing shipped migration bodies. The test defines it locally with a comment rather than reaching into a migration module's namespace.
- **`test_replaying_the_branch_over_a_healthy_database_changes_nothing` now upgrades to `_REPAIR_REVISION` instead of `head`.** Its subject is that the `0056` branch replay is a no-op; comparing against `head` only worked while `0056` was head. A later revision is free to change the schema deliberately, and that would otherwise read as the replay having damaged something. This matches the file's existing design of reading revisions from the script directory so a new revision needs no test edit.
- **`_rebuild_every_table` drops expression-based indexes.** Batch mode cannot reflect them, so the helper leaves the database good enough only to read column defaults back from. Documented on the helper so it is not reused for index assertions.

## Dependencies

None. Chains `20260819_0057` onto `20260819_0056`, which is on `master`. Re-verified against `origin/master` at `702ea94d6`: no other lane has taken `0057`.
