### PR TITLE
chore(guard): retire the spent 20260725_0037 body-edit declaration

### DIFF
--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -558,30 +558,13 @@ class DeclaredBodyEdit:
     reason: str
 
 
-DECLARED_BODY_EDITS: tuple[DeclaredBodyEdit, ...] = (
-    DeclaredBodyEdit(
-        revision="20260725_0037",
-        body="d56e9ae949018bb1d0adc6edc1609d2f39052eb1bf70688add968c7304f4525a",
-        reason=(
-            "The revision backfilled media_object_references by regex-scanning every agent "
-            "message for media URLs. Only that scan is gone; the DDL and the precondition "
-            "20260819_0056 relies on to prove its replay repaired anything are untouched. "
-            "Removed because no forward revision can express the "
-            "removal: 20260819_0056 replays this body, so a later revision runs after the "
-            "scan it would have to prevent, and the rows the scan writes are byte-identical "
-            "to the ones media_service.register() writes when a second session reuses a "
-            "token, so nothing downstream can delete one without deleting the other. What "
-            "the divergence costs is bounded by the read path rather than argued: the table "
-            "only ever widens access, vibe/ui_server.py falls back to the media row's own "
-            "session and scope when the reference set is empty, and the owner short-circuit "
-            "returns before consulting it at all -- so a row the scan would have written is "
-            "at worst a 404 for a non-owner holding partial project access, never a leak. "
-            "The scan is also already inert wherever it can still run: a fresh install "
-            "crosses this revision with media_objects and messages empty, and a database "
-            "that already crossed it is stamped and never reruns it."
-        ),
-    ),
-)
+#: Empty is the steady state, not an omission. An entry lives here only between the
+#: edit and the release that ships it, and ``spent_body_edit_declarations`` reports it
+#: the moment the baseline moves past -- which is what stops the list from accumulating
+#: into the standing allowlist the rest of this module refuses to keep. The reason text
+#: goes with it: the release it justified is out, so the argument now belongs to the
+#: history of that release rather than to a live guard.
+DECLARED_BODY_EDITS: tuple[DeclaredBodyEdit, ...] = ()
 
 
 def _declared_body_edits() -> dict[str, DeclaredBodyEdit]:


### PR DESCRIPTION
## What this changes

`DECLARED_BODY_EDITS` in `scripts/migration_release_guard.py` becomes empty. That
retires the `20260725_0037` declaration, which v3.0.13rc1 has already made spent.

## Why `migration-release-guard` is red on master

The guard reports two properties about released migration bodies. One watches for
an *undeclared* edit; the other, `spent_body_edit_declarations`, watches for a
declaration that no longer describes an edit against the current baseline.

A concrete walk-through of the entry in question:

1. `20260725_0037` shipped in an earlier release with a regex scan that backfilled
   `media_object_references` from message history.
2. #1583 removed that scan from the released body. That is an edit to a shipped
   surface, so it needed a declaration pinning the sha256 of the exact replacement.
3. **v3.0.13rc1 then shipped the replacement.** From that tag onwards, `shipped` and
   `current` agree on the body, `edited_released_bodies` has nothing left to accept,
   and the declaration is authorising an edit that no longer exists.

Step 3 is what the guard reports, and it has been failing on master — and therefore
on every open PR — since the release:

```
DECLARED_BODY_EDITS names 20260725_0037, which is not an edit against v3.0.13rc1;
a declaration is spent once the release ships the body it pinned and must be
removed rather than left standing
```

This is a designed cleanup reminder, not a defect. Its own docstring states the
purpose: the report "keeps `DECLARED_BODY_EDITS` holding only edits made since the
last release, so it never becomes the standing allowlist the rest of this module
refuses to keep". Removing the entry is the action the report asks for; suppressing
the report, or leaving the entry standing, is what would break the property.

Empty is therefore the steady state of that tuple, not an omission — an entry lives
in it only between an edit and the release that ships that edit. The replacement
comment says so, so the next reader does not read `()` as something missing.

## Why the reason text goes with it

The declaration carried a long argument for why the divergence between databases
that ran the scan and ones that never will is bounded. That argument justified
shipping the edit; the release it justified is out, so it belongs to that release's
history (`git log -S`, and #1583's own commit) rather than to a live guard.

It is not being dropped for lack of a home — there is genuinely nothing left for it
to guard. The behaviour it described is visible in the read path itself:
`_request_can_read_media_row` in `vibe/ui_server.py` consults
`media_service.referenced_session_ids`, falls back to the media row's own session and
scope when the set is empty, and the runtime-owner short-circuit returns before ever
reaching it. A database with the backfilled rows and one without take the same two
branches of code that is already there. Adding a comment about a divergence the code
treats uniformly would be noise, and adding one to the migration file itself is not
even available: `body_fingerprint` hashes the whole file source, so a comment-only
edit to a released migration is indistinguishable from a code edit and would trip
`edited_released_bodies` — correctly, since a guard cannot tell the two apart and a
comment-only exemption would be trivially abusable.

## Evidence

Local, on this branch:

```
baseline: v3.0.13rc1
spent:  (none)
edited: (none)
migration release guard passed (baseline v3.0.13rc1)   # exit 0
```

- `python3 scripts/migration_release_guard.py` → passed, exit 0
- `python3 -m pytest tests/test_migration_release_guard.py -q` → **69 passed**
- `ruff check scripts/migration_release_guard.py` → All checks passed

Test coverage is unaffected by the tuple being empty. Three of the four tests that
touch it monkeypatch `DECLARED_BODY_EDITS` with synthetic entries
(`test_a_declaration_that_describes_no_edit_is_reported_as_spent` among them), so the
spent-report property is still exercised directly. The fourth,
`test_the_real_graph_has_no_undeclared_edit_and_no_spent_declaration`, is the one CI
is failing on today and is what now passes.

## Scope

One file, one tuple. No migration, no runtime code, no behaviour change — this only
retires a release-window declaration whose release has shipped.
