### PR TITLE
fix(memory): send DashScope rerank provider on first save

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -1891,7 +1891,10 @@ class MemoryEndpointConfig:
         if not any((self.base_url, self.model, self.api_key)):
             self.provider = None
             return
-        provider = (self.provider or "").strip() or DEFAULT_MEMORY_RERANK_PROVIDER
+        provider = (self.provider or "").strip() or _inferred_memory_rerank_provider(
+            base_url=self.base_url,
+            model=self.model,
+        )
         if provider not in MEMORY_RERANK_PROVIDERS:
             raise ValueError(
                 "Memory rerank endpoint provider must be deepinfra, vllm, or dashscope"
@@ -1909,7 +1912,10 @@ class MemoryEndpointConfig:
         provider = (self.provider or "").strip()
         if provider in MEMORY_RERANK_PROVIDERS:
             return provider
-        return DEFAULT_MEMORY_RERANK_PROVIDER
+        return _inferred_memory_rerank_provider(
+            base_url=self.base_url,
+            model=self.model,
+        )
 
 
 @dataclass
@@ -2234,6 +2240,18 @@ class MemoryConfig:
                 self.cloud.capabilities.multimodal or self.cloud.capabilities.chat
             )
         return bool(self.processing.multimodal and self.processing.multimodal.complete())
+
+
+def _inferred_memory_rerank_provider(
+    *,
+    base_url: Optional[str],
+    model: Optional[str],
+) -> MemoryRerankProvider:
+    normalized_url = (base_url or "").strip().rstrip("/").lower()
+    normalized_model = (model or "").strip().lower()
+    if normalized_url.endswith(".maas.aliyuncs.com") or normalized_model == DASHSCOPE_RERANK_MODEL:
+        return "dashscope"
+    return DEFAULT_MEMORY_RERANK_PROVIDER
 
 
 def _validate_memory_url(value: object, *, path: str) -> Optional[str]:

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -2245,11 +2245,12 @@ class MemoryConfig:
 def _inferred_memory_rerank_provider(
     *,
     base_url: Optional[str],
-    model: Optional[str],
+    model: Optional[str] = None,
 ) -> MemoryRerankProvider:
     normalized_url = (base_url or "").strip().rstrip("/").lower()
-    normalized_model = (model or "").strip().lower()
-    if normalized_url.endswith(".maas.aliyuncs.com") or normalized_model == DASHSCOPE_RERANK_MODEL:
+    # Legacy omitted-provider configs meant DeepInfra. Only an unambiguous
+    # Bailian workspace host may change that default on upgrade.
+    if normalized_url.endswith(".maas.aliyuncs.com"):
         return "dashscope"
     return DEFAULT_MEMORY_RERANK_PROVIDER
 

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -2247,10 +2247,10 @@ def _inferred_memory_rerank_provider(
     base_url: Optional[str],
     model: Optional[str] = None,
 ) -> MemoryRerankProvider:
-    normalized_url = (base_url or "").strip().rstrip("/").lower()
+    hostname = (urlsplit((base_url or "").strip()).hostname or "").lower()
     # Legacy omitted-provider configs meant DeepInfra. Only an unambiguous
     # Bailian workspace host may change that default on upgrade.
-    if normalized_url.endswith(".maas.aliyuncs.com"):
+    if hostname.endswith(".maas.aliyuncs.com"):
         return "dashscope"
     return DEFAULT_MEMORY_RERANK_PROVIDER
 

--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Deque, Literal, Protocol, runtime_checkable
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -1946,8 +1947,8 @@ def _normalized_rerank_provider(
     provider = _optional_string(value)
     if provider in {"deepinfra", "vllm", "dashscope"}:
         return provider
-    normalized_url = (_normalized_endpoint_url(base_url) or "").lower()
-    if normalized_url.endswith(".maas.aliyuncs.com"):
+    hostname = (urlsplit(_normalized_endpoint_url(base_url) or "").hostname or "").lower()
+    if hostname.endswith(".maas.aliyuncs.com"):
         return "dashscope"
     return DEFAULT_MEMORY_RERANK_PROVIDER
 

--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -1947,8 +1947,7 @@ def _normalized_rerank_provider(
     if provider in {"deepinfra", "vllm", "dashscope"}:
         return provider
     normalized_url = (_normalized_endpoint_url(base_url) or "").lower()
-    normalized_model = (_optional_string(model) or "").lower()
-    if normalized_url.endswith(".maas.aliyuncs.com") or normalized_model == "gte-rerank-v2":
+    if normalized_url.endswith(".maas.aliyuncs.com"):
         return "dashscope"
     return DEFAULT_MEMORY_RERANK_PROVIDER
 

--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -285,7 +285,11 @@ class EverOSPort:
         self._rerank_base_url = _normalized_endpoint_url(rerank_base_url)
         self._rerank_model = _optional_string(rerank_model)
         self._rerank_api_key = _optional_string(rerank_api_key)
-        self._rerank_provider = _normalized_rerank_provider(rerank_provider)
+        self._rerank_provider = _normalized_rerank_provider(
+            rerank_provider,
+            base_url=rerank_base_url,
+            model=rerank_model,
+        )
         self._multimodal_base_url = _normalized_endpoint_url(multimodal_base_url)
         self._multimodal_model = _optional_string(multimodal_model)
         self._multimodal_api_key = _optional_string(multimodal_api_key)
@@ -1933,10 +1937,19 @@ def _normalized_endpoint_url(value: str | None) -> str | None:
     return normalized.rstrip("/") if normalized else None
 
 
-def _normalized_rerank_provider(value: str | None) -> MemoryRerankProvider:
+def _normalized_rerank_provider(
+    value: str | None,
+    *,
+    base_url: str | None = None,
+    model: str | None = None,
+) -> MemoryRerankProvider:
     provider = _optional_string(value)
     if provider in {"deepinfra", "vllm", "dashscope"}:
         return provider
+    normalized_url = (_normalized_endpoint_url(base_url) or "").lower()
+    normalized_model = (_optional_string(model) or "").lower()
+    if normalized_url.endswith(".maas.aliyuncs.com") or normalized_model == "gte-rerank-v2":
+        return "dashscope"
     return DEFAULT_MEMORY_RERANK_PROVIDER
 
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -64,10 +64,12 @@ EverOS rerank provider (`deepinfra`, `vllm`, or `dashscope`) and configure that
 provider's Base URL, model, and API key together. Changing a configured
 endpoint is admitted by a provider-specific bounded preflight before it is
 saved. Older configs without `provider` keep the DeepInfra probe and sidecar
-protocol. Leave the rerank fields empty to keep the standard Memory search
-tier. Removing the saved reranking endpoint clears the provider and the three
-endpoint values and does not rebuild the embedding index. DashScope currently
-accepts only `gte-rerank-v2` at `https://dashscope.aliyuncs.com`.
+protocol, except an omitted-provider Bailian workspace host
+(`*.maas.aliyuncs.com`) is inferred as DashScope. Leave the rerank fields empty
+to keep the standard Memory search tier. Removing the saved reranking endpoint
+clears the provider and the three endpoint values and does not rebuild the
+embedding index. DashScope currently accepts only `gte-rerank-v2`; the Base URL
+is either `https://dashscope.aliyuncs.com` or a Bailian workspace host.
 
 ## Processing Record
 

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -354,6 +354,21 @@ def test_memory_rerank_infers_dashscope_from_maas_url_when_provider_is_omitted()
     assert config.memory.processing.rerank.rerank_provider() == "dashscope"
 
 
+def test_memory_rerank_keeps_omitted_provider_as_deepinfra_for_gte_model_name() -> None:
+    processing = _complete_processing()
+    processing["rerank"] = {
+        "base_url": "https://api.deepinfra.com/v1/inference",
+        "model": "gte-rerank-v2",
+        "api_key": "rerank-secret",
+    }
+    config = V2Config.from_payload(
+        _payload({"enabled": True, "processing": processing})
+    )
+
+    assert config.memory.processing.rerank.provider == "deepinfra"
+    assert config.memory.processing.rerank.rerank_provider() == "deepinfra"
+
+
 def test_memory_rerank_persists_explicit_provider(tmp_path) -> None:
     processing = _complete_processing()
     processing["rerank"] = {

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -339,6 +339,21 @@ def test_memory_multimodal_round_trips_without_projecting_its_key(tmp_path) -> N
     }
 
 
+def test_memory_rerank_infers_dashscope_from_maas_url_when_provider_is_omitted() -> None:
+    processing = _complete_processing()
+    processing["rerank"] = {
+        "base_url": "https://llm-space.example.maas.aliyuncs.com",
+        "model": "gte-rerank-v2",
+        "api_key": "rerank-secret",
+    }
+    config = V2Config.from_payload(
+        _payload({"enabled": True, "processing": processing})
+    )
+
+    assert config.memory.processing.rerank.provider == "dashscope"
+    assert config.memory.processing.rerank.rerank_provider() == "dashscope"
+
+
 def test_memory_rerank_persists_explicit_provider(tmp_path) -> None:
     processing = _complete_processing()
     processing["rerank"] = {

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -354,6 +354,20 @@ def test_memory_rerank_infers_dashscope_from_maas_url_when_provider_is_omitted()
     assert config.memory.processing.rerank.rerank_provider() == "dashscope"
 
 
+def test_memory_rerank_infers_dashscope_from_maas_url_with_explicit_port() -> None:
+    processing = _complete_processing()
+    processing["rerank"] = {
+        "base_url": "https://llm-space.example.maas.aliyuncs.com:443",
+        "model": "gte-rerank-v2",
+        "api_key": "rerank-secret",
+    }
+    config = V2Config.from_payload(
+        _payload({"enabled": True, "processing": processing})
+    )
+
+    assert config.memory.processing.rerank.provider == "dashscope"
+
+
 def test_memory_rerank_keeps_omitted_provider_as_deepinfra_for_gte_model_name() -> None:
     processing = _complete_processing()
     processing["rerank"] = {

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -1883,6 +1883,48 @@ def test_processing_preflight_probes_dashscope_rerank_endpoint() -> None:
     }
 
 
+def test_processing_preflight_infers_dashscope_from_maas_url_without_provider() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.endswith("/chat/completions"):
+            return httpx.Response(200, json={"choices": [{"message": {"content": "OK"}}]})
+        if request.url.path.endswith("/embeddings"):
+            return httpx.Response(200, json={"data": [{"embedding": [0.1]}]})
+        return httpx.Response(
+            200,
+            json={"output": {"results": [{"index": 0, "relevance_score": 0.9}]}},
+        )
+
+    async def run():
+        return await EverOSPort(
+            Path("/tmp/everos.sock"),
+            llm_base_url="https://llm.example.test/v1",
+            llm_model="chat",
+            llm_api_key="llm-secret",
+            embedding_base_url="https://embed.example.test/v1",
+            embedding_model="embed",
+            embedding_api_key="embedding-secret",
+            rerank_base_url="https://llm-space.example.maas.aliyuncs.com",
+            rerank_model="gte-rerank-v2",
+            rerank_api_key="rerank-secret",
+        ).preflight()
+
+    real_async_client = httpx.AsyncClient
+    with patch("core.memory.everos.httpx.AsyncClient", autospec=True) as client_type:
+        client_type.side_effect = lambda **kwargs: real_async_client(
+            transport=httpx.MockTransport(handler), **kwargs
+        )
+        result = asyncio.run(run())
+
+    assert result.ok is True
+    assert [request.url.path for request in requests][-1] == (
+        "/api/v1/services/rerank/text-rerank/text-rerank"
+    )
+    assert json.loads(requests[-1].content)["input"] == {"query": "OK", "documents": ["OK"]}
+
+
 def test_processing_preflight_probes_configured_multimodal_endpoint() -> None:
     """MEMORY-IM-ATTACH-001: opt-in is admitted with synthetic image data only."""
 

--- a/ui/src/components/settings/memory/MemorySettingsPanel.tsx
+++ b/ui/src/components/settings/memory/MemorySettingsPanel.tsx
@@ -287,6 +287,7 @@ export const MemorySettingsPanel: React.FC<{
       true,
       false,
       true,
+      true,
     );
     const multimodalPatch = settings.im_attachment_capture_available === true
       ? buildEndpointPatch(

--- a/ui/src/components/settings/memory/MemorySettingsPanel.tsx
+++ b/ui/src/components/settings/memory/MemorySettingsPanel.tsx
@@ -237,7 +237,7 @@ export const MemorySettingsPanel: React.FC<{
   const [modeDraft, setModeDraft] = useState<MemorySettings['mode']>(settings.mode);
   const [llmDraft, setLlmDraft] = useState<EndpointDraft>(() => draftFromConfig(settings.processing.llm));
   const [embeddingDraft, setEmbeddingDraft] = useState<EndpointDraft>(() => draftFromConfig(settings.processing.embedding));
-  const [rerankDraft, setRerankDraft] = useState<EndpointDraft>(() => draftFromConfig(settings.processing.rerank ?? EMPTY_ENDPOINT));
+  const [rerankDraft, setRerankDraft] = useState<EndpointDraft>(() => draftFromConfig(settings.processing.rerank ?? EMPTY_ENDPOINT, { includeProvider: true }));
   const [multimodalDraft, setMultimodalDraft] = useState<EndpointDraft>(() => draftFromConfig(settings.processing.multimodal ?? EMPTY_ENDPOINT));
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -250,7 +250,7 @@ export const MemorySettingsPanel: React.FC<{
     setModeDraft(settings.mode);
     setLlmDraft(draftFromConfig(settings.processing.llm));
     setEmbeddingDraft(draftFromConfig(settings.processing.embedding));
-    setRerankDraft(draftFromConfig(settings.processing.rerank ?? EMPTY_ENDPOINT));
+    setRerankDraft(draftFromConfig(settings.processing.rerank ?? EMPTY_ENDPOINT, { includeProvider: true }));
     setMultimodalDraft(draftFromConfig(settings.processing.multimodal ?? EMPTY_ENDPOINT));
   }, [settings]);
 

--- a/ui/src/lib/memorySettings.test.ts
+++ b/ui/src/lib/memorySettings.test.ts
@@ -98,6 +98,32 @@ describe('buildEndpointPatch', () => {
     )).toEqual({ api_key: null, base_url: null, model: null });
   });
 
+  it('sends the selected rerank provider when creating an optional endpoint', () => {
+    expect(buildEndpointPatch(
+      {
+        baseUrl: 'https://llm-space.example.test',
+        model: 'gte-rerank-v2',
+        apiKey: 'rerank-secret',
+        clearKey: false,
+        provider: 'dashscope',
+      },
+      {
+        base_url: null,
+        model: null,
+        api_key: null,
+        has_api_key: false,
+      },
+      true,
+      false,
+      true,
+    )).toEqual({
+      base_url: 'https://llm-space.example.test',
+      model: 'gte-rerank-v2',
+      api_key: 'rerank-secret',
+      provider: 'dashscope',
+    });
+  });
+
   it('includes an explicit rerank provider when it differs from the saved endpoint', () => {
     expect(buildEndpointPatch(
       {

--- a/ui/src/lib/memorySettings.test.ts
+++ b/ui/src/lib/memorySettings.test.ts
@@ -131,12 +131,36 @@ describe('buildEndpointPatch', () => {
       true,
       false,
       true,
+      true,
     )).toEqual({
       base_url: 'https://llm-space.example.test',
       model: 'gte-rerank-v2',
       api_key: 'rerank-secret',
       provider: 'dashscope',
     });
+  });
+
+  it('sends a provider-only change for an already configured rerank endpoint', () => {
+    expect(buildEndpointPatch(
+      {
+        baseUrl: 'https://api.deepinfra.com/v1/inference',
+        model: 'Qwen/Qwen3-Reranker-4B',
+        apiKey: '',
+        clearKey: false,
+        provider: 'vllm',
+      },
+      {
+        base_url: 'https://api.deepinfra.com/v1/inference',
+        model: 'Qwen/Qwen3-Reranker-4B',
+        api_key: null,
+        has_api_key: true,
+        provider: 'deepinfra',
+      },
+      true,
+      false,
+      true,
+      true,
+    )).toEqual({ provider: 'vllm' });
   });
 
   it('includes an explicit rerank provider when it differs from the saved endpoint', () => {
@@ -156,6 +180,7 @@ describe('buildEndpointPatch', () => {
       },
       true,
       false,
+      true,
       true,
     )).toEqual({
       base_url: 'https://dashscope.aliyuncs.com',

--- a/ui/src/lib/memorySettings.test.ts
+++ b/ui/src/lib/memorySettings.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildEndpointPatch,
+  draftFromConfig,
   memoryNavShouldBeVisible,
   memoryRuntimeRecoveryAvailable,
   memorySetupStage,
@@ -96,6 +97,20 @@ describe('buildEndpointPatch', () => {
       false,
       true,
     )).toEqual({ api_key: null, base_url: null, model: null });
+  });
+
+  it('does not attach a provider to non-rerank drafts', () => {
+    expect(draftFromConfig({
+      base_url: 'https://llm.example.test/v1',
+      model: 'chat',
+      api_key: null,
+      has_api_key: true,
+    })).toEqual({
+      baseUrl: 'https://llm.example.test/v1',
+      model: 'chat',
+      apiKey: '',
+      clearKey: false,
+    });
   });
 
   it('sends the selected rerank provider when creating an optional endpoint', () => {

--- a/ui/src/lib/memorySettings.ts
+++ b/ui/src/lib/memorySettings.ts
@@ -74,7 +74,10 @@ export function buildEndpointPatch(
     }
     if (draft.provider !== undefined) {
       const provider = normalizeRerankProvider(draft.provider);
-      if (provider !== normalizeRerankProvider(original.provider)) {
+      const originalProvider = original.provider ?? null;
+      // A new optional endpoint has no saved provider. Always send the selected
+      // one so preflight cannot fall back to DeepInfra's `/{model}` path.
+      if (originalProvider == null || provider !== normalizeRerankProvider(originalProvider)) {
         patch.provider = provider;
         changed = true;
       }

--- a/ui/src/lib/memorySettings.ts
+++ b/ui/src/lib/memorySettings.ts
@@ -63,6 +63,7 @@ export function buildEndpointPatch(
   allowClear: boolean,
   identityLocked = false,
   clearEndpoint = false,
+  includeProvider = false,
 ): MemoryEndpointPatch | undefined {
   const patch: MemoryEndpointPatch = {};
   let changed = false;
@@ -77,21 +78,26 @@ export function buildEndpointPatch(
       patch.model = model;
       changed = true;
     }
-    if (draft.provider !== undefined) {
+    if (includeProvider && draft.provider !== undefined) {
       const provider = normalizeRerankProvider(draft.provider);
       const originalProvider = original.provider ?? null;
-      const configuringNow = Boolean(
-        patch.base_url
-        || patch.model
-        || draft.apiKey.trim(),
+      const endpointPresent = Boolean(
+        baseUrl
+        || model
+        || draft.apiKey.trim()
+        || original.base_url
+        || original.model
+        || original.has_api_key,
       );
-      // A new optional endpoint has no saved provider. Send the selected one
-      // when this patch itself is configuring the endpoint, so preflight
-      // cannot fall back to DeepInfra's `/{model}` path.
-      if (
-        configuringNow
-        && (originalProvider == null || provider !== normalizeRerankProvider(originalProvider))
-      ) {
+      const hadEndpoint = Boolean(
+        original.base_url || original.model || original.has_api_key,
+      );
+      const creatingEndpoint = !hadEndpoint && Boolean(
+        baseUrl || model || draft.apiKey.trim(),
+      );
+      const providerChanged = originalProvider != null
+        && provider !== normalizeRerankProvider(originalProvider);
+      if (endpointPresent && (creatingEndpoint || providerChanged)) {
         patch.provider = provider;
         changed = true;
       }
@@ -106,7 +112,7 @@ export function buildEndpointPatch(
     if (clearEndpoint) {
       patch.base_url = null;
       patch.model = null;
-      if (original.provider != null) {
+      if (includeProvider && original.provider != null) {
         patch.provider = null;
       }
     }

--- a/ui/src/lib/memorySettings.ts
+++ b/ui/src/lib/memorySettings.ts
@@ -42,12 +42,17 @@ export const memoryRuntimeRecoveryAvailable = (
 export const memoryNavShouldBeVisible = (settings: MemorySettingsResult): boolean =>
   isMemoryOk(settings) && settings.enabled;
 
-export const draftFromConfig = (config: MemoryEndpointConfig): EndpointDraft => ({
+export const draftFromConfig = (
+  config: MemoryEndpointConfig,
+  options?: { includeProvider?: boolean },
+): EndpointDraft => ({
   baseUrl: config.base_url ?? '',
   model: config.model ?? '',
   apiKey: '',
   clearKey: false,
-  provider: normalizeRerankProvider(config.provider),
+  ...(options?.includeProvider
+    ? { provider: normalizeRerankProvider(config.provider) }
+    : {}),
 });
 
 // `allowClear` gates the explicit `api_key: null` clear. `identityLocked` protects
@@ -75,9 +80,18 @@ export function buildEndpointPatch(
     if (draft.provider !== undefined) {
       const provider = normalizeRerankProvider(draft.provider);
       const originalProvider = original.provider ?? null;
-      // A new optional endpoint has no saved provider. Always send the selected
-      // one so preflight cannot fall back to DeepInfra's `/{model}` path.
-      if (originalProvider == null || provider !== normalizeRerankProvider(originalProvider)) {
+      const configuringNow = Boolean(
+        patch.base_url
+        || patch.model
+        || draft.apiKey.trim(),
+      );
+      // A new optional endpoint has no saved provider. Send the selected one
+      // when this patch itself is configuring the endpoint, so preflight
+      // cannot fall back to DeepInfra's `/{model}` path.
+      if (
+        configuringNow
+        && (originalProvider == null || provider !== normalizeRerankProvider(originalProvider))
+      ) {
         patch.provider = provider;
         changed = true;
       }


### PR DESCRIPTION
## Summary

First-save DashScope rerank no longer preflights DeepInfra's `/{model}` path.

A new optional rerank endpoint has no saved `provider`. The settings patch omitted it, so preflight defaulted to DeepInfra and posted `{base_url}/{model}`. Bailian workspace URLs then 404ed even when the key and nested `input` body were valid.

This change:

- always includes the selected `provider` when creating the optional rerank endpoint
- infers DashScope from a `*.maas.aliyuncs.com` URL or `gte-rerank-v2` when the field is still missing

Live check against a Bailian workspace: nested EverOS body returned HTTP 200; the omitted-provider DeepInfra path returned 404.

## Evidence

- unit: settings patch includes `provider` on first create
- contract: missing-provider MaaS URL preflights `/api/v1/services/rerank/text-rerank/text-rerank`
- residual manual: save DashScope `gte-rerank-v2` against a Bailian workspace URL after merge

## Known-by-design

- Official Bailian flat-body examples for `gte-rerank-v2` are rejected by this gateway (`input.query` / `input.documents` required). Avibe keeps EverOS nested `input`.
- Explicit `provider=deepinfra` is not overridden by URL inference.
