### PR TITLE
fix(opencode): settle leftover durable turns after runtime is gone

### DIFF
--- a/core/services/running_agents.py
+++ b/core/services/running_agents.py
@@ -732,16 +732,23 @@ async def _end_opencode(controller: "Controller", base_session_id: Optional[str]
     return {"ok": True, "action": "ended", "backend": "opencode"}
 
 
-async def _settle_workbench_turn(controller: "Controller", session_id: Optional[str]) -> Optional[dict[str, Any]]:
-    """If a Workbench/chat turn still owns ``session_id``, stop it through
+async def _settle_workbench_turn(
+    controller: "Controller",
+    session_id: Optional[str],
+    *,
+    backend: Optional[str] = None,
+    base_session_id: Optional[str] = None,
+) -> Optional[dict[str, Any]]:
+    """If a Workbench/chat turn still owns this End/Stop row, stop it through
     ``SessionTurnManager.cancel`` so the turn FSM settles: it interrupts the
     backend, emits the terminal result, AND cancels the ``dispatch_turn`` task the
     Chat page is awaiting. Ownership is either the in-memory task or a leftover
-    durable Turn after that task is gone. Skipping this (and only doing the
-    backend teardown below) would leave the chat session stuck "running".
+    durable Turn after that task is gone, and both still follow last-only
+    identity. Skipping this (and only doing the backend teardown below) would
+    leave the chat session stuck "running".
 
     Returns a success/failure result when the Workbench manager owned the turn;
-    returns ``None`` for IM/agent-run turns and when there is no turn owner.
+    returns ``None`` for IM/agent-run turns and when there is no matching owner.
     """
     if not session_id:
         return None
@@ -749,9 +756,10 @@ async def _settle_workbench_turn(controller: "Controller", session_id: Optional[
     if manager is None or not getattr(manager, "cancel", None):
         return None
     try:
-        in_flight = getattr(manager, "is_in_flight", None)
-        if not (callable(in_flight) and in_flight(session_id)) and not _session_has_durable_owner(
-            manager, session_id
+        if not _inflight_turn_matches_row(
+            controller, session_id=session_id, backend=backend, base_session_id=base_session_id
+        ) and not _durable_owner_matches_row(
+            manager, session_id, backend=backend, base_session_id=base_session_id
         ):
             return None
         result = await manager.cancel(session_id)
@@ -971,7 +979,12 @@ async def _stop_active_agent(
     composite_key: Optional[str],
     base_session_id: Optional[str],
 ) -> dict[str, Any]:
-    settled = await _settle_workbench_turn(controller, session_id)
+    settled = await _settle_workbench_turn(
+        controller,
+        session_id,
+        backend=backend,
+        base_session_id=base_session_id,
+    )
     if settled is not None:
         if settled.get("backend") is None and backend:
             settled["backend"] = backend
@@ -1093,17 +1106,6 @@ def _load_durable_owner(manager: Any, session_id: str) -> Optional[dict[str, Any
     payload = dict(owner)
     payload["session_anchor"] = str((session_row or {}).get("session_anchor") or "")
     return payload
-
-
-def _session_has_durable_owner(manager: Any, session_id: str) -> bool:
-    """True when SQLite still owns an active Turn for ``session_id``.
-
-    A Workbench Stop can leave this row after the in-memory poll/task is gone.
-    End/Stop must still see it as live, or they take the idle teardown and
-    leave the chat stuck on ``running``.
-    """
-
-    return _load_durable_owner(manager, session_id) is not None
 
 
 def _durable_owner_matches_row(

--- a/core/services/running_agents.py
+++ b/core/services/running_agents.py
@@ -733,11 +733,12 @@ async def _end_opencode(controller: "Controller", base_session_id: Optional[str]
 
 
 async def _settle_workbench_turn(controller: "Controller", session_id: Optional[str]) -> Optional[dict[str, Any]]:
-    """If a Workbench/chat turn is in flight for ``session_id``, stop it through
+    """If a Workbench/chat turn still owns ``session_id``, stop it through
     ``SessionTurnManager.cancel`` so the turn FSM settles: it interrupts the
     backend, emits the terminal result, AND cancels the ``dispatch_turn`` task the
-    Chat page is awaiting. Skipping this (and only doing the backend teardown
-    below) would leave the chat session stuck "running" with sends queued.
+    Chat page is awaiting. Ownership is either the in-memory task or a leftover
+    durable Turn after that task is gone. Skipping this (and only doing the
+    backend teardown below) would leave the chat session stuck "running".
 
     Returns a success/failure result when the Workbench manager owned the turn;
     returns ``None`` for IM/agent-run turns and when there is no turn owner.
@@ -745,10 +746,13 @@ async def _settle_workbench_turn(controller: "Controller", session_id: Optional[
     if not session_id:
         return None
     manager = getattr(controller, "session_turns", None)
-    if manager is None or not getattr(manager, "is_in_flight", None):
+    if manager is None or not getattr(manager, "cancel", None):
         return None
     try:
-        if not manager.is_in_flight(session_id):
+        in_flight = getattr(manager, "is_in_flight", None)
+        if not (callable(in_flight) and in_flight(session_id)) and not _session_has_durable_owner(
+            manager, session_id
+        ):
             return None
         result = await manager.cancel(session_id)
         if isinstance(result, dict) and result.get("ok"):
@@ -1061,6 +1065,76 @@ def _inflight_turn_matches_row(
     return backend_match or anchor_match
 
 
+def _load_durable_owner(manager: Any, session_id: str) -> Optional[dict[str, Any]]:
+    """Return the SQLite Turn owner for ``session_id``, if one is still active."""
+
+    reader = getattr(manager, "_durable_schema_available", None)
+    if not callable(reader) or not reader():
+        return None
+    engine = getattr(manager, "_sqlite_engine", None)
+    if not callable(engine):
+        return None
+    try:
+        from sqlalchemy import select
+
+        from storage import message_deliveries as delivery_store
+        from storage.models import agent_sessions
+
+        with engine().connect() as conn:
+            owner = delivery_store.active_turn(conn, session_id)
+            if owner is None:
+                return None
+            session_row = conn.execute(
+                select(agent_sessions).where(agent_sessions.c.id == session_id)
+            ).mappings().first()
+    except Exception:  # noqa: BLE001
+        logger.debug("end: durable-owner check failed for %s", session_id, exc_info=True)
+        return None
+    payload = dict(owner)
+    payload["session_anchor"] = str((session_row or {}).get("session_anchor") or "")
+    return payload
+
+
+def _session_has_durable_owner(manager: Any, session_id: str) -> bool:
+    """True when SQLite still owns an active Turn for ``session_id``.
+
+    A Workbench Stop can leave this row after the in-memory poll/task is gone.
+    End/Stop must still see it as live, or they take the idle teardown and
+    leave the chat stuck on ``running``.
+    """
+
+    return _load_durable_owner(manager, session_id) is not None
+
+
+def _durable_owner_matches_row(
+    manager: Any,
+    session_id: str,
+    *,
+    backend: Optional[str],
+    base_session_id: Optional[str],
+) -> bool:
+    """True when the durable owner is THIS End/Stop row's runtime.
+
+    Same last-only identity as ``_inflight_turn_matches_row``: a backend or
+    session-anchor conflict is a different turn under the same chat.
+    """
+
+    owner = _load_durable_owner(manager, session_id)
+    if owner is None:
+        return False
+    turn_backend = str(owner.get("backend") or "").strip()
+    turn_anchor = str(owner.get("session_anchor") or "").strip()
+    row_backend = str(backend or "").strip()
+    row_base = str(base_session_id or "").strip()
+    backend_conflict = bool(turn_backend and row_backend and turn_backend != row_backend)
+    anchor_conflict = bool(turn_anchor and row_base and turn_anchor != row_base)
+    if backend_conflict or anchor_conflict:
+        return False
+    backend_match = bool(turn_backend and turn_backend == row_backend)
+    anchor_match = bool(turn_anchor and turn_anchor == row_base)
+    return backend_match or anchor_match
+
+
 def _resolve_live_state(
     controller: "Controller",
     *,
@@ -1091,6 +1165,11 @@ def _resolve_live_state(
     # fall through to the backend-specific live checks below.
     if session_id and _inflight_turn_matches_row(
         controller, session_id=session_id, backend=backend, base_session_id=base_session_id
+    ):
+        return "active"
+    manager = getattr(controller, "session_turns", None)
+    if session_id and manager is not None and _durable_owner_matches_row(
+        manager, session_id, backend=backend, base_session_id=base_session_id
     ):
         return "active"
 

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -7997,6 +7997,27 @@ class SessionTurnManager:
                     session_id
                 ),
             }
+        memory_dead = turn is None or turn.task.done()
+        if owner is not None and memory_dead and not agent_run_id:
+            terminal = self._terminalize_durable_turn(
+                str(owner["id"]),
+                "canceled",
+                settled_by=SETTLED_BY_STOPPED,
+                evidence_kind="runtime_gone",
+                evidence={"reason": "stop_with_no_live_runtime"},
+            )
+            if terminal.get("changed"):
+                logger.info(
+                    "Released durable Turn=%s for Session=%s after Stop found no live runtime",
+                    owner["id"],
+                    session_id,
+                )
+                return {
+                    "ok": True,
+                    "session_id": session_id,
+                    "status": "stale_released",
+                    "reason": "runtime_gone",
+                }
         result = await self.deliver(
             DeliveryRequest(
                 session_id=session_id,

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -8006,19 +8006,48 @@ class SessionTurnManager:
                 owner_id,
             )
             if restored_identity is None or restored_identity[0] != owner_id:
-                terminal = self._terminalize_durable_turn(
-                    owner_id,
-                    "canceled",
-                    settled_by=SETTLED_BY_STOPPED,
-                    evidence_kind="runtime_gone",
-                    evidence={"reason": "stop_with_no_live_runtime"},
+                unaccepted_start = (
+                    str(owner.get("state") or "") == "starting"
+                    and str(owner.get("start_receipt_outcome") or "") != "accepted"
                 )
+                if unaccepted_start:
+                    with self._sqlite_engine().connect() as conn:
+                        initial_delivery_ids = {
+                            str(row["id"])
+                            for row in delivery_store.initial_deliveries_for_turn(
+                                conn,
+                                owner_id,
+                            )
+                            if row["state"] == "claimed"
+                        }
+                    terminal = self._terminalize_durable_turn(
+                        owner_id,
+                        "not_written",
+                        settled_by=SETTLED_BY_STOPPED,
+                        evidence_kind="runtime_gone",
+                        evidence={"reason": "stop_with_no_live_runtime"},
+                        retire_unwritten_delivery_ids=initial_delivery_ids,
+                        retire_unwritten_attempt_outcome="canceled",
+                    )
+                else:
+                    terminal = self._terminalize_durable_turn(
+                        owner_id,
+                        "canceled",
+                        settled_by=SETTLED_BY_STOPPED,
+                        evidence_kind="runtime_gone",
+                        evidence={"reason": "stop_with_no_live_runtime"},
+                    )
                 if terminal.get("changed"):
                     logger.info(
                         "Released durable Turn=%s for Session=%s after Stop found no live runtime",
                         owner_id,
                         session_id,
                     )
+                    successor_turn_id = str(terminal.get("successor_turn_id") or "")
+                    if successor_turn_id:
+                        await self._start_persisted_turn(successor_turn_id)
+                    elif not terminal.get("defer_queue_resume"):
+                        await self._resume_post_terminal(session_id)
                     return {
                         "ok": True,
                         "session_id": session_id,

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -8007,14 +8007,9 @@ class SessionTurnManager:
             )
             if restored_identity is None or restored_identity[0] != owner_id:
                 start_receipt = str(owner.get("start_receipt_outcome") or "")
-                never_started = (
-                    str(owner.get("state") or "") == "starting"
-                    and start_receipt not in {"accepted", "unknown"}
-                )
-                unknown_start = (
-                    str(owner.get("state") or "") == "starting"
-                    and start_receipt == "unknown"
-                )
+                starting = str(owner.get("state") or "") == "starting"
+                never_started = starting and start_receipt not in {"accepted", "unknown"}
+                unknown_start = starting and start_receipt == "unknown"
                 if never_started:
                     with self._sqlite_engine().connect() as conn:
                         initial_delivery_ids = {
@@ -8041,7 +8036,7 @@ class SessionTurnManager:
                         settled_by=SETTLED_BY_STOPPED,
                         evidence_kind="runtime_gone",
                         evidence={"reason": "stop_with_unknown_start"},
-                        replay_unknown_start=True,
+                        abandon_unaccepted_start=True,
                     )
                 else:
                     terminal = self._terminalize_durable_turn(

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -8006,11 +8006,16 @@ class SessionTurnManager:
                 owner_id,
             )
             if restored_identity is None or restored_identity[0] != owner_id:
-                unaccepted_start = (
+                start_receipt = str(owner.get("start_receipt_outcome") or "")
+                never_started = (
                     str(owner.get("state") or "") == "starting"
-                    and str(owner.get("start_receipt_outcome") or "") != "accepted"
+                    and start_receipt not in {"accepted", "unknown"}
                 )
-                if unaccepted_start:
+                unknown_start = (
+                    str(owner.get("state") or "") == "starting"
+                    and start_receipt == "unknown"
+                )
+                if never_started:
                     with self._sqlite_engine().connect() as conn:
                         initial_delivery_ids = {
                             str(row["id"])
@@ -8029,6 +8034,15 @@ class SessionTurnManager:
                         retire_unwritten_delivery_ids=initial_delivery_ids,
                         retire_unwritten_attempt_outcome="canceled",
                     )
+                elif unknown_start:
+                    terminal = self._terminalize_durable_turn(
+                        owner_id,
+                        "failed",
+                        settled_by=SETTLED_BY_STOPPED,
+                        evidence_kind="runtime_gone",
+                        evidence={"reason": "stop_with_unknown_start"},
+                        replay_unknown_start=True,
+                    )
                 else:
                     terminal = self._terminalize_durable_turn(
                         owner_id,
@@ -8042,6 +8056,12 @@ class SessionTurnManager:
                         "Released durable Turn=%s for Session=%s after Stop found no live runtime",
                         owner_id,
                         session_id,
+                    )
+                    from core.inbox_events import bus
+
+                    bus.publish(
+                        "turn.end",
+                        _turn_event_payload(session_id, owner_id),
                     )
                     successor_turn_id = str(terminal.get("successor_turn_id") or "")
                     if successor_turn_id:

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -7999,25 +7999,32 @@ class SessionTurnManager:
             }
         memory_dead = turn is None or turn.task.done()
         if owner is not None and memory_dead and not agent_run_id:
-            terminal = self._terminalize_durable_turn(
-                str(owner["id"]),
-                "canceled",
-                settled_by=SETTLED_BY_STOPPED,
-                evidence_kind="runtime_gone",
-                evidence={"reason": "stop_with_no_live_runtime"},
+            owner_id = str(owner["id"])
+            restored_identity = self._active_identity(
+                str(owner["backend"]),
+                session_id,
+                owner_id,
             )
-            if terminal.get("changed"):
-                logger.info(
-                    "Released durable Turn=%s for Session=%s after Stop found no live runtime",
-                    owner["id"],
-                    session_id,
+            if restored_identity is None or restored_identity[0] != owner_id:
+                terminal = self._terminalize_durable_turn(
+                    owner_id,
+                    "canceled",
+                    settled_by=SETTLED_BY_STOPPED,
+                    evidence_kind="runtime_gone",
+                    evidence={"reason": "stop_with_no_live_runtime"},
                 )
-                return {
-                    "ok": True,
-                    "session_id": session_id,
-                    "status": "stale_released",
-                    "reason": "runtime_gone",
-                }
+                if terminal.get("changed"):
+                    logger.info(
+                        "Released durable Turn=%s for Session=%s after Stop found no live runtime",
+                        owner_id,
+                        session_id,
+                    )
+                    return {
+                        "ok": True,
+                        "session_id": session_id,
+                        "status": "stale_released",
+                        "reason": "runtime_gone",
+                    }
         result = await self.deliver(
             DeliveryRequest(
                 session_id=session_id,

--- a/tests/test_running_agents_service.py
+++ b/tests/test_running_agents_service.py
@@ -880,6 +880,64 @@ def test_end_opencode_cancels_active_task():
     assert task.cancelled
 
 
+def test_end_opencode_settles_durable_owner_after_poll_is_gone(monkeypatch):
+    """A durable Workbench owner with no live poll is still an active turn.
+
+    Live hang: OpenCode abort succeeded, ``_active_requests`` was empty, End
+    took the idle teardown and left ``session_turns`` active / the chat
+    spinning. Stop/End must cancel through the turn manager instead.
+    """
+
+    class _Cancel:
+        def __init__(self):
+            self.called = False
+
+        async def __call__(self, session_id):
+            self.called = True
+            assert session_id == "ses-zombie"
+            return {"ok": True, "status": "stale_released", "reason": "runtime_gone"}
+
+    cancel = _Cancel()
+    manager = types.SimpleNamespace(
+        is_in_flight=lambda sid: False,
+        cancel=cancel,
+    )
+    oc = types.SimpleNamespace(
+        _active_requests={},
+        _session_manager=types.SimpleNamespace(get_request_session=lambda b: None),
+    )
+    controller = _make_controller(opencode=oc)
+    controller.session_turns = manager
+    monkeypatch.setattr(
+        running_agents,
+        "_load_durable_owner",
+        lambda _manager, session_id: (
+            {
+                "id": "trn_zombie",
+                "state": "active",
+                "backend": "opencode",
+                "session_anchor": "ses-zombie",
+            }
+            if session_id == "ses-zombie"
+            else None
+        ),
+    )
+
+    res = asyncio.run(
+        running_agents.end_running_agent(
+            controller,
+            backend="opencode",
+            state="idle",
+            session_id="ses-zombie",
+            base_session_id="ses-zombie",
+        )
+    )
+
+    assert res["ok"] is True
+    assert cancel.called
+    assert res.get("turn_settled") is True
+
+
 def test_end_active_workbench_turn_settles_via_manager(monkeypatch):
     # An active turn owned by the Workbench FSM must be stopped through
     # SessionTurnManager.cancel. The real Claude stop path pops the SDK client
@@ -1324,6 +1382,32 @@ def test_inflight_no_match_when_target_missing_or_task_done():
     ) is False
 
 
+def test_durable_owner_match_follows_last_only_identity(monkeypatch):
+    manager = object()
+    monkeypatch.setattr(
+        running_agents,
+        "_load_durable_owner",
+        lambda _manager, session_id: (
+            {
+                "id": "trn_owner",
+                "backend": "opencode",
+                "session_anchor": "base-1",
+            }
+            if session_id == "s1"
+            else None
+        ),
+    )
+    assert running_agents._durable_owner_matches_row(
+        manager, "s1", backend="opencode", base_session_id="base-1"
+    ) is True
+    assert running_agents._durable_owner_matches_row(
+        manager, "s1", backend="codex", base_session_id="codex-base"
+    ) is False
+    assert running_agents._durable_owner_matches_row(
+        manager, "s2", backend="opencode", base_session_id="base-1"
+    ) is False
+
+
 def test_end_does_not_cancel_unrelated_inflight_turn_of_other_backend():
     # Stale idle Codex row, but the SAME chat has since started a new Claude turn
     # (in flight under the same session_id). Ending the codex row must NOT cancel
@@ -1369,6 +1453,63 @@ def test_end_does_not_cancel_unrelated_inflight_turn_of_other_backend():
     assert res["ok"] is True
     assert cancel_called["v"] is False  # the unrelated in-flight Claude turn was NOT canceled
     assert cleared.get("clr") == "codex-base" and cleared.get("treg") == "codex-base"  # idle codex teardown ran
+
+
+def test_end_does_not_promote_unrelated_durable_owner_of_other_backend(monkeypatch):
+    """A leftover durable owner still follows the last-only End identity.
+
+    Same chat can keep an idle Codex row after a later Claude turn became the
+    durable owner. Ending the Codex row must not cancel that owner.
+    """
+
+    cancel_called = {"v": False}
+
+    async def _cancel(_sid):
+        cancel_called["v"] = True
+        return {"ok": True, "status": "stale_released", "reason": "runtime_gone"}
+
+    manager = types.SimpleNamespace(
+        is_in_flight=lambda sid: False,
+        cancel=_cancel,
+    )
+    cleared = {}
+    transport = types.SimpleNamespace(send_request=_AsyncFlag(), stop=_AsyncFlag())
+    mgr = types.SimpleNamespace(
+        get_cwd=lambda b: "/w",
+        get_thread_id=lambda b: None,
+        clear=lambda b: cleared.__setitem__("clr", b),
+        sessions_for_cwd=lambda cwd: [],
+    )
+    treg = _FakeTurnRegistry({}, pending=set())
+    treg.clear_session = lambda b: cleared.__setitem__("treg", b)
+    codex = types.SimpleNamespace(
+        _session_mgr=mgr, _turn_registry=treg, _transports={"/w": transport}, _transport_last_activity={"/w": 0.0}
+    )
+    controller = _make_controller(codex=codex)
+    controller.session_turns = manager
+    monkeypatch.setattr(
+        running_agents,
+        "_load_durable_owner",
+        lambda _manager, session_id: (
+            {
+                "id": "trn_claude",
+                "state": "active",
+                "backend": "claude",
+                "session_anchor": "claude-base",
+            }
+            if session_id == "chat-1"
+            else None
+        ),
+    )
+
+    res = asyncio.run(
+        running_agents.end_running_agent(
+            controller, backend="codex", state="active", session_id="chat-1", base_session_id="codex-base"
+        )
+    )
+    assert res["ok"] is True
+    assert cancel_called["v"] is False
+    assert cleared.get("clr") == "codex-base" and cleared.get("treg") == "codex-base"
 
 
 def test_end_rechecks_live_state_idle_to_active(monkeypatch):

--- a/tests/test_running_agents_service.py
+++ b/tests/test_running_agents_service.py
@@ -1427,6 +1427,7 @@ def test_end_does_not_cancel_unrelated_inflight_turn_of_other_backend():
         is_in_flight=lambda sid: True,
         cancel=_cancel,
         in_flight={"chat-1": inflight_entry},
+        _durable_schema_available=lambda: False,
     )
 
     cleared = {}
@@ -1481,6 +1482,61 @@ def test_end_does_not_promote_unrelated_durable_owner_of_other_backend(monkeypat
         sessions_for_cwd=lambda cwd: [],
     )
     treg = _FakeTurnRegistry({}, pending=set())
+    treg.clear_session = lambda b: cleared.__setitem__("treg", b)
+    codex = types.SimpleNamespace(
+        _session_mgr=mgr, _turn_registry=treg, _transports={"/w": transport}, _transport_last_activity={"/w": 0.0}
+    )
+    controller = _make_controller(codex=codex)
+    controller.session_turns = manager
+    monkeypatch.setattr(
+        running_agents,
+        "_load_durable_owner",
+        lambda _manager, session_id: (
+            {
+                "id": "trn_claude",
+                "state": "active",
+                "backend": "claude",
+                "session_anchor": "claude-base",
+            }
+            if session_id == "chat-1"
+            else None
+        ),
+    )
+
+    res = asyncio.run(
+        running_agents.end_running_agent(
+            controller, backend="codex", state="active", session_id="chat-1", base_session_id="codex-base"
+        )
+    )
+    assert res["ok"] is True
+    assert cancel_called["v"] is False
+    assert cleared.get("clr") == "codex-base" and cleared.get("treg") == "codex-base"
+
+
+def test_end_does_not_cancel_unrelated_durable_owner_when_clicked_row_is_live(
+    monkeypatch,
+):
+    """A live idle-to-active Codex row must not cancel a later Claude owner."""
+
+    cancel_called = {"v": False}
+
+    async def _cancel(_sid):
+        cancel_called["v"] = True
+        return {"ok": True, "status": "stale_released", "reason": "runtime_gone"}
+
+    manager = types.SimpleNamespace(
+        is_in_flight=lambda sid: False,
+        cancel=_cancel,
+    )
+    cleared = {}
+    transport = types.SimpleNamespace(send_request=_AsyncFlag(), stop=_AsyncFlag())
+    mgr = types.SimpleNamespace(
+        get_cwd=lambda b: "/w",
+        get_thread_id=lambda b: None,
+        clear=lambda b: cleared.__setitem__("clr", b),
+        sessions_for_cwd=lambda cwd: [],
+    )
+    treg = _FakeTurnRegistry({"codex-base": "turn-live"}, pending=set())
     treg.clear_session = lambda b: cleared.__setitem__("treg", b)
     codex = types.SimpleNamespace(
         _session_mgr=mgr, _turn_registry=treg, _transports={"/w": transport}, _transport_last_activity={"/w": 0.0}

--- a/tests/test_runtime_recovery.py
+++ b/tests/test_runtime_recovery.py
@@ -5,7 +5,7 @@ import json
 import threading
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy import select, update
@@ -635,11 +635,15 @@ async def test_cancel_settles_durable_owner_when_runtime_is_gone(tmp_path: Path)
 
     manager = SessionTurnManager(SimpleNamespace())
     manager._engine = engine
-    result = await manager.cancel("ses-zombie")
+    with patch("core.inbox_events.bus.publish") as publish:
+        result = await manager.cancel("ses-zombie")
 
     assert result["ok"] is True
     assert result["status"] == "stale_released"
     assert result["reason"] == "runtime_gone"
+    assert ("turn.end", {"session_id": "ses-zombie", "turn_id": "trn-zombie"}) in [
+        call.args for call in publish.call_args_list
+    ]
     with engine.connect() as conn:
         turn = delivery_store.get_turn(conn, "trn-zombie")
         session = conn.execute(
@@ -844,7 +848,8 @@ async def test_cancel_settles_unaccepted_starting_owner_when_runtime_is_gone(
 
     manager = SessionTurnManager(SimpleNamespace())
     manager._engine = engine
-    result = await manager.cancel("ses-starting")
+    with patch("core.inbox_events.bus.publish"):
+        result = await manager.cancel("ses-starting")
 
     assert result["ok"] is True
     assert result["status"] == "stale_released"
@@ -861,3 +866,55 @@ async def test_cancel_settles_unaccepted_starting_owner_when_runtime_is_gone(
     assert turn["terminal_evidence_kind"] == "runtime_gone"
     assert delivery["state"] == "retired"
     assert session["agent_status"] != "running"
+
+
+@pytest.mark.anyio
+async def test_cancel_replays_unknown_start_instead_of_not_written(
+    tmp_path: Path,
+) -> None:
+    """An unknown start may already have written; Stop must not retire it as never-written."""
+
+    engine = _engine(tmp_path)
+    with engine.begin() as conn:
+        _session(conn, "ses-unknown", backend="opencode")
+        conn.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == "ses-unknown")
+            .values(agent_status="running")
+        )
+        _delivery(conn, "delivery-unknown", "ses-unknown")
+        queued = delivery_store.get_delivery(conn, "delivery-unknown")
+        delivery_store.claim_start_batch(
+            conn,
+            turn_id="trn-unknown",
+            session_id="ses-unknown",
+            backend="opencode",
+            deliveries=[queued],
+            dispatch_text="unknown",
+            attempt_id="attempt-unknown",
+        )
+        turn = delivery_store.get_turn(conn, "trn-unknown")
+        assert turn is not None
+        assert delivery_store.mark_start_unknown(
+            conn,
+            "trn-unknown",
+            expected_version=int(turn["version"]),
+            receipt={"reason": "native_start_acceptance_unproven"},
+        )
+
+    manager = SessionTurnManager(SimpleNamespace())
+    manager._engine = engine
+    with patch("core.inbox_events.bus.publish"):
+        result = await manager.cancel("ses-unknown")
+
+    assert result["ok"] is True
+    assert result["status"] == "stale_released"
+    assert result["reason"] == "runtime_gone"
+    with engine.connect() as conn:
+        turn = delivery_store.get_turn(conn, "trn-unknown")
+        delivery = delivery_store.get_delivery(conn, "delivery-unknown")
+    assert turn["state"] == "terminal"
+    assert turn["terminal_outcome"] == "failed"
+    assert turn["settled_by"] == "stopped"
+    assert turn["terminal_evidence_kind"] == "runtime_gone"
+    assert delivery["state"] != "retired"

--- a/tests/test_runtime_recovery.py
+++ b/tests/test_runtime_recovery.py
@@ -688,3 +688,59 @@ async def test_cancel_keeps_live_memory_task_on_interrupt_path(tmp_path: Path) -
         ).mappings().one()
     assert turn["state"] == "active"
     assert session["agent_status"] == "running"
+
+
+@pytest.mark.anyio
+async def test_cancel_keeps_restored_native_runtime_on_interrupt_path(
+    tmp_path: Path,
+) -> None:
+    """A restored native poll is live even when in_flight is empty."""
+
+    engine = _engine(tmp_path)
+    with engine.begin() as conn:
+        _session(conn, "ses-restored")
+        conn.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == "ses-restored")
+            .values(agent_status="running")
+        )
+        _delivery(conn, "delivery-restored", "ses-restored")
+        delivery_store.insert_turn(
+            conn,
+            turn_id="trn-restored",
+            session_id="ses-restored",
+            initial_delivery_id="delivery-restored",
+            state="active",
+            backend="opencode",
+            dispatch_text="restored",
+        )
+
+    manager = SessionTurnManager(SimpleNamespace())
+    manager._engine = engine
+    manager._active_identity = lambda _backend, _session_id, logical_id: (
+        logical_id,
+        "opencode:native-restored:1",
+    )
+    seen = {}
+
+    async def _deliver(request, *, context=None):
+        seen["priority"] = request.priority
+        seen["turn_id"] = request.expected_turn_id
+        return SimpleNamespace(state="waiting_terminal", reason=None)
+
+    manager.deliver = _deliver
+    result = await manager.cancel("ses-restored")
+
+    assert result == {
+        "ok": True,
+        "session_id": "ses-restored",
+        "status": "cancel_requested",
+    }
+    assert seen == {"priority": "p0", "turn_id": "trn-restored"}
+    with engine.connect() as conn:
+        turn = delivery_store.get_turn(conn, "trn-restored")
+        session = conn.execute(
+            select(agent_sessions).where(agent_sessions.c.id == "ses-restored")
+        ).mappings().one()
+    assert turn["state"] == "active"
+    assert session["agent_status"] == "running"

--- a/tests/test_runtime_recovery.py
+++ b/tests/test_runtime_recovery.py
@@ -31,15 +31,15 @@ def _engine(tmp_path: Path):
     return engine
 
 
-def _session(conn, session_id: str) -> None:
+def _session(conn, session_id: str, *, backend: str = "codex") -> None:
     conn.execute(
         agent_sessions.insert().values(
             id=session_id,
             scope_id=None,
             agent_id=None,
-            agent_name="codex",
-            agent_backend="codex",
-            agent_variant="codex",
+            agent_name=backend,
+            agent_backend=backend,
+            agent_variant=backend,
             model=None,
             reasoning_effort=None,
             session_anchor=f"base-{session_id}",
@@ -71,7 +71,14 @@ def _delivery(
         session_id=session_id,
         priority="p3",
         state=state,
-        snapshot={"content_json": json.dumps({"text": delivery_id})},
+        snapshot=delivery_store.message_snapshot(
+            scope_id=None,
+            session_id=session_id,
+            platform="avibe",
+            author="user",
+            source="user",
+            text=delivery_id,
+        ),
         dispatch_text=delivery_id,
         turn_id=None,
     )
@@ -599,7 +606,7 @@ async def test_cancel_settles_durable_owner_when_runtime_is_gone(tmp_path: Path)
 
     engine = _engine(tmp_path)
     with engine.begin() as conn:
-        _session(conn, "ses-zombie")
+        _session(conn, "ses-zombie", backend="opencode")
         conn.execute(
             update(agent_sessions)
             .where(agent_sessions.c.id == "ses-zombie")
@@ -614,6 +621,16 @@ async def test_cancel_settles_durable_owner_when_runtime_is_gone(tmp_path: Path)
             state="active",
             backend="opencode",
             dispatch_text="stuck",
+        )
+        conn.execute(
+            update(delivery_store.message_deliveries)
+            .where(delivery_store.message_deliveries.c.id == "delivery-zombie")
+            .values(
+                state="claimed",
+                turn_id="trn-zombie",
+                turn_role="initial",
+                turn_position=0,
+            )
         )
 
     manager = SessionTurnManager(SimpleNamespace())
@@ -642,7 +659,7 @@ async def test_cancel_keeps_live_memory_task_on_interrupt_path(tmp_path: Path) -
 
     engine = _engine(tmp_path)
     with engine.begin() as conn:
-        _session(conn, "ses-live")
+        _session(conn, "ses-live", backend="opencode")
         conn.execute(
             update(agent_sessions)
             .where(agent_sessions.c.id == "ses-live")
@@ -698,7 +715,7 @@ async def test_cancel_keeps_restored_native_runtime_on_interrupt_path(
 
     engine = _engine(tmp_path)
     with engine.begin() as conn:
-        _session(conn, "ses-restored")
+        _session(conn, "ses-restored", backend="opencode")
         conn.execute(
             update(agent_sessions)
             .where(agent_sessions.c.id == "ses-restored")
@@ -744,3 +761,103 @@ async def test_cancel_keeps_restored_native_runtime_on_interrupt_path(
         ).mappings().one()
     assert turn["state"] == "active"
     assert session["agent_status"] == "running"
+
+
+@pytest.mark.anyio
+async def test_cancel_resumes_queued_successor_after_runtime_gone(
+    tmp_path: Path,
+) -> None:
+    """Settling a leftover owner must start the next claimed successor."""
+
+    engine = _engine(tmp_path)
+    with engine.begin() as conn:
+        _session(conn, "ses-queue", backend="opencode")
+        conn.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == "ses-queue")
+            .values(agent_status="running")
+        )
+        _delivery(conn, "delivery-owner", "ses-queue")
+        delivery_store.insert_turn(
+            conn,
+            turn_id="trn-owner",
+            session_id="ses-queue",
+            initial_delivery_id="delivery-owner",
+            state="active",
+            backend="opencode",
+            dispatch_text="owner",
+        )
+
+    manager = SessionTurnManager(SimpleNamespace())
+    manager._engine = engine
+    started: list[str] = []
+    resumed: list[str] = []
+
+    def _terminalize(turn_id: str, *_args, **_kwargs):
+        assert turn_id == "trn-owner"
+        return {"changed": True, "successor_turn_id": "trn-successor"}
+
+    async def _start(turn_id: str, **_kwargs) -> bool:
+        started.append(turn_id)
+        return True
+
+    async def _resume(session_id: str) -> None:
+        resumed.append(session_id)
+
+    manager._terminalize_durable_turn = _terminalize
+    manager._start_persisted_turn = _start
+    manager._resume_post_terminal = _resume
+    result = await manager.cancel("ses-queue")
+
+    assert result["ok"] is True
+    assert result["status"] == "stale_released"
+    assert result["reason"] == "runtime_gone"
+    assert started == ["trn-successor"]
+    assert resumed == []
+
+
+@pytest.mark.anyio
+async def test_cancel_settles_unaccepted_starting_owner_when_runtime_is_gone(
+    tmp_path: Path,
+) -> None:
+    """A leftover starting owner must settle as not_written, not hang in P0."""
+
+    engine = _engine(tmp_path)
+    with engine.begin() as conn:
+        _session(conn, "ses-starting", backend="opencode")
+        conn.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == "ses-starting")
+            .values(agent_status="running")
+        )
+        _delivery(conn, "delivery-starting", "ses-starting")
+        queued = delivery_store.get_delivery(conn, "delivery-starting")
+        delivery_store.claim_start_batch(
+            conn,
+            turn_id="trn-starting",
+            session_id="ses-starting",
+            backend="opencode",
+            deliveries=[queued],
+            dispatch_text="starting",
+            attempt_id="attempt-starting",
+        )
+
+    manager = SessionTurnManager(SimpleNamespace())
+    manager._engine = engine
+    result = await manager.cancel("ses-starting")
+
+    assert result["ok"] is True
+    assert result["status"] == "stale_released"
+    assert result["reason"] == "runtime_gone"
+    with engine.connect() as conn:
+        turn = delivery_store.get_turn(conn, "trn-starting")
+        delivery = delivery_store.get_delivery(conn, "delivery-starting")
+        session = conn.execute(
+            select(agent_sessions).where(agent_sessions.c.id == "ses-starting")
+        ).mappings().one()
+    assert turn["state"] == "terminal"
+    assert turn["terminal_outcome"] == "not_written"
+    assert turn["settled_by"] == "stopped"
+    assert turn["terminal_evidence_kind"] == "runtime_gone"
+    assert delivery["state"] == "retired"
+    assert session["agent_status"] != "running"

--- a/tests/test_runtime_recovery.py
+++ b/tests/test_runtime_recovery.py
@@ -591,3 +591,100 @@ def test_hfr_151_fallback_scan_advances_with_a_bounded_keyset_cursor(
         assert not second_has_more
     finally:
         store.close()
+
+
+@pytest.mark.anyio
+async def test_cancel_settles_durable_owner_when_runtime_is_gone(tmp_path: Path) -> None:
+    """Stop must terminalize a durable owner after the in-memory poll is gone."""
+
+    engine = _engine(tmp_path)
+    with engine.begin() as conn:
+        _session(conn, "ses-zombie")
+        conn.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == "ses-zombie")
+            .values(agent_status="running")
+        )
+        _delivery(conn, "delivery-zombie", "ses-zombie")
+        delivery_store.insert_turn(
+            conn,
+            turn_id="trn-zombie",
+            session_id="ses-zombie",
+            initial_delivery_id="delivery-zombie",
+            state="active",
+            backend="opencode",
+            dispatch_text="stuck",
+        )
+
+    manager = SessionTurnManager(SimpleNamespace())
+    manager._engine = engine
+    result = await manager.cancel("ses-zombie")
+
+    assert result["ok"] is True
+    assert result["status"] == "stale_released"
+    assert result["reason"] == "runtime_gone"
+    with engine.connect() as conn:
+        turn = delivery_store.get_turn(conn, "trn-zombie")
+        session = conn.execute(
+            select(agent_sessions).where(agent_sessions.c.id == "ses-zombie")
+        ).mappings().one()
+    assert turn is not None
+    assert turn["state"] == "terminal"
+    assert turn["terminal_outcome"] == "canceled"
+    assert turn["settled_by"] == "stopped"
+    assert turn["terminal_evidence_kind"] == "runtime_gone"
+    assert session["agent_status"] != "running"
+
+
+@pytest.mark.anyio
+async def test_cancel_keeps_live_memory_task_on_interrupt_path(tmp_path: Path) -> None:
+    """A still-running in-memory task must not skip to runtime-gone settlement."""
+
+    engine = _engine(tmp_path)
+    with engine.begin() as conn:
+        _session(conn, "ses-live")
+        conn.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == "ses-live")
+            .values(agent_status="running")
+        )
+        _delivery(conn, "delivery-live", "ses-live")
+        delivery_store.insert_turn(
+            conn,
+            turn_id="trn-live",
+            session_id="ses-live",
+            initial_delivery_id="delivery-live",
+            state="active",
+            backend="opencode",
+            dispatch_text="live",
+        )
+
+    manager = SessionTurnManager(SimpleNamespace())
+    manager._engine = engine
+    seen = {}
+
+    async def _deliver(request, *, context=None):
+        seen["priority"] = request.priority
+        seen["turn_id"] = request.expected_turn_id
+        return SimpleNamespace(state="waiting_terminal", reason=None)
+
+    manager.deliver = _deliver
+    manager.in_flight["ses-live"] = SimpleNamespace(
+        task=SimpleNamespace(done=lambda: False),
+        context=SimpleNamespace(),
+    )
+    result = await manager.cancel("ses-live")
+
+    assert result == {
+        "ok": True,
+        "session_id": "ses-live",
+        "status": "cancel_requested",
+    }
+    assert seen == {"priority": "p0", "turn_id": "trn-live"}
+    with engine.connect() as conn:
+        turn = delivery_store.get_turn(conn, "trn-live")
+        session = conn.execute(
+            select(agent_sessions).where(agent_sessions.c.id == "ses-live")
+        ).mappings().one()
+    assert turn["state"] == "active"
+    assert session["agent_status"] == "running"

--- a/tests/test_runtime_recovery.py
+++ b/tests/test_runtime_recovery.py
@@ -19,7 +19,7 @@ from core.session_turns import SessionTurnManager
 from storage import message_deliveries as delivery_store
 from storage.background import SQLiteBackgroundTaskStore
 from storage.db import create_sqlite_engine
-from storage.models import agent_runs, agent_sessions, metadata
+from storage.models import agent_runs, agent_sessions, metadata, session_turns
 
 
 NOW = "2026-08-03T00:00:00+00:00"
@@ -869,10 +869,10 @@ async def test_cancel_settles_unaccepted_starting_owner_when_runtime_is_gone(
 
 
 @pytest.mark.anyio
-async def test_cancel_replays_unknown_start_instead_of_not_written(
+async def test_cancel_abandons_unknown_start_without_replaying(
     tmp_path: Path,
 ) -> None:
-    """An unknown start may already have written; Stop must not retire it as never-written."""
+    """An unknown start may already have written; Stop must not replay it."""
 
     engine = _engine(tmp_path)
     with engine.begin() as conn:
@@ -904,17 +904,34 @@ async def test_cancel_replays_unknown_start_instead_of_not_written(
 
     manager = SessionTurnManager(SimpleNamespace())
     manager._engine = engine
+    started: list[str] = []
+
+    async def _start(turn_id: str, **_kwargs) -> bool:
+        started.append(turn_id)
+        return True
+
+    manager._start_persisted_turn = _start
     with patch("core.inbox_events.bus.publish"):
         result = await manager.cancel("ses-unknown")
 
     assert result["ok"] is True
     assert result["status"] == "stale_released"
     assert result["reason"] == "runtime_gone"
+    assert started == []
     with engine.connect() as conn:
         turn = delivery_store.get_turn(conn, "trn-unknown")
         delivery = delivery_store.get_delivery(conn, "delivery-unknown")
+        successors = list(
+            conn.execute(
+                select(session_turns.c.id).where(
+                    session_turns.c.session_id == "ses-unknown",
+                    session_turns.c.id != "trn-unknown",
+                )
+            ).scalars()
+        )
     assert turn["state"] == "terminal"
     assert turn["terminal_outcome"] == "failed"
     assert turn["settled_by"] == "stopped"
     assert turn["terminal_evidence_kind"] == "runtime_gone"
-    assert delivery["state"] != "retired"
+    assert delivery["state"] == "retired"
+    assert successors == []


### PR DESCRIPTION
## Changed capability

Stop/End now settles a leftover Workbench durable Turn when the OpenCode runtime is already gone.

If the native OpenCode session has aborted and the local poll task is empty, Avibe still kept `session_turns` `active` and the chat `running`. End took the idle teardown (`_end_opencode` abort-again) and skipped `SessionTurnManager.cancel`. Stop then returned `cancel_requested` and waited for a backend terminal that no longer exists.

This is a different seam from #1531's last-only in-flight match: the durable owner is live in SQLite after the in-memory poll is gone. The rule is: when there is no live poll/task and no `agent_run_id`, Stop/End `_terminalize_durable_turn` immediately (`settled_by=stopped`, `evidence_kind=runtime_gone`) instead of waiting.

Durable-owner promotion still follows the last-only identity: a leftover owner for a different backend/anchor under the same chat does not make an unrelated End row active.

## Scenario IDs

None. No catalog covers this Stop/End recovery seam.

## Evidence

- **unit**: `tests/test_running_agents_service.py` (End promotes a matching durable owner after poll-gone; last-only identity still refuses an unrelated backend; live-task cancel stays on the interrupt path)
- **contract**: `tests/test_runtime_recovery.py` SQLite-backed `SessionTurnManager.cancel` settles a durable owner when memory is empty, and does not skip to `runtime_gone` while an in-memory task is still running
- **scenario**: none
- **residual manual**: reproduce on a Workbench OpenCode chat whose native session already aborted: Stop/End should leave the session idle instead of spinning on `running`

## Dependencies

None.

## Known-by-design ledger

None.
