### PR TITLE
perf(runtime): stop prepare reinstalling managed deps that are already current

### DIFF
--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -938,6 +938,82 @@ def test_refresh_avault_if_stale_installs_when_missing(monkeypatch):
     assert out["version"] == api.AVAULT_VERSION
 
 
+def _stub_avault_install_state(monkeypatch, *, version, ready_floor):
+    """Answer every avault code path from one fake on-disk install."""
+    state = {"version": version, "installs": 0}
+    monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
+    monkeypatch.setattr(api, "resolve_cli_path", lambda _b: "/usr/local/bin/avault" if state["version"] else None)
+    monkeypatch.setattr(api, "_probe_avault_version", lambda path: state["version"] if path else None)
+    monkeypatch.setattr(api, "_avault_ready_min_version", lambda: ready_floor)
+    monkeypatch.setattr(
+        api,
+        "_managed_avault_release_satisfies_ready_minimum",
+        lambda: api._version_at_least(api.AVAULT_VERSION, ready_floor),
+    )
+
+    def _install(force=False):
+        state["installs"] += 1
+        state["version"] = api.AVAULT_VERSION
+        return {"ok": True, "changed": True}
+
+    monkeypatch.setattr(api, "install_avault", _install)
+    return state
+
+
+@pytest.mark.parametrize(
+    "version, ready_floor",
+    [
+        (None, api.AVAULT_VERSION),
+        ("0.1.1", api.AVAULT_VERSION),
+        (api.AVAULT_VERSION, api.AVAULT_VERSION),
+        ("99.0.0", api.AVAULT_VERSION),
+        (api.AVAULT_VERSION, "99.0.0"),
+    ],
+)
+def test_refresh_avault_if_stale_never_answers_healthier_than_forcing(monkeypatch, version, ready_floor):
+    # The property the whole change rests on: skipping a redundant download may
+    # not change the verdict. Whatever ``ensure_avault_installed(force=True)``
+    # concludes about an install state, the currency path must conclude the same
+    # thing — it may only skip the reinstall. Being at the pin is not the whole
+    # of being ready: when the readiness floor is raised ahead of the published
+    # pin, a binary equal to the pin is still ``upgrade_required``, and only the
+    # forced path used to say so.
+    forced_state = _stub_avault_install_state(monkeypatch, version=version, ready_floor=ready_floor)
+    forced = api.ensure_avault_installed(force=True)
+
+    stale_state = _stub_avault_install_state(monkeypatch, version=version, ready_floor=ready_floor)
+    stale = api.refresh_avault_if_stale()
+
+    assert stale["ok"] == forced["ok"]
+    assert stale.get("status") == forced.get("status")
+    assert stale.get("reason") == forced.get("reason")
+    assert stale_state["installs"] <= forced_state["installs"]
+
+
+def test_refresh_askill_if_stale_repairs_an_unreadable_binary_without_the_latest_probe(monkeypatch):
+    # A binary that cannot report its version is broken, not current, and that
+    # verdict must not depend on the upstream probe answering: prepare used to
+    # force this install unconditionally, so gating the repair on a reachable
+    # latest would report a broken askill as ready during a network blip.
+    monkeypatch.setattr(
+        api,
+        "askill_status",
+        lambda: {"id": "askill", "installed": True, "version": None, "status": "unknown", "path": "/x/askill"},
+    )
+    monkeypatch.setattr(api, "_cached_latest_askill", lambda: None)
+    calls = []
+    monkeypatch.setattr(
+        api,
+        "ensure_askill_installed",
+        lambda force=False: calls.append(force) or {"ok": True, "installed": True, "changed": True, "path": "/x/askill"},
+    )
+
+    out = api.refresh_askill_if_stale()
+
+    assert calls == [True]
+    assert out["action"] == "refresh_unknown_version"
+
+
 def test_dependencies_status_shape(monkeypatch):
     monkeypatch.setattr(
         api.V2Config,

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -823,6 +823,121 @@ def test_reconcile_askill_auto_update_skips_when_disabled(monkeypatch):
     assert out == {"ok": True, "skipped": True, "reason": "askill_auto_update_disabled"}
 
 
+def test_refresh_askill_if_stale_does_not_run_the_installer_when_current(monkeypatch):
+    # The askill.sh installer re-downloads the CLI whenever it runs, so the
+    # shared currency owner must answer "already current" without invoking it.
+    monkeypatch.setattr(
+        api,
+        "askill_update_status",
+        lambda **_: {
+            "id": "askill",
+            "installed": True,
+            "version": "0.1.14",
+            "status": "ready",
+            "path": "/x/askill",
+            "latest_version": "0.1.14",
+            "has_update": False,
+        },
+    )
+    monkeypatch.setattr(api, "ensure_askill_installed", lambda force=False: pytest.fail("should not install"))
+
+    out = api.refresh_askill_if_stale()
+
+    assert out["ok"] is True
+    assert out["reason"] == "up_to_date"
+    assert "action" not in out
+
+
+def test_refresh_askill_if_stale_ignores_the_auto_update_gate(monkeypatch):
+    # ``VIBE_ASKILL_AUTO_UPDATE`` disables the update-checker cadence, not the
+    # lifecycle refresh that ``vibe runtime prepare`` performs; keeping the gate
+    # in the cadence wrapper is what lets both callers share one decision.
+    monkeypatch.setenv("VIBE_ASKILL_AUTO_UPDATE", "0")
+    monkeypatch.setattr(
+        api,
+        "askill_update_status",
+        lambda **_: {
+            "id": "askill",
+            "installed": True,
+            "version": "0.1.13",
+            "status": "ready",
+            "latest_version": "0.1.14",
+            "has_update": True,
+        },
+    )
+    calls = []
+    monkeypatch.setattr(
+        api,
+        "ensure_askill_installed",
+        lambda force=False: calls.append(force) or {"ok": True, "installed": True, "changed": True, "path": "/x/askill"},
+    )
+
+    out = api.refresh_askill_if_stale()
+
+    assert calls == [True]
+    assert out["action"] == "update"
+
+
+def test_refresh_avault_if_stale_does_not_force_when_the_pin_is_satisfied(monkeypatch):
+    monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
+    monkeypatch.setattr(api, "resolve_cli_path", lambda _b: "/usr/local/bin/avault")
+    monkeypatch.setattr(api, "_probe_avault_version", lambda _path: api.AVAULT_VERSION)
+    monkeypatch.setattr(api, "install_avault", lambda force=False: pytest.fail("should not reinstall the pinned release"))
+
+    out = api.refresh_avault_if_stale()
+
+    assert out["ok"] is True
+    assert out["changed"] is False
+    assert out["version"] == api.AVAULT_VERSION
+
+
+def test_refresh_avault_if_stale_upgrades_a_binary_below_the_pin(monkeypatch):
+    # Skipping the install is conditional on the pin, not unconditional: prepare
+    # still has to raise a stale managed binary on upgrade.
+    stale = api.AVAULT_P2_MIN_VERSION
+    assert api._version_at_least(api.AVAULT_VERSION, stale)
+    state = {"version": stale}
+    monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
+    monkeypatch.setattr(api, "resolve_cli_path", lambda _b: "/usr/local/bin/avault")
+    monkeypatch.setattr(api, "_probe_avault_version", lambda _path: state["version"])
+    calls = []
+
+    def _install(force=False):
+        calls.append(force)
+        state["version"] = api.AVAULT_VERSION
+        return {"ok": True}
+
+    monkeypatch.setattr(api, "install_avault", _install)
+
+    out = api.refresh_avault_if_stale()
+
+    assert calls == [True]
+    assert out["ok"] is True
+    assert out["version"] == api.AVAULT_VERSION
+
+
+def test_refresh_avault_if_stale_installs_when_missing(monkeypatch):
+    state = {"path": None}
+    monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
+    monkeypatch.setattr(api, "resolve_cli_path", lambda _b: state["path"])
+    monkeypatch.setattr(api, "_probe_avault_version", lambda path: api.AVAULT_VERSION if path else None)
+    calls = []
+
+    def _install(force=False):
+        calls.append(force)
+        state["path"] = "/usr/local/bin/avault"
+        return {"ok": True}
+
+    monkeypatch.setattr(api, "install_avault", _install)
+
+    out = api.refresh_avault_if_stale()
+
+    assert calls == [True]
+    assert out["ok"] is True
+    assert out["installed"] is True
+    assert out["version"] == api.AVAULT_VERSION
+
+
 def test_dependencies_status_shape(monkeypatch):
     monkeypatch.setattr(
         api.V2Config,

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -1014,6 +1014,72 @@ def test_refresh_askill_if_stale_repairs_an_unreadable_binary_without_the_latest
     assert out["action"] == "refresh_unknown_version"
 
 
+# Strings a version probe can produce that no comparison can order: absent,
+# empty, a development build, a git description, a partial number. The point is
+# not the list — it is that each one makes `_compare_versions` answer False, the
+# same answer it gives for "already newest", which is how "cannot tell" used to
+# be read as "current".
+UNORDERABLE_VERSIONS = [None, "", "dev", "unknown", "askill", "g1a2b3c", "0.1.x"]
+
+
+@pytest.mark.parametrize("version", UNORDERABLE_VERSIONS)
+def test_askill_status_calls_an_unorderable_version_unknown(monkeypatch, version):
+    # One field owns the fact, so prepare and the Dependencies page cannot
+    # disagree about whether a binary reporting `dev` is healthy.
+    monkeypatch.setattr(
+        api,
+        "askill_status",
+        lambda: {"id": "askill", "installed": True, "version": version, "status": "ready", "path": "/x/askill"},
+    )
+    monkeypatch.setattr(api, "_cached_latest_askill", lambda: "0.1.14")
+
+    assert api.askill_update_status()["status"] == "unknown"
+
+
+@pytest.mark.parametrize("version", UNORDERABLE_VERSIONS)
+def test_refresh_askill_if_stale_repairs_an_unorderable_local_version(monkeypatch, version):
+    # `up_to_date` must be an affirmative verdict, never the branch everything
+    # unrecognised falls into. A version that cannot be ordered against the
+    # published one means unknown, and unknown gets the repair the forced path
+    # would have performed — asserted over the shapes a probe can produce rather
+    # than over the one the review happened to name.
+    monkeypatch.setattr(
+        api,
+        "askill_status",
+        lambda: {"id": "askill", "installed": True, "version": version, "status": "ready", "path": "/x/askill"},
+    )
+    monkeypatch.setattr(api, "_cached_latest_askill", lambda: "0.1.14")
+    calls = []
+    monkeypatch.setattr(
+        api,
+        "ensure_askill_installed",
+        lambda force=False: calls.append(force) or {"ok": True, "installed": True, "changed": True},
+    )
+
+    out = api.refresh_askill_if_stale()
+
+    assert calls == [True], f"{version!r} is not a version we can trust as current"
+    assert out["action"] == "refresh_unknown_version"
+
+
+@pytest.mark.parametrize("latest", UNORDERABLE_VERSIONS)
+def test_refresh_askill_if_stale_needs_an_orderable_latest_to_claim_currency(monkeypatch, latest):
+    # The same rule on the upstream side: with nothing orderable to compare
+    # against, staleness is undecided. The owner reports that instead of
+    # currency, and each caller decides (prepare installs, the cadence skips).
+    monkeypatch.setattr(
+        api,
+        "askill_status",
+        lambda: {"id": "askill", "installed": True, "version": "0.1.14", "status": "ready", "path": "/x/askill"},
+    )
+    monkeypatch.setattr(api, "_cached_latest_askill", lambda: latest)
+    monkeypatch.setattr(api, "ensure_askill_installed", lambda force=False: pytest.fail("the owner decides, it does not install here"))
+
+    out = api.refresh_askill_if_stale()
+
+    assert out["reason"] == "latest_unavailable"
+
+
 def test_dependencies_status_shape(monkeypatch):
     monkeypatch.setattr(
         api.V2Config,

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -29,7 +29,7 @@ from core.show_pages import (
     show_public_event_write_token,
 )
 from storage.pagination import PageRequest
-from vibe import cli
+from vibe import api, cli
 
 
 @dataclass(frozen=True)
@@ -370,6 +370,41 @@ def test_runtime_prepare_tmux_runs_when_terminal_enabled(monkeypatch):
 
     assert cli._ensure_tmux_during_prepare(force=True) == {"ok": True}
     assert calls == [True]
+
+
+def test_runtime_prepare_downloads_nothing_when_managed_deps_are_current(monkeypatch):
+    # Prepare is the chokepoint that keeps managed local deps current, which is
+    # not the same as reinstalling them: every install here is a network download
+    # (askill ~30s, avault ~20s), so a prepare with nothing to change must reach
+    # none of them. Stubbing the installers rather than the decision keeps this
+    # honest whichever way the wrappers ask the question.
+    monkeypatch.delenv("VIBE_INSTALL_SKIP_ASKILL", raising=False)
+    monkeypatch.delenv("VIBE_INSTALL_SKIP_AVAULT", raising=False)
+    monkeypatch.setattr(api, "install_askill", lambda: pytest.fail("askill must not reinstall when current"))
+    monkeypatch.setattr(api, "install_avault", lambda force=False: pytest.fail("avault must not reinstall when current"))
+    monkeypatch.setattr(
+        api,
+        "askill_status",
+        lambda: {"id": "askill", "installed": True, "version": "0.1.14", "status": "ready", "path": "/x/askill"},
+    )
+    monkeypatch.setattr(api, "_cached_latest_askill", lambda: "0.1.14")
+    monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
+    monkeypatch.setattr(api, "resolve_cli_path", lambda _b: "/usr/local/bin/avault")
+    monkeypatch.setattr(api, "_probe_avault_version", lambda _path: api.AVAULT_VERSION)
+
+    askill = cli._ensure_askill_during_prepare()
+    avault = cli._ensure_avault_during_prepare()
+
+    assert askill == {
+        "ok": True,
+        "installed": True,
+        "changed": False,
+        "path": "/x/askill",
+        "version": "0.1.14",
+    }
+    assert avault["ok"] is True
+    assert avault["changed"] is False
+    assert avault["version"] == api.AVAULT_VERSION
 
 
 def _save_config() -> V2Config:

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -48,12 +48,12 @@ def _stub_runtime_prepare_dependencies(
 ):
     calls = {"askill": [], "avault": [], "tmux": [], "git": []}
 
-    def fake_askill(offline=False):
-        calls["askill"].append({"offline": offline})
+    def fake_askill(offline=False, force=False):
+        calls["askill"].append({"offline": offline, "force": force})
         return askill_result or {"ok": True, "installed": True}
 
-    def fake_avault(offline=False):
-        calls["avault"].append({"offline": offline})
+    def fake_avault(offline=False, force=False):
+        calls["avault"].append({"offline": offline, "force": force})
         return avault_result or {"ok": True, "installed": True}
 
     def fake_tmux(offline=False, force=False):
@@ -292,45 +292,29 @@ def test_runtime_prepare_cli_strict_allows_unsupported_git_platform(monkeypatch,
 def test_runtime_prepare_cli_skips_avault_offline(monkeypatch, capsys):
     parser = cli.build_parser()
     args = parser.parse_args(["runtime", "prepare", "--offline", "--json"])
-    seen = {"askill": None, "avault": None, "tmux": None, "git": None}
 
     class FakeRuntimeManager:
         def prepare(self, *, force=False, offline=None):
             assert offline is True
             return {"ok": True}
 
-    def fake_askill(offline=False):
-        seen["askill"] = offline
-        return {"ok": True, "skipped": True, "reason": "offline"}
-
-    def fake_avault(offline=False):
-        seen["avault"] = offline
-        return {"ok": True, "skipped": True, "reason": "offline"}
-
-    def fake_tmux(offline=False, force=False):
-        seen["tmux"] = {"offline": offline, "force": force}
-        return {"ok": True, "skipped": True, "reason": "offline"}
-
-    def fake_git(offline=None, force=False):
-        seen["git"] = {"offline": offline, "force": force}
-        return {"ok": True, "installed": True}
-
     monkeypatch.setattr(cli, "_show_runtime_manager_from_args", lambda parsed: FakeRuntimeManager())
-    monkeypatch.setattr(cli, "_ensure_askill_during_prepare", fake_askill)
-    monkeypatch.setattr(cli, "_ensure_avault_during_prepare", fake_avault)
-    monkeypatch.setattr(cli, "_ensure_tmux_during_prepare", fake_tmux)
-    monkeypatch.setattr(cli, "_ensure_git_during_prepare", fake_git)
+    offline_result = {"ok": True, "skipped": True, "reason": "offline"}
+    calls = _stub_runtime_prepare_dependencies(
+        monkeypatch,
+        askill_result=offline_result,
+        avault_result=offline_result,
+        tmux_result=offline_result,
+    )
 
     assert cli.cmd_runtime(args) == 0
     payload = json.loads(capsys.readouterr().out)
-    assert seen == {
-        "askill": True,
-        "avault": True,
-        "tmux": {"offline": True, "force": False},
-        "git": {"offline": True, "force": False},
-    }
-    assert payload["avault"] == {"ok": True, "skipped": True, "reason": "offline"}
-    assert payload["tmux"] == {"ok": True, "skipped": True, "reason": "offline"}
+    for phase, recorded in calls.items():
+        assert recorded, f"{phase} phase did not run"
+        assert all(call["offline"] for call in recorded), phase
+        assert all(call["force"] is False for call in recorded), phase
+    assert payload["avault"] == offline_result
+    assert payload["tmux"] == offline_result
     assert payload["git"] == {"ok": True, "installed": True}
 
 
@@ -405,6 +389,51 @@ def test_runtime_prepare_downloads_nothing_when_managed_deps_are_current(monkeyp
     assert avault["ok"] is True
     assert avault["changed"] is False
     assert avault["version"] == api.AVAULT_VERSION
+
+
+def test_runtime_prepare_force_still_reinstalls_current_managed_deps(monkeypatch):
+    # The mirror of the test above, and the boundary of the change: making the
+    # ordinary prepare cheap must not take the repair away. A corrupted binary
+    # can still report the current version, so `--force` has to reach the
+    # installer for exactly the states the currency check skips.
+    monkeypatch.delenv("VIBE_INSTALL_SKIP_ASKILL", raising=False)
+    monkeypatch.delenv("VIBE_INSTALL_SKIP_AVAULT", raising=False)
+    installed = []
+    monkeypatch.setattr(api, "refresh_askill_if_stale", lambda: pytest.fail("--force must not settle for a currency check"))
+    monkeypatch.setattr(api, "refresh_avault_if_stale", lambda: pytest.fail("--force must not settle for a currency check"))
+    monkeypatch.setattr(api, "install_askill", lambda: installed.append("askill") or {"ok": True})
+    monkeypatch.setattr(api, "install_avault", lambda force=False: installed.append("avault") or {"ok": True, "changed": True})
+    monkeypatch.setattr(api, "_configured_avault_cli_path", lambda: "avault")
+    monkeypatch.setattr(api, "resolve_cli_path", lambda _b: "/usr/local/bin/askill")
+    monkeypatch.setattr(api, "_probe_avault_version", lambda _path: api.AVAULT_VERSION)
+
+    assert cli._ensure_askill_during_prepare(force=True)["ok"] is True
+    assert cli._ensure_avault_during_prepare(force=True)["ok"] is True
+    assert installed == ["askill", "avault"]
+
+
+def test_runtime_prepare_force_reaches_every_managed_dependency(monkeypatch):
+    # `--force` is advertised by the parser as "reinstall even when the cached
+    # runtime matches", so it belongs to every dependency phase, not to the ones
+    # that happen to accept it. Asserted over whatever phases ran rather than a
+    # list of names, so a phase added later fails here instead of silently
+    # ignoring the flag.
+    parser = cli.build_parser()
+    args = parser.parse_args(["runtime", "prepare", "--force"])
+
+    class FakeRuntimeManager:
+        def prepare(self, *, force=False, offline=None):
+            assert force is True
+            return {"ok": True}
+
+    monkeypatch.setattr(cli, "_show_runtime_manager_from_args", lambda parsed: FakeRuntimeManager())
+    calls = _stub_runtime_prepare_dependencies(monkeypatch)
+
+    assert cli.cmd_runtime(args) == 0
+    assert calls, "prepare recorded no dependency phases"
+    for phase, recorded in calls.items():
+        assert recorded, f"{phase} phase did not run"
+        assert all(call["force"] is True for call in recorded), phase
 
 
 def _save_config() -> V2Config:

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -391,6 +391,35 @@ def test_runtime_prepare_downloads_nothing_when_managed_deps_are_current(monkeyp
     assert avault["version"] == api.AVAULT_VERSION
 
 
+@pytest.mark.parametrize("reason", ["latest_unavailable", "a_reason_invented_after_this_test"])
+def test_runtime_prepare_installs_when_currency_was_not_established(monkeypatch, reason):
+    # "I did not install" and "it is current" are different facts, and prepare
+    # may only report ready for the second. `up_to_date` is the one verdict that
+    # states it; every other non-install verdict — the upstream probe failing
+    # today, whatever is added later — means unknown, so prepare installs rather
+    # than printing `askill ready.` off a check that never happened. Keyed on the
+    # verdict rather than on a list of reasons, so a reason added later inherits
+    # the safe branch instead of a false pass.
+    monkeypatch.delenv("VIBE_INSTALL_SKIP_ASKILL", raising=False)
+    monkeypatch.setattr(
+        api,
+        "refresh_askill_if_stale",
+        lambda: {"ok": True, "skipped": True, "reason": reason, "status": {"path": "/x/askill", "version": "0.1.14"}},
+    )
+    forced = []
+    monkeypatch.setattr(
+        api,
+        "ensure_askill_installed",
+        lambda force=False: forced.append(force) or {"ok": True, "installed": True, "changed": True},
+    )
+
+    out = cli._ensure_askill_during_prepare()
+
+    assert forced == [True], "an unestablished currency must reach the installer"
+    assert out["changed"] is True
+    assert out["action"] == "refresh_currency_unknown"
+
+
 def test_runtime_prepare_force_still_reinstalls_current_managed_deps(monkeypatch):
     # The mirror of the test above, and the boundary of the change: making the
     # ordinary prepare cheap must not take the repair away. A corrupted binary

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -8183,7 +8183,11 @@ def askill_update_status(*, include_latest: bool = True) -> dict:
         "has_update": has_update,
         "auto_update": not _askill_auto_update_disabled(),
     }
-    if current.get("installed") and current_version is None:
+    if current.get("installed") and not _is_comparable_version(current_version):
+        # Not just a missing version: a version nobody can order (``dev``, a git
+        # sha) tells us as little as no version at all, and every consumer —
+        # the Dependencies page, prepare — must read the same fact from the same
+        # field rather than re-deriving it from the raw string.
         out["status"] = "unknown"
     return out
 
@@ -8201,6 +8205,10 @@ def refresh_askill_if_stale() -> dict:
     Callers own their own policy gate; this function only decides staleness. An
     install attempt is reported by ``action``, so its absence means the
     dependency was already current.
+
+    ``up_to_date`` is an affirmative verdict, never a fallthrough: it requires
+    two versions that could actually be ordered. Anything else is unknown, and
+    unknown is answered by the repair the forced path would have done.
     """
     status = askill_update_status()
     if not status.get("installed"):
@@ -8209,9 +8217,11 @@ def refresh_askill_if_stale() -> dict:
         return result
 
     latest = status.get("latest_version")
-    if status.get("version") is None:
-        # A binary that cannot report its version is not current, it is broken —
-        # whether or not the upstream probe answered. Deciding that before the
+    if status.get("status") == "unknown":
+        # A binary whose version cannot be ordered is not current, it is broken —
+        # whether it reported nothing or reported ``dev``. The status field owns
+        # that judgement (see ``askill_update_status``) so this path and the
+        # Dependencies page cannot disagree. Deciding it before the
         # ``latest_unavailable`` exit keeps the repair from being gated on
         # network reachability: callers that used to force this install
         # unconditionally would otherwise be told a broken askill is ready
@@ -8222,10 +8232,16 @@ def refresh_askill_if_stale() -> dict:
         result["latest_version"] = latest
         return result
 
-    if latest is None:
+    if not _is_comparable_version(latest):
+        # No usable upstream version to compare against — missing, or a string
+        # that cannot be ordered. Either way staleness is undecided, which is a
+        # different fact from being current; each caller owns what to do with it
+        # (prepare installs, the update cadence skips).
         return {"ok": True, "skipped": True, "reason": "latest_unavailable", "status": status}
 
     if not status.get("has_update"):
+        # Two comparable versions, compared: this is the one state that may claim
+        # currency, and it is reached only by having established it.
         return {"ok": True, "skipped": True, "reason": "up_to_date", "status": status}
 
     logger.info("askill update available: %s -> %s", status.get("version"), latest)
@@ -8873,15 +8889,48 @@ def _cached_latest(name: str) -> str | None:
     return latest
 
 
+def _is_comparable_version(value: str | None) -> bool:
+    """Whether *value* can be ordered against another version at all.
+
+    The single owner of "do we actually have a version?", because a nonempty
+    string is not the same fact: ``askill --version`` answers ``askill dev`` on a
+    development build, and the last token of that is stored as the version. Both
+    comparison helpers deliberately return False for anything they cannot parse,
+    so every caller that asks a comparison instead of asking this reads "cannot
+    tell" as "no update available" — which is how a broken binary comes to look
+    current. Ask this first; a False answer means unknown, not healthy.
+    """
+    if not value:
+        return False
+    try:
+        from packaging.version import InvalidVersion, Version
+
+        try:
+            Version(value)
+            return True
+        except InvalidVersion:
+            pass
+    except Exception:  # pragma: no cover - packaging is a transitive dep
+        pass
+
+    core = value.split("+", 1)[0].split("-", 1)[0]
+    try:
+        tuple(int(part) for part in core.split("."))
+    except ValueError:
+        return False
+    return True
+
+
 def _compare_versions(current: str | None, latest: str | None) -> bool:
     """Return True when *latest* is strictly greater than *current*.
 
     Honors PEP 440 / semver pre-release ordering when possible (e.g. ``0.77.1``
     is greater than ``0.77.1-beta.0``). Falls back to a conservative numeric
     tuple comparison; returns False on any parsing failure so we never nag the
-    user with a phantom update.
+    user with a phantom update. That conservatism is why "no update" is not a
+    statement about health: use ``_is_comparable_version`` to tell the two apart.
     """
-    if not current or not latest or current == latest:
+    if not _is_comparable_version(current) or not _is_comparable_version(latest) or current == latest:
         return False
 
     try:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -7516,10 +7516,21 @@ def refresh_avault_if_stale() -> dict:
     an equal or older managed release on purpose — so callers that only want the
     pin satisfied come here instead of charging every call a ~20s reinstall of
     the release that is already on disk.
+
+    Skipping the install may never report a healthier state than forcing it
+    would. Being at the pin is not the whole of being current: when the
+    readiness floor is raised ahead of the published pin, a binary equal to
+    ``AVAULT_VERSION`` is still ``upgrade_required``, and only the forced path
+    surfaces that release gap. So the question is asked of the status as a
+    whole, not of the version alone.
     """
     status = avault_status()
-    pin_satisfied = bool(status.get("installed")) and _version_at_least(status.get("version"), AVAULT_VERSION)
-    return ensure_avault_installed(force=not pin_satisfied)
+    current = (
+        bool(status.get("installed"))
+        and status.get("status") == "ready"
+        and _version_at_least(status.get("version"), AVAULT_VERSION)
+    )
+    return ensure_avault_installed(force=not current)
 
 
 def avault_status() -> dict:
@@ -8198,15 +8209,21 @@ def refresh_askill_if_stale() -> dict:
         return result
 
     latest = status.get("latest_version")
-    if latest is None:
-        return {"ok": True, "skipped": True, "reason": "latest_unavailable", "status": status}
-
     if status.get("version") is None:
+        # A binary that cannot report its version is not current, it is broken —
+        # whether or not the upstream probe answered. Deciding that before the
+        # ``latest_unavailable`` exit keeps the repair from being gated on
+        # network reachability: callers that used to force this install
+        # unconditionally would otherwise be told a broken askill is ready
+        # whenever the latest lookup failed too.
         logger.info("askill local version is unknown; refreshing managed dependency")
         result = ensure_askill_installed(force=True)
         result["action"] = "refresh_unknown_version"
         result["latest_version"] = latest
         return result
+
+    if latest is None:
+        return {"ok": True, "skipped": True, "reason": "latest_unavailable", "status": status}
 
     if not status.get("has_update"):
         return {"ok": True, "skipped": True, "reason": "up_to_date", "status": status}

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -7504,6 +7504,24 @@ def _probe_avault_version(path: str | None) -> str | None:
     return None
 
 
+def refresh_avault_if_stale() -> dict:
+    """Bring avault to the managed pin, installing only when that changes it.
+
+    Sibling of ``refresh_askill_if_stale`` for the version-pinned dependency, so
+    both managed local deps answer "am I current?" before paying for an install.
+    The wanted version is ``AVAULT_VERSION`` rather than an upstream latest, so
+    the staleness question is answered locally with no download at all.
+
+    ``force`` on ``ensure_avault_installed`` stays a repair verb — it reinstalls
+    an equal or older managed release on purpose — so callers that only want the
+    pin satisfied come here instead of charging every call a ~20s reinstall of
+    the release that is already on disk.
+    """
+    status = avault_status()
+    pin_satisfied = bool(status.get("installed")) and _version_at_least(status.get("version"), AVAULT_VERSION)
+    return ensure_avault_installed(force=not pin_satisfied)
+
+
 def avault_status() -> dict:
     """Report whether avault is installed and its version (best-effort)."""
     path = _resolve_avault_cli_path()
@@ -8159,18 +8177,20 @@ def askill_update_status(*, include_latest: bool = True) -> dict:
     return out
 
 
-def reconcile_askill_auto_update() -> dict:
-    """Install or refresh askill as a required managed dependency.
+def refresh_askill_if_stale() -> dict:
+    """Bring askill to the published version, installing only when that changes it.
 
-    This runs from the shared update checker cadence but is intentionally
-    independent of ``update.auto_update``. Avibe owns askill as a local runtime
-    dependency for Skills; disabling product self-upgrades must not strand that
-    dependency on an incompatible CLI contract. Operators can still disable this
-    reconcile loop with ``VIBE_ASKILL_AUTO_UPDATE=0`` or ``VIBE_INSTALL_SKIP_ASKILL``.
+    The single owner of "is the managed askill current, and make it so". Every
+    caller that wants currency asks this instead of forcing an install, because
+    the askill.sh installer re-downloads the CLI on every run: answering the
+    question costs one cached version probe, answering it by reinstalling costs
+    ~30s of network even when the local binary is already the published version.
+    ``refresh_avault_if_stale`` is the same rule for the version-pinned sibling.
+
+    Callers own their own policy gate; this function only decides staleness. An
+    install attempt is reported by ``action``, so its absence means the
+    dependency was already current.
     """
-    if _askill_auto_update_disabled():
-        return {"ok": True, "skipped": True, "reason": "askill_auto_update_disabled"}
-
     status = askill_update_status()
     if not status.get("installed"):
         result = ensure_askill_installed(force=False)
@@ -8199,6 +8219,20 @@ def reconcile_askill_auto_update() -> dict:
     with _BACKEND_CACHE_LOCK:
         _BACKEND_LATEST_CACHE.pop("askill", None)
     return result
+
+
+def reconcile_askill_auto_update() -> dict:
+    """Install or refresh askill as a required managed dependency.
+
+    This runs from the shared update checker cadence but is intentionally
+    independent of ``update.auto_update``. Avibe owns askill as a local runtime
+    dependency for Skills; disabling product self-upgrades must not strand that
+    dependency on an incompatible CLI contract. Operators can still disable this
+    reconcile loop with ``VIBE_ASKILL_AUTO_UPDATE=0`` or ``VIBE_INSTALL_SKIP_ASKILL``.
+    """
+    if _askill_auto_update_disabled():
+        return {"ok": True, "skipped": True, "reason": "askill_auto_update_disabled"}
+    return refresh_askill_if_stale()
 
 
 # =============================================================================

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -14324,18 +14324,34 @@ def _ensure_askill_during_prepare(offline: bool = False) -> dict:
     same lifecycle points as the Show Page runtime (post install / upgrade),
     with a ``VIBE_INSTALL_SKIP_ASKILL`` escape hatch mirroring the Show Runtime
     one. Skipped under ``--offline`` (the askill installer needs the network).
-    Refreshes askill to latest even when a binary already exists — prepare is
-    the chokepoint that keeps required local deps current on upgrade. An askill
-    hiccup never fails the prepare; the Dependencies page offers a manual retry.
+    Refreshes askill to latest so prepare stays the chokepoint that keeps
+    required local deps current on upgrade, but asks whether that refresh would
+    change anything before running the installer: askill.sh re-downloads the CLI
+    on every run, so an unconditional refresh charged every prepare ~30s to
+    install the version already on disk. An askill hiccup never fails the
+    prepare; the Dependencies page offers a manual retry.
     """
     if offline:
         return {"ok": True, "skipped": True, "reason": "offline"}
     if os.environ.get("VIBE_INSTALL_SKIP_ASKILL", "").strip().lower() in _TRUTHY_ENV_VALUES:
         return {"ok": True, "skipped": True, "reason": "VIBE_INSTALL_SKIP_ASKILL"}
     try:
-        return api.ensure_askill_installed(force=True)
+        result = api.refresh_askill_if_stale()
     except Exception as exc:  # noqa: BLE001
         return {"ok": False, "message": str(exc)}
+    if result.get("ok") and not result.get("action"):
+        # No install was attempted, so askill was already current. Report that as
+        # ready rather than skipped, so prepare's dependency lines read the same
+        # way as the pinned providers when nothing needed doing.
+        status = result.get("status") or {}
+        return {
+            "ok": True,
+            "installed": True,
+            "changed": False,
+            "path": status.get("path"),
+            "version": status.get("version"),
+        }
+    return result
 
 
 def _ensure_tmux_during_prepare(offline: bool = False, force: bool = False) -> dict:
@@ -14389,13 +14405,18 @@ def _clean_git_runtime(*, keep_previous: int, dry_run: bool = False) -> dict:
 
 
 def _ensure_avault_during_prepare(offline: bool = False) -> dict:
-    """Ensure avault (the Vault custody core) alongside other local deps."""
+    """Ensure avault (the Vault custody core) alongside other local deps.
+
+    Raises avault to the managed pin on upgrade, but only downloads when the pin
+    is not already satisfied: the reinstall it used to force on every prepare
+    took ~20s to put back the release that was already installed.
+    """
     if offline:
         return {"ok": True, "skipped": True, "reason": "offline"}
     if os.environ.get("VIBE_INSTALL_SKIP_AVAULT", "").strip().lower() in _TRUTHY_ENV_VALUES:
         return {"ok": True, "skipped": True, "reason": "VIBE_INSTALL_SKIP_AVAULT"}
     try:
-        return api.ensure_avault_installed(force=True)
+        return api.refresh_avault_if_stale()
     except Exception as exc:  # noqa: BLE001
         return {"ok": False, "message": str(exc)}
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -14162,10 +14162,11 @@ def cmd_runtime(args) -> int:
     if command == "prepare":
         offline = True if getattr(args, "offline", False) else None
         payload = manager.prepare(force=getattr(args, "force", False), offline=offline)
-        askill = _ensure_askill_during_prepare(offline=bool(offline))
-        tmux = _ensure_tmux_during_prepare(offline=bool(offline), force=getattr(args, "force", False))
-        git = _ensure_git_during_prepare(offline=offline, force=getattr(args, "force", False))
-        avault = _ensure_avault_during_prepare(offline=bool(offline))
+        force = bool(getattr(args, "force", False))
+        askill = _ensure_askill_during_prepare(offline=bool(offline), force=force)
+        tmux = _ensure_tmux_during_prepare(offline=bool(offline), force=force)
+        git = _ensure_git_during_prepare(offline=offline, force=force)
+        avault = _ensure_avault_during_prepare(offline=bool(offline), force=force)
         payload["askill"] = askill
         payload["avault"] = avault
         payload["tmux"] = tmux
@@ -14317,7 +14318,7 @@ def _prepare_show_runtime_after_install(vibe_path: str | None) -> None:
         print(detail)
 
 
-def _ensure_askill_during_prepare(offline: bool = False) -> dict:
+def _ensure_askill_during_prepare(offline: bool = False, force: bool = False) -> dict:
     """Ensure askill (a required local dependency) alongside the Show Runtime.
 
     Folded into ``vibe runtime prepare`` so askill auto-installs at exactly the
@@ -14330,12 +14331,20 @@ def _ensure_askill_during_prepare(offline: bool = False) -> dict:
     on every run, so an unconditional refresh charged every prepare ~30s to
     install the version already on disk. An askill hiccup never fails the
     prepare; the Dependencies page offers a manual retry.
+
+    ``force`` is prepare's ``--force``, and it means repair, not currency: a
+    corrupted binary can still report the current version, so an explicit
+    ``vibe runtime prepare --force`` must reinstall rather than ask. Currency is
+    the default; repair stays available on request, exactly as it is for the
+    Show Runtime, tmux, and git phases.
     """
     if offline:
         return {"ok": True, "skipped": True, "reason": "offline"}
     if os.environ.get("VIBE_INSTALL_SKIP_ASKILL", "").strip().lower() in _TRUTHY_ENV_VALUES:
         return {"ok": True, "skipped": True, "reason": "VIBE_INSTALL_SKIP_ASKILL"}
     try:
+        if force:
+            return api.ensure_askill_installed(force=True)
         result = api.refresh_askill_if_stale()
     except Exception as exc:  # noqa: BLE001
         return {"ok": False, "message": str(exc)}
@@ -14404,18 +14413,22 @@ def _clean_git_runtime(*, keep_previous: int, dry_run: bool = False) -> dict:
         return {"ok": False, "removed": [], "message": str(exc)}
 
 
-def _ensure_avault_during_prepare(offline: bool = False) -> dict:
+def _ensure_avault_during_prepare(offline: bool = False, force: bool = False) -> dict:
     """Ensure avault (the Vault custody core) alongside other local deps.
 
     Raises avault to the managed pin on upgrade, but only downloads when the pin
     is not already satisfied: the reinstall it used to force on every prepare
-    took ~20s to put back the release that was already installed.
+    took ~20s to put back the release that was already installed. ``force`` is
+    prepare's ``--force`` repair request and still reinstalls the managed
+    release, since a corrupted binary can report the pinned version.
     """
     if offline:
         return {"ok": True, "skipped": True, "reason": "offline"}
     if os.environ.get("VIBE_INSTALL_SKIP_AVAULT", "").strip().lower() in _TRUTHY_ENV_VALUES:
         return {"ok": True, "skipped": True, "reason": "VIBE_INSTALL_SKIP_AVAULT"}
     try:
+        if force:
+            return api.ensure_avault_installed(force=True)
         return api.refresh_avault_if_stale()
     except Exception as exc:  # noqa: BLE001
         return {"ok": False, "message": str(exc)}

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -14337,6 +14337,10 @@ def _ensure_askill_during_prepare(offline: bool = False, force: bool = False) ->
     ``vibe runtime prepare --force`` must reinstall rather than ask. Currency is
     the default; repair stays available on request, exactly as it is for the
     Show Runtime, tmux, and git phases.
+
+    Only an explicit ``up_to_date`` verdict may report ready. Any other verdict
+    that installed nothing means currency was not established, not that it holds,
+    so prepare installs instead of claiming a fact it never checked.
     """
     if offline:
         return {"ok": True, "skipped": True, "reason": "offline"}
@@ -14346,21 +14350,35 @@ def _ensure_askill_during_prepare(offline: bool = False, force: bool = False) ->
         if force:
             return api.ensure_askill_installed(force=True)
         result = api.refresh_askill_if_stale()
+        if not (result.get("ok") and result.get("action") is None):
+            return result
+        if result.get("reason") != "up_to_date":
+            # The owner skipped without establishing currency — today that is
+            # ``latest_unavailable``, when the upstream version probe failed.
+            # Prepare is the chokepoint that must *make* the dependency current,
+            # so with no evidence either way it does what it did before this fast
+            # path existed and installs. The probe and the askill.sh installer
+            # are independent paths: a rate-limited or blipped version lookup
+            # says nothing about whether the install would succeed, and reporting
+            # ready off the back of it would claim currency we never checked.
+            # Only ``up_to_date`` may report ready, so a skip reason added later
+            # takes this branch rather than inheriting a false pass.
+            refreshed = api.ensure_askill_installed(force=True)
+            refreshed["action"] = "refresh_currency_unknown"
+            return refreshed
     except Exception as exc:  # noqa: BLE001
         return {"ok": False, "message": str(exc)}
-    if result.get("ok") and not result.get("action"):
-        # No install was attempted, so askill was already current. Report that as
-        # ready rather than skipped, so prepare's dependency lines read the same
-        # way as the pinned providers when nothing needed doing.
-        status = result.get("status") or {}
-        return {
-            "ok": True,
-            "installed": True,
-            "changed": False,
-            "path": status.get("path"),
-            "version": status.get("version"),
-        }
-    return result
+    # Already current, and the owner said so: report ready rather than skipped so
+    # prepare's dependency lines read the same way as the pinned providers when
+    # nothing needed doing.
+    status = result.get("status") or {}
+    return {
+        "ok": True,
+        "installed": True,
+        "changed": False,
+        "path": status.get("path"),
+        "version": status.get("version"),
+    }
 
 
 def _ensure_tmux_during_prepare(offline: bool = False, force: bool = False) -> dict:


### PR DESCRIPTION
## Changed capability

`vibe runtime prepare` no longer reinstalls managed local dependencies that are
already current. It stays the lifecycle chokepoint that keeps them current — it
just asks the question before paying for the answer.

Two of prepare's five phases were hardcoded to `force=True`:

| phase | before | after (plain `prepare`) | `prepare --force` |
| --- | --- | --- | --- |
| Show Runtime | fetch + reuse build (#1594) | unchanged | reinstall |
| askill | `ensure_askill_installed(force=True)` → `curl askill.sh \| sh` every time | install only when upstream is newer | reinstall |
| tmux | `force=False` (pinned) | unchanged | reinstall |
| git runtime | `force=False` (pinned) | unchanged | reinstall |
| avault | `ensure_avault_installed(force=True)` → reinstall pinned release every time | install only when the pin is unsatisfied | reinstall |

## Why `force` was the wrong verb

`force` collapses two different intents:

- **repair this binary** — `vibe doctor`'s `_repair_managed_dependency`, the
  Dependencies page install job. A reinstall is the whole point.
- **make sure it is current** — prepare, post-install, `vibe upgrade`.

Prepare wanted the second and was charged for the first. `ensure_avault_installed`
says so out loud in its own comment: "``force`` may still reinstall an equal or
older managed version to repair a binary."

So this PR does not widen `force`. It gives prepare the currency verb:

- `refresh_askill_if_stale()` — extracted from `reconcile_askill_auto_update()`,
  which already implemented exactly this decision for the update-checker cadence.
  Prepare was a second, more expensive implementation of the same concern. The
  cadence keeps its `VIBE_ASKILL_AUTO_UPDATE` gate in the wrapper; prepare stays
  ungated, exactly as before.
- `refresh_avault_if_stale()` — the same rule for the version-pinned sibling,
  answered locally against `AVAULT_VERSION`, so it costs no network at all.

`force` keeps its repair meaning at every other call site — including
`vibe runtime prepare --force`, which the parser advertises as "reinstall even
when the cached runtime matches" and which now reaches all five phases.

## The invariant this rests on

**The currency verb may never report a healthier state than the repair verb
would.** It may only skip a download that would change nothing. Round 1 of
review found two places where the first cut broke that, and a third the reviewer
had not reached; all three are members of that one class:

1. `prepare --force` stopped reaching askill and avault. A corrupted binary can
   still report the current version, so repair has to stay available on request.
2. avault currency asked the version alone. With the readiness floor raised ahead
   of the published pin, a binary equal to `AVAULT_VERSION` is still
   `upgrade_required` — and only the forced path surfaced that release gap. The
   question is now asked of the whole status.
3. `refresh_askill_if_stale` returned `latest_unavailable` before noticing a
   binary that cannot report its version, which gated the repair on the upstream
   probe answering. An unreadable binary is broken, not current, regardless of
   network reachability.

Round 2 found a fourth member, in the reporting layer rather than the decision:
prepare's wrapper keyed "already current" on the *absence* of an install, so a
`latest_unavailable` skip — currency unknown, because the upstream probe failed —
printed `askill ready.` off a check that never happened. The translation now keys
on the owner's explicit `up_to_date` verdict, and any other non-install verdict
installs, since prepare is the chokepoint whose job is to *make* the dependency
current. Two heads carrying one class tripped the circuit breaker, so the callers
were inventoried before editing: `refresh_askill_if_stale` has exactly two, and
prepare and the update-checker cadence need opposite policies for that verdict —
so the closure belongs at the verdict boundary, not in the shared owner.

### Round 3: the shape underneath all five

Round 3 flagged a fifth member — `askill --version` on a development build
answers `askill dev`, that last token is stored as the version, and
`_compare_versions("dev", "0.1.14")` returns False, which the branch labelled
`up_to_date`. Third findings-bearing head, same class, so the class was closed at
the property level instead of the branch.

The shape: **`up_to_date` was a fallthrough**, the default arm after a chain of
negative exits, and both version comparators return False for anything they
cannot parse — the same answer they give for "already newest". So every state we
could not judge arrived at "current": no local version (member 3), no upstream
version, and a version nobody can order.

One owner for the fact now:

- `_is_comparable_version()` decides whether a string can be ordered at all.
- `_compare_versions()` asks it before comparing, so "cannot tell" and "no
  update" stop sharing a return value.
- `askill_update_status()` reports `status: "unknown"` for an unorderable
  version, not only for a missing one — so the Dependencies page and prepare read
  one field instead of each re-deriving health from the raw string.
- `refresh_askill_if_stale()` keys the repair off that status, and requires an
  orderable `latest` before it will compare. `up_to_date` is now reachable only
  by having actually ordered two real versions.

avault has no member of this class: its check asks `_version_at_least()`, whose
conservative False means "not at the pin" and already routes to the install.

## Capability preserved

- askill still refreshes when upstream publishes a newer version, and still
  installs when missing.
- avault still rises to the managed pin on upgrade, and still refuses to
  downgrade a newer user/custom binary.
- `force=False` on avault only guarantees the *ready minimum*, not the pin, which
  is why prepare asks about `AVAULT_VERSION` rather than just calling
  `ensure_avault_installed()` with no argument.
- An already-current askill now reports `askill ready.` instead of
  `askill: skipped (up_to_date).`, matching how the pinned providers read when
  there is nothing to do.
- When the upstream version probe fails, prepare still installs, exactly as it
  did before this PR. The probe and the `askill.sh` installer are independent
  paths, so a rate-limited lookup is not evidence that the install would fail —
  and it is never evidence that the local binary is current.
- A development or otherwise unorderable askill build is repaired rather than
  reported ready, on both the plain and the forced path. This is the one place
  the PR is *stricter* than pre-PR behaviour on the update cadence too: the
  cadence used to leave such a binary alone forever.

## Evidence

**Unit** — `tests/test_local_deps.py`, `tests/test_show_pages.py`:
the currency owners do not reach the installer when current, do install when
stale or missing, `refresh_askill_if_stale` is deliberately not silenced by
`VIBE_ASKILL_AUTO_UPDATE=0`, and a prepare with everything current reaches
neither `install_askill` nor `install_avault` (the test stubs the *installers*,
not the decision, so it stays honest however the wrappers ask).

The invariant above is tested as a property rather than as a list of cases:
`refresh_avault_if_stale` is parametrized over install states (missing, older,
at the pin, newer, at the pin under a raised readiness floor) and asserted to
reach the same `ok` / `status` / `reason` as `ensure_avault_installed(force=True)`
while performing no more installs — so a readiness floor or release gap added
later is covered without editing the test. `prepare --force` is asserted over
whatever dependency phases were recorded, not over a list of names, so a phase
added later fails the test instead of silently ignoring the flag. The reporting
member is keyed the same way: a skip carrying a reason invented after the test
must still reach the installer, so a verdict added later inherits the safe branch
rather than a false pass. The round-3 closure is parametrized over the shapes a
version probe can produce that nothing can order — absent, empty, `dev`,
`unknown`, a git description, a partial number — on both sides of the comparison,
so a new unparsable answer inherits the repair rather than a false pass.

`tests/test_upgrade_flow.py` and `tests/test_version_identity.py` cover
`_compare_versions`'s other consumers and stay green: an unparsable input already
returned False through the inner parse, so the new predicate changes which
*callers* can read that False as health, not the comparison itself.

**Scenario** — local Incus, existing warm `master` environment, interleaved
`vibe runtime prepare --strict` from the same instance (old code = deployed
source, new code = same tree with these two files overlaid via `PYTHONPATH`):

```
before1   75s | askill installed. avault installed.
after1    15s | askill ready.     avault ready.
before2   68s | askill installed. avault installed.
after2     4s | askill ready.     avault ready.
before3   28s | askill installed. avault installed.
after3     5s | askill ready.     avault ready.
```

Per-phase, same warm process:

```
new  refresh_askill_if_stale         0.65s
new  refresh_avault_if_stale         0.22s
old  ensure_askill(force=True)      20.41s
old  ensure_avault(force=True)       4.75s
```

Service health verified after the runs: `avibe-regression` active (running),
internal server ready.

**Robustness, found while measuring** — one `force=True` control run hit a
transient DNS failure and reported `avault not ready: avault download failed
after 3 attempts`, on an instance whose pinned avault was healthy and installed.
Under the old behavior every prepare put a working dependency at the mercy of a
network blip; the new behavior does not make that request at all for avault,
whose currency is decided locally. For askill the decision needs one version
probe, and if that probe is the thing the blip breaks, prepare installs rather
than guessing.

**Pre-merge re-run on the deployed branch** (head `84cd9c0e`, synced into the
same local Incus `master` environment with the runner, service healthy
afterwards):

```
incus_regression.py up --target master   200.5s   end to end
vibe runtime prepare --strict             34.5s / 43.8s
vibe runtime prepare --force --strict    105.3s   askill/avault/tmux/git all reinstalled
```

The round-3 predicate was exercised against the deployed code: `dev`, `unknown`,
a git description and a partial number are all `_is_comparable_version() ==
False`, `askill_update_status()` reports `unknown` for them, and
`refresh_askill_if_stale()` answers `refresh_unknown_version` with a forced
install.

**One honest correction to the sentence this paragraph used to end with.** On
that environment the askill fast path never engaged: `api.github.com` answers
`403 rate limit exceeded` for the egress IP, so `latest_version` is `None`,
`refresh_askill_if_stale` returns `latest_unavailable`, and prepare installs —
correctly, by the rule above, but that phase saves nothing and now pays a probe
before paying the install. So in the probe-failing state this is a second or two
*worse* than before this PR, not "no worse"; avault, Show Runtime, tmux and git
still make the run roughly twice as fast overall (34-44s against a 28-75s
baseline).

The cause is not the rule, it is the cache: `_BACKEND_LATEST_CACHE` holds the
one-hour success TTL **in process memory**, and `vibe runtime prepare` is a
short-lived CLI process, so every invocation re-probes and spends from the
unauthenticated 60-requests-per-hour-per-IP budget until the probes start
failing. Persisting that cache across processes is a separate concern with its
own owner and is filed as follow-up work rather than widened into this PR.

## Known-by-design ledger

- **Prepare does not honour `VIBE_ASKILL_AUTO_UPDATE=0`.** Unchanged from before
  this PR: that variable gates the update-checker cadence, not the lifecycle
  chokepoint. Prepare calls `refresh_askill_if_stale()` directly rather than the
  gated `reconcile_askill_auto_update()` so the behaviour is identical to
  `ensure_askill_installed(force=True)` in that respect.
- ~~**`latest_unavailable` reports ready, not skipped.**~~ **Retired in
  f177813** — this was not by design, it was the fourth member of the class
  above. "I installed nothing" was being read as "it is current". Prepare now
  reports ready only for an explicit `up_to_date` verdict and installs when
  currency could not be established.
- **`_ensure_*_during_prepare` still swallow exceptions.** Pre-existing and
  intentional: a dependency hiccup must not fail the prepare, and the
  Dependencies page offers a manual retry.

## Dependencies

None. Follows #1594, which cut the Show Runtime rebuild inside the same command.

