### PR TITLE
fix(ui): skip entrance animation for dock-minimized windows

### DIFF
--- a/ui/src/components/apps/AppWindow.tsx
+++ b/ui/src/components/apps/AppWindow.tsx
@@ -14,6 +14,7 @@ import { useUnsavedChangesActionGuard } from '../../context/useUnsavedChangesAct
 import { clampToLayer, resizeBounds, type ResizeDir } from '../../lib/windowBounds';
 import { WindowBodyGestureShield } from './WindowBodyGestureShield';
 import { shouldShieldWindowBody } from './windowGesture';
+import { appWindowMotionClass } from './windowMotion';
 import { ErrorBoundary } from '../ui/error-boundary';
 import { ShowPageAnnotateControl } from '../workbench/ShowPageAnnotateControl';
 import { ShowPageShareControl } from '../workbench/ShowPageShareControl';
@@ -53,6 +54,11 @@ export const AppWindow: React.FC<{
   // CSS owns the timing). Minimizing is a pure mounted hide (see className) so the
   // window body — terminal session, editor buffer — stays alive and intact.
   const [exitKind, setExitKind] = useState<'close' | null>(null);
+  // Frozen at first paint: a reload of a Dock-minimized window must not play the
+  // entrance keyframe (it animates opacity to 1 over the minimized hide). Restoring
+  // later still morphs via the transform/opacity transition; flipping this would
+  // re-add the in-class and replay the keyframe on top of that morph.
+  const [skipEntrance] = useState(win.minimized);
   // Animate window GEOMETRY (maximize/restore) but NOT during a drag/resize, which must track the
   // pointer instantly. `dragging` is state (not a ref) so the transition is enabled in the SAME render
   // that changes the bounds — otherwise the geometry jumps before the transition class arrives and
@@ -288,7 +294,7 @@ export const AppWindow: React.FC<{
           ? 'transition-[transform,opacity] duration-200 ease-out'
           : 'transition-[left,top,width,height,transform,opacity] duration-300 ease-out',
         win.maximized ? 'rounded-none' : 'rounded-xl',
-        exitKind === 'close' ? 'animate-appwindow-out' : 'animate-appwindow-in',
+        appWindowMotionClass({ exitKind, skipEntrance }),
         // Minimize = mounted hide: the body stays alive (terminal/editor state preserved) while the
         // window shrinks toward the Dock (inline transform above) and stops taking pointer events.
         win.minimized ? 'pointer-events-none opacity-0' : 'pointer-events-auto',

--- a/ui/src/components/apps/windowMotion.test.ts
+++ b/ui/src/components/apps/windowMotion.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { appWindowMotionClass, type AppWindowExitKind } from './windowMotion';
+
+describe('appWindowMotionClass', () => {
+  it('close always wins; skipEntrance is the only way a live window skips the in-keyframe', () => {
+    const exitKinds: AppWindowExitKind[] = ['close', null];
+    const skipFlags = [false, true];
+    for (const exitKind of exitKinds) {
+      for (const skipEntrance of skipFlags) {
+        const cls = appWindowMotionClass({ exitKind, skipEntrance });
+        if (exitKind === 'close') {
+          expect(cls).toBe('animate-appwindow-out');
+        } else if (skipEntrance) {
+          expect(cls).toBeUndefined();
+        } else {
+          expect(cls).toBe('animate-appwindow-in');
+        }
+      }
+    }
+  });
+});

--- a/ui/src/components/apps/windowMotion.ts
+++ b/ui/src/components/apps/windowMotion.ts
@@ -1,0 +1,21 @@
+export type AppWindowExitKind = 'close' | null;
+
+/**
+ * Which motion class a window root should carry.
+ *
+ * A window that mounted already minimized (reload of a Dock-hidden window)
+ * must not play `animate-appwindow-in`: that keyframe animates `opacity` to 1
+ * and wins over the minimized `opacity-0` class, so the window flashes at
+ * full size before disappearing. Capture skipEntrance at first paint and keep
+ * it for the instance's life — restoring from the Dock uses the CSS
+ * transform/opacity transition, and toggling the in-class on restore would
+ * re-trigger the keyframe on top of that morph.
+ */
+export function appWindowMotionClass(opts: {
+  exitKind: AppWindowExitKind;
+  skipEntrance: boolean;
+}): string | undefined {
+  if (opts.exitKind === 'close') return 'animate-appwindow-out';
+  if (opts.skipEntrance) return undefined;
+  return 'animate-appwindow-in';
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -656,9 +656,11 @@ pre,
   animation: slide-in 0.2s ease-out;
 }
 
-/* App windows (Apps layer): a subtle scale+fade on open/restore, and a
-   scale-down toward the Dock on minimize/close. Short enough to read as
-   responsiveness, not a transition you wait on. */
+/* App windows (Apps layer): a subtle scale+fade on open, and a scale-down
+   toward the Dock on close. Short enough to read as responsiveness, not a
+   transition you wait on. A window that mounts already minimized must NOT
+   take animate-appwindow-in — this keyframe writes opacity/transform and
+   would flash the window at full size before the minimized hide sticks. */
 @keyframes appwindow-in {
   from { opacity: 0; transform: scale(0.97) translateY(6px); }
   to { opacity: 1; transform: scale(1) translateY(0); }


### PR DESCRIPTION
## Capability

A workbench app window that was minimized to the Dock no longer flashes at full size when the page reloads.

Root cause: `AppWindow` always mounted with `animate-appwindow-in`. That keyframe writes `opacity`/`transform` and wins over the minimized `opacity-0` hide, so a restored-from-storage minimized window plays the open animation, appears, then disappears.

Fix: capture `skipEntrance` at first paint from `win.minimized`, and omit the in-keyframe for that instance. Close still uses `animate-appwindow-out`. Restore from the Dock still uses the existing CSS transform/opacity morph — flipping the in-class on restore would replay the keyframe on top of that morph.

## Evidence

- **Unit:** `ui/src/components/apps/windowMotion.test.ts` enumerates every `(exitKind, skipEntrance)` pair: close always wins; skipEntrance is the only way a live window skips the in-keyframe.
- **Local:** `npm run lint`, focused vitest, `npm run build` in `ui/`.
- **Residual manual:** reload the workbench with a window minimized to the Dock; the frame must stay hidden. Open a new window (entrance still plays). Restore from the Dock (morph still plays).

## Known-by-design

None.
