### PR TITLE
refactor(memory): own admission metadata vocabulary

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -56,6 +56,7 @@ from core.memory.admission import (
     WORKBENCH_PLATFORM,
     CaptureAdmission,
     InboundTurnFacts,
+    admitted_user_id,
 )
 from core.memory.blocking import run_blocking
 from core.memory.operation_lock import MemoryOperationBusy, MemoryOperationLease
@@ -1897,14 +1898,15 @@ class Controller:
         payload = context.platform_specific if isinstance(context.platform_specific, dict) else {}
         metadata = payload.get("message_metadata")
         metadata = metadata if isinstance(metadata, dict) else {}
-        memory_user_id = metadata.get("_memory_user_id")
-        if isinstance(memory_user_id, str) and memory_user_id.strip():
-            user_id = memory_user_id.strip()
+        memory_user_id = admitted_user_id(metadata)
+        if memory_user_id is not None:
+            user_id = memory_user_id
         else:
             # IM: the platform sender id is what admission and
             # ``principal_for_user_key(f"{platform}:{user_id}")`` expect.
-            # Workbench without ``_memory_user_id`` keeps the scope fallback
-            # (typically ``"workbench"``), which admission rejects.
+            # Workbench without a Memory principal in delivery metadata keeps
+            # the scope fallback (typically ``"workbench"``), which admission
+            # rejects.
             user_id = getattr(context, "user_id", None)
         workdir = None
         if include_workdir:

--- a/core/memory/admission.py
+++ b/core/memory/admission.py
@@ -37,6 +37,59 @@ WORKBENCH_PLATFORM = "avibe"
 IM_PLATFORMS = frozenset({"slack", "discord", "telegram", "lark", "feishu", "wechat"})
 ADMISSIBLE_PLATFORMS = IM_PLATFORMS | {WORKBENCH_PLATFORM}
 
+# Durable delivery-metadata keys for Memory admission facts. Readers and
+# writers share these names so the queue layer does not own the vocabulary.
+MEMORY_USER_ID_METADATA = "_memory_user_id"
+MEMORY_ORDINARY_TEXT_METADATA = "_memory_ordinary_text"
+MEMORY_CLI_ADMITTED_METADATA = "_memory_cli_admitted"
+
+
+def _admission_metadata(metadata: object) -> dict:
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def admitted_user_id(metadata: object) -> str | None:
+    """Return the Memory principal, or None when the stored value is unusable.
+
+    Only a non-empty string is usable. Surrounding whitespace is stripped;
+    a blank or non-string value is treated as missing.
+    """
+
+    memory_user_id = _admission_metadata(metadata).get(MEMORY_USER_ID_METADATA)
+    if not isinstance(memory_user_id, str) or not memory_user_id.strip():
+        return None
+    if memory_user_id != memory_user_id.strip():
+        return memory_user_id.strip()
+    return memory_user_id
+
+
+def is_ordinary_text(metadata: object) -> bool:
+    """True only when the surface stored a literal JSON/Python ``True``."""
+
+    return _admission_metadata(metadata).get(MEMORY_ORDINARY_TEXT_METADATA) is True
+
+
+def is_cli_admitted(metadata: object) -> bool:
+    """True only when the surface stored a literal JSON/Python ``True``."""
+
+    return _admission_metadata(metadata).get(MEMORY_CLI_ADMITTED_METADATA) is True
+
+
+def merge_identity(metadata: object) -> tuple[str | None, bool, bool]:
+    """Return the Memory facts that one dispatch context must keep singular.
+
+    ``author_id`` is the web-push ownership identity, not the Memory principal.
+    Keep the durable Memory identity alongside the two admission flags so a
+    merged turn can never cross principals.
+    """
+
+    metadata = _admission_metadata(metadata)
+    return (
+        admitted_user_id(metadata),
+        is_ordinary_text(metadata),
+        is_cli_admitted(metadata),
+    )
+
 
 class PrincipalDirectory(Protocol):
     """Derives install-local opaque identifiers for Memory scope inputs."""

--- a/core/memory/admission.py
+++ b/core/memory/admission.py
@@ -22,6 +22,15 @@ import logging
 import time
 from typing import Protocol
 
+from core.memory.admission_metadata import (
+    MEMORY_CLI_ADMITTED_METADATA as MEMORY_CLI_ADMITTED_METADATA,
+    MEMORY_ORDINARY_TEXT_METADATA as MEMORY_ORDINARY_TEXT_METADATA,
+    MEMORY_USER_ID_METADATA as MEMORY_USER_ID_METADATA,
+    admitted_user_id as admitted_user_id,
+    is_cli_admitted as is_cli_admitted,
+    is_ordinary_text as is_ordinary_text,
+    merge_identity as merge_identity,
+)
 from core.memory.attachments import workbench_capture_attachments
 from core.memory.im_attachments import (
     IM_ATTACHMENT_CAPTURE_PLATFORMS,
@@ -36,59 +45,6 @@ logger = logging.getLogger(__name__)
 WORKBENCH_PLATFORM = "avibe"
 IM_PLATFORMS = frozenset({"slack", "discord", "telegram", "lark", "feishu", "wechat"})
 ADMISSIBLE_PLATFORMS = IM_PLATFORMS | {WORKBENCH_PLATFORM}
-
-# Durable delivery-metadata keys for Memory admission facts. Readers and
-# writers share these names so the queue layer does not own the vocabulary.
-MEMORY_USER_ID_METADATA = "_memory_user_id"
-MEMORY_ORDINARY_TEXT_METADATA = "_memory_ordinary_text"
-MEMORY_CLI_ADMITTED_METADATA = "_memory_cli_admitted"
-
-
-def _admission_metadata(metadata: object) -> dict:
-    return metadata if isinstance(metadata, dict) else {}
-
-
-def admitted_user_id(metadata: object) -> str | None:
-    """Return the Memory principal, or None when the stored value is unusable.
-
-    Only a non-empty string is usable. Surrounding whitespace is stripped;
-    a blank or non-string value is treated as missing.
-    """
-
-    memory_user_id = _admission_metadata(metadata).get(MEMORY_USER_ID_METADATA)
-    if not isinstance(memory_user_id, str) or not memory_user_id.strip():
-        return None
-    if memory_user_id != memory_user_id.strip():
-        return memory_user_id.strip()
-    return memory_user_id
-
-
-def is_ordinary_text(metadata: object) -> bool:
-    """True only when the surface stored a literal JSON/Python ``True``."""
-
-    return _admission_metadata(metadata).get(MEMORY_ORDINARY_TEXT_METADATA) is True
-
-
-def is_cli_admitted(metadata: object) -> bool:
-    """True only when the surface stored a literal JSON/Python ``True``."""
-
-    return _admission_metadata(metadata).get(MEMORY_CLI_ADMITTED_METADATA) is True
-
-
-def merge_identity(metadata: object) -> tuple[str | None, bool, bool]:
-    """Return the Memory facts that one dispatch context must keep singular.
-
-    ``author_id`` is the web-push ownership identity, not the Memory principal.
-    Keep the durable Memory identity alongside the two admission flags so a
-    merged turn can never cross principals.
-    """
-
-    metadata = _admission_metadata(metadata)
-    return (
-        admitted_user_id(metadata),
-        is_ordinary_text(metadata),
-        is_cli_admitted(metadata),
-    )
 
 
 class PrincipalDirectory(Protocol):

--- a/core/memory/admission_metadata.py
+++ b/core/memory/admission_metadata.py
@@ -1,0 +1,60 @@
+"""Durable Memory admission-metadata keys and their read semantics.
+
+Kept as a leaf module so storage and lightweight Memory-runtime checks can
+share the vocabulary without importing CaptureAdmission (attachments, IM
+leases, aiohttp).
+"""
+
+from __future__ import annotations
+
+
+MEMORY_USER_ID_METADATA = "_memory_user_id"
+MEMORY_ORDINARY_TEXT_METADATA = "_memory_ordinary_text"
+MEMORY_CLI_ADMITTED_METADATA = "_memory_cli_admitted"
+
+
+def _admission_metadata(metadata: object) -> dict:
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def admitted_user_id(metadata: object) -> str | None:
+    """Return the Memory principal, or None when the stored value is unusable.
+
+    Only a non-empty string is usable. Surrounding whitespace is stripped;
+    a blank or non-string value is treated as missing.
+    """
+
+    memory_user_id = _admission_metadata(metadata).get(MEMORY_USER_ID_METADATA)
+    if not isinstance(memory_user_id, str) or not memory_user_id.strip():
+        return None
+    if memory_user_id != memory_user_id.strip():
+        return memory_user_id.strip()
+    return memory_user_id
+
+
+def is_ordinary_text(metadata: object) -> bool:
+    """True only when the surface stored a literal JSON/Python ``True``."""
+
+    return _admission_metadata(metadata).get(MEMORY_ORDINARY_TEXT_METADATA) is True
+
+
+def is_cli_admitted(metadata: object) -> bool:
+    """True only when the surface stored a literal JSON/Python ``True``."""
+
+    return _admission_metadata(metadata).get(MEMORY_CLI_ADMITTED_METADATA) is True
+
+
+def merge_identity(metadata: object) -> tuple[str | None, bool, bool]:
+    """Return the Memory facts that one dispatch context must keep singular.
+
+    ``author_id`` is the web-push ownership identity, not the Memory principal.
+    Keep the durable Memory identity alongside the two admission flags so a
+    merged turn can never cross principals.
+    """
+
+    metadata = _admission_metadata(metadata)
+    return (
+        admitted_user_id(metadata),
+        is_ordinary_text(metadata),
+        is_cli_admitted(metadata),
+    )

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -78,6 +78,11 @@ from storage.models import (
 )
 from storage.workbench_sessions_service import derive_session_harness_activities
 from core.message_output import terminal_turn_output
+from core.memory.admission import (
+    is_cli_admitted as memory_cli_admitted,
+    is_ordinary_text as memory_ordinary_text,
+    merge_identity as memory_admission_merge_identity,
+)
 from core.runtime_activation import (
     RuntimeActivationIdentity,
     RuntimeActivationRegistry,
@@ -378,25 +383,9 @@ def _scheduled_merge_key(row: dict[str, Any]) -> Optional[tuple[str, ...]]:
 
 
 def _memory_admission_merge_identity(row: dict[str, Any]) -> tuple[str | None, bool, bool]:
-    """Return the Memory facts that one dispatch context must keep singular.
+    """Opaque Memory identity for one delivery row's merge batch."""
 
-    ``author_id`` is the web-push ownership identity, not the Memory principal.
-    Keep the durable Memory identity alongside the two admission flags so a
-    merged turn can never cross principals. Only a non-empty string is usable.
-    """
-
-    metadata = row.get("metadata")
-    metadata = metadata if isinstance(metadata, dict) else {}
-    memory_user_id = metadata.get("_memory_user_id")
-    if not isinstance(memory_user_id, str) or not memory_user_id.strip():
-        memory_user_id = None
-    elif memory_user_id != memory_user_id.strip():
-        memory_user_id = memory_user_id.strip()
-    return (
-        memory_user_id,
-        metadata.get("_memory_ordinary_text") is True,
-        metadata.get("_memory_cli_admitted") is True,
-    )
+    return memory_admission_merge_identity(row.get("metadata"))
 
 
 def _collect_delivery_segment(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -2276,14 +2265,14 @@ class SessionTurnManager:
             else str(delivery["id"])
         )
         # Routing identity only. Memory's principal already travels in
-        # ``platform_specific["message_metadata"]["_memory_user_id"]``.
+        # delivery ``message_metadata`` via the Memory admission vocabulary.
         if payload.get("author_id"):
             context.user_id = str(payload["author_id"])
         if context.platform_specific is None:
             context.platform_specific = {}
         metadata = payload.get("metadata") or {}
-        context.is_ordinary_text = metadata.get("_memory_ordinary_text") is True
-        if metadata.get("_memory_cli_admitted") is True:
+        context.is_ordinary_text = memory_ordinary_text(metadata)
+        if memory_cli_admitted(metadata):
             context.platform_specific["memory_cli_admitted"] = True
         else:
             context.platform_specific.pop("memory_cli_admitted", None)

--- a/storage/message_deliveries.py
+++ b/storage/message_deliveries.py
@@ -16,6 +16,11 @@ from storage.delivery_states import (
     RUN_CANCEL_RETIRE_STATES,
     policy_for,
 )
+from core.memory.admission import (
+    MEMORY_CLI_ADMITTED_METADATA,
+    MEMORY_ORDINARY_TEXT_METADATA,
+    MEMORY_USER_ID_METADATA,
+)
 from storage.models import (
     agent_runs,
     agent_sessions,
@@ -30,9 +35,6 @@ TURN_OWNER_STATES = ("starting", "active")
 WEB_PUSH_USER_KEY_METADATA = "_web_push_user_key"
 WEB_PUSH_USER_KEYS_METADATA = "_web_push_user_keys"
 WEB_PUSH_AUTHORIZATION_CONTEXTS_METADATA = "_web_push_authorization_contexts"
-MEMORY_USER_ID_METADATA = "_memory_user_id"
-MEMORY_ORDINARY_TEXT_METADATA = "_memory_ordinary_text"
-MEMORY_CLI_ADMITTED_METADATA = "_memory_cli_admitted"
 
 
 def utc_now_iso() -> str:

--- a/storage/message_deliveries.py
+++ b/storage/message_deliveries.py
@@ -16,7 +16,7 @@ from storage.delivery_states import (
     RUN_CANCEL_RETIRE_STATES,
     policy_for,
 )
-from core.memory.admission import (
+from core.memory.admission_metadata import (
     MEMORY_CLI_ADMITTED_METADATA,
     MEMORY_ORDINARY_TEXT_METADATA,
     MEMORY_USER_ID_METADATA,

--- a/tests/test_memory_admission.py
+++ b/tests/test_memory_admission.py
@@ -11,7 +11,16 @@ from types import SimpleNamespace
 
 import pytest
 
-from core.memory.admission import CaptureAdmission, InboundTurnFacts
+from core.memory.admission import (
+    MEMORY_CLI_ADMITTED_METADATA,
+    MEMORY_ORDINARY_TEXT_METADATA,
+    MEMORY_USER_ID_METADATA,
+    CaptureAdmission,
+    InboundTurnFacts,
+    is_cli_admitted,
+    is_ordinary_text,
+    merge_identity,
+)
 from core.memory.attachments import workbench_capture_attachments
 from core.memory.types import CaptureAttachment, CaptureRequest, CaptureSkipped
 from core.handlers.inbound_attachments import InboundAttachmentMaterializer
@@ -617,6 +626,57 @@ def test_unparseable_upload_does_not_cost_its_turn_the_text(monkeypatch, tmp_pat
     assert isinstance(request, CaptureRequest)
     assert request.text == "see the attached export"
     assert request.attachments == ()
+
+
+@pytest.mark.parametrize(
+    ("metadata", "expected"),
+    [
+        (None, (None, False, False)),
+        ("not-a-dict", (None, False, False)),
+        (1, (None, False, False)),
+        (["_memory_user_id", "local"], (None, False, False)),
+        ({}, (None, False, False)),
+        ({MEMORY_USER_ID_METADATA: None}, (None, False, False)),
+        ({MEMORY_USER_ID_METADATA: ""}, (None, False, False)),
+        ({MEMORY_USER_ID_METADATA: "   "}, (None, False, False)),
+        ({MEMORY_USER_ID_METADATA: 1}, (None, False, False)),
+        ({MEMORY_USER_ID_METADATA: True}, (None, False, False)),
+        ({MEMORY_USER_ID_METADATA: ["local"]}, (None, False, False)),
+        ({MEMORY_USER_ID_METADATA: "local"}, ("local", False, False)),
+        ({MEMORY_USER_ID_METADATA: "  local  "}, ("local", False, False)),
+        (
+            {
+                MEMORY_USER_ID_METADATA: "local",
+                MEMORY_ORDINARY_TEXT_METADATA: True,
+                MEMORY_CLI_ADMITTED_METADATA: True,
+            },
+            ("local", True, True),
+        ),
+        (
+            {
+                MEMORY_ORDINARY_TEXT_METADATA: "true",
+                MEMORY_CLI_ADMITTED_METADATA: 1,
+            },
+            (None, False, False),
+        ),
+        (
+            {
+                MEMORY_ORDINARY_TEXT_METADATA: False,
+                MEMORY_CLI_ADMITTED_METADATA: False,
+            },
+            (None, False, False),
+        ),
+    ],
+)
+def test_merge_identity_normalizes_unusable_metadata(
+    metadata: object,
+    expected: tuple[str | None, bool, bool],
+) -> None:
+    """Queue merge identity matches today's strip/None/`is True` semantics."""
+
+    assert merge_identity(metadata) == expected
+    assert is_ordinary_text(metadata) is expected[1]
+    assert is_cli_admitted(metadata) is expected[2]
 
 
 def test_workbench_submits_are_classified_beside_their_im_siblings() -> None:

--- a/tests/test_memory_admission.py
+++ b/tests/test_memory_admission.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import io
 import os
+import subprocess
+import sys
 import zipfile
 from pathlib import Path
 from types import SimpleNamespace
@@ -677,6 +679,28 @@ def test_merge_identity_normalizes_unusable_metadata(
     assert merge_identity(metadata) == expected
     assert is_ordinary_text(metadata) is expected[1]
     assert is_cli_admitted(metadata) is expected[2]
+
+
+def test_delivery_store_shares_metadata_keys_without_capture_admission() -> None:
+    """Storage can name the keys without loading CaptureAdmission or aiohttp."""
+
+    script = """
+import sys
+from storage import message_deliveries
+from core.memory.admission_metadata import MEMORY_USER_ID_METADATA
+assert message_deliveries.MEMORY_USER_ID_METADATA is MEMORY_USER_ID_METADATA
+assert "core.memory.admission" not in sys.modules
+assert "core.memory.im_attachments" not in sys.modules
+assert "core.handlers" not in sys.modules
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[1],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_workbench_submits_are_classified_beside_their_im_siblings() -> None:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -11027,6 +11027,11 @@ async def sessions_messages_create(session_id: str):
     in Step 6 — the session-scoped stream replaced it.
     """
 
+    from core.memory.admission import (
+        MEMORY_CLI_ADMITTED_METADATA,
+        MEMORY_ORDINARY_TEXT_METADATA,
+        MEMORY_USER_ID_METADATA,
+    )
     from core.services import sessions as workbench_sessions_service
     from core.web_push_notifications import (
         WEB_PUSH_AUTHORIZATION_CONTEXTS_METADATA,
@@ -11127,9 +11132,9 @@ async def sessions_messages_create(session_id: str):
                 {
                     **(payload.get("metadata") or {}),
                     "_web_push_user_key": web_push_user_key,
-                    "_memory_user_id": memory_user_id,
-                    "_memory_cli_admitted": memory_cli_admitted,
-                    "_memory_ordinary_text": memory_ordinary_text,
+                    MEMORY_USER_ID_METADATA: memory_user_id,
+                    MEMORY_CLI_ADMITTED_METADATA: memory_cli_admitted,
+                    MEMORY_ORDINARY_TEXT_METADATA: memory_ordinary_text,
                 },
                 getattr(g, "authorization_context", None),
             )


### PR DESCRIPTION
## Capability

Memory admission-metadata vocabulary is now owned by `core/memory/admission.py`. The delivery queue layer (`core/session_turns.py`) no longer names `_memory_*` keys or parses Memory identity; it compares an opaque merge-identity tuple. The Workbench writer (`vibe/ui_server.py`) uses the same exported key constants, so reader and writer share one definition.

This is item C4 from the Memory-independence audit on #1584: keep FIFO merge-segmentation behavior, extract the predicate behind a Memory-owned surface. No behavior change.

Context: #1584. Follows merged #1588 (routing identity stays on `author_id`; this PR only swaps the metadata-literal reads in `_hydrate_delivery_context`).

## Out of scope (parallel PR)

Does not touch session lifecycle lock / capture-scheduling (C2/C3). Does not change `_hydrate_delivery_context`'s routing-identity assignment.

## Evidence

- **Unit:** `tests/test_memory_admission.py::test_merge_identity_normalizes_unusable_metadata` covers None / whitespace / non-string metadata with today's strip/`is True` semantics.
- **Contract:** existing merge-segmentation and hydrate tests in `tests/test_session_delivery_fsm.py` pass unchanged (no-behavior-change evidence).
- **Scenario:** none; no user-facing flow change.
- **Residual manual:** none; deferred to the orchestrator integration pass if desired.