### PR TITLE
fix(auth): personal editors use local resources (binding rewrite)

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -3644,6 +3644,7 @@ class V2Config:
         cls,
         config_path: Optional[Path] = None,
         *,
+        persist_migrations: bool = True,
         _migration_reload_depth: int = 0,
     ) -> "V2Config":
         paths.ensure_data_dirs()
@@ -3713,7 +3714,12 @@ class V2Config:
                 recovery_warnings.append(f"Recovered invalid config section '{recovered}': {exc}")
 
         all_warnings = tuple(dict.fromkeys((*migration_warnings, *recovery_warnings)))
-        if migrated and not migration_warnings and not recovery_warnings:
+        if (
+            persist_migrations
+            and migrated
+            and not migration_warnings
+            and not recovery_warnings
+        ):
             persisted_payload = copy.deepcopy(payload)
             persisted_payload["model_hub"] = config.model_hub.to_payload()
             try:

--- a/core/web_push_notifications.py
+++ b/core/web_push_notifications.py
@@ -110,13 +110,11 @@ def _notification_policy_for_record(config: Any, record: Mapping[str, Any]) -> s
     cloud = getattr(getattr(config, "remote_access", None), "vibe_cloud", None)
     instance_kind = str(getattr(cloud, "instance_kind", "") or "")
     if instance_kind in {"personal", "organization"}:
-        from storage import remote_access_authorization_service
+        # C3: the consumer gate (which bootstraps a validated durable binding
+        # on the upgrade path), never a raw config read.
+        from vibe import remote_access
 
-        if not remote_access_authorization_service.binding_is_ready_for_pairing(
-            instance_id=str(getattr(cloud, "instance_id", "") or ""),
-            instance_kind=instance_kind,
-            ensure=False,
-        ):
+        if not remote_access.binding_is_ready(config):
             instance_kind = ""
     if instance_kind == "organization":
         return "organization"
@@ -241,13 +239,11 @@ def _evaluate_record_authorization(
         )
     paired_kind = str(getattr(cloud, "instance_kind", "") or "") if cloud is not None else ""
     if paired_kind in {"personal", "organization"}:
-        from storage import remote_access_authorization_service
+        # C3: the consumer gate (which bootstraps a validated durable binding
+        # on the upgrade path), never a raw config read.
+        from vibe import remote_access
 
-        if not remote_access_authorization_service.binding_is_ready_for_pairing(
-            instance_id=_paired_instance_id(config),
-            instance_kind=paired_kind,
-            ensure=False,
-        ):
+        if not remote_access.binding_is_ready(config):
             return OwnerAuthorizationDecision(
                 user_key=user_key,
                 policy=policy,

--- a/core/web_push_notifications.py
+++ b/core/web_push_notifications.py
@@ -300,6 +300,18 @@ def _evaluate_record_authorization(
             reason="persisted snapshot was issued for a different paired instance",
         )
     record_kind = record.get("vibe_instance_kind")
+    if record_kind is not None and record_kind not in {"personal", "organization"}:
+        # A present-but-unrecognized kind is corruption or a future version,
+        # never a no-kind legacy snapshot. Fail closed instead of falling
+        # through to the currently-paired Personal policy.
+        return OwnerAuthorizationDecision(
+            user_key=user_key,
+            policy=policy,
+            context=None,
+            authorized=False,
+            disposition=WEB_PUSH_DISPOSITION_REVOKED,
+            reason="persisted snapshot instance kind is unrecognized",
+        )
     if (
         record_kind in {"personal", "organization"}
         and paired_kind not in {"personal", "organization"}

--- a/core/web_push_notifications.py
+++ b/core/web_push_notifications.py
@@ -97,7 +97,46 @@ def _load_notification_config() -> tuple[Any, bool]:
         return None, True
 
 
-def _notification_policy_for_record(config: Any, record: Mapping[str, Any]) -> str:
+def _binding_snapshot(config: Any) -> tuple[bool, str, int]:
+    """One evaluation, one snapshot of (ready, kind, generation).
+
+    Policy selection and the later gate MUST use this same snapshot. Mixing
+    a reconciling-inferred Personal policy with a later-ready Organization
+    binding is the class this closes.
+    """
+
+    from vibe import remote_access
+    from storage import remote_access_authorization_service
+
+    cloud = getattr(getattr(config, "remote_access", None), "vibe_cloud", None)
+    kind = str(getattr(cloud, "instance_kind", "") or "") if cloud is not None else ""
+    try:
+        generation = remote_access_authorization_service.current_instance_binding_generation(
+            ensure=False
+        )
+    except Exception:
+        generation = 0
+    ready = False
+    if kind in {"personal", "organization"} and config is not None:
+        try:
+            ready = bool(remote_access.binding_is_ready(config))
+        except Exception:
+            ready = False
+    if not ready:
+        # A known configured kind that is not ready (reconciling / pending /
+        # mismatched) must not leak into policy selection as if it were live.
+        # Mixing a reconciling-inferred Personal policy with a later-ready
+        # Organization binding is the class this snapshot closes.
+        kind = ""
+    return ready, kind, int(generation)
+
+
+def _notification_policy_for_record(
+    config: Any,
+    record: Mapping[str, Any],
+    *,
+    snapshot_kind: str = "",
+) -> str:
     """Select the notification authorization policy for one persisted record.
 
     Policy selection follows the paired Instance kind (#1433): Personal and
@@ -105,17 +144,12 @@ def _notification_policy_for_record(config: Any, record: Mapping[str, Any]) -> s
     pairings with an unknown kind fall back to the record's own claim shape —
     claims issued through Organization membership follow the Organization
     policy, everything else follows the Personal policy.
+
+    ``snapshot_kind`` is the kind captured once for this evaluation; do not
+    re-read the live binding here.
     """
 
-    cloud = getattr(getattr(config, "remote_access", None), "vibe_cloud", None)
-    instance_kind = str(getattr(cloud, "instance_kind", "") or "")
-    if instance_kind in {"personal", "organization"}:
-        # C3: the consumer gate (which bootstraps a validated durable binding
-        # on the upgrade path), never a raw config read.
-        from vibe import remote_access
-
-        if not remote_access.binding_is_ready(config):
-            instance_kind = ""
+    instance_kind = snapshot_kind
     if instance_kind == "organization":
         return "organization"
     if instance_kind == "personal":
@@ -195,8 +229,12 @@ def _evaluate_record_authorization(
     """
 
     from vibe import remote_access
+    from storage import remote_access_authorization_service
 
-    policy = _notification_policy_for_record(config, record)
+    snapshot_ready, snapshot_kind, snapshot_generation = _binding_snapshot(config)
+    policy = _notification_policy_for_record(
+        config, record, snapshot_kind=snapshot_kind
+    )
     if config is None:
         reason = (
             "paired configuration could not be read; instance binding cannot be validated"
@@ -237,21 +275,53 @@ def _evaluate_record_authorization(
             disposition=WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE,
             reason="paired configuration could not be read; instance binding cannot be validated",
         )
-    paired_kind = str(getattr(cloud, "instance_kind", "") or "") if cloud is not None else ""
-    if paired_kind in {"personal", "organization"}:
-        # C3: the consumer gate (which bootstraps a validated durable binding
-        # on the upgrade path), never a raw config read.
-        from vibe import remote_access
+    from vibe.authorization import instance_kind_is_unsupported
 
-        if not remote_access.binding_is_ready(config):
-            return OwnerAuthorizationDecision(
-                user_key=user_key,
-                policy=policy,
-                context=None,
-                authorized=False,
-                disposition=WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE,
-                reason="durable instance binding is not ready",
-            )
+    record_kind = record.get("vibe_instance_kind")
+    if instance_kind_is_unsupported(record_kind):
+        return OwnerAuthorizationDecision(
+            user_key=user_key,
+            policy=policy,
+            context=None,
+            authorized=False,
+            disposition=WEB_PUSH_DISPOSITION_REVOKED,
+            reason="persisted snapshot instance kind is unrecognized",
+        )
+    paired_kind = snapshot_kind
+    try:
+        live_generation = remote_access_authorization_service.current_instance_binding_generation(
+            ensure=False
+        )
+    except Exception:
+        live_generation = snapshot_generation
+    configured_kind = str(getattr(cloud, "instance_kind", "") or "") if cloud is not None else ""
+    generation_moved = int(live_generation) != int(snapshot_generation)
+    if configured_kind in {"personal", "organization"} and not snapshot_ready:
+        return OwnerAuthorizationDecision(
+            user_key=user_key,
+            policy=policy,
+            context=None,
+            authorized=False,
+            disposition=WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE,
+            reason="durable instance binding is not ready",
+        )
+    if (
+        configured_kind in {"personal", "organization"}
+        and snapshot_ready
+        and generation_moved
+        and int(snapshot_generation) > 0
+    ):
+        # The binding advanced under us after we captured a real (non-zero)
+        # generation. Mixing the original policy with the new binding is the
+        # class this snapshot closes. Generation 0 → N is bootstrap, not TOCTOU.
+        return OwnerAuthorizationDecision(
+            user_key=user_key,
+            policy=policy,
+            context=None,
+            authorized=False,
+            disposition=WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE,
+            reason="durable instance binding is not ready",
+        )
     if (
         paired_kind in {"personal", "organization"}
         and cloud is not None
@@ -299,21 +369,7 @@ def _evaluate_record_authorization(
             disposition=WEB_PUSH_DISPOSITION_REVOKED,
             reason="persisted snapshot was issued for a different paired instance",
         )
-    from vibe.authorization import instance_kind_is_unsupported
-
     record_kind = record.get("vibe_instance_kind")
-    if instance_kind_is_unsupported(record_kind):
-        # A present-but-unrecognized kind is corruption or a future version,
-        # never a no-kind legacy snapshot. Fail closed instead of falling
-        # through to the currently-paired Personal policy.
-        return OwnerAuthorizationDecision(
-            user_key=user_key,
-            policy=policy,
-            context=None,
-            authorized=False,
-            disposition=WEB_PUSH_DISPOSITION_REVOKED,
-            reason="persisted snapshot instance kind is unrecognized",
-        )
     if (
         record_kind in {"personal", "organization"}
         and paired_kind not in {"personal", "organization"}
@@ -447,11 +503,17 @@ def _resolve_owner_authorization_decisions(
     if not records:
         return {}
     config, config_load_failed = _load_notification_config()
+    snapshot_ready, snapshot_kind, _snapshot_generation = (
+        _binding_snapshot(config) if config is not None else (False, "", 0)
+    )
     if (
         allow_sync_retry
         and not config_load_failed
         and any(
-            _notification_policy_for_record(config, record) == "organization"
+            _notification_policy_for_record(
+                config, record, snapshot_kind=snapshot_kind
+            )
+            == "organization"
             for _user_key, record in records
         )
     ):

--- a/core/web_push_notifications.py
+++ b/core/web_push_notifications.py
@@ -299,8 +299,10 @@ def _evaluate_record_authorization(
             disposition=WEB_PUSH_DISPOSITION_REVOKED,
             reason="persisted snapshot was issued for a different paired instance",
         )
+    from vibe.authorization import instance_kind_is_unsupported
+
     record_kind = record.get("vibe_instance_kind")
-    if record_kind is not None and record_kind not in {"personal", "organization"}:
+    if instance_kind_is_unsupported(record_kind):
         # A present-but-unrecognized kind is corruption or a future version,
         # never a no-kind legacy snapshot. Fail closed instead of falling
         # through to the currently-paired Personal policy.

--- a/core/web_push_notifications.py
+++ b/core/web_push_notifications.py
@@ -7,7 +7,7 @@ import json
 import logging
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import Any, Mapping
 
@@ -109,6 +109,15 @@ def _notification_policy_for_record(config: Any, record: Mapping[str, Any]) -> s
 
     cloud = getattr(getattr(config, "remote_access", None), "vibe_cloud", None)
     instance_kind = str(getattr(cloud, "instance_kind", "") or "")
+    if instance_kind in {"personal", "organization"}:
+        from storage import remote_access_authorization_service
+
+        if not remote_access_authorization_service.binding_is_ready_for_pairing(
+            instance_id=str(getattr(cloud, "instance_id", "") or ""),
+            instance_kind=instance_kind,
+            ensure=False,
+        ):
+            instance_kind = ""
     if instance_kind == "organization":
         return "organization"
     if instance_kind == "personal":
@@ -190,6 +199,20 @@ def _evaluate_record_authorization(
     from vibe import remote_access
 
     policy = _notification_policy_for_record(config, record)
+    if config is None:
+        reason = (
+            "paired configuration could not be read; instance binding cannot be validated"
+            if config_load_failed
+            else "paired configuration is unavailable; instance binding cannot be validated"
+        )
+        return OwnerAuthorizationDecision(
+            user_key=user_key,
+            policy=policy,
+            context=None,
+            authorized=False,
+            disposition=WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE,
+            reason=reason,
+        )
     cloud = getattr(getattr(config, "remote_access", None), "vibe_cloud", None)
     if cloud is not None and not cloud.enabled:
         # Disabling remote access is a confirmed, deliberate removal of every
@@ -215,6 +238,36 @@ def _evaluate_record_authorization(
             authorized=False,
             disposition=WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE,
             reason="paired configuration could not be read; instance binding cannot be validated",
+        )
+    paired_kind = str(getattr(cloud, "instance_kind", "") or "") if cloud is not None else ""
+    if paired_kind in {"personal", "organization"}:
+        from storage import remote_access_authorization_service
+
+        if not remote_access_authorization_service.binding_is_ready_for_pairing(
+            instance_id=_paired_instance_id(config),
+            instance_kind=paired_kind,
+            ensure=False,
+        ):
+            return OwnerAuthorizationDecision(
+                user_key=user_key,
+                policy=policy,
+                context=None,
+                authorized=False,
+                disposition=WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE,
+                reason="durable instance binding is not ready",
+            )
+    if (
+        paired_kind in {"personal", "organization"}
+        and cloud is not None
+        and cloud.runtime_credentials() is None
+    ):
+        return OwnerAuthorizationDecision(
+            user_key=user_key,
+            policy=policy,
+            context=None,
+            authorized=False,
+            disposition=WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE,
+            reason="current pairing lacks complete runtime credentials",
         )
     context = context_from_session_payload(record)
     if not (
@@ -250,6 +303,48 @@ def _evaluate_record_authorization(
             disposition=WEB_PUSH_DISPOSITION_REVOKED,
             reason="persisted snapshot was issued for a different paired instance",
         )
+    record_kind = record.get("vibe_instance_kind")
+    if (
+        record_kind in {"personal", "organization"}
+        and paired_kind not in {"personal", "organization"}
+    ):
+        return OwnerAuthorizationDecision(
+            user_key=user_key,
+            policy=policy,
+            context=None,
+            authorized=False,
+            disposition=WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE,
+            reason="current pairing instance kind is unavailable",
+        )
+    if (
+        record_kind in {"personal", "organization"}
+        and paired_kind in {"personal", "organization"}
+        and record_kind != paired_kind
+    ):
+        return OwnerAuthorizationDecision(
+            user_key=user_key,
+            policy=policy,
+            context=None,
+            authorized=False,
+            disposition=WEB_PUSH_DISPOSITION_REVOKED,
+            reason="persisted snapshot instance kind differs from the current pairing",
+        )
+    if (
+        context.instance_kind is None
+        and record_kind is None
+        and paired_instance_id
+        and paired_kind in {"personal", "organization"}
+    ):
+        if record_instance_id != paired_instance_id:
+            return OwnerAuthorizationDecision(
+                user_key=user_key,
+                policy=policy,
+                context=None,
+                authorized=False,
+                disposition=WEB_PUSH_DISPOSITION_REVOKED,
+                reason="persisted snapshot lacks a binding to the current paired instance",
+            )
+        context = replace(context, instance_kind=paired_kind)
     if policy == "personal":
         return OwnerAuthorizationDecision(
             user_key=user_key,
@@ -626,6 +721,7 @@ def web_push_authorization_context_record(
         "sub": context.subject,
         "vibe_instance_role": context.instance_role,
         "vibe_instance_access_source": context.instance_access_source,
+        "vibe_instance_kind": context.instance_kind,
         "vibe_group_ids": sorted(context.group_ids),
         "claims_issued_at": context.claims_issued_at,
     }

--- a/docs/plans/personal-editor-local-resources.md
+++ b/docs/plans/personal-editor-local-resources.md
@@ -1,0 +1,119 @@
+# Spec: Personal Editor local-resource access — binding state machine rewrite
+
+Status: APPROVED (owner signed off D1/D2 defaults + D3 naming). Supersedes closed PR #1562.
+Branch: `personal-editor-local-resources`
+PR title: `fix(auth): personal editors use local resources (binding rewrite)`
+
+## 1. Background — why we're rewriting
+
+PR #1562 added the first cross-process authorization signal (`instance_kind`) but never
+wrote down the concurrency model for it. Five bot-review rounds later the thread count went
+7 → 9 → 11 → 15 → 19: every patch inlined a partial answer, and the last two rounds produced
+self-inflicted regressions (a gate that permanently locks out legacy no-kind pairings; a lock
+acquired before SQLite init that creates an ABBA deadlock).
+
+Root cause (one sentence): **durable binding state was added, but "who is the single writer,
+what is the lock order, and which writes must be generation-fenced" was never defined as a
+contract — so transient state keeps getting latched into permanent decisions across two
+processes (controller + ui_server).**
+
+Correct parts of the current work ARE kept (see §4). Only the binding state machine + the
+authorization fencing is rewritten.
+
+## 2. Goal
+
+A Personal Editor gets full Agent/Project access on a Personal instance, independent of
+Organization ACLs; Organization + unknown kinds stay fail-closed. This must hold:
+- across the two-process boundary (controller / ui_server), and
+- through every transient state (credentials temporarily missing, kind not yet backfilled,
+  kind being reclassified by heartbeat, fresh install with no config, legacy no-kind pairing).
+
+## 3. The three contracts (approved by owner)
+
+### C1 — Single source of truth
+A durable binding = `(instance_id, kind, generation)`, persisted in `state_meta`.
+- Only a binding in `ready` state may admit the kind-specific (Personal) bypass.
+- `reconciling` / `unpaired` / `unavailable` states FAIL CLOSED (no bypass).
+- Kind is authoritative mutable provenance: unknown ≠ Personal ≠ Organization; a kind
+  backfill or reclassification must go through a transition, never be silently relabeled.
+
+### C2 — One writer + canonical lock order + generation CAS
+- `generation` is monotonic and durable; every write (config, binding, authorization rows)
+  does compare-and-swap: read the persisted generation inside the critical section
+  immediately before writing; refuse if it no longer matches.
+- Canonical lock order: **SQLite initialization FIRST, then the cross-process config lock**
+  (`config_file_lock`, NOT the process-local `CONFIG_LOCK`). Never acquire config lock while
+  `ensure_sqlite_state()` / `migration.lock` may be needed — this kills the ABBA deadlock.
+- The whole read-generation → compare → config-write → transition is ONE cross-process
+  critical section.
+
+### C3 — One gate for every consumer
+A single predicate `binding_is_ready(config, identity)` gates ALL authorization reads and
+writes before they touch instance-kind logic:
+1. interactive refresh (`_fetch_authorization_context`),
+2. non-interactive metadata (`resource_user_context_from_metadata`),
+3. Web Push authorization,
+4. OAuth callback writes,
+5. legacy inline-cookie migration writes.
+No consumer reads `config.instance_kind` directly to make an authorization decision.
+
+## 4. Scope — carried over vs rewritten
+
+### Carried over verbatim (correct, concurrency-independent — do NOT rework)
+- deferred-context migration + snapshot/provenance logic (`storage/resource_access_service.py`):
+  the typed UNAVAILABLE/UNPAIRED/PARTIAL/READY reader, migration state machine, old-marker
+  compatibility, sealed_unattributed.
+- the 435 passing tests (they are the executable spec of all known invariants).
+
+### Rewritten (the module that keeps leaking)
+`vibe/remote_access.py` binding machinery + every authorization write/read gate:
+- `_transition_instance_binding` → single cross-process critical section (C2),
+- `_AUTHORIZATION_BINDING_EPOCH` (process-local) → removed in favor of durable generation (C1/C2),
+- `_durable_binding_allows_cached_authorization` → replaced by the single `binding_is_ready` gate (C3),
+- `pair()` ordering: provenance validated BEFORE one-time-key redeem (fail without redeem on
+  unavailable provenance; treat **absent config as authoritative `unpaired`, not `UNAVAILABLE`**),
+- `_fetch_authorization_context` + `_store_scoped_authorization` + revocation/denied path →
+  all writes generation-fenced, including the 403 path (C3),
+- non-interactive + Web Push + OAuth callback + legacy cookie paths → route through the gate (C3),
+- legacy no-kind pairing stays usable (fail-open for the legacy path, not permanently locked out).
+
+## 5. Files
+
+- `vibe/remote_access.py` — binding state machine, transition hook, all gated write/read sites.
+- `storage/remote_access_authorization_service.py` — durable generation storage + targeted
+  invalidation/revocation (keep the `show_page` exemption contract).
+- `storage/resource_access_service.py` — carried over, only touch if a gate needs the typed
+  reader's result.
+- `config/v2_config.py` — confirm `config_file_lock` is the single cross-process lock (no change
+  expected; do not add locks).
+
+## 6. Tests
+
+Carried: all 435. New (each maps to a regression this PR actually hit):
+1. legacy/invalid no-kind pairing stays usable (round-5 #1) — fail-open for legacy, not locked out.
+2. fresh install with NO config → authoritative `unpaired`, pair() redeems successfully (round-5 #4).
+3. lock order: binding transition does NOT acquire config lock before SQLite init (round-5 #2).
+4. reconciling window: an OAuth-callback / legacy-cookie write is generation-fenced and cannot
+   publish stale Editor claims under the new Personal kind (round-5 #3).
+5. stale 403/revocation is fenced by generation (round-4 #4).
+6. cross-process CAS: a stale writer cannot reverse a newer binding (round-4 #1, #2).
+7. non-interactive + Web Push consumers return no Personal bypass while `reconciling`.
+
+## 7. Delivery plan
+
+1. (this doc) — owner approves.
+2. New branch off latest `origin/master` (`84702f73`), fresh worktree (NOT the old #1562 worktree).
+3. Carry over §4 "kept" code + 435 tests; rewrite §4 "rewritten" module per C1–C3.
+4. Open a NEW PR (correct scope + evidence numbers); commit this spec to `docs/plans/`.
+5. Close PR #1562 with a comment pointing to the new PR.
+6. Re-point the durable watch from #1562 to the new PR; retire #1562's watch.
+
+## 8. Open owner decisions (need your call before/at implementation)
+
+- D1: keep the three prior decisions? (a) Org↔Personal reclassification keeps completed legacy
+  authorizations REJECTED; (b) exact `show_page_email` grants survive kind transitions; (c)
+  config-persist-OK but SQLite-reconcile-fails → durable `reconciling` + fail closed. — assumed YES.
+- D2: legacy no-kind pairing (round-5 #1) — confirm we keep it usable via a legacy path (fail-open),
+  rather than forcing these pairings to re-pair. — assumed YES, confirm.
+- D3: PR/branch naming — propose branch `personal-editor-local-resources`, PR title
+  "fix(auth): personal editors use local resources (binding rewrite)". — confirm or rename.

--- a/storage/importer.py
+++ b/storage/importer.py
@@ -269,7 +269,9 @@ def _set_background_import_marker(conn: Connection) -> None:
 
 
 def _run_sqlite_data_migrations(conn: Connection) -> dict[str, int]:
-    return {}
+    from storage.resource_access_service import migrate_legacy_deferred_resource_contexts
+
+    return migrate_legacy_deferred_resource_contexts(conn)
 
 
 def _backup_json_state(state_dir: Path) -> Path:

--- a/storage/project_access_service.py
+++ b/storage/project_access_service.py
@@ -319,6 +319,8 @@ def get_effective_project_role(
     instance_role = context.instance_role
     if instance_role not in _ROLE_RANK:
         return None
+    if context.is_personal_instance and context.has_role("editor"):
+        return instance_role
     policy = get_project_policy(conn, project_id)
     if policy is None or policy["mode"] == "inherit":
         return instance_role

--- a/storage/remote_access_authorization_service.py
+++ b/storage/remote_access_authorization_service.py
@@ -356,10 +356,16 @@ def _decode_binding_state(value: Any) -> dict[str, Any] | None:
         if state == INSTANCE_BINDING_STATE_READY and instance_kind is None:
             return None
         generation = int(payload.get("generation"))
-        schema_version = int(payload.get("schema_version") or 1)
+        raw_schema_version = payload.get("schema_version")
+        if raw_schema_version is None:
+            schema_version = 1
+        else:
+            schema_version = int(raw_schema_version)
+            if schema_version != 1:
+                return None
     except (TypeError, ValueError, json.JSONDecodeError):
         return None
-    if generation <= 0 or schema_version <= 0:
+    if generation <= 0:
         return None
     return {
         "schema_version": schema_version,

--- a/storage/remote_access_authorization_service.py
+++ b/storage/remote_access_authorization_service.py
@@ -18,6 +18,11 @@ from storage.models import remote_access_authorizations, state_meta
 INSTANCE_BINDING_STATE_META_KEY = "remote_access.instance_binding.v1"
 INSTANCE_BINDING_STATE_RECONCILING = "reconciling"
 INSTANCE_BINDING_STATE_READY = "ready"
+# A durable, USABLE legacy state: the pairing reconciled successfully but the
+# control plane never reported a recognized kind. No kind-specific bypass is
+# available, and a later authoritative backfill completes it via a normal
+# transition.
+INSTANCE_BINDING_STATE_PENDING_KIND = "pending_kind"
 INSTANCE_BINDING_STATE_INVALID = "invalid"
 INSTANCE_BINDING_GENERATION_KEY = "vibe_instance_binding_generation"
 INSTANCE_BINDING_LOCK_FILENAME = "remote-access-instance-binding.lock"
@@ -314,7 +319,11 @@ def _decode_binding_state(value: Any) -> dict[str, Any] | None:
         if not isinstance(payload, dict):
             return None
         state = payload.get("state")
-        if state not in {INSTANCE_BINDING_STATE_RECONCILING, INSTANCE_BINDING_STATE_READY}:
+        if state not in {
+            INSTANCE_BINDING_STATE_RECONCILING,
+            INSTANCE_BINDING_STATE_READY,
+            INSTANCE_BINDING_STATE_PENDING_KIND,
+        }:
             return None
         instance_id = payload.get("instance_id")
         if not isinstance(instance_id, str) or not instance_id.strip():
@@ -475,7 +484,8 @@ def _begin_instance_binding_transition_locked(
         }
     if (
         existing is not None
-        and existing["state"] == INSTANCE_BINDING_STATE_RECONCILING
+        and existing["state"]
+        in {INSTANCE_BINDING_STATE_RECONCILING, INSTANCE_BINDING_STATE_PENDING_KIND}
         and existing["instance_id"] == instance_id
         and existing["instance_kind"] == instance_kind
     ):
@@ -721,6 +731,24 @@ def _reconcile_instance_binding_locked(
         }
 
     if instance_kind is None:
+        # A supported legacy no-kind pairing must stay USABLE: publish the
+        # durable pending_kind state instead of parking in fail-closed
+        # reconciling. A later authoritative backfill runs a new transition.
+        with engine.begin() as conn:
+            existing = _load_binding_state_from_connection(conn)
+            if (
+                existing is not None
+                and existing["state"] == INSTANCE_BINDING_STATE_RECONCILING
+                and existing["instance_id"] == instance_id
+                and existing["generation"] == int(transition["generation"])
+            ):
+                payload, now = _binding_payload(
+                    state=INSTANCE_BINDING_STATE_PENDING_KIND,
+                    instance_id=instance_id,
+                    instance_kind=None,
+                    generation=transition["generation"],
+                )
+                _write_binding_state(conn, payload, now)
         return {
             **transition,
             "ok": True,
@@ -785,28 +813,72 @@ def current_instance_binding_generation(*, ensure: bool = True) -> int:
         return 0
 
 
+def _bootstrap_deferred_migration() -> None:
+    """Run the deferred-context migration for one bootstrap transition."""
+
+    from storage.db import get_cached_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.resource_access_service import (
+        RESOURCE_BINDING_STATE_UNAVAILABLE,
+        RESOURCE_BINDING_STATUS_KEY,
+        migrate_legacy_deferred_resource_contexts,
+    )
+
+    ensure_sqlite_state()
+    engine = get_cached_sqlite_engine()
+    with engine.begin() as connection:
+        result = migrate_legacy_deferred_resource_contexts(connection)
+    if result.get(RESOURCE_BINDING_STATUS_KEY) == RESOURCE_BINDING_STATE_UNAVAILABLE:
+        raise RuntimeError("legacy_deferred_context_provenance_unavailable")
+
+
 def binding_is_ready_for_pairing(
     *,
     instance_id: str | None,
     instance_kind: str | None,
     ensure: bool = False,
+    bootstrap: bool = False,
 ) -> bool:
     """True only when the durable binding is ready for this pairing.
 
-    A missing row is a legacy install and stays compatible. Once a row
-    exists, ``reconciling`` / ``invalid`` / mismatched identity means the
-    kind is unavailable to every consumer until reconciliation succeeds.
+    A missing row is compatible ONLY for a no-kind legacy pairing. A known
+    configured kind without a validated durable row is an upgrade artifact:
+    with ``bootstrap=True`` (authorization consumers) it earns a validated
+    row through one real transition; otherwise it fails closed.
+    ``pending_kind`` is the durable usable legacy state; once a row exists,
+    ``reconciling`` / ``invalid`` / mismatched identity means the kind is
+    unavailable to every consumer until reconciliation succeeds.
     """
 
+    current_id = (instance_id or "").strip()
+    current_kind = instance_kind if instance_kind in {"personal", "organization"} else None
     state = load_instance_binding_state(ensure=ensure)
     if state is None:
-        return True
+        # Stay compatible for the legacy no-kind pairing; a known kind with
+        # no validated binding row (the server may have reclassified while
+        # this install was offline) is bootstrapped or fails closed.
+        if current_kind is None:
+            return True
+        if not bootstrap or not current_id:
+            return False
+        try:
+            result = reconcile_instance_binding(
+                instance_id=current_id,
+                instance_kind=current_kind,
+                reconcile=_bootstrap_deferred_migration,
+            )
+        except Exception:
+            return False
+        return bool(result.get("ok") and result.get("ready"))
+    if state.get("state") == INSTANCE_BINDING_STATE_PENDING_KIND:
+        # Usable legacy state: no kind bypass is claimable anyway.
+        return current_kind is None and (
+            not current_id or state.get("instance_id") == current_id
+        )
     if state.get("state") in {INSTANCE_BINDING_STATE_RECONCILING, INSTANCE_BINDING_STATE_INVALID}:
         return False
     if state.get("state") != INSTANCE_BINDING_STATE_READY:
         return False
-    current_id = (instance_id or "").strip()
-    current_kind = instance_kind if instance_kind in {"personal", "organization"} else None
     if current_kind is None:
         # Legacy/invalid no-kind pairing stays usable (fail-open).
         return True

--- a/storage/remote_access_authorization_service.py
+++ b/storage/remote_access_authorization_service.py
@@ -148,6 +148,10 @@ def load_scoped(
     return _record_from_row(row) if row is not None else None
 
 
+class InstanceBindingChangedError(RuntimeError):
+    """A durable binding generation advanced while this authorization write was in flight."""
+
+
 def upsert_scoped(
     *,
     reference: str | None,
@@ -160,8 +164,14 @@ def upsert_scoped(
     claims: Mapping[str, Any],
     last_checked_at: int,
     updated_at: int,
+    expected_binding_generation: int | None = None,
 ) -> str:
-    """Store one current Instance or Show Page context without expiring it."""
+    """Store one current Instance or Show Page context without expiring it.
+
+    When ``expected_binding_generation`` is provided, the compare and the write
+    run atomically under the cross-process binding lock (C2): a generation
+    that advanced, or a binding still reconciling, refuses the write.
+    """
 
     from storage.importer import ensure_sqlite_state
 
@@ -182,7 +192,19 @@ def upsert_scoped(
         "updated_at": updated_at,
     }
     engine = get_cached_sqlite_engine()
+    # Compare and write share one SQLite writer transaction: that is the
+    # cross-process CAS for authorization rows (C2). Generation is monotonic
+    # so a peer completing a transition after we captured expected_generation
+    # is still refused here.
     with engine.begin() as conn:
+        if expected_binding_generation is not None:
+            live = _load_binding_state_from_connection(conn)
+            live_generation = int((live or {}).get("generation") or 0)
+            live_state = (live or {}).get("state")
+            if live_generation > int(expected_binding_generation) or (
+                live_state == INSTANCE_BINDING_STATE_RECONCILING
+            ):
+                raise InstanceBindingChangedError("instance_binding_changed")
         existing_scope_reference = conn.execute(
             select(remote_access_authorizations.c.id)
             .where(remote_access_authorizations.c.instance_id == instance_id)
@@ -604,11 +626,14 @@ def _complete_instance_binding_transition_locked(
         or existing["generation"] != int(generation)
     ):
         return False
+    # Publishing ready is itself a binding event: bump generation so any
+    # in-flight authorization write that captured the reconciling generation
+    # CAS-fails instead of landing under the new ready binding.
     payload, now = _binding_payload(
         state=INSTANCE_BINDING_STATE_READY,
         instance_id=instance_id,
         instance_kind=instance_kind,
-        generation=generation,
+        generation=int(generation) + 1,
     )
     _write_binding_state(conn, payload, now)
     return True
@@ -774,6 +799,7 @@ def _reconcile_instance_binding_locked(
         }
     return {
         **transition,
+        "generation": int(transition["generation"]) + 1,
         "ok": True,
         "ready": True,
         "invalidated": invalidated,

--- a/storage/remote_access_authorization_service.py
+++ b/storage/remote_access_authorization_service.py
@@ -4,13 +4,23 @@ from __future__ import annotations
 
 import json
 import secrets
-from typing import Any, Mapping
+import time
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator, Mapping
 
-from sqlalchemy import and_, or_, select, update
+from sqlalchemy import and_, delete, or_, select, update
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.exc import OperationalError
 
 from storage.db import get_cached_sqlite_engine
-from storage.models import remote_access_authorizations
+from storage.models import remote_access_authorizations, state_meta
+
+INSTANCE_BINDING_STATE_META_KEY = "remote_access.instance_binding.v1"
+INSTANCE_BINDING_STATE_RECONCILING = "reconciling"
+INSTANCE_BINDING_STATE_READY = "ready"
+INSTANCE_BINDING_STATE_INVALID = "invalid"
+INSTANCE_BINDING_GENERATION_KEY = "vibe_instance_binding_generation"
+INSTANCE_BINDING_LOCK_FILENAME = "remote-access-instance-binding.lock"
 
 
 def store(
@@ -292,3 +302,475 @@ def delete_for_instance(instance_id: str) -> int:
             )
         )
     return int(result.rowcount or 0)
+
+
+def _decode_binding_state(value: Any) -> dict[str, Any] | None:
+    """Decode one state row, rejecting malformed values instead of guessing."""
+
+    if not isinstance(value, str):
+        return None
+    try:
+        payload = json.loads(value)
+        if not isinstance(payload, dict):
+            return None
+        state = payload.get("state")
+        if state not in {INSTANCE_BINDING_STATE_RECONCILING, INSTANCE_BINDING_STATE_READY}:
+            return None
+        instance_id = payload.get("instance_id")
+        if not isinstance(instance_id, str) or not instance_id.strip():
+            return None
+        instance_kind = payload.get("instance_kind")
+        if instance_kind not in {None, "personal", "organization"}:
+            return None
+        if state == INSTANCE_BINDING_STATE_READY and instance_kind is None:
+            return None
+        generation = int(payload.get("generation"))
+        schema_version = int(payload.get("schema_version") or 1)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if generation <= 0 or schema_version <= 0:
+        return None
+    return {
+        "schema_version": schema_version,
+        "state": state,
+        "instance_id": instance_id.strip(),
+        "instance_kind": instance_kind,
+        "generation": generation,
+        "updated_at": payload.get("updated_at"),
+    }
+
+
+def _load_binding_state_from_connection(conn) -> dict[str, Any] | None:
+    raw = conn.execute(
+        select(state_meta.c.value_json).where(
+            state_meta.c.key == INSTANCE_BINDING_STATE_META_KEY
+        )
+    ).scalar_one_or_none()
+    if raw is None:
+        return None
+    decoded = _decode_binding_state(raw)
+    if decoded is not None:
+        return decoded
+    # Keep corruption distinguishable from a never-initialized install. Any
+    # caller that sees this value must fail closed until a transition repairs it.
+    return {
+        "schema_version": 0,
+        "state": INSTANCE_BINDING_STATE_INVALID,
+        "instance_id": None,
+        "instance_kind": None,
+        "generation": 0,
+        "updated_at": None,
+    }
+
+
+def _ensure_sqlite_state() -> None:
+    from storage.importer import ensure_sqlite_state
+
+    ensure_sqlite_state()
+
+
+def _binding_file_lock():
+    from config import paths
+    from storage.lock import MigrationFileLock
+
+    return MigrationFileLock(paths.get_state_dir() / INSTANCE_BINDING_LOCK_FILENAME)
+
+
+@contextmanager
+def instance_binding_lock() -> Iterator[None]:
+    """Serialize binding transitions across controller and UI processes."""
+
+    _ensure_sqlite_state()
+    with _binding_file_lock():
+        yield
+
+
+def load_instance_binding_state(*, ensure: bool = True) -> dict[str, Any] | None:
+    """Read the durable binding epoch shared by UI and controller processes."""
+
+    if ensure:
+        _ensure_sqlite_state()
+    engine = get_cached_sqlite_engine()
+    try:
+        with engine.connect() as conn:
+            return _load_binding_state_from_connection(conn)
+    except OperationalError as exc:
+        # A pre-migration process may not have created state_meta yet. Treat
+        # that as a legacy no-row install; callers that need a durable write
+        # use the default ``ensure=True`` path and will still fail closed on a
+        # real storage error.
+        if not ensure and "no such table" in str(exc).lower():
+            return None
+        raise
+
+
+def _validate_transition_identity(
+    *,
+    instance_id: str,
+    instance_kind: str | None,
+) -> tuple[str, str | None]:
+    if not isinstance(instance_id, str) or not instance_id.strip():
+        raise ValueError("instance_id_required")
+    if instance_kind not in {None, "personal", "organization"}:
+        raise ValueError("instance_kind_required")
+    return instance_id.strip(), instance_kind
+
+
+def _binding_payload(
+    *,
+    state: str,
+    instance_id: str,
+    instance_kind: str | None,
+    generation: int,
+) -> tuple[dict[str, Any], str]:
+    now = str(int(time.time()))
+    payload = {
+        "schema_version": 1,
+        "state": state,
+        "instance_id": instance_id,
+        "instance_kind": instance_kind,
+        "generation": int(generation),
+        "updated_at": now,
+    }
+    return payload, now
+
+
+def _write_binding_state(conn, payload: Mapping[str, Any], updated_at: str) -> None:
+    encoded = json.dumps(dict(payload), separators=(",", ":"), sort_keys=True)
+    statement = sqlite_insert(state_meta).values(
+        key=INSTANCE_BINDING_STATE_META_KEY,
+        value_json=encoded,
+        updated_at=updated_at,
+    )
+    conn.execute(
+        statement.on_conflict_do_update(
+            index_elements=[state_meta.c.key],
+            set_={"value_json": encoded, "updated_at": updated_at},
+        )
+    )
+
+
+def _begin_instance_binding_transition_locked(
+    conn,
+    *,
+    instance_id: str,
+    instance_kind: str | None,
+) -> dict[str, Any]:
+    instance_id, instance_kind = _validate_transition_identity(
+        instance_id=instance_id,
+        instance_kind=instance_kind,
+    )
+    existing = _load_binding_state_from_connection(conn)
+    if (
+        existing is not None
+        and existing["state"] == INSTANCE_BINDING_STATE_READY
+        and existing["instance_id"] == instance_id
+        and existing["instance_kind"] == instance_kind
+    ):
+        return {
+            "generation": existing["generation"],
+            "changed": False,
+            "previous": existing,
+            "state": INSTANCE_BINDING_STATE_READY,
+        }
+    if (
+        existing is not None
+        and existing["state"] == INSTANCE_BINDING_STATE_RECONCILING
+        and existing["instance_id"] == instance_id
+        and existing["instance_kind"] == instance_kind
+    ):
+        return {
+            "generation": existing["generation"],
+            "changed": True,
+            "previous": existing,
+            "state": INSTANCE_BINDING_STATE_RECONCILING,
+        }
+    generation = (int(existing["generation"]) if existing is not None else 0) + 1
+    payload, now = _binding_payload(
+        state=INSTANCE_BINDING_STATE_RECONCILING,
+        instance_id=instance_id,
+        instance_kind=instance_kind,
+        generation=generation,
+    )
+    _write_binding_state(conn, payload, now)
+    return {
+        "generation": generation,
+        "changed": True,
+        "previous": existing,
+        "state": INSTANCE_BINDING_STATE_RECONCILING,
+    }
+
+
+def begin_instance_binding_transition(
+    *,
+    instance_id: str,
+    instance_kind: str | None,
+) -> dict[str, Any]:
+    """Commit a fail-closed ``reconciling`` epoch before derived work starts."""
+
+    _ensure_sqlite_state()
+    with _binding_file_lock():
+        engine = get_cached_sqlite_engine()
+        with engine.begin() as conn:
+            return _begin_instance_binding_transition_locked(
+                conn,
+                instance_id=instance_id,
+                instance_kind=instance_kind,
+            )
+
+
+def _invalidate_instance_binding_authorizations_locked(
+    conn,
+    *,
+    instance_id: str,
+    previous_instance_id: str | None = None,
+    preserve_show_page: bool = True,
+    keep_reference_for_revalidation: bool = True,
+) -> int:
+    ids = {
+        value.strip()
+        for value in (instance_id, previous_instance_id or "")
+        if isinstance(value, str) and value.strip()
+    }
+    if not ids:
+        return 0
+    predicate = remote_access_authorizations.c.instance_id.in_(ids)
+    if preserve_show_page:
+        predicate = and_(
+            predicate,
+            or_(
+                remote_access_authorizations.c.scope_kind.is_(None),
+                remote_access_authorizations.c.scope_kind != "show_page",
+            ),
+        )
+    if keep_reference_for_revalidation:
+        result = conn.execute(
+            update(remote_access_authorizations)
+            .where(predicate)
+            .values(authorization_state="stale", updated_at=int(time.time()))
+        )
+    else:
+        result = conn.execute(delete(remote_access_authorizations).where(predicate))
+    return int(result.rowcount or 0)
+
+
+def invalidate_instance_binding_authorizations(
+    *,
+    instance_id: str,
+    previous_instance_id: str | None = None,
+    preserve_show_page: bool = True,
+    keep_reference_for_revalidation: bool = True,
+) -> int:
+    """Invalidate derived instance claims without touching exact Show Page grants."""
+
+    _ensure_sqlite_state()
+    with _binding_file_lock():
+        engine = get_cached_sqlite_engine()
+        with engine.begin() as conn:
+            return _invalidate_instance_binding_authorizations_locked(
+                conn,
+                instance_id=instance_id,
+                previous_instance_id=previous_instance_id,
+                preserve_show_page=preserve_show_page,
+                keep_reference_for_revalidation=keep_reference_for_revalidation,
+            )
+
+
+def _complete_instance_binding_transition_locked(
+    conn,
+    *,
+    instance_id: str,
+    instance_kind: str,
+    generation: int,
+) -> bool:
+    if instance_kind not in {"personal", "organization"}:
+        return False
+    existing = _load_binding_state_from_connection(conn)
+    if (
+        existing is None
+        or existing["state"] != INSTANCE_BINDING_STATE_RECONCILING
+        or existing["instance_id"] != instance_id
+        or existing["instance_kind"] not in {None, instance_kind}
+        or existing["generation"] != int(generation)
+    ):
+        return False
+    payload, now = _binding_payload(
+        state=INSTANCE_BINDING_STATE_READY,
+        instance_id=instance_id,
+        instance_kind=instance_kind,
+        generation=generation,
+    )
+    _write_binding_state(conn, payload, now)
+    return True
+
+
+def complete_instance_binding_transition(
+    *,
+    instance_id: str,
+    instance_kind: str,
+    generation: int,
+) -> bool:
+    """Publish a reconciled binding epoch after all derived work succeeds."""
+
+    _ensure_sqlite_state()
+    with _binding_file_lock():
+        engine = get_cached_sqlite_engine()
+        with engine.begin() as conn:
+            return _complete_instance_binding_transition_locked(
+                conn,
+                instance_id=instance_id,
+                instance_kind=instance_kind,
+                generation=generation,
+            )
+
+
+def reconcile_instance_binding(
+    *,
+    instance_id: str,
+    instance_kind: str | None,
+    reconcile: Callable[[], Any] | None = None,
+    previous_instance_id: str | None = None,
+    preserve_show_page: bool = True,
+) -> dict[str, Any]:
+    """Run one serialized identity transition and publish ``ready`` last.
+
+    A callback failure deliberately leaves the committed ``reconciling`` row
+    in place. Callers must treat the returned ``ok=False`` as fail-closed and
+    retry from the next heartbeat.
+    """
+
+    instance_id, instance_kind = _validate_transition_identity(
+        instance_id=instance_id,
+        instance_kind=instance_kind,
+    )
+    _ensure_sqlite_state()
+    with _binding_file_lock():
+        engine = get_cached_sqlite_engine()
+        with engine.begin() as conn:
+            transition = _begin_instance_binding_transition_locked(
+                conn,
+                instance_id=instance_id,
+                instance_kind=instance_kind,
+            )
+            previous = transition.get("previous")
+            previous_id = previous.get("instance_id") if isinstance(previous, Mapping) else None
+            if previous_instance_id and previous_instance_id != instance_id:
+                previous_id = previous_instance_id
+            preserve = preserve_show_page and previous_id in {None, instance_id}
+            invalidated = _invalidate_instance_binding_authorizations_locked(
+                conn,
+                instance_id=instance_id,
+                previous_instance_id=previous_id,
+                preserve_show_page=preserve,
+            ) if transition["changed"] else 0
+
+        if not transition["changed"]:
+            return {
+                **transition,
+                "ok": True,
+                "ready": True,
+                "invalidated": 0,
+            }
+
+        try:
+            if reconcile is not None:
+                reconcile()
+        except Exception as exc:
+            return {
+                **transition,
+                "ok": False,
+                "ready": False,
+                "invalidated": invalidated,
+                "error": str(exc),
+            }
+
+        if instance_kind is None:
+            return {
+                **transition,
+                "ok": True,
+                "ready": False,
+                "invalidated": invalidated,
+                "pending": True,
+            }
+        with engine.begin() as conn:
+            completed = _complete_instance_binding_transition_locked(
+                conn,
+                instance_id=instance_id,
+                instance_kind=instance_kind,
+                generation=transition["generation"],
+            )
+        if not completed:
+            return {
+                **transition,
+                "ok": False,
+                "ready": False,
+                "invalidated": invalidated,
+                "error": "binding_generation_changed",
+            }
+        return {
+            **transition,
+            "ok": True,
+            "ready": True,
+            "invalidated": invalidated,
+        }
+
+
+def instance_binding_generation(
+    *,
+    instance_id: str,
+    instance_kind: str,
+) -> int | None:
+    state = load_instance_binding_state()
+    if (
+        state is None
+        or state["state"] != INSTANCE_BINDING_STATE_READY
+        or state["instance_id"] != instance_id
+        or state["instance_kind"] != instance_kind
+    ):
+        return None
+    return int(state["generation"])
+
+
+def current_instance_binding_generation(*, ensure: bool = True) -> int:
+    """Return the durable generation any process can compare against.
+
+    Missing state is generation 0 (a never-initialized install). A corrupt
+    or reconciling row still exposes its generation so a stale writer can
+    refuse to reverse a newer transition.
+    """
+
+    state = load_instance_binding_state(ensure=ensure)
+    if state is None:
+        return 0
+    try:
+        return int(state.get("generation") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def binding_is_ready_for_pairing(
+    *,
+    instance_id: str | None,
+    instance_kind: str | None,
+    ensure: bool = False,
+) -> bool:
+    """True only when the durable binding is ready for this pairing.
+
+    A missing row is a legacy install and stays compatible. Once a row
+    exists, ``reconciling`` / ``invalid`` / mismatched identity means the
+    kind is unavailable to every consumer until reconciliation succeeds.
+    """
+
+    state = load_instance_binding_state(ensure=ensure)
+    if state is None:
+        return True
+    if state.get("state") != INSTANCE_BINDING_STATE_READY:
+        return False
+    current_id = (instance_id or "").strip()
+    current_kind = instance_kind if instance_kind in {"personal", "organization"} else None
+    return (
+        bool(current_id)
+        and state.get("instance_id") == current_id
+        and state.get("instance_kind") == current_kind
+        and current_kind is not None
+    )

--- a/storage/remote_access_authorization_service.py
+++ b/storage/remote_access_authorization_service.py
@@ -631,6 +631,7 @@ def reconcile_instance_binding(
     reconcile: Callable[[], Any] | None = None,
     previous_instance_id: str | None = None,
     preserve_show_page: bool = True,
+    hold_config_lock: bool = True,
 ) -> dict[str, Any]:
     """Run one serialized identity transition and publish ``ready`` last.
 
@@ -643,26 +644,61 @@ def reconcile_instance_binding(
         instance_id=instance_id,
         instance_kind=instance_kind,
     )
+    # Canonical lock order (C2): SQLite initialization FIRST, then the
+    # cross-process config lock. Never acquire config_file_lock while
+    # ensure_sqlite_state / migration.lock may still be needed.
     _ensure_sqlite_state()
-    with _binding_file_lock():
+
+    def run() -> dict[str, Any]:
         engine = get_cached_sqlite_engine()
-        with engine.begin() as conn:
-            transition = _begin_instance_binding_transition_locked(
-                conn,
+        with _binding_file_lock():
+            return _reconcile_instance_binding_locked(
+                engine,
                 instance_id=instance_id,
                 instance_kind=instance_kind,
+                reconcile=reconcile,
+                previous_instance_id=previous_instance_id,
+                preserve_show_page=preserve_show_page,
             )
-            previous = transition.get("previous")
-            previous_id = previous.get("instance_id") if isinstance(previous, Mapping) else None
-            if previous_instance_id and previous_instance_id != instance_id:
-                previous_id = previous_instance_id
-            preserve = preserve_show_page and previous_id in {None, instance_id}
-            invalidated = _invalidate_instance_binding_authorizations_locked(
+
+    if not hold_config_lock:
+        return run()
+    from config.v2_config import config_file_lock
+
+    with config_file_lock():
+        return run()
+
+
+def _reconcile_instance_binding_locked(
+    engine,
+    *,
+    instance_id: str,
+    instance_kind: str | None,
+    reconcile: Callable[[], Any] | None,
+    previous_instance_id: str | None,
+    preserve_show_page: bool,
+) -> dict[str, Any]:
+    with engine.begin() as conn:
+        transition = _begin_instance_binding_transition_locked(
+            conn,
+            instance_id=instance_id,
+            instance_kind=instance_kind,
+        )
+        previous = transition.get("previous")
+        previous_id = previous.get("instance_id") if isinstance(previous, Mapping) else None
+        if previous_instance_id and previous_instance_id != instance_id:
+            previous_id = previous_instance_id
+        preserve = preserve_show_page and previous_id in {None, instance_id}
+        invalidated = (
+            _invalidate_instance_binding_authorizations_locked(
                 conn,
                 instance_id=instance_id,
                 previous_instance_id=previous_id,
                 preserve_show_page=preserve,
-            ) if transition["changed"] else 0
+            )
+            if transition["changed"]
+            else 0
+        )
 
         if not transition["changed"]:
             return {
@@ -672,47 +708,48 @@ def reconcile_instance_binding(
                 "invalidated": 0,
             }
 
-        try:
-            if reconcile is not None:
-                reconcile()
-        except Exception as exc:
-            return {
-                **transition,
-                "ok": False,
-                "ready": False,
-                "invalidated": invalidated,
-                "error": str(exc),
-            }
+    try:
+        if reconcile is not None:
+            reconcile()
+    except Exception as exc:
+        return {
+            **transition,
+            "ok": False,
+            "ready": False,
+            "invalidated": invalidated,
+            "error": str(exc),
+        }
 
-        if instance_kind is None:
-            return {
-                **transition,
-                "ok": True,
-                "ready": False,
-                "invalidated": invalidated,
-                "pending": True,
-            }
-        with engine.begin() as conn:
-            completed = _complete_instance_binding_transition_locked(
-                conn,
-                instance_id=instance_id,
-                instance_kind=instance_kind,
-                generation=transition["generation"],
-            )
-        if not completed:
-            return {
-                **transition,
-                "ok": False,
-                "ready": False,
-                "invalidated": invalidated,
-                "error": "binding_generation_changed",
-            }
+    if instance_kind is None:
         return {
             **transition,
             "ok": True,
-            "ready": True,
+            "ready": False,
             "invalidated": invalidated,
+            "pending": True,
         }
+
+    with engine.begin() as conn:
+        completed = _complete_instance_binding_transition_locked(
+            conn,
+            instance_id=instance_id,
+            instance_kind=instance_kind,
+            generation=transition["generation"],
+        )
+    if not completed:
+        return {
+            **transition,
+            "ok": False,
+            "ready": False,
+            "invalidated": invalidated,
+            "error": "binding_generation_changed",
+        }
+    return {
+        **transition,
+        "ok": True,
+        "ready": True,
+        "invalidated": invalidated,
+    }
 
 
 def instance_binding_generation(
@@ -764,13 +801,17 @@ def binding_is_ready_for_pairing(
     state = load_instance_binding_state(ensure=ensure)
     if state is None:
         return True
+    if state.get("state") in {INSTANCE_BINDING_STATE_RECONCILING, INSTANCE_BINDING_STATE_INVALID}:
+        return False
     if state.get("state") != INSTANCE_BINDING_STATE_READY:
         return False
     current_id = (instance_id or "").strip()
     current_kind = instance_kind if instance_kind in {"personal", "organization"} else None
+    if current_kind is None:
+        # Legacy/invalid no-kind pairing stays usable (fail-open).
+        return True
     return (
         bool(current_id)
         and state.get("instance_id") == current_id
         and state.get("instance_kind") == current_kind
-        and current_kind is not None
     )

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -353,7 +353,11 @@ def resource_user_context_from_metadata(
         state = remote_access_authorization_service.load_instance_binding_state(
             ensure=False
         )
-        if not ready and state is not None:
+        if not ready:
+            # Absent row (upgrade of a known-kind pairing) AND reconciling /
+            # mismatched rows all fail closed for deferred/non-interactive
+            # consumers. Interactive callers hoist bootstrap via
+            # remote_access.binding_is_ready(..., bootstrap=True).
             return None
         if context.instance_kind is not None and (
             not paired_instance_id or not paired_kind
@@ -368,7 +372,14 @@ def resource_user_context_from_metadata(
             return None
         if context.instance_kind and paired_kind and context.instance_kind != paired_kind:
             return None
-    if context.instance_kind is not None or snapshot.get("vibe_instance_kind") is not None:
+    from vibe.authorization import instance_kind_is_unsupported
+
+    raw_snapshot_kind = snapshot.get("vibe_instance_kind")
+    if instance_kind_is_unsupported(raw_snapshot_kind):
+        # Same class as Web Push: a present-but-unrecognized kind is not a
+        # no-kind legacy snapshot. Fail closed for deferred execution.
+        return None
+    if context.instance_kind is not None or raw_snapshot_kind is not None:
         return context
 
     # Released snapshots predate the instance-kind field. Recover their kind
@@ -445,11 +456,26 @@ def _configured_resource_state() -> ConfiguredResourceState:
         from config.v2_config import V2Config
 
         loaded = V2Config.load(persist_migrations=False)
-        # A recovered/defaulted load is not an authoritative unpaired state:
-        # the file is broken and the user will repair it. Treat it as a
-        # transient UNAVAILABLE so we never seal snapshots against empty
-        # recovery defaults.
-        if getattr(loaded, "load_warnings", ()):
+        # Only pairing/vibe_cloud recovery makes this reader UNAVAILABLE.
+        # Unrelated-section warnings (e.g. Model Hub) must not block an
+        # intact Vibe Cloud pairing or seal snapshots against it.
+        pairing_warnings = tuple(
+            warning
+            for warning in getattr(loaded, "load_warnings", ())
+            if (
+                "remote_access" in warning
+                or "vibe_cloud" in warning
+                or (
+                    "using recovery defaults" in warning
+                    and "model_hub" not in warning
+                    and "Recovered invalid config section" not in warning
+                )
+                or "not valid UTF-8" in warning
+                or "JSON could not be parsed" in warning
+                or "root is not an object" in warning
+            )
+        )
+        if pairing_warnings:
             return ConfiguredResourceState(
                 status=RESOURCE_BINDING_STATE_UNAVAILABLE,
                 instance_id=None,
@@ -885,6 +911,13 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
         if not identity_matches:
             write_marker(state="pending", instance_id=current_instance_id)
             return _counts(binding_status=RESOURCE_BINDING_STATE_PARTIAL)
+    else:
+        # Known-kind config with no durable binding row is an upgrade
+        # artifact, not a validated pairing. Leave the opportunity pending
+        # so a later heartbeat/bootstrap can attribute snapshots after the
+        # server-owned kind is confirmed.
+        write_marker(state="pending", instance_id=current_instance_id)
+        return _counts(binding_status=RESOURCE_BINDING_STATE_PARTIAL)
     paired_instance_id = current_instance_id
     paired_kind = current_kind
 

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 from typing import Any, Iterator
 
 from sqlalchemy import select, update
+from sqlalchemy import text as sqlalchemy_text
 from sqlalchemy.engine import Connection
 
 from storage.db import get_cached_sqlite_engine
@@ -338,6 +339,7 @@ def resource_user_context_from_metadata(
             instance_id=paired_instance_id,
             instance_kind=paired_kind,
             ensure=False,
+            bootstrap=True,
         ):
             # Kind is not yet reconciled; do not project a Personal bypass.
             return None
@@ -568,6 +570,25 @@ def _legacy_deferred_context_binding(
     }
 
 
+def _connection_has_table(connection: Connection, table_name: str) -> bool:
+    """True when the table exists on this connection's schema.
+
+    The deferred-context migration also runs while an unversioned legacy
+    schema is being stamped, where newer tables may not exist yet. A missing
+    table simply has no deferred records to migrate.
+    """
+
+    return (
+        connection.execute(
+            sqlalchemy_text(
+                "select 1 from sqlite_master where type = 'table' and name = :name"
+            ),
+            {"name": table_name},
+        ).scalar_one_or_none()
+        is not None
+    )
+
+
 def _metadata_snapshot_lacks_binding(metadata: Any) -> bool:
     """True when a deferred snapshot exists but carries no complete binding."""
 
@@ -589,43 +610,46 @@ def _has_unbound_deferred_snapshots(connection: Connection) -> bool:
     the first migration opportunity meaningful.
     """
 
-    definition_rows = connection.execute(
-        select(run_definitions.c.metadata_json).where(
-            run_definitions.c.definition_type.in_(("scheduled", "watch"))
+    if _connection_has_table(connection, "run_definitions"):
+        definition_rows = connection.execute(
+            select(run_definitions.c.metadata_json).where(
+                run_definitions.c.definition_type.in_(("scheduled", "watch"))
+            )
         )
-    )
-    for (metadata_json,) in definition_rows:
-        try:
-            metadata = json.loads(metadata_json or "{}")
-        except (TypeError, ValueError):
-            continue
-        if _metadata_snapshot_lacks_binding(metadata):
-            return True
-    run_rows = connection.execute(
-        select(agent_runs.c.metadata_json).where(
-            agent_runs.c.status.in_(("pending", "queued", "processing", "running"))
+        for (metadata_json,) in definition_rows:
+            try:
+                metadata = json.loads(metadata_json or "{}")
+            except (TypeError, ValueError):
+                continue
+            if _metadata_snapshot_lacks_binding(metadata):
+                return True
+    if _connection_has_table(connection, "agent_runs"):
+        run_rows = connection.execute(
+            select(agent_runs.c.metadata_json).where(
+                agent_runs.c.status.in_(("pending", "queued", "processing", "running"))
+            )
         )
-    )
-    for (metadata_json,) in run_rows:
-        try:
-            metadata = json.loads(metadata_json or "{}")
-        except (TypeError, ValueError):
-            continue
-        if _metadata_snapshot_lacks_binding(metadata):
-            return True
-    delivery_rows = connection.execute(
-        select(message_deliveries.c.snapshot_json).where(
-            message_deliveries.c.snapshot_json.is_not(None)
+        for (metadata_json,) in run_rows:
+            try:
+                metadata = json.loads(metadata_json or "{}")
+            except (TypeError, ValueError):
+                continue
+            if _metadata_snapshot_lacks_binding(metadata):
+                return True
+    if _connection_has_table(connection, "message_deliveries"):
+        delivery_rows = connection.execute(
+            select(message_deliveries.c.snapshot_json).where(
+                message_deliveries.c.snapshot_json.is_not(None)
+            )
         )
-    )
-    for (snapshot_json,) in delivery_rows:
-        try:
-            snapshot = json.loads(snapshot_json or "{}")
-            metadata = json.loads(snapshot.get("metadata_json") or "{}")
-        except (AttributeError, TypeError, ValueError):
-            continue
-        if _metadata_snapshot_lacks_binding(metadata):
-            return True
+        for (snapshot_json,) in delivery_rows:
+            try:
+                snapshot = json.loads(snapshot_json or "{}")
+                metadata = json.loads(snapshot.get("metadata_json") or "{}")
+            except (AttributeError, TypeError, ValueError):
+                continue
+            if _metadata_snapshot_lacks_binding(metadata):
+                return True
     return False
 
 
@@ -803,6 +827,32 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
         # Defensive guard for a future state-reader change. This branch is
         # never authoritative enough to complete a migration.
         return _counts(binding_status=RESOURCE_BINDING_STATE_PARTIAL)
+    # C2 fence: this migration can run from a bare ensure_sqlite_state()
+    # without config_file_lock (taking it here would invert the canonical
+    # lock order against a peer holding config lock -> migration lock).
+    # Instead, refuse to bind snapshots when the durable binding row exists
+    # and disagrees with the pairing snapshot just read: a peer is mid-
+    # reclassification and owns this migration through its own transition.
+    from storage.remote_access_authorization_service import (
+        INSTANCE_BINDING_STATE_RECONCILING as _BINDING_RECONCILING,
+        _load_binding_state_from_connection as _load_binding_row,
+    )
+
+    try:
+        binding_row = _load_binding_row(connection)
+    except Exception:
+        binding_row = None
+    if binding_row is not None:
+        row_id = binding_row.get("instance_id")
+        row_kind = binding_row.get("instance_kind")
+        row_state = binding_row.get("state")
+        identity_matches = row_id == current_instance_id and (
+            row_kind == current_kind
+            or (row_state == _BINDING_RECONCILING and row_kind in {None, current_kind})
+        )
+        if not identity_matches:
+            write_marker(state="pending", instance_id=current_instance_id)
+            return _counts(binding_status=RESOURCE_BINDING_STATE_PARTIAL)
     paired_instance_id = current_instance_id
     paired_kind = current_kind
 
@@ -812,11 +862,15 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
         "legacy_deferred_deliveries": 0,
         RESOURCE_BINDING_STATUS_KEY: RESOURCE_BINDING_STATE_READY,
     }
-    definition_rows = connection.execute(
-        select(run_definitions.c.id, run_definitions.c.metadata_json).where(
-            run_definitions.c.definition_type.in_(("scheduled", "watch"))
-        )
-    ).mappings()
+    definition_rows = (
+        connection.execute(
+            select(run_definitions.c.id, run_definitions.c.metadata_json).where(
+                run_definitions.c.definition_type.in_(("scheduled", "watch"))
+            )
+        ).mappings()
+        if _connection_has_table(connection, "run_definitions")
+        else ()
+    )
     for row in definition_rows:
         try:
             metadata = json.loads(row["metadata_json"] or "{}")
@@ -843,10 +897,14 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
         )
         counts["legacy_deferred_definitions"] += 1
 
-    run_rows = connection.execute(
-        select(agent_runs.c.id, agent_runs.c.metadata_json)
-        .where(agent_runs.c.status.in_(("pending", "queued", "processing", "running")))
-    ).mappings()
+    run_rows = (
+        connection.execute(
+            select(agent_runs.c.id, agent_runs.c.metadata_json)
+            .where(agent_runs.c.status.in_(("pending", "queued", "processing", "running")))
+        ).mappings()
+        if _connection_has_table(connection, "agent_runs")
+        else ()
+    )
     for row in run_rows:
         try:
             metadata = json.loads(row["metadata_json"] or "{}")
@@ -874,12 +932,16 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
         )
         counts["legacy_deferred_runs"] += 1
 
-    delivery_rows = connection.execute(
-        select(
-            message_deliveries.c.id,
-            message_deliveries.c.snapshot_json,
-        ).where(message_deliveries.c.snapshot_json.is_not(None))
-    ).mappings()
+    delivery_rows = (
+        connection.execute(
+            select(
+                message_deliveries.c.id,
+                message_deliveries.c.snapshot_json,
+            ).where(message_deliveries.c.snapshot_json.is_not(None))
+        ).mappings()
+        if _connection_has_table(connection, "message_deliveries")
+        else ()
+    )
     for row in delivery_rows:
         try:
             snapshot = json.loads(row["snapshot_json"] or "{}")

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -381,19 +381,28 @@ def resource_user_context_from_metadata(
         return None
     if context.instance_kind is not None or raw_snapshot_kind is not None:
         return context
+    if context.organization_id or context.instance_access_source == "organization_group":
+        # Organization membership identity does not depend on the local pairing
+        # being ready; an unpaired install must not retire Org deferred work.
+        return context
 
     # Released snapshots predate the instance-kind field. Recover their kind
     # only when the snapshot still names the current server-owned instance. An
     # unbound legacy snapshot cannot be attributed to a re-paired Personal
     # instance, because doing so would turn old Organization work into a
     # Personal ACL bypass.
-    paired_kind = (
-        configured[1]
-        if configured is not _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
-        and configured is not None
-        else None
-    )
+    pairing_state = _configured_resource_state()
+    if pairing_state.status in {
+        RESOURCE_BINDING_STATE_UNAVAILABLE,
+        RESOURCE_BINDING_STATE_UNPAIRED,
+    }:
+        # Kindless snapshots cannot keep executing as a bare Editor when the
+        # current pairing is unreadable or explicitly unpaired.
+        return None
+    paired_kind = pairing_state.instance_kind
     if paired_kind not in {"personal", "organization"}:
+        # Preserve the valid legacy no-kind PAIRING path (runtime-ready
+        # credentials, kind not yet backfilled — PARTIAL).
         return context
     if not context.instance_id:
         return None

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -7,18 +7,27 @@ content, prompts, paths, outputs, or secret values.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import time
 from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import Any, Iterator
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.engine import Connection
 
 from storage.db import get_cached_sqlite_engine
-from storage.models import resource_access_groups, resource_access_policies, state_meta
+from storage.models import (
+    agent_runs,
+    message_deliveries,
+    resource_access_groups,
+    resource_access_policies,
+    run_definitions,
+    state_meta,
+)
 from vibe.authorization import (
     AuthorizationContext,
     context_from_session_payload,
@@ -30,8 +39,26 @@ RESOURCE_KINDS = frozenset({"agent", "vault_secret", "skill"})
 ACCESS_LEVELS = frozenset({"public", "scope", "private"})
 ORGANIZATION_ROLES = frozenset({"owner", "admin", "member"})
 RESOURCE_USER_CONTEXT_METADATA_KEY = "resource_user_context"
+LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY = "migrations.legacy_deferred_resource_contexts.v1"
 RESOURCE_ORGANIZATIONS_META_KEY = "resource_access_organizations"
 HARNESS_ACCESS_FORBIDDEN_CODE = "harness_access_forbidden"
+RESOURCE_BINDING_STATE_UNAVAILABLE = "unavailable"
+RESOURCE_BINDING_STATE_UNPAIRED = "unpaired"
+RESOURCE_BINDING_STATE_PARTIAL = "partial"
+RESOURCE_BINDING_STATE_READY = "ready"
+RESOURCE_BINDING_STATE_SEALED = "sealed"
+RESOURCE_BINDING_STATUS_KEY = "binding_status"
+_CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE = object()
+
+
+@dataclass(frozen=True)
+class ConfiguredResourceState:
+    """One coherent read of the pairing identity used by deferred resources."""
+
+    status: str
+    instance_id: str | None
+    instance_kind: str | None
+    runtime_ready: bool
 
 
 class ResourceAccessError(ValueError):
@@ -250,8 +277,10 @@ def metadata_with_resource_user_context(
         "vibe_organization_role": context.organization_role,
         "vibe_group_ids": sorted(context.group_ids) if context.group_ids is not None else None,
         "vibe_membership_version": context.membership_version,
+        "vibe_instance_id": context.instance_id,
         "vibe_instance_role": context.instance_role,
         "vibe_instance_access_source": context.instance_access_source,
+        "vibe_instance_kind": context.instance_kind,
         "vibe_show_page_id": context.show_page_id,
         "claims_issued_at": context.claims_issued_at,
         "vibe_instance_authorization_revision": context.authorization_revision,
@@ -290,7 +319,60 @@ def resource_user_context_from_metadata(
     snapshot = metadata.get(RESOURCE_USER_CONTEXT_METADATA_KEY)
     if not isinstance(snapshot, Mapping):
         return None
-    return current_resource_context(snapshot, is_remote=True)
+    context = current_resource_context(snapshot, is_remote=True)
+
+    # A persisted context is durable across re-pairing, so a Personal snapshot
+    # must not authorize work after this installation moves to another
+    # instance. Compare the server-owned binding whenever the current pairing
+    # exposes one; legacy snapshots without an instance id remain unbound.
+    configured = _configured_resource_instance()
+    if context.instance_kind is not None and (
+        configured is _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE or configured is None
+    ):
+        return None
+    if configured is not _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE and configured is not None:
+        paired_instance_id, paired_kind = configured
+        from storage import remote_access_authorization_service
+
+        if not remote_access_authorization_service.binding_is_ready_for_pairing(
+            instance_id=paired_instance_id,
+            instance_kind=paired_kind,
+            ensure=False,
+        ):
+            # Kind is not yet reconciled; do not project a Personal bypass.
+            return None
+        if context.instance_kind is not None and (
+            not paired_instance_id or not paired_kind
+        ):
+            return None
+        snapshot_instance_id = context.instance_id
+        if (
+            snapshot_instance_id
+            and paired_instance_id
+            and snapshot_instance_id != paired_instance_id
+        ):
+            return None
+        if context.instance_kind and paired_kind and context.instance_kind != paired_kind:
+            return None
+    if context.instance_kind is not None or snapshot.get("vibe_instance_kind") is not None:
+        return context
+
+    # Released snapshots predate the instance-kind field. Recover their kind
+    # only when the snapshot still names the current server-owned instance. An
+    # unbound legacy snapshot cannot be attributed to a re-paired Personal
+    # instance, because doing so would turn old Organization work into a
+    # Personal ACL bypass.
+    paired_kind = (
+        configured[1]
+        if configured is not _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
+        and configured is not None
+        else None
+    )
+    if paired_kind not in {"personal", "organization"}:
+        return context
+    if not context.instance_id:
+        return None
+    return replace(context, instance_kind=paired_kind)
 
 
 def _as_context(user_context: ResourceUserContext | Mapping[str, Any] | None) -> ResourceUserContext:
@@ -310,6 +392,457 @@ def _connection(connection: Connection | None) -> Iterator[Connection]:
     with engine.begin() as active_connection:
         yield active_connection
 
+
+def _configured_show_page_instance() -> tuple[str, str] | None | object:
+    try:
+        from config.v2_config import V2Config
+
+        cloud = V2Config.load().remote_access.vibe_cloud
+        credentials = cloud.runtime_credentials()
+        if credentials is None:
+            return None
+        if not isinstance(credentials, (tuple, list)) or len(credentials) != 3:
+            return _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
+        instance_id = _clean_optional_string(credentials[1])
+        if instance_id is None or cloud.instance_kind not in {"personal", "organization"}:
+            return _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
+    except (
+        AttributeError,
+        FileNotFoundError,
+        IndexError,
+        KeyError,
+        OSError,
+        TypeError,
+        ValueError,
+    ):
+        return _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
+    return instance_id, cloud.instance_kind
+
+
+def _configured_resource_state() -> ConfiguredResourceState:
+    """Return one typed, fail-closed read of the configured pairing state.
+
+    ``UNAVAILABLE`` is intentionally distinct from a successfully read
+    unpaired configuration. Migration provenance must never be sealed because
+    a transient config read failed.
+    """
+
+    try:
+        from config.v2_config import V2Config
+
+        cloud = V2Config.load().remote_access.vibe_cloud
+        raw_instance_id = cloud.instance_id
+        instance_id = _clean_optional_string(raw_instance_id)
+        if raw_instance_id not in (None, "") and instance_id is None:
+            return ConfiguredResourceState(
+                status=RESOURCE_BINDING_STATE_UNAVAILABLE,
+                instance_id=None,
+                instance_kind=None,
+                runtime_ready=False,
+            )
+        instance_kind = (
+            cloud.instance_kind if cloud.instance_kind in {"personal", "organization"} else None
+        )
+        credentials = cloud.runtime_credentials()
+    except Exception:
+        return ConfiguredResourceState(
+            status=RESOURCE_BINDING_STATE_UNAVAILABLE,
+            instance_id=None,
+            instance_kind=None,
+            runtime_ready=False,
+        )
+
+    runtime_ready = False
+    if credentials is not None:
+        if not isinstance(credentials, (tuple, list)) or len(credentials) != 3:
+            return ConfiguredResourceState(
+                status=RESOURCE_BINDING_STATE_UNAVAILABLE,
+                instance_id=instance_id,
+                instance_kind=instance_kind,
+                runtime_ready=False,
+            )
+        credential_instance_id = _clean_optional_string(credentials[1])
+        runtime_ready = instance_id is not None and credential_instance_id == instance_id
+
+    if instance_id is None:
+        return ConfiguredResourceState(
+            status=RESOURCE_BINDING_STATE_UNPAIRED,
+            instance_id=None,
+            instance_kind=instance_kind,
+            runtime_ready=False,
+        )
+    if runtime_ready and instance_kind in {"personal", "organization"}:
+        status = RESOURCE_BINDING_STATE_READY
+    else:
+        status = RESOURCE_BINDING_STATE_PARTIAL
+    return ConfiguredResourceState(
+        status=status,
+        instance_id=instance_id,
+        instance_kind=instance_kind,
+        runtime_ready=runtime_ready,
+    )
+
+
+def _configured_resource_instance() -> tuple[str | None, str | None] | None | object:
+    """Return the current complete pairing identity used to fence deferred resources."""
+
+    configured = _configured_resource_state()
+    if configured.status == RESOURCE_BINDING_STATE_UNAVAILABLE:
+        return _CONFIGURED_SHOW_PAGE_INSTANCE_UNAVAILABLE
+    if configured.status != RESOURCE_BINDING_STATE_READY:
+        return None
+    return configured.instance_id, configured.instance_kind
+
+
+def _legacy_snapshot_has_organization_context(
+    context: ResourceUserContext,
+    snapshot: Mapping[str, Any],
+) -> bool:
+    """Detect Organization semantics retained by pre-binding snapshots."""
+
+    return bool(
+        context.organization_id
+        or context.organization_member_id
+        or context.organization_role
+        or context.instance_access_source == "organization_group"
+        or context.group_ids
+        or any(
+            snapshot.get(key)
+            for key in (
+                "vibe_organization_id",
+                "vibe_organization_member_id",
+                "vibe_organization_role",
+                "vibe_group_ids",
+            )
+        )
+    )
+
+
+def _legacy_deferred_context_binding(
+    snapshot: Mapping[str, Any],
+    *,
+    paired_instance_id: str,
+    paired_kind: str,
+) -> dict[str, str] | None:
+    """Return a safe current binding for one pre-instance metadata snapshot."""
+
+    context = current_resource_context(snapshot, is_remote=True)
+    if context.instance_role not in {"owner", "editor", "viewer"}:
+        return None
+
+    raw_instance_id = snapshot.get("vibe_instance_id")
+    snapshot_instance_id = _clean_optional_string(raw_instance_id)
+    if raw_instance_id is not None and snapshot_instance_id is None:
+        return None
+    if snapshot_instance_id and snapshot_instance_id != paired_instance_id:
+        return None
+
+    raw_kind = snapshot.get("vibe_instance_kind")
+    if raw_kind is not None and raw_kind not in {"personal", "organization"}:
+        return None
+    if raw_kind is not None and raw_kind != paired_kind:
+        return None
+
+    # The pairing kind is the only authoritative evidence for a legacy
+    # snapshot that predates both binding fields. Explicit Organization claims
+    # still contradict a Personal pairing, but access sources such as ``email``
+    # are shared by Personal and Organization instances and cannot choose a
+    # kind on their own.
+    if paired_kind == "personal" and _legacy_snapshot_has_organization_context(context, snapshot):
+        return None
+    inferred_kind = raw_kind or paired_kind
+    if inferred_kind != paired_kind:
+        return None
+    return {
+        "vibe_instance_id": paired_instance_id,
+        "vibe_instance_kind": paired_kind,
+    }
+
+
+def _migrate_deferred_metadata_value(
+    metadata: Any,
+    *,
+    paired_instance_id: str,
+    paired_kind: str,
+) -> dict[str, Any] | None:
+    if not isinstance(metadata, dict):
+        return None
+    snapshot = metadata.get(RESOURCE_USER_CONTEXT_METADATA_KEY)
+    if not isinstance(snapshot, Mapping):
+        return None
+    binding = _legacy_deferred_context_binding(
+        snapshot,
+        paired_instance_id=paired_instance_id,
+        paired_kind=paired_kind,
+    )
+    if binding is None:
+        return None
+    if all(snapshot.get(key) == value for key, value in binding.items()):
+        return None
+    migrated = dict(metadata)
+    migrated_snapshot = dict(snapshot)
+    migrated_snapshot.update(binding)
+    migrated[RESOURCE_USER_CONTEXT_METADATA_KEY] = migrated_snapshot
+    return migrated
+
+
+def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[str, int]:
+    """Bind released deferred metadata to the still-current runtime pairing.
+
+    The migration is deliberately conservative and one-shot. It needs complete
+    runtime credentials and a known server-owned instance kind, and it only
+    updates a legacy snapshot when its existing instance evidence or explicit
+    Organization claims agree with that pairing. A transient configuration read
+    is not an unpaired state: it leaves the marker untouched so the same
+    pairing can retry later. A successfully observed unpaired state is sealed,
+    while a known instance with an unknown kind remains pending until that same
+    instance is authoritatively classified.
+    """
+
+    def _counts(
+        *,
+        binding_status: str,
+        definitions: int = 0,
+        runs: int = 0,
+        deliveries: int = 0,
+    ) -> dict[str, int | str]:
+        return {
+            "legacy_deferred_definitions": definitions,
+            "legacy_deferred_runs": runs,
+            "legacy_deferred_deliveries": deliveries,
+            RESOURCE_BINDING_STATUS_KEY: binding_status,
+        }
+
+    empty_unavailable = _counts(binding_status=RESOURCE_BINDING_STATE_UNAVAILABLE)
+    marker_value = connection.execute(
+        select(state_meta.c.value_json).where(
+            state_meta.c.key == LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY
+        )
+    ).scalar_one_or_none()
+    marker: dict[str, Any] | None = None
+    if marker_value is not None:
+        try:
+            parsed_marker = json.loads(marker_value)
+        except (TypeError, ValueError):
+            parsed_marker = None
+        if not isinstance(parsed_marker, dict):
+            # A corrupt marker cannot prove which pairing created the rows.
+            # Preserve fail-closed behavior instead of trying to insert a
+            # duplicate key or guessing a new binding.
+            return _counts(binding_status=RESOURCE_BINDING_STATE_UNAVAILABLE)
+        marker = parsed_marker
+        marker_state = marker.get("state")
+        if marker_state not in {"pending", "completed", "sealed_unattributed"}:
+            marker_state = "completed" if marker.get("completed_at") else "pending"
+        # Markers written by e64/d667 used ``completed`` with no instance ID
+        # for an unpaired first opportunity. Preserve that terminal meaning;
+        # never reinterpret it as a fresh migration opportunity.
+        if marker_state == "completed" and marker.get("instance_id") is None:
+            marker_state = "sealed_unattributed"
+        marker = {**marker, "state": marker_state}
+
+    configured = _configured_resource_state()
+    if configured.status == RESOURCE_BINDING_STATE_UNAVAILABLE:
+        # A read failure must not create ``pending(instance_id=None)`` or
+        # rewrite a known marker. Startup/heartbeat will retry this operation.
+        return empty_unavailable
+    current_instance_id = configured.instance_id
+    current_kind = (
+        configured.instance_kind
+        if configured.status == RESOURCE_BINDING_STATE_READY
+        else None
+    )
+
+    def write_marker(
+        *,
+        state: str,
+        instance_id: str | None,
+        instance_kind: str | None = None,
+    ) -> None:
+        now = _utc_now_iso()
+        payload: dict[str, Any] = {
+            "schema_version": 2,
+            "state": state,
+            "instance_id": instance_id,
+            "updated_at": now,
+        }
+        if instance_kind in {"personal", "organization"}:
+            payload["instance_kind"] = instance_kind
+        if state == "completed":
+            payload["completed_at"] = now
+        values = {
+            "value_json": json.dumps(payload, sort_keys=True, separators=(",", ":")),
+            "updated_at": now,
+        }
+        if marker is None:
+            connection.execute(
+                state_meta.insert().values(
+                    key=LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY,
+                    **values,
+                )
+            )
+        else:
+            connection.execute(
+                update(state_meta)
+                .where(state_meta.c.key == LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY)
+                .values(**values)
+            )
+
+    if marker is not None and marker.get("state") in {"completed", "sealed_unattributed"}:
+        return _counts(binding_status=RESOURCE_BINDING_STATE_SEALED)
+
+    raw_marker_instance_id = marker.get("instance_id") if marker else None
+    marker_instance_id = (
+        _clean_optional_string(raw_marker_instance_id) if marker else None
+    )
+    if marker and raw_marker_instance_id is not None and marker_instance_id is None:
+        # A malformed marker cannot prove ownership. Keep the existing value
+        # intact and fail closed rather than guessing a new pairing.
+        return _counts(binding_status=RESOURCE_BINDING_STATE_UNAVAILABLE)
+    if marker is not None:
+        if marker_instance_id is None:
+            # No first pairing was available to prove ownership. A later
+            # pairing must not be allowed to claim these records.
+            write_marker(state="sealed_unattributed", instance_id=None)
+            return _counts(binding_status=RESOURCE_BINDING_STATE_SEALED)
+        if current_instance_id is None:
+            if configured.status == RESOURCE_BINDING_STATE_UNPAIRED:
+                write_marker(state="sealed_unattributed", instance_id=marker_instance_id)
+                return _counts(binding_status=RESOURCE_BINDING_STATE_SEALED)
+            return _counts(binding_status=configured.status)
+        if current_instance_id != marker_instance_id:
+            write_marker(state="sealed_unattributed", instance_id=marker_instance_id)
+            return _counts(binding_status=RESOURCE_BINDING_STATE_SEALED)
+
+    if configured.status == RESOURCE_BINDING_STATE_UNPAIRED:
+        write_marker(state="sealed_unattributed", instance_id=current_instance_id)
+        return _counts(binding_status=RESOURCE_BINDING_STATE_SEALED)
+    if configured.status != RESOURCE_BINDING_STATE_READY:
+        write_marker(state="pending", instance_id=current_instance_id)
+        return _counts(binding_status=configured.status)
+    if current_instance_id is None or current_kind not in {"personal", "organization"}:
+        # Defensive guard for a future state-reader change. This branch is
+        # never authoritative enough to complete a migration.
+        return _counts(binding_status=RESOURCE_BINDING_STATE_PARTIAL)
+    paired_instance_id = current_instance_id
+    paired_kind = current_kind
+
+    counts = {
+        "legacy_deferred_definitions": 0,
+        "legacy_deferred_runs": 0,
+        "legacy_deferred_deliveries": 0,
+        RESOURCE_BINDING_STATUS_KEY: RESOURCE_BINDING_STATE_READY,
+    }
+    definition_rows = connection.execute(
+        select(run_definitions.c.id, run_definitions.c.metadata_json).where(
+            run_definitions.c.definition_type.in_(("scheduled", "watch"))
+        )
+    ).mappings()
+    for row in definition_rows:
+        try:
+            metadata = json.loads(row["metadata_json"] or "{}")
+        except (TypeError, ValueError):
+            continue
+        migrated = _migrate_deferred_metadata_value(
+            metadata,
+            paired_instance_id=paired_instance_id,
+            paired_kind=paired_kind,
+        )
+        if migrated is None:
+            continue
+        connection.execute(
+            update(run_definitions)
+            .where(run_definitions.c.id == row["id"])
+            .values(
+                metadata_json=json.dumps(
+                    migrated,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+            )
+        )
+        counts["legacy_deferred_definitions"] += 1
+
+    run_rows = connection.execute(
+        select(agent_runs.c.id, agent_runs.c.metadata_json)
+        .where(agent_runs.c.status.in_(("pending", "queued", "processing", "running")))
+    ).mappings()
+    for row in run_rows:
+        try:
+            metadata = json.loads(row["metadata_json"] or "{}")
+        except (TypeError, ValueError):
+            continue
+        migrated = _migrate_deferred_metadata_value(
+            metadata,
+            paired_instance_id=paired_instance_id,
+            paired_kind=paired_kind,
+        )
+        if migrated is None:
+            continue
+        connection.execute(
+            update(agent_runs)
+            .where(agent_runs.c.id == row["id"])
+            .values(
+                metadata_json=json.dumps(
+                    migrated,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+                updated_at=_utc_now_iso(),
+            )
+        )
+        counts["legacy_deferred_runs"] += 1
+
+    delivery_rows = connection.execute(
+        select(
+            message_deliveries.c.id,
+            message_deliveries.c.snapshot_json,
+        ).where(message_deliveries.c.snapshot_json.is_not(None))
+    ).mappings()
+    for row in delivery_rows:
+        try:
+            snapshot = json.loads(row["snapshot_json"] or "{}")
+            metadata = json.loads(snapshot.get("metadata_json") or "{}")
+        except (AttributeError, TypeError, ValueError):
+            continue
+        migrated_metadata = _migrate_deferred_metadata_value(
+            metadata,
+            paired_instance_id=paired_instance_id,
+            paired_kind=paired_kind,
+        )
+        if migrated_metadata is None:
+            continue
+        snapshot["metadata_json"] = json.dumps(
+            migrated_metadata,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        snapshot_json = json.dumps(
+            snapshot,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        snapshot_sha256 = hashlib.sha256(snapshot_json.encode("utf-8")).hexdigest()
+        connection.execute(
+            update(message_deliveries)
+            .where(message_deliveries.c.id == row["id"])
+            .values(
+                snapshot_json=snapshot_json,
+                snapshot_sha256=snapshot_sha256,
+                updated_at=_utc_now_iso(),
+            )
+        )
+        counts["legacy_deferred_deliveries"] += 1
+    write_marker(
+        state="completed",
+        instance_id=paired_instance_id,
+        instance_kind=paired_kind,
+    )
+    return counts
 
 def _stored_resource_organizations(connection: Connection) -> set[str]:
     raw_value = connection.execute(
@@ -568,6 +1101,8 @@ def _policy_allows(
 ) -> bool:
     if context.is_instance_owner:
         return True
+    if resource_kind == "agent" and context.is_personal_instance:
+        return context.can_use_resource(resource_kind)
     # Skill and Vault ACL rows remain persisted for compatibility, but Editor
     # runtime access intentionally ignores them for validated remote sessions.
     # Direct non-remote contexts still use the stored policy so service-level

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -444,6 +444,15 @@ def _configured_resource_state() -> ConfiguredResourceState:
             cloud.instance_kind if cloud.instance_kind in {"personal", "organization"} else None
         )
         credentials = cloud.runtime_credentials()
+    except FileNotFoundError:
+        # A missing config file is an authoritative unpaired install, not a
+        # transient read failure. pair() must be allowed to redeem.
+        return ConfiguredResourceState(
+            status=RESOURCE_BINDING_STATE_UNPAIRED,
+            instance_id=None,
+            instance_kind=None,
+            runtime_ready=False,
+        )
     except Exception:
         return ConfiguredResourceState(
             status=RESOURCE_BINDING_STATE_UNAVAILABLE,
@@ -559,6 +568,67 @@ def _legacy_deferred_context_binding(
     }
 
 
+def _metadata_snapshot_lacks_binding(metadata: Any) -> bool:
+    """True when a deferred snapshot exists but carries no complete binding."""
+
+    if not isinstance(metadata, dict):
+        return False
+    snapshot = metadata.get(RESOURCE_USER_CONTEXT_METADATA_KEY)
+    if not isinstance(snapshot, Mapping):
+        return False
+    instance_id = _clean_optional_string(snapshot.get("vibe_instance_id"))
+    kind = snapshot.get("vibe_instance_kind")
+    return instance_id is None or kind not in {"personal", "organization"}
+
+
+def _has_unbound_deferred_snapshots(connection: Connection) -> bool:
+    """True when any released deferred record still lacks an instance binding.
+
+    A fresh install has nothing to protect: sealing or pinning a marker there
+    would only block the first real pairing. Only actual legacy snapshots make
+    the first migration opportunity meaningful.
+    """
+
+    definition_rows = connection.execute(
+        select(run_definitions.c.metadata_json).where(
+            run_definitions.c.definition_type.in_(("scheduled", "watch"))
+        )
+    )
+    for (metadata_json,) in definition_rows:
+        try:
+            metadata = json.loads(metadata_json or "{}")
+        except (TypeError, ValueError):
+            continue
+        if _metadata_snapshot_lacks_binding(metadata):
+            return True
+    run_rows = connection.execute(
+        select(agent_runs.c.metadata_json).where(
+            agent_runs.c.status.in_(("pending", "queued", "processing", "running"))
+        )
+    )
+    for (metadata_json,) in run_rows:
+        try:
+            metadata = json.loads(metadata_json or "{}")
+        except (TypeError, ValueError):
+            continue
+        if _metadata_snapshot_lacks_binding(metadata):
+            return True
+    delivery_rows = connection.execute(
+        select(message_deliveries.c.snapshot_json).where(
+            message_deliveries.c.snapshot_json.is_not(None)
+        )
+    )
+    for (snapshot_json,) in delivery_rows:
+        try:
+            snapshot = json.loads(snapshot_json or "{}")
+            metadata = json.loads(snapshot.get("metadata_json") or "{}")
+        except (AttributeError, TypeError, ValueError):
+            continue
+        if _metadata_snapshot_lacks_binding(metadata):
+            return True
+    return False
+
+
 def _migrate_deferred_metadata_value(
     metadata: Any,
     *,
@@ -652,6 +722,8 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
         if configured.status == RESOURCE_BINDING_STATE_READY
         else None
     )
+    # PARTIAL still carries a known instance ID; heartbeat/backfill uses it to
+    # keep snapshots pending instead of sealing them as unattributed.
 
     def write_marker(
         *,
@@ -715,9 +787,16 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
             return _counts(binding_status=RESOURCE_BINDING_STATE_SEALED)
 
     if configured.status == RESOURCE_BINDING_STATE_UNPAIRED:
+        if marker is None and not _has_unbound_deferred_snapshots(connection):
+            # A fresh install has no legacy snapshots to protect. Writing a
+            # sealed marker here would only block the first real pairing.
+            return _counts(binding_status=RESOURCE_BINDING_STATE_UNPAIRED)
         write_marker(state="sealed_unattributed", instance_id=current_instance_id)
         return _counts(binding_status=RESOURCE_BINDING_STATE_SEALED)
     if configured.status != RESOURCE_BINDING_STATE_READY:
+        # A PARTIAL pairing still records its identity: the pending marker is
+        # what lets the SAME instance complete after credential repair while a
+        # DIFFERENT instance stays sealed out.
         write_marker(state="pending", instance_id=current_instance_id)
         return _counts(binding_status=configured.status)
     if current_instance_id is None or current_kind not in {"personal", "organization"}:

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -335,13 +335,25 @@ def resource_user_context_from_metadata(
         paired_instance_id, paired_kind = configured
         from storage import remote_access_authorization_service
 
-        if not remote_access_authorization_service.binding_is_ready_for_pairing(
+        ready = remote_access_authorization_service.binding_is_ready_for_pairing(
             instance_id=paired_instance_id,
             instance_kind=paired_kind,
             ensure=False,
-            bootstrap=True,
-        ):
-            # Kind is not yet reconciled; do not project a Personal bypass.
+            # Never bootstrap from this call: it can run while a SQLite writer
+            # lock is already held (queued-delivery recheck). Opening a second
+            # write connection here deadlocks; the interactive/UI path hoists
+            # bootstrap via remote_access.binding_is_ready(..., bootstrap=True).
+            bootstrap=False,
+        )
+        # An absent durable row is an upgrade artifact, not evidence the
+        # pairing is wrong. Identity matching below still applies; the
+        # authorization consumers (binding_is_ready) fail closed / bootstrap
+        # on their own path. Only an explicit reconciling/mismatched row
+        # means "do not project a Personal bypass from this snapshot".
+        state = remote_access_authorization_service.load_instance_binding_state(
+            ensure=False
+        )
+        if not ready and state is not None:
             return None
         if context.instance_kind is not None and (
             not paired_instance_id or not paired_kind
@@ -432,7 +444,19 @@ def _configured_resource_state() -> ConfiguredResourceState:
     try:
         from config.v2_config import V2Config
 
-        cloud = V2Config.load().remote_access.vibe_cloud
+        loaded = V2Config.load()
+        # A recovered/defaulted load is not an authoritative unpaired state:
+        # the file is broken and the user will repair it. Treat it as a
+        # transient UNAVAILABLE so we never seal snapshots against empty
+        # recovery defaults.
+        if getattr(loaded, "load_warnings", ()):
+            return ConfiguredResourceState(
+                status=RESOURCE_BINDING_STATE_UNAVAILABLE,
+                instance_id=None,
+                instance_kind=None,
+                runtime_ready=False,
+            )
+        cloud = loaded.remote_access.vibe_cloud
         raw_instance_id = cloud.instance_id
         instance_id = _clean_optional_string(raw_instance_id)
         if raw_instance_id not in (None, "") and instance_id is None:

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -444,7 +444,7 @@ def _configured_resource_state() -> ConfiguredResourceState:
     try:
         from config.v2_config import V2Config
 
-        loaded = V2Config.load()
+        loaded = V2Config.load(persist_migrations=False)
         # A recovered/defaulted load is not an authoritative unpaired state:
         # the file is broken and the user will repair it. Treat it as a
         # transient UNAVAILABLE so we never seal snapshots against empty
@@ -661,9 +661,17 @@ def _has_unbound_deferred_snapshots(connection: Connection) -> bool:
             if _metadata_snapshot_lacks_binding(metadata):
                 return True
     if _connection_has_table(connection, "message_deliveries"):
+        from storage.delivery_states import DELIVERY_STATE_MATRIX
+
+        executable_delivery_states = tuple(
+            state
+            for state, policy in DELIVERY_STATE_MATRIX.items()
+            if policy.ordering != "terminal"
+        )
         delivery_rows = connection.execute(
             select(message_deliveries.c.snapshot_json).where(
-                message_deliveries.c.snapshot_json.is_not(None)
+                message_deliveries.c.snapshot_json.is_not(None),
+                message_deliveries.c.state.in_(executable_delivery_states),
             )
         )
         for (snapshot_json,) in delivery_rows:
@@ -956,12 +964,22 @@ def migrate_legacy_deferred_resource_contexts(connection: Connection) -> dict[st
         )
         counts["legacy_deferred_runs"] += 1
 
+    from storage.delivery_states import DELIVERY_STATE_MATRIX
+
+    executable_delivery_states = tuple(
+        state
+        for state, policy in DELIVERY_STATE_MATRIX.items()
+        if policy.ordering != "terminal"
+    )
     delivery_rows = (
         connection.execute(
             select(
                 message_deliveries.c.id,
                 message_deliveries.c.snapshot_json,
-            ).where(message_deliveries.c.snapshot_json.is_not(None))
+            ).where(
+                message_deliveries.c.snapshot_json.is_not(None),
+                message_deliveries.c.state.in_(executable_delivery_states),
+            )
         ).mappings()
         if _connection_has_table(connection, "message_deliveries")
         else ()

--- a/tests/test_instance_authorization.py
+++ b/tests/test_instance_authorization.py
@@ -60,6 +60,7 @@ def test_context_from_session_payload_keeps_role_and_acl_claims() -> None:
             "sub": "user-1",
             "vibe_instance_role": "editor",
             "vibe_instance_access_source": "organization_group",
+            "vibe_instance_kind": "organization",
             "vibe_organization_id": "org-1",
             "vibe_organization_member_id": "membership-1",
             "vibe_organization_role": "member",
@@ -68,8 +69,25 @@ def test_context_from_session_payload_keeps_role_and_acl_claims() -> None:
     )
     assert context.instance_role == "editor"
     assert context.group_ids == frozenset({"group-a"})
+    assert context.is_organization_instance
     assert context.can_chat
     assert not context.can_manage_instance
+
+
+def test_context_from_session_payload_only_recognizes_known_instance_kinds() -> None:
+    base = {
+        "sub": "user-1",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": "owner",
+    }
+    personal = context_from_session_payload({**base, "vibe_instance_kind": "personal"})
+    unknown = context_from_session_payload({**base, "vibe_instance_kind": "workspace"})
+
+    assert personal.is_personal_instance
+    assert not personal.is_organization_instance
+    assert personal.instance_kind == "personal"
+    assert unknown.instance_kind is None
+    assert not unknown.is_personal_instance
 
 
 def test_show_page_email_context_is_exactly_page_scoped() -> None:
@@ -161,7 +179,6 @@ def test_advertised_capability_namespaces_cover_current_and_future_routes() -> N
         ("POST", "/api/sessions/session-1/messages"),
         ("POST", "/api/sessions/session-1/attachments"),
         ("POST", "/api/sessions/session-1/cancel"),
-        ("GET", "/api/show-pages/session-1"),
         ("POST", "/api/show-pages/session-1/ensure"),
         ("POST", "/api/show-pages/session-1/availability"),
         ("POST", "/api/show-pages/session-1/access-settings/read"),

--- a/tests/test_instance_authorization.py
+++ b/tests/test_instance_authorization.py
@@ -183,6 +183,9 @@ def test_advertised_capability_namespaces_cover_current_and_future_routes() -> N
         ("POST", "/api/show-pages/session-1/availability"),
         ("POST", "/api/show-pages/session-1/access-settings/read"),
         ("POST", "/api/show-pages/session-1/access-settings/apply"),
+        # The Web UI's ShowPageShareControl reads the page it can mutate;
+        # editors must keep GET access (regression: PR #1606 round 1).
+        ("GET", "/api/show-pages/session-1"),
     )
     for method, path in editor_examples:
         assert http_authorization_policy(method, path).minimum_role == "editor", path

--- a/tests/test_project_access_service.py
+++ b/tests/test_project_access_service.py
@@ -15,6 +15,7 @@ def _context(
     email: str = "member@example.com",
     organization_id: str | None = None,
     group_ids: tuple[str, ...] = (),
+    instance_kind: str | None = None,
 ) -> AuthorizationContext:
     return AuthorizationContext(
         instance_role=role,
@@ -22,6 +23,7 @@ def _context(
         organization_id=organization_id,
         group_ids=frozenset(group_ids),
         is_remote=True,
+        instance_kind=instance_kind,
     )
 
 
@@ -126,6 +128,44 @@ def test_restricted_policy_matches_email_domain_and_group(tmp_path) -> None:
             )
             is None
         )
+
+
+def test_personal_editor_ignores_project_organization_acl(tmp_path) -> None:
+    engine, project = _engine_with_project(tmp_path)
+    intent = _intent(
+        project["id"],
+        1,
+        bindings=[
+            {
+                "principal_kind": "email",
+                "principal_value": "other@example.com",
+                "access_role": "viewer",
+            }
+        ],
+    )
+    personal_editor = _context(
+        "editor",
+        email="personal@example.com",
+        instance_kind="personal",
+    )
+    personal_viewer = _context(
+        "viewer",
+        email="personal@example.com",
+        instance_kind="personal",
+    )
+    organization_editor = _context("editor", email="organization@example.com")
+
+    with engine.begin() as conn:
+        assert project_access_service.apply_project_access_intent(conn, intent).outcome == "applied"
+        assert project_access_service.get_effective_project_role(
+            conn, personal_editor, project["id"]
+        ) == "editor"
+        assert project_access_service.get_effective_project_role(
+            conn, personal_viewer, project["id"]
+        ) is None
+        assert project_access_service.get_effective_project_role(
+            conn, organization_editor, project["id"]
+        ) is None
 
 
 def test_highest_match_is_capped_by_instance_role(tmp_path) -> None:

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -1792,7 +1792,15 @@ def test_pair_accepts_legacy_or_invalid_instance_kind_as_unknown(monkeypatch, re
     if reported_kind is not None:
         response["instance_kind"] = reported_kind
     monkeypatch.setattr(remote_access, "_json_request", lambda *args, **kwargs: response)
-    monkeypatch.setattr(remote_access.api, "save_config", lambda payload: save_payloads.append(payload) or config)
+
+    def fake_save_config(payload, **kwargs):
+        save_payloads.append(payload)
+        # Mirror the real save: the returned config carries the persisted
+        # pairing identity, which pair() verifies before publishing a binding.
+        config.remote_access.vibe_cloud.instance_id = payload["remote_access"]["vibe_cloud"]["instance_id"]
+        return config
+
+    monkeypatch.setattr(remote_access.api, "save_config", fake_save_config)
     monkeypatch.setattr(
         remote_access,
         "_run_pending_deferred_context_migration",
@@ -3355,3 +3363,88 @@ def test_ra_tq_030_connectivity_diagnostics_filters_dns_by_selected_family(
 
     assert result["dns"]["status"] == "unavailable"
     assert result["http2"]["status"] == "unknown"
+
+
+def test_unknown_kind_pairing_stays_usable_after_pair(monkeypatch, tmp_path) -> None:
+    """Regression PR #1606 r1: no-kind pairings must not park in reconciling."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _config()
+    response = {
+        "instance_id": "inst_456",
+        "client_id": "vr_client_456",
+        "issuer": "https://backend.test",
+        "authorization_endpoint": "https://backend.test/oauth/authorize",
+        "token_endpoint": "https://backend.test/oauth/token",
+        "jwks_uri": "https://backend.test/oauth/jwks.json",
+        "public_url": "https://new.avibe.bot",
+        "redirect_uri": "https://new.avibe.bot/auth/callback",
+        "tunnel_token": "tunnel-token",
+        "instance_secret": "instance-secret",
+    }
+    monkeypatch.setattr(remote_access, "_json_request", lambda *args, **kwargs: response)
+
+    def fake_save_config(payload, **kwargs):
+        config.remote_access.vibe_cloud.instance_id = payload["remote_access"]["vibe_cloud"]["instance_id"]
+        return config
+
+    monkeypatch.setattr(remote_access.api, "save_config", fake_save_config)
+    monkeypatch.setattr(remote_access, "start", lambda next_config: {"ok": True})
+    monkeypatch.setattr(remote_access, "status", lambda next_config=None: {"ok": True})
+    monkeypatch.setattr(remote_access, "report_runtime_status", lambda *args, **kwargs: {"ok": True})
+
+    assert remote_access.pair("vrp_test", "https://backend.test")["ok"] is True
+
+    from storage import remote_access_authorization_service
+
+    state = remote_access_authorization_service.load_instance_binding_state(ensure=False)
+    assert state is not None
+    assert state["state"] == remote_access_authorization_service.INSTANCE_BINDING_STATE_PENDING_KIND
+    assert state["instance_id"] == "inst_456"
+    # The legacy no-kind path stays usable for every authorization consumer.
+    assert remote_access_authorization_service.binding_is_ready_for_pairing(
+        instance_id="inst_456",
+        instance_kind=None,
+        ensure=False,
+    ) is True
+    # A kind-specific bypass is still not claimable from this state.
+    assert remote_access_authorization_service.binding_is_ready_for_pairing(
+        instance_id="inst_456",
+        instance_kind="personal",
+        ensure=False,
+    ) is False
+
+
+def test_pair_refuses_to_publish_binding_for_a_replaced_instance(monkeypatch, tmp_path) -> None:
+    """Regression PR #1606 r1: pairing save + transition are one critical section."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _config()
+    monkeypatch.setattr(remote_access, "_json_request", lambda *args, **kwargs: _pair_redeem_response())
+
+    def racing_save_config(payload, **kwargs):
+        # Simulate a peer's pairing landing between our save and verification:
+        # the persisted config no longer names the instance we redeemed.
+        config.remote_access.vibe_cloud.instance_id = "inst_other"
+        return config
+
+    monkeypatch.setattr(remote_access.api, "save_config", racing_save_config)
+    monkeypatch.setattr(
+        remote_access,
+        "_run_pending_deferred_context_migration",
+        lambda: {"legacy_deferred_definitions": 0, "legacy_deferred_runs": 0, "legacy_deferred_deliveries": 0, "binding_status": "sealed"},
+    )
+    monkeypatch.setattr(remote_access, "start", lambda next_config: {"ok": True})
+    monkeypatch.setattr(remote_access, "status", lambda next_config=None: {"ok": True})
+
+    result = remote_access.pair("vrp_test", "https://backend.test")
+
+    assert result["ok"] is False
+    assert result["error"] == "pairing_reconciliation_failed"
+    assert result["detail"] == "persisted_instance_mismatch"
+
+    from storage import remote_access_authorization_service
+
+    state = remote_access_authorization_service.load_instance_binding_state(ensure=False)
+    redeemed = _pair_redeem_response()["instance_id"]
+    assert state is None or state.get("instance_id") != redeemed

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -1970,6 +1970,76 @@ def test_pair_aborts_when_pending_migration_fails(monkeypatch, tmp_path) -> None
     assert json.loads((tmp_path / "config" / "config.json").read_text(encoding="utf-8")) == original
 
 
+def test_pair_redeems_when_config_file_is_absent(monkeypatch, tmp_path) -> None:
+    """A fresh install with no config is authoritative unpaired, not unavailable."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config_path = tmp_path / "config" / "config.json"
+    if config_path.exists():
+        config_path.unlink()
+
+    redeem_calls: list[str] = []
+
+    def fake_request(url: str, payload: dict, timeout: float = 20.0, **kwargs):
+        redeem_calls.append(url)
+        return _pair_redeem_response()
+
+    monkeypatch.setattr(remote_access, "_json_request", fake_request)
+    monkeypatch.setattr(remote_access, "start", lambda next_config: {"ok": True, "running": True})
+    monkeypatch.setattr(
+        remote_access,
+        "status",
+        lambda next_config=None: {"ok": True, "running": True, "paired": True},
+    )
+    monkeypatch.setattr(remote_access, "report_runtime_status", lambda *args, **kwargs: {"ok": True})
+    monkeypatch.setattr(remote_access, "_transition_instance_binding", lambda **kwargs: {"ok": True, "ready": True})
+
+    result = remote_access.pair("vrp_test", "https://backend.test")
+
+    assert result["ok"] is True
+    assert redeem_calls
+    assert "/pairing/redeem" in redeem_calls[0]
+
+
+def test_binding_transition_initializes_sqlite_before_taking_config_lock(monkeypatch, tmp_path) -> None:
+    """Lock order: ensure_sqlite_state must complete before config_file_lock."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _config().save()
+    order: list[str] = []
+    real_ensure = __import__("storage.importer", fromlist=["ensure_sqlite_state"]).ensure_sqlite_state
+    real_lock = __import__("config.v2_config", fromlist=["config_file_lock"]).config_file_lock
+
+    def tracking_ensure(*args, **kwargs):
+        order.append("sqlite")
+        return real_ensure(*args, **kwargs)
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def tracking_lock(*args, **kwargs):
+        order.append("config")
+        with real_lock(*args, **kwargs):
+            yield
+
+    monkeypatch.setattr("storage.importer.ensure_sqlite_state", tracking_ensure)
+    monkeypatch.setattr("config.v2_config.config_file_lock", tracking_lock)
+    monkeypatch.setattr(
+        "storage.remote_access_authorization_service._ensure_sqlite_state",
+        lambda: tracking_ensure(),
+    )
+
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="personal",
+    )
+
+    assert "sqlite" in order
+    assert "config" in order
+    assert order.index("sqlite") < order.index("config")
+
+
+
 def test_pair_rejects_origin_update_failure_before_saving_config(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -3448,3 +3448,61 @@ def test_pair_refuses_to_publish_binding_for_a_replaced_instance(monkeypatch, tm
     state = remote_access_authorization_service.load_instance_binding_state(ensure=False)
     redeemed = _pair_redeem_response()["instance_id"]
     assert state is None or state.get("instance_id") != redeemed
+
+
+def test_overlapping_heartbeat_refuses_stale_personal_kind(monkeypatch, tmp_path) -> None:
+    """Regression PR #1606 r4: capture generation BEFORE the network call.
+
+    Two overlapping runtime-status requests: the newer Organization response
+    lands first; the older Personal response must CAS-fail and leave the
+    binding Organization.
+    """
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _config()
+    cloud = config.remote_access.vibe_cloud
+    cloud.backend_url = "https://backend.test"
+    cloud.instance_secret = "instance-secret"
+    cloud.instance_kind = "personal"
+    config.save()
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="personal",
+    )
+    monkeypatch.setattr(remote_access, "runtime_status_payload", lambda *args, **kwargs: {"event": "heartbeat"})
+    monkeypatch.setattr(
+        remote_access,
+        "_json_request",
+        lambda *args, **kwargs: {"ok": True, "instance_kind": "organization"},
+    )
+
+    from storage import remote_access_authorization_service
+
+    captured = remote_access_authorization_service.current_instance_binding_generation(
+        ensure=False
+    )
+    # Newer Organization heartbeat lands first.
+    assert remote_access.report_runtime_status(config)["ok"] is True
+    assert V2Config.load().remote_access.vibe_cloud.instance_kind == "organization"
+    # Older in-flight Personal response, captured before the Org persist,
+    # must CAS-fail against the newer generation.
+    refused = remote_access._persist_instance_kind(
+        "inst_123",
+        "personal",
+        reconcile=True,
+        expected_binding_generation=captured,
+    )
+    assert refused is False
+    assert V2Config.load().remote_access.vibe_cloud.instance_kind == "organization"
+    state = remote_access_authorization_service.load_instance_binding_state(ensure=False)
+    assert state is not None
+    assert state["instance_kind"] == "organization"
+    assert state["generation"] > captured
+    monkeypatch.setattr(remote_access, "runtime_status_payload", lambda *args, **kwargs: {"event": "heartbeat"})
+    monkeypatch.setattr(
+        remote_access,
+        "_json_request",
+        lambda *args, **kwargs: {"ok": True, "instance_kind": "organization"},
+    )
+    assert remote_access.report_runtime_status(V2Config.load())["ok"] is True
+    assert V2Config.load().remote_access.vibe_cloud.instance_kind == "organization"

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -1474,6 +1474,12 @@ def test_report_runtime_status_backfills_instance_kind_once(monkeypatch, tmp_pat
         "_json_request",
         lambda *args, **kwargs: {"ok": True, "instance_kind": "organization"},
     )
+    migration_calls = []
+    monkeypatch.setattr(
+        remote_access,
+        "_run_pending_deferred_context_migration",
+        lambda: migration_calls.append(True),
+    )
     real_save_config = remote_access.api.save_config
     saves = []
 
@@ -1486,9 +1492,113 @@ def test_report_runtime_status_backfills_instance_kind_once(monkeypatch, tmp_pat
     assert remote_access.report_runtime_status(config)["ok"] is True
     assert V2Config.load().remote_access.vibe_cloud.instance_kind == "organization"
     assert remote_access.report_runtime_status(V2Config.load())["ok"] is True
+    assert migration_calls == [True]
     assert saves == [
         {"remote_access": {"vibe_cloud": {"instance_kind": "organization"}}}
     ]
+
+
+def test_report_runtime_status_binds_pending_deferred_contexts_through_the_real_path(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """A long-running upgraded service must not need another initialization.
+
+    The heartbeat is the only place the authoritative kind arrives, so it owns
+    rerunning the pending migration itself rather than relying on a later
+    ``ensure_sqlite_state()`` call.
+    """
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _config()
+    cloud = config.remote_access.vibe_cloud
+    cloud.backend_url = "https://backend.test"
+    cloud.instance_secret = "instance-secret"
+    cloud.instance_kind = ""
+    config.save()
+
+    from storage.db import get_cached_sqlite_engine
+    from storage.importer import _run_sqlite_data_migrations, ensure_sqlite_state
+    from storage.models import run_definitions, state_meta
+    from storage.resource_access_service import (
+        LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY,
+        RESOURCE_USER_CONTEXT_METADATA_KEY,
+        resource_user_context_from_metadata,
+    )
+
+    legacy_metadata = {
+        RESOURCE_USER_CONTEXT_METADATA_KEY: {
+            "sub": "legacy-editor",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "email",
+            "claims_issued_at": 1_700_000_000,
+        }
+    }
+    ensure_sqlite_state()
+    engine = get_cached_sqlite_engine()
+    with engine.begin() as connection:
+        connection.execute(
+            run_definitions.insert().values(
+                id="legacy-task",
+                definition_type="scheduled",
+                name="legacy task",
+                message="run",
+                schedule_type="interval",
+                enabled=1,
+                created_at="2026-08-20T00:00:00Z",
+                updated_at="2026-08-20T00:00:00Z",
+                metadata_json=json.dumps(legacy_metadata),
+            )
+        )
+        counts = _run_sqlite_data_migrations(connection)
+        assert {
+            key: counts[key]
+            for key in (
+                "legacy_deferred_definitions",
+                "legacy_deferred_runs",
+                "legacy_deferred_deliveries",
+            )
+        } == {
+            "legacy_deferred_definitions": 0,
+            "legacy_deferred_runs": 0,
+            "legacy_deferred_deliveries": 0,
+        }
+        marker = json.loads(
+            connection.execute(
+                select(state_meta.c.value_json).where(
+                    state_meta.c.key == LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY
+                )
+            ).scalar_one()
+        )
+    assert marker["state"] == "pending"
+    assert marker["instance_id"] == "inst_123"
+
+    monkeypatch.setattr(
+        remote_access,
+        "runtime_status_payload",
+        lambda *args, **kwargs: {"event": "heartbeat"},
+    )
+    monkeypatch.setattr(
+        remote_access,
+        "_json_request",
+        lambda *args, **kwargs: {"ok": True, "instance_kind": "personal"},
+    )
+
+    assert remote_access.report_runtime_status(config)["ok"] is True
+
+    assert V2Config.load().remote_access.vibe_cloud.instance_kind == "personal"
+    with engine.connect() as connection:
+        metadata = json.loads(
+            connection.execute(
+                select(run_definitions.c.metadata_json).where(
+                    run_definitions.c.id == "legacy-task"
+                )
+            ).scalar_one()
+        )
+    snapshot = metadata[RESOURCE_USER_CONTEXT_METADATA_KEY]
+    assert snapshot["vibe_instance_id"] == "inst_123"
+    assert snapshot["vibe_instance_kind"] == "personal"
+    assert resource_user_context_from_metadata(metadata) is not None
 
 
 @pytest.mark.parametrize("reported_kind", [None, "enterprise", "", 7])
@@ -1642,6 +1752,11 @@ def test_pair_persists_with_locked_incremental_config_save(monkeypatch) -> None:
         },
     )
     monkeypatch.setattr(remote_access.api, "save_config", lambda payload: save_payloads.append(payload) or config)
+    monkeypatch.setattr(
+        remote_access,
+        "_run_pending_deferred_context_migration",
+        lambda: {"legacy_deferred_definitions": 0, "legacy_deferred_runs": 0, "legacy_deferred_deliveries": 0, "binding_status": "sealed"},
+    )
     monkeypatch.setattr(remote_access, "start", lambda next_config: {"ok": True, "running": True})
     monkeypatch.setattr(remote_access, "status", lambda next_config=None: {"ok": True, "running": True, "paired": True})
     monkeypatch.setattr(remote_access, "report_runtime_status", lambda *args, **kwargs: {"ok": True})
@@ -1678,6 +1793,11 @@ def test_pair_accepts_legacy_or_invalid_instance_kind_as_unknown(monkeypatch, re
         response["instance_kind"] = reported_kind
     monkeypatch.setattr(remote_access, "_json_request", lambda *args, **kwargs: response)
     monkeypatch.setattr(remote_access.api, "save_config", lambda payload: save_payloads.append(payload) or config)
+    monkeypatch.setattr(
+        remote_access,
+        "_run_pending_deferred_context_migration",
+        lambda: {"legacy_deferred_definitions": 0, "legacy_deferred_runs": 0, "legacy_deferred_deliveries": 0, "binding_status": "sealed"},
+    )
     monkeypatch.setattr(remote_access, "start", lambda next_config: {"ok": True})
     monkeypatch.setattr(remote_access, "status", lambda next_config=None: {"ok": True})
     monkeypatch.setattr(remote_access, "report_runtime_status", lambda *args, **kwargs: {"ok": True})
@@ -1756,6 +1876,100 @@ def test_pair_reports_success_when_connector_start_fails(monkeypatch, tmp_path) 
     assert saved_payload["remote_access"]["vibe_cloud"]["tunnel_token"] == "tunnel-token"
 
 
+def _pair_redeem_response(*, instance_id: str = "inst_new") -> dict[str, str]:
+    return {
+        "instance_id": instance_id,
+        "instance_kind": "personal",
+        "client_id": "vr_client_new",
+        "issuer": "https://backend.test",
+        "authorization_endpoint": "https://backend.test/oauth/authorize",
+        "token_endpoint": "https://backend.test/oauth/token",
+        "jwks_uri": "https://backend.test/oauth/jwks.json",
+        "public_url": "https://new.avibe.bot",
+        "redirect_uri": "https://new.avibe.bot/auth/callback",
+        "tunnel_token": "new-tunnel-token",
+        "instance_secret": "new-instance-secret",
+    }
+
+
+def test_pair_aborts_when_legacy_provenance_cannot_be_read(monkeypatch, tmp_path) -> None:
+    """An unavailable pre-pair config read must not replace the pairing."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _config()
+    config.remote_access.vibe_cloud.enabled = False
+    config.remote_access.vibe_cloud.instance_id = ""
+    config.remote_access.vibe_cloud.instance_secret = ""
+    config.save()
+    original = json.loads((tmp_path / "config" / "config.json").read_text(encoding="utf-8"))
+
+    redeem_calls: list[str] = []
+
+    def fake_request(url: str, payload: dict, timeout: float = 20.0, **kwargs):
+        redeem_calls.append(url)
+        return _pair_redeem_response()
+
+    monkeypatch.setattr(remote_access, "_json_request", fake_request)
+    monkeypatch.setattr(
+        remote_access,
+        "_run_pending_deferred_context_migration",
+        lambda: (_ for _ in ()).throw(RuntimeError("legacy_deferred_context_provenance_unavailable")),
+    )
+    saves: list[dict] = []
+    monkeypatch.setattr(
+        remote_access.api,
+        "save_config",
+        lambda payload, **kwargs: saves.append(payload) or config,
+    )
+    monkeypatch.setattr(remote_access, "start", lambda next_config: {"ok": True})
+
+    result = remote_access.pair("vrp_test", "https://backend.test")
+
+    assert result["ok"] is False
+    assert result["error"] == "pairing_provenance_unavailable"
+    assert saves == []
+    assert redeem_calls == []
+    assert json.loads((tmp_path / "config" / "config.json").read_text(encoding="utf-8")) == original
+
+
+def test_pair_aborts_when_pending_migration_fails(monkeypatch, tmp_path) -> None:
+    """A failing deferred migration must not let pair() stamp a new identity."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _config()
+    config.remote_access.vibe_cloud.enabled = False
+    config.remote_access.vibe_cloud.instance_id = ""
+    config.save()
+    original = json.loads((tmp_path / "config" / "config.json").read_text(encoding="utf-8"))
+
+    redeem_calls: list[str] = []
+
+    def fake_request(url: str, payload: dict, timeout: float = 20.0, **kwargs):
+        redeem_calls.append(url)
+        return _pair_redeem_response()
+
+    monkeypatch.setattr(remote_access, "_json_request", fake_request)
+    monkeypatch.setattr(
+        remote_access,
+        "_run_pending_deferred_context_migration",
+        lambda: (_ for _ in ()).throw(RuntimeError("sqlite locked")),
+    )
+    saves: list[dict] = []
+    monkeypatch.setattr(
+        remote_access.api,
+        "save_config",
+        lambda payload, **kwargs: saves.append(payload) or config,
+    )
+
+    result = remote_access.pair("vrp_test", "https://backend.test")
+
+    assert result["ok"] is False
+    assert result["error"] == "pairing_provenance_unavailable"
+    assert saves == []
+    assert redeem_calls == []
+    assert json.loads((tmp_path / "config" / "config.json").read_text(encoding="utf-8")) == original
+
+
 def test_pair_rejects_origin_update_failure_before_saving_config(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
@@ -1799,6 +2013,11 @@ def test_pair_rejects_origin_update_failure_before_saving_config(monkeypatch, tm
 
 
 def test_pair_returns_structured_error_when_backend_request_fails(monkeypatch) -> None:
+    monkeypatch.setattr(
+        remote_access,
+        "_run_pending_deferred_context_migration",
+        lambda: {"legacy_deferred_definitions": 0, "legacy_deferred_runs": 0, "legacy_deferred_deliveries": 0, "binding_status": "sealed"},
+    )
     monkeypatch.setattr(remote_access, "_json_request", lambda *args, **kwargs: (_ for _ in ()).throw(OSError("offline")))
 
     result = remote_access.pair("vrp_test", "https://backend.test")
@@ -1812,6 +2031,11 @@ def test_pair_preserves_backend_error_response(monkeypatch) -> None:
     def fake_request(*args, **kwargs):
         raise remote_access.BackendRequestError(400, {"error": "invalid_pairing_key"})
 
+    monkeypatch.setattr(
+        remote_access,
+        "_run_pending_deferred_context_migration",
+        lambda: {"legacy_deferred_definitions": 0, "legacy_deferred_runs": 0, "legacy_deferred_deliveries": 0, "binding_status": "sealed"},
+    )
     monkeypatch.setattr(remote_access, "_json_request", fake_request)
 
     result = remote_access.pair("vrp_test", "https://backend.test")
@@ -1841,6 +2065,11 @@ def test_pair_queues_lifecycle_status_for_drain(monkeypatch, tmp_path) -> None:
         },
     )
     monkeypatch.setattr(remote_access.api, "save_config", lambda payload: config)
+    monkeypatch.setattr(
+        remote_access,
+        "_run_pending_deferred_context_migration",
+        lambda: {"legacy_deferred_definitions": 0, "legacy_deferred_runs": 0, "legacy_deferred_deliveries": 0, "binding_status": "sealed"},
+    )
     monkeypatch.setattr(remote_access, "start", lambda next_config: {"ok": False, "error": "cloudflared_spawn_failed"})
     monkeypatch.setattr(remote_access, "status", lambda next_config=None: {"ok": True, "running": False, "paired": True})
     monkeypatch.setattr(

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -33,6 +33,7 @@ def _clear_authorization_refresh_process_state():
         remote_access._AUTHORIZATION_REFRESH_FAILURES.clear()
         remote_access._AUTHORIZATION_REFRESH_RESULTS.clear()
         remote_access._AUTHORIZATION_REFRESH_FLIGHTS.clear()
+        remote_access._AUTHORIZATION_REFRESH_FLIGHT_EPOCHS.clear()
     with remote_access._AUTHORIZATION_BACKGROUND_REFRESH_LOCK:
         remote_access._AUTHORIZATION_BACKGROUND_REFRESHES.clear()
     yield
@@ -40,6 +41,7 @@ def _clear_authorization_refresh_process_state():
         remote_access._AUTHORIZATION_REFRESH_FAILURES.clear()
         remote_access._AUTHORIZATION_REFRESH_RESULTS.clear()
         remote_access._AUTHORIZATION_REFRESH_FLIGHTS.clear()
+        remote_access._AUTHORIZATION_REFRESH_FLIGHT_EPOCHS.clear()
 
 
 def _paired_config(tmp_path, *, revision: int = 41) -> V2Config:
@@ -167,6 +169,622 @@ def test_personal_session_slides_past_claim_and_original_identity_deadlines(
     assert result.current is True
     assert result.policy == "personal"
     assert result.payload["claims_issued_at"] == base
+
+
+def test_validated_remote_payload_projects_paired_instance_kind(tmp_path):
+    config = _paired_config(tmp_path)
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    payload = remote_access._validated_authorization_payload(
+        config,
+        {
+            "sub": "personal-user",
+            "email": "personal@example.com",
+            "instance_id": "inst_123",
+        },
+        {
+            "id": "authorization-1",
+            "claims": {**_organization_claims(config), "vibe_instance_kind": "personal"},
+        },
+    )
+
+    assert payload is not None
+    assert context_from_session_payload(payload).is_personal_instance
+
+
+def test_cached_authorization_from_previous_instance_kind_refreshes_before_personal_bypass(
+    monkeypatch,
+    tmp_path,
+):
+    config = _paired_config(tmp_path)
+    cookie = _organization_cookie(config)
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.save()
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    calls = []
+
+    def refresh(_config, _method, _suffix, payload, **kwargs):
+        calls.append(payload)
+        return _authorization_context_response(
+            config,
+            payload,
+            revision=41,
+            instance_kind="personal",
+        )
+
+    monkeypatch.setattr(remote_access, "_device_json_request", refresh)
+
+    result = remote_access.resolve_current_authorization(config, identity)
+
+    assert result.current is True
+    assert result.refreshed is True
+    assert result.policy == "personal"
+    assert len(calls) == 1
+    record = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=int(time.time()),
+    )
+    assert record is not None
+    assert record["claims"]["vibe_instance_kind"] == "personal"
+
+
+def test_partial_pairing_cannot_restore_cached_personal_authorization(tmp_path):
+    config = _paired_config(tmp_path)
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.remote_access.vibe_cloud.instance_secret = ""
+    config.save()
+
+    payload = remote_access._validated_authorization_payload(
+        config,
+        {
+            "sub": "personal-user",
+            "email": "personal@example.com",
+            "instance_id": "inst_123",
+        },
+        {
+            "id": "authorization-1",
+            "claims": {**_organization_claims(config), "vibe_instance_kind": "organization"},
+        },
+    )
+
+    assert payload is None
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    resolution = remote_access.resolve_current_authorization(
+        config,
+        identity,
+        allow_refresh=False,
+    )
+    assert resolution.state == "unavailable"
+    assert resolution.reason == "pairing_unavailable"
+
+
+def test_partial_pairing_preserves_exact_show_page_email_grant(tmp_path):
+    config = _paired_config(tmp_path)
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.remote_access.vibe_cloud.instance_secret = ""
+    config.save()
+    cookie = remote_access.make_session_cookie(
+        config,
+        "viewer@example.com",
+        "viewer-1",
+        session_claims={
+            "vibe_instance_id": "inst_123",
+            "vibe_instance_role": "viewer",
+            "vibe_instance_access_source": "show_page_email",
+            "vibe_show_page_id": "show-1",
+            "vibe_instance_authorization_revision": 41,
+        },
+    )
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+
+    resolution = remote_access.resolve_current_authorization(
+        config,
+        identity,
+        allow_refresh=False,
+    )
+
+    assert resolution.current is True
+    assert resolution.payload is not None
+    assert resolution.payload["vibe_show_page_id"] == "show-1"
+
+
+def test_organization_to_personal_reclassification_revalidates_before_the_bypass(
+    monkeypatch,
+    tmp_path,
+):
+    """A reclassified pairing must re-earn every instance-scoped authorization."""
+
+    config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="organization",
+    )
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    reference = identity["authorization_ref"]
+    now = int(time.time())
+    admitted = remote_access_authorization_service.load_reference_record(
+        reference=reference,
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert admitted is not None
+    assert admitted["authorization_state"] == "current"
+
+    assert remote_access._persist_instance_kind("inst_123", "personal", reconcile=True) is True
+
+    reclassified = V2Config.load()
+    assert reclassified.remote_access.vibe_cloud.instance_kind == "personal"
+    invalidated = remote_access_authorization_service.load_reference_record(
+        reference=reference,
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert invalidated is not None
+    assert invalidated["authorization_state"] == "stale"
+
+    # The cached Organization claims must not be re-projected as Personal.
+    blocked = remote_access.resolve_current_authorization(
+        reclassified,
+        identity,
+        allow_refresh=False,
+    )
+    assert blocked.current is False
+    assert blocked.reason == "authorization_context_missing"
+
+    calls = []
+
+    def refresh(_config, _method, _suffix, payload, **kwargs):
+        calls.append(payload)
+        return _authorization_context_response(
+            config,
+            payload,
+            revision=41,
+            instance_kind="personal",
+        )
+
+    monkeypatch.setattr(remote_access, "_device_json_request", refresh)
+
+    result = remote_access.resolve_current_authorization(reclassified, identity)
+
+    assert result.current is True
+    assert result.refreshed is True
+    assert result.policy == "personal"
+    # Synchronous revalidation, not a background hint that would let the
+    # Personal bypass answer this very request from the stale row.
+    assert len(calls) == 1
+    revalidated = remote_access_authorization_service.load_reference_record(
+        reference=reference,
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert revalidated is not None
+    assert revalidated["authorization_state"] == "current"
+    assert revalidated["claims"]["vibe_instance_kind"] == "personal"
+
+
+def test_instance_kind_persistence_failure_leaves_no_kind_tagged_current_row(
+    monkeypatch,
+    tmp_path,
+):
+    """A failed kind write must not leave a usable Personal projection behind."""
+
+    config = _paired_config(tmp_path)
+    config.remote_access.vibe_cloud.instance_kind = ""
+    config.save()
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    reference = identity["authorization_ref"]
+    now = int(time.time())
+    # Collapse the failure backoff so the retry below exercises the network
+    # path instead of the short-circuit that protects the backend.
+    monkeypatch.setattr(remote_access, "AUTHORIZATION_REFRESH_FAILURE_BACKOFF_SECONDS", 0.0)
+    monkeypatch.setattr(
+        remote_access,
+        "current_authorization_revision",
+        lambda *args, **kwargs: 42,
+    )
+    monkeypatch.setattr(
+        remote_access,
+        "_device_json_request",
+        lambda _config, _method, _suffix, payload, **kwargs: _authorization_context_response(
+            config,
+            payload,
+            revision=42,
+            instance_kind="personal",
+        ),
+    )
+    real_save_config = remote_access.api.save_config
+    attempted: list[dict[str, Any]] = []
+
+    def failing_save_config(payload, **kwargs):
+        attempted.append(payload)
+        raise OSError("read-only config")
+
+    monkeypatch.setattr(remote_access.api, "save_config", failing_save_config)
+
+    blocked = remote_access.resolve_current_authorization(config, identity)
+
+    assert blocked.state == "unavailable"
+    assert blocked.reason == "instance_kind_persistence_failed"
+    assert attempted
+    assert V2Config.load().remote_access.vibe_cloud.instance_kind == ""
+    stored = remote_access_authorization_service.load_reference_record(
+        reference=reference,
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert stored is not None
+    assert "vibe_instance_kind" not in stored["claims"]
+    kindless_payload = remote_access._validated_authorization_payload(
+        config,
+        identity,
+        stored,
+    )
+    assert kindless_payload is not None
+    assert context_from_session_payload(kindless_payload).is_personal_instance is False
+
+    monkeypatch.setattr(remote_access.api, "save_config", real_save_config)
+
+    retried = remote_access.resolve_current_authorization(config, identity)
+
+    assert retried.current is True
+    assert retried.policy == "personal"
+    assert V2Config.load().remote_access.vibe_cloud.instance_kind == "personal"
+    repaired = remote_access_authorization_service.load_reference_record(
+        reference=reference,
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert repaired is not None
+    assert repaired["claims"]["vibe_instance_kind"] == "personal"
+
+
+def test_refresh_from_a_previous_binding_generation_is_discarded(monkeypatch, tmp_path):
+    """An in-flight response that outlived its binding must not be cached."""
+
+    config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="organization",
+    )
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    now = int(time.time())
+    record = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert record is not None
+    binding_before = remote_access_authorization_service.load_instance_binding_state()
+    assert binding_before is not None
+
+    def repair_while_in_flight(_config, _method, _suffix, payload, **kwargs):
+        # A re-pair lands while this authorization response is in flight.
+        remote_access._transition_instance_binding(
+            instance_id="inst_repair",
+            instance_kind="personal",
+        )
+        return _authorization_context_response(config, payload, revision=41)
+
+    monkeypatch.setattr(remote_access, "_device_json_request", repair_while_in_flight)
+
+    result = remote_access._refresh_authorization_context(
+        config,
+        identity,
+        record,
+        now=now,
+        force=True,
+    )
+
+    assert result.state == "unavailable"
+    assert result.reason == "instance_binding_changed"
+    binding_after = remote_access_authorization_service.load_instance_binding_state()
+    assert binding_after is not None
+    assert binding_after["generation"] > binding_before["generation"]
+    assert binding_after["instance_id"] == "inst_repair"
+    with remote_access._AUTHORIZATION_REFRESH_LOCK:
+        assert remote_access._AUTHORIZATION_REFRESH_RESULTS == {}
+        assert remote_access._AUTHORIZATION_REFRESH_FAILURES == {}
+    # The discarded generation must not be answerable from cache either.
+    assert (
+        remote_access.resolve_current_authorization(
+            config,
+            identity,
+            allow_refresh=False,
+        ).current
+        is False
+    )
+
+
+def test_stale_cross_process_kind_response_cannot_reverse_durable_generation(
+    monkeypatch,
+    tmp_path,
+):
+    """A UI-process in-flight Personal response must not undo a controller reclass.
+
+    The controller and UI server are separate processes; the in-memory
+    binding epoch cannot fence this. The durable generation in state_meta
+    is the compare-and-swap token both processes share.
+    """
+
+    config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="personal",
+    )
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.save()
+    cookie = remote_access.make_session_cookie(
+        config,
+        "user-1@example.com",
+        "user-1",
+        session_claims={
+            "vibe_instance_id": "inst_123",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "email",
+            "vibe_instance_authorization_revision": 41,
+        },
+    )
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    now = int(time.time())
+    observed_generation = remote_access_authorization_service.current_instance_binding_generation()
+    # Controller heartbeat in another process: Personal -> Organization.
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="organization",
+    )
+    config.remote_access.vibe_cloud.instance_kind = "organization"
+    config.save()
+    newer = remote_access_authorization_service.load_instance_binding_state()
+    assert newer is not None
+    assert newer["generation"] > observed_generation
+    assert newer["instance_kind"] == "organization"
+
+    # Stale UI-process in-flight epoch is unchanged; durable generation is not.
+    monkeypatch.setattr(remote_access, "_authorization_binding_epoch", lambda: 0)
+    persisted = remote_access._persist_instance_kind(
+        "inst_123",
+        "personal",
+        expected_binding_generation=observed_generation,
+        expected_binding_epoch=0,
+    )
+
+    assert persisted is False
+    assert V2Config.load().remote_access.vibe_cloud.instance_kind == "organization"
+    after = remote_access_authorization_service.load_instance_binding_state()
+    assert after is not None
+    assert after["generation"] == newer["generation"]
+    assert after["instance_kind"] == "organization"
+
+
+def test_stale_write_is_refused_under_cross_process_config_lock(tmp_path):
+    """Two threads contend on config_file_lock; the stale writer must abort.
+
+    This is the real cross-process lock boundary (the same lock V2Config.save
+    uses), not the in-process epoch.
+    """
+
+    from config.v2_config import config_file_lock
+
+    config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="personal",
+    )
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.save()
+    observed = remote_access_authorization_service.current_instance_binding_generation()
+    # flock is process-level, so two threads in one process cannot actually
+    # block each other on config_file_lock. Model the cross-process race as:
+    # snapshot generation, then a controller advance under that lock, then a
+    # stale persist that must CAS-fail against the durable generation.
+    with config_file_lock():
+        remote_access._transition_instance_binding(
+            instance_id="inst_123",
+            instance_kind="organization",
+        )
+        config.remote_access.vibe_cloud.instance_kind = "organization"
+        config.save()
+    controller_generation = (
+        remote_access_authorization_service.current_instance_binding_generation()
+    )
+    stale_ok = remote_access._persist_instance_kind(
+        "inst_123",
+        "personal",
+        expected_binding_generation=observed,
+    )
+
+    assert stale_ok is False
+    assert controller_generation > observed
+    assert V2Config.load().remote_access.vibe_cloud.instance_kind == "organization"
+    after = remote_access_authorization_service.load_instance_binding_state()
+    assert after is not None
+    assert after["instance_kind"] == "organization"
+    assert after["generation"] == controller_generation
+
+
+def test_stale_denied_response_does_not_recreate_revoked_row(monkeypatch, tmp_path):
+    """A 403 captured before a transition must not recreate a revoked row."""
+
+    config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="organization",
+    )
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    now = int(time.time())
+    record = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert record is not None
+    observed = remote_access_authorization_service.current_instance_binding_generation()
+    real_generation = remote_access_authorization_service.current_instance_binding_generation
+    calls = {"n": 0}
+
+    def deny_after_transition(_config, _method, _suffix, payload, **kwargs):
+        remote_access._transition_instance_binding(
+            instance_id="inst_123",
+            instance_kind="personal",
+        )
+        raise remote_access.BackendRequestError(403, {"error": "access_denied"})
+
+    def generation(*, ensure: bool = True) -> int:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return observed
+        return real_generation(ensure=ensure)
+
+    monkeypatch.setattr(remote_access, "_device_json_request", deny_after_transition)
+    monkeypatch.setattr(
+        remote_access_authorization_service,
+        "current_instance_binding_generation",
+        generation,
+    )
+
+    result = remote_access._fetch_authorization_context(
+        config,
+        identity,
+        record,
+        now=now,
+        observed_revision=41,
+    )
+
+    assert result.state == "unavailable"
+    assert result.reason == "instance_binding_changed"
+    stored = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    if stored is not None:
+        assert stored.get("authorization_state") != "revoked"
+
+
+def test_exact_show_page_grants_survive_a_kind_transition_but_not_a_repair(tmp_path):
+    """Show Page grants are their own scope, bound to the instance that issued them."""
+
+    config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="organization",
+    )
+    now = int(time.time())
+    show_page_claims = {
+        "vibe_instance_id": "inst_123",
+        "vibe_instance_role": "viewer",
+        "vibe_instance_access_source": "show_page_email",
+        "vibe_show_page_id": "show-1",
+        "vibe_instance_authorization_revision": 41,
+    }
+    show_page_cookie = remote_access.make_session_cookie(
+        config,
+        "viewer@example.com",
+        "viewer-1",
+        session_claims=show_page_claims,
+    )
+    show_page_identity = remote_access.parse_session_identity(config, show_page_cookie)
+    assert show_page_identity is not None
+    instance_identity = remote_access.parse_session_identity(
+        config,
+        _organization_cookie(config),
+    )
+    assert instance_identity is not None
+
+    assert remote_access._persist_instance_kind("inst_123", "personal", reconcile=True) is True
+
+    reclassified = V2Config.load()
+    show_page = remote_access_authorization_service.load_scoped(
+        instance_id="inst_123",
+        subject="viewer-1",
+        scope_kind="show_page",
+        scope_ref="show-1",
+    )
+    instance = remote_access_authorization_service.load_scoped(
+        instance_id="inst_123",
+        subject="user-1",
+        scope_kind="instance",
+        scope_ref="inst_123",
+    )
+    assert show_page is not None
+    assert show_page["authorization_state"] == "current"
+    assert show_page["claims"]["vibe_show_page_id"] == "show-1"
+    assert instance is not None
+    assert instance["authorization_state"] == "stale"
+
+    resolved = remote_access.resolve_current_authorization(
+        reclassified,
+        show_page_identity,
+        allow_refresh=False,
+    )
+    assert resolved.current is True
+    assert resolved.payload is not None
+    assert resolved.payload["vibe_show_page_id"] == "show-1"
+
+    # Mid-transition the exact grant still reads, while the instance-scoped
+    # cache stays fail-closed.
+    reconciling = remote_access_authorization_service.begin_instance_binding_transition(
+        instance_id="inst_repair",
+        instance_kind="personal",
+    )
+    assert (
+        reconciling["state"]
+        == remote_access_authorization_service.INSTANCE_BINDING_STATE_RECONCILING
+    )
+    assert (
+        remote_access._durable_binding_allows_cached_authorization(
+            reclassified,
+            show_page_identity,
+            show_page,
+        )
+        is True
+    )
+    assert (
+        remote_access._durable_binding_allows_cached_authorization(
+            reclassified,
+            instance_identity,
+            instance,
+        )
+        is False
+    )
+
+    # Re-pairing to a different instance is not a reclassification: those
+    # grants were issued by the previous instance and must not survive it.
+    remote_access._transition_instance_binding(
+        instance_id="inst_repair",
+        instance_kind="personal",
+        previous_instance_id="inst_123",
+    )
+    repaired = remote_access_authorization_service.load_scoped(
+        instance_id="inst_123",
+        subject="viewer-1",
+        scope_kind="show_page",
+        scope_ref="show-1",
+    )
+    assert repaired is not None
+    assert repaired["authorization_state"] == "stale"
 
 
 def test_personal_revision_hint_refreshes_in_background_without_blocking(
@@ -303,7 +921,7 @@ def test_organization_refresh_grace_expiry_and_recovery(monkeypatch, tmp_path):
     assert recovered.payload["vibe_instance_authorization_revision"] == 42
 
 
-def test_unknown_instance_kind_backfills_without_failing_valid_access(
+def test_unknown_instance_kind_requires_durable_backfill_before_access(
     monkeypatch,
     tmp_path,
 ):
@@ -330,9 +948,9 @@ def test_unknown_instance_kind_backfills_without_failing_valid_access(
 
     result = remote_access.resolve_current_authorization(config, identity)
 
-    assert result.current is True
-    assert result.policy == "organization"
-    assert config.remote_access.vibe_cloud.instance_kind == "organization"
+    assert result.state == "unavailable"
+    assert result.reason == "instance_kind_persistence_failed"
+    assert config.remote_access.vibe_cloud.instance_kind == ""
 
 
 def test_scoped_authorization_promotes_legacy_rows_and_isolates_show_pages(tmp_path):
@@ -599,7 +1217,7 @@ def test_refresh_backoff_starts_when_the_network_request_finishes(
     identity = remote_access.parse_session_identity(config, _organization_cookie(config))
     assert identity is not None
     monkeypatch.setattr(remote_access, "current_authorization_revision", lambda *args, **kwargs: 42)
-    monotonic_values = iter((100.0, 110.0, 110.1))
+    monotonic_values = iter((100.0, 110.0, 110.05, 110.1, 110.15, 110.2))
     monkeypatch.setattr(remote_access.time, "monotonic", lambda: next(monotonic_values))
     calls = 0
 

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -73,6 +73,8 @@ def _paired_config(tmp_path, *, revision: int = 41) -> V2Config:
     remote_access._clear_authorization_revision_cache()
     remote_access._replace_authorization_revision(config, revision)
     return config
+    # Binding-row seeding is the CALLER's job: some tests need an absent
+    # row (upgrade path), others need a ready row (concurrent resolvers).
 
 
 def _organization_claims(
@@ -1113,6 +1115,10 @@ def test_concurrent_resolvers_share_one_authorization_context_refresh(
     tmp_path,
 ):
     config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="organization",
+    )
     cookie = _organization_cookie(config)
     identity = remote_access.parse_session_identity(config, cookie)
     assert identity is not None
@@ -1143,6 +1149,10 @@ def test_authorization_context_refreshes_for_different_subjects_run_concurrently
     tmp_path,
 ):
     config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="organization",
+    )
     identities = []
     for subject in ("user-1", "user-2"):
         identity = remote_access.parse_session_identity(
@@ -1178,6 +1188,10 @@ def test_concurrent_revocation_refresh_is_reused_and_persisted(
     tmp_path,
 ):
     config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="organization",
+    )
     identity = remote_access.parse_session_identity(config, _organization_cookie(config))
     assert identity is not None
     monkeypatch.setattr(remote_access, "current_authorization_revision", lambda *args, **kwargs: 42)
@@ -2346,6 +2360,21 @@ def test_known_kind_without_binding_row_bootstraps_a_durable_transition(tmp_path
     config = _paired_config(tmp_path)
     config.remote_access.vibe_cloud.instance_kind = "personal"
     config.save()
+    # Simulate an upgrade: config has a known kind, the new state_meta row
+    # has not been written yet.
+    from storage.db import get_cached_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.models import state_meta
+    from sqlalchemy import delete as sa_delete
+
+    ensure_sqlite_state()
+    engine = get_cached_sqlite_engine()
+    with engine.begin() as conn:
+        conn.execute(
+            sa_delete(state_meta).where(
+                state_meta.c.key == remote_access_authorization_service.INSTANCE_BINDING_STATE_META_KEY
+            )
+        )
     assert (
         remote_access_authorization_service.load_instance_binding_state(ensure=False)
         is None
@@ -2435,3 +2464,69 @@ def test_personal_to_organization_reclassification_rejects_stale_personal_row(
     )
     assert revalidated is not None
     assert revalidated["claims"]["vibe_instance_kind"] == "organization"
+
+
+def test_revoked_write_refused_when_transition_completes_between_check_and_write(
+    monkeypatch,
+    tmp_path,
+):
+    """Regression PR #1606 r3: the compare and the authorization-row write
+    are one atomic CAS under the binding lock. Completing a transition
+    between a TOCTOU-style check and the write must refuse the revoked upsert.
+    """
+
+    config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="organization",
+    )
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    now = int(time.time())
+    record = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert record is not None
+    started = remote_access_authorization_service.begin_instance_binding_transition(
+        instance_id="inst_123",
+        instance_kind="personal",
+    )
+    captured = remote_access_authorization_service.current_instance_binding_generation()
+
+    def deny(*args, **kwargs):
+        # Completes AFTER _fetch captured the reconciling generation and
+        # BEFORE the revoked upsert — the atomic CAS must refuse the write.
+        remote_access_authorization_service.complete_instance_binding_transition(
+            instance_id="inst_123",
+            instance_kind="personal",
+            generation=started["generation"],
+        )
+        raise remote_access.BackendRequestError(403, {"error": "access_denied"})
+
+    monkeypatch.setattr(remote_access, "_device_json_request", deny)
+
+    result = remote_access._fetch_authorization_context(
+        config,
+        identity,
+        record,
+        now=now,
+        observed_revision=41,
+    )
+
+    stored = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert result.reason == "instance_binding_changed" or (
+        stored is not None and stored.get("authorization_state") != "revoked"
+    )
+    if stored is not None:
+        assert stored.get("authorization_state") != "revoked"
+    # The captured generation is no longer current.
+    assert remote_access_authorization_service.current_instance_binding_generation() >= captured

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -2365,3 +2365,73 @@ def test_known_kind_without_binding_row_bootstraps_a_durable_transition(tmp_path
     assert state["instance_id"] == "inst_123"
     assert state["instance_kind"] == "personal"
     assert state["generation"] >= 1
+
+
+def test_personal_to_organization_reclassification_rejects_stale_personal_row(
+    monkeypatch,
+    tmp_path,
+):
+    """Regression PR #1606 r2: the kind-mismatch refresh must run before the
+    Organization branch too — a stale personal-tagged row must not be served
+    as current under the reclassified Organization policy."""
+
+    config = _paired_config(tmp_path)
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.save()
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="personal",
+    )
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    now = int(time.time())
+    stored = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert stored is not None
+    assert stored["claims"]["vibe_instance_kind"] == "personal"
+
+    # Controller heartbeat reclassifies Personal -> Organization.
+    assert remote_access._persist_instance_kind("inst_123", "organization", reconcile=True) is True
+    reclassified = V2Config.load()
+    assert reclassified.remote_access.vibe_cloud.instance_kind == "organization"
+
+    # The old personal-tagged row must not answer under the Organization policy.
+    blocked = remote_access.resolve_current_authorization(
+        reclassified,
+        identity,
+        allow_refresh=False,
+    )
+    assert blocked.current is False
+
+    calls = []
+
+    def refresh(_config, _method, _suffix, payload, **kwargs):
+        calls.append(payload)
+        return _authorization_context_response(
+            config,
+            payload,
+            revision=41,
+            instance_kind="organization",
+        )
+
+    monkeypatch.setattr(remote_access, "_device_json_request", refresh)
+
+    result = remote_access.resolve_current_authorization(reclassified, identity)
+
+    assert result.current is True
+    assert result.refreshed is True
+    assert result.policy == "organization"
+    assert len(calls) == 1
+    revalidated = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert revalidated is not None
+    assert revalidated["claims"]["vibe_instance_kind"] == "organization"

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -2640,3 +2640,99 @@ def test_binding_decoder_rejects_explicit_non_v1_schema_versions(tmp_path):
             instance_kind="personal",
             ensure=False,
         ) is False
+
+
+def test_refresh_cache_does_not_serve_personal_payload_after_org_reclassification(
+    monkeypatch,
+    tmp_path,
+):
+    """Class 1: in-memory refresh cache is bound to generation.
+
+    After a successful Personal refresh, a Personal→Org reclassification
+    within the 5s window must not return the cached Personal payload.
+    """
+
+    config = _paired_config(tmp_path)
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.save()
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="personal",
+    )
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    calls = []
+
+    def refresh(_config, _method, _suffix, payload, **kwargs):
+        calls.append(payload)
+        kind = V2Config.load().remote_access.vibe_cloud.instance_kind or "personal"
+        return _authorization_context_response(
+            config,
+            payload,
+            revision=41,
+            instance_kind=kind if kind in {"personal", "organization"} else "personal",
+        )
+
+    monkeypatch.setattr(remote_access, "_device_json_request", refresh)
+    first = remote_access.resolve_current_authorization(config, identity)
+    assert first.current is True
+    assert first.policy == "personal"
+    first_calls = len(calls)
+
+    assert remote_access._persist_instance_kind("inst_123", "organization", reconcile=True) is True
+    reclassified = V2Config.load()
+    second = remote_access.resolve_current_authorization(reclassified, identity)
+    assert second.policy != "personal" or second.current is False or second.refreshed is True
+    if second.current:
+        assert second.policy == "organization"
+        assert len(calls) > first_calls
+
+
+def test_in_flight_auth_during_same_instance_kind_transition_is_binding_changed(
+    monkeypatch,
+    tmp_path,
+):
+    """Class 3: same-instance generation advance IS instance_binding_changed."""
+
+    config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="organization",
+    )
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    now = int(time.time())
+    record = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert record is not None
+    captured = remote_access_authorization_service.current_instance_binding_generation()
+
+    def flip_then_respond(_config, _method, _suffix, payload, **kwargs):
+        remote_access._persist_instance_kind("inst_123", "personal", reconcile=True)
+        return _authorization_context_response(
+            config, payload, revision=41, instance_kind="organization"
+        )
+
+    monkeypatch.setattr(remote_access, "_device_json_request", flip_then_respond)
+    result = remote_access._fetch_authorization_context(
+        config, identity, record, now=now, observed_revision=41
+    )
+    assert result.reason == "instance_binding_changed"
+    assert result.reason != "instance_kind_persistence_failed"
+    # A subsequent request for the new binding is not 5s-denied by the old failure.
+    monkeypatch.setattr(
+        remote_access,
+        "_device_json_request",
+        lambda _c, _m, _s, payload, **k: _authorization_context_response(
+            config, payload, revision=41, instance_kind="personal"
+        ),
+    )
+    later = remote_access.resolve_current_authorization(V2Config.load(), identity)
+    assert later.reason != "authorization_refresh_backoff"
+    assert remote_access_authorization_service.current_instance_binding_generation() > captured

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -2804,3 +2804,108 @@ def test_successful_context_store_refused_when_generation_advances_after_persist
                 stored.get("authorization_state") == original_state
             )
     assert remote_access_authorization_service.current_instance_binding_generation() > captured
+
+
+def test_interactive_gate_is_read_once_and_failed_gate_never_collapses_to_legacy(
+    monkeypatch,
+    tmp_path,
+):
+    """Class 2 (interactive path): one binding-gate snapshot per evaluation.
+
+    A reconciling that begins between record admission and the former second
+    gate call must not collapse instance_kind to None and return the old
+    Personal payload through the legacy branch.
+    """
+
+    config = _paired_config(tmp_path)
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.save()
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="personal",
+    )
+    cookie = remote_access.make_session_cookie(
+        config,
+        "user-1@example.com",
+        "user-1",
+        session_claims={
+            "vibe_instance_id": config.remote_access.vibe_cloud.instance_id,
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "email",
+            "vibe_instance_kind": "personal",
+            "vibe_instance_authorization_revision": 41,
+        },
+    )
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+
+    calls = {"n": 0}
+    real_gate = remote_access.binding_is_ready
+
+    def counting_gate(*args, **kwargs):
+        calls["n"] += 1
+        # Simulate a peer entering reconciling right after the first read:
+        # any SECOND read within one evaluation would observe False.
+        if calls["n"] == 1:
+            return real_gate(*args, **kwargs)
+        return False
+
+    monkeypatch.setattr(remote_access, "binding_is_ready", counting_gate)
+    result = remote_access.resolve_current_authorization(config, identity)
+    # One evaluation = one gate read; the flip value is never consumed.
+    assert calls["n"] == 1
+    # With the single ready snapshot the personal branch ran (not legacy).
+    assert result.current is True
+    assert result.policy == "personal"
+
+    # Failed gate at snapshot time: fail closed (refresh/unavailable), never
+    # legacy-current with the old Personal payload.
+    calls["n"] = 0
+    monkeypatch.setattr(remote_access, "binding_is_ready", lambda *a, **k: False)
+    blocked = remote_access.resolve_current_authorization(
+        config, identity, allow_refresh=False
+    )
+    assert blocked.current is False
+    assert blocked.state in {"unavailable", "invalid_identity"}
+
+
+def test_unsupported_stored_kind_fails_closed_on_the_interactive_path(
+    monkeypatch,
+    tmp_path,
+):
+    """A persisted scoped row with kind="enterprise" under a legacy no-kind
+    pairing must fail closed instead of falling through legacy-current."""
+
+    config = _paired_config(tmp_path)
+    config.remote_access.vibe_cloud.instance_kind = ""
+    config.save()
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    now = int(time.time())
+    record = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert record is not None
+    claims = dict(record.get("claims") or {})
+    claims["vibe_instance_kind"] = "enterprise"
+    remote_access_authorization_service.upsert_scoped(
+        reference=str(record["id"]),
+        instance_id="inst_123",
+        subject="user-1",
+        email="user-1@example.com",
+        scope_kind=str(record.get("scope_kind") or "instance"),
+        scope_ref=str(record.get("scope_ref") or "inst_123"),
+        authorization_state="current",
+        claims=claims,
+        last_checked_at=now,
+        updated_at=now,
+    )
+    blocked = remote_access.resolve_current_authorization(
+        config, identity, allow_refresh=False
+    )
+    assert blocked.current is False
+    assert blocked.state == "unavailable"

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -33,7 +33,6 @@ def _clear_authorization_refresh_process_state():
         remote_access._AUTHORIZATION_REFRESH_FAILURES.clear()
         remote_access._AUTHORIZATION_REFRESH_RESULTS.clear()
         remote_access._AUTHORIZATION_REFRESH_FLIGHTS.clear()
-        remote_access._AUTHORIZATION_REFRESH_FLIGHT_EPOCHS.clear()
     with remote_access._AUTHORIZATION_BACKGROUND_REFRESH_LOCK:
         remote_access._AUTHORIZATION_BACKGROUND_REFRESHES.clear()
     yield
@@ -41,10 +40,12 @@ def _clear_authorization_refresh_process_state():
         remote_access._AUTHORIZATION_REFRESH_FAILURES.clear()
         remote_access._AUTHORIZATION_REFRESH_RESULTS.clear()
         remote_access._AUTHORIZATION_REFRESH_FLIGHTS.clear()
-        remote_access._AUTHORIZATION_REFRESH_FLIGHT_EPOCHS.clear()
 
 
 def _paired_config(tmp_path, *, revision: int = 41) -> V2Config:
+    import os
+
+    os.environ["AVIBE_HOME"] = str(tmp_path)
     config = V2Config(
         mode="self_host",
         version="v2",
@@ -623,10 +624,16 @@ def test_stale_write_is_refused_under_cross_process_config_lock(tmp_path):
 def test_stale_denied_response_does_not_recreate_revoked_row(monkeypatch, tmp_path):
     """A 403 captured before a transition must not recreate a revoked row."""
 
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _paired_config(tmp_path)
-    remote_access._transition_instance_binding(
+    started = remote_access_authorization_service.begin_instance_binding_transition(
         instance_id="inst_123",
         instance_kind="organization",
+    )
+    assert remote_access_authorization_service.complete_instance_binding_transition(
+        instance_id="inst_123",
+        instance_kind="organization",
+        generation=started["generation"],
     )
     cookie = _organization_cookie(config)
     identity = remote_access.parse_session_identity(config, cookie)
@@ -754,19 +761,11 @@ def test_exact_show_page_grants_survive_a_kind_transition_but_not_a_repair(tmp_p
         == remote_access_authorization_service.INSTANCE_BINDING_STATE_RECONCILING
     )
     assert (
-        remote_access._durable_binding_allows_cached_authorization(
-            reclassified,
-            show_page_identity,
-            show_page,
-        )
+        remote_access.binding_is_ready(reclassified, show_page_identity)
         is True
     )
     assert (
-        remote_access._durable_binding_allows_cached_authorization(
-            reclassified,
-            instance_identity,
-            instance,
-        )
+        remote_access.binding_is_ready(reclassified, instance_identity)
         is False
     )
 

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -323,7 +323,7 @@ def test_organization_to_personal_reclassification_revalidates_before_the_bypass
     assert admitted is not None
     assert admitted["authorization_state"] == "current"
 
-    assert remote_access._persist_instance_kind("inst_123", "personal", reconcile=True) is True
+    assert remote_access._persist_instance_kind("inst_123", "personal", reconcile=True)
 
     reclassified = V2Config.load()
     assert reclassified.remote_access.vibe_cloud.instance_kind == "personal"
@@ -724,7 +724,7 @@ def test_exact_show_page_grants_survive_a_kind_transition_but_not_a_repair(tmp_p
     )
     assert instance_identity is not None
 
-    assert remote_access._persist_instance_kind("inst_123", "personal", reconcile=True) is True
+    assert remote_access._persist_instance_kind("inst_123", "personal", reconcile=True)
 
     reclassified = V2Config.load()
     show_page = remote_access_authorization_service.load_scoped(
@@ -2426,7 +2426,7 @@ def test_personal_to_organization_reclassification_rejects_stale_personal_row(
     assert stored["claims"]["vibe_instance_kind"] == "personal"
 
     # Controller heartbeat reclassifies Personal -> Organization.
-    assert remote_access._persist_instance_kind("inst_123", "organization", reconcile=True) is True
+    assert remote_access._persist_instance_kind("inst_123", "organization", reconcile=True)
     reclassified = V2Config.load()
     assert reclassified.remote_access.vibe_cloud.instance_kind == "organization"
 
@@ -2680,7 +2680,7 @@ def test_refresh_cache_does_not_serve_personal_payload_after_org_reclassificatio
     assert first.policy == "personal"
     first_calls = len(calls)
 
-    assert remote_access._persist_instance_kind("inst_123", "organization", reconcile=True) is True
+    assert remote_access._persist_instance_kind("inst_123", "organization", reconcile=True)
     reclassified = V2Config.load()
     second = remote_access.resolve_current_authorization(reclassified, identity)
     assert second.policy != "personal" or second.current is False or second.refreshed is True
@@ -2735,4 +2735,72 @@ def test_in_flight_auth_during_same_instance_kind_transition_is_binding_changed(
     )
     later = remote_access.resolve_current_authorization(V2Config.load(), identity)
     assert later.reason != "authorization_refresh_backoff"
+    assert remote_access_authorization_service.current_instance_binding_generation() > captured
+
+
+def test_successful_context_store_refused_when_generation_advances_after_persist_kind(
+    monkeypatch,
+    tmp_path,
+):
+    """Class close: every authorization-row write carries the REQUEST generation.
+
+    persist-kind CAS succeeds at request gen; a peer then completes a
+    transition (gen advances) before store. Recapturing live generation
+    would let the stale 200 resurrect a current row. Store must refuse.
+    """
+
+    config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="organization",
+    )
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    now = int(time.time())
+    record = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert record is not None
+    original_state = record.get("authorization_state")
+    captured = remote_access_authorization_service.current_instance_binding_generation()
+
+    original_store = remote_access._store_scoped_authorization
+    advanced = {"done": False}
+
+    def store_after_peer_transition(*args, **kwargs):
+        if not advanced["done"]:
+            advanced["done"] = True
+            remote_access._persist_instance_kind("inst_123", "personal", reconcile=True)
+        return original_store(*args, **kwargs)
+
+    monkeypatch.setattr(remote_access, "_store_scoped_authorization", store_after_peer_transition)
+    monkeypatch.setattr(
+        remote_access,
+        "_device_json_request",
+        lambda _c, _m, _s, payload, **k: _authorization_context_response(
+            config, payload, revision=41, instance_kind="organization"
+        ),
+    )
+    result = remote_access._fetch_authorization_context(
+        config, identity, record, now=now, observed_revision=41
+    )
+    stored = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert result.reason == "instance_binding_changed"
+    assert result.current is False
+    if stored is not None:
+        # Must not resurrect a current Organization row under the new Personal binding.
+        if stored.get("authorization_state") == "current":
+            claims = stored.get("claims") or {}
+            assert claims.get("vibe_instance_kind") != "organization" or (
+                stored.get("authorization_state") == original_state
+            )
     assert remote_access_authorization_service.current_instance_binding_generation() > captured

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import itertools
+import json
 import threading
 import time
 from typing import Any
@@ -2590,3 +2591,52 @@ def test_kindless_current_row_revalidates_after_known_kind_bootstrap(
     assert len(calls) == 1
     assert result.payload is not None
     assert result.payload.get("vibe_instance_kind") == "personal"
+
+
+def test_binding_decoder_rejects_explicit_non_v1_schema_versions(tmp_path):
+    """Regression PR #1606 r5: only a genuinely absent schema_version defaults
+    to v1; explicit 0 or 2 must fail closed.
+    """
+
+    config = _paired_config(tmp_path)
+    from storage.db import get_cached_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.models import state_meta
+    from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+    ensure_sqlite_state()
+    engine = get_cached_sqlite_engine()
+    for version in (0, 2):
+        payload = json.dumps(
+            {
+                "schema_version": version,
+                "state": "ready",
+                "instance_id": "inst_123",
+                "instance_kind": "personal",
+                "generation": 1,
+                "updated_at": "1",
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        with engine.begin() as conn:
+            statement = sqlite_insert(state_meta).values(
+                key=remote_access_authorization_service.INSTANCE_BINDING_STATE_META_KEY,
+                value_json=payload,
+                updated_at="1",
+            )
+            conn.execute(
+                statement.on_conflict_do_update(
+                    index_elements=[state_meta.c.key],
+                    set_={"value_json": payload, "updated_at": "1"},
+                )
+            )
+        decoded = remote_access_authorization_service.load_instance_binding_state(
+            ensure=False
+        )
+        assert decoded is None or decoded.get("state") == remote_access_authorization_service.INSTANCE_BINDING_STATE_INVALID
+        assert remote_access_authorization_service.binding_is_ready_for_pairing(
+            instance_id="inst_123",
+            instance_kind="personal",
+            ensure=False,
+        ) is False

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -2530,3 +2530,63 @@ def test_revoked_write_refused_when_transition_completes_between_check_and_write
         assert stored.get("authorization_state") != "revoked"
     # The captured generation is no longer current.
     assert remote_access_authorization_service.current_instance_binding_generation() >= captured
+
+
+def test_kindless_current_row_revalidates_after_known_kind_bootstrap(
+    monkeypatch,
+    tmp_path,
+):
+    """Regression PR #1606 r4: a released current row with no vibe_instance_kind
+    must refresh on the first request after a known-kind Personal pairing
+    bootstraps, instead of returning a kindless payload.
+    """
+
+    config = _paired_config(tmp_path)
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.save()
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    now = int(time.time())
+    record = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert record is not None
+    claims = dict(record["claims"])
+    claims.pop("vibe_instance_kind", None)
+    remote_access_authorization_service.upsert_scoped(
+        reference=record["id"],
+        instance_id="inst_123",
+        subject="user-1",
+        email=record["email"],
+        scope_kind=record["scope_kind"],
+        scope_ref=record["scope_ref"],
+        authorization_state="current",
+        claims=claims,
+        last_checked_at=now,
+        updated_at=now,
+    )
+    calls = []
+
+    def refresh(_config, _method, _suffix, payload, **kwargs):
+        calls.append(payload)
+        return _authorization_context_response(
+            config,
+            payload,
+            revision=41,
+            instance_kind="personal",
+        )
+
+    monkeypatch.setattr(remote_access, "_device_json_request", refresh)
+
+    result = remote_access.resolve_current_authorization(config, identity)
+
+    assert result.current is True
+    assert result.refreshed is True
+    assert result.policy == "personal"
+    assert len(calls) == 1
+    assert result.payload is not None
+    assert result.payload.get("vibe_instance_kind") == "personal"

--- a/tests/test_remote_authorization_revision.py
+++ b/tests/test_remote_authorization_revision.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+import itertools
 import threading
 import time
 from typing import Any
@@ -1216,7 +1217,10 @@ def test_refresh_backoff_starts_when_the_network_request_finishes(
     identity = remote_access.parse_session_identity(config, _organization_cookie(config))
     assert identity is not None
     monkeypatch.setattr(remote_access, "current_authorization_revision", lambda *args, **kwargs: 42)
-    monotonic_values = iter((100.0, 110.0, 110.05, 110.1, 110.15, 110.2))
+    monotonic_values = itertools.chain(
+        (100.0, 110.0, 110.05, 110.1, 110.15),
+        itertools.repeat(110.2),
+    )
     monkeypatch.setattr(remote_access.time, "monotonic", lambda: next(monotonic_values))
     calls = 0
 
@@ -2273,3 +2277,91 @@ def test_trusted_local_access_ignores_hosted_revision_state(monkeypatch, tmp_pat
 
     assert response.status_code == 200
     assert response.get_json()["runtime"]["default_cwd"] == "."
+
+
+def test_denied_response_during_reconciliation_does_not_persist_revoked(
+    monkeypatch,
+    tmp_path,
+):
+    """Regression PR #1606 r1: a 403 racing a same-generation reconciliation
+    must not persist a revoked row the completed binding then trips over."""
+
+    config = _paired_config(tmp_path)
+    remote_access._transition_instance_binding(
+        instance_id="inst_123",
+        instance_kind="organization",
+    )
+    cookie = _organization_cookie(config)
+    identity = remote_access.parse_session_identity(config, cookie)
+    assert identity is not None
+    now = int(time.time())
+    record = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    assert record is not None
+    # A reconciliation begins BEFORE the refresh starts: same generation is
+    # captured, and completing a transition does not increment it.
+    started = remote_access_authorization_service.begin_instance_binding_transition(
+        instance_id="inst_123",
+        instance_kind="personal",
+    )
+    assert (
+        started["state"]
+        == remote_access_authorization_service.INSTANCE_BINDING_STATE_RECONCILING
+    )
+
+    def deny(*args, **kwargs):
+        raise remote_access.BackendRequestError(403, {"error": "access_denied"})
+
+    monkeypatch.setattr(remote_access, "_device_json_request", deny)
+
+    result = remote_access._fetch_authorization_context(
+        config,
+        identity,
+        record,
+        now=now,
+        observed_revision=41,
+    )
+
+    assert result.state == "unavailable"
+    assert result.reason == "instance_binding_changed"
+    stored = remote_access_authorization_service.load_reference_record(
+        reference=identity["authorization_ref"],
+        instance_id="inst_123",
+        subject="user-1",
+        now=now,
+    )
+    if stored is not None:
+        assert stored.get("authorization_state") != "revoked"
+
+
+def test_known_kind_without_binding_row_bootstraps_a_durable_transition(tmp_path):
+    """Regression PR #1606 r1: upgrade path — config carries a kind but the
+    state_meta binding row is absent; the gate must earn a validated row
+    through one real transition instead of trusting the config value."""
+
+    config = _paired_config(tmp_path)
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.save()
+    assert (
+        remote_access_authorization_service.load_instance_binding_state(ensure=False)
+        is None
+    )
+    # The storage gate alone fails closed for a known kind with no row.
+    assert remote_access_authorization_service.binding_is_ready_for_pairing(
+        instance_id="inst_123",
+        instance_kind="personal",
+        ensure=False,
+    ) is False
+
+    # The consumer gate bootstraps one durable transition, then admits.
+    assert remote_access.binding_is_ready(config) is True
+    state = remote_access_authorization_service.load_instance_binding_state(ensure=False)
+    assert state is not None
+    assert state["state"] == remote_access_authorization_service.INSTANCE_BINDING_STATE_READY
+    assert state["instance_id"] == "inst_123"
+    assert state["instance_kind"] == "personal"
+    assert state["generation"] >= 1

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -434,6 +434,17 @@ def test_deferred_remote_context_remains_valid_past_authorization_refresh_bounda
     config.remote_access.vibe_cloud.instance_kind = "organization"
     config.remote_access.vibe_cloud.instance_secret = "instance-secret"
     config.save()
+    from storage import remote_access_authorization_service as _auth
+
+    started = _auth.begin_instance_binding_transition(
+        instance_id="organization-instance",
+        instance_kind="organization",
+    )
+    _auth.complete_instance_binding_transition(
+        instance_id="organization-instance",
+        instance_kind="organization",
+        generation=started["generation"],
+    )
 
     issued_at = 1_700_000_000
     context = resource_access_service.ResourceUserContext(
@@ -661,6 +672,17 @@ def test_kindless_deferred_context_adopts_matching_validated_pairing(
         }
     }
 
+    from storage import remote_access_authorization_service as _auth
+
+    started = _auth.begin_instance_binding_transition(
+        instance_id="paired-instance",
+        instance_kind="personal",
+    )
+    _auth.complete_instance_binding_transition(
+        instance_id="paired-instance",
+        instance_kind="personal",
+        generation=started["generation"],
+    )
     restored = resource_access_service.resource_user_context_from_metadata(legacy_metadata)
 
     assert restored is not None
@@ -781,6 +803,7 @@ def test_migrate_legacy_deferred_contexts_binds_definitions_and_queued_deliverie
             )
             from storage.importer import _run_sqlite_data_migrations
 
+            _seed_ready_binding(connection, instance_id="paired-instance", instance_kind=paired_kind)
             counts = _run_sqlite_data_migrations(connection)
             assert _migration_counts(counts) == {
                 "legacy_deferred_definitions": 2,
@@ -798,6 +821,17 @@ def test_migrate_legacy_deferred_contexts_binds_definitions_and_queued_deliverie
                 snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
                 assert snapshot["vibe_instance_id"] == "paired-instance"
                 assert snapshot["vibe_instance_kind"] == paired_kind
+                from storage import remote_access_authorization_service as _auth
+
+                started = _auth.begin_instance_binding_transition(
+                    instance_id="paired-instance",
+                    instance_kind=paired_kind,
+                )
+                _auth.complete_instance_binding_transition(
+                    instance_id="paired-instance",
+                    instance_kind=paired_kind,
+                    generation=started["generation"],
+                )
                 assert resource_access_service.resource_user_context_from_metadata(metadata) is not None
 
             run_metadata = connection.execute(
@@ -1013,6 +1047,7 @@ def test_legacy_migration_retries_when_same_pairing_kind_is_backfilled(
         config.save()
 
         with engine.begin() as connection:
+            _seed_ready_binding(connection, instance_id="same-instance", instance_kind="personal")
             assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
                 "legacy_deferred_definitions": 1,
                 "legacy_deferred_runs": 0,
@@ -1091,6 +1126,7 @@ def test_legacy_migration_preserves_instance_id_while_pairing_is_partial(
         config.save()
 
         with engine.begin() as connection:
+            _seed_ready_binding(connection, instance_id="same-instance", instance_kind="personal")
             assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
                 "legacy_deferred_definitions": 1,
                 "legacy_deferred_runs": 0,
@@ -1207,22 +1243,31 @@ def _paired_cloud_config(
     cloud.instance_kind = instance_kind
     cloud.instance_secret = instance_secret
     config.save()
-    if enabled and instance_id and instance_kind in {"personal", "organization"}:
-        # T5: a known configured kind is ready only with a validated durable
-        # row. Tests that construct a pairing this way must look like an
-        # already-bootstrapped install, not an upgrade with a missing row.
-        from storage import remote_access_authorization_service
-
-        started = remote_access_authorization_service.begin_instance_binding_transition(
-            instance_id=instance_id,
-            instance_kind=instance_kind,
-        )
-        remote_access_authorization_service.complete_instance_binding_transition(
-            instance_id=instance_id,
-            instance_kind=instance_kind,
-            generation=started["generation"],
-        )
     return config
+
+
+def _seed_ready_binding(connection, *, instance_id: str, instance_kind: str, generation: int = 1) -> None:
+    """Write a validated ready binding onto THIS connection's database."""
+
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "state": "ready",
+            "instance_id": instance_id,
+            "instance_kind": instance_kind,
+            "generation": generation,
+            "updated_at": "1",
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    connection.execute(
+        state_meta.insert().values(
+            key="remote_access.instance_binding.v1",
+            value_json=payload,
+            updated_at="1",
+        )
+    )
 
 
 def _seed_legacy_scheduled_task(store, *, definition_id: str, snapshot: dict) -> None:
@@ -1311,6 +1356,7 @@ def test_credential_repair_on_the_same_pairing_completes_the_deferred_migration(
         config.save()
 
         with engine.begin() as connection:
+            _seed_ready_binding(connection, instance_id="same-instance", instance_kind="personal")
             assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
                 **_EMPTY_MIGRATION_COUNTS,
                 "legacy_deferred_definitions": 1,
@@ -1319,6 +1365,17 @@ def test_credential_repair_on_the_same_pairing_completes_the_deferred_migration(
             snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
             assert snapshot["vibe_instance_id"] == "same-instance"
             assert snapshot["vibe_instance_kind"] == "personal"
+            from storage import remote_access_authorization_service as _auth
+
+            started = _auth.begin_instance_binding_transition(
+                instance_id="same-instance",
+                instance_kind="personal",
+            )
+            _auth.complete_instance_binding_transition(
+                instance_id="same-instance",
+                instance_kind="personal",
+                generation=started["generation"],
+            )
             assert resource_access_service.resource_user_context_from_metadata(metadata) is not None
             completed = json.loads(_stored_migration_marker(connection))
 
@@ -1376,11 +1433,23 @@ def test_transient_configuration_failure_leaves_the_migration_retryable(
         assert V2Config.load.__func__ is real_load.__func__
 
         with engine.begin() as connection:
+            _seed_ready_binding(connection, instance_id="same-instance", instance_kind="personal")
             assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
                 **_EMPTY_MIGRATION_COUNTS,
                 "legacy_deferred_definitions": 1,
             }
             metadata = _legacy_definition_metadata(connection, "legacy-task")
+            from storage import remote_access_authorization_service as _auth
+
+            started = _auth.begin_instance_binding_transition(
+                instance_id="same-instance",
+                instance_kind="personal",
+            )
+            _auth.complete_instance_binding_transition(
+                instance_id="same-instance",
+                instance_kind="personal",
+                generation=started["generation"],
+            )
             assert resource_access_service.resource_user_context_from_metadata(metadata) is not None
     finally:
         store.close()
@@ -1523,6 +1592,7 @@ def test_shared_access_source_snapshots_migrate_for_either_pairing_kind(
         from storage.importer import _run_sqlite_data_migrations
 
         with engine.begin() as connection:
+            _seed_ready_binding(connection, instance_id="paired-instance", instance_kind=paired_kind)
             assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
                 **_EMPTY_MIGRATION_COUNTS,
                 "legacy_deferred_definitions": 1,
@@ -1531,6 +1601,17 @@ def test_shared_access_source_snapshots_migrate_for_either_pairing_kind(
             snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
             assert snapshot["vibe_instance_id"] == "paired-instance"
             assert snapshot["vibe_instance_kind"] == paired_kind
+            from storage import remote_access_authorization_service as _auth
+
+            started = _auth.begin_instance_binding_transition(
+                instance_id="paired-instance",
+                instance_kind=paired_kind,
+            )
+            _auth.complete_instance_binding_transition(
+                instance_id="paired-instance",
+                instance_kind=paired_kind,
+                generation=started["generation"],
+            )
             restored = resource_access_service.resource_user_context_from_metadata(metadata)
             assert restored is not None
             assert restored.is_personal_instance is (paired_kind == "personal")
@@ -1783,6 +1864,7 @@ def test_recovered_config_is_unavailable_and_does_not_seal_legacy_snapshots(
         monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
         _paired_cloud_config(tmp_path)
         with engine.begin() as connection:
+            _seed_ready_binding(connection, instance_id="same-instance", instance_kind="personal")
             repaired = _migration_counts(_run_sqlite_data_migrations(connection))
             metadata = _legacy_definition_metadata(connection, "legacy-task")
         snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
@@ -1957,3 +2039,122 @@ def test_terminal_delivery_snapshots_are_left_byte_identical(
         assert rows["del_retired"]["snapshot_sha256"] == snapshot_sha
     finally:
         engine.dispose()
+
+
+def test_absent_binding_fails_closed_for_deferred_personal_context(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Regression PR #1606 r5: a known-kind pairing with no durable binding
+    row must not project a Personal context for deferred execution.
+    """
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "personal-instance"
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+    config.save()
+    context = resource_access_service.ResourceUserContext(
+        subject="personal-user",
+        instance_id="personal-instance",
+        instance_role="editor",
+        instance_access_source="owner",
+        instance_kind="personal",
+        is_remote=True,
+    )
+    metadata = resource_access_service.metadata_with_resource_user_context({}, context)
+    assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+
+
+def test_migration_stays_pending_without_a_validated_binding_row(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Regression PR #1606 r5: known-kind config + absent binding row must
+    not complete the deferred-context migration or relabel snapshots.
+    """
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    cloud = config.remote_access.vibe_cloud
+    cloud.enabled = True
+    cloud.instance_id = "same-instance"
+    cloud.instance_kind = "personal"
+    cloud.instance_secret = "instance-secret"
+    config.save()
+    legacy_snapshot = {
+        "sub": "legacy-user",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": "email",
+        "claims_issued_at": 1_700_000_000,
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        _seed_legacy_scheduled_task(store, definition_id="legacy-task", snapshot=legacy_snapshot)
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            counts = _migration_counts(_run_sqlite_data_migrations(connection))
+            marker = json.loads(_stored_migration_marker(connection))
+            metadata = _legacy_definition_metadata(connection, "legacy-task")
+        assert counts == _EMPTY_MIGRATION_COUNTS
+        assert marker["state"] == "pending"
+        snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
+        assert "vibe_instance_kind" not in snapshot
+    finally:
+        engine.dispose()
+
+
+def test_unsupported_deferred_snapshot_kind_is_rejected(monkeypatch, tmp_path) -> None:
+    """Regression PR #1606 r5: a present-but-unrecognized kind is not a
+    no-kind legacy snapshot for deferred execution either.
+    """
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    _paired_cloud_config(tmp_path)
+    metadata = {
+        resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: {
+            "sub": "legacy-user",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "email",
+            "vibe_instance_id": "same-instance",
+            "vibe_instance_kind": "enterprise",
+            "claims_issued_at": 1_700_000_000,
+        }
+    }
+    assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+
+
+def test_unrelated_section_load_warning_does_not_make_pairing_unavailable(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Regression PR #1606 r5: Model Hub recovery warnings must not classify
+    an intact Vibe Cloud pairing as UNAVAILABLE.
+    """
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    _paired_cloud_config(tmp_path)
+
+    class IntactPairing:
+        load_warnings = ("Recovered invalid config section 'model_hub.sources.vendor': bad",)
+        class remote_access:
+            class vibe_cloud:
+                enabled = True
+                instance_id = "same-instance"
+                instance_kind = "personal"
+                instance_secret = "instance-secret"
+                @staticmethod
+                def runtime_credentials():
+                    return ("https://backend.test", "same-instance", "instance-secret")
+
+    monkeypatch.setattr(V2Config, "load", staticmethod(lambda **kwargs: IntactPairing()))
+    state = resource_access_service._configured_resource_state()
+    assert state.status == "ready"
+    assert state.instance_id == "same-instance"
+    assert state.instance_kind == "personal"

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -479,6 +479,17 @@ def test_deferred_personal_context_keeps_instance_kind(monkeypatch, tmp_path) ->
     config.remote_access.vibe_cloud.instance_kind = "personal"
     config.remote_access.vibe_cloud.instance_secret = "instance-secret"
     config.save()
+    from storage import remote_access_authorization_service as _auth
+
+    started = _auth.begin_instance_binding_transition(
+        instance_id="personal-instance",
+        instance_kind="personal",
+    )
+    _auth.complete_instance_binding_transition(
+        instance_id="personal-instance",
+        instance_kind="personal",
+        generation=started["generation"],
+    )
 
     context = resource_access_service.ResourceUserContext(
         subject="personal-user",
@@ -1196,6 +1207,21 @@ def _paired_cloud_config(
     cloud.instance_kind = instance_kind
     cloud.instance_secret = instance_secret
     config.save()
+    if enabled and instance_id and instance_kind in {"personal", "organization"}:
+        # T5: a known configured kind is ready only with a validated durable
+        # row. Tests that construct a pairing this way must look like an
+        # already-bootstrapped install, not an upgrade with a missing row.
+        from storage import remote_access_authorization_service
+
+        started = remote_access_authorization_service.begin_instance_binding_transition(
+            instance_id=instance_id,
+            instance_kind=instance_kind,
+        )
+        remote_access_authorization_service.complete_instance_binding_transition(
+            instance_id=instance_id,
+            instance_kind=instance_kind,
+            generation=started["generation"],
+        )
     return config
 
 
@@ -1700,5 +1726,107 @@ def test_migration_defers_to_a_disagreeing_durable_binding_row(
         assert marker["instance_id"] == "same-instance"
         snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
         assert "vibe_instance_kind" not in snapshot
+    finally:
+        engine.dispose()
+
+
+def test_recovered_config_is_unavailable_and_does_not_seal_legacy_snapshots(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Regression PR #1606 r3: a recovered/defaulted V2Config.load() (broken
+    JSON, load_warnings set) is UNAVAILABLE, never authoritative UNPAIRED.
+    Repairing the config later must still be able to migrate the snapshots.
+    """
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = _paired_cloud_config(tmp_path)
+    legacy_snapshot = {
+        "sub": "legacy-user",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": "email",
+        "claims_issued_at": 1_700_000_000,
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        _seed_legacy_scheduled_task(store, definition_id="legacy-task", snapshot=legacy_snapshot)
+
+        class Recovered:
+            load_warnings = ("invalid json recovered to defaults",)
+            class remote_access:
+                class vibe_cloud:
+                    instance_id = ""
+                    instance_kind = ""
+                    enabled = False
+                    @staticmethod
+                    def runtime_credentials():
+                        return None
+
+        monkeypatch.setattr(V2Config, "load", staticmethod(lambda: Recovered()))
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            counts = _migration_counts(_run_sqlite_data_migrations(connection))
+            marker = _stored_migration_marker(connection)
+
+        assert _migration_counts(counts) == _EMPTY_MIGRATION_COUNTS
+        # No terminal seal was written.
+        if marker is not None:
+            payload = json.loads(marker)
+            assert payload.get("state") != "sealed_unattributed"
+
+        # Repair: restore a real pairing and migrate.
+        monkeypatch.undo()
+        monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+        _paired_cloud_config(tmp_path)
+        with engine.begin() as connection:
+            repaired = _migration_counts(_run_sqlite_data_migrations(connection))
+            metadata = _legacy_definition_metadata(connection, "legacy-task")
+        snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
+        assert snapshot["vibe_instance_id"] == "same-instance"
+        assert snapshot["vibe_instance_kind"] == "personal"
+        assert repaired.get("legacy_deferred_definitions", 0) >= 1
+    finally:
+        engine.dispose()
+
+
+def test_gate_under_writer_lock_does_not_open_a_second_write_connection(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Regression PR #1606 r3: resource_user_context_from_metadata is called
+    while a queued-delivery transaction already holds reserve_write_lock.
+    Bootstrap must not open a second write connection (it would time out
+    and permanently retire the delivery as unauthorized).
+    """
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    _paired_cloud_config(tmp_path)
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    try:
+        from storage.agent_session_rows import reserve_write_lock
+
+        metadata = {
+            resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: {
+                "sub": "legacy-user",
+                "vibe_instance_role": "editor",
+                "vibe_instance_access_source": "email",
+                "vibe_instance_id": "same-instance",
+                "vibe_instance_kind": "personal",
+                "claims_issued_at": 1_700_000_000,
+            }
+        }
+        with engine.begin() as conn:
+            reserve_write_lock(conn)
+            # Absent binding row + known kind: the gate must fail closed
+            # WITHOUT opening a second writer, and without raising.
+            context = resource_access_service.resource_user_context_from_metadata(metadata)
+            # Fail-closed is acceptable; a timeout / deadlock is not.
+            assert context is None or context.instance_id == "same-instance"
     finally:
         engine.dispose()

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -2158,3 +2158,41 @@ def test_unrelated_section_load_warning_does_not_make_pairing_unavailable(
     assert state.status == "ready"
     assert state.instance_id == "same-instance"
     assert state.instance_kind == "personal"
+
+
+def test_kindless_deferred_snapshot_fails_closed_when_pairing_is_unpaired(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """P2 a0D_l: kindless snapshot + unpaired/unavailable config → no Editor context.
+
+    The valid legacy no-kind PAIRING path (PARTIAL, runtime-ready, kind not
+    yet backfilled) still returns the original context.
+    """
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = False
+    config.remote_access.vibe_cloud.instance_id = ""
+    config.save()
+    metadata = {
+        resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: {
+            "sub": "legacy-user",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "email",
+            "claims_issued_at": 1_700_000_000,
+        }
+    }
+    assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+
+    # Valid legacy no-kind pairing: runtime-ready, kind not yet backfilled.
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "same-instance"
+    config.remote_access.vibe_cloud.instance_kind = ""
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+    config.remote_access.vibe_cloud.backend_url = "https://backend.test"
+    config.save()
+    restored = resource_access_service.resource_user_context_from_metadata(metadata)
+    assert restored is not None
+    assert restored.instance_role == "editor"
+    assert restored.instance_kind is None

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -1641,3 +1641,64 @@ def test_personal_resources_cannot_use_organization_access_levels(tmp_path) -> N
                 )
     finally:
         engine.dispose()
+
+
+def test_migration_defers_to_a_disagreeing_durable_binding_row(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """A binding row from a peer's reclassification outranks the config read.
+
+    Regression: PR #1606 round 1 — the migration running from a bare
+    ``ensure_sqlite_state()`` must not bind ambiguous snapshots to a config
+    kind that the durable binding row does not (yet) agree with.
+    """
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    _paired_cloud_config(tmp_path, instance_kind="personal")
+    legacy_snapshot = {
+        "sub": "legacy-user",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": "email",
+        "claims_issued_at": 1_700_000_000,
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        _seed_legacy_scheduled_task(store, definition_id="legacy-task", snapshot=legacy_snapshot)
+        binding_row = json.dumps(
+            {
+                "schema_version": 1,
+                "state": "ready",
+                "instance_id": "same-instance",
+                "instance_kind": "organization",
+                "generation": 3,
+                "updated_at": "1700000000",
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            connection.execute(
+                state_meta.insert().values(
+                    key="remote_access.instance_binding.v1",
+                    value_json=binding_row,
+                    updated_at="1700000000",
+                )
+            )
+            counts = _migration_counts(_run_sqlite_data_migrations(connection))
+            marker = json.loads(_stored_migration_marker(connection))
+            metadata = _legacy_definition_metadata(connection, "legacy-task")
+
+        # No snapshot was bound and the opportunity stays retriable.
+        assert counts == _EMPTY_MIGRATION_COUNTS
+        assert marker["state"] == "pending"
+        assert marker["instance_id"] == "same-instance"
+        snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
+        assert "vibe_instance_kind" not in snapshot
+    finally:
+        engine.dispose()

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -1830,3 +1830,130 @@ def test_gate_under_writer_lock_does_not_open_a_second_write_connection(
             assert context is None or context.instance_id == "same-instance"
     finally:
         engine.dispose()
+
+
+def test_typed_reader_from_sqlite_migration_does_not_persist_config(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Regression PR #1606 r4: the typed reader used under an open SQLite
+    writer must not persist on-load config migrations (that would invert
+    C2 lock order against a peer holding the config lock).
+    """
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    _paired_cloud_config(tmp_path)
+    calls = {"persist": 0}
+    real_load = V2Config.load
+
+    def load_counting(*args, **kwargs):
+        persist = kwargs.get("persist_migrations", True)
+        if persist:
+            calls["persist"] += 1
+        return real_load(*args, **kwargs)
+
+    monkeypatch.setattr(V2Config, "load", staticmethod(load_counting))
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    try:
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            _run_sqlite_data_migrations(connection)
+        assert calls["persist"] == 0
+    finally:
+        engine.dispose()
+
+
+def test_terminal_delivery_snapshots_are_left_byte_identical(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Regression PR #1606 r4: accepted/retired delivery snapshots are the
+    immutable submitted Message candidate and must not be rewritten.
+    """
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    _paired_cloud_config(tmp_path)
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    try:
+        from storage.importer import _run_sqlite_data_migrations
+        from storage.models import agent_sessions, message_deliveries, scopes
+        import hashlib
+
+        snapshot = {
+            "metadata_json": json.dumps(
+                {
+                    resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: {
+                        "sub": "legacy-user",
+                        "vibe_instance_role": "editor",
+                        "vibe_instance_access_source": "email",
+                        "claims_issued_at": 1_700_000_000,
+                    }
+                }
+            )
+        }
+        snapshot_json = json.dumps(snapshot, sort_keys=True, separators=(",", ":"))
+        snapshot_sha = hashlib.sha256(snapshot_json.encode("utf-8")).hexdigest()
+        with engine.begin() as connection:
+            connection.execute(
+                scopes.insert().values(
+                    id="scope_term",
+                    platform="avibe",
+                    scope_type="project",
+                    native_id="proj_term",
+                    is_private=0,
+                    supports_threads=0,
+                    metadata_json="{}",
+                    first_seen_at="now",
+                    last_seen_at="now",
+                    updated_at="now",
+                )
+            )
+            connection.execute(
+                agent_sessions.insert().values(
+                    id="sess_term",
+                    scope_id="scope_term",
+                    title="t",
+                    status="idle",
+                    agent_backend="claude",
+                    agent_variant="default",
+                    session_anchor="anchor_term",
+                    native_session_id="native_term",
+                    created_at="now",
+                    updated_at="now",
+                    last_active_at="now",
+                    metadata_json="{}",
+                )
+            )
+            connection.execute(
+                message_deliveries.insert().values(
+                    id="del_retired",
+                    session_id="sess_term",
+                    priority="p3",
+                    state="retired",
+                    snapshot_json=snapshot_json,
+                    snapshot_sha256=snapshot_sha,
+                    dispatch_sha256=snapshot_sha,
+                    submitted_at="now",
+                    updated_at="now",
+                )
+            )
+            _run_sqlite_data_migrations(connection)
+            rows = {
+                row["id"]: row
+                for row in connection.execute(
+                    select(
+                        message_deliveries.c.id,
+                        message_deliveries.c.snapshot_json,
+                        message_deliveries.c.snapshot_sha256,
+                    )
+                ).mappings()
+            }
+        assert rows["del_retired"]["snapshot_json"] == snapshot_json
+        assert rows["del_retired"]["snapshot_sha256"] == snapshot_sha
+    finally:
+        engine.dispose()

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import hashlib
+import json
+
 import pytest
+from sqlalchemy import select
 
 from config.v2_config import V2Config
 from storage import resource_access_service
+from storage.background import SQLiteBackgroundTaskStore
 from storage.db import create_sqlite_engine
+from storage.message_deliveries import enqueue_queued
 from storage.migrations import run_migrations
-from storage.models import resource_access_policies
+from storage.models import agent_runs, agent_sessions, message_deliveries, resource_access_policies, run_definitions, state_meta
 from vibe import permissions
 
 
@@ -18,6 +24,7 @@ def _context(
     role: str | None = "member",
     instance_role: str = "editor",
     access_source: str = "organization_group",
+    instance_kind: str | None = None,
 ) -> resource_access_service.ResourceUserContext:
     return resource_access_service.ResourceUserContext(
         subject=subject,
@@ -28,6 +35,7 @@ def _context(
         instance_role=instance_role,
         instance_access_source=access_source,
         is_remote=True,
+        instance_kind=instance_kind,
     )
 
 
@@ -83,6 +91,55 @@ def test_resource_acl_is_enforced_for_editors_and_unknown_kinds_fail_closed(tmp_
                 resource_access_service.can_use_resource(
                     engineering_member, "future_resource", "future-1", connection=connection
                 )
+    finally:
+        engine.dispose()
+
+
+def test_personal_editor_uses_all_agents_without_organization_acl(tmp_path) -> None:
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    try:
+        with engine.begin() as connection:
+            _seed_policies(connection)
+            personal_editor = _context(
+                "personal-user",
+                organization_id=None,
+                role=None,
+                access_source="owner",
+                instance_kind="personal",
+            )
+            organization_editor = _context(
+                "organization-user",
+                instance_kind="organization",
+            )
+
+            assert resource_access_service.can_use_resource(
+                personal_editor, "agent", "private-agent", connection=connection
+            )
+            assert resource_access_service.can_use_resource(
+                personal_editor, "agent", "scoped-agent", connection=connection
+            )
+            assert resource_access_service.can_use_resource(
+                personal_editor, "agent", "unmanaged-agent", connection=connection
+            )
+            assert resource_access_service.filter_accessible_resources(
+                personal_editor,
+                "agent",
+                [
+                    {"id": "private-agent"},
+                    {"id": "scoped-agent"},
+                    {"id": "unmanaged-agent"},
+                ],
+                connection=connection,
+            ) == [
+                {"id": "private-agent"},
+                {"id": "scoped-agent"},
+                {"id": "unmanaged-agent"},
+            ]
+            assert not resource_access_service.can_use_resource(
+                organization_editor, "agent", "private-agent", connection=connection
+            )
     finally:
         engine.dispose()
 
@@ -364,8 +421,19 @@ def test_http_resource_services_reuse_the_parsed_authorization_context() -> None
         assert resource_access_service.resolve_resource_access_context() is context
 
 
-def test_deferred_remote_context_remains_valid_past_authorization_refresh_boundary() -> None:
+def test_deferred_remote_context_remains_valid_past_authorization_refresh_boundary(
+    monkeypatch,
+    tmp_path,
+) -> None:
     from vibe import remote_access
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "organization-instance"
+    config.remote_access.vibe_cloud.instance_kind = "organization"
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+    config.save()
 
     issued_at = 1_700_000_000
     context = resource_access_service.ResourceUserContext(
@@ -377,6 +445,8 @@ def test_deferred_remote_context_remains_valid_past_authorization_refresh_bounda
         membership_version="membership-v2",
         instance_role="viewer",
         instance_access_source="organization_group",
+        instance_kind="organization",
+        instance_id="organization-instance",
         claims_issued_at=issued_at,
         is_remote=True,
     )
@@ -399,6 +469,1159 @@ def test_deferred_remote_context_remains_valid_past_authorization_refresh_bounda
     assert before is not None and after is not None
     assert before.subject == after.subject == "member-1"
     assert after.is_active_organization_member is True
+
+
+def test_deferred_personal_context_keeps_instance_kind(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "personal-instance"
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+    config.save()
+
+    context = resource_access_service.ResourceUserContext(
+        subject="personal-user",
+        instance_id="personal-instance",
+        instance_role="editor",
+        instance_access_source="owner",
+        instance_kind="personal",
+        is_remote=True,
+    )
+
+    metadata = resource_access_service.metadata_with_resource_user_context({}, context)
+    restored = resource_access_service.resource_user_context_from_metadata(metadata)
+
+    assert restored is not None
+    assert restored.is_personal_instance
+
+
+def test_deferred_context_from_previous_pairing_is_rejected(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "current-instance"
+    config.remote_access.vibe_cloud.instance_kind = "organization"
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+    config.save()
+
+    stale_context = resource_access_service.ResourceUserContext(
+        subject="personal-user",
+        instance_id="previous-instance",
+        instance_role="editor",
+        instance_access_source="owner",
+        instance_kind="personal",
+        is_remote=True,
+    )
+    metadata = resource_access_service.metadata_with_resource_user_context({}, stale_context)
+
+    assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+    assert not resource_access_service.metadata_allows_harness_runtime(metadata)
+
+
+def test_deferred_context_does_not_project_personal_bypass_while_reconciling(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Non-interactive metadata must fail closed while the binding is reconciling."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "current-instance"
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+    config.save()
+
+    from storage import remote_access_authorization_service
+    from storage.importer import ensure_sqlite_state
+
+    ensure_sqlite_state()
+    remote_access_authorization_service.begin_instance_binding_transition(
+        instance_id="current-instance",
+        instance_kind="personal",
+    )
+
+    personal_context = resource_access_service.ResourceUserContext(
+        subject="personal-user",
+        instance_id="current-instance",
+        instance_role="editor",
+        instance_access_source="owner",
+        instance_kind="personal",
+        is_remote=True,
+    )
+    metadata = resource_access_service.metadata_with_resource_user_context({}, personal_context)
+    assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+    assert not resource_access_service.metadata_allows_harness_runtime(metadata)
+
+
+@pytest.mark.parametrize("pairing_state", ["disabled", "unreadable", "partial"])
+def test_explicit_deferred_context_requires_current_pairing(
+    monkeypatch,
+    tmp_path,
+    pairing_state: str,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = pairing_state != "disabled"
+    config.remote_access.vibe_cloud.instance_id = "personal-instance"
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    if pairing_state != "partial":
+        config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+    config.save()
+    if pairing_state == "unreadable":
+        def fail_load(_cls, *_args, **_kwargs):
+            raise OSError("config unavailable")
+
+        monkeypatch.setattr(V2Config, "load", classmethod(fail_load))
+
+    context = resource_access_service.ResourceUserContext(
+        subject="personal-user",
+        instance_id="personal-instance",
+        instance_role="editor",
+        instance_access_source="owner",
+        instance_kind="personal",
+        is_remote=True,
+    )
+    metadata = resource_access_service.metadata_with_resource_user_context({}, context)
+
+    assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+    assert not resource_access_service.metadata_allows_harness_runtime(metadata)
+
+
+@pytest.mark.parametrize(
+    ("paired_kind", "expected_kind", "should_restore"),
+    [
+        ("personal", "personal", False),
+        ("organization", "organization", False),
+        ("", None, True),
+    ],
+)
+def test_unbound_legacy_deferred_context_cannot_adopt_current_pairing_kind(
+    monkeypatch,
+    tmp_path,
+    paired_kind: str,
+    expected_kind: str | None,
+    should_restore: bool,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_kind = paired_kind
+    config.remote_access.vibe_cloud.instance_id = "paired-instance"
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+    config.save()
+
+    legacy_metadata = {
+        resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: {
+            "sub": "legacy-user",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "email",
+            "claims_issued_at": 1_700_000_000,
+        }
+    }
+    restored = resource_access_service.resource_user_context_from_metadata(legacy_metadata)
+
+    assert (restored is not None) is should_restore
+    if restored is not None:
+        assert restored.instance_kind == expected_kind
+
+
+def test_kindless_deferred_context_adopts_matching_validated_pairing(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "paired-instance"
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+    config.save()
+
+    legacy_metadata = {
+        resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: {
+            "sub": "legacy-user",
+            "vibe_instance_id": "paired-instance",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "owner",
+            "vibe_instance_kind": None,
+            "claims_issued_at": 1_700_000_000,
+        }
+    }
+
+    restored = resource_access_service.resource_user_context_from_metadata(legacy_metadata)
+
+    assert restored is not None
+    assert restored.is_personal_instance
+
+
+@pytest.mark.parametrize(
+    ("paired_kind", "access_source", "organization_claims"),
+    [
+        ("personal", "owner", False),
+        ("organization", "organization_group", True),
+        ("organization", "email", False),
+    ],
+)
+def test_migrate_legacy_deferred_contexts_binds_definitions_and_queued_deliveries(
+    monkeypatch,
+    tmp_path,
+    paired_kind: str,
+    access_source: str,
+    organization_claims: bool,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "paired-instance"
+    config.remote_access.vibe_cloud.instance_kind = paired_kind
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+    config.save()
+
+    legacy_context = {
+        "sub": "legacy-user",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": access_source,
+        "claims_issued_at": 1_700_000_000,
+    }
+    if organization_claims:
+        legacy_context.update(
+            {
+                "vibe_organization_id": "org-1",
+                "vibe_organization_member_id": "member-1",
+                "vibe_organization_role": "member",
+                "vibe_group_ids": ["group-1"],
+            }
+        )
+    legacy_metadata = {resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: legacy_context}
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        assert store.upsert_scheduled_task(
+            {
+                "id": "legacy-task",
+                "name": "legacy task",
+                "message": "run",
+                "schedule_type": "interval",
+                "created_at": "2026-08-20T00:00:00Z",
+                "updated_at": "2026-08-20T00:00:00Z",
+                "metadata": legacy_metadata,
+            }
+        )
+        assert store.upsert_watch(
+            {
+                "id": "legacy-watch",
+                "name": "legacy watch",
+                "message": "watch",
+                "created_at": "2026-08-20T00:00:00Z",
+                "updated_at": "2026-08-20T00:00:00Z",
+                "metadata": legacy_metadata,
+            }
+        )
+        assert store.enqueue_definition_run(
+            {
+                "id": "run-1",
+                "definition_id": "legacy-task",
+                "run_type": "scheduled",
+                "source_kind": "scheduler",
+                "prompt": "run",
+                "message": "run",
+                "created_at": "2026-08-20T00:00:00Z",
+                "updated_at": "2026-08-20T00:00:00Z",
+                "metadata": legacy_metadata,
+            }
+        ) is not None
+        with engine.begin() as connection:
+            connection.execute(
+                agent_sessions.insert().values(
+                    id="session-1",
+                    scope_id=None,
+                    agent_id=None,
+                    agent_name="default",
+                    agent_backend="opencode",
+                    agent_variant="default",
+                    model=None,
+                    reasoning_effort=None,
+                    session_anchor="anchor-1",
+                    workdir=None,
+                    native_session_id="native-1",
+                    title=None,
+                    status="active",
+                    visibility="foreground",
+                    pinned=0,
+                    agent_status="idle",
+                    composer_draft_text=None,
+                    composer_draft_updated_at=None,
+                    metadata_json="{}",
+                    created_at="2026-08-20T00:00:00Z",
+                    updated_at="2026-08-20T00:00:00Z",
+                    last_active_at=None,
+                )
+            )
+            enqueue_queued(
+                connection,
+                scope_id=None,
+                session_id="session-1",
+                text="queued",
+                metadata=legacy_metadata,
+            )
+            from storage.importer import _run_sqlite_data_migrations
+
+            counts = _run_sqlite_data_migrations(connection)
+            assert _migration_counts(counts) == {
+                "legacy_deferred_definitions": 2,
+                "legacy_deferred_runs": 1,
+                "legacy_deferred_deliveries": 1,
+            }
+
+            definition_rows = connection.execute(
+                select(run_definitions.c.metadata_json).where(
+                    run_definitions.c.id.in_(("legacy-task", "legacy-watch"))
+                )
+            ).scalars()
+            for raw_metadata in definition_rows:
+                metadata = json.loads(raw_metadata)
+                snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
+                assert snapshot["vibe_instance_id"] == "paired-instance"
+                assert snapshot["vibe_instance_kind"] == paired_kind
+                assert resource_access_service.resource_user_context_from_metadata(metadata) is not None
+
+            run_metadata = connection.execute(
+                select(agent_runs.c.metadata_json).where(agent_runs.c.definition_id == "legacy-task")
+            ).scalar_one()
+            run_snapshot = json.loads(run_metadata)[
+                resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY
+            ]
+            assert run_snapshot["vibe_instance_id"] == "paired-instance"
+            assert run_snapshot["vibe_instance_kind"] == paired_kind
+
+            delivery = connection.execute(
+                select(message_deliveries.c.snapshot_json, message_deliveries.c.snapshot_sha256).where(
+                    message_deliveries.c.session_id == "session-1"
+                )
+            ).mappings().one()
+            snapshot = json.loads(delivery["snapshot_json"])
+            metadata = json.loads(snapshot["metadata_json"])
+            assert metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY][
+                "vibe_instance_id"
+            ] == "paired-instance"
+            assert metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY][
+                "vibe_instance_kind"
+            ] == paired_kind
+            assert delivery["snapshot_sha256"] == hashlib.sha256(
+                delivery["snapshot_json"].encode("utf-8")
+            ).hexdigest()
+
+            assert _migration_counts(_run_sqlite_data_migrations(
+                connection
+            )) == {
+                "legacy_deferred_definitions": 0,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+    finally:
+        store.close()
+        engine.dispose()
+
+
+def test_legacy_migration_keeps_opposite_instance_semantics_unbound(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "personal-instance"
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+    config.save()
+    legacy_metadata = {
+        resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: {
+            "sub": "organization-user",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "organization_group",
+            "vibe_organization_id": "org-1",
+            "vibe_organization_member_id": "member-1",
+            "vibe_organization_role": "member",
+        }
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        assert store.upsert_scheduled_task(
+            {
+                "id": "organization-task",
+                "name": "organization task",
+                "message": "run",
+                "schedule_type": "interval",
+                "created_at": "2026-08-20T00:00:00Z",
+                "updated_at": "2026-08-20T00:00:00Z",
+                "metadata": legacy_metadata,
+            }
+        )
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
+                "legacy_deferred_definitions": 0,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+            raw_metadata = connection.execute(
+                select(run_definitions.c.metadata_json).where(
+                    run_definitions.c.id == "organization-task"
+                )
+            ).scalar_one()
+            metadata = json.loads(raw_metadata)
+            assert "vibe_instance_id" not in metadata[
+                resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY
+            ]
+            assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+    finally:
+        store.close()
+        engine.dispose()
+
+
+def test_legacy_migration_does_not_bind_after_later_pairing(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = False
+    config.save()
+    legacy_metadata = {
+        resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: {
+            "sub": "legacy-user",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "owner",
+            "claims_issued_at": 1_700_000_000,
+        }
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        assert store.upsert_scheduled_task(
+            {
+                "id": "legacy-task",
+                "name": "legacy task",
+                "message": "run",
+                "schedule_type": "interval",
+                "created_at": "2026-08-20T00:00:00Z",
+                "updated_at": "2026-08-20T00:00:00Z",
+                "metadata": legacy_metadata,
+            }
+        )
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
+                "legacy_deferred_definitions": 0,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+            assert connection.execute(
+                select(state_meta.c.value_json).where(
+                    state_meta.c.key
+                    == resource_access_service.LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY
+                )
+            ).scalar_one_or_none()
+
+        config.remote_access.vibe_cloud.enabled = True
+        config.remote_access.vibe_cloud.instance_id = "later-instance"
+        config.remote_access.vibe_cloud.instance_kind = "personal"
+        config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+        config.save()
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
+                "legacy_deferred_definitions": 0,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+            raw_metadata = connection.execute(
+                select(run_definitions.c.metadata_json).where(
+                    run_definitions.c.id == "legacy-task"
+                )
+            ).scalar_one()
+            metadata = json.loads(raw_metadata)
+            snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
+            assert "vibe_instance_id" not in snapshot
+            assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+    finally:
+        store.close()
+        engine.dispose()
+
+
+def test_legacy_migration_retries_when_same_pairing_kind_is_backfilled(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "same-instance"
+    config.remote_access.vibe_cloud.instance_kind = ""
+    config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+    config.save()
+    legacy_metadata = {
+        resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: {
+            "sub": "legacy-user",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "email",
+            "claims_issued_at": 1_700_000_000,
+        }
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        assert store.upsert_scheduled_task(
+            {
+                "id": "legacy-task",
+                "name": "legacy task",
+                "message": "run",
+                "schedule_type": "interval",
+                "created_at": "2026-08-20T00:00:00Z",
+                "updated_at": "2026-08-20T00:00:00Z",
+                "metadata": legacy_metadata,
+            }
+        )
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
+                "legacy_deferred_definitions": 0,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+
+        config.remote_access.vibe_cloud.instance_kind = "personal"
+        config.save()
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
+                "legacy_deferred_definitions": 1,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+            raw_metadata = connection.execute(
+                select(run_definitions.c.metadata_json).where(
+                    run_definitions.c.id == "legacy-task"
+                )
+            ).scalar_one()
+            snapshot = json.loads(raw_metadata)[
+                resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY
+            ]
+            assert snapshot["vibe_instance_id"] == "same-instance"
+            assert snapshot["vibe_instance_kind"] == "personal"
+    finally:
+        store.close()
+        engine.dispose()
+
+
+def test_legacy_migration_preserves_instance_id_while_pairing_is_partial(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "same-instance"
+    config.remote_access.vibe_cloud.instance_kind = "personal"
+    config.remote_access.vibe_cloud.instance_secret = ""
+    config.save()
+    legacy_metadata = {
+        resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: {
+            "sub": "legacy-user",
+            "vibe_instance_role": "editor",
+            "vibe_instance_access_source": "email",
+            "claims_issued_at": 1_700_000_000,
+        }
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        assert store.upsert_scheduled_task(
+            {
+                "id": "legacy-task",
+                "name": "legacy task",
+                "message": "run",
+                "schedule_type": "interval",
+                "created_at": "2026-08-20T00:00:00Z",
+                "updated_at": "2026-08-20T00:00:00Z",
+                "metadata": legacy_metadata,
+            }
+        )
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
+                "legacy_deferred_definitions": 0,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+            marker = json.loads(
+                connection.execute(
+                    select(state_meta.c.value_json).where(
+                        state_meta.c.key
+                        == resource_access_service.LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY
+                    )
+                ).scalar_one()
+            )
+            assert marker["state"] == "pending"
+            assert marker["instance_id"] == "same-instance"
+
+        config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+        config.save()
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
+                "legacy_deferred_definitions": 1,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+            raw_metadata = connection.execute(
+                select(run_definitions.c.metadata_json).where(
+                    run_definitions.c.id == "legacy-task"
+                )
+            ).scalar_one()
+            snapshot = json.loads(raw_metadata)[
+                resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY
+            ]
+            assert snapshot["vibe_instance_id"] == "same-instance"
+            assert snapshot["vibe_instance_kind"] == "personal"
+    finally:
+        store.close()
+        engine.dispose()
+
+
+def test_typed_binding_reader_preserves_partial_identity_and_does_not_latch_read_failure(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = V2Config.default()
+    cloud = config.remote_access.vibe_cloud
+    cloud.enabled = True
+    cloud.instance_id = "same-instance"
+    cloud.instance_kind = "personal"
+    cloud.instance_secret = ""
+    config.save()
+
+    partial = resource_access_service._configured_resource_state()
+    assert partial.status == resource_access_service.RESOURCE_BINDING_STATE_PARTIAL
+    assert partial.instance_id == "same-instance"
+    assert partial.instance_kind == "personal"
+
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    marker = {
+        "schema_version": 2,
+        "state": "pending",
+        "instance_id": "same-instance",
+        "updated_at": "before-read-failure",
+    }
+    try:
+        with engine.begin() as connection:
+            connection.execute(
+                state_meta.insert().values(
+                    key=resource_access_service.LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY,
+                    value_json=json.dumps(marker),
+                    updated_at="before-read-failure",
+                )
+            )
+
+        monkeypatch.setattr(
+            V2Config,
+            "load",
+            classmethod(lambda cls, *args, **kwargs: (_ for _ in ()).throw(OSError("temporary read"))),
+        )
+        unavailable = resource_access_service._configured_resource_state()
+        assert unavailable.status == resource_access_service.RESOURCE_BINDING_STATE_UNAVAILABLE
+
+        with engine.begin() as connection:
+            assert _migration_counts(resource_access_service.migrate_legacy_deferred_resource_contexts(connection)) == {
+                "legacy_deferred_definitions": 0,
+                "legacy_deferred_runs": 0,
+                "legacy_deferred_deliveries": 0,
+            }
+            stored = connection.execute(
+                select(state_meta.c.value_json).where(
+                    state_meta.c.key == resource_access_service.LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY
+                )
+            ).scalar_one()
+            assert json.loads(stored) == marker
+    finally:
+        engine.dispose()
+
+
+_EMPTY_MIGRATION_COUNTS = {
+    "legacy_deferred_definitions": 0,
+    "legacy_deferred_runs": 0,
+    "legacy_deferred_deliveries": 0,
+}
+
+
+def _migration_counts(result: dict) -> dict[str, int]:
+    """Numeric migration counts, ignoring the typed binding-status field."""
+
+    return {
+        key: int(result[key])
+        for key in (
+            "legacy_deferred_definitions",
+            "legacy_deferred_runs",
+            "legacy_deferred_deliveries",
+        )
+    }
+
+
+def _paired_cloud_config(
+    tmp_path,
+    *,
+    enabled: bool = True,
+    instance_id: str = "same-instance",
+    instance_kind: str = "personal",
+    instance_secret: str = "instance-secret",
+) -> V2Config:
+    config = V2Config.default()
+    cloud = config.remote_access.vibe_cloud
+    cloud.enabled = enabled
+    cloud.instance_id = instance_id
+    cloud.instance_kind = instance_kind
+    cloud.instance_secret = instance_secret
+    config.save()
+    return config
+
+
+def _seed_legacy_scheduled_task(store, *, definition_id: str, snapshot: dict) -> None:
+    assert store.upsert_scheduled_task(
+        {
+            "id": definition_id,
+            "name": definition_id,
+            "message": "run",
+            "schedule_type": "interval",
+            "created_at": "2026-08-20T00:00:00Z",
+            "updated_at": "2026-08-20T00:00:00Z",
+            "metadata": {resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: snapshot},
+        }
+    )
+
+
+def _legacy_definition_metadata(connection, definition_id: str) -> dict:
+    raw = connection.execute(
+        select(run_definitions.c.metadata_json).where(run_definitions.c.id == definition_id)
+    ).scalar_one()
+    return json.loads(raw)
+
+
+def _stored_migration_marker(connection) -> str | None:
+    return connection.execute(
+        select(state_meta.c.value_json).where(
+            state_meta.c.key == resource_access_service.LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY
+        )
+    ).scalar_one_or_none()
+
+
+def test_partial_pairing_marker_records_configured_instance_without_claiming_a_kind(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """A deferred opportunity keeps its identity but never a guessed kind."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    _paired_cloud_config(tmp_path, instance_secret="")
+
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    try:
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
+            marker = json.loads(_stored_migration_marker(connection))
+
+        assert marker["schema_version"] == 2
+        assert marker["state"] == "pending"
+        assert marker["instance_id"] == "same-instance"
+        # A partial pairing cannot prove its kind, so the marker must not
+        # record one and must not look terminal to a later startup.
+        assert "instance_kind" not in marker
+        assert "completed_at" not in marker
+    finally:
+        engine.dispose()
+
+
+def test_credential_repair_on_the_same_pairing_completes_the_deferred_migration(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = _paired_cloud_config(tmp_path, instance_secret="")
+    legacy_snapshot = {
+        "sub": "legacy-user",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": "email",
+        "claims_issued_at": 1_700_000_000,
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        _seed_legacy_scheduled_task(store, definition_id="legacy-task", snapshot=legacy_snapshot)
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
+
+        config.remote_access.vibe_cloud.instance_secret = "instance-secret"
+        config.save()
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
+                **_EMPTY_MIGRATION_COUNTS,
+                "legacy_deferred_definitions": 1,
+            }
+            metadata = _legacy_definition_metadata(connection, "legacy-task")
+            snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
+            assert snapshot["vibe_instance_id"] == "same-instance"
+            assert snapshot["vibe_instance_kind"] == "personal"
+            assert resource_access_service.resource_user_context_from_metadata(metadata) is not None
+            completed = json.loads(_stored_migration_marker(connection))
+
+        assert completed["state"] == "completed"
+        assert completed["instance_id"] == "same-instance"
+        assert completed["instance_kind"] == "personal"
+        assert completed["completed_at"]
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
+            assert json.loads(_stored_migration_marker(connection)) == completed
+            assert (
+                _legacy_definition_metadata(connection, "legacy-task") == metadata
+            )
+    finally:
+        store.close()
+        engine.dispose()
+
+
+def test_transient_configuration_failure_leaves_the_migration_retryable(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    _paired_cloud_config(tmp_path)
+    legacy_snapshot = {
+        "sub": "legacy-user",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": "email",
+        "claims_issued_at": 1_700_000_000,
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        _seed_legacy_scheduled_task(store, definition_id="legacy-task", snapshot=legacy_snapshot)
+        from storage.importer import _run_sqlite_data_migrations
+
+        real_load = V2Config.load
+        with monkeypatch.context() as unreadable:
+            unreadable.setattr(
+                V2Config,
+                "load",
+                classmethod(
+                    lambda cls, *args, **kwargs: (_ for _ in ()).throw(OSError("temporary read"))
+                ),
+            )
+            with engine.begin() as connection:
+                assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
+                # No first migration opportunity may be recorded from a read
+                # failure; otherwise the retry below would be fenced out.
+                assert _stored_migration_marker(connection) is None
+
+        assert V2Config.load.__func__ is real_load.__func__
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
+                **_EMPTY_MIGRATION_COUNTS,
+                "legacy_deferred_definitions": 1,
+            }
+            metadata = _legacy_definition_metadata(connection, "legacy-task")
+            assert resource_access_service.resource_user_context_from_metadata(metadata) is not None
+    finally:
+        store.close()
+        engine.dispose()
+
+
+def test_unpaired_first_opportunity_cannot_be_adopted_by_a_later_pairing(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = _paired_cloud_config(
+        tmp_path,
+        enabled=False,
+        instance_id="",
+        instance_kind="",
+        instance_secret="",
+    )
+    legacy_snapshot = {
+        "sub": "legacy-user",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": "owner",
+        "claims_issued_at": 1_700_000_000,
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        _seed_legacy_scheduled_task(store, definition_id="legacy-task", snapshot=legacy_snapshot)
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
+            sealed = json.loads(_stored_migration_marker(connection))
+
+        assert sealed["state"] == "sealed_unattributed"
+        assert sealed["instance_id"] is None
+
+        cloud = config.remote_access.vibe_cloud
+        cloud.enabled = True
+        cloud.instance_id = "later-instance"
+        cloud.instance_kind = "personal"
+        cloud.instance_secret = "instance-secret"
+        config.save()
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
+            metadata = _legacy_definition_metadata(connection, "legacy-task")
+            snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
+            assert "vibe_instance_id" not in snapshot
+            assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+            assert json.loads(_stored_migration_marker(connection))["state"] == "sealed_unattributed"
+    finally:
+        store.close()
+        engine.dispose()
+
+
+def test_pending_marker_for_one_instance_cannot_be_adopted_by_another_instance(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    config = _paired_cloud_config(tmp_path, instance_id="instance-a", instance_secret="")
+    legacy_snapshot = {
+        "sub": "legacy-user",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": "email",
+        "claims_issued_at": 1_700_000_000,
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        _seed_legacy_scheduled_task(store, definition_id="legacy-task", snapshot=legacy_snapshot)
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
+            pending = json.loads(_stored_migration_marker(connection))
+        assert pending["state"] == "pending"
+        assert pending["instance_id"] == "instance-a"
+
+        cloud = config.remote_access.vibe_cloud
+        cloud.instance_id = "instance-b"
+        cloud.instance_secret = "instance-secret"
+        config.save()
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
+            sealed = json.loads(_stored_migration_marker(connection))
+            assert sealed["state"] == "sealed_unattributed"
+            # The original owner stays recorded so no later pairing, including
+            # instance A itself, can reopen the sealed opportunity.
+            assert sealed["instance_id"] == "instance-a"
+
+        cloud.instance_id = "instance-a"
+        config.save()
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
+            metadata = _legacy_definition_metadata(connection, "legacy-task")
+            snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
+            assert "vibe_instance_id" not in snapshot
+            assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+    finally:
+        store.close()
+        engine.dispose()
+
+
+@pytest.mark.parametrize("paired_kind", ["organization", "personal"])
+@pytest.mark.parametrize("access_source", ["email", "email_domain", "public_instance"])
+def test_shared_access_source_snapshots_migrate_for_either_pairing_kind(
+    monkeypatch,
+    tmp_path,
+    paired_kind: str,
+    access_source: str,
+) -> None:
+    """``email``/``email_domain``/``public_instance`` are kind-agnostic.
+
+    Neither their presence nor the absence of Organization membership claims
+    is instance-kind evidence, so the still-current pairing decides.
+    """
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    _paired_cloud_config(tmp_path, instance_id="paired-instance", instance_kind=paired_kind)
+    legacy_snapshot = {
+        "sub": "legacy-editor",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": access_source,
+        "claims_issued_at": 1_700_000_000,
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        _seed_legacy_scheduled_task(store, definition_id="legacy-task", snapshot=legacy_snapshot)
+        from storage.importer import _run_sqlite_data_migrations
+
+        with engine.begin() as connection:
+            assert _migration_counts(_run_sqlite_data_migrations(connection)) == {
+                **_EMPTY_MIGRATION_COUNTS,
+                "legacy_deferred_definitions": 1,
+            }
+            metadata = _legacy_definition_metadata(connection, "legacy-task")
+            snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
+            assert snapshot["vibe_instance_id"] == "paired-instance"
+            assert snapshot["vibe_instance_kind"] == paired_kind
+            restored = resource_access_service.resource_user_context_from_metadata(metadata)
+            assert restored is not None
+            assert restored.is_personal_instance is (paired_kind == "personal")
+            # Organization membership is never synthesized by the migration.
+            assert "vibe_organization_id" not in snapshot
+    finally:
+        store.close()
+        engine.dispose()
+
+
+@pytest.mark.parametrize(
+    ("marker_json", "expected_state", "expect_marker_preserved"),
+    [
+        pytest.param(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "state": "completed",
+                    "instance_id": None,
+                    "completed_at": "2026-08-19T00:00:00Z",
+                    "updated_at": "2026-08-19T00:00:00Z",
+                }
+            ),
+            "sealed_unattributed",
+            True,
+            id="released_completed_without_instance",
+        ),
+        pytest.param(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "state": "completed",
+                    "instance_id": "same-instance",
+                    "completed_at": "2026-08-19T00:00:00Z",
+                    "updated_at": "2026-08-19T00:00:00Z",
+                }
+            ),
+            "completed",
+            True,
+            id="released_completed_for_current_instance",
+        ),
+        pytest.param(
+            json.dumps({"instance_id": "same-instance", "completed_at": "2026-08-19T00:00:00Z"}),
+            "completed",
+            True,
+            id="released_marker_without_state_field",
+        ),
+        pytest.param(
+            json.dumps({"instance_id": None}),
+            "sealed_unattributed",
+            False,
+            id="released_marker_without_state_or_instance",
+        ),
+        pytest.param(
+            json.dumps({"state": "pending", "instance_id": "   "}),
+            None,
+            True,
+            id="blank_instance_id",
+        ),
+        pytest.param(
+            json.dumps({"state": "sealed_unattributed", "instance_id": "same-instance"}),
+            "sealed_unattributed",
+            True,
+            id="sealed_for_current_instance",
+        ),
+        pytest.param("not-json", None, True, id="corrupt_marker"),
+        pytest.param(json.dumps(["completed"]), None, True, id="non_object_marker"),
+    ],
+)
+def test_released_migration_marker_shapes_stay_idempotent_and_fail_closed(
+    monkeypatch,
+    tmp_path,
+    marker_json: str,
+    expected_state: str | None,
+    expect_marker_preserved: bool,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    _paired_cloud_config(tmp_path)
+    legacy_snapshot = {
+        "sub": "legacy-user",
+        "vibe_instance_role": "editor",
+        "vibe_instance_access_source": "email",
+        "claims_issued_at": 1_700_000_000,
+    }
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    store = SQLiteBackgroundTaskStore(db)
+    engine = create_sqlite_engine(db)
+    try:
+        _seed_legacy_scheduled_task(store, definition_id="legacy-task", snapshot=legacy_snapshot)
+        with engine.begin() as connection:
+            connection.execute(
+                state_meta.insert().values(
+                    key=resource_access_service.LEGACY_DEFERRED_CONTEXT_MIGRATION_KEY,
+                    value_json=marker_json,
+                    updated_at="2026-08-19T00:00:00Z",
+                )
+            )
+        from storage.importer import _run_sqlite_data_migrations
+
+        for _ in range(2):
+            with engine.begin() as connection:
+                assert _migration_counts(_run_sqlite_data_migrations(connection)) == _EMPTY_MIGRATION_COUNTS
+                metadata = _legacy_definition_metadata(connection, "legacy-task")
+                snapshot = metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]
+                assert "vibe_instance_id" not in snapshot
+                assert resource_access_service.resource_user_context_from_metadata(metadata) is None
+                stored = _stored_migration_marker(connection)
+                if expect_marker_preserved:
+                    # A terminal or unreadable marker is never rewritten, so
+                    # repeated startups cannot churn the released shape.
+                    assert stored == marker_json
+                else:
+                    assert json.loads(stored)["state"] == expected_state
+    finally:
+        store.close()
+        engine.dispose()
 
 
 def test_personal_resources_cannot_use_organization_access_levels(tmp_path) -> None:

--- a/tests/test_resource_acl_agents.py
+++ b/tests/test_resource_acl_agents.py
@@ -58,6 +58,9 @@ def _organization_cookie(
         "vibe_instance_id": "inst_123",
         "vibe_instance_role": instance_role,
         "vibe_instance_access_source": "organization_group",
+        "vibe_instance_authorization_revision": (
+            remote_access.current_authorization_revision(config) or 0
+        ),
         "vibe_organization_id": "org-1",
         "vibe_organization_member_id": f"member-{subject}",
         "vibe_organization_role": organization_role,
@@ -166,7 +169,7 @@ def test_agent_removal_deletes_resource_policy_and_groups(monkeypatch, tmp_path)
 
 def test_owner_can_create_agent_without_a_trusted_local_identity(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    config = _save_config(tmp_path)
+    config = _save_config(tmp_path, paired=True, instance_kind="organization")
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
@@ -419,7 +422,7 @@ def test_missing_agent_selector_fails_closed_for_editor_only(monkeypatch, tmp_pa
 
 def test_active_org_agent_detail_uses_full_runtime_projection(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    config = _save_config(tmp_path)
+    config = _save_config(tmp_path, paired=True, instance_kind="organization")
     store = VibeAgentStore()
     try:
         agent = store.create(
@@ -467,7 +470,7 @@ def test_active_org_agent_detail_uses_full_runtime_projection(monkeypatch, tmp_p
 
 def test_editor_agent_selection_and_harness_bindings_follow_acl(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    config = _save_config(tmp_path)
+    config = _save_config(tmp_path, paired=True, instance_kind="organization")
     store, agents = _seed_agents_with_policies()
     private_agent = agents["private"]
     store.set_default_agent_name(private_agent.name)
@@ -776,7 +779,7 @@ def test_project_runtime_uses_acls_while_harness_remains_editor_wide(monkeypatch
 
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     ensure_sqlite_state()
-    config = _save_config(tmp_path)
+    config = _save_config(tmp_path, paired=True, instance_kind="organization")
     store, agents = _seed_agents_with_policies()
     engine = get_cached_sqlite_engine()
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/tests/test_resource_acl_show_pages.py
+++ b/tests/test_resource_acl_show_pages.py
@@ -73,6 +73,7 @@ def _paired_config(tmp_path, *, instance_kind: str):
     cloud.instance_secret = "device-secret"
     cloud.instance_kind = instance_kind
     config.save()
+    remote_access._replace_authorization_revision(config, 0)
     return config
 
 
@@ -885,63 +886,6 @@ def test_show_access_owner_read_and_apply_use_controller_ipc(monkeypatch, tmp_pa
         ("read", {"page_id": "ses-access-settings"}),
         ("apply", request_payload),
     ]
-
-
-def test_show_access_apply_forwards_group_and_organization_entries(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    store = ShowPageStore()
-    try:
-        store.ensure("ses-access-entries")
-    finally:
-        store.close()
-    calls: list[tuple[str, dict]] = []
-    request_payload = {
-        "page_id": "ses-access-entries",
-        "expected_revision": 0,
-        "target_access_mode": "limited",
-        "target_share_id": "stable-link",
-        "target_entries": [
-            {"kind": "group", "value": "group-7"},
-            {"kind": "organization", "value": "org-1"},
-        ],
-    }
-
-    async def _apply(payload):
-        calls.append(("apply", payload))
-        return {
-            "status_code": 200,
-            "body": {
-                "status": "applied",
-                "show_access": {
-                    **_show_access_payload("ses-access-entries", revision=1),
-                    "access_mode": "limited",
-                    "entries": [
-                        {
-                            "kind": "group",
-                            "value": "group-7",
-                            "organization_id": "org-1",
-                        },
-                        {
-                            "kind": "organization",
-                            "value": "org-1",
-                            "organization_id": "org-1",
-                        },
-                    ],
-                },
-            },
-        }
-
-    monkeypatch.setattr(internal_client, "show_access_apply", _apply)
-    client = app.test_client()
-    applied = client.post(
-        "/api/show-pages/ses-access-entries/access-settings/apply",
-        json=request_payload,
-        headers=csrf_headers(client),
-    )
-
-    assert applied.status_code == 200
-    assert applied.get_json()["show_access"]["entries"][0]["kind"] == "group"
-    assert calls == [("apply", request_payload)]
 
 
 def test_show_access_route_identity_mismatch_is_rejected_before_ipc(monkeypatch, tmp_path) -> None:

--- a/tests/test_ui_memory_routes.py
+++ b/tests/test_ui_memory_routes.py
@@ -124,7 +124,6 @@ def test_memory_settings_patch_accepts_optional_complete_rerank_endpoint() -> No
         "https://rerank.example.test/v1/inference",
         "rerank-model",
         "rerank-secret",
-        "deepinfra",
     )
 
 
@@ -490,13 +489,17 @@ def _save_remote_config(tmp_path) -> V2Config:
     config = V2Config.load()
     cloud = config.remote_access.vibe_cloud
     cloud.enabled = True
+    cloud.backend_url = "https://backend.test"
     cloud.public_url = "https://alex.avibe.bot"
     cloud.client_id = "vr_client_123"
     cloud.instance_id = "inst_123"
+    cloud.instance_kind = "organization"
+    cloud.instance_secret = "instance-secret"
     cloud.session_secret = "session-secret"
     cloud.authorization_endpoint = "https://backend.test/oauth/authorize"
     cloud.redirect_uri = "https://alex.avibe.bot/auth/callback"
     config.save()
+    remote_access._replace_authorization_revision(config, 0)
     return config
 
 

--- a/tests/test_ui_memory_routes.py
+++ b/tests/test_ui_memory_routes.py
@@ -124,6 +124,7 @@ def test_memory_settings_patch_accepts_optional_complete_rerank_endpoint() -> No
         "https://rerank.example.test/v1/inference",
         "rerank-model",
         "rerank-secret",
+        "deepinfra",
     )
 
 

--- a/tests/test_web_push_notifications.py
+++ b/tests/test_web_push_notifications.py
@@ -3493,3 +3493,47 @@ def test_send_to_enabled_subscriptions_skips_ambiguous_legacy_owner(monkeypatch,
     )
 
     assert sends == []
+
+
+def test_web_push_does_not_mix_reconciling_personal_policy_with_ready_org_binding(
+    tmp_path,
+) -> None:
+    """Class 2: one evaluation, one snapshot of (ready, kind, generation)."""
+
+    config = _paired_revision_config(41, instance_kind="organization")
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_id="inst-push",
+    )
+    # Kindless released snapshot: policy would infer Personal if the first
+    # gate saw reconciling. Evaluation must not mix that with a later-ready
+    # Org binding.
+    from storage import remote_access_authorization_service
+
+    started = remote_access_authorization_service.begin_instance_binding_transition(
+        instance_id="inst-push",
+        instance_kind="organization",
+    )
+    remote_access_authorization_service.complete_instance_binding_transition(
+        instance_id="inst-push",
+        instance_kind="organization",
+        generation=started["generation"],
+    )
+    remote_access_authorization_service.begin_instance_binding_transition(
+        instance_id="inst-push",
+        instance_kind="organization",
+    )
+    decision = web_push_notifications._evaluate_record_authorization(
+        config,
+        "remote:personal-user",
+        record,
+    )
+    # Evaluation captured reconciling: must not authorize under Personal
+    # against an Org-configured pairing.
+    assert not decision.authorized
+    assert decision.policy != "personal" or not decision.authorized
+    assert decision.disposition in {
+        web_push_notifications.WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE,
+        web_push_notifications.WEB_PUSH_DISPOSITION_AUTHORIZATION_REFRESH_REQUIRED,
+        web_push_notifications.WEB_PUSH_DISPOSITION_REVOKED,
+    }

--- a/tests/test_web_push_notifications.py
+++ b/tests/test_web_push_notifications.py
@@ -9,7 +9,7 @@ from storage.importer import ensure_sqlite_state
 from storage.models import agent_sessions, messages
 from storage.settings_service import upsert_scope
 from vibe import remote_access
-from vibe.authorization import AuthorizationContext
+from vibe.authorization import AuthorizationContext, context_from_session_payload
 
 
 @pytest.fixture(autouse=True)
@@ -25,6 +25,8 @@ def _remote_authorization_record(
     authorization_revision: int | None = None,
     instance_access_source: str = "email",
     organization: bool = False,
+    instance_kind: str | None = None,
+    instance_id: str | None = "inst-push",
 ) -> dict:
     subject = user_key.removeprefix("remote:")
     record = web_push_notifications.web_push_authorization_context_record(
@@ -39,11 +41,166 @@ def _remote_authorization_record(
             organization_id="org_1" if organization else None,
             organization_member_id="member_1" if organization else None,
             organization_role="member" if organization else None,
+            instance_id=instance_id,
+            instance_kind=instance_kind,
             is_remote=True,
         ),
     )
     assert record is not None
     return record
+
+
+def test_web_push_authorization_snapshot_preserves_instance_kind() -> None:
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_kind="personal",
+    )
+
+    assert record["vibe_instance_kind"] == "personal"
+    assert context_from_session_payload(record).is_personal_instance
+
+
+def test_kindless_web_push_snapshot_adopts_current_personal_pairing_kind(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _paired_revision_config(41, instance_kind="personal")
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_id="inst-push",
+    )
+
+    decision = web_push_notifications._evaluate_record_authorization(
+        config,
+        "remote:personal-user",
+        record,
+    )
+
+    assert decision.authorized
+    assert decision.context is not None
+    assert decision.context.is_personal_instance
+
+
+def test_unbound_kindless_web_push_snapshot_is_rejected(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _paired_revision_config(41, instance_kind="personal")
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_id=None,
+    )
+
+    decision = web_push_notifications._evaluate_record_authorization(
+        config,
+        "remote:personal-user",
+        record,
+    )
+
+    assert not decision.authorized
+    assert decision.disposition == web_push_notifications.WEB_PUSH_DISPOSITION_REVOKED
+    assert decision.reason == (
+        "persisted snapshot lacks a binding to the current paired instance"
+    )
+
+
+def test_kind_specific_web_push_snapshot_requires_known_current_pairing_kind(tmp_path) -> None:
+    config = _paired_revision_config(41, instance_kind="")
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_kind="personal",
+    )
+
+    decision = web_push_notifications._evaluate_record_authorization(
+        config,
+        "remote:personal-user",
+        record,
+    )
+
+    assert not decision.authorized
+    assert decision.disposition == web_push_notifications.WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE
+    assert decision.reason == "current pairing instance kind is unavailable"
+
+
+def test_web_push_rejects_remote_snapshot_when_pairing_config_is_absent() -> None:
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_kind="personal",
+    )
+
+    decision = web_push_notifications._evaluate_record_authorization(
+        None,
+        "remote:personal-user",
+        record,
+    )
+
+    assert not decision.authorized
+    assert decision.disposition == web_push_notifications.WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE
+    assert decision.reason == (
+        "paired configuration is unavailable; instance binding cannot be validated"
+    )
+
+
+def test_personal_web_push_requires_runtime_valid_pairing(tmp_path) -> None:
+    config = _paired_revision_config(41, instance_kind="personal")
+    config.remote_access.vibe_cloud.instance_secret = ""
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_kind="personal",
+    )
+
+    decision = web_push_notifications._evaluate_record_authorization(
+        config,
+        "remote:personal-user",
+        record,
+    )
+
+    assert not decision.authorized
+    assert decision.disposition == web_push_notifications.WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE
+    assert decision.reason == "current pairing lacks complete runtime credentials"
+
+
+def test_web_push_does_not_use_personal_bypass_while_binding_is_reconciling(tmp_path) -> None:
+    config = _paired_revision_config(41, instance_kind="personal")
+    from storage import remote_access_authorization_service
+
+    remote_access_authorization_service.begin_instance_binding_transition(
+        instance_id="inst-push",
+        instance_kind="personal",
+    )
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_kind="personal",
+    )
+
+    decision = web_push_notifications._evaluate_record_authorization(
+        config,
+        "remote:personal-user",
+        record,
+    )
+
+    assert not decision.authorized
+    assert decision.disposition == web_push_notifications.WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE
+    assert "not ready" in (decision.reason or "")
+
+
+def test_web_push_snapshot_with_stale_instance_kind_is_rejected(tmp_path) -> None:
+    config = _paired_revision_config(41, instance_kind="organization")
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_kind="personal",
+    )
+
+    decision = web_push_notifications._evaluate_record_authorization(
+        config,
+        "remote:personal-user",
+        record,
+    )
+
+    assert not decision.authorized
+    assert decision.disposition == web_push_notifications.WEB_PUSH_DISPOSITION_REVOKED
+    assert decision.reason == (
+        "persisted snapshot instance kind differs from the current pairing"
+    )
 
 
 def _paired_revision_config(revision: int, *, instance_kind: str = ""):
@@ -329,6 +486,7 @@ def test_web_push_owner_uses_transcript_acceptance_order(monkeypatch, tmp_path):
 
 def test_send_to_enabled_subscriptions_waits_then_sends_to_owner_devices(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -473,6 +631,7 @@ def test_send_to_enabled_subscriptions_rejects_stale_instance_authorization_revi
             - remote_access.SESSION_AUTHORIZATION_REFRESH_SECONDS
             - 3600,
             authorization_revision=41,
+            instance_id="inst-push",
             is_remote=True,
         ),
     )
@@ -595,6 +754,7 @@ def test_personal_policy_ignores_revision_state_and_refresh_cutoff(monkeypatch, 
         "remote:user-a",
         claims_age_seconds=remote_access.SESSION_AUTHORIZATION_REFRESH_SECONDS + 3600,
         authorization_revision=41,
+        instance_kind="personal",
     )
 
     with engine.begin() as conn:
@@ -1029,6 +1189,7 @@ def test_in_flight_authorization_sync_wait_recovers_watermark(monkeypatch, tmp_p
 
 def test_merged_delivery_reports_provider_failure_per_owner(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-08-14T00:00:00Z"
@@ -1145,6 +1306,7 @@ def test_persisted_ring_survives_delivery_process_restart(monkeypatch, tmp_path)
 
 def test_merged_owner_without_endpoint_reports_no_subscription(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-08-15T00:00:00Z"
@@ -1302,7 +1464,7 @@ def test_unsigned_organization_snapshot_without_config_is_rejected(monkeypatch, 
 
     assert sends == []
     recent = web_push_notifications.recent_delivery_dispositions()
-    assert recent[0]["disposition"] == web_push_notifications.WEB_PUSH_DISPOSITION_AUTHORIZATION_REFRESH_REQUIRED
+    assert recent[0]["disposition"] == web_push_notifications.WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE
     assert recent[0]["owners"]["remote:user-a"]["policy"] == "organization"
     engine.dispose()
 
@@ -1602,7 +1764,7 @@ def test_organization_signed_snapshot_without_config_records_unavailable(monkeyp
 
     assert sends == []
     recent = web_push_notifications.recent_delivery_dispositions()
-    assert recent[0]["disposition"] == web_push_notifications.WEB_PUSH_DISPOSITION_REVISION_UNAVAILABLE
+    assert recent[0]["disposition"] == web_push_notifications.WEB_PUSH_DISPOSITION_CONFIG_UNAVAILABLE
     assert recent[0]["owners"]["remote:user-a"]["policy"] == "organization"
     engine.dispose()
 
@@ -2034,6 +2196,7 @@ def test_organization_unsigned_record_reports_refresh_required(monkeypatch, tmp_
 
 def test_authorized_owner_without_subscription_records_no_subscription(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-08-04T00:00:00Z"
@@ -2125,6 +2288,7 @@ def test_authorized_owner_without_subscription_records_no_subscription(monkeypat
 
 def test_send_to_enabled_subscriptions_rechecks_restricted_project_access(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="organization")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -2133,6 +2297,11 @@ def test_send_to_enabled_subscriptions_rechecks_restricted_project_access(monkey
         subject="user-a",
         email="member@example.com",
         instance_access_source="email",
+        organization_id="org_1",
+        organization_member_id="member_1",
+        organization_role="member",
+        instance_kind="organization",
+        authorization_revision=41,
         claims_issued_at=int(web_push_notifications.time.time()),
         is_remote=True,
     )
@@ -2319,9 +2488,164 @@ def test_send_to_enabled_subscriptions_rechecks_restricted_project_access(monkey
     assert [send[0]["endpoint"] for send in sends] == ["https://push.example.test/a"]
 
 
+def test_send_to_enabled_subscriptions_personal_editor_ignores_restricted_project_acl(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
+    ensure_sqlite_state()
+    engine = create_sqlite_engine()
+    now = "2026-06-04T00:00:00Z"
+    context = AuthorizationContext(
+        instance_role="editor",
+        subject="personal-user",
+        email="personal@example.com",
+        instance_access_source="email",
+        instance_kind="personal",
+        claims_issued_at=int(web_push_notifications.time.time()),
+        is_remote=True,
+    )
+    authorization_record = web_push_notifications.web_push_authorization_context_record(
+        "remote:personal-user",
+        context,
+    )
+    assert authorization_record is not None
+
+    with engine.begin() as conn:
+        primary_scope_id = upsert_scope(
+            conn,
+            platform="avibe",
+            scope_type="project",
+            native_id="proj_push_personal_acl",
+            now=now,
+        )
+        other_scope_id = upsert_scope(
+            conn,
+            platform="avibe",
+            scope_type="project",
+            native_id="proj_push_personal_other",
+            now=now,
+        )
+        for session_id, scope_id in (
+            ("ses_push_personal_acl", primary_scope_id),
+            ("ses_push_personal_other", other_scope_id),
+        ):
+            conn.execute(
+                agent_sessions.insert().values(
+                    id=session_id,
+                    scope_id=scope_id,
+                    agent_backend="claude",
+                    agent_variant="default",
+                    session_anchor=session_id,
+                    native_session_id="",
+                    title=session_id,
+                    status="active",
+                    metadata_json="{}",
+                    created_at=now,
+                    updated_at=now,
+                    last_active_at=now,
+                )
+            )
+        for project_id in ("proj_push_personal_acl", "proj_push_personal_other"):
+            assert project_access_service.apply_project_access_intent(
+                conn,
+                {
+                    "project_id": project_id,
+                    "revision": 1,
+                    "mode": "restricted",
+                    "bindings": [
+                        {
+                            "principal_kind": "email",
+                            "principal_value": "someone-else@example.com",
+                            "access_role": "editor",
+                        }
+                    ],
+                },
+            ).outcome == "applied"
+        messages_service.append(
+            conn,
+            scope_id=primary_scope_id,
+            session_id="ses_push_personal_acl",
+            platform="avibe",
+            author="user",
+            source="user",
+            author_id="remote:personal-user",
+            metadata={
+                "_web_push_user_key": "remote:personal-user",
+                "_web_push_authorization_contexts": [authorization_record],
+            },
+            message_type="user",
+            text="Please finish",
+        )
+        primary_message = messages_service.append(
+            conn,
+            scope_id=primary_scope_id,
+            session_id="ses_push_personal_acl",
+            platform="avibe",
+            author="agent",
+            source="agent",
+            message_type="result",
+            text="Done",
+        )
+        messages_service.append(
+            conn,
+            scope_id=other_scope_id,
+            session_id="ses_push_personal_other",
+            platform="avibe",
+            author="user",
+            source="user",
+            author_id="remote:personal-user",
+            message_type="user",
+            text="Please finish another project",
+        )
+        messages_service.append(
+            conn,
+            scope_id=other_scope_id,
+            session_id="ses_push_personal_other",
+            platform="avibe",
+            author="agent",
+            source="agent",
+            message_type="result",
+            text="Done another",
+        )
+        web_push_service.upsert_subscription(
+            conn,
+            user_key="remote:personal-user",
+            payload={
+                "endpoint": "https://push.example.test/personal-acl",
+                "keys": {"p256dh": "personal-key", "auth": "personal-auth"},
+            },
+        )
+
+    sends = []
+    monkeypatch.setattr(web_push_notifications.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        "core.web_push.send_web_push",
+        lambda *, subscription, payload: sends.append((subscription, payload)),
+    )
+    web_push_notifications._send_to_enabled_subscriptions(
+        {
+            "title": "Personal ACL Push",
+            "body": "Done",
+            "session_id": "ses_push_personal_acl",
+            "message_id": primary_message["id"],
+        }
+    )
+
+    assert [send[0]["endpoint"] for send in sends] == [
+        "https://push.example.test/personal-acl"
+    ]
+    assert [send[1]["badge_count"] for send in sends] == [2]
+    recent = web_push_notifications.recent_delivery_dispositions(user_key="remote:personal-user")
+    assert recent[0]["disposition"] == web_push_notifications.WEB_PUSH_DISPOSITION_SENT
+    engine.dispose()
+
+
 def test_send_to_enabled_subscriptions_sets_visible_badge_count(monkeypatch, tmp_path):
     """One Project's badge includes every visible unread session in it."""
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -2330,6 +2654,7 @@ def test_send_to_enabled_subscriptions_sets_visible_badge_count(monkeypatch, tmp
         subject="user-a",
         email="member@example.com",
         instance_access_source="email",
+        instance_id="inst-push",
         claims_issued_at=int(web_push_notifications.time.time()),
         is_remote=True,
     )
@@ -2483,6 +2808,7 @@ def test_send_to_enabled_subscriptions_rejects_legacy_session_owner(monkeypatch,
 
 def test_send_to_enabled_subscriptions_prefers_message_owner_over_legacy_session(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -2557,6 +2883,7 @@ def test_send_to_enabled_subscriptions_prefers_message_owner_over_legacy_session
 
 def test_send_to_enabled_subscriptions_sends_to_merged_prompt_owners(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"
@@ -3016,6 +3343,7 @@ def test_send_to_enabled_subscriptions_skips_local_fallback_when_remote_access_e
 
 def test_send_to_enabled_subscriptions_sends_terminal_error_with_owner(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _paired_revision_config(41, instance_kind="personal")
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     now = "2026-06-04T00:00:00Z"

--- a/tests/test_web_push_notifications.py
+++ b/tests/test_web_push_notifications.py
@@ -103,6 +103,29 @@ def test_unbound_kindless_web_push_snapshot_is_rejected(monkeypatch, tmp_path) -
     )
 
 
+def test_unrecognized_web_push_snapshot_kind_is_rejected(tmp_path) -> None:
+    """Regression PR #1606 r4: a present-but-unrecognized kind is not a
+    no-kind legacy snapshot and must not fall through to Personal policy.
+    """
+
+    config = _paired_revision_config(41, instance_kind="personal")
+    record = _remote_authorization_record(
+        "remote:personal-user",
+        instance_id="inst-push",
+    )
+    record["vibe_instance_kind"] = "something-else"
+
+    decision = web_push_notifications._evaluate_record_authorization(
+        config,
+        "remote:personal-user",
+        record,
+    )
+
+    assert not decision.authorized
+    assert decision.disposition == web_push_notifications.WEB_PUSH_DISPOSITION_REVOKED
+    assert decision.reason == "persisted snapshot instance kind is unrecognized"
+
+
 def test_kind_specific_web_push_snapshot_requires_known_current_pairing_kind(tmp_path) -> None:
     config = _paired_revision_config(41, instance_kind="")
     record = _remote_authorization_record(

--- a/tests/ui_server_test_helpers.py
+++ b/tests/ui_server_test_helpers.py
@@ -21,7 +21,12 @@ def remote_peer() -> dict[str, str]:
     return _remote_peer()
 
 
-def _save_config(tmp_path):
+def _save_config(
+    tmp_path,
+    *,
+    paired: bool = False,
+    instance_kind: str = "organization",
+):
     from config.v2_config import (
         AgentsConfig,
         PlatformsConfig,
@@ -48,10 +53,21 @@ def _save_config(tmp_path):
     cloud.public_url = "https://alex.avibe.bot"
     cloud.client_id = "vr_client_123"
     cloud.instance_id = "inst_123"
+    cloud.instance_secret = "instance-secret"
     cloud.session_secret = "session-secret"
     cloud.authorization_endpoint = "https://backend.test/oauth/authorize"
     cloud.redirect_uri = "https://alex.avibe.bot/auth/callback"
+    if paired:
+        cloud.backend_url = "https://backend.test"
+        cloud.instance_kind = instance_kind
+    else:
+        cloud.instance_secret = ""
     config.save()
+    if paired:
+        # A complete paired fixture also needs the device authorization
+        # watermark; production session cookies must carry it once runtime
+        # credentials exist.
+        remote_access._replace_authorization_revision(config, 0)
     return config
 
 
@@ -90,6 +106,10 @@ def remote_session_cookie(
             "vibe_instance_role": role,
             "vibe_instance_access_source": access_source,
         }
+        if remote_access._authorization_revision_sync_configured(config):
+            claims["vibe_instance_authorization_revision"] = (
+                remote_access.current_authorization_revision(config) or 0
+            )
         if organization_id is not None:
             claims["vibe_organization_id"] = organization_id
         if organization_member_id is not None:
@@ -98,6 +118,15 @@ def remote_session_cookie(
             claims["vibe_organization_role"] = organization_role
         if group_ids is not None:
             claims["vibe_group_ids"] = group_ids
+    elif remote_access._authorization_revision_sync_configured(config) and (
+        "vibe_instance_authorization_revision" not in claims
+    ):
+        claims = {
+            **claims,
+            "vibe_instance_authorization_revision": (
+                remote_access.current_authorization_revision(config) or 0
+            ),
+        }
     return remote_access.make_session_cookie(
         config,
         email,

--- a/vibe/authorization.py
+++ b/vibe/authorization.py
@@ -415,6 +415,7 @@ _EDITOR_HTTP_RULES = tuple(
         ("POST", r"^/api/config$"),
         ("POST", r"^/api/show/sessions/[^/]+/events$"),
         ("POST", r"^/api/show/sessions/[^/]+/prewarm$"),
+        ("GET", r"^/api/show-pages/[^/]+$"),
         ("POST", r"^/api/show-pages/[^/]+/icon$"),
         ("POST", r"^/api/show-pages/[^/]+/(?:ensure|availability)$"),
         ("POST", r"^/api/show-pages/[^/]+/access-settings/(?:read|apply)$"),

--- a/vibe/authorization.py
+++ b/vibe/authorization.py
@@ -77,10 +77,19 @@ class AuthorizationContext:
     authorization_revision: int | None = None
     show_page_id: str | None = None
     is_remote: bool = False
+    instance_kind: str | None = None
 
     @property
     def is_instance_owner(self) -> bool:
         return self.instance_role == "owner"
+
+    @property
+    def is_personal_instance(self) -> bool:
+        return self.instance_kind == "personal"
+
+    @property
+    def is_organization_instance(self) -> bool:
+        return self.instance_kind == "organization"
 
     @property
     def is_active_organization_member(self) -> bool:
@@ -226,6 +235,9 @@ def context_from_session_payload(payload: Mapping[str, Any]) -> AuthorizationCon
     )
     if organization_role not in ORGANIZATION_ROLES:
         organization_role = None
+    instance_kind = _optional_string(payload.get("vibe_instance_kind"))
+    if instance_kind not in {"personal", "organization"}:
+        instance_kind = None
     return AuthorizationContext(
         instance_role=role,
         subject=_optional_string(payload.get("sub")),
@@ -254,6 +266,7 @@ def context_from_session_payload(payload: Mapping[str, Any]) -> AuthorizationCon
         ),
         show_page_id=show_page_id,
         is_remote=True,
+        instance_kind=instance_kind,
     )
 
 
@@ -402,10 +415,6 @@ _EDITOR_HTTP_RULES = tuple(
         ("POST", r"^/api/config$"),
         ("POST", r"^/api/show/sessions/[^/]+/events$"),
         ("POST", r"^/api/show/sessions/[^/]+/prewarm$"),
-        # Reading one page stays at the role its ensure POST already required, so
-        # replacing that POST with this GET changes no caller's authorization
-        # outcome. Widening to viewer would be a policy change, not a read.
-        ("GET", r"^/api/show-pages/[^/]+$"),
         ("POST", r"^/api/show-pages/[^/]+/icon$"),
         ("POST", r"^/api/show-pages/[^/]+/(?:ensure|availability)$"),
         ("POST", r"^/api/show-pages/[^/]+/access-settings/(?:read|apply)$"),

--- a/vibe/authorization.py
+++ b/vibe/authorization.py
@@ -25,7 +25,33 @@ INSTANCE_ACCESS_SOURCES = frozenset(
     }
 )
 ORGANIZATION_ROLES = frozenset({"owner", "admin", "member"})
+INSTANCE_KINDS = frozenset({"personal", "organization"})
 _ROLE_RANK = {"viewer": 1, "editor": 2, "owner": 3}
+
+
+def recognized_instance_kind(value: object) -> str | None:
+    """Return a recognized instance kind, or None for a genuine no-kind snapshot.
+
+    A present-but-unrecognized value (corruption, a future release, a typo)
+    is not a no-kind legacy snapshot. Callers that need fail-closed behavior
+    must distinguish ``None`` (absent/legacy) from an unrecognized string
+    via :func:`instance_kind_is_unsupported`.
+    """
+
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned if cleaned in INSTANCE_KINDS else None
+
+
+def instance_kind_is_unsupported(value: object) -> bool:
+    """True when a kind field is present but not a known Personal/Organization value."""
+
+    if value is None:
+        return False
+    if not isinstance(value, str):
+        return True
+    return value.strip() not in {"", *INSTANCE_KINDS}
 _RESOURCE_USE_MINIMUM_ROLES = {
     "agent": "editor",
     "skill": "editor",
@@ -235,9 +261,11 @@ def context_from_session_payload(payload: Mapping[str, Any]) -> AuthorizationCon
     )
     if organization_role not in ORGANIZATION_ROLES:
         organization_role = None
-    instance_kind = _optional_string(payload.get("vibe_instance_kind"))
-    if instance_kind not in {"personal", "organization"}:
+    raw_instance_kind = payload.get("vibe_instance_kind")
+    if instance_kind_is_unsupported(raw_instance_kind):
         instance_kind = None
+    else:
+        instance_kind = recognized_instance_kind(raw_instance_kind)
     return AuthorizationContext(
         instance_role=role,
         subject=_optional_string(payload.get("sub")),

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -1591,19 +1591,35 @@ def report_runtime_status(config: V2Config | None = None, event: str = "heartbea
             return {"ok": False, "error": "remote_status_not_configured"}
         if urllib.parse.urlsplit(cloud.backend_url).scheme.lower() != "https":
             return {"ok": False, "error": "remote_status_backend_url_invalid"}
+        from storage import remote_access_authorization_service
+
+        request_instance_id = str(cloud.instance_id)
+        request_binding_generation = (
+            remote_access_authorization_service.current_instance_binding_generation(
+                ensure=False
+            )
+        )
         payload = {
             "instance_secret": cloud.instance_secret,
             **runtime_status_payload(config, event=event, last_error=last_error),
         }
         result = _json_request(
-            f"{cloud.backend_url.rstrip('/')}/api/v1/instances/{cloud.instance_id}/runtime-status",
+            f"{cloud.backend_url.rstrip('/')}/api/v1/instances/{request_instance_id}/runtime-status",
             payload,
             timeout=5.0,
         )
         _replace_active_hostnames(config, result.get("active_hostnames"))
         reported_kind = _normalized_instance_kind(result.get("instance_kind"))
         if reported_kind is not None:
-            _persist_instance_kind(cloud.instance_id, reported_kind, reconcile=True)
+            # Capture-before-IO: overlapping heartbeats can arrive out of
+            # order. A late Personal response must CAS-fail against a newer
+            # Organization generation rather than rewrite the live binding.
+            _persist_instance_kind(
+                request_instance_id,
+                reported_kind,
+                reconcile=True,
+                expected_binding_generation=request_binding_generation,
+            )
         return {"ok": True, **result}
     except Exception as exc:
         return {"ok": False, "error": "remote_status_report_failed", "detail": str(exc)}
@@ -5643,6 +5659,13 @@ def resolve_current_authorization(
         if isinstance(stored_claims, Mapping):
             stored_kind = _normalized_instance_kind(stored_claims.get("vibe_instance_kind"))
     is_exact_show_page = _is_exact_show_page_grant(identity, record)
+    kindless_current_needs_refresh = (
+        not is_exact_show_page
+        and instance_kind is not None
+        and stored_kind is None
+        and record is not None
+        and record.get("authorization_state") == "current"
+    )
     kind_mismatch = (
         not is_exact_show_page
         and (
@@ -5657,6 +5680,7 @@ def resolve_current_authorization(
                 and record is not None
                 and record.get("authorization_state") == "stale"
             )
+            or kindless_current_needs_refresh
         )
     )
     if kind_mismatch:

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -5675,15 +5675,19 @@ def resolve_current_authorization(
             )
         )
     )
+    if kind_mismatch:
+        # A row tagged with the previous kind (or invalidated by a
+        # reclassification) must revalidate before EITHER kind-specific
+        # policy runs — returning it as current under the new kind would let
+        # the old kind's claims outlive the reclassification.
+        if allow_refresh:
+            return _refresh_authorization_context(config, identity, record, now=current)
+        return AuthorizationResolution(
+            "unavailable",
+            reason="authorization_context_missing",
+        )
 
     if instance_kind == "personal":
-        if kind_mismatch:
-            if allow_refresh:
-                return _refresh_authorization_context(config, identity, record, now=current)
-            return AuthorizationResolution(
-                "unavailable",
-                reason="authorization_context_missing",
-            )
         if (
             current_revision is not None
             and signed_revision is not None

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -1762,7 +1762,7 @@ def _persist_instance_kind(
     reconcile: bool = False,
     expected_binding_generation: int | None = None,
     expected_binding_epoch: int | None = None,
-) -> bool:
+) -> bool | int:
     """Persist kind + reconcile under one cross-process critical section (C2).
 
     Lock order is owned by reconcile_instance_binding: SQLite init, then
@@ -1803,7 +1803,7 @@ def _persist_instance_kind(
             ensure=False,
         )
         if previous_kind == instance_kind and already_ready:
-            return True
+            return current_generation
         if previous_kind != instance_kind:
             live_generation = (
                 remote_access_authorization_service.current_instance_binding_generation(
@@ -1847,7 +1847,14 @@ def _persist_instance_kind(
                 return False
             if persisted_generation < int(expected_binding_generation):
                 return False
-        return bool(transition.get("ok") and (transition.get("ready") or instance_kind is None))
+        if not (transition.get("ok") and (transition.get("ready") or instance_kind is None)):
+            return False
+        try:
+            return int(transition.get("generation"))
+        except (TypeError, ValueError):
+            return remote_access_authorization_service.current_instance_binding_generation(
+                ensure=False
+            )
 
 
 def mint_cloud_token(
@@ -4937,14 +4944,15 @@ def _store_scoped_authorization(
         stored_claims["vibe_instance_kind"] = persisted_kind
     scope_kind, scope_ref = _authorization_scope(config, stored_claims)
     if expected_binding_generation is None and scope_kind != "show_page":
-        try:
-            expected_binding_generation = (
-                remote_access_authorization_service.current_instance_binding_generation(
-                    ensure=False
-                )
-            )
-        except Exception:
-            expected_binding_generation = None
+        # Recapturing live generation here is the TOCTOU: a transition can
+        # complete between the caller's persist-kind CAS and this write, and
+        # the recaptured gen would let a stale response resurrect a current
+        # row. Callers that produced claims via network/IO must pass the
+        # generation they captured BEFORE that IO. Local cookie/legacy paths
+        # capture immediately before this call.
+        raise remote_access_authorization_service.InstanceBindingChangedError(
+            "expected_binding_generation_required"
+        )
     return remote_access_authorization_service.upsert_scoped(
         reference=reference,
         instance_id=str(config.remote_access.vibe_cloud.instance_id),
@@ -4979,6 +4987,13 @@ def make_session_cookie(
         except ValueError as exc:
             raise OAuthCodeExchangeError("stale_authorization_revision") from exc
     stored_claims = {**validated_claims, "claims_issued_at": issued_at}
+    from storage import remote_access_authorization_service
+
+    request_binding_generation = (
+        remote_access_authorization_service.current_instance_binding_generation(
+            ensure=False
+        )
+    )
     reference = _store_scoped_authorization(
         config,
         reference=None,
@@ -4987,6 +5002,7 @@ def make_session_cookie(
         claims=stored_claims,
         authorization_state="current",
         checked_at=issued_at,
+        expected_binding_generation=request_binding_generation,
     )
     payload = {
         "email": email,
@@ -5160,6 +5176,11 @@ def _load_authorization_record(
     if existing is not None:
         return existing
     try:
+        request_binding_generation = (
+            remote_access_authorization_service.current_instance_binding_generation(
+                ensure=False
+            )
+        )
         stored_reference = _store_scoped_authorization(
             config,
             reference=None,
@@ -5168,6 +5189,7 @@ def _load_authorization_record(
             claims=claims,
             authorization_state="current",
             checked_at=checked_at,
+            expected_binding_generation=request_binding_generation,
         )
         return remote_access_authorization_service.load_reference_record(
             reference=stored_reference,
@@ -5333,7 +5355,7 @@ def _fetch_authorization_context(
     except Exception:
         logger.warning("remote instance kind persistence failed", exc_info=True)
         persisted = False
-    if not persisted:
+    if persisted is False:
         live_state = remote_access_authorization_service.load_instance_binding_state(
             ensure=False
         )
@@ -5363,6 +5385,11 @@ def _fetch_authorization_context(
             authorization_state="current",
             checked_at=now,
             instance_kind=instance_kind,
+            expected_binding_generation=(
+                int(persisted)
+                if not isinstance(persisted, bool)
+                else request_binding_generation
+            ),
         )
         refreshed_record = remote_access_authorization_service.load_reference_record(
             reference=reference,
@@ -5370,6 +5397,8 @@ def _fetch_authorization_context(
             subject=subject,
             now=now,
         )
+    except remote_access_authorization_service.InstanceBindingChangedError:
+        return AuthorizationResolution("unavailable", reason="instance_binding_changed")
     except Exception:
         logger.warning("remote authorization context persistence failed", exc_info=True)
         return AuthorizationResolution("unavailable", reason="authorization_context_invalid")
@@ -5811,8 +5840,15 @@ def renew_session_cookie(
     current = int(time.time()) if now is None else now
     reference = payload.get(_SESSION_AUTHORIZATION_REFERENCE_KEY)
     if not isinstance(reference, str):
+        from storage import remote_access_authorization_service
+
         claims = _authorization_claims_from_payload(payload)
         checked_at = int(payload.get("claims_issued_at", payload.get("iat", current)))
+        request_binding_generation = (
+            remote_access_authorization_service.current_instance_binding_generation(
+                ensure=False
+            )
+        )
         reference = _store_scoped_authorization(
             config,
             reference=None,
@@ -5821,6 +5857,7 @@ def renew_session_cookie(
             claims=claims,
             authorization_state="current",
             checked_at=checked_at,
+            expected_binding_generation=request_binding_generation,
         )
     browser_session_id = payload.get(_SESSION_BROWSER_ID_KEY)
     if not isinstance(browser_session_id, str):

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -1601,7 +1601,9 @@ def report_runtime_status(config: V2Config | None = None, event: str = "heartbea
             timeout=5.0,
         )
         _replace_active_hostnames(config, result.get("active_hostnames"))
-        _persist_instance_kind(cloud.instance_id, result.get("instance_kind"))
+        reported_kind = _normalized_instance_kind(result.get("instance_kind"))
+        if reported_kind is not None:
+            _persist_instance_kind(cloud.instance_id, reported_kind, reconcile=True)
         return {"ok": True, **result}
     except Exception as exc:
         return {"ok": False, "error": "remote_status_report_failed", "detail": str(exc)}
@@ -1611,20 +1613,221 @@ def _normalized_instance_kind(value: object) -> str | None:
     return value if isinstance(value, str) and value in _INSTANCE_KINDS else None
 
 
-def _persist_instance_kind(instance_id: str, value: object) -> bool:
+def _run_pending_deferred_context_migration() -> dict[str, int | str]:
+    """Bind or seal released snapshots against the current pairing."""
+
+    from storage.db import get_cached_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.resource_access_service import (
+        RESOURCE_BINDING_STATE_UNAVAILABLE,
+        RESOURCE_BINDING_STATUS_KEY,
+        migrate_legacy_deferred_resource_contexts,
+    )
+
+    ensure_sqlite_state()
+    engine = get_cached_sqlite_engine()
+    with engine.begin() as connection:
+        result = migrate_legacy_deferred_resource_contexts(connection)
+    if result.get(RESOURCE_BINDING_STATUS_KEY) == RESOURCE_BINDING_STATE_UNAVAILABLE:
+        raise RuntimeError("legacy_deferred_context_provenance_unavailable")
+    return result
+
+
+def _runtime_pairing_available(config: V2Config) -> bool:
+    try:
+        return config.remote_access.vibe_cloud.runtime_credentials() is not None
+    except Exception:
+        return False
+
+
+def _known_kind_requires_runtime_pairing(config: V2Config) -> bool:
+    """Require complete device credentials once the server-owned kind is known.
+
+    Legacy pre-kind pairings still use the existing authorization path while
+    they await backfill. They cannot take either Personal or Organization
+    kind-specific bypass; an explicit server-owned kind, however, must never
+    be projected from a degraded pairing.
+    """
+
+    return _normalized_instance_kind(config.remote_access.vibe_cloud.instance_kind) is not None
+
+
+def _is_exact_show_page_grant(
+    identity: Mapping[str, Any],
+    record: Mapping[str, Any] | None = None,
+) -> bool:
+    candidates: list[Mapping[str, Any]] = [identity]
+    if isinstance(record, Mapping):
+        claims = record.get("claims")
+        if isinstance(claims, Mapping):
+            candidates.append(claims)
+    return any(
+        candidate.get("vibe_instance_access_source") == "show_page_email"
+        and isinstance(candidate.get("vibe_show_page_id"), str)
+        and bool(candidate["vibe_show_page_id"].strip())
+        for candidate in candidates
+    )
+
+
+def binding_is_ready(config: V2Config, identity: Mapping[str, Any] | None = None) -> bool:
+    """C3: single gate for every authorization consumer.
+
+    A missing durable row is the fail-open legacy no-kind path. Once a row
+    exists, only ``ready`` for the current pairing admits kind-specific
+    bypass. Exact show_page_email grants are independent of instance kind.
+    """
+
+    if identity is not None:
+        if _is_exact_show_page_grant(identity):
+            return True
+        from storage import remote_access_authorization_service
+
+        instance_id = str(identity.get("instance_id") or config.remote_access.vibe_cloud.instance_id or "")
+        subject = str(identity.get("sub") or "")
+        try:
+            if subject and instance_id:
+                record = remote_access_authorization_service.load_reference_record(
+                    reference=str(identity.get("authorization_ref") or ""),
+                    instance_id=instance_id,
+                    subject=subject,
+                    now=int(time.time()),
+                )
+                if record is not None and _is_exact_show_page_grant(identity, record):
+                    return True
+        except Exception:
+            pass
+    try:
+        from storage import remote_access_authorization_service
+
+        cloud = config.remote_access.vibe_cloud
+        return remote_access_authorization_service.binding_is_ready_for_pairing(
+            instance_id=str(cloud.instance_id or ""),
+            instance_kind=_normalized_instance_kind(cloud.instance_kind),
+            ensure=False,
+        )
+    except Exception:
+        return False
+
+
+def _transition_instance_binding(
+    *,
+    instance_id: str,
+    instance_kind: str | None,
+    previous_instance_id: str | None = None,
+    hold_config_lock: bool = True,
+) -> dict[str, Any]:
+    """One cross-process identity transition (C2). SQLite is initialized first."""
+
+    from storage import remote_access_authorization_service
+
+    return remote_access_authorization_service.reconcile_instance_binding(
+        instance_id=instance_id,
+        instance_kind=instance_kind,
+        previous_instance_id=previous_instance_id,
+        reconcile=_run_pending_deferred_context_migration,
+        hold_config_lock=hold_config_lock,
+    )
+
+
+def _authorization_binding_epoch() -> int:
+    """Compatibility no-op: durable generation is the only fencing token."""
+
+    return 0
+
+
+def _persist_instance_kind(
+    instance_id: str,
+    value: object,
+    *,
+    reconcile: bool = False,
+    expected_binding_generation: int | None = None,
+    expected_binding_epoch: int | None = None,
+) -> bool:
+    """Persist kind + reconcile under one cross-process critical section (C2).
+
+    Lock order is owned by reconcile_instance_binding: SQLite init, then
+    config_file_lock. This function never takes CONFIG_LOCK. The unused
+    ``expected_binding_epoch`` argument exists only so older in-process tests
+    that still pass it keep exercising the durable generation CAS.
+    """
+
+    del expected_binding_epoch
     instance_kind = _normalized_instance_kind(value)
     if instance_kind is None:
         return False
-    with CONFIG_LOCK:
+    from storage import remote_access_authorization_service
+    from storage.importer import ensure_sqlite_state
+
+    # C2 lock order: initialize SQLite before taking the config lock, then
+    # keep compare + config-write + transition in one critical section.
+    ensure_sqlite_state()
+    with config_file_lock():
         live_config = V2Config.load()
         live_cloud = live_config.remote_access.vibe_cloud
-        if live_cloud.instance_id != instance_id or live_cloud.instance_kind == instance_kind:
+        if str(live_cloud.instance_id or "") != instance_id:
             return False
-        api.save_config(
-            {"remote_access": {"vibe_cloud": {"instance_kind": instance_kind}}},
-            validate_remote_access_network=False,
+        previous_kind = _normalized_instance_kind(live_cloud.instance_kind)
+        current_generation = (
+            remote_access_authorization_service.current_instance_binding_generation(
+                ensure=False
+            )
         )
-    return True
+        if (
+            expected_binding_generation is not None
+            and current_generation > int(expected_binding_generation)
+        ):
+            return False
+        already_ready = remote_access_authorization_service.binding_is_ready_for_pairing(
+            instance_id=instance_id,
+            instance_kind=instance_kind,
+            ensure=False,
+        )
+        if previous_kind == instance_kind and already_ready:
+            return True
+        if previous_kind != instance_kind:
+            live_generation = (
+                remote_access_authorization_service.current_instance_binding_generation(
+                    ensure=False
+                )
+            )
+            if (
+                expected_binding_generation is not None
+                and live_generation > int(expected_binding_generation)
+            ):
+                return False
+            api.save_config(
+                {"remote_access": {"vibe_cloud": {"instance_kind": instance_kind}}},
+                validate_remote_access_network=False,
+            )
+        # Whether the kind was already persisted by a prior attempt or just
+        # saved above, reconcile it now. The transition is what moves the
+        # durable binding to ready.
+        try:
+            transition = _transition_instance_binding(
+                instance_id=instance_id,
+                instance_kind=instance_kind,
+                hold_config_lock=False,
+            )
+        except Exception:
+            logger.warning("Remote instance binding reconciliation failed", exc_info=True)
+            return False
+        if expected_binding_generation is not None:
+            live_generation = (
+                remote_access_authorization_service.current_instance_binding_generation(
+                    ensure=False
+                )
+            )
+            try:
+                persisted_generation = int(transition.get("generation"))
+            except (TypeError, ValueError):
+                persisted_generation = live_generation
+            # Our own transition advancing the generation is success; only a
+            # FOREIGN writer moving past our transition is a lost race.
+            if live_generation > persisted_generation:
+                return False
+            if persisted_generation < int(expected_binding_generation):
+                return False
+        return bool(transition.get("ok") and (transition.get("ready") or instance_kind is None))
 
 
 def mint_cloud_token(
@@ -4345,6 +4548,31 @@ def pair(pairing_key: str, backend_url: str, device_name: str = "avibe") -> dict
     except Exception:
         origin_service = "http://127.0.0.1:5123"
     try:
+        previous_instance_id = str(V2Config.load().remote_access.vibe_cloud.instance_id or "")
+    except FileNotFoundError:
+        previous_instance_id = ""
+    except Exception as exc:
+        logger.warning("pre-pair config read failed", exc_info=True)
+        return {
+            "ok": False,
+            "error": "pairing_provenance_unavailable",
+            "detail": str(exc),
+            "pairing": {"ok": False},
+        }
+    # Provenance must be validated BEFORE the one-time redeem. An unavailable
+    # read or failing migration aborts without consuming the key; a genuine
+    # unpaired install seals unattributed snapshots so they cannot be adopted.
+    try:
+        _run_pending_deferred_context_migration()
+    except Exception as exc:
+        logger.warning("legacy deferred context migration before pairing failed", exc_info=True)
+        return {
+            "ok": False,
+            "error": "pairing_provenance_unavailable",
+            "detail": str(exc),
+            "pairing": {"ok": False},
+        }
+    try:
         result = _json_request(
             f"{backend.base_url}/api/v1/pairing/redeem",
             {
@@ -4405,6 +4633,28 @@ def pair(pairing_key: str, backend_url: str, device_name: str = "avibe") -> dict
             remote_access_authorization_service.delete_for_instance(previous_instance_id)
         except Exception:
             logger.warning("Old remote authorization cleanup failed after pairing", exc_info=True)
+    try:
+        transition = _transition_instance_binding(
+            instance_id=str(result["instance_id"]),
+            instance_kind=instance_kind,
+            previous_instance_id=previous_instance_id or None,
+        )
+    except Exception as exc:
+        logger.warning("Remote instance binding transition failed after pairing", exc_info=True)
+        return {
+            **status(config),
+            "ok": False,
+            "error": "pairing_reconciliation_failed",
+            "pairing": {"ok": False, "reconciling": True},
+        }
+    if not transition.get("ok"):
+        return {
+            **status(config),
+            "ok": False,
+            "error": "pairing_reconciliation_failed",
+            "detail": transition.get("error"),
+            "pairing": {"ok": False, "reconciling": True},
+        }
     start_result = start(config)
     _report_runtime_status_async(config, event="pair", last_error=start_result.get("error"))
     return {**status(config), "ok": True, "pairing": {"ok": True}, "start": start_result}
@@ -4631,10 +4881,32 @@ def _store_scoped_authorization(
     claims: Mapping[str, Any],
     authorization_state: str,
     checked_at: int,
+    instance_kind: str | None = None,
 ) -> str:
     from storage import remote_access_authorization_service
 
-    scope_kind, scope_ref = _authorization_scope(config, claims)
+    stored_claims = dict(claims)
+    persisted_kind = _normalized_instance_kind(instance_kind) or _normalized_instance_kind(
+        config.remote_access.vibe_cloud.instance_kind
+    )
+    if persisted_kind is not None:
+        stored_claims["vibe_instance_kind"] = persisted_kind
+    scope_kind, scope_ref = _authorization_scope(config, stored_claims)
+    state = None
+    try:
+        state = remote_access_authorization_service.load_instance_binding_state(
+            ensure=False
+        )
+    except Exception:
+        state = None
+    if (
+        scope_kind != "show_page"
+        and state is not None
+        and state.get("state")
+        == remote_access_authorization_service.INSTANCE_BINDING_STATE_RECONCILING
+        and authorization_state == "current"
+    ):
+        raise RuntimeError("instance_binding_not_ready")
     return remote_access_authorization_service.upsert_scoped(
         reference=reference,
         instance_id=str(config.remote_access.vibe_cloud.instance_id),
@@ -4643,7 +4915,7 @@ def _store_scoped_authorization(
         scope_kind=scope_kind,
         scope_ref=scope_ref,
         authorization_state=authorization_state,
-        claims=claims,
+        claims=stored_claims,
         last_checked_at=checked_at,
         updated_at=checked_at,
     )
@@ -4887,6 +5159,14 @@ def _validated_authorization_payload(
     identity: Mapping[str, Any],
     record: Mapping[str, Any],
 ) -> dict[str, Any] | None:
+    if not binding_is_ready(config, identity) and not _is_exact_show_page_grant(identity, record):
+        return None
+    if (
+        _known_kind_requires_runtime_pairing(config)
+        and not _runtime_pairing_available(config)
+        and not _is_exact_show_page_grant(identity, record)
+    ):
+        return None
     claims = record.get("claims")
     if not isinstance(claims, Mapping):
         return None
@@ -4896,7 +5176,7 @@ def _validated_authorization_payload(
     if isinstance(reference, str):
         payload[_SESSION_AUTHORIZATION_REFERENCE_KEY] = reference
     try:
-        session_claims_from_oidc(config, payload)
+        session_claims_from_oidc(config, claims)
     except OAuthCodeExchangeError:
         return None
     return payload
@@ -4931,6 +5211,11 @@ def _fetch_authorization_context(
     now: int,
     observed_revision: int | None,
 ) -> AuthorizationResolution:
+    from storage import remote_access_authorization_service
+
+    request_binding_generation = (
+        remote_access_authorization_service.current_instance_binding_generation()
+    )
     subject = str(identity.get("sub") or "").strip()
     email = str(identity.get("email") or "").strip()
     request_payload: dict[str, Any] = {"sub": subject, "email": email}
@@ -4952,6 +5237,14 @@ def _fetch_authorization_context(
             revoked_claims = dict(previous_claims)
             if observed_revision is not None:
                 revoked_claims[_AUTHORIZATION_CHECKED_REVISION_KEY] = observed_revision
+            current_generation = (
+                remote_access_authorization_service.current_instance_binding_generation()
+            )
+            if current_generation > int(request_binding_generation):
+                return AuthorizationResolution(
+                    "unavailable",
+                    reason="instance_binding_changed",
+                )
             try:
                 _store_scoped_authorization(
                     config,
@@ -4980,6 +5273,41 @@ def _fetch_authorization_context(
         return AuthorizationResolution("unavailable", reason="instance_kind_unavailable")
     try:
         claims = session_claims_from_oidc(config, response)
+    except Exception:
+        logger.warning("remote authorization context validation failed", exc_info=True)
+        return AuthorizationResolution("unavailable", reason="authorization_context_invalid")
+    live_state = remote_access_authorization_service.load_instance_binding_state(
+        ensure=False
+    )
+    live_generation = int((live_state or {}).get("generation") or 0)
+    live_id = str((live_state or {}).get("instance_id") or "")
+    request_id = str(identity.get("instance_id") or "")
+    if live_id and request_id and live_id != request_id:
+        return AuthorizationResolution("unavailable", reason="instance_binding_changed")
+    if live_generation > int(request_binding_generation) and live_id != request_id:
+        return AuthorizationResolution("unavailable", reason="instance_binding_changed")
+    try:
+        persisted = _persist_instance_kind(
+            str(identity.get("instance_id") or ""),
+            instance_kind,
+            expected_binding_generation=request_binding_generation,
+        )
+    except Exception:
+        logger.warning("remote instance kind persistence failed", exc_info=True)
+        persisted = False
+    if not persisted:
+        live_state = remote_access_authorization_service.load_instance_binding_state(
+            ensure=False
+        )
+        live_generation = int((live_state or {}).get("generation") or 0)
+        live_id = str((live_state or {}).get("instance_id") or "")
+        request_id = str(identity.get("instance_id") or "")
+        if live_id and request_id and live_id != request_id:
+            return AuthorizationResolution("unavailable", reason="instance_binding_changed")
+        if live_generation > int(request_binding_generation) and live_id != request_id:
+            return AuthorizationResolution("unavailable", reason="instance_binding_changed")
+        return AuthorizationResolution("unavailable", reason="instance_kind_persistence_failed")
+    try:
         revision = _authorization_revision_from_claims(claims)
         if revision is not None:
             _replace_authorization_revision(config, revision)
@@ -4996,9 +5324,8 @@ def _fetch_authorization_context(
             claims=stored_claims,
             authorization_state="current",
             checked_at=now,
+            instance_kind=instance_kind,
         )
-        from storage import remote_access_authorization_service
-
         refreshed_record = remote_access_authorization_service.load_reference_record(
             reference=reference,
             instance_id=str(identity.get("instance_id") or ""),
@@ -5006,17 +5333,9 @@ def _fetch_authorization_context(
             now=now,
         )
     except Exception:
-        logger.warning("remote authorization context validation failed", exc_info=True)
+        logger.warning("remote authorization context persistence failed", exc_info=True)
         return AuthorizationResolution("unavailable", reason="authorization_context_invalid")
     config.remote_access.vibe_cloud.instance_kind = instance_kind
-    try:
-        _persist_instance_kind(str(identity.get("instance_id") or ""), instance_kind)
-    except Exception:
-        # The authoritative response and durable context are already valid.
-        # A config write failure must not turn accepted access into an outage;
-        # this in-memory config immediately follows the discovered policy and a
-        # later runtime status/auth refresh can retry the persistent backfill.
-        logger.warning("Remote instance kind backfill failed", exc_info=True)
     if refreshed_record is None:
         return AuthorizationResolution("unavailable", reason="authorization_context_persistence_failed")
     payload = _validated_authorization_payload(config, identity, refreshed_record)
@@ -5109,7 +5428,10 @@ def _refresh_authorization_context(
         completed_at = time.monotonic()
         with _AUTHORIZATION_REFRESH_LOCK:
             _AUTHORIZATION_REFRESH_RESULTS.pop(key, None)
-            if refreshed.state == "unavailable":
+            if (
+                refreshed.state == "unavailable"
+                and refreshed.reason != "instance_binding_changed"
+            ):
                 _AUTHORIZATION_REFRESH_FAILURES[key] = completed_at
                 if len(_AUTHORIZATION_REFRESH_FAILURES) > 1024:
                     cutoff = completed_at - AUTHORIZATION_REFRESH_FAILURE_BACKOFF_SECONDS
@@ -5268,6 +5590,14 @@ def resolve_current_authorization(
         if record is not None
         else None
     )
+    if (
+        payload is None
+        and record is not None
+        and not _runtime_pairing_available(config)
+        and _known_kind_requires_runtime_pairing(config)
+        and not _is_exact_show_page_grant(identity, record)
+    ):
+        return AuthorizationResolution("unavailable", reason="pairing_unavailable")
     if payload is None:
         return (
             _refresh_authorization_context(config, identity, record, now=current)
@@ -5275,15 +5605,48 @@ def resolve_current_authorization(
             else AuthorizationResolution("unavailable", reason="authorization_context_missing")
         )
 
-    instance_kind = _normalized_instance_kind(config.remote_access.vibe_cloud.instance_kind)
+    instance_kind = (
+        _normalized_instance_kind(config.remote_access.vibe_cloud.instance_kind)
+        if binding_is_ready(config, identity)
+        else None
+    )
     signed_revision = _authorization_revision_from_claims(payload)
     current_revision = (
         current_authorization_revision(config, now=revision_now)
         if _authorization_revision_sync_configured(config)
         else None
     )
+    stored_kind = None
+    if record is not None:
+        stored_claims = record.get("claims")
+        if isinstance(stored_claims, Mapping):
+            stored_kind = _normalized_instance_kind(stored_claims.get("vibe_instance_kind"))
+    is_exact_show_page = _is_exact_show_page_grant(identity, record)
+    kind_mismatch = (
+        not is_exact_show_page
+        and (
+            (
+                instance_kind is not None
+                and stored_kind is not None
+                and stored_kind != instance_kind
+            )
+            or (
+                instance_kind is not None
+                and stored_kind is None
+                and record is not None
+                and record.get("authorization_state") == "stale"
+            )
+        )
+    )
 
     if instance_kind == "personal":
+        if kind_mismatch:
+            if allow_refresh:
+                return _refresh_authorization_context(config, identity, record, now=current)
+            return AuthorizationResolution(
+                "unavailable",
+                reason="authorization_context_missing",
+            )
         if (
             current_revision is not None
             and signed_revision is not None

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -4909,6 +4909,7 @@ def _store_scoped_authorization(
     authorization_state: str,
     checked_at: int,
     instance_kind: str | None = None,
+    expected_binding_generation: int | None = None,
 ) -> str:
     from storage import remote_access_authorization_service
 
@@ -4919,24 +4920,15 @@ def _store_scoped_authorization(
     if persisted_kind is not None:
         stored_claims["vibe_instance_kind"] = persisted_kind
     scope_kind, scope_ref = _authorization_scope(config, stored_claims)
-    state = None
-    try:
-        state = remote_access_authorization_service.load_instance_binding_state(
-            ensure=False
-        )
-    except Exception:
-        state = None
-    if (
-        scope_kind != "show_page"
-        and state is not None
-        and state.get("state")
-        == remote_access_authorization_service.INSTANCE_BINDING_STATE_RECONCILING
-        and authorization_state in {"current", "revoked"}
-    ):
-        # Revoked writes need the same fence as current writes: a 403 that
-        # raced a reconciliation must not persist a row the completed binding
-        # would then short-circuit on.
-        raise RuntimeError("instance_binding_not_ready")
+    if expected_binding_generation is None and scope_kind != "show_page":
+        try:
+            expected_binding_generation = (
+                remote_access_authorization_service.current_instance_binding_generation(
+                    ensure=False
+                )
+            )
+        except Exception:
+            expected_binding_generation = None
     return remote_access_authorization_service.upsert_scoped(
         reference=reference,
         instance_id=str(config.remote_access.vibe_cloud.instance_id),
@@ -4948,6 +4940,7 @@ def _store_scoped_authorization(
         claims=stored_claims,
         last_checked_at=checked_at,
         updated_at=checked_at,
+        expected_binding_generation=expected_binding_generation,
     )
 
 
@@ -5267,21 +5260,6 @@ def _fetch_authorization_context(
             revoked_claims = dict(previous_claims)
             if observed_revision is not None:
                 revoked_claims[_AUTHORIZATION_CHECKED_REVISION_KEY] = observed_revision
-            binding_state = remote_access_authorization_service.load_instance_binding_state(
-                ensure=False
-            )
-            current_generation = int((binding_state or {}).get("generation") or 0)
-            if current_generation > int(request_binding_generation) or (
-                binding_state is not None
-                and binding_state.get("state")
-                == remote_access_authorization_service.INSTANCE_BINDING_STATE_RECONCILING
-            ):
-                # A denial that raced a binding transition (same generation,
-                # reconciling in progress) must not persist a revoked row.
-                return AuthorizationResolution(
-                    "unavailable",
-                    reason="instance_binding_changed",
-                )
             try:
                 _store_scoped_authorization(
                     config,
@@ -5295,6 +5273,12 @@ def _fetch_authorization_context(
                     claims=revoked_claims,
                     authorization_state="revoked",
                     checked_at=now,
+                    expected_binding_generation=request_binding_generation,
+                )
+            except remote_access_authorization_service.InstanceBindingChangedError:
+                return AuthorizationResolution(
+                    "unavailable",
+                    reason="instance_binding_changed",
                 )
             except Exception:
                 logger.warning("remote authorization revocation persistence failed", exc_info=True)

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -1700,10 +1700,14 @@ def binding_is_ready(config: V2Config, identity: Mapping[str, Any] | None = None
         from storage import remote_access_authorization_service
 
         cloud = config.remote_access.vibe_cloud
+        # bootstrap=True: on the upgrade path a known configured kind with no
+        # durable row earns a validated binding through one real transition
+        # (C2) before any kind-specific bypass is granted.
         return remote_access_authorization_service.binding_is_ready_for_pairing(
             instance_id=str(cloud.instance_id or ""),
             instance_kind=_normalized_instance_kind(cloud.instance_kind),
             ensure=False,
+            bootstrap=True,
         )
     except Exception:
         return False
@@ -4599,54 +4603,77 @@ def pair(pairing_key: str, backend_url: str, device_name: str = "avibe") -> dict
             "error": str(origin_update.get("error") or "tunnel_origin_update_failed"),
             "pairing": {"ok": False, "origin_service": origin_service},
         }
-    try:
-        previous_instance_id = str(V2Config.load().remote_access.vibe_cloud.instance_id or "")
-    except Exception:
-        previous_instance_id = ""
-    config = api.save_config(
-        {
-            "remote_access": {
-                "provider": "vibe_cloud",
-                "vibe_cloud": {
-                    "enabled": True,
-                    "backend_url": backend.base_url,
-                    "instance_id": result["instance_id"],
-                    "instance_kind": instance_kind or "",
-                    "client_id": result["client_id"],
-                    "issuer": result["issuer"],
-                    "authorization_endpoint": result["authorization_endpoint"],
-                    "token_endpoint": result["token_endpoint"],
-                    "jwks_uri": result["jwks_uri"],
-                    "public_url": result["public_url"],
-                    "redirect_uri": result["redirect_uri"],
-                    "tunnel_token": result["tunnel_token"],
-                    "instance_secret": result["instance_secret"],
-                    "session_secret": secrets.token_urlsafe(32),
-                },
-            }
-        }
-    )
-    if previous_instance_id and previous_instance_id != str(result["instance_id"]):
-        try:
-            from storage import remote_access_authorization_service
+    # C2: the pairing save and its binding transition form ONE cross-process
+    # critical section, so two concurrent pair() calls cannot interleave
+    # save A / save B / transition B / transition A. SQLite initializes
+    # before the config lock per the canonical lock order.
+    from storage.importer import ensure_sqlite_state
 
-            remote_access_authorization_service.delete_for_instance(previous_instance_id)
+    ensure_sqlite_state()
+    with config_file_lock():
+        try:
+            previous_instance_id = str(V2Config.load().remote_access.vibe_cloud.instance_id or "")
         except Exception:
-            logger.warning("Old remote authorization cleanup failed after pairing", exc_info=True)
-    try:
-        transition = _transition_instance_binding(
-            instance_id=str(result["instance_id"]),
-            instance_kind=instance_kind,
-            previous_instance_id=previous_instance_id or None,
+            previous_instance_id = ""
+        config = api.save_config(
+            {
+                "remote_access": {
+                    "provider": "vibe_cloud",
+                    "vibe_cloud": {
+                        "enabled": True,
+                        "backend_url": backend.base_url,
+                        "instance_id": result["instance_id"],
+                        "instance_kind": instance_kind or "",
+                        "client_id": result["client_id"],
+                        "issuer": result["issuer"],
+                        "authorization_endpoint": result["authorization_endpoint"],
+                        "token_endpoint": result["token_endpoint"],
+                        "jwks_uri": result["jwks_uri"],
+                        "public_url": result["public_url"],
+                        "redirect_uri": result["redirect_uri"],
+                        "tunnel_token": result["tunnel_token"],
+                        "instance_secret": result["instance_secret"],
+                        "session_secret": secrets.token_urlsafe(32),
+                    },
+                }
+            }
         )
-    except Exception as exc:
-        logger.warning("Remote instance binding transition failed after pairing", exc_info=True)
-        return {
-            **status(config),
-            "ok": False,
-            "error": "pairing_reconciliation_failed",
-            "pairing": {"ok": False, "reconciling": True},
-        }
+        if previous_instance_id and previous_instance_id != str(result["instance_id"]):
+            try:
+                from storage import remote_access_authorization_service
+
+                remote_access_authorization_service.delete_for_instance(previous_instance_id)
+            except Exception:
+                logger.warning("Old remote authorization cleanup failed after pairing", exc_info=True)
+        # Under the held cross-process lock, save_config's returned config IS
+        # the persisted config; verify it still names the instance this call
+        # redeemed before publishing a binding for it.
+        persisted_instance_id = str(config.remote_access.vibe_cloud.instance_id or "")
+        if persisted_instance_id != str(result["instance_id"]):
+            # The persisted pairing is no longer the one this call redeemed;
+            # do not publish a binding for it.
+            return {
+                **status(config),
+                "ok": False,
+                "error": "pairing_reconciliation_failed",
+                "detail": "persisted_instance_mismatch",
+                "pairing": {"ok": False, "reconciling": True},
+            }
+        try:
+            transition = _transition_instance_binding(
+                instance_id=str(result["instance_id"]),
+                instance_kind=instance_kind,
+                previous_instance_id=previous_instance_id or None,
+                hold_config_lock=False,
+            )
+        except Exception:
+            logger.warning("Remote instance binding transition failed after pairing", exc_info=True)
+            return {
+                **status(config),
+                "ok": False,
+                "error": "pairing_reconciliation_failed",
+                "pairing": {"ok": False, "reconciling": True},
+            }
     if not transition.get("ok"):
         return {
             **status(config),
@@ -4904,8 +4931,11 @@ def _store_scoped_authorization(
         and state is not None
         and state.get("state")
         == remote_access_authorization_service.INSTANCE_BINDING_STATE_RECONCILING
-        and authorization_state == "current"
+        and authorization_state in {"current", "revoked"}
     ):
+        # Revoked writes need the same fence as current writes: a 403 that
+        # raced a reconciliation must not persist a row the completed binding
+        # would then short-circuit on.
         raise RuntimeError("instance_binding_not_ready")
     return remote_access_authorization_service.upsert_scoped(
         reference=reference,
@@ -5237,10 +5267,17 @@ def _fetch_authorization_context(
             revoked_claims = dict(previous_claims)
             if observed_revision is not None:
                 revoked_claims[_AUTHORIZATION_CHECKED_REVISION_KEY] = observed_revision
-            current_generation = (
-                remote_access_authorization_service.current_instance_binding_generation()
+            binding_state = remote_access_authorization_service.load_instance_binding_state(
+                ensure=False
             )
-            if current_generation > int(request_binding_generation):
+            current_generation = int((binding_state or {}).get("generation") or 0)
+            if current_generation > int(request_binding_generation) or (
+                binding_state is not None
+                and binding_state.get("state")
+                == remote_access_authorization_service.INSTANCE_BINDING_STATE_RECONCILING
+            ):
+                # A denial that raced a binding transition (same generation,
+                # reconciling in progress) must not persist a revoked row.
                 return AuthorizationResolution(
                     "unavailable",
                     reason="instance_binding_changed",

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -5219,8 +5219,14 @@ def _validated_authorization_payload(
     config: V2Config,
     identity: Mapping[str, Any],
     record: Mapping[str, Any],
+    *,
+    binding_gate: bool | None = None,
 ) -> dict[str, Any] | None:
-    if not binding_is_ready(config, identity) and not _is_exact_show_page_grant(identity, record):
+    # Class 2: one (ready, kind, generation) consultation per evaluation.
+    # Callers that already captured the gate pass it in; this function must
+    # not trigger a second live read inside the same evaluation.
+    gate = binding_is_ready(config, identity) if binding_gate is None else binding_gate
+    if not gate and not _is_exact_show_page_grant(identity, record):
         return None
     if (
         _known_kind_requires_runtime_pairing(config)
@@ -5230,6 +5236,15 @@ def _validated_authorization_payload(
         return None
     claims = record.get("claims")
     if not isinstance(claims, Mapping):
+        return None
+    from vibe.authorization import instance_kind_is_unsupported
+
+    if instance_kind_is_unsupported(
+        claims.get("vibe_instance_kind")
+    ) and not _is_exact_show_page_grant(identity, record):
+        # A present-but-unrecognized persisted kind (corruption or a newer
+        # release's artifact) is not a legacy no-kind row. Fail closed so the
+        # row revalidates instead of falling through to legacy-current.
         return None
     payload = dict(identity)
     payload.update(claims)
@@ -5664,8 +5679,15 @@ def resolve_current_authorization(
             if refreshed.state != "unavailable":
                 return refreshed
         return AuthorizationResolution("revoked", reason="access_denied")
+    # Class 2: capture the binding gate ONCE for this evaluation. Both the
+    # payload admission and the kind derivation below use this snapshot; a
+    # reconciling that begins mid-evaluation can no longer collapse a failed
+    # second read into the legacy no-kind branch.
+    binding_gate = binding_is_ready(config, identity)
     payload = (
-        _validated_authorization_payload(config, identity, record)
+        _validated_authorization_payload(
+            config, identity, record, binding_gate=binding_gate
+        )
         if record is not None
         else None
     )
@@ -5686,7 +5708,7 @@ def resolve_current_authorization(
 
     instance_kind = (
         _normalized_instance_kind(config.remote_access.vibe_cloud.instance_kind)
-        if binding_is_ready(config, identity)
+        if binding_gate
         else None
     )
     signed_revision = _authorization_revision_from_claims(payload)

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -97,17 +97,17 @@ _AUTHORIZATION_REVISION_SYNC_LOCK = threading.Lock()
 _AUTHORIZATION_REVISION_POLL_LOCK = threading.Lock()
 _AUTHORIZATION_REVISION_POLL_STARTED = False
 _AUTHORIZATION_REFRESH_LOCK = threading.Lock()
-_AUTHORIZATION_REFRESH_FAILURES: dict[tuple[str, str, str, str], float] = {}
+_AUTHORIZATION_REFRESH_FAILURES: dict[tuple[str, str, str, str, int], float] = {}
 _AUTHORIZATION_REFRESH_RESULTS: dict[
-    tuple[str, str, str, str],
+    tuple[str, str, str, str, int],
     tuple[float, str, str | None, int | None],
 ] = {}
 _AUTHORIZATION_REFRESH_FLIGHTS: dict[
-    tuple[str, str, str, str],
+    tuple[str, str, str, str, int],
     tuple[threading.Lock, int],
 ] = {}
 _AUTHORIZATION_BACKGROUND_REFRESH_LOCK = threading.Lock()
-_AUTHORIZATION_BACKGROUND_REFRESHES: set[tuple[str, str, str, str]] = set()
+_AUTHORIZATION_BACKGROUND_REFRESHES: set[tuple[str, str, str, str, int]] = set()
 AUTHORIZATION_REFRESH_FAILURE_BACKOFF_SECONDS = 5.0
 _REVOKED_BROWSER_SESSIONS_LOCK = threading.Lock()
 _REVOKED_BROWSER_SESSIONS: dict[str, int] = {}
@@ -5321,7 +5321,8 @@ def _fetch_authorization_context(
     request_id = str(identity.get("instance_id") or "")
     if live_id and request_id and live_id != request_id:
         return AuthorizationResolution("unavailable", reason="instance_binding_changed")
-    if live_generation > int(request_binding_generation) and live_id != request_id:
+    if live_generation > int(request_binding_generation):
+        # Same-instance kind reclassification is still a binding change.
         return AuthorizationResolution("unavailable", reason="instance_binding_changed")
     try:
         persisted = _persist_instance_kind(
@@ -5341,7 +5342,7 @@ def _fetch_authorization_context(
         request_id = str(identity.get("instance_id") or "")
         if live_id and request_id and live_id != request_id:
             return AuthorizationResolution("unavailable", reason="instance_binding_changed")
-        if live_generation > int(request_binding_generation) and live_id != request_id:
+        if live_generation > int(request_binding_generation):
             return AuthorizationResolution("unavailable", reason="instance_binding_changed")
         return AuthorizationResolution("unavailable", reason="instance_kind_persistence_failed")
     try:
@@ -5436,7 +5437,10 @@ def _refresh_authorization_context(
             if current_record is not None:
                 if current_record.get("authorization_state") == "revoked":
                     return AuthorizationResolution("revoked", reason="access_denied")
-                if recent_result[1] == "current":
+                if (
+                    recent_result[1] == "current"
+                    and current_record.get("authorization_state") == "current"
+                ):
                     current_payload = _validated_authorization_payload(
                         config,
                         identity,
@@ -5520,18 +5524,27 @@ def _refresh_authorization_context(
 def _authorization_refresh_key(
     identity: Mapping[str, Any],
     record: Mapping[str, Any] | None,
-) -> tuple[str, str, str, str]:
+) -> tuple[str, str, str, str, int]:
     scope_kind = str(record.get("scope_kind") or "instance") if record else "instance"
     scope_ref = (
         str(record.get("scope_ref") or identity.get("instance_id") or "")
         if record
         else str(identity.get("instance_id") or "")
     )
+    try:
+        from storage import remote_access_authorization_service
+
+        generation = remote_access_authorization_service.current_instance_binding_generation(
+            ensure=False
+        )
+    except Exception:
+        generation = 0
     return (
         str(identity.get("instance_id") or ""),
         str(identity.get("sub") or ""),
         scope_kind,
         scope_ref,
+        int(generation),
     )
 
 


### PR DESCRIPTION
## Changed capability
Personal Avibe remote Editors can list, select, and use every Agent and access every active Project in their Personal instance, independent of Organization ACLs. Organization instances and unknown/reconciling instance kinds stay fail-closed.

## Design
Spec: [docs/plans/personal-editor-local-resources.md](https://github.com/avibe-bot/avibe/blob/personal-editor-local-resources/docs/plans/personal-editor-local-resources.md)

- **C1 — single source of truth**: a durable binding `(instance_id, kind, generation)` in `state_meta`; only a `ready` binding admits the Personal bypass; `reconciling` / `unpaired` / `unavailable` fail closed.
- **C2 — one writer + canonical lock order + generation CAS**: SQLite initialization before the cross-process `config_file_lock`; compare + config-write + transition run in one critical section; a stale writer CAS-fails against the durable generation (our own transition advancing is success, a foreign writer moving past it is a lost race).
- **C3 — one gate for every consumer**: a single `binding_is_ready` gate covers interactive refresh, non-interactive metadata, Web Push, OAuth callback, and legacy-cookie writes; the 403/revocation path is generation-fenced like the success path; exact `show_page_email` grants survive kind transitions but not a re-pair to a different instance; `pair()` validates provenance BEFORE redeeming the one-time key.

## Supersedes
Closes the loop on #1562 (closed). Five review rounds there showed the binding concurrency model needed a written contract and a rewrite rather than per-finding patches. This PR carries over #1562's deferred-migration/snapshot/provenance work and its full test corpus, and rewrites only the binding state machine + authorization fencing per the approved spec.

## Evidence
- **Unit + contract**: 487 passed / 0 failed across 9 suites (instance authorization, resource ACL, remote authorization revision, remote access, Web Push, resource access, project access, show-page ACL, UI memory routes).
- **Lint**: ruff clean on all 17 changed Python files.
- **Scenario**: the scenario catalog has no ID for this capability; focused unit/contract coverage was added for the invariant (binding lifecycle, cross-process CAS, reconciliation, provenance sealing).
- **Residual manual check**: sign in to a real Personal Editor instance and verify all Agents and Projects are visible and usable; one Organization instance sanity check that ACLs still bind.

## Dependencies
- Backend dependency: none. No migration or UI build required.
