### PR TITLE
fix(ui): stop waking a live workbench event stream into a reconnect

### DIFF
--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -2799,6 +2799,31 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     eventBridgeConnectedRef.current = false;
   };
 
+  /**
+   * The stream's own handshake, or null while events cannot reach handlers. A
+   * controller-sourced stream also needs its bridge up: the browser leg being
+   * open says nothing about the controller leg behind it.
+   */
+  const workbenchEventHandshake = () => {
+    const connection = eventConnectionRef.current;
+    if (!connection) return null;
+    if (connection.source === 'controller' && !eventBridgeConnectedRef.current) return null;
+    return connection;
+  };
+
+  /**
+   * Events are flowing end to end right now, so a reconnect would close no gap.
+   *
+   * Transport liveness is the browser's to own: it errors the stream on network
+   * changes and on HTTP/2 ping timeouts, which is what `readyState` reports. The
+   * server's own keep-alive is an SSE comment plus it only fires after 15s of
+   * silence on the timeout branch, so it is invisible to EventSource and absent
+   * from a stream busy delivering events this context filters out -- a
+   * last-frame staleness check built on it would call healthy streams dead.
+   */
+  const isWorkbenchEventStreamLive = () =>
+    eventSourceRef.current?.readyState === EventSource.OPEN && workbenchEventHandshake() !== null;
+
   function reconnectWorkbenchEventSource(): void {
     if (eventHandlersRef.current.size === 0) return;
     closeActiveWorkbenchEventSource();
@@ -2810,6 +2835,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       eventReconnectLoopRef.current = new WorkbenchEventReconnectLoop({
         reconnect: reconnectWorkbenchEventSource,
         isVisible: () => document.visibilityState === 'visible',
+        isStreamLive: isWorkbenchEventStreamLive,
       });
     }
     return eventReconnectLoopRef.current;
@@ -3051,7 +3077,9 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
 
   const wakeWorkbenchEvents = () => {
     if (eventHandlersRef.current.size === 0 || document.visibilityState !== 'visible') return;
-    setWorkbenchEventConnectionState('reconnecting');
+    // The indicator belongs to whoever opens a stream: openWorkbenchEventSource
+    // marks it reconnecting on every attempt. Announcing it here instead made a
+    // wake that keeps a live stream flash "reconnecting" over a healthy one.
     getWorkbenchEventReconnectLoop().wake();
   };
   wakeWorkbenchEventsRef.current = wakeWorkbenchEvents;
@@ -3988,17 +4016,11 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
           handlers.onConnectionState?.(eventConnectionStateRef.current);
         }
       });
-      if (
-        eventConnectionRef.current &&
-        (eventConnectionRef.current.source !== 'controller' || eventBridgeConnectedRef.current)
-      ) {
+      if (workbenchEventHandshake()) {
         queueMicrotask(() => {
-          if (
-            eventHandlersRef.current.has(handlers) &&
-            eventConnectionRef.current &&
-            (eventConnectionRef.current.source !== 'controller' || eventBridgeConnectedRef.current)
-          ) {
-            handlers.onConnected?.(eventConnectionRef.current);
+          const connected = workbenchEventHandshake();
+          if (eventHandlersRef.current.has(handlers) && connected) {
+            handlers.onConnected?.(connected);
           }
         });
       }

--- a/ui/src/lib/workbenchEventConnection.test.ts
+++ b/ui/src/lib/workbenchEventConnection.test.ts
@@ -13,7 +13,11 @@ describe('WorkbenchEventReconnectLoop', () => {
   it('retries terminal failures forever with bounded backoff and resets after recovery', () => {
     vi.useFakeTimers();
     const reconnect = vi.fn();
-    const loop = new WorkbenchEventReconnectLoop({ reconnect, isVisible: () => true });
+    const loop = new WorkbenchEventReconnectLoop({
+      reconnect,
+      isVisible: () => true,
+      isStreamLive: () => false,
+    });
 
     for (const delayMs of [1_000, 2_000, 4_000, 8_000, 15_000, 15_000]) {
       loop.failed();
@@ -36,7 +40,11 @@ describe('WorkbenchEventReconnectLoop', () => {
     vi.useFakeTimers();
     let visible = true;
     const reconnect = vi.fn();
-    const loop = new WorkbenchEventReconnectLoop({ reconnect, isVisible: () => visible });
+    const loop = new WorkbenchEventReconnectLoop({
+      reconnect,
+      isVisible: () => visible,
+      isStreamLive: () => false,
+    });
 
     loop.attemptStarted();
     vi.advanceTimersByTime(WORKBENCH_EVENT_OPEN_TIMEOUT_MS - 1);
@@ -58,5 +66,42 @@ describe('WorkbenchEventReconnectLoop', () => {
     loop.wake();
     vi.advanceTimersByTime(60_000);
     expect(reconnect).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves a live stream alone on wake while still dropping the backoff', () => {
+    vi.useFakeTimers();
+    let streamLive = false;
+    const reconnect = vi.fn();
+    const loop = new WorkbenchEventReconnectLoop({
+      reconnect,
+      isVisible: () => true,
+      isStreamLive: () => streamLive,
+    });
+
+    for (const delayMs of [1_000, 2_000, 4_000, 8_000, 15_000]) {
+      loop.failed();
+      vi.advanceTimersByTime(delayMs);
+    }
+    expect(reconnect).toHaveBeenCalledTimes(5);
+    reconnect.mockClear();
+
+    // A retry is waiting out the ceiling when the stream comes back up.
+    loop.failed();
+    streamLive = true;
+    loop.wake();
+    vi.advanceTimersByTime(60_000);
+    // A stream that never dropped missed nothing, so waking must not recycle
+    // it -- every consumer refetches on reconnect to close a gap that a live
+    // stream does not have. The queued retry is cancelled, not deferred.
+    expect(reconnect).not.toHaveBeenCalled();
+
+    // Clearing the backoff is the other half of waking: the next real drop
+    // retries from the shortest delay instead of resuming at the ceiling.
+    streamLive = false;
+    loop.failed();
+    vi.advanceTimersByTime(999);
+    expect(reconnect).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(reconnect).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/src/lib/workbenchEventConnection.ts
+++ b/ui/src/lib/workbenchEventConnection.ts
@@ -9,12 +9,15 @@ type TimerHandle = ReturnType<typeof setTimeout>;
 interface WorkbenchEventReconnectLoopOptions {
   reconnect: () => void;
   isVisible: () => boolean;
+  /** Whether events are flowing end to end right now, so no gap needs closing. */
+  isStreamLive: () => boolean;
 }
 
 /** Owns the retry policy; EventSource wiring stays in ApiContext. */
 export class WorkbenchEventReconnectLoop {
   private readonly reconnect: () => void;
   private readonly isVisible: () => boolean;
+  private readonly isStreamLive: () => boolean;
   private retryTimer: TimerHandle | null = null;
   private openTimer: TimerHandle | null = null;
   private retryAttempt = 0;
@@ -23,6 +26,7 @@ export class WorkbenchEventReconnectLoop {
   constructor(options: WorkbenchEventReconnectLoopOptions) {
     this.reconnect = options.reconnect;
     this.isVisible = options.isVisible;
+    this.isStreamLive = options.isStreamLive;
   }
 
   attemptStarted(): void {
@@ -56,10 +60,19 @@ export class WorkbenchEventReconnectLoop {
     }, delayMs);
   }
 
+  /** The page came back or the network returned: stop waiting out a backoff. */
   wake(): void {
     if (this.stopped || !this.isVisible()) return;
+    // A backoff was sized while nobody was watching. Someone is watching now,
+    // so the next attempt should not sit out the rest of a 15s delay.
     this.retryAttempt = 0;
     this.clearRetryTimer();
+    // An unbroken stream missed nothing, so there is no gap to close. Recycling
+    // it would manufacture the very outage -- and the catch-up read every
+    // consumer runs on reconnect -- that waking exists to recover from.
+    // Checked before clearOpenTimer() so a stream that is open at the transport
+    // but has not completed its handshake keeps its watchdog armed.
+    if (this.isStreamLive()) return;
     this.clearOpenTimer();
     this.reconnect();
   }


### PR DESCRIPTION
## Changed capability

Coming back to the workbench no longer recycles a healthy SSE stream, so the
focus edge stops triggering a second, duplicated wave of catch-up reads.

Measured on one away-and-return in the local Incus regression environment
(`/chat/<id>` with a Show Page open), instrumenting `EventSource.prototype.close`:

```
t=1ms    fetch      /api/inbox?platform=avibe&limit=30
t=2ms    fetch      /api/sessions/<id>/turn-state
t=2ms    SSE CLOSE  /api/events   readyState: 1   <-- healthy stream killed
t=2ms    SSE OPEN   /api/events
t=3ms    fetch      /status
t=3ms    fetch      /api/sessions/<id>/messages?limit=50&tail=1
t=3ms    fetch      /api/sessions/<id>/queue
t=4ms    fetch      /api/sessions/<id>/turn-state          (dup)
t=8ms    fetch      /api/sessions/<id>
--- new stream's `connected` event ---
t=122ms  fetch      /api/workbench/projects-bootstrap
t=123ms  fetch      /api/sessions/<id>/messages?...        (dup)
t=123ms  fetch      /api/sessions/<id>/queue               (dup)
t=123ms  fetch      /api/sessions/<id>/turn-state          (dup)
t=123ms  fetch      /api/show-pages
t=123ms  fetch      /api/sessions/<id>                     (dup)
t=125ms  fetch      /api/vault/requests?status=pending&...
```

The second cluster is not an independent trigger. `onPageReactivated` fires the
first wave *and* calls `wakeIfVisible()`, and `wake()` called
`reconnectWorkbenchEventSource()` with no liveness check — closing the stream at
`readyState: 1` (OPEN). Every store's `onConnected` handler then ran its
missed-event catch-up, replaying 5 of the first wave's reads.

15 requests + 1 stream teardown becomes 7 requests and 0 teardowns. Gating the
remaining focus-edge refetches to poll-only data sources is a separate change.

## Why the guard is correct

`wake()` earns its keep by not making a page someone is now watching sit out the
rest of a 15s backoff — that is the `retryAttempt = 0` + `clearRetryTimer()`
pair, which still runs unconditionally. `reconnect()` is only meaningful when
there is no live stream. An unbroken stream missed nothing, so recycling it
manufactures the very outage, and the catch-up reads that close one, that waking
exists to recover from.

The live predicate requires both the transport (`readyState === OPEN`) and the
app-level handshake, and for a controller-sourced stream also its bridge: the
browser leg being open says nothing about the controller leg behind it. A
half-open stream is therefore *not* live and still gets the forced reconnect, so
the guard fails toward one redundant reconnect rather than toward silence. The
check sits before `clearOpenTimer()` so a stream open at the transport but
mid-handshake keeps its watchdog armed.

## Known-by-design ledger

- **No last-frame staleness check.** A zombie stream (`OPEN` but silently dead)
  used to be healed by the blind reconnect, as a side effect rather than by
  design — and only if the user happened to blur and refocus, never while they
  sat reading. Transport liveness belongs to the browser, which errors the stream
  on network changes and HTTP/2 ping timeouts. The server keep-alive cannot back
  a client-side staleness check as it stands: it is an SSE *comment*
  (`: ping\n\n`), invisible to `EventSource`, and it is emitted only on the
  `asyncio.TimeoutError` branch after 15s of queue silence — so a stream busy
  delivering events this context filters out sends none, and a staleness check
  would call healthy streams dead. Making it observable and wall-clock means
  restructuring an authorization-filtering hot loop, which does not belong in a
  request-reduction change. Noted as a possible follow-up.
- **`setWorkbenchEventConnectionState('reconnecting')` removed from the wake
  site.** `openWorkbenchEventSource()` already marks every real attempt, so the
  wake-site write was redundant on the reconnect path and an outright lie on the
  live path — it flashed "reconnecting" over a stream that was never touched.

## Evidence layers

- **Unit** — `ui/src/lib/workbenchEventConnection.test.ts`: a wake on a live
  stream cancels the queued retry without reconnecting, and the cleared backoff
  still sends the next real drop back to the shortest delay. Verified to fail
  when the guard is removed (`expected "vi.fn()" to not be called at all, but
  actually been called 1 times`).
- **Build/type** — `npm run build` in `ui/` (`validate:imports && tsc -b && vite build`).
- **Suite** — full `ui/` vitest run, 242 files / 3105 tests.
- **Residual manual check** — re-measure the away-and-return burst in the local
  Incus regression environment after merge.
