### PR TITLE
fix(ui): move mobile permissions into more settings

### DIFF
--- a/ui/src/components/AppShell.test.tsx
+++ b/ui/src/components/AppShell.test.tsx
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import type { ReactNode } from 'react';
@@ -226,10 +226,11 @@ describe('AppShell workbench sidebar', () => {
 
 describe('AppShell Permissions navigation', () => {
   it.each([
-    ['personal', 2],
-    [null, 2],
-    ['organization', 2],
-  ] as const)('shows current-instance Permissions for %s instances', async (instanceKind, expectedCount) => {
+    'personal',
+    null,
+    'organization',
+  ] as const)('keeps current-instance Permissions in More Settings for %s instances', async (instanceKind) => {
+    const user = userEvent.setup();
     instanceAuth.instanceKind = instanceKind;
 
     render(
@@ -243,16 +244,23 @@ describe('AppShell Permissions navigation', () => {
     );
 
     expect(await screen.findByTestId('dashboard')).toBeTruthy();
-    const permissionEntries = screen.queryAllByText('nav.permissions');
-    expect(permissionEntries).toHaveLength(expectedCount);
-    const advancedEntries = screen.queryAllByText('nav.advancedSettings');
-    expect(advancedEntries).toHaveLength(expectedCount);
-    permissionEntries.forEach((permission, index) => {
-      expect(
-        permission.compareDocumentPosition(advancedEntries[index]!)
-          & Node.DOCUMENT_POSITION_FOLLOWING,
-      ).toBeTruthy();
-    });
+
+    const moreTab = screen.getByRole('button', { name: 'nav.more' });
+    const bottomNav = moreTab.closest('nav');
+    expect(bottomNav).not.toBeNull();
+    expect(within(bottomNav!).queryByText('nav.permissions')).toBeNull();
+
+    await user.click(moreTab);
+    const moreSettings = screen.getByRole('dialog');
+    expect(within(moreSettings).getByRole('link', { name: 'nav.permissions' }).getAttribute('href')).toBe(
+      '/admin/permissions',
+    );
+
+    const desktopSidebar = document.querySelector('aside');
+    expect(desktopSidebar).not.toBeNull();
+    expect(within(desktopSidebar!).getByRole('link', { name: 'nav.permissions' }).getAttribute('href')).toBe(
+      '/admin/permissions',
+    );
   });
 });
 

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -498,13 +498,12 @@ export const AppShell: React.FC = () => {
   const items: ShellNavItem[] = shellMode === 'admin' ? visibleAdminItems : [];
 
   // A bottom tab bar can't hold the nested admin nav, so mobile keeps a trimmed
-  // bar with Workbench, Control Panel, and More (which opens the full nested nav
-  // sheet). See ``adminMenuOpen``.
+  // bar with Workbench, Control Panel, More, and Advanced Settings. Permissions
+  // stays in the More sheet with the other overflow destinations.
   const adminMobileTabsAll: ShellNavItem[] = [
     { to: '/', label: t('nav.workbench'), icon: Sparkles, variant: 'workbench' },
     { to: '/admin/dashboard', label: t('nav.dashboard'), icon: LayoutDashboard },
     { label: t('nav.more'), icon: Menu, onClick: () => setAdminMenuOpen(true), match: () => adminMenuOpen },
-    { to: '/admin/permissions', label: t('nav.permissions'), icon: ShieldCheck },
     {
       to: '/admin/settings/messaging',
       label: t('nav.advancedSettings'),


### PR DESCRIPTION
## What changed

- Remove Permissions from the mobile Control Panel tab bar.
- Let the existing overflow derivation place Permissions in the More Settings sheet.
- Keep the desktop sidebar destination unchanged for every current instance kind.

## Evidence

- Unit: all 20 `AppShell` tests pass, including mobile tab, More Settings, and desktop sidebar assertions.
- Build: the UI production build passes.
- Lint: the UI lint baseline passes without drift.
- Scenario: no catalog scenario applies to this navigation-only change.
- Manual: no additional end-to-end verification was required; the change reuses the existing responsive navigation and sheet components.

## Risk

Low. This only changes which existing mobile navigation surface owns the Permissions link; the route and authorization behavior are unchanged.

## Dependencies

None.
