### PR TITLE
fix(memory): repair stale profile summary

### DIFF
--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -1410,6 +1410,7 @@ def _structured_profile(value: Any) -> MemoryProfile | None:
     summary = _safe_text(value.get("summary")) if "summary" in value else None
     explicit_info = _structured_explicit_info(value)
     implicit_traits = _structured_implicit_traits(value)
+    summary = _repair_stale_profile_summary(summary, explicit_info, implicit_traits)
     updated_at = _normalized_profile_timestamp(value.get("profile_timestamp_ms"))
 
     # A provider timestamp is metadata, not readable profile content. Unknown
@@ -1422,6 +1423,38 @@ def _structured_profile(value: Any) -> MemoryProfile | None:
         implicit_traits=implicit_traits,
         updated_at=updated_at,
     )
+
+
+def _repair_stale_profile_summary(
+    summary: str | None,
+    explicit_info: tuple[MemoryProfileExplicitInfo, ...],
+    implicit_traits: tuple[MemoryProfileTrait, ...],
+) -> str | None:
+    """Repair EverAlgo summaries surfaced by EverOS when pinned to item one.
+
+    EverAlgo's profile updater appends new items but rebuilds ``summary`` from
+    the first non-empty explicit description. That makes a transient first
+    message the permanent headline. Only the distinctive stale shape is
+    changed here; provider-authored summaries that differ from the first item
+    remain authoritative, and the raw provider JSON stays untouched.
+    """
+
+    if summary is None:
+        return None
+
+    if len(explicit_info) > 1 and summary == explicit_info[0].description:
+        for info in reversed(explicit_info[1:]):
+            if info.description != summary:
+                return info.description
+        return summary
+
+    if not explicit_info and len(implicit_traits) > 1 and summary == implicit_traits[0].description:
+        for trait in reversed(implicit_traits[1:]):
+            candidate = trait.description or trait.trait
+            if candidate and candidate != summary:
+                return candidate
+
+    return summary
 
 
 def _structured_explicit_info(value: dict[str, Any]) -> tuple[MemoryProfileExplicitInfo, ...]:

--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -1448,12 +1448,6 @@ def _repair_stale_profile_summary(
                 return info.description
         return summary
 
-    if not explicit_info and len(implicit_traits) > 1 and summary == implicit_traits[0].description:
-        for trait in reversed(implicit_traits[1:]):
-            candidate = trait.description or trait.trait
-            if candidate and candidate != summary:
-                return candidate
-
     return summary
 
 

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -1252,6 +1252,63 @@ def test_profile_maps_known_fields_without_collapsing_basis_and_evidence() -> No
     assert json.loads(items[0].text)["implicit_traits"][0]["evidence"] == "Three recent planning discussions."
 
 
+def test_profile_repairs_provider_summary_pinned_to_first_explicit_item() -> None:
+    profile_data = {
+        "summary": "Continue",
+        "explicit_info": [
+            {"category": "conversation", "description": "Continue"},
+            {
+                "category": "engineering",
+                "description": "Prefers evidence-backed engineering decisions.",
+            },
+        ],
+        "implicit_traits": [
+            {
+                "trait": "systematic",
+                "description": "Builds a causal model before choosing scope.",
+            }
+        ],
+        "profile_timestamp_ms": 1_757_000_000_000,
+    }
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"data": {"profiles": [{"user_id": "owner-1", "profile_data": profile_data}]}},
+        )
+
+    with _sidecar_transport(handler):
+        items = asyncio.run(EverOSPort(Path("/tmp/everos.sock")).profile("owner-1", PROJECT))
+
+    assert items[0].profile is not None
+    assert items[0].profile.summary == "Prefers evidence-backed engineering decisions."
+    # The compatibility correction is read-only; raw provider data remains available.
+    assert json.loads(items[0].text)["summary"] == "Continue"
+
+
+def test_profile_preserves_provider_summary_that_is_not_the_first_item() -> None:
+    profile_data = {
+        "summary": "A concise portrait of the user's stable preferences.",
+        "explicit_info": [
+            {"description": "Uses Python."},
+            {"description": "Prefers written updates."},
+        ],
+        "profile_timestamp_ms": 1_757_000_000_000,
+    }
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"data": {"profiles": [{"user_id": "owner-1", "profile_data": profile_data}]}},
+        )
+
+    with _sidecar_transport(handler):
+        items = asyncio.run(EverOSPort(Path("/tmp/everos.sock")).profile("owner-1", PROJECT))
+
+    assert items[0].profile is not None
+    assert items[0].profile.summary == profile_data["summary"]
+
+
 def test_profile_timestamp_without_recognized_content_uses_the_raw_fallback() -> None:
     raw_profile = {
         "profile_timestamp_ms": 1_754_012_345_678,


### PR DESCRIPTION
## What changed

Closes #1612.

The EverOS adapter now repairs the known stale-profile shape where the provider's `summary` equals the first explicit profile item while later profile items exist. It selects the latest distinct valid explicit item as the caller-facing summary. Provider-authored summaries that differ from the first item remain unchanged, and this correction leaves the adapter's legacy canonical `text` projection unchanged.

## Why

EverAlgo appends profile updates but rebuilds `summary` from the first explicit description. A one-off first message therefore remains the permanent headline even while the profile timestamp and structured details advance.

## Evidence

- Unit: `tests/test_memory_everos.py` covers stale-summary repair, preservation of a valid provider summary, and preservation of the legacy text projection.
- Contract: `MemoryProfile` and the public profile envelope are unchanged; this is an adapter-only compatibility correction.
- Scenario: no existing scenario catalog covers profile-summary projection; the focused adapter tests exercise the provider response boundary directly.
- Regression: `python3 -m pytest tests/test_memory_everos.py tests/test_memory_runtime.py tests/test_ui_memory_routes.py` -> 430 passed.
- Lint: `ruff check core/memory/everos.py tests/test_memory_everos.py` -> passed.
- Residual manual check: verify the existing user's live profile page after the patched Avibe runtime is installed and the profile is reloaded.

## Known-by-design ledger

- The fix is intentionally read-only at the Avibe boundary. It does not rewrite or delete provider data and does not require users to clear Memory.
- The compatibility heuristic is narrow: summaries that do not match the first explicit item remain provider-authoritative.
- The upstream EverAlgo implementation still needs a semantic summary fix; this PR keeps Avibe usable while the runtime remains pinned to the affected provider behavior.
