### PR TITLE
fix(ui): reconcile agent definitions after reconnect

### DIFF
--- a/ui/src/components/workbench/AgentsPage.test.tsx
+++ b/ui/src/components/workbench/AgentsPage.test.tsx
@@ -709,6 +709,50 @@ describe('AgentsPage reconnect reconciliation', () => {
   });
 
   it.each([
+    { field: 'name', initial: 'agent-a', draft: 'agent-a ', submitted: 'agent-a continued', patch: { name: 'agent-a continued' } },
+    { field: 'description', initial: 'description', draft: 'description ', submitted: 'description continued', patch: { description: 'description continued' } },
+    { field: 'systemPrompt', initial: 'system prompt', draft: 'system prompt ', submitted: 'system prompt continued', patch: { system_prompt: 'system prompt continued' } },
+  ] as const)('preserves an active raw $field draft across same-agent reconciliation', async ({ field, initial, draft, submitted, patch }) => {
+    const initialAgent = brief('agent-a', field === 'description' ? initial : 'description');
+    const changedAgent = { ...initialAgent, model: 'reconciled-model' };
+    const finalAgent = {
+      ...changedAgent,
+      ...(field === 'name' ? { name: submitted, display_name: submitted } : {}),
+      ...(field === 'description' ? { description: submitted } : {}),
+    };
+    let readCount = 0;
+    const getVibeAgent = vi.fn((requestedName: string) => {
+      readCount += 1;
+      if (readCount === 1) return Promise.resolve(fullAgent(initialAgent, field === 'systemPrompt' ? initial : 'prompt'));
+      if (readCount === 2) return Promise.resolve(fullAgent(changedAgent, field === 'systemPrompt' ? initial : 'prompt'));
+      return Promise.resolve(fullAgent({ ...finalAgent, name: field === 'name' ? requestedName : finalAgent.name }, submitted));
+    });
+    const updateVibeAgent = vi.fn().mockResolvedValue({ ok: true });
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(initialAgent)), getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    let editedInput: HTMLInputElement | HTMLTextAreaElement;
+    if (field === 'systemPrompt') {
+      await waitFor(() => expect(screen.getByDisplayValue('description')).toBeTruthy());
+      fireEvent.click(screen.getByText('agents.detail.systemPrompt').closest('button')!);
+      editedInput = screen.getByPlaceholderText('agents.create.systemPromptPlaceholder');
+      fireEvent.change(editedInput, { target: { value: draft } });
+    } else {
+      await waitFor(() => expect(screen.getByDisplayValue(initial)).toBeTruthy());
+      editedInput = screen.getByDisplayValue(initial);
+      fireEvent.change(editedInput, { target: { value: draft } });
+    }
+
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    expect(editedInput.value).toBe(draft);
+
+    fireEvent.change(editedInput, { target: { value: submitted } });
+    fireEvent.blur(editedInput);
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledWith('agent-a', patch));
+  });
+
+  it.each([
     { field: 'description', label: 'description' },
     { field: 'systemPrompt', label: 'inline system prompt' },
   ] as const)('adopts a newer server snapshot after a $label edit is restored to baseline', async ({ field }) => {
@@ -833,6 +877,36 @@ describe('AgentsPage reconnect reconciliation', () => {
       await waitFor(() => expect(screen.getByRole('button', { name: 'medium', exact: true }).className).toContain('bg-mint-soft'));
     }
     expect(screen.queryByText(`${field} failed`)).toBeTruthy();
+  });
+
+  it.each([
+    { label: 'transport rejection', update: 'reject' as const, message: 'enabled transport failed' },
+    { label: 'HTTP ok false', update: 'okfalse' as const, message: 'enabled server rejected' },
+    { label: 'authoritative drain failure', update: 'drain' as const, message: 'enabled drain failed' },
+  ])('consumes enabled background failures ($label)', async ({ update, message }) => {
+    const agent = brief('agent-a', 'description');
+    const getVibeAgent = vi.fn().mockResolvedValueOnce(fullAgent(agent, 'prompt'));
+    const updateVibeAgent = vi.fn();
+    if (update === 'reject') {
+      updateVibeAgent.mockRejectedValueOnce({ message });
+      getVibeAgent.mockResolvedValue(fullAgent(agent, 'prompt'));
+    } else if (update === 'okfalse') {
+      updateVibeAgent.mockResolvedValueOnce({ ok: false, message });
+      getVibeAgent.mockResolvedValue(fullAgent(agent, 'prompt'));
+    } else {
+      updateVibeAgent.mockResolvedValueOnce({ ok: true });
+      getVibeAgent.mockRejectedValueOnce({ message });
+      getVibeAgent.mockResolvedValue(fullAgent(agent, 'prompt'));
+    }
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agent)), getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('description')).toBeTruthy());
+    const toggle = screen.getByRole('switch', { name: 'agents.detail.enabled' });
+    fireEvent.click(toggle);
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledWith('agent-a', { enabled: false }));
+    await waitFor(() => expect(screen.getByText(message)).toBeTruthy());
+    expect(toggle.getAttribute('aria-checked')).toBe('true');
   });
 
   it('preserves a newer model edit when an older mutation drain settles', async () => {

--- a/ui/src/components/workbench/AgentsPage.test.tsx
+++ b/ui/src/components/workbench/AgentsPage.test.tsx
@@ -25,6 +25,12 @@ const apiRef = vi.hoisted(() => ({ current: null as FakeApi | null }));
 const showToast = vi.hoisted(() => vi.fn());
 let handlers: WorkbenchEventHandlers | null = null;
 
+vi.stubGlobal('ResizeObserver', class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+});
+
 vi.mock('../../context/ApiContext', async () => {
   const actual = await vi.importActual<typeof import('../../context/ApiContext')>('../../context/ApiContext');
   return { ...actual, useApi: () => apiRef.current };
@@ -217,6 +223,79 @@ describe('AgentsPage reconnect reconciliation', () => {
     expect(listVibeAgents).toHaveBeenCalledTimes(2);
   });
 
+  it('does not retry a failed reconciliation debt until the next reconnect edge', async () => {
+    const agent = brief('agent-a', 'A');
+    const update = vi.fn().mockResolvedValue(fullAgent(agent, 'ack'));
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agent, 'initial'))
+      .mockRejectedValueOnce({ code: 'agent_backend_unavailable', message: 'temporary failure' })
+      .mockResolvedValueOnce(fullAgent({ ...agent, description: 'after reconnect' }, 'after reconnect'));
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agent)), getVibeAgent, undefined, undefined, update);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    fireEvent.change(screen.getByDisplayValue('A'), { target: { value: 'A edited' } });
+    fireEvent.blur(screen.getByDisplayValue('A edited'));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByText('temporary failure')).toBeTruthy());
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(getVibeAgent).toHaveBeenCalledTimes(2);
+
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
+    await waitFor(() => expect(screen.getByDisplayValue('after reconnect')).toBeTruthy());
+  });
+
+  it('does not create a follow-on reconciliation request after unmount', async () => {
+    const agent = brief('agent-a', 'A');
+    const pending = deferred<ReturnType<typeof fullAgent>>();
+    const update = vi.fn().mockResolvedValue(fullAgent(agent, 'ack'));
+    const getVibeAgent = vi.fn().mockResolvedValueOnce(fullAgent(agent, 'initial')).mockReturnValueOnce(pending.promise);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agent)), getVibeAgent, undefined, undefined, update);
+    const view = renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    fireEvent.change(screen.getByDisplayValue('A'), { target: { value: 'A edited' } });
+    fireEvent.blur(screen.getByDisplayValue('A edited'));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    view.unmount();
+    act(() => pending.reject({ code: 'agent_backend_unavailable', message: 'unmounted failure' }));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(getVibeAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps an explicit detail dismissal closed across reconnect list publication', async () => {
+    const agent = brief('agent-a', 'A');
+    const listVibeAgents = vi.fn().mockResolvedValue(listResult(agent));
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agent, 'initial'))
+      .mockResolvedValueOnce(fullAgent(agent, 'explicit selection'));
+    const api = makeApi(listVibeAgents, getVibeAgent);
+    renderPage(api);
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'common.close' }));
+    expect(screen.queryByDisplayValue('A')).toBeNull();
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(listVibeAgents).toHaveBeenCalledTimes(2));
+    expect(screen.queryByDisplayValue('A')).toBeNull();
+    expect(getVibeAgent).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText('agent-a').closest('button')!);
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    expect(getVibeAgent).toHaveBeenCalledTimes(2);
+  });
+
   it('keeps an older pre-gap read from overwriting the post-gap definition snapshot', async () => {
     const stale = brief('stale-agent', 'before the gap');
     const fresh = brief('fresh-agent', 'changed during the gap');
@@ -365,7 +444,7 @@ describe('AgentsPage reconnect reconciliation', () => {
 
     act(() => drainRead.resolve(fullAgent(server, 'authoritative prompt')));
     await waitFor(() => expect(screen.getByRole('combobox', { hidden: true }).textContent).toContain('server-model'));
-    expect(screen.getByDisplayValue('local patch')).toBeTruthy();
+    expect(screen.getByDisplayValue('server description')).toBeTruthy();
   });
 
   it('uses operation epochs to suppress an old A -> B -> A selection response', async () => {
@@ -559,7 +638,7 @@ describe('AgentsPage reconnect reconciliation', () => {
     await waitFor(() => expect(screen.getByText('agents.detail.systemPrompt').closest('button')).toBeTruthy());
     fireEvent.click(screen.getByText('agents.detail.systemPrompt').closest('button')!);
     await waitFor(() => expect(screen.getByDisplayValue('final prompt')).toBeTruthy());
-    expect(screen.getByDisplayValue('local A')).toBeTruthy();
+    expect(screen.getByDisplayValue('final A')).toBeTruthy();
     expect(getVibeAgent).toHaveBeenCalledTimes(4);
   });
 
@@ -627,6 +706,82 @@ describe('AgentsPage reconnect reconciliation', () => {
     act(() => handlers?.onConnected?.());
     await waitFor(() => expect(screen.getByDisplayValue('external description')).toBeTruthy());
     expect(screen.getByDisplayValue('external description')).toBeTruthy();
+  });
+
+  it.each(['model', 'effort'] as const)('restores the authoritative value after a failed %s mutation', async (field) => {
+    const initial = {
+      ...brief('agent-a', 'description'),
+      model: 'old-model',
+      reasoning_effort: 'medium' as const,
+    };
+    const update = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(initial, 'initial prompt'))
+      .mockResolvedValueOnce(fullAgent(initial, 'authoritative prompt'));
+    const updateVibeAgent = vi.fn().mockReturnValue(update.promise);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(initial)), getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('description')).toBeTruthy());
+    if (field === 'model') {
+      fireEvent.click(screen.getByRole('combobox'));
+      fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value: 'new-model' } });
+      fireEvent.click(screen.getByText('Use "new-model"'));
+      await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledWith('agent-a', { model: 'new-model' }));
+    } else {
+      fireEvent.click(screen.getByRole('button', { name: 'high', exact: true }));
+      await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledWith('agent-a', { reasoning_effort: 'high' }));
+    }
+
+    act(() => update.reject({ message: `${field} failed` }));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    if (field === 'model') {
+      await waitFor(() => expect(screen.getByRole('combobox', { hidden: true }).textContent).toContain('old-model'));
+    } else {
+      await waitFor(() => expect(screen.getByRole('button', { name: 'medium', exact: true }).className).toContain('bg-mint-soft'));
+    }
+    expect(screen.queryByText(`${field} failed`)).toBeTruthy();
+  });
+
+  it('preserves a newer model edit when an older mutation drain settles', async () => {
+    const initial = { ...brief('agent-a', 'description'), model: 'old-model', reasoning_effort: 'medium' as const };
+    const firstPatch = deferred<ReturnType<typeof fullAgent>>();
+    const secondPatch = deferred<ReturnType<typeof fullAgent>>();
+    const firstDrain = deferred<ReturnType<typeof fullAgent>>();
+    const secondDrain = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(initial, 'initial prompt'))
+      .mockReturnValueOnce(firstDrain.promise)
+      .mockReturnValueOnce(secondDrain.promise);
+    const updateVibeAgent = vi.fn()
+      .mockReturnValueOnce(firstPatch.promise)
+      .mockReturnValueOnce(secondPatch.promise);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(initial)), getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('description')).toBeTruthy());
+    const chooseModel = (value: string) => {
+      fireEvent.click(screen.getByRole('combobox'));
+      fireEvent.change(screen.getByPlaceholderText('Search...'), { target: { value } });
+      fireEvent.click(screen.getByText(`Use "${value}"`));
+    };
+    chooseModel('model-one');
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledWith('agent-a', { model: 'model-one' }));
+    act(() => firstPatch.resolve(fullAgent({ ...initial, model: 'model-one' }, 'first acknowledgement')));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    chooseModel('model-two');
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledWith('agent-a', { model: 'model-two' }));
+    act(() => firstDrain.resolve(fullAgent({ ...initial, model: 'model-one' }, 'first drain')));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByRole('combobox', { hidden: true }).textContent).toContain('model-two');
+
+    act(() => secondPatch.reject({ message: 'second failed' }));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+    act(() => secondDrain.resolve(fullAgent(initial, 'final authoritative')));
+    await waitFor(() => expect(screen.getByRole('combobox', { hidden: true }).textContent).toContain('old-model'));
   });
 
   it('reseeds an untouched open prompt editor but preserves an edited modal draft', async () => {
@@ -867,7 +1022,7 @@ describe('AgentsPage reconnect reconciliation', () => {
       expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
     });
     act(() => rollbackA.resolve(fullAgent({ ...agentA, description: 'A after patch' }, 'A reconciled')));
-    await waitFor(() => expect(screen.getByDisplayValue('A local')).toBeTruthy());
+    await waitFor(() => expect(screen.getByDisplayValue('A after patch')).toBeTruthy());
     fireEvent.click(screen.getByText('agents.detail.systemPrompt').closest('button')!);
     expect(screen.getByDisplayValue('A reconciled')).toBeTruthy();
     expect(screen.getByText('A mutation failed')).toBeTruthy();

--- a/ui/src/components/workbench/AgentsPage.test.tsx
+++ b/ui/src/components/workbench/AgentsPage.test.tsx
@@ -14,11 +14,14 @@ type FakeApi = {
   listVibeAgents: ReturnType<typeof vi.fn>;
   getVibeAgent: ReturnType<typeof vi.fn>;
   getVibeAgentOnboarding: ReturnType<typeof vi.fn>;
+  onboardVibeAgents: ReturnType<typeof vi.fn>;
+  updateVibeAgent: ReturnType<typeof vi.fn>;
   getRunningAgents: ReturnType<typeof vi.fn>;
   connectWorkbenchEvents: ReturnType<typeof vi.fn>;
 };
 
 const apiRef = vi.hoisted(() => ({ current: null as FakeApi | null }));
+const showToast = vi.hoisted(() => vi.fn());
 let handlers: WorkbenchEventHandlers | null = null;
 
 vi.mock('../../context/ApiContext', async () => {
@@ -26,7 +29,7 @@ vi.mock('../../context/ApiContext', async () => {
   return { ...actual, useApi: () => apiRef.current };
 });
 
-vi.mock('../../context/ToastContext', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../../context/ToastContext', () => ({ useToast: () => ({ showToast }) }));
 vi.mock('./CapabilityTabs', () => ({ CapabilityTabs: () => null }));
 vi.mock('../../lib/backendModels', async () => ({
   loadBackendModelsWithRefresh: (_api: unknown, _backend: string, onLoaded: (payload: { models: string[] }) => void) => {
@@ -74,15 +77,27 @@ const fullAgent = (briefAgent: VibeAgentBrief, systemPrompt: string) => ({
   },
 });
 
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+};
+
 function makeApi(
   listVibeAgents: FakeApi['listVibeAgents'],
   getVibeAgent: FakeApi['getVibeAgent'] = vi.fn().mockResolvedValue({ ok: false }),
   getVibeAgentOnboarding: FakeApi['getVibeAgentOnboarding'] = vi.fn().mockResolvedValue({ available: false }),
+  onboardVibeAgents: FakeApi['onboardVibeAgents'] = vi.fn().mockResolvedValue({ available: false }),
+  updateVibeAgent: FakeApi['updateVibeAgent'] = vi.fn().mockResolvedValue({ ok: false }),
 ): FakeApi {
   return {
     listVibeAgents,
     getVibeAgent,
     getVibeAgentOnboarding,
+    onboardVibeAgents,
+    updateVibeAgent,
     getRunningAgents: vi.fn().mockResolvedValue({ ok: true, counts: { total: 2 } }),
     connectWorkbenchEvents: vi.fn((next: WorkbenchEventHandlers) => {
       handlers = next;
@@ -126,6 +141,7 @@ afterEach(() => {
   cleanup();
   apiRef.current = null;
   handlers = null;
+  showToast.mockReset();
 });
 
 describe('AgentsPage load requests follow the rank that can serve them', () => {
@@ -242,7 +258,10 @@ describe('AgentsPage reconnect reconciliation', () => {
 
     act(() => handlers?.onConnected?.());
     await waitFor(() => expect(screen.getByDisplayValue('after gap')).toBeTruthy());
-    expect(getVibeAgent).toHaveBeenNthCalledWith(2, 'agent-a', { cache: false });
+    expect(getVibeAgent).toHaveBeenNthCalledWith(2, 'agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
     expect(api.getRunningAgents).toHaveBeenCalledTimes(2);
 
     const secondRow = screen.getByText('agent-b').closest('button');
@@ -250,6 +269,189 @@ describe('AgentsPage reconnect reconciliation', () => {
     fireEvent.click(secondRow!);
     await waitFor(() => expect(screen.getByDisplayValue('another agent')).toBeTruthy());
     expect(api.connectWorkbenchEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a successful PATCH win over a reconnect GET that settles later', async () => {
+    const initial = { ...brief('agent-a', 'before patch'), model: 'old-model' };
+    const server = { ...initial, description: 'server description', model: 'server-model' };
+    const patchResult = fullAgent({ ...initial, description: 'local patch', model: 'patched-model' }, 'patched prompt');
+    const staleRead = deferred<ReturnType<typeof fullAgent>>();
+    const patch = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(initial, 'before prompt'))
+      .mockReturnValueOnce(staleRead.promise);
+    const listVibeAgents = vi.fn().mockResolvedValue(listResult(server));
+    const updateVibeAgent = vi.fn().mockReturnValue(patch.promise);
+    const api = makeApi(listVibeAgents, getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('before patch')).toBeTruthy());
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+
+    const description = screen.getByDisplayValue('before patch');
+    fireEvent.change(description, { target: { value: 'local patch' } });
+    fireEvent.blur(description);
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledWith('agent-a', { description: 'local patch' }));
+    act(() => patch.resolve(patchResult));
+    await waitFor(() => expect(screen.getByDisplayValue('local patch')).toBeTruthy());
+
+    act(() => staleRead.resolve(fullAgent(initial, 'stale reconnect prompt')));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByDisplayValue('local patch')).toBeTruthy();
+    expect(screen.queryByDisplayValue('server description')).toBeNull();
+  });
+
+  it('uses operation epochs to suppress an old A -> B -> A selection response', async () => {
+    const agentA = brief('agent-a', 'A before');
+    const agentB = brief('agent-b', 'B');
+    const oldA = deferred<ReturnType<typeof fullAgent>>();
+    const readB = deferred<ReturnType<typeof fullAgent>>();
+    const readAAgain = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+      .mockReturnValueOnce(oldA.promise)
+      .mockReturnValueOnce(readB.promise)
+      .mockReturnValueOnce(readAAgain.promise);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult([agentA, agentB])), getVibeAgent);
+    renderPage(api);
+
+    await waitFor(() => expect(screen.getByDisplayValue('A before')).toBeTruthy());
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+    const agentARow = screen.getAllByText('agent-a').find((node) => node.closest('button'))?.closest('button');
+    expect(agentARow).not.toBeNull();
+    fireEvent.click(agentARow!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(4));
+
+    act(() => oldA.resolve(fullAgent(agentA, 'old A response')));
+    act(() => readB.resolve(fullAgent(agentB, 'B response')));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByDisplayValue('A before')).toBeTruthy();
+
+    act(() => readAAgain.resolve(fullAgent({ ...agentA, description: 'A after ABA' }, 'new A response')));
+    await waitFor(() => expect(screen.getByDisplayValue('A after ABA')).toBeTruthy());
+  });
+
+  it('preserves dirty drafts while clean detail fields adopt a same-agent snapshot', async () => {
+    const initial = { ...brief('agent-a', 'clean description'), model: 'old-model' };
+    const changed = { ...initial, description: 'server description', model: 'new-model' };
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(initial, 'clean prompt'))
+      .mockResolvedValueOnce(fullAgent(changed, 'server prompt'));
+    const api = makeApi(
+      vi.fn()
+        .mockResolvedValueOnce(listResult(initial))
+        .mockResolvedValueOnce(listResult(changed)),
+      getVibeAgent,
+    );
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('clean description')).toBeTruthy());
+    fireEvent.change(screen.getByDisplayValue('clean description'), { target: { value: 'dirty description' } });
+    const promptToggle = screen.getByText('agents.detail.systemPrompt').closest('button');
+    expect(promptToggle).not.toBeNull();
+    fireEvent.click(promptToggle!);
+    const inlinePrompt = screen.getByPlaceholderText('agents.create.systemPromptPlaceholder');
+    fireEvent.change(inlinePrompt, { target: { value: 'dirty inline prompt' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'agents.detail.systemPromptExpand' }));
+    const modalPrompt = screen.getAllByPlaceholderText('agents.create.systemPromptPlaceholder').at(-1)!;
+    fireEvent.change(modalPrompt, { target: { value: 'dirty modal prompt' } });
+
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(screen.getByRole('combobox', { hidden: true }).textContent).toContain('new-model'));
+    expect(screen.getByDisplayValue('dirty description')).toBeTruthy();
+    expect(screen.getByDisplayValue('dirty inline prompt')).toBeTruthy();
+    expect(screen.getByDisplayValue('dirty modal prompt')).toBeTruthy();
+    expect(screen.getByText('agents.detail.systemPromptEditorHint')).toBeTruthy();
+  });
+
+  it('orders onboarding reads around a mutation and ignores stale results', async () => {
+    const agent = brief('agent-a', 'agent description');
+    const initial = deferred<ReturnType<typeof onboardingResult>>();
+    const reconnect = deferred<ReturnType<typeof onboardingResult>>();
+    const overlap = deferred<ReturnType<typeof onboardingResult>>();
+    const onboardingResult = (notOnboarded: number, privateCount: number) => ({
+      ok: true,
+      available: true,
+      organization_id: 'org-1',
+      agents: [],
+      counts: { total: 1, system: 0, custom: 1, not_onboarded: notOnboarded, private: privateCount, published: 0, conflicts: 0 },
+    });
+    const mutation = deferred<ReturnType<typeof onboardingResult>>();
+    const getVibeAgentOnboarding = vi.fn()
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(reconnect.promise)
+      .mockReturnValueOnce(overlap.promise);
+    const api = makeApi(
+      vi.fn().mockResolvedValue(listResult(agent)),
+      vi.fn().mockResolvedValue({ ok: false }),
+      getVibeAgentOnboarding,
+      vi.fn().mockReturnValue(mutation.promise),
+    );
+    renderPage(api, { canManageAgents: true });
+    await waitFor(() => expect(handlers).not.toBeNull());
+
+    act(() => handlers?.onConnected?.());
+    act(() => reconnect.resolve(onboardingResult(1, 0)));
+    await waitFor(() => expect(screen.getByText('agents.onboarding.privateCount:{"count":0}')).toBeTruthy());
+    act(() => initial.resolve(onboardingResult(1, 1)));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText('agents.onboarding.privateCount:{"count":0}')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('agents.onboarding.onboardPrivate'));
+    await waitFor(() => expect(api.onboardVibeAgents).toHaveBeenCalledTimes(1));
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgentOnboarding).toHaveBeenCalledTimes(3));
+    act(() => mutation.resolve(onboardingResult(0, 1)));
+    await waitFor(() => expect(screen.getByText('agents.onboarding.notOnboardedCount:{"count":0}')).toBeTruthy());
+    act(() => overlap.resolve(onboardingResult(1, 0)));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText('agents.onboarding.notOnboardedCount:{"count":0}')).toBeTruthy();
+  });
+
+  it('silences expected selected disappearance but surfaces unexpected current failures', async () => {
+    const agent = brief('agent-a', 'agent description');
+    const expectedApi = makeApi(
+      vi.fn().mockResolvedValue(listResult(agent)),
+      vi.fn()
+        .mockResolvedValueOnce(fullAgent(agent, 'prompt'))
+        .mockRejectedValueOnce({ code: 'agent_not_found', message: 'gone' }),
+    );
+    renderPage(expectedApi);
+    await waitFor(() => expect(screen.getByDisplayValue('agent description')).toBeTruthy());
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(screen.queryByDisplayValue('agent description')).toBeNull());
+    expect(showToast).not.toHaveBeenCalled();
+
+    cleanup();
+    handlers = null;
+    const unexpectedApi = makeApi(
+      vi.fn().mockResolvedValue(listResult(agent)),
+      vi.fn()
+        .mockResolvedValueOnce(fullAgent(agent, 'prompt'))
+        .mockRejectedValueOnce({ code: 'agent_backend_unavailable', message: 'backend unavailable' }),
+    );
+    renderPage(unexpectedApi);
+    await waitFor(() => expect(screen.getByDisplayValue('agent description')).toBeTruthy());
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(screen.getByText('backend unavailable')).toBeTruthy());
   });
 
   it('reconciles organization onboarding inventory only from the gap owner', async () => {

--- a/ui/src/components/workbench/AgentsPage.test.tsx
+++ b/ui/src/components/workbench/AgentsPage.test.tsx
@@ -1586,6 +1586,51 @@ describe('AgentsPage reconnect reconciliation', () => {
   });
 
   it.each([
+    { label: 'rejected', reject: true, code: 'agent_not_found' },
+    { label: 'ok-false', reject: false, code: 'agent_access_forbidden' },
+  ])('drains accepted-A debt after pending B disappears on the same edge ($label)', async ({ reject, code }) => {
+    const agentA = { ...brief('agent-a', 'A before'), model: 'a-model' };
+    const agentB = brief('agent-b', 'B');
+    const pendingB = deferred<ReturnType<typeof fullAgent>>();
+    const patch = deferred<unknown>();
+    const catchupB = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+      .mockReturnValueOnce(pendingB.promise)
+      .mockReturnValueOnce(catchupB.promise)
+      .mockResolvedValueOnce(fullAgent({ ...agentA, description: 'A after debt' }, 'A reconciled'));
+    const updateVibeAgent = vi.fn().mockReturnValue(patch.promise);
+    const api = makeApi(
+      vi.fn().mockResolvedValue(listResult([agentA, agentB])),
+      getVibeAgent,
+      undefined,
+      undefined,
+      updateVibeAgent,
+    );
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('A before')).toBeTruthy());
+    fireEvent.change(screen.getByDisplayValue('A before'), { target: { value: 'A local' } });
+    fireEvent.blur(screen.getByDisplayValue('A local'));
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+
+    act(() => patch.resolve({ ok: true }));
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+    if (reject) act(() => catchupB.reject({ code, message: 'B disappeared' }));
+    else act(() => catchupB.resolve({ ok: false, code, message: 'B disappeared' } as never));
+
+    await waitFor(() => expect(screen.getByDisplayValue('A after debt')).toBeTruthy());
+    expect(getVibeAgent).toHaveBeenNthCalledWith(4, 'agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
+    expect(screen.queryByText('agent-b')).toBeNull();
+  });
+
+  it.each([
     { label: 'HTTP ok false', rejected: false, result: { ok: false, message: 'delete rejected' } },
     { label: 'transport rejection', rejected: true, result: { code: 'delete_failed', message: 'delete failed' } },
   ])('keeps an in-flight selection read valid after DELETE $label', async ({ rejected, result }) => {
@@ -1660,6 +1705,7 @@ describe('AgentsPage reconnect reconciliation', () => {
       });
       expect(listVibeAgents).toHaveBeenCalledTimes(2);
       expect(screen.queryByDisplayValue('A')).toBeNull();
+      expect(screen.queryByText('agent-a')).toBeNull();
       expect(showToast).not.toHaveBeenCalled();
     },
   );
@@ -2021,6 +2067,25 @@ describe('AgentsPage reconnect reconciliation', () => {
       cache: false,
       expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
     });
+  });
+
+  it('retains auto-selection after a transient detail failure until the next edge', async () => {
+    const agent = brief('agent-a', 'A');
+    const getVibeAgent = vi.fn()
+      .mockRejectedValueOnce({ message: 'temporary detail failure' })
+      .mockResolvedValueOnce(fullAgent({ ...agent, description: 'A recovered' }, 'prompt'));
+    const api = makeApi(
+      vi.fn().mockResolvedValue(listResult(agent)),
+      getVibeAgent,
+    );
+    renderPage(api);
+
+    await waitFor(() => expect(screen.getByText('temporary detail failure')).toBeTruthy());
+    expect(getVibeAgent).toHaveBeenCalledTimes(1);
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(screen.getByDisplayValue('A recovered')).toBeTruthy());
+    expect(getVibeAgent).toHaveBeenCalledTimes(2);
+    expect(getVibeAgent).toHaveBeenNthCalledWith(2, 'agent-a', { cache: false });
   });
 
   it('does not resume A when a newer C intent wins during the B catch-up read', async () => {

--- a/ui/src/components/workbench/AgentsPage.test.tsx
+++ b/ui/src/components/workbench/AgentsPage.test.tsx
@@ -401,6 +401,73 @@ describe('AgentsPage reconnect reconciliation', () => {
     expect(api.connectWorkbenchEvents).toHaveBeenCalledTimes(1);
   });
 
+  it('orders a list-first gap retirement before the same-edge accepted-A read', async () => {
+    const agentA = brief('agent-a', 'A before gap');
+    const agentB = brief('agent-b', 'B pending');
+    const staleB = deferred<ReturnType<typeof fullAgent>>();
+    const catchupA = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+      .mockReturnValueOnce(staleB.promise)
+      .mockReturnValueOnce(catchupA.promise);
+    const listVibeAgents = vi.fn()
+      .mockResolvedValueOnce(listResult([agentA, agentB]))
+      .mockResolvedValueOnce(listResult(agentA));
+    const api = makeApi(listVibeAgents, getVibeAgent);
+    renderPage(api);
+
+    await waitFor(() => expect(screen.getByDisplayValue('A before gap')).toBeTruthy());
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
+    expect(listVibeAgents).toHaveBeenCalledTimes(2);
+
+    act(() => catchupA.resolve(fullAgent({ ...agentA, description: 'A after gap' }, 'A changed prompt')));
+    await waitFor(() => expect(screen.getByDisplayValue('A after gap')).toBeTruthy());
+    act(() => staleB.resolve(fullAgent(agentB, 'stale B')));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByDisplayValue('A after gap')).toBeTruthy();
+    expect(getVibeAgent.mock.calls.slice(3).some(([name]) => name === 'agent-b')).toBe(false);
+  });
+
+  it('carries a row-tap drill-down intent through a reconnect replacement read', async () => {
+    const agentA = brief('agent-a', 'A');
+    const agentB = brief('agent-b', 'B');
+    const staleB = deferred<ReturnType<typeof fullAgent>>();
+    const freshB = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+      .mockReturnValueOnce(staleB.promise)
+      .mockReturnValueOnce(freshB.promise);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult([agentA, agentB])), getVibeAgent);
+    renderPage(api);
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+    act(() => freshB.resolve(fullAgent({ ...agentB, description: 'B after reconnect' }, 'B after reconnect')));
+    await waitFor(() => expect(screen.getByDisplayValue('B after reconnect')).toBeTruthy());
+    const detail = screen.getByDisplayValue('B after reconnect').closest('.self-start');
+    expect(detail?.className).not.toContain('max-lg:hidden');
+    act(() => staleB.resolve(fullAgent(agentB, 'stale B')));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByDisplayValue('B after reconnect')).toBeTruthy();
+  });
+
   it('lets a successful PATCH win over a reconnect GET that settles later', async () => {
     const initial = { ...brief('agent-a', 'before patch'), model: 'old-model' };
     const server = { ...initial, description: 'server description', model: 'server-model' };
@@ -488,6 +555,59 @@ describe('AgentsPage reconnect reconciliation', () => {
     });
     expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-b', { cache: false });
     expect(getVibeAgent).toHaveBeenNthCalledWith(4, 'agent-a', { cache: false });
+  });
+
+  it.each([
+    { label: 'A succeeds', failA: false },
+    { label: 'A fails', failA: true },
+  ])('isolates field settlement across A/B panel instances when $label', async ({ failA }) => {
+    const agentA = brief('agent-a', 'A initial');
+    const agentB = brief('agent-b', 'B initial');
+    const readB = deferred<ReturnType<typeof fullAgent>>();
+    const drainB = deferred<ReturnType<typeof fullAgent>>();
+    const patchA = deferred<unknown>();
+    const patchB = deferred<unknown>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A prompt'))
+      .mockReturnValueOnce(readB.promise)
+      .mockReturnValueOnce(drainB.promise);
+    const updateVibeAgent = vi.fn()
+      .mockReturnValueOnce(patchA.promise)
+      .mockReturnValueOnce(patchB.promise);
+    const api = makeApi(
+      vi.fn().mockResolvedValue(listResult([agentA, agentB])),
+      getVibeAgent,
+      undefined,
+      undefined,
+      updateVibeAgent,
+    );
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('A initial')).toBeTruthy());
+    fireEvent.change(screen.getByDisplayValue('A initial'), { target: { value: 'A local' } });
+    fireEvent.blur(screen.getByDisplayValue('A local'));
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledWith('agent-a', { description: 'A local' }));
+
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    act(() => readB.resolve(fullAgent(agentB, 'B prompt')));
+    await waitFor(() => expect(screen.getByDisplayValue('B initial')).toBeTruthy());
+
+    fireEvent.change(screen.getByDisplayValue('B initial'), { target: { value: 'B local' } });
+    fireEvent.blur(screen.getByDisplayValue('B local'));
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledWith('agent-b', { description: 'B local' }));
+
+    act(() => (failA ? patchA.reject({ message: 'A failed' }) : patchA.resolve({ ok: true })));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByDisplayValue('B local')).toBeTruthy();
+
+    act(() => patchB.resolve({ ok: true }));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+    act(() => drainB.resolve(fullAgent({ ...agentB, description: 'B authoritative' }, 'B final prompt')));
+    await waitFor(() => expect(screen.getByDisplayValue('B authoritative')).toBeTruthy());
   });
 
   it('keeps the current selection intent when DELETE fails', async () => {
@@ -1303,31 +1423,25 @@ describe('AgentsPage reconnect reconciliation', () => {
   });
 
   it.each(['agent_not_found', 'agent_access_forbidden'] as const)(
-    'retires an expected disappearance before an older list response can auto-select A (%s)',
+    'retires an expected disappearance without recursively refreshing Definitions (%s)',
     async (code) => {
       const agentA = brief('agent-a', 'A');
-      const agentB = brief('agent-b', 'B');
-      const oldList = deferred<ReturnType<typeof listResult>>();
-      const freshList = deferred<ReturnType<typeof listResult>>();
       const getVibeAgent = vi.fn()
         .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
-        .mockRejectedValueOnce({ code, message: 'gone' })
-        .mockResolvedValue(fullAgent(agentB, 'B fresh'));
-      const listVibeAgents = vi.fn()
-        .mockResolvedValueOnce(listResult(agentA))
-        .mockReturnValueOnce(oldList.promise)
-        .mockReturnValueOnce(freshList.promise);
+        .mockRejectedValueOnce({ code, message: 'gone' });
+      const listVibeAgents = vi.fn().mockResolvedValue(listResult(agentA));
       const api = makeApi(listVibeAgents, getVibeAgent);
       renderPage(api);
 
       await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
       act(() => handlers?.onConnected?.());
       await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
-      await waitFor(() => expect(listVibeAgents).toHaveBeenCalledTimes(3));
-      act(() => oldList.resolve(listResult(agentA)));
-      act(() => freshList.resolve(listResult(agentB)));
-      await waitFor(() => expect(screen.getByDisplayValue('B')).toBeTruthy());
-      expect(getVibeAgent.mock.calls.slice(2).some(([name]) => name === 'agent-a')).toBe(false);
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(listVibeAgents).toHaveBeenCalledTimes(2);
+      expect(screen.queryByDisplayValue('A')).toBeNull();
       expect(showToast).not.toHaveBeenCalled();
     },
   );

--- a/ui/src/components/workbench/AgentsPage.test.tsx
+++ b/ui/src/components/workbench/AgentsPage.test.tsx
@@ -828,6 +828,139 @@ describe('AgentsPage reconnect reconciliation', () => {
   it.each([
     { label: 'thrown failure', reject: true },
     { label: 'HTTP ok false', reject: false },
+  ])('drains a settled mutation after selection rollback for $label', async ({ reject }) => {
+    const agentA = { ...brief('agent-a', 'A'), model: 'a-model' };
+    const agentB = brief('agent-b', 'B');
+    const pendingB = deferred<ReturnType<typeof fullAgent>>();
+    const patch = deferred<unknown>();
+    const rollbackA = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+      .mockReturnValueOnce(pendingB.promise)
+      .mockReturnValueOnce(rollbackA.promise);
+    const updateVibeAgent = vi.fn().mockReturnValue(patch.promise);
+    const api = makeApi(
+      vi.fn().mockResolvedValue(listResult([agentA, agentB])),
+      getVibeAgent,
+      undefined,
+      undefined,
+      updateVibeAgent,
+    );
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    fireEvent.change(screen.getByDisplayValue('A'), { target: { value: 'A local' } });
+    fireEvent.blur(screen.getByDisplayValue('A local'));
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+
+    if (reject) act(() => patch.reject({ message: 'A mutation failed' }));
+    else act(() => patch.resolve({ ok: false, message: 'A mutation failed' }));
+    await waitFor(() => expect(screen.getByText('A mutation failed')).toBeTruthy());
+    expect(getVibeAgent).toHaveBeenCalledTimes(2);
+
+    act(() => pendingB.reject({ code: 'agent_backend_unavailable', message: 'B unavailable' }));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
+    act(() => rollbackA.resolve(fullAgent({ ...agentA, description: 'A after patch' }, 'A reconciled')));
+    await waitFor(() => expect(screen.getByDisplayValue('A local')).toBeTruthy());
+    fireEvent.click(screen.getByText('agents.detail.systemPrompt').closest('button')!);
+    expect(screen.getByDisplayValue('A reconciled')).toBeTruthy();
+    expect(screen.getByText('A mutation failed')).toBeTruthy();
+  });
+
+  it.each([
+    { label: 'HTTP ok false', rejected: false, result: { ok: false, message: 'delete rejected' } },
+    { label: 'transport rejection', rejected: true, result: { code: 'delete_failed', message: 'delete failed' } },
+  ])('keeps an in-flight selection read valid after DELETE $label', async ({ rejected, result }) => {
+    const agent = brief('agent-a', 'A');
+    const reconnect = deferred<ReturnType<typeof fullAgent>>();
+    const removeVibeAgent = rejected ? vi.fn().mockRejectedValue(result) : vi.fn().mockResolvedValue(result);
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agent, 'initial'))
+      .mockReturnValueOnce(reconnect.promise);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agent)), getVibeAgent, undefined, undefined, undefined, removeVibeAgent);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    fireEvent.click(screen.getByRole('button', { name: 'common.delete' }));
+    await waitFor(() => expect(removeVibeAgent).toHaveBeenCalledWith('agent-a'));
+    act(() => reconnect.resolve(fullAgent({ ...agent, description: 'A remains' }, 'fresh A')));
+    await waitFor(() => expect(screen.getByDisplayValue('A remains')).toBeTruthy());
+    expect(screen.getByText(result.message)).toBeTruthy();
+    expect(getVibeAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not restore or auto-select a deleted A when a pending B selection fails', async () => {
+    const agentA = brief('agent-a', 'A');
+    const agentB = brief('agent-b', 'B');
+    const pendingB = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+      .mockReturnValueOnce(pendingB.promise)
+      .mockResolvedValue(fullAgent(agentB, 'B retry'));
+    const removeVibeAgent = vi.fn().mockResolvedValue({ ok: true });
+    const api = makeApi(
+      vi.fn().mockResolvedValue(listResult([agentA, agentB])),
+      getVibeAgent,
+      undefined,
+      undefined,
+      undefined,
+      removeVibeAgent,
+    );
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    fireEvent.click(screen.getByRole('button', { name: 'common.delete' }));
+    await waitFor(() => expect(removeVibeAgent).toHaveBeenCalledWith('agent-a'));
+    act(() => pendingB.reject({ code: 'agent_backend_unavailable', message: 'B unavailable' }));
+    await waitFor(() => expect(screen.queryByDisplayValue('A initial')).toBeNull());
+    expect(getVibeAgent.mock.calls.slice(2).some(([name]) => name === 'agent-a')).toBe(false);
+  });
+
+  it.each(['agent_not_found', 'agent_access_forbidden'] as const)(
+    'retires an expected disappearance before an older list response can auto-select A (%s)',
+    async (code) => {
+      const agentA = brief('agent-a', 'A');
+      const agentB = brief('agent-b', 'B');
+      const oldList = deferred<ReturnType<typeof listResult>>();
+      const freshList = deferred<ReturnType<typeof listResult>>();
+      const getVibeAgent = vi.fn()
+        .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+        .mockRejectedValueOnce({ code, message: 'gone' })
+        .mockResolvedValue(fullAgent(agentB, 'B fresh'));
+      const listVibeAgents = vi.fn()
+        .mockResolvedValueOnce(listResult(agentA))
+        .mockReturnValueOnce(oldList.promise)
+        .mockReturnValueOnce(freshList.promise);
+      const api = makeApi(listVibeAgents, getVibeAgent);
+      renderPage(api);
+
+      await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+      act(() => handlers?.onConnected?.());
+      await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(listVibeAgents).toHaveBeenCalledTimes(3));
+      act(() => oldList.resolve(listResult(agentA)));
+      act(() => freshList.resolve(listResult(agentB)));
+      await waitFor(() => expect(screen.getByDisplayValue('B')).toBeTruthy());
+      expect(getVibeAgent.mock.calls.slice(2).some(([name]) => name === 'agent-a')).toBe(false);
+      expect(showToast).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { label: 'thrown failure', reject: true },
+    { label: 'HTTP ok false', reject: false },
   ])('keeps a current mutation $label visible through its drain and Definitions refresh', async ({ reject }) => {
     const agentA = brief('agent-a', 'A');
     const drain = deferred<ReturnType<typeof fullAgent>>();

--- a/ui/src/components/workbench/AgentsPage.test.tsx
+++ b/ui/src/components/workbench/AgentsPage.test.tsx
@@ -55,17 +55,34 @@ const brief = (name: string, description: string): VibeAgentBrief => ({
   updated_at: '2026-08-21T00:00:00Z',
 });
 
-const listResult = (agent: VibeAgentBrief) => ({
+const listResult = (agents: VibeAgentBrief | VibeAgentBrief[]) => ({
   ok: true,
-  agents: [agent],
-  default_agent_name: agent.name,
+  agents: Array.isArray(agents) ? agents : [agents],
+  default_agent_name: Array.isArray(agents) ? agents[0]?.name ?? null : agents.name,
 });
 
-function makeApi(listVibeAgents: FakeApi['listVibeAgents']): FakeApi {
+const fullAgent = (briefAgent: VibeAgentBrief, systemPrompt: string) => ({
+  ok: true,
+  default_agent_name: briefAgent.name,
+  agent: {
+    ...briefAgent,
+    model: briefAgent.model ?? 'gpt-5',
+    reasoning_effort: briefAgent.reasoning_effort ?? 'medium',
+    system_prompt: systemPrompt,
+    created_at: '2026-08-21T00:00:00Z',
+    metadata: {},
+  },
+});
+
+function makeApi(
+  listVibeAgents: FakeApi['listVibeAgents'],
+  getVibeAgent: FakeApi['getVibeAgent'] = vi.fn().mockResolvedValue({ ok: false }),
+  getVibeAgentOnboarding: FakeApi['getVibeAgentOnboarding'] = vi.fn().mockResolvedValue({ available: false }),
+): FakeApi {
   return {
     listVibeAgents,
-    getVibeAgent: vi.fn().mockResolvedValue({ ok: false }),
-    getVibeAgentOnboarding: vi.fn().mockResolvedValue({ available: false }),
+    getVibeAgent,
+    getVibeAgentOnboarding,
     getRunningAgents: vi.fn().mockResolvedValue({ ok: true, counts: { total: 2 } }),
     connectWorkbenchEvents: vi.fn((next: WorkbenchEventHandlers) => {
       handlers = next;
@@ -159,7 +176,7 @@ describe('AgentsPage reconnect reconciliation', () => {
     act(() => handlers?.onConnected?.());
     await waitFor(() => expect(screen.getByText('fresh-agent')).toBeTruthy());
 
-    expect(listVibeAgents).toHaveBeenNthCalledWith(1, { includeDisabled: true });
+    expect(listVibeAgents).toHaveBeenNthCalledWith(1, { includeDisabled: true, cache: false });
     expect(listVibeAgents).toHaveBeenNthCalledWith(2, { includeDisabled: true, cache: false });
     expect(api.getRunningAgents).toHaveBeenCalledTimes(2);
 
@@ -204,5 +221,64 @@ describe('AgentsPage reconnect reconciliation', () => {
     expect(screen.queryByText('stale-agent')).toBeNull();
     expect(listVibeAgents).toHaveBeenNthCalledWith(3, { includeDisabled: true, cache: false });
     expect(api.getRunningAgents).toHaveBeenCalledTimes(2);
+  });
+
+  it('refreshes the selected full definition and keeps one stable subscription', async () => {
+    const first = brief('agent-a', 'before gap');
+    const second = brief('agent-b', 'another agent');
+    const changed = { ...first, description: 'after gap' };
+    const listVibeAgents = vi.fn()
+      .mockResolvedValueOnce(listResult([first, second]))
+      .mockResolvedValueOnce(listResult([changed, second]));
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(first, 'before prompt'))
+      .mockResolvedValueOnce(fullAgent(changed, 'after prompt'))
+      .mockResolvedValueOnce(fullAgent(second, 'second prompt'));
+    const api = makeApi(listVibeAgents, getVibeAgent);
+    renderPage(api);
+
+    await waitFor(() => expect(screen.getByDisplayValue('before gap')).toBeTruthy());
+    expect(api.connectWorkbenchEvents).toHaveBeenCalledTimes(1);
+
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(screen.getByDisplayValue('after gap')).toBeTruthy());
+    expect(getVibeAgent).toHaveBeenNthCalledWith(2, 'agent-a', { cache: false });
+    expect(api.getRunningAgents).toHaveBeenCalledTimes(2);
+
+    const secondRow = screen.getByText('agent-b').closest('button');
+    expect(secondRow).not.toBeNull();
+    fireEvent.click(secondRow!);
+    await waitFor(() => expect(screen.getByDisplayValue('another agent')).toBeTruthy());
+    expect(api.connectWorkbenchEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it('reconciles organization onboarding inventory only from the gap owner', async () => {
+    const agent = brief('agent-a', 'agent');
+    const onboarding = (notOnboarded: number) => ({
+      ok: true,
+      available: true,
+      organization_id: 'org-1',
+      agents: [],
+      counts: { total: 1, system: 0, custom: 1, not_onboarded: notOnboarded, private: 1 - notOnboarded, published: 0, conflicts: 0 },
+    });
+    const getVibeAgentOnboarding = vi.fn()
+      .mockResolvedValueOnce(onboarding(1))
+      .mockResolvedValueOnce(onboarding(0));
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agent)), vi.fn().mockResolvedValue({ ok: false }), getVibeAgentOnboarding);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByText('agents.onboarding.notOnboardedCount:{"count":1}')).toBeTruthy());
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(screen.getByText('agents.onboarding.notOnboardedCount:{"count":0}')).toBeTruthy());
+
+    expect(getVibeAgentOnboarding).toHaveBeenCalledTimes(2);
+    act(() => {
+      handlers?.onEventBridgeStatus?.({ connected: false });
+      handlers?.onEventBridgeStatus?.({ connected: true });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(getVibeAgentOnboarding).toHaveBeenCalledTimes(2);
   });
 });

--- a/ui/src/components/workbench/AgentsPage.test.tsx
+++ b/ui/src/components/workbench/AgentsPage.test.tsx
@@ -439,6 +439,48 @@ describe('AgentsPage reconnect reconciliation', () => {
     expect(getVibeAgent.mock.calls.slice(3).some(([name]) => name === 'agent-b')).toBe(false);
   });
 
+  it.each([
+    { label: 'rejected read', response: 'reject' as const },
+    { label: 'HTTP ok false', response: 'okfalse' as const },
+  ])('continues to accepted A after an unexpected B catch-up failure ($label)', async ({ response }) => {
+    const agentA = brief('agent-a', 'A before gap');
+    const agentB = brief('agent-b', 'B pending');
+    const staleB = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+      .mockReturnValueOnce(staleB.promise)
+      .mockImplementationOnce(() => response === 'reject'
+        ? Promise.reject({ code: 'agent_backend_unavailable', message: 'B catch-up failed' })
+        : Promise.resolve({ ok: false, message: 'B catch-up failed' }))
+      .mockResolvedValueOnce(fullAgent({ ...agentA, description: 'A after failed B' }, 'A recovered'));
+    const listVibeAgents = vi.fn().mockResolvedValue(listResult([agentA, agentB]));
+    const api = makeApi(listVibeAgents, getVibeAgent);
+    renderPage(api);
+
+    await waitFor(() => expect(screen.getByDisplayValue('A before gap')).toBeTruthy());
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(screen.getByDisplayValue('A after failed B')).toBeTruthy());
+    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-b', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
+    expect(getVibeAgent).toHaveBeenNthCalledWith(4, 'agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
+    expect(listVibeAgents).toHaveBeenCalledTimes(2);
+    expect(screen.getByText('B catch-up failed')).toBeTruthy();
+    act(() => staleB.resolve(fullAgent(agentB, 'stale B')));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByDisplayValue('A after failed B')).toBeTruthy();
+    expect(getVibeAgent.mock.calls.slice(4).some(([name]) => name === 'agent-b')).toBe(false);
+  });
+
   it('carries a row-tap drill-down intent through a reconnect replacement read', async () => {
     const agentA = brief('agent-a', 'A');
     const agentB = brief('agent-b', 'B');
@@ -964,6 +1006,40 @@ describe('AgentsPage reconnect reconciliation', () => {
     expect(screen.getByDisplayValue('saved prompt')).toBeTruthy();
   });
 
+  it('lets a newer reconnect publish satisfy a successful prompt save drain', async () => {
+    const agent = brief('agent-a', 'description');
+    const firstDrain = deferred<ReturnType<typeof fullAgent>>();
+    const reconnect = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agent, 'initial prompt'))
+      .mockReturnValueOnce(firstDrain.promise)
+      .mockReturnValueOnce(reconnect.promise);
+    const updateVibeAgent = vi.fn().mockResolvedValue({ ok: true });
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agent)), getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('description')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'agents.detail.systemPromptExpand' }));
+    fireEvent.change(screen.getByPlaceholderText('agents.create.systemPromptPlaceholder'), {
+      target: { value: 'saved prompt' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+    act(() => reconnect.resolve(fullAgent(agent, 'saved prompt')));
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    expect(screen.queryByText('Agent reconciliation failed')).toBeNull();
+    act(() => firstDrain.resolve(fullAgent(agent, 'stale drain')));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(updateVibeAgent).toHaveBeenCalledTimes(1);
+  });
+
   it.each(['model', 'effort'] as const)('restores the authoritative value after a failed %s mutation', async (field) => {
     const initial = {
       ...brief('agent-a', 'description'),
@@ -997,6 +1073,28 @@ describe('AgentsPage reconnect reconciliation', () => {
       await waitFor(() => expect(screen.getByRole('button', { name: 'medium', exact: true }).className).toContain('bg-mint-soft'));
     }
     expect(screen.queryByText(`${field} failed`)).toBeTruthy();
+  });
+
+  it.each([
+    { label: 'underlying message', failure: { message: 'authoritative drain failed' }, expected: 'authoritative drain failed' },
+    { label: 'message-less fallback', failure: {}, expected: 'errorBoundary.title' },
+  ])('surfaces the $label from a current mutation drain', async ({ failure, expected }) => {
+    const agent = brief('agent-a', 'before');
+    const drain = deferred<ReturnType<typeof fullAgent>>();
+    const updateVibeAgent = vi.fn().mockResolvedValue({ ok: true });
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agent, 'prompt'))
+      .mockReturnValueOnce(drain.promise);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agent)), getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('before')).toBeTruthy());
+    fireEvent.change(screen.getByDisplayValue('before'), { target: { value: 'submitted' } });
+    fireEvent.blur(screen.getByDisplayValue('submitted'));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    act(() => drain.reject(failure));
+    await waitFor(() => expect(screen.getByText(expected)).toBeTruthy());
+    expect(screen.queryByText('Agent reconciliation failed')).toBeNull();
   });
 
   it.each([
@@ -1630,6 +1728,45 @@ describe('AgentsPage reconnect reconciliation', () => {
     fireEvent.change(screen.getByDisplayValue('agent-new'), { target: { value: 'agent-lost' } });
     fireEvent.blur(screen.getByDisplayValue('agent-lost'));
     await waitFor(() => expect(screen.getByDisplayValue('agent-new')).toBeTruthy());
+  });
+
+  it('lets a newer new-name read satisfy a superseded rename drain', async () => {
+    const oldAgent = brief('agent-old', 'description');
+    const renamedAgent = { ...oldAgent, name: 'agent-new', display_name: 'agent-new' };
+    const oldDrain = deferred<ReturnType<typeof fullAgent>>();
+    const newRead = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(oldAgent, 'prompt'))
+      .mockReturnValueOnce(oldDrain.promise)
+      .mockReturnValueOnce(newRead.promise);
+    const updateVibeAgent = vi.fn().mockResolvedValue({ ok: true });
+    const api = makeApi(
+      vi.fn()
+        .mockResolvedValueOnce(listResult(oldAgent))
+        .mockResolvedValue(listResult(renamedAgent)),
+      getVibeAgent,
+      undefined,
+      undefined,
+      updateVibeAgent,
+    );
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('agent-old')).toBeTruthy());
+    fireEvent.change(screen.getByDisplayValue('agent-old'), { target: { value: 'agent-new' } });
+    fireEvent.blur(screen.getByDisplayValue('agent-new'));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+    act(() => newRead.resolve(fullAgent(renamedAgent, 'prompt')));
+    await waitFor(() => expect(screen.getByDisplayValue('agent-new')).toBeTruthy());
+    act(() => oldDrain.resolve(fullAgent(renamedAgent, 'stale rename drain')));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    fireEvent.blur(screen.getByDisplayValue('agent-new'));
+    expect(updateVibeAgent).toHaveBeenCalledTimes(1);
   });
 
   it('cancels modal-only prompt edits without dirtying the shared field', async () => {

--- a/ui/src/components/workbench/AgentsPage.test.tsx
+++ b/ui/src/components/workbench/AgentsPage.test.tsx
@@ -1220,4 +1220,116 @@ describe('AgentsPage reconnect reconciliation', () => {
     });
     expect(getVibeAgentOnboarding).toHaveBeenCalledTimes(2);
   });
+
+  it.each(['agent_not_found', 'agent_access_forbidden'] as const)(
+    'restores accepted A when pending B disappears (%s)',
+    async (code) => {
+      const agentA = brief('agent-a', 'A');
+      const agentB = brief('agent-b', 'B');
+      const pendingB = deferred<ReturnType<typeof fullAgent>>();
+      const getVibeAgent = vi.fn()
+        .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+        .mockReturnValueOnce(pendingB.promise)
+        .mockResolvedValueOnce(fullAgent({ ...agentA, description: 'A after gap' }, 'A refreshed'))
+        .mockResolvedValueOnce(fullAgent({ ...agentA, description: 'A after mutation' }, 'A mutation drain'));
+      const updateVibeAgent = vi.fn().mockResolvedValue(fullAgent(agentA, 'ack'));
+      const api = makeApi(
+        vi.fn().mockResolvedValue(listResult([agentA, agentB])),
+        getVibeAgent,
+        undefined,
+        undefined,
+        updateVibeAgent,
+      );
+      renderPage(api, { canManageAgents: true });
+
+      await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+      fireEvent.click(screen.getByText('agent-b').closest('button')!);
+      await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+      act(() => pendingB.reject({ code, message: 'B disappeared' }));
+      await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+
+      act(() => handlers?.onConnected?.());
+      await waitFor(() => expect(screen.getByDisplayValue('A after gap')).toBeTruthy());
+      expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-a', {
+        cache: false,
+        expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+      });
+      expect(getVibeAgent.mock.calls.slice(2).some(([name]) => name === 'agent-b')).toBe(false);
+
+      fireEvent.change(screen.getByDisplayValue('A after gap'), { target: { value: 'A local' } });
+      fireEvent.blur(screen.getByDisplayValue('A local'));
+      await waitFor(() => expect(screen.getByDisplayValue('A after mutation')).toBeTruthy());
+      expect(getVibeAgent).toHaveBeenNthCalledWith(4, 'agent-a', {
+        cache: false,
+        expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+      });
+    },
+  );
+
+  it('migrates a stable-id rename and keeps the reconciled name clean', async () => {
+    const oldAgent = brief('agent-old', 'description');
+    const renamedAgent = { ...oldAgent, name: 'agent-new', display_name: 'agent-new' };
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(oldAgent, 'prompt'))
+      .mockResolvedValueOnce(fullAgent(renamedAgent, 'prompt'));
+    const updateVibeAgent = vi.fn().mockResolvedValue(fullAgent(renamedAgent, 'prompt'));
+    const listVibeAgents = vi.fn()
+      .mockResolvedValueOnce(listResult(oldAgent))
+      .mockResolvedValue(listResult(renamedAgent));
+    const api = makeApi(listVibeAgents, getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('agent-old')).toBeTruthy());
+    const nameInput = screen.getByDisplayValue('agent-old');
+    fireEvent.change(nameInput, { target: { value: 'agent-new' } });
+    fireEvent.blur(screen.getByDisplayValue('agent-new'));
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledWith('agent-old', { name: 'agent-new' }));
+    await waitFor(() => expect(screen.getByDisplayValue('agent-new')).toBeTruthy());
+    expect(getVibeAgent).toHaveBeenNthCalledWith(2, 'agent-new', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
+
+    fireEvent.blur(screen.getByDisplayValue('agent-new'));
+    expect(updateVibeAgent).toHaveBeenCalledTimes(1);
+
+    updateVibeAgent.mockRejectedValueOnce({ message: 'rename failed' });
+    fireEvent.change(screen.getByDisplayValue('agent-new'), { target: { value: 'agent-lost' } });
+    fireEvent.blur(screen.getByDisplayValue('agent-lost'));
+    await waitFor(() => expect(screen.getByDisplayValue('agent-new')).toBeTruthy());
+  });
+
+  it('cancels modal-only prompt edits without dirtying the shared field', async () => {
+    const agent = brief('agent-a', 'description');
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agent, 'server prompt'))
+      .mockResolvedValueOnce(fullAgent(agent, 'new server prompt'))
+      .mockResolvedValueOnce(fullAgent(agent, 'latest server prompt'));
+    const updateVibeAgent = vi.fn();
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agent)), getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('description')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'agents.detail.systemPromptExpand' }));
+    const modal = screen.getByRole('dialog');
+    fireEvent.change(screen.getByPlaceholderText('agents.create.systemPromptPlaceholder'), {
+      target: { value: 'canceled modal text' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'common.cancel' }));
+    expect(updateVibeAgent).not.toHaveBeenCalled();
+
+    act(() => handlers?.onConnected?.());
+    fireEvent.click(screen.getByRole('button', { name: 'agents.detail.systemPromptExpand' }));
+    await waitFor(() => expect(screen.getByDisplayValue('new server prompt')).toBeTruthy());
+    fireEvent.change(screen.getByPlaceholderText('agents.create.systemPromptPlaceholder'), {
+      target: { value: 'x-canceled modal text' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(updateVibeAgent).not.toHaveBeenCalled();
+
+    act(() => handlers?.onConnected?.());
+    fireEvent.click(screen.getByRole('button', { name: 'agents.detail.systemPromptExpand' }));
+    await waitFor(() => expect(screen.getByDisplayValue('latest server prompt')).toBeTruthy());
+    expect(modal).not.toBeNull();
+  });
 });

--- a/ui/src/components/workbench/AgentsPage.test.tsx
+++ b/ui/src/components/workbench/AgentsPage.test.tsx
@@ -1040,6 +1040,126 @@ describe('AgentsPage reconnect reconciliation', () => {
     expect(updateVibeAgent).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps the selected catch-up barrier alive when a manual list refresh supersedes it', async () => {
+    const agent = brief('agent-a', 'before');
+    const gapList = deferred<ReturnType<typeof listResult>>();
+    const manualList = deferred<ReturnType<typeof listResult>>();
+    const detail = deferred<ReturnType<typeof fullAgent>>();
+    const refreshed = { ...agent, description: 'after gap' };
+    const listVibeAgents = vi.fn()
+      .mockResolvedValueOnce(listResult(agent))
+      .mockReturnValueOnce(gapList.promise)
+      .mockReturnValueOnce(manualList.promise);
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agent, 'initial'))
+      .mockReturnValueOnce(detail.promise);
+    const api = makeApi(listVibeAgents, getVibeAgent);
+    renderPage(api);
+
+    await waitFor(() => expect(screen.getByDisplayValue('before')).toBeTruthy());
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(listVibeAgents).toHaveBeenCalledTimes(2));
+    fireEvent.click(screen.getByRole('button', { name: 'common.refresh' }));
+    await waitFor(() => expect(listVibeAgents).toHaveBeenCalledTimes(3));
+
+    act(() => manualList.resolve(listResult(refreshed)));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    expect(getVibeAgent).toHaveBeenNthCalledWith(2, 'agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
+    act(() => detail.resolve(fullAgent(refreshed, 'reconciled')));
+    await waitFor(() => expect(screen.getByDisplayValue('after gap')).toBeTruthy());
+
+    act(() => gapList.resolve(listResult(agent)));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByDisplayValue('after gap')).toBeTruthy();
+    expect(getVibeAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it('publishes the Definitions list only after the authoritative mutation detail drain', async () => {
+    const agent = brief('agent-a', 'before');
+    const preMutationList = deferred<ReturnType<typeof listResult>>();
+    const postDrainList = deferred<ReturnType<typeof listResult>>();
+    const drain = deferred<ReturnType<typeof fullAgent>>();
+    const finalAgent = { ...agent, description: 'after mutation' };
+    const listVibeAgents = vi.fn()
+      .mockResolvedValueOnce(listResult(agent))
+      .mockReturnValueOnce(preMutationList.promise)
+      .mockReturnValueOnce(postDrainList.promise);
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agent, 'initial'))
+      .mockReturnValueOnce(drain.promise)
+      .mockResolvedValue(fullAgent(finalAgent, 'final'));
+    const updateVibeAgent = vi.fn().mockResolvedValue({ ok: true });
+    const api = makeApi(listVibeAgents, getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('before')).toBeTruthy());
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(listVibeAgents).toHaveBeenCalledTimes(2));
+    fireEvent.change(screen.getByDisplayValue('before'), { target: { value: 'local' } });
+    fireEvent.blur(screen.getByDisplayValue('local'));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+
+    act(() => drain.resolve(fullAgent(finalAgent, 'final')));
+    await waitFor(() => expect(listVibeAgents).toHaveBeenCalledTimes(3));
+    fireEvent.click(screen.getByRole('button', { name: 'agents.detail.systemPromptExpand' }));
+    expect(screen.getByDisplayValue('final')).toBeTruthy();
+    act(() => postDrainList.resolve(listResult(finalAgent)));
+    await waitFor(() => expect(screen.getAllByText('after mutation').length).toBeGreaterThan(0));
+
+    act(() => preMutationList.resolve(listResult(agent)));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getAllByText('after mutation').length).toBeGreaterThan(0);
+  });
+
+  it('keeps per-operation mutation outcomes independent within one detail barrier', async () => {
+    const agent = brief('agent-a', 'before');
+    const descriptionPatch = deferred<unknown>();
+    const promptPatch = deferred<unknown>();
+    const drain = deferred<ReturnType<typeof fullAgent>>();
+    const finalAgent = { ...agent, description: 'server description' };
+    const updateVibeAgent = vi.fn()
+      .mockReturnValueOnce(descriptionPatch.promise)
+      .mockReturnValueOnce(promptPatch.promise);
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agent, 'initial prompt'))
+      .mockReturnValueOnce(drain.promise);
+    const api = makeApi(
+      vi.fn().mockResolvedValue(listResult(finalAgent)),
+      getVibeAgent,
+      undefined,
+      undefined,
+      updateVibeAgent,
+    );
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('before')).toBeTruthy());
+    fireEvent.change(screen.getByDisplayValue('before'), { target: { value: 'local description' } });
+    fireEvent.blur(screen.getByDisplayValue('local description'));
+    fireEvent.click(screen.getByRole('button', { name: 'agents.detail.systemPromptExpand' }));
+    fireEvent.change(screen.getByPlaceholderText('agents.create.systemPromptPlaceholder'), {
+      target: { value: 'saved prompt' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }));
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledTimes(2));
+
+    act(() => promptPatch.resolve({ ok: true }));
+    act(() => descriptionPatch.reject({ message: 'description failed' }));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    act(() => drain.resolve(fullAgent(finalAgent, 'saved prompt')));
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    expect(screen.getByText('description failed')).toBeTruthy();
+    expect(updateVibeAgent).toHaveBeenCalledWith('agent-a', { system_prompt: 'saved prompt' });
+  });
+
   it.each(['model', 'effort'] as const)('restores the authoritative value after a failed %s mutation', async (field) => {
     const initial = {
       ...brief('agent-a', 'description'),
@@ -1729,6 +1849,30 @@ describe('AgentsPage reconnect reconciliation', () => {
     fireEvent.blur(screen.getByDisplayValue('agent-lost'));
     await waitFor(() => expect(screen.getByDisplayValue('agent-new')).toBeTruthy());
   });
+
+  it.each(['agent_not_found', 'agent_access_forbidden'] as const)(
+    'localizes rename retirement errors without manufacturing English (%s)',
+    async (code) => {
+      const oldAgent = brief('agent-old', 'description');
+      const renamedAgent = { ...oldAgent, name: 'agent-new', display_name: 'agent-new' };
+      const getVibeAgent = vi.fn()
+        .mockResolvedValueOnce(fullAgent(oldAgent, 'prompt'))
+        .mockRejectedValueOnce({ code });
+      const updateVibeAgent = vi.fn().mockResolvedValue({ ok: true });
+      const listVibeAgents = vi.fn()
+        .mockResolvedValueOnce(listResult(oldAgent))
+        .mockResolvedValue(listResult(renamedAgent));
+      const api = makeApi(listVibeAgents, getVibeAgent, undefined, undefined, updateVibeAgent);
+      renderPage(api, { canManageAgents: true });
+
+      await waitFor(() => expect(screen.getByDisplayValue('agent-old')).toBeTruthy());
+      fireEvent.change(screen.getByDisplayValue('agent-old'), { target: { value: 'agent-new' } });
+      fireEvent.blur(screen.getByDisplayValue('agent-new'));
+      await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledWith('agent-old', { name: 'agent-new' }));
+      await waitFor(() => expect(screen.getByText('errorBoundary.title')).toBeTruthy());
+      expect(screen.queryByText('Agent is no longer available')).toBeNull();
+    },
+  );
 
   it('lets a newer new-name read satisfy a superseded rename drain', async () => {
     const oldAgent = brief('agent-old', 'description');

--- a/ui/src/components/workbench/AgentsPage.test.tsx
+++ b/ui/src/components/workbench/AgentsPage.test.tsx
@@ -583,6 +583,134 @@ describe('AgentsPage reconnect reconciliation', () => {
     expect(screen.getByDisplayValue('B after reconnect')).toBeTruthy();
   });
 
+  it('joins the live debt producer when selecting the current Agent again', async () => {
+    const agent = brief('agent-a', 'description');
+    const debtRead = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agent, 'initial prompt'))
+      .mockReturnValueOnce(debtRead.promise);
+    const updateVibeAgent = vi.fn().mockResolvedValue({ ok: true });
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agent)), getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('description')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'agents.detail.systemPromptExpand' }));
+    fireEvent.change(screen.getByPlaceholderText('agents.create.systemPromptPlaceholder'), {
+      target: { value: 'saved prompt' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }));
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+
+    const row = screen.getAllByText('agent-a').find((node) => node.closest('button'))?.closest('button');
+    expect(row).not.toBeNull();
+    fireEvent.click(row!);
+    expect(getVibeAgent).toHaveBeenCalledTimes(2);
+
+    act(() => debtRead.resolve(fullAgent({ ...agent, description: 'after debt' }, 'saved prompt')));
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    await waitFor(() => expect(api.listVibeAgents).toHaveBeenCalledTimes(2));
+    expect(screen.getByDisplayValue('after debt')).toBeTruthy();
+    expect(updateVibeAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('joins a pending reconnect producer when selecting the current Agent again', async () => {
+    const agent = brief('agent-a', 'before');
+    const reconnectRead = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agent, 'initial prompt'))
+      .mockReturnValueOnce(reconnectRead.promise);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agent)), getVibeAgent);
+    renderPage(api);
+
+    await waitFor(() => expect(screen.getByDisplayValue('before')).toBeTruthy());
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+
+    const row = screen.getAllByText('agent-a').find((node) => node.closest('button'))?.closest('button');
+    expect(row).not.toBeNull();
+    fireEvent.click(row!);
+    expect(getVibeAgent).toHaveBeenCalledTimes(2);
+
+    act(() => reconnectRead.resolve(fullAgent({ ...agent, description: 'after reconnect' }, 'fresh prompt')));
+    await waitFor(() => expect(screen.getByDisplayValue('after reconnect')).toBeTruthy());
+    const detail = screen.getByDisplayValue('after reconnect').closest('.self-start');
+    expect(detail?.className).not.toContain('max-lg:hidden');
+  });
+
+  it('does not let a lower-floor selection read satisfy later mutation debt', async () => {
+    const agent = brief('agent-a', 'before');
+    const selectionRead = deferred<ReturnType<typeof fullAgent>>();
+    const debtRead = deferred<ReturnType<typeof fullAgent>>();
+    const patch = deferred<unknown>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agent, 'initial prompt'))
+      .mockReturnValueOnce(selectionRead.promise)
+      .mockReturnValueOnce(debtRead.promise);
+    const updateVibeAgent = vi.fn().mockReturnValue(patch.promise);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agent)), getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('before')).toBeTruthy());
+    const row = screen.getAllByText('agent-a').find((node) => node.closest('button'))?.closest('button');
+    expect(row).not.toBeNull();
+    fireEvent.click(row!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+
+    const description = screen.getByDisplayValue('before');
+    fireEvent.change(description, { target: { value: 'local mutation' } });
+    fireEvent.blur(description);
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledWith('agent-a', { description: 'local mutation' }));
+    act(() => patch.resolve({ ok: true }));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+
+    act(() => selectionRead.resolve(fullAgent({ ...agent, description: 'stale selection' }, 'stale prompt')));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByDisplayValue('local mutation')).toBeTruthy();
+
+    act(() => debtRead.resolve(fullAgent({ ...agent, description: 'authoritative mutation' }, 'fresh prompt')));
+    await waitFor(() => expect(screen.getByDisplayValue('authoritative mutation')).toBeTruthy());
+    expect(getVibeAgent).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([
+    { label: 'rejected debt read', rejected: true },
+    { label: 'ok-false debt read', rejected: false },
+  ])('settles every same-agent consumer when the joined stage has a $label', async ({ rejected }) => {
+    const agent = brief('agent-a', 'description');
+    const debtRead = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agent, 'initial prompt'))
+      .mockReturnValueOnce(debtRead.promise);
+    const updateVibeAgent = vi.fn().mockResolvedValue({ ok: true });
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agent)), getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('description')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'agents.detail.systemPromptExpand' }));
+    fireEvent.change(screen.getByPlaceholderText('agents.create.systemPromptPlaceholder'), {
+      target: { value: 'joined prompt' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    const row = screen.getAllByText('agent-a').find((node) => node.closest('button'))?.closest('button');
+    expect(row).not.toBeNull();
+    fireEvent.click(row!);
+    expect(getVibeAgent).toHaveBeenCalledTimes(2);
+
+    if (rejected) {
+      act(() => debtRead.reject({ message: 'joined debt failed' }));
+    } else {
+      act(() => debtRead.resolve({ ok: false, message: 'joined debt failed' } as never));
+    }
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeTruthy());
+    expect(screen.getByText('joined debt failed')).toBeTruthy();
+    expect(updateVibeAgent).toHaveBeenCalledTimes(1);
+  });
+
   it('lets a successful PATCH win over a reconnect GET that settles later', async () => {
     const initial = { ...brief('agent-a', 'before patch'), model: 'old-model' };
     const server = { ...initial, description: 'server description', model: 'server-model' };

--- a/ui/src/components/workbench/AgentsPage.test.tsx
+++ b/ui/src/components/workbench/AgentsPage.test.tsx
@@ -1,73 +1,79 @@
 /* @vitest-environment jsdom */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 
 import { InstanceAuthorizationContext } from '../../context/InstanceAuthorizationContext';
+import type { VibeAgentBrief, WorkbenchEventHandlers } from '../../context/ApiContext';
 import type { InstanceCapabilities, InstanceRole } from '../../lib/sessionInfo';
 import { OWNER_INSTANCE_CAPABILITIES } from '../../lib/sessionInfo';
 import { AgentsPage } from './AgentsPage';
 
-const api = vi.hoisted(() => ({
-  listVibeAgents: vi.fn(),
-  getVibeAgent: vi.fn(),
-  getVibeAgentOnboarding: vi.fn(),
-  getRunningAgents: vi.fn(),
-  connectWorkbenchEvents: vi.fn(),
-}));
+type FakeApi = {
+  listVibeAgents: ReturnType<typeof vi.fn>;
+  getVibeAgent: ReturnType<typeof vi.fn>;
+  getVibeAgentOnboarding: ReturnType<typeof vi.fn>;
+  getRunningAgents: ReturnType<typeof vi.fn>;
+  connectWorkbenchEvents: ReturnType<typeof vi.fn>;
+};
 
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
-}));
+const apiRef = vi.hoisted(() => ({ current: null as FakeApi | null }));
+let handlers: WorkbenchEventHandlers | null = null;
 
-vi.mock('../../context/ApiContext', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../../context/ApiContext')>()),
-  useApi: () => api,
-}));
+vi.mock('../../context/ApiContext', async () => {
+  const actual = await vi.importActual<typeof import('../../context/ApiContext')>('../../context/ApiContext');
+  return { ...actual, useApi: () => apiRef.current };
+});
 
-vi.mock('../../context/ToastContext', () => ({
-  useToast: () => ({ showToast: vi.fn() }),
-}));
-
-// The detail panel's model catalog is an HTTP read of its own; serve it locally
-// so this file is about which requests the page load issues, not about the
-// catalog's contents.
-vi.mock('../../lib/backendModels', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../../lib/backendModels')>()),
-  loadBackendModelsWithRefresh: (
-    _api: unknown,
-    _backend: string,
-    onLoaded: (payload: { models: string[] }) => void,
-  ) => {
+vi.mock('../../context/ToastContext', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('./CapabilityTabs', () => ({ CapabilityTabs: () => null }));
+vi.mock('../../lib/backendModels', async () => ({
+  loadBackendModelsWithRefresh: (_api: unknown, _backend: string, onLoaded: (payload: { models: string[] }) => void) => {
     onLoaded({ models: [] });
     return () => {};
   },
 }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, unknown>) => (values ? `${key}:${JSON.stringify(values)}` : key),
+  }),
+}));
 
-vi.mock('./AgentGraphTab', () => ({ AgentGraphTab: () => null }));
-vi.mock('./NewAgentDialog', () => ({ NewAgentDialog: () => null }));
-vi.mock('./RunAgentDialog', () => ({ RunAgentDialog: () => null }));
-vi.mock('./GlobalPromptsDialog', () => ({ GlobalPromptsDialog: () => null }));
-
-const AGENT = {
-  id: 'agt-claude',
-  name: 'claude',
-  display_name: 'claude',
-  description: null,
-  backend: 'claude',
-  model: 'sonnet',
+const brief = (name: string, description: string): VibeAgentBrief => ({
+  id: `id-${name}`,
+  name,
+  display_name: name,
+  description,
+  backend: 'codex',
+  model: null,
   reasoning_effort: null,
   enabled: true,
   archived: false,
   archived_at: null,
-  source: 'builtin',
-  updated_at: '2026-08-19T00:00:00Z',
-};
+  source: 'custom',
+  updated_at: '2026-08-21T00:00:00Z',
+});
 
-// A remote Instance Member: the rank keeps Agent CRUD (`can_manage_agents`) but
-// is not the Instance Owner. Bulk onboarding is Owner-only on the HTTP policy,
-// so this is exactly the projection that used to 403 on page load.
+const listResult = (agent: VibeAgentBrief) => ({
+  ok: true,
+  agents: [agent],
+  default_agent_name: agent.name,
+});
+
+function makeApi(listVibeAgents: FakeApi['listVibeAgents']): FakeApi {
+  return {
+    listVibeAgents,
+    getVibeAgent: vi.fn().mockResolvedValue({ ok: false }),
+    getVibeAgentOnboarding: vi.fn().mockResolvedValue({ available: false }),
+    getRunningAgents: vi.fn().mockResolvedValue({ ok: true, counts: { total: 2 } }),
+    connectWorkbenchEvents: vi.fn((next: WorkbenchEventHandlers) => {
+      handlers = next;
+      return vi.fn();
+    }),
+  };
+}
+
 const MEMBER_CAPABILITIES: InstanceCapabilities = {
   ...OWNER_INSTANCE_CAPABILITIES,
   is_instance_owner: false,
@@ -75,11 +81,23 @@ const MEMBER_CAPABILITIES: InstanceCapabilities = {
   can_manage_access_members: false,
 };
 
-function renderPage(instanceRole: InstanceRole, capabilities: InstanceCapabilities) {
+function renderPage(
+  api: FakeApi,
+  {
+    remote = false,
+    instanceKind = null,
+    instanceRole = 'owner' as InstanceRole,
+    capabilities = { ...OWNER_INSTANCE_CAPABILITIES, can_manage_agents: false },
+  }: {
+    remote?: boolean;
+    instanceKind?: 'organization' | 'personal' | null;
+    instanceRole?: InstanceRole;
+    capabilities?: InstanceCapabilities;
+  } = {},
+) {
+  apiRef.current = api;
   return render(
-    <InstanceAuthorizationContext.Provider
-      value={{ remote: true, instanceKind: 'organization', instanceRole, capabilities }}
-    >
+    <InstanceAuthorizationContext.Provider value={{ remote, instanceKind, instanceRole, capabilities }}>
       <MemoryRouter initialEntries={['/agents']}>
         <AgentsPage />
       </MemoryRouter>
@@ -87,36 +105,23 @@ function renderPage(instanceRole: InstanceRole, capabilities: InstanceCapabiliti
   );
 }
 
-// jsdom has no layout, so the capability tab strip's scroll-into-view is a
-// no-op here; the page itself stays real.
-const originalScrollIntoView = Element.prototype.scrollIntoView;
-
-beforeEach(() => {
-  Element.prototype.scrollIntoView = vi.fn();
-  api.listVibeAgents.mockReset();
-  api.listVibeAgents.mockResolvedValue({ ok: true, agents: [AGENT], default_agent_name: 'claude' });
-  api.getVibeAgent.mockReset();
-  api.getVibeAgent.mockResolvedValue({ ok: true, agent: AGENT });
-  api.getVibeAgentOnboarding.mockReset();
-  api.getVibeAgentOnboarding.mockResolvedValue({ available: false });
-  api.getRunningAgents.mockReset();
-  api.getRunningAgents.mockResolvedValue({ ok: true, counts: { total: 0 } });
-  api.connectWorkbenchEvents.mockReset();
-  api.connectWorkbenchEvents.mockReturnValue(() => {});
-});
-
 afterEach(() => {
   cleanup();
-  vi.clearAllMocks();
-  Element.prototype.scrollIntoView = originalScrollIntoView;
+  apiRef.current = null;
+  handlers = null;
 });
 
 describe('AgentsPage load requests follow the rank that can serve them', () => {
   it('does not request the Owner-only onboarding inventory for a member', async () => {
-    const view = renderPage('member', MEMBER_CAPABILITIES);
+    const listVibeAgents = vi.fn().mockResolvedValue(listResult(brief('claude', '')));
+    const api = makeApi(listVibeAgents);
+    const view = renderPage(api, {
+      remote: true,
+      instanceKind: 'organization',
+      instanceRole: 'member',
+      capabilities: MEMBER_CAPABILITIES,
+    });
 
-    // Wait on a request the member IS entitled to, so the assertion below runs
-    // after the page load has actually settled rather than before it starts.
     await waitFor(() => expect(api.listVibeAgents).toHaveBeenCalled());
     await waitFor(() => expect(api.getVibeAgent).toHaveBeenCalled());
     expect(api.getVibeAgentOnboarding).not.toHaveBeenCalled();
@@ -124,9 +129,80 @@ describe('AgentsPage load requests follow the rank that can serve them', () => {
   });
 
   it('still requests the onboarding inventory for the instance owner', async () => {
-    const view = renderPage('owner', OWNER_INSTANCE_CAPABILITIES);
+    const listVibeAgents = vi.fn().mockResolvedValue(listResult(brief('claude', '')));
+    const api = makeApi(listVibeAgents);
+    const view = renderPage(api, {
+      remote: true,
+      instanceKind: 'organization',
+      instanceRole: 'owner',
+      capabilities: OWNER_INSTANCE_CAPABILITIES,
+    });
 
     await waitFor(() => expect(api.getVibeAgentOnboarding).toHaveBeenCalled());
     view.unmount();
+  });
+});
+
+describe('AgentsPage reconnect reconciliation', () => {
+  it('refreshes definitions from the server on the gap edge without bridge-status duplication', async () => {
+    const stale = brief('stale-agent', 'before the gap');
+    const fresh = brief('fresh-agent', 'changed during the gap');
+    const listVibeAgents = vi.fn()
+      .mockResolvedValueOnce(listResult(stale))
+      .mockResolvedValueOnce(listResult(fresh));
+    const api = makeApi(listVibeAgents);
+    renderPage(api);
+
+    await waitFor(() => expect(screen.getByText('stale-agent')).toBeTruthy());
+    expect(handlers).not.toBeNull();
+
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(screen.getByText('fresh-agent')).toBeTruthy());
+
+    expect(listVibeAgents).toHaveBeenNthCalledWith(1, { includeDisabled: true });
+    expect(listVibeAgents).toHaveBeenNthCalledWith(2, { includeDisabled: true, cache: false });
+    expect(api.getRunningAgents).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      handlers?.onEventBridgeStatus?.({ connected: false });
+      handlers?.onEventBridgeStatus?.({ connected: true });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(listVibeAgents).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps an older pre-gap read from overwriting the post-gap definition snapshot', async () => {
+    const stale = brief('stale-agent', 'before the gap');
+    const fresh = brief('fresh-agent', 'changed during the gap');
+    let resolvePreGap!: (value: ReturnType<typeof listResult>) => void;
+    const preGap = new Promise<ReturnType<typeof listResult>>((resolve) => {
+      resolvePreGap = resolve;
+    });
+    const listVibeAgents = vi.fn()
+      .mockResolvedValueOnce(listResult(stale))
+      .mockReturnValueOnce(preGap)
+      .mockResolvedValueOnce(listResult(fresh));
+    const api = makeApi(listVibeAgents);
+    renderPage(api);
+
+    await waitFor(() => expect(screen.getByText('stale-agent')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'common.refresh' }));
+    await waitFor(() => expect(listVibeAgents).toHaveBeenCalledTimes(2));
+
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(screen.getByText('fresh-agent')).toBeTruthy());
+
+    resolvePreGap(listResult(stale));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('fresh-agent')).toBeTruthy();
+    expect(screen.queryByText('stale-agent')).toBeNull();
+    expect(listVibeAgents).toHaveBeenNthCalledWith(3, { includeDisabled: true, cache: false });
+    expect(api.getRunningAgents).toHaveBeenCalledTimes(2);
   });
 });

--- a/ui/src/components/workbench/AgentsPage.test.tsx
+++ b/ui/src/components/workbench/AgentsPage.test.tsx
@@ -360,7 +360,10 @@ describe('AgentsPage reconnect reconciliation', () => {
     expect(secondRow).not.toBeNull();
     fireEvent.click(secondRow!);
     await waitFor(() => expect(screen.getByDisplayValue('another agent')).toBeTruthy());
-    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-b', { cache: false });
+    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-b', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
     expect(api.connectWorkbenchEvents).toHaveBeenCalledTimes(1);
   });
 
@@ -382,7 +385,10 @@ describe('AgentsPage reconnect reconciliation', () => {
 
     act(() => handlers?.onConnected?.());
     await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
-    expect(getVibeAgent).toHaveBeenNthCalledWith(2, 'agent-b', { cache: false });
+    expect(getVibeAgent).toHaveBeenNthCalledWith(2, 'agent-b', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
     expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-b', {
       cache: false,
       expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
@@ -400,6 +406,73 @@ describe('AgentsPage reconnect reconciliation', () => {
     await waitFor(() => expect(screen.getByDisplayValue('B')).toBeTruthy());
     expect(api.connectWorkbenchEvents).toHaveBeenCalledTimes(1);
   });
+
+  it('does not reuse an invalidated A debt stage after B fails', async () => {
+    const agentA = brief('agent-a', 'A');
+    const agentB = brief('agent-b', 'B');
+    const patch = deferred<unknown>();
+    const oldDebt = deferred<ReturnType<typeof fullAgent>>();
+    const pendingB = deferred<ReturnType<typeof fullAgent>>();
+    const freshDebt = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+      .mockReturnValueOnce(oldDebt.promise)
+      .mockReturnValueOnce(pendingB.promise)
+      .mockReturnValueOnce(freshDebt.promise);
+    const updateVibeAgent = vi.fn().mockReturnValue(patch.promise);
+    const api = makeApi(
+      vi.fn().mockResolvedValue(listResult([agentA, agentB])),
+      getVibeAgent,
+      undefined,
+      undefined,
+      updateVibeAgent,
+    );
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    fireEvent.change(screen.getByDisplayValue('A'), { target: { value: 'A edited' } });
+    fireEvent.blur(screen.getByDisplayValue('A edited'));
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledTimes(1));
+    act(() => patch.resolve({ ok: true }));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+    act(() => pendingB.reject({ code: 'agent_backend_unavailable', message: 'B unavailable' }));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(4));
+
+    act(() => freshDebt.resolve(fullAgent({ ...agentA, description: 'A after B' }, 'fresh A')));
+    await waitFor(() => expect(screen.getByDisplayValue('A after B')).toBeTruthy());
+    act(() => oldDebt.resolve(fullAgent(agentA, 'stale A')));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByDisplayValue('A after B')).toBeTruthy();
+    expect(getVibeAgent).toHaveBeenCalledTimes(4);
+  });
+
+  it.each(['agent_not_found', 'agent_access_forbidden'] as const)(
+    'tombstones a stale row on direct selection without a repeat read (%s)',
+    async (code) => {
+      const agentA = brief('agent-a', 'A');
+      const agentB = brief('agent-b', 'B');
+      const getVibeAgent = vi.fn()
+        .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+        .mockRejectedValueOnce({ code, message: 'B disappeared' });
+      const listVibeAgents = vi.fn().mockResolvedValue(listResult([agentA, agentB]));
+      const api = makeApi(listVibeAgents, getVibeAgent);
+      renderPage(api);
+
+      await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+      fireEvent.click(screen.getByText('agent-b').closest('button')!);
+      await waitFor(() => expect(screen.queryByText('agent-b')).toBeNull());
+      expect(screen.getByDisplayValue('A')).toBeTruthy();
+      expect(getVibeAgent).toHaveBeenCalledTimes(2);
+      expect(listVibeAgents).toHaveBeenCalledTimes(2);
+      expect(showToast).not.toHaveBeenCalled();
+    },
+  );
 
   it('orders a list-first gap retirement before the same-edge accepted-A read', async () => {
     const agentA = brief('agent-a', 'A before gap');
@@ -595,8 +668,14 @@ describe('AgentsPage reconnect reconciliation', () => {
       cache: false,
       expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
     });
-    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-b', { cache: false });
-    expect(getVibeAgent).toHaveBeenNthCalledWith(4, 'agent-a', { cache: false });
+    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-b', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
+    expect(getVibeAgent).toHaveBeenNthCalledWith(4, 'agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
   });
 
   it.each([
@@ -1490,7 +1569,10 @@ describe('AgentsPage reconnect reconciliation', () => {
     fireEvent.click(rowA!);
     await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
     await waitFor(() => expect(screen.getByDisplayValue('A after return')).toBeTruthy());
-    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-a', { cache: false });
+    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
   });
 
   it.each([
@@ -1534,7 +1616,10 @@ describe('AgentsPage reconnect reconciliation', () => {
     expect(screen.getByText('A mutation failed')).toBeTruthy();
     fireEvent.click(screen.getByText('agent-a').closest('button')!);
     await waitFor(() => expect(screen.getByDisplayValue('A after failed return')).toBeTruthy());
-    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-a', { cache: false });
+    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
   });
 
   it.each([
@@ -1703,7 +1788,9 @@ describe('AgentsPage reconnect reconciliation', () => {
         await Promise.resolve();
         await Promise.resolve();
       });
-      expect(listVibeAgents).toHaveBeenCalledTimes(2);
+      // Detail retirement schedules one bounded Definitions follow-up so a
+      // replacement identity can be discovered; it must not recurse further.
+      expect(listVibeAgents).toHaveBeenCalledTimes(3);
       expect(screen.queryByDisplayValue('A')).toBeNull();
       expect(screen.queryByText('agent-a')).toBeNull();
       expect(showToast).not.toHaveBeenCalled();
@@ -2085,7 +2172,10 @@ describe('AgentsPage reconnect reconciliation', () => {
     act(() => handlers?.onConnected?.());
     await waitFor(() => expect(screen.getByDisplayValue('A recovered')).toBeTruthy());
     expect(getVibeAgent).toHaveBeenCalledTimes(2);
-    expect(getVibeAgent).toHaveBeenNthCalledWith(2, 'agent-a', { cache: false });
+    expect(getVibeAgent).toHaveBeenNthCalledWith(2, 'agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
   });
 
   it('does not resume A when a newer C intent wins during the B catch-up read', async () => {

--- a/ui/src/components/workbench/AgentsPage.test.tsx
+++ b/ui/src/components/workbench/AgentsPage.test.tsx
@@ -708,6 +708,98 @@ describe('AgentsPage reconnect reconciliation', () => {
     expect(screen.getByDisplayValue('external description')).toBeTruthy();
   });
 
+  it.each([
+    { field: 'description', label: 'description' },
+    { field: 'systemPrompt', label: 'inline system prompt' },
+  ] as const)('adopts a newer server snapshot after a $label edit is restored to baseline', async ({ field }) => {
+    const initial = brief('agent-a', 'before');
+    const changed = { ...initial, description: 'server description' };
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(initial, 'before prompt'))
+      .mockResolvedValueOnce(fullAgent(changed, 'server prompt'));
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(initial)), getVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('before')).toBeTruthy());
+    if (field === 'description') {
+      const input = screen.getByDisplayValue('before');
+      fireEvent.change(input, { target: { value: 'local description' } });
+      fireEvent.change(input, { target: { value: 'before' } });
+      fireEvent.blur(input);
+      expect(api.updateVibeAgent).not.toHaveBeenCalled();
+    } else {
+      fireEvent.click(screen.getByRole('button', { name: /agents\.detail\.systemPromptCount/ }));
+      const input = screen.getByDisplayValue('before prompt');
+      fireEvent.change(input, { target: { value: 'local prompt' } });
+      fireEvent.change(input, { target: { value: 'before prompt' } });
+      fireEvent.blur(input);
+      expect(api.updateVibeAgent).not.toHaveBeenCalled();
+    }
+
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(screen.getByDisplayValue(field === 'description' ? 'server description' : 'server prompt')).toBeTruthy());
+  });
+
+  it('restores the authoritative name on Escape and does not rename on blur', async () => {
+    const initial = brief('agent-a', 'description');
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(initial, 'prompt'))
+      .mockResolvedValueOnce(fullAgent({ ...initial, description: 'after gap' }, 'prompt'));
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(initial)), getVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('agent-a')).toBeTruthy());
+    const input = screen.getByDisplayValue('agent-a');
+    fireEvent.change(input, { target: { value: 'local-name' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    fireEvent.blur(input);
+    expect(screen.getByDisplayValue('agent-a')).toBeTruthy();
+    expect(api.updateVibeAgent).not.toHaveBeenCalled();
+
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(screen.getByDisplayValue('after gap')).toBeTruthy());
+    expect(api.updateVibeAgent).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { label: 'rejected PATCH', patch: 'reject' as const },
+    { label: 'ok-false PATCH', patch: 'okfalse' as const },
+    { label: 'failed authoritative drain', patch: 'drain' as const },
+  ])('keeps the prompt editor draft open after a $label and closes after retry', async ({ patch }) => {
+    const initial = brief('agent-a', 'description');
+    const getVibeAgent = vi.fn().mockResolvedValueOnce(fullAgent(initial, 'server prompt'));
+    const updateVibeAgent = vi.fn();
+    if (patch === 'drain') {
+      getVibeAgent.mockRejectedValueOnce({ message: 'drain failed' });
+      updateVibeAgent.mockResolvedValueOnce(fullAgent(initial, 'acknowledged'));
+    } else {
+      getVibeAgent.mockResolvedValueOnce(fullAgent(initial, 'server prompt'));
+      if (patch === 'reject') updateVibeAgent.mockRejectedValueOnce({ message: 'save failed' });
+      else updateVibeAgent.mockResolvedValueOnce({ ok: false, message: 'save failed' });
+    }
+    getVibeAgent.mockResolvedValueOnce(fullAgent({ ...initial, description: 'saved' }, 'saved prompt'));
+    updateVibeAgent.mockResolvedValueOnce(fullAgent({ ...initial, description: 'saved' }, 'saved prompt'));
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(initial)), getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('description')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'agents.detail.systemPromptExpand' }));
+    const draft = screen.getByPlaceholderText('agents.create.systemPromptPlaceholder');
+    fireEvent.change(draft, { target: { value: 'failed private draft' } });
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }));
+
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByDisplayValue('failed private draft')).toBeTruthy());
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(document.body.textContent).toContain(patch === 'drain' ? 'drain failed' : 'save failed');
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }));
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    fireEvent.click(screen.getByRole('button', { name: /agents\.detail\.systemPromptCount/ }));
+    expect(screen.getByDisplayValue('saved prompt')).toBeTruthy();
+  });
+
   it.each(['model', 'effort'] as const)('restores the authoritative value after a failed %s mutation', async (field) => {
     const initial = {
       ...brief('agent-a', 'description'),
@@ -898,6 +990,59 @@ describe('AgentsPage reconnect reconciliation', () => {
     act(() => reconnect.resolve(result(2)));
     await waitFor(() => expect(screen.getByText('agents.onboarding.privateCount:{"count":2}')).toBeTruthy());
     expect(screen.queryByText('agents.onboarding.privateCount:{"count":99}')).toBeNull();
+  });
+
+  it('keeps onboarding submission locked until its settlement inventory publishes', async () => {
+    const agent = brief('agent-a', 'agent description');
+    const settlement = deferred<ReturnType<typeof onboardingResult>>();
+    const onboardingResult = (notOnboarded: number) => ({
+      ok: true,
+      available: true,
+      organization_id: 'org-1',
+      agents: [],
+      counts: { total: 1, system: 0, custom: 1, not_onboarded: notOnboarded, private: 0, published: 0, conflicts: 0 },
+    });
+    const getVibeAgentOnboarding = vi.fn()
+      .mockResolvedValueOnce(onboardingResult(1))
+      .mockReturnValueOnce(settlement.promise);
+    const onboardVibeAgents = vi.fn().mockResolvedValue({ ok: true, created: 1 });
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agent)), vi.fn().mockResolvedValue(fullAgent(agent, 'prompt')), getVibeAgentOnboarding, onboardVibeAgents);
+    renderPage(api, { canManageAgents: true });
+
+    const button = await screen.findByRole('button', { name: 'agents.onboarding.onboardPrivate' });
+    fireEvent.click(button);
+    await waitFor(() => expect(onboardVibeAgents).toHaveBeenCalledTimes(1));
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(button);
+    expect(onboardVibeAgents).toHaveBeenCalledTimes(1);
+
+    act(() => settlement.resolve(onboardingResult(0)));
+    await waitFor(() => expect((screen.getByRole('button', { name: 'agents.onboarding.onboarded' }) as HTMLButtonElement).disabled).toBe(true));
+  });
+
+  it('does not re-enable stale onboarding inventory after settlement failure', async () => {
+    const agent = brief('agent-a', 'agent description');
+    const settlement = deferred<ReturnType<typeof onboardingResult>>();
+    const onboardingResult = (notOnboarded: number) => ({
+      ok: true,
+      available: true,
+      organization_id: 'org-1',
+      agents: [],
+      counts: { total: 1, system: 0, custom: 1, not_onboarded: notOnboarded, private: 0, published: 0, conflicts: 0 },
+    });
+    const getVibeAgentOnboarding = vi.fn()
+      .mockResolvedValueOnce(onboardingResult(1))
+      .mockReturnValueOnce(settlement.promise);
+    const onboardVibeAgents = vi.fn().mockResolvedValue({ ok: true, created: 1 });
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agent)), vi.fn().mockResolvedValue(fullAgent(agent, 'prompt')), getVibeAgentOnboarding, onboardVibeAgents);
+    renderPage(api, { canManageAgents: true });
+
+    const button = await screen.findByRole('button', { name: 'agents.onboarding.onboardPrivate' });
+    fireEvent.click(button);
+    await waitFor(() => expect(onboardVibeAgents).toHaveBeenCalledTimes(1));
+    act(() => settlement.reject(new Error('inventory unavailable')));
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'agents.onboarding.onboardPrivate' })).toBeNull());
+    expect(onboardVibeAgents).toHaveBeenCalledTimes(1);
   });
 
   it('does not drain a non-selected mutation and retires it before returning to that agent', async () => {
@@ -1331,5 +1476,114 @@ describe('AgentsPage reconnect reconciliation', () => {
     fireEvent.click(screen.getByRole('button', { name: 'agents.detail.systemPromptExpand' }));
     await waitFor(() => expect(screen.getByDisplayValue('latest server prompt')).toBeTruthy());
     expect(modal).not.toBeNull();
+  });
+
+  it.each([
+    { label: 'rejected expected disappearance', reject: true },
+    { label: 'ok-false expected disappearance', reject: false },
+  ])('continues the same catch-up edge to accepted A after B $label', async ({ reject }) => {
+    const agentA = brief('agent-a', 'A before gap');
+    const agentB = brief('agent-b', 'B');
+    const preGapB = deferred<ReturnType<typeof fullAgent>>();
+    const catchupA = fullAgent({ ...agentA, description: 'A changed during gap' }, 'A changed prompt');
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+      .mockReturnValueOnce(preGapB.promise)
+      .mockImplementationOnce(() =>
+        reject
+          ? Promise.reject({ code: 'agent_not_found', message: 'B disappeared' })
+          : Promise.resolve({ ok: false, code: 'agent_not_found', message: 'B disappeared' }),
+      )
+      .mockResolvedValueOnce(catchupA);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult([agentA, agentB])), getVibeAgent);
+    renderPage(api);
+
+    await waitFor(() => expect(screen.getByDisplayValue('A before gap')).toBeTruthy());
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(screen.getByDisplayValue('A changed during gap')).toBeTruthy());
+    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-b', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
+    expect(getVibeAgent).toHaveBeenNthCalledWith(4, 'agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
+
+    act(() => preGapB.resolve(fullAgent(agentB, 'stale B')));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByDisplayValue('A changed during gap')).toBeTruthy();
+    expect(getVibeAgent.mock.calls.slice(3).some(([name]) => name === 'agent-b')).toBe(false);
+  });
+
+  it('does not retry a failed resumed A until the next reconnect edge', async () => {
+    const agentA = brief('agent-a', 'A before gap');
+    const agentB = brief('agent-b', 'B');
+    const preGapB = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+      .mockReturnValueOnce(preGapB.promise)
+      .mockRejectedValueOnce({ code: 'agent_not_found', message: 'B disappeared' })
+      .mockRejectedValueOnce({ code: 'agent_backend_unavailable', message: 'A unavailable' })
+      .mockResolvedValueOnce(fullAgent({ ...agentA, description: 'A after next gap' }, 'A recovered'));
+    const api = makeApi(vi.fn().mockResolvedValue(listResult([agentA, agentB])), getVibeAgent);
+    renderPage(api);
+
+    await waitFor(() => expect(screen.getByDisplayValue('A before gap')).toBeTruthy());
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(4));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(getVibeAgent).toHaveBeenCalledTimes(4);
+
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(screen.getByDisplayValue('A after next gap')).toBeTruthy());
+    expect(getVibeAgent).toHaveBeenNthCalledWith(5, 'agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
+  });
+
+  it('does not resume A when a newer C intent wins during the B catch-up read', async () => {
+    const agentA = brief('agent-a', 'A');
+    const agentB = brief('agent-b', 'B');
+    const agentC = brief('agent-c', 'C');
+    const preGapB = deferred<ReturnType<typeof fullAgent>>();
+    const catchupB = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+      .mockReturnValueOnce(preGapB.promise)
+      .mockReturnValueOnce(catchupB.promise)
+      .mockResolvedValueOnce(fullAgent(agentC, 'C current'));
+    const api = makeApi(vi.fn().mockResolvedValue(listResult([agentA, agentB, agentC])), getVibeAgent);
+    renderPage(api);
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+
+    fireEvent.click(screen.getByText('agent-c').closest('button')!);
+    await waitFor(() => expect(screen.getByDisplayValue('C')).toBeTruthy());
+    act(() => catchupB.reject({ code: 'agent_not_found', message: 'B disappeared' }));
+    act(() => preGapB.resolve(fullAgent(agentB, 'stale B')));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByDisplayValue('C')).toBeTruthy();
+    expect(getVibeAgent.mock.calls.slice(3).some(([name]) => name === 'agent-a')).toBe(false);
   });
 });

--- a/ui/src/components/workbench/AgentsPage.test.tsx
+++ b/ui/src/components/workbench/AgentsPage.test.tsx
@@ -268,6 +268,44 @@ describe('AgentsPage reconnect reconciliation', () => {
     expect(secondRow).not.toBeNull();
     fireEvent.click(secondRow!);
     await waitFor(() => expect(screen.getByDisplayValue('another agent')).toBeTruthy());
+    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-b', { cache: false });
+    expect(api.connectWorkbenchEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets a pending B selection outrank a reconnect read for accepted A', async () => {
+    const agentA = brief('agent-a', 'A');
+    const agentB = brief('agent-b', 'B');
+    const pendingB = deferred<ReturnType<typeof fullAgent>>();
+    const pendingReconnectA = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+      .mockReturnValueOnce(pendingB.promise)
+      .mockReturnValueOnce(pendingReconnectA.promise);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult([agentA, agentB])), getVibeAgent);
+    renderPage(api);
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+    expect(getVibeAgent).toHaveBeenNthCalledWith(2, 'agent-b', { cache: false });
+    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
+
+    act(() => pendingReconnectA.resolve(fullAgent({ ...agentA, description: 'A refreshed' }, 'A reconnect')));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getAllByText('agent-a').length).toBeGreaterThan(1);
+    expect(screen.queryByDisplayValue('A refreshed')).toBeNull();
+
+    act(() => pendingB.resolve(fullAgent(agentB, 'B selected')));
+    await waitFor(() => expect(screen.getByDisplayValue('B')).toBeTruthy());
     expect(api.connectWorkbenchEvents).toHaveBeenCalledTimes(1);
   });
 
@@ -276,10 +314,12 @@ describe('AgentsPage reconnect reconciliation', () => {
     const server = { ...initial, description: 'server description', model: 'server-model' };
     const patchResult = fullAgent({ ...initial, description: 'local patch', model: 'patched-model' }, 'patched prompt');
     const staleRead = deferred<ReturnType<typeof fullAgent>>();
+    const drainRead = deferred<ReturnType<typeof fullAgent>>();
     const patch = deferred<ReturnType<typeof fullAgent>>();
     const getVibeAgent = vi.fn()
       .mockResolvedValueOnce(fullAgent(initial, 'before prompt'))
-      .mockReturnValueOnce(staleRead.promise);
+      .mockReturnValueOnce(staleRead.promise)
+      .mockReturnValueOnce(drainRead.promise);
     const listVibeAgents = vi.fn().mockResolvedValue(listResult(server));
     const updateVibeAgent = vi.fn().mockReturnValue(patch.promise);
     const api = makeApi(listVibeAgents, getVibeAgent, undefined, undefined, updateVibeAgent);
@@ -295,6 +335,12 @@ describe('AgentsPage reconnect reconciliation', () => {
     await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledWith('agent-a', { description: 'local patch' }));
     act(() => patch.resolve(patchResult));
     await waitFor(() => expect(screen.getByDisplayValue('local patch')).toBeTruthy());
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
+    expect(screen.getByRole('combobox', { hidden: true }).textContent).toContain('old-model');
 
     act(() => staleRead.resolve(fullAgent(initial, 'stale reconnect prompt')));
     await act(async () => {
@@ -303,6 +349,10 @@ describe('AgentsPage reconnect reconciliation', () => {
     });
     expect(screen.getByDisplayValue('local patch')).toBeTruthy();
     expect(screen.queryByDisplayValue('server description')).toBeNull();
+
+    act(() => drainRead.resolve(fullAgent(server, 'authoritative prompt')));
+    await waitFor(() => expect(screen.getByRole('combobox', { hidden: true }).textContent).toContain('server-model'));
+    expect(screen.getByDisplayValue('local patch')).toBeTruthy();
   });
 
   it('uses operation epochs to suppress an old A -> B -> A selection response', async () => {
@@ -340,6 +390,51 @@ describe('AgentsPage reconnect reconciliation', () => {
 
     act(() => readAAgain.resolve(fullAgent({ ...agentA, description: 'A after ABA' }, 'new A response')));
     await waitFor(() => expect(screen.getByDisplayValue('A after ABA')).toBeTruthy());
+    expect(getVibeAgent).toHaveBeenNthCalledWith(2, 'agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
+    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-b', { cache: false });
+    expect(getVibeAgent).toHaveBeenNthCalledWith(4, 'agent-a', { cache: false });
+  });
+
+  it('treats concurrent PATCH responses as acknowledgements and drains once', async () => {
+    const initial = { ...brief('agent-a', 'base description'), model: 'base-model', enabled: true };
+    const patchOne = deferred<ReturnType<typeof fullAgent>>();
+    const patchTwo = deferred<ReturnType<typeof fullAgent>>();
+    const drain = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(initial, 'base prompt'))
+      .mockReturnValueOnce(drain.promise);
+    const updateVibeAgent = vi.fn()
+      .mockReturnValueOnce(patchOne.promise)
+      .mockReturnValueOnce(patchTwo.promise);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(initial)), getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('base description')).toBeTruthy());
+    fireEvent.change(screen.getByDisplayValue('base description'), { target: { value: 'local description' } });
+    fireEvent.blur(screen.getByDisplayValue('local description'));
+    fireEvent.click(screen.getByRole('switch'));
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledTimes(2));
+
+    act(() => patchTwo.resolve(fullAgent({ ...initial, description: 'wrong second', enabled: false }, 'wrong second prompt')));
+    act(() => patchOne.resolve(fullAgent({ ...initial, description: 'wrong first', enabled: true }, 'wrong first prompt')));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    expect(screen.queryByDisplayValue('wrong first prompt')).toBeNull();
+    expect(screen.queryByDisplayValue('wrong second prompt')).toBeNull();
+    expect(getVibeAgent).toHaveBeenNthCalledWith(2, 'agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
+    });
+    fireEvent.click(screen.getByText('agents.detail.systemPrompt').closest('button')!);
+    expect(screen.getByDisplayValue('base prompt')).toBeTruthy();
+
+    act(() => drain.resolve(fullAgent({ ...initial, description: 'final description', enabled: false }, 'final prompt')));
+    await waitFor(() => expect(screen.getByDisplayValue('local description')).toBeTruthy());
+    await waitFor(() => expect(screen.getByDisplayValue('final prompt')).toBeTruthy());
+    expect(getVibeAgent).toHaveBeenCalledTimes(2);
+    expect(api.connectWorkbenchEvents).toHaveBeenCalledTimes(1);
   });
 
   it('preserves dirty drafts while clean detail fields adopt a same-agent snapshot', async () => {

--- a/ui/src/components/workbench/AgentsPage.test.tsx
+++ b/ui/src/components/workbench/AgentsPage.test.tsx
@@ -16,6 +16,7 @@ type FakeApi = {
   getVibeAgentOnboarding: ReturnType<typeof vi.fn>;
   onboardVibeAgents: ReturnType<typeof vi.fn>;
   updateVibeAgent: ReturnType<typeof vi.fn>;
+  removeVibeAgent: ReturnType<typeof vi.fn>;
   getRunningAgents: ReturnType<typeof vi.fn>;
   connectWorkbenchEvents: ReturnType<typeof vi.fn>;
 };
@@ -79,10 +80,12 @@ const fullAgent = (briefAgent: VibeAgentBrief, systemPrompt: string) => ({
 
 const deferred = <T,>() => {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((next) => {
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((next, fail) => {
     resolve = next;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 };
 
 function makeApi(
@@ -91,6 +94,7 @@ function makeApi(
   getVibeAgentOnboarding: FakeApi['getVibeAgentOnboarding'] = vi.fn().mockResolvedValue({ available: false }),
   onboardVibeAgents: FakeApi['onboardVibeAgents'] = vi.fn().mockResolvedValue({ available: false }),
   updateVibeAgent: FakeApi['updateVibeAgent'] = vi.fn().mockResolvedValue({ ok: false }),
+  removeVibeAgent: FakeApi['removeVibeAgent'] = vi.fn().mockResolvedValue({ ok: true }),
 ): FakeApi {
   return {
     listVibeAgents,
@@ -98,6 +102,7 @@ function makeApi(
     getVibeAgentOnboarding,
     onboardVibeAgents,
     updateVibeAgent,
+    removeVibeAgent,
     getRunningAgents: vi.fn().mockResolvedValue({ ok: true, counts: { total: 2 } }),
     connectWorkbenchEvents: vi.fn((next: WorkbenchEventHandlers) => {
       handlers = next;
@@ -119,17 +124,22 @@ function renderPage(
     remote = false,
     instanceKind = null,
     instanceRole = 'owner' as InstanceRole,
-    capabilities = { ...OWNER_INSTANCE_CAPABILITIES, can_manage_agents: false },
+    canManageAgents = false,
+    capabilities,
   }: {
     remote?: boolean;
     instanceKind?: 'organization' | 'personal' | null;
     instanceRole?: InstanceRole;
+    canManageAgents?: boolean;
     capabilities?: InstanceCapabilities;
   } = {},
 ) {
   apiRef.current = api;
+  const effectiveCapabilities = capabilities ?? { ...OWNER_INSTANCE_CAPABILITIES, can_manage_agents: canManageAgents };
   return render(
-    <InstanceAuthorizationContext.Provider value={{ remote, instanceKind, instanceRole, capabilities }}>
+    <InstanceAuthorizationContext.Provider
+      value={{ remote, instanceKind, instanceRole, capabilities: effectiveCapabilities }}
+    >
       <MemoryRouter initialEntries={['/agents']}>
         <AgentsPage />
       </MemoryRouter>
@@ -139,6 +149,7 @@ function renderPage(
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   apiRef.current = null;
   handlers = null;
   showToast.mockReset();
@@ -258,6 +269,8 @@ describe('AgentsPage reconnect reconciliation', () => {
 
     act(() => handlers?.onConnected?.());
     await waitFor(() => expect(screen.getByDisplayValue('after gap')).toBeTruthy());
+    fireEvent.click(screen.getByText('agents.detail.systemPrompt').closest('button')!);
+    expect(screen.getByDisplayValue('after prompt')).toBeTruthy();
     expect(getVibeAgent).toHaveBeenNthCalledWith(2, 'agent-a', {
       cache: false,
       expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
@@ -272,15 +285,15 @@ describe('AgentsPage reconnect reconciliation', () => {
     expect(api.connectWorkbenchEvents).toHaveBeenCalledTimes(1);
   });
 
-  it('lets a pending B selection outrank a reconnect read for accepted A', async () => {
+  it('reissues the pending B selection at reconnect and suppresses the pre-gap B response', async () => {
     const agentA = brief('agent-a', 'A');
     const agentB = brief('agent-b', 'B');
-    const pendingB = deferred<ReturnType<typeof fullAgent>>();
-    const pendingReconnectA = deferred<ReturnType<typeof fullAgent>>();
+    const oldB = deferred<ReturnType<typeof fullAgent>>();
+    const freshB = deferred<ReturnType<typeof fullAgent>>();
     const getVibeAgent = vi.fn()
       .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
-      .mockReturnValueOnce(pendingB.promise)
-      .mockReturnValueOnce(pendingReconnectA.promise);
+      .mockReturnValueOnce(oldB.promise)
+      .mockReturnValueOnce(freshB.promise);
     const api = makeApi(vi.fn().mockResolvedValue(listResult([agentA, agentB])), getVibeAgent);
     renderPage(api);
 
@@ -291,20 +304,20 @@ describe('AgentsPage reconnect reconciliation', () => {
     act(() => handlers?.onConnected?.());
     await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
     expect(getVibeAgent).toHaveBeenNthCalledWith(2, 'agent-b', { cache: false });
-    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-a', {
+    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-b', {
       cache: false,
       expectedCodes: ['agent_not_found', 'agent_access_forbidden'],
     });
 
-    act(() => pendingReconnectA.resolve(fullAgent({ ...agentA, description: 'A refreshed' }, 'A reconnect')));
+    act(() => oldB.resolve(fullAgent({ ...agentB, description: 'old B' }, 'old B response')));
     await act(async () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(screen.getAllByText('agent-a').length).toBeGreaterThan(1);
-    expect(screen.queryByDisplayValue('A refreshed')).toBeNull();
+    expect(screen.getByDisplayValue('A')).toBeTruthy();
+    expect(screen.queryByDisplayValue('old B')).toBeNull();
 
-    act(() => pendingB.resolve(fullAgent(agentB, 'B selected')));
+    act(() => freshB.resolve(fullAgent(agentB, 'B selected')));
     await waitFor(() => expect(screen.getByDisplayValue('B')).toBeTruthy());
     expect(api.connectWorkbenchEvents).toHaveBeenCalledTimes(1);
   });
@@ -398,6 +411,73 @@ describe('AgentsPage reconnect reconciliation', () => {
     expect(getVibeAgent).toHaveBeenNthCalledWith(4, 'agent-a', { cache: false });
   });
 
+  it('keeps the current selection intent when DELETE fails', async () => {
+    const agent = brief('agent-a', 'A');
+    const reconnect = deferred<ReturnType<typeof fullAgent>>();
+    const removeVibeAgent = vi.fn().mockResolvedValue({ ok: false, message: 'delete rejected' });
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agent, 'initial'))
+      .mockReturnValueOnce(reconnect.promise);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agent)), getVibeAgent, undefined, undefined, undefined, removeVibeAgent);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'common.delete' }));
+    await waitFor(() => expect(removeVibeAgent).toHaveBeenCalledWith('agent-a'));
+    expect(screen.getByDisplayValue('A')).toBeTruthy();
+
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    act(() => reconnect.resolve(fullAgent({ ...agent, description: 'A refreshed' }, 'reconciled')));
+    await waitFor(() => expect(screen.getByDisplayValue('A refreshed')).toBeTruthy());
+  });
+
+  it('does not let successful DELETE cancel a newer pending selection', async () => {
+    const agentA = brief('agent-a', 'A');
+    const agentB = brief('agent-b', 'B');
+    const pendingB = deferred<ReturnType<typeof fullAgent>>();
+    const removeVibeAgent = vi.fn().mockResolvedValue({ ok: true });
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+      .mockReturnValueOnce(pendingB.promise);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult([agentA, agentB])), getVibeAgent, undefined, undefined, undefined, removeVibeAgent);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    fireEvent.click(screen.getByRole('button', { name: 'common.delete' }));
+    await waitFor(() => expect(removeVibeAgent).toHaveBeenCalledWith('agent-a'));
+    act(() => pendingB.resolve(fullAgent(agentB, 'B selected')));
+    await waitFor(() => expect(screen.getByDisplayValue('B')).toBeTruthy());
+    expect(screen.queryByDisplayValue('A initial')).toBeNull();
+  });
+
+  it('rolls a failed current selection back to the accepted Agent', async () => {
+    const agentA = brief('agent-a', 'A');
+    const agentB = brief('agent-b', 'B');
+    const failedB = deferred<ReturnType<typeof fullAgent>>();
+    const reconnectA = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+      .mockReturnValueOnce(failedB.promise)
+      .mockReturnValueOnce(reconnectA.promise);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult([agentA, agentB])), getVibeAgent);
+    renderPage(api);
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    act(() => failedB.reject({ code: 'agent_backend_unavailable', message: 'B unavailable' }));
+    await waitFor(() => expect(screen.getByText('B unavailable')).toBeTruthy());
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+    act(() => reconnectA.resolve(fullAgent({ ...agentA, description: 'A after rollback' }, 'A reconciled')));
+    await waitFor(() => expect(screen.getByDisplayValue('A after rollback')).toBeTruthy());
+  });
+
   it('treats concurrent PATCH responses as acknowledgements and drains once', async () => {
     const initial = { ...brief('agent-a', 'base description'), model: 'base-model', enabled: true };
     const patchOne = deferred<ReturnType<typeof fullAgent>>();
@@ -437,6 +517,52 @@ describe('AgentsPage reconnect reconciliation', () => {
     expect(api.connectWorkbenchEvents).toHaveBeenCalledTimes(1);
   });
 
+  it('lets the post-batch read win across an A -> B -> A selection race', async () => {
+    const agentA = { ...brief('agent-a', 'A'), model: 'base-model' };
+    const agentB = brief('agent-b', 'B');
+    const patch = deferred<ReturnType<typeof fullAgent>>();
+    const oldB = deferred<ReturnType<typeof fullAgent>>();
+    const oldA = deferred<ReturnType<typeof fullAgent>>();
+    const drain = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+      .mockReturnValueOnce(oldB.promise)
+      .mockReturnValueOnce(oldA.promise)
+      .mockReturnValueOnce(drain.promise);
+    const updateVibeAgent = vi.fn().mockReturnValue(patch.promise);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult([agentA, agentB])), getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    fireEvent.change(screen.getByDisplayValue('A'), { target: { value: 'local A' } });
+    fireEvent.blur(screen.getByDisplayValue('local A'));
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    const rowA = screen.getAllByText('agent-a').find((node) => node.closest('button'))?.closest('button');
+    expect(rowA).not.toBeNull();
+    fireEvent.click(rowA!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+
+    act(() => patch.resolve(fullAgent({ ...agentA, description: 'wrong patch response' }, 'wrong patch prompt')));
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(4));
+    act(() => oldB.resolve(fullAgent(agentB, 'old B')));
+    act(() => oldA.resolve(fullAgent({ ...agentA, description: 'old A' }, 'old A')));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.queryByDisplayValue('old A')).toBeNull();
+
+    act(() => drain.resolve(fullAgent({ ...agentA, description: 'final A' }, 'final prompt')));
+    await waitFor(() => expect(screen.getByText('agents.detail.systemPrompt').closest('button')).toBeTruthy());
+    fireEvent.click(screen.getByText('agents.detail.systemPrompt').closest('button')!);
+    await waitFor(() => expect(screen.getByDisplayValue('final prompt')).toBeTruthy());
+    expect(screen.getByDisplayValue('local A')).toBeTruthy();
+    expect(getVibeAgent).toHaveBeenCalledTimes(4);
+  });
+
   it('preserves dirty drafts while clean detail fields adopt a same-agent snapshot', async () => {
     const initial = { ...brief('agent-a', 'clean description'), model: 'old-model' };
     const changed = { ...initial, description: 'server description', model: 'new-model' };
@@ -471,11 +597,70 @@ describe('AgentsPage reconnect reconciliation', () => {
     expect(screen.getByText('agents.detail.systemPromptEditorHint')).toBeTruthy();
   });
 
+  it('canonicalizes trimmed description and inline prompt saves', async () => {
+    const initial = brief('agent-a', 'before');
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(initial, 'old prompt'))
+      .mockResolvedValueOnce(fullAgent({ ...initial, description: 'canonical description' }, 'old prompt'))
+      .mockResolvedValueOnce(fullAgent({ ...initial, description: 'canonical description' }, 'canonical prompt'))
+      .mockResolvedValueOnce(fullAgent({ ...initial, description: 'external description' }, 'external prompt'));
+    const updateVibeAgent = vi.fn().mockResolvedValue({ ok: true, agent: fullAgent(initial, 'ack').agent });
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(initial)), getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('before')).toBeTruthy());
+    const description = screen.getByDisplayValue('before');
+    fireEvent.change(description, { target: { value: '  canonical description  ' } });
+    fireEvent.blur(description);
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledWith('agent-a', { description: 'canonical description' }));
+    expect(screen.getByDisplayValue('canonical description')).toBeTruthy();
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+
+    fireEvent.click(screen.getByText('agents.detail.systemPrompt').closest('button')!);
+    const inlinePrompt = screen.getByPlaceholderText('agents.create.systemPromptPlaceholder');
+    fireEvent.change(inlinePrompt, { target: { value: '  canonical prompt  ' } });
+    fireEvent.blur(inlinePrompt);
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledWith('agent-a', { system_prompt: 'canonical prompt' }));
+    expect(screen.getByDisplayValue('canonical prompt')).toBeTruthy();
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(screen.getByDisplayValue('external description')).toBeTruthy());
+    expect(screen.getByDisplayValue('external description')).toBeTruthy();
+  });
+
+  it('reseeds an untouched open prompt editor but preserves an edited modal draft', async () => {
+    const initial = brief('agent-a', 'description');
+    const changed = { ...initial, description: 'description', model: 'new-model' };
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(initial, 'old prompt'))
+      .mockResolvedValueOnce(fullAgent(changed, 'new prompt'))
+      .mockResolvedValueOnce(fullAgent({ ...changed, description: 'description 2' }, 'latest prompt'))
+      .mockResolvedValueOnce(fullAgent({ ...changed, description: 'description 3' }, 'reconciled prompt'));
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(initial)), getVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('description')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'agents.detail.systemPromptExpand' }));
+    await waitFor(() => expect(screen.getAllByDisplayValue('old prompt').length).toBeGreaterThan(0));
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(screen.getByDisplayValue('new prompt')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }));
+    fireEvent.click(screen.getByRole('button', { name: 'agents.detail.systemPromptExpand' }));
+    await waitFor(() => expect(screen.getByDisplayValue('new prompt')).toBeTruthy());
+
+    const modalPrompt = screen.getAllByPlaceholderText('agents.create.systemPromptPlaceholder').at(-1)!;
+    fireEvent.change(modalPrompt, { target: { value: 'edited modal draft' } });
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(screen.getByDisplayValue('edited modal draft')).toBeTruthy());
+  });
+
   it('orders onboarding reads around a mutation and ignores stale results', async () => {
     const agent = brief('agent-a', 'agent description');
     const initial = deferred<ReturnType<typeof onboardingResult>>();
     const reconnect = deferred<ReturnType<typeof onboardingResult>>();
-    const overlap = deferred<ReturnType<typeof onboardingResult>>();
+    const gapAfterMutation = deferred<ReturnType<typeof onboardingResult>>();
+    const settlement = deferred<ReturnType<typeof onboardingResult>>();
     const onboardingResult = (notOnboarded: number, privateCount: number) => ({
       ok: true,
       available: true,
@@ -483,16 +668,17 @@ describe('AgentsPage reconnect reconciliation', () => {
       agents: [],
       counts: { total: 1, system: 0, custom: 1, not_onboarded: notOnboarded, private: privateCount, published: 0, conflicts: 0 },
     });
-    const mutation = deferred<ReturnType<typeof onboardingResult>>();
     const getVibeAgentOnboarding = vi.fn()
       .mockReturnValueOnce(initial.promise)
       .mockReturnValueOnce(reconnect.promise)
-      .mockReturnValueOnce(overlap.promise);
+      .mockReturnValueOnce(gapAfterMutation.promise)
+      .mockReturnValueOnce(settlement.promise);
+    const post = deferred<ReturnType<typeof onboardingResult>>();
     const api = makeApi(
       vi.fn().mockResolvedValue(listResult(agent)),
       vi.fn().mockResolvedValue({ ok: false }),
       getVibeAgentOnboarding,
-      vi.fn().mockReturnValue(mutation.promise),
+      vi.fn().mockReturnValue(post.promise),
     );
     renderPage(api, { canManageAgents: true });
     await waitFor(() => expect(handlers).not.toBeNull());
@@ -511,14 +697,182 @@ describe('AgentsPage reconnect reconciliation', () => {
     await waitFor(() => expect(api.onboardVibeAgents).toHaveBeenCalledTimes(1));
     act(() => handlers?.onConnected?.());
     await waitFor(() => expect(getVibeAgentOnboarding).toHaveBeenCalledTimes(3));
-    act(() => mutation.resolve(onboardingResult(0, 1)));
-    await waitFor(() => expect(screen.getByText('agents.onboarding.notOnboardedCount:{"count":0}')).toBeTruthy());
-    act(() => overlap.resolve(onboardingResult(1, 0)));
+    act(() => gapAfterMutation.resolve(onboardingResult(0, 3)));
+    await waitFor(() => expect(screen.getByText('agents.onboarding.privateCount:{"count":3}')).toBeTruthy());
+    act(() => post.resolve(onboardingResult(0, 99)));
+    act(() => settlement.resolve(onboardingResult(1, 2)));
     await act(async () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(screen.getByText('agents.onboarding.notOnboardedCount:{"count":0}')).toBeTruthy();
+    await waitFor(() => expect(screen.getByText('agents.onboarding.notOnboardedCount:{"count":1}')).toBeTruthy());
+    expect(screen.getByText('agents.onboarding.privateCount:{"count":2}')).toBeTruthy();
+    expect(getVibeAgentOnboarding).toHaveBeenCalledTimes(4);
+  });
+
+  it('keeps a newer reconnect onboarding snapshot over a settled mutation read', async () => {
+    const agent = brief('agent-a', 'agent description');
+    const settlement = deferred<{ available: boolean; counts: Record<string, number> }>();
+    const reconnect = deferred<{ available: boolean; counts: Record<string, number> }>();
+    const result = (privateCount: number) => ({
+      ok: true,
+      available: true,
+      organization_id: 'org-1',
+      agents: [],
+      counts: { total: 1, system: 0, custom: 1, not_onboarded: 1, private: privateCount, published: 0, conflicts: 0 },
+    });
+    const getVibeAgentOnboarding = vi.fn()
+      .mockResolvedValueOnce(result(0))
+      .mockReturnValueOnce(settlement.promise)
+      .mockReturnValueOnce(reconnect.promise);
+    const post = vi.fn().mockResolvedValue(result(99));
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agent)), vi.fn().mockResolvedValue({ ok: false }), getVibeAgentOnboarding, post);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByText('agents.onboarding.privateCount:{"count":0}')).toBeTruthy());
+    fireEvent.click(screen.getByText('agents.onboarding.onboardPrivate'));
+    await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(getVibeAgentOnboarding).toHaveBeenCalledTimes(3));
+    act(() => settlement.resolve(result(1)));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText('agents.onboarding.privateCount:{"count":0}')).toBeTruthy();
+    act(() => reconnect.resolve(result(2)));
+    await waitFor(() => expect(screen.getByText('agents.onboarding.privateCount:{"count":2}')).toBeTruthy());
+    expect(screen.queryByText('agents.onboarding.privateCount:{"count":99}')).toBeNull();
+  });
+
+  it('does not drain a non-selected mutation and retires it before returning to that agent', async () => {
+    const agentA = { ...brief('agent-a', 'A'), model: 'a-model' };
+    const agentB = brief('agent-b', 'B');
+    const pendingB = deferred<ReturnType<typeof fullAgent>>();
+    const finalA = fullAgent({ ...agentA, description: 'A after return' }, 'A after return');
+    const patch = deferred<ReturnType<typeof fullAgent>>();
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+      .mockReturnValueOnce(pendingB.promise)
+      .mockResolvedValueOnce(finalA);
+    const listVibeAgents = vi.fn().mockResolvedValue(listResult([agentA, agentB]));
+    const updateVibeAgent = vi.fn().mockReturnValue(patch.promise);
+    const api = makeApi(listVibeAgents, getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    fireEvent.change(screen.getByDisplayValue('A'), { target: { value: 'A local' } });
+    fireEvent.blur(screen.getByDisplayValue('A local'));
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    act(() => patch.resolve(fullAgent({ ...agentA, description: 'A local' }, 'A ack')));
+    await waitFor(() => expect(listVibeAgents).toHaveBeenCalledTimes(2));
+    expect(getVibeAgent).toHaveBeenCalledTimes(2);
+
+    act(() => pendingB.resolve(fullAgent(agentB, 'B selected')));
+    await waitFor(() => expect(screen.getByDisplayValue('B')).toBeTruthy());
+    const rowA = screen.getAllByText('agent-a').find((node) => node.closest('button'))?.closest('button');
+    expect(rowA).not.toBeNull();
+    fireEvent.click(rowA!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(3));
+    await waitFor(() => expect(screen.getByDisplayValue('A after return')).toBeTruthy());
+    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-a', { cache: false });
+  });
+
+  it.each([
+    { label: 'thrown failure', reject: true },
+    { label: 'HTTP ok false', reject: false },
+  ])('keeps a non-selected mutation $label visible after Definitions refresh', async ({ reject }) => {
+    const agentA = brief('agent-a', 'A');
+    const agentB = brief('agent-b', 'B');
+    const pendingB = deferred<ReturnType<typeof fullAgent>>();
+    const patch = deferred<unknown>();
+    const finalA = fullAgent({ ...agentA, description: 'A after failed return' }, 'A after failed return');
+    const getVibeAgent = vi.fn()
+      .mockResolvedValueOnce(fullAgent(agentA, 'A initial'))
+      .mockReturnValueOnce(pendingB.promise)
+      .mockResolvedValueOnce(finalA);
+    const updateVibeAgent = vi.fn().mockReturnValue(patch.promise);
+    const api = makeApi(
+      vi.fn().mockResolvedValue(listResult([agentA, agentB])),
+      getVibeAgent,
+      undefined,
+      undefined,
+      updateVibeAgent,
+    );
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    fireEvent.change(screen.getByDisplayValue('A'), { target: { value: 'A local' } });
+    fireEvent.blur(screen.getByDisplayValue('A local'));
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByText('agent-b').closest('button')!);
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+
+    if (reject) {
+      act(() => patch.reject({ message: 'A mutation failed' }));
+    } else {
+      act(() => patch.resolve({ ok: false, message: 'A mutation failed' }));
+    }
+    await waitFor(() => expect(screen.getByText('A mutation failed')).toBeTruthy());
+    act(() => pendingB.resolve(fullAgent(agentB, 'B selected')));
+    await waitFor(() => expect(screen.getByDisplayValue('B')).toBeTruthy());
+    expect(screen.getByText('A mutation failed')).toBeTruthy();
+    fireEvent.click(screen.getByText('agent-a').closest('button')!);
+    await waitFor(() => expect(screen.getByDisplayValue('A after failed return')).toBeTruthy());
+    expect(getVibeAgent).toHaveBeenNthCalledWith(3, 'agent-a', { cache: false });
+  });
+
+  it.each([
+    { label: 'thrown failure', reject: true },
+    { label: 'HTTP ok false', reject: false },
+  ])('keeps a current mutation $label visible through its drain and Definitions refresh', async ({ reject }) => {
+    const agentA = brief('agent-a', 'A');
+    const drain = deferred<ReturnType<typeof fullAgent>>();
+    const patch = deferred<unknown>();
+    const getVibeAgent = vi.fn().mockResolvedValueOnce(fullAgent(agentA, 'A initial')).mockReturnValueOnce(drain.promise);
+    const updateVibeAgent = vi.fn().mockReturnValue(patch.promise);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agentA)), getVibeAgent, undefined, undefined, updateVibeAgent);
+    renderPage(api, { canManageAgents: true });
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    fireEvent.change(screen.getByDisplayValue('A'), { target: { value: 'A local' } });
+    fireEvent.blur(screen.getByDisplayValue('A local'));
+    await waitFor(() => expect(updateVibeAgent).toHaveBeenCalledTimes(1));
+    if (reject) {
+      act(() => patch.reject({ message: 'A mutation failed' }));
+    } else {
+      act(() => patch.resolve({ ok: false, message: 'A mutation failed' }));
+    }
+    await waitFor(() => expect(getVibeAgent).toHaveBeenCalledTimes(2));
+    act(() => drain.resolve(fullAgent({ ...agentA, description: 'A server' }, 'A server prompt')));
+    await waitFor(() => expect(screen.getByText('A mutation failed')).toBeTruthy());
+    expect(screen.getByText('A mutation failed')).toBeTruthy();
+  });
+
+  it.each([
+    {
+      label: 'an ok-false response',
+      response: { ok: false, message: 'server detail rejected' },
+      expected: 'server detail rejected',
+    },
+    {
+      label: 'a mismatched response',
+      response: fullAgent(brief('agent-b', 'B'), 'wrong identity'),
+      expected: 'errorBoundary.title',
+    },
+  ])('rolls back a selected load for $label with a localized fallback', async ({ response, expected }) => {
+    const agentA = brief('agent-a', 'A');
+    const getVibeAgent = vi.fn().mockResolvedValueOnce(fullAgent(agentA, 'A initial')).mockResolvedValueOnce(response);
+    const api = makeApi(vi.fn().mockResolvedValue(listResult(agentA)), getVibeAgent);
+    renderPage(api);
+
+    await waitFor(() => expect(screen.getByDisplayValue('A')).toBeTruthy());
+    act(() => handlers?.onConnected?.());
+    await waitFor(() => expect(screen.getByText(expected)).toBeTruthy());
+    expect(screen.getByDisplayValue('A')).toBeTruthy();
   });
 
   it('silences expected selected disappearance but surfaces unexpected current failures', async () => {

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -120,6 +120,8 @@ type SelectedReadPurpose = 'selection' | 'reconcile' | 'continuation' | 'debt';
 type SelectedReadStage = {
   key: string;
   identity: string;
+  identityEpoch: number;
+  causalFloor: number;
   intentGeneration: number;
   readGeneration: number;
   debtVersion?: number;
@@ -154,6 +156,7 @@ type SelectedCoordinator = {
   desiredName: string | null;
   desiredOpenDetail: boolean;
   desiredSource: 'user' | 'auto' | 'passive';
+  identityEpoch: number;
   intentGeneration: number;
   readGenerations: Map<string, number>;
   accepted: VibeAgentFull | null;
@@ -188,6 +191,7 @@ const createSelectedCoordinator = (): SelectedCoordinator => ({
   desiredName: null,
   desiredOpenDetail: false,
   desiredSource: 'passive',
+  identityEpoch: 0,
   intentGeneration: 0,
   readGenerations: new Map(),
   accepted: null,
@@ -425,6 +429,7 @@ export const AgentsPage: React.FC = () => {
     ((identity: string, options?: {
       expectedCodes?: readonly string[];
       debtOnly?: boolean;
+      causalFloor?: number;
       refreshDefinitions?: boolean;
       rollbackOnFailure?: boolean;
       clearSelectionError?: boolean;
@@ -465,19 +470,19 @@ export const AgentsPage: React.FC = () => {
       options: { auto?: boolean; openDetail?: boolean; source?: 'user' | 'auto' | 'passive' } = {},
     ) => {
       const coordinator = selectedCoordinatorRef.current;
-      if (coordinator.desiredName && coordinator.desiredName !== identity) {
+      const identityChanged = coordinator.desiredName !== identity;
+      if (coordinator.desiredName && identityChanged) {
         releaseSelectedDebtWaiters(coordinator, coordinator.desiredName);
         advanceSelectedRead(coordinator, coordinator.desiredName);
       }
-      if (identity) advanceSelectedRead(coordinator, identity);
+      if (identity && identityChanged) advanceSelectedRead(coordinator, identity);
       if (identity && !options.auto) {
         coordinator.retired.delete(identity);
         coordinator.retiredAtDefinitionsVersion.delete(identity);
         coordinator.autoSelectDismissed = false;
         coordinator.autoSelectReason = null;
       }
-      const debt = identity ? coordinator.reconciliationDebt.get(identity) : null;
-      if (debt) debt.scheduled = false;
+      if (identityChanged) coordinator.identityEpoch += 1;
       coordinator.intentGeneration += 1;
       coordinator.desiredName = identity;
       coordinator.desiredOpenDetail = Boolean(identity && options.openDetail);
@@ -568,6 +573,7 @@ export const AgentsPage: React.FC = () => {
                 clearSelectionError: false,
                 purpose: 'continuation',
                 obligationId: catchUpEpochRef.current || token.version,
+                causalFloor: catchUpEpochRef.current || token.version,
               });
             }
           }
@@ -615,15 +621,13 @@ export const AgentsPage: React.FC = () => {
         waiter.resolve({ ok: false, error: options.cause ?? { code: 'agent_not_found' } });
       }
       if (pendingIdentity) {
-        coordinator.intentGeneration += 1;
         // A pending selection can disappear without invalidating the accepted
         // entity. Keep that accepted entity eligible for reconnect/debt
         // reconciliation instead of leaving visible A with no desired A.
-        coordinator.desiredName = acceptedCanResume ? acceptedIdentity : null;
-        // A vanished pending selection must not transfer its mobile drill-down
-        // request to the fallback identity.
-        coordinator.desiredOpenDetail = false;
-        coordinator.desiredSource = 'passive';
+        beginSelectedIntent(acceptedCanResume ? acceptedIdentity : null, {
+          source: 'passive',
+          openDetail: false,
+        });
       }
       if (coordinator.accepted?.name === identity) {
         coordinator.desiredOpenDetail = false;
@@ -648,7 +652,7 @@ export const AgentsPage: React.FC = () => {
         intentGeneration: coordinator.intentGeneration,
       };
     },
-    [clearResourceError, commitSelected],
+    [beginSelectedIntent, clearResourceError, commitSelected],
   );
   retireSelectedIdentityRef.current = retireSelectedIdentity;
 
@@ -680,6 +684,7 @@ export const AgentsPage: React.FC = () => {
         coordinator.mutations.set(newName, oldBatch);
       }
 
+      coordinator.identityEpoch += 1;
       coordinator.intentGeneration += 1;
       if (desiredMatches) coordinator.desiredName = newName;
       if (acceptedMatches && accepted) {
@@ -693,6 +698,8 @@ export const AgentsPage: React.FC = () => {
   const launchSelectedRead = useCallback(
     async (options: {
       identity: string;
+      identityEpoch: number;
+      causalFloor: number;
       readGeneration: number;
       intentGeneration?: number;
       expectedCodes?: readonly string[];
@@ -705,9 +712,9 @@ export const AgentsPage: React.FC = () => {
       const isCurrent = () =>
         selectedMountedRef.current &&
         selectedReadIsCurrent(coordinator, options.identity, options.readGeneration) &&
+        coordinator.identityEpoch === options.identityEpoch &&
         coordinator.desiredName === options.identity &&
-        !coordinator.retired.has(options.identity) &&
-        (options.intentGeneration === undefined || coordinator.intentGeneration === options.intentGeneration);
+        !coordinator.retired.has(options.identity);
       const finishDebt = (published: boolean, error?: unknown) => {
         if (options.debtVersion === undefined) return;
         const debt = coordinator.reconciliationDebt.get(options.identity);
@@ -786,6 +793,7 @@ export const AgentsPage: React.FC = () => {
       options: {
         expectedCodes?: readonly string[];
         debtOnly?: boolean;
+        causalFloor?: number;
         refreshDefinitions?: boolean;
         rollbackOnFailure?: boolean;
         clearSelectionError?: boolean;
@@ -800,8 +808,14 @@ export const AgentsPage: React.FC = () => {
       const debt = coordinator.reconciliationDebt.get(identity);
       if (options.debtOnly && !debt) return null;
       if (coordinator.mutations.has(identity) && options.debtOnly) return null;
-      const debtVersion = options.debtOnly ? debt?.version : undefined;
-      if (debtVersion !== undefined) debt!.scheduled = true;
+      // A selected-detail stage is the physical producer. Its purpose and
+      // obligation are consumer metadata; the scheduler derives the causal
+      // floor from the current identity debt so a same-agent selection can
+      // join a live debt read instead of creating a debt-blind replacement.
+      const debtVersion = debt?.version;
+      const identityEpoch = coordinator.identityEpoch;
+      const causalFloor = options.causalFloor ?? 0;
+      const currentReadGeneration = coordinator.readGenerations.get(identity) ?? 0;
       const obligationId = options.obligationId ?? ++coordinator.nextObligationId;
       const intentGeneration = coordinator.intentGeneration;
       const existing = [...coordinator.stages.values()].find(
@@ -809,18 +823,22 @@ export const AgentsPage: React.FC = () => {
           !stage.invalidated &&
           !stage.settled &&
           stage.identity === identity &&
-          stage.intentGeneration === intentGeneration &&
-          stage.debtVersion === debtVersion &&
-          stage.purpose === purpose &&
-          stage.obligationId === obligationId,
+          stage.identityEpoch === identityEpoch &&
+          stage.readGeneration === currentReadGeneration &&
+          stage.causalFloor >= causalFloor &&
+          (stage.debtVersion ?? 0) >= (debtVersion ?? 0),
       );
-      if (existing) return existing.promise;
+      if (existing) {
+        if (debtVersion !== undefined) debt!.scheduled = true;
+        return existing.promise;
+      }
 
-      // A new compatible stage is the only place that advances an identity's
-      // read generation. This invalidates every older stage, including a
-      // promise that was already started before a newer selection intent.
+      // A new producer is the only place that advances an identity's read
+      // generation. This invalidates every older stage, including a lower-floor
+      // read that started before a newer mutation created reconciliation debt.
       const nextReadGeneration = advanceSelectedRead(coordinator, identity);
-      const key = [identity, intentGeneration, nextReadGeneration, debtVersion ?? '-', purpose, obligationId].join('::');
+      if (debtVersion !== undefined) debt!.scheduled = true;
+      const key = [identity, identityEpoch, nextReadGeneration, causalFloor, debtVersion ?? '-', purpose, obligationId].join('::');
       let resolveStage!: (outcome: SelectedReadOutcome) => void;
       const promise = new Promise<SelectedReadOutcome>((resolve) => {
         resolveStage = resolve;
@@ -828,6 +846,8 @@ export const AgentsPage: React.FC = () => {
       const stage: SelectedReadStage = {
         key,
         identity,
+        identityEpoch,
+        causalFloor,
         intentGeneration,
         readGeneration: nextReadGeneration,
         debtVersion,
@@ -867,6 +887,8 @@ export const AgentsPage: React.FC = () => {
       void (async () => {
         const outcome = await launchSelectedRead({
           identity: stage.identity,
+          identityEpoch: stage.identityEpoch,
+          causalFloor: stage.causalFloor,
           readGeneration: stage.readGeneration,
           intentGeneration: stage.intentGeneration,
           expectedCodes: stage.expectedCodes,
@@ -908,6 +930,7 @@ export const AgentsPage: React.FC = () => {
             clearSelectionError: false,
             purpose: 'continuation',
             obligationId: stage.obligationId,
+            causalFloor: stage.causalFloor,
           });
         }
         drainSelectedStagesRef.current?.();
@@ -1034,7 +1057,7 @@ export const AgentsPage: React.FC = () => {
     [publishMutationError],
   );
 
-  const reconcileSelected = useCallback(async (edgeEpoch?: number) => {
+  const reconcileSelected = useCallback(async (edgeEpoch?: number, causalFloor = 0) => {
     const coordinator = selectedCoordinatorRef.current;
     const identity = coordinator.desiredName;
     if (!identity || coordinator.mutations.has(identity)) return;
@@ -1046,7 +1069,8 @@ export const AgentsPage: React.FC = () => {
           !stage.invalidated &&
           !stage.settled &&
           stage.identity === identity &&
-          stage.obligationId === edgeEpoch,
+          stage.obligationId === edgeEpoch &&
+          stage.causalFloor >= causalFloor,
       )
     ) return;
     const debt = coordinator.reconciliationDebt.get(identity);
@@ -1057,6 +1081,7 @@ export const AgentsPage: React.FC = () => {
       debtOnly: Boolean(debt),
       purpose: 'reconcile',
       obligationId: edgeEpoch ?? ++coordinator.nextObligationId,
+      causalFloor,
     });
   }, []);
 
@@ -1064,7 +1089,7 @@ export const AgentsPage: React.FC = () => {
     const edgeEpoch = ++catchUpEpochRef.current;
     const applied = await refreshRef.current();
     if (!applied || !selectedMountedRef.current || catchUpEpochRef.current !== edgeEpoch) return;
-    await reconcileSelected(edgeEpoch);
+    await reconcileSelected(edgeEpoch, edgeEpoch);
   }, [reconcileSelected]);
 
   useEffect(() => {

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -115,6 +115,26 @@ type SelectedReconciliationDebt = {
 };
 
 type AutoSelectReason = 'initial' | 'replacement';
+type SelectedReadPurpose = 'selection' | 'reconcile' | 'continuation' | 'debt';
+
+type SelectedReadStage = {
+  key: string;
+  identity: string;
+  intentGeneration: number;
+  readGeneration: number;
+  debtVersion?: number;
+  obligationId: number;
+  purpose: SelectedReadPurpose;
+  expectedCodes?: readonly string[];
+  debtOnly: boolean;
+  refreshDefinitions: boolean;
+  rollbackOnFailure: boolean;
+  clearSelectionError: boolean;
+  invalidated: boolean;
+  promise: Promise<SelectedReadOutcome>;
+  resolve: (outcome: SelectedReadOutcome) => void;
+  settled: boolean;
+};
 
 type SelectedRetirement = {
   retired: boolean;
@@ -138,8 +158,11 @@ type SelectedCoordinator = {
   readGenerations: Map<string, number>;
   accepted: VibeAgentFull | null;
   acceptedGeneration: number;
-  activeReads: Map<string, Promise<SelectedReadOutcome>>;
-  activeReadCauses: Map<string, 'selection' | 'reconcile' | 'continuation' | 'debt'>;
+  stages: Map<string, SelectedReadStage>;
+  stageQueue: SelectedReadStage[];
+  stageDrainActive: boolean;
+  obligationAttempts: Map<number, Set<string>>;
+  nextObligationId: number;
   nextBatchId: number;
   nextOperationId: number;
   nextMutationVersion: number;
@@ -169,8 +192,11 @@ const createSelectedCoordinator = (): SelectedCoordinator => ({
   readGenerations: new Map(),
   accepted: null,
   acceptedGeneration: 0,
-  activeReads: new Map(),
-  activeReadCauses: new Map(),
+  stages: new Map(),
+  stageQueue: [],
+  stageDrainActive: false,
+  obligationAttempts: new Map(),
+  nextObligationId: 0,
   nextBatchId: 0,
   nextOperationId: 0,
   nextMutationVersion: 0,
@@ -185,6 +211,9 @@ const createSelectedCoordinator = (): SelectedCoordinator => ({
 const advanceSelectedRead = (coordinator: SelectedCoordinator, identity: string): number => {
   const next = (coordinator.readGenerations.get(identity) ?? 0) + 1;
   coordinator.readGenerations.set(identity, next);
+  for (const stage of coordinator.stages.values()) {
+    if (stage.identity === identity && stage.readGeneration < next) stage.invalidated = true;
+  }
   return next;
 };
 
@@ -371,6 +400,14 @@ export const AgentsPage: React.FC = () => {
       onboardingVersionRef.current.invalidate();
       const coordinator = selectedCoordinatorRef.current;
       for (const identity of coordinator.readGenerations.keys()) advanceSelectedRead(coordinator, identity);
+      for (const stage of coordinator.stageQueue.splice(0)) {
+        stage.invalidated = true;
+        if (!stage.settled) {
+          stage.settled = true;
+          stage.resolve({ kind: 'stale' });
+        }
+      }
+      coordinator.stages.clear();
       for (const batch of coordinator.mutations.values()) {
         for (const operation of batch.operations.splice(0)) {
           operation.resolve?.({ ok: false, error: new Error('Agent page unmounted') });
@@ -391,11 +428,11 @@ export const AgentsPage: React.FC = () => {
       refreshDefinitions?: boolean;
       rollbackOnFailure?: boolean;
       clearSelectionError?: boolean;
-      followContinuation?: boolean;
-      allowSupersede?: boolean;
-      cause?: 'selection' | 'reconcile' | 'continuation' | 'debt';
+      purpose?: SelectedReadPurpose;
+      obligationId?: number;
     }) => Promise<SelectedReadOutcome> | null)
   >(null);
+  const drainSelectedStagesRef = useRef<(() => void) | null>(null);
   const retireSelectedIdentityRef = useRef<
     ((identity: string, options?: { refreshDefinitions?: boolean; cause?: unknown }) => SelectedRetirement) | null
   >(null);
@@ -521,7 +558,18 @@ export const AgentsPage: React.FC = () => {
         );
         if (retired.length > 0) {
           for (const identity of retired) {
-            retireSelectedIdentityRef.current?.(identity, { refreshDefinitions: false });
+            const retirement = retireSelectedIdentityRef.current?.(identity, { refreshDefinitions: false });
+            if (retirement?.resumedIdentity) {
+              const resumedDebt = coordinator.reconciliationDebt.get(retirement.resumedIdentity);
+              scheduleSelectedReadRef.current?.(retirement.resumedIdentity, {
+                expectedCodes: SELECTED_DISAPPEARANCE_CODES,
+                debtOnly: Boolean(resumedDebt),
+                rollbackOnFailure: false,
+                clearSelectionError: false,
+                purpose: 'continuation',
+                obligationId: catchUpEpochRef.current || token.version,
+              });
+            }
           }
         }
         settleBarrier(true);
@@ -587,7 +635,11 @@ export const AgentsPage: React.FC = () => {
       }
       clearResourceError('selection');
       if (options.refreshDefinitions !== false) {
-        definitionsVersionRef.current.invalidate();
+        // The causal follow-up itself must not resurrect the tombstone. Mark
+        // the identity through the version that this refresh is about to
+        // publish; a later external Definitions edge may reintroduce it.
+        const followUpVersion = definitionsVersionRef.current.invalidate() + 1;
+        coordinator.retiredAtDefinitionsVersion.set(identity, followUpVersion);
         void refreshRef.current();
       }
       return {
@@ -698,7 +750,7 @@ export const AgentsPage: React.FC = () => {
           return { kind: 'published' };
         }
         const code = errorCodeOf(value);
-        if (options.expectedCodes?.includes(code ?? '')) {
+        if ((options.expectedCodes ?? SELECTED_DISAPPEARANCE_CODES).includes(code ?? '')) {
           const retirement = retireSelectedIdentityRef.current?.(options.identity, {
             refreshDefinitions: options.refreshDefinitions === true,
             cause: value,
@@ -737,74 +789,135 @@ export const AgentsPage: React.FC = () => {
         refreshDefinitions?: boolean;
         rollbackOnFailure?: boolean;
         clearSelectionError?: boolean;
-        followContinuation?: boolean;
-        allowSupersede?: boolean;
-        cause?: 'selection' | 'reconcile' | 'continuation' | 'debt';
+        purpose?: SelectedReadPurpose;
+        obligationId?: number;
       } = {},
     ): Promise<SelectedReadOutcome> | null => {
       if (!selectedMountedRef.current || !identity) return null;
       const coordinator = selectedCoordinatorRef.current;
       if (coordinator.retired.has(identity) || coordinator.desiredName !== identity) return null;
-      const activeRead = coordinator.activeReads.get(identity);
-      const cause = options.cause ?? 'selection';
-      if (
-        activeRead &&
-        !(options.allowSupersede === true && !(cause === 'reconcile' && coordinator.activeReadCauses.get(identity) === 'continuation'))
-      ) return activeRead;
-      // User selection is an explicit intent and may read immediately even
-      // while that identity has a pending mutation. Passive/debt drains wait
-      // for acknowledgements so they cannot publish an intermediate snapshot.
-      if (coordinator.mutations.has(identity) && options.debtOnly) return null;
+      const purpose = options.purpose ?? 'selection';
       const debt = coordinator.reconciliationDebt.get(identity);
       if (options.debtOnly && !debt) return null;
-      if (debt && options.debtOnly && debt.scheduled) return null;
-      const debtVersion = debt?.version;
-      if (debt) debt.scheduled = true;
-      const readGeneration = advanceSelectedRead(coordinator, identity);
+      if (coordinator.mutations.has(identity) && options.debtOnly) return null;
+      const debtVersion = options.debtOnly ? debt?.version : undefined;
+      if (debtVersion !== undefined) debt!.scheduled = true;
+      const obligationId = options.obligationId ?? ++coordinator.nextObligationId;
       const intentGeneration = coordinator.intentGeneration;
-      const read = launchSelectedRead({
+      const existing = [...coordinator.stages.values()].find(
+        (stage) =>
+          !stage.invalidated &&
+          !stage.settled &&
+          stage.identity === identity &&
+          stage.intentGeneration === intentGeneration &&
+          stage.debtVersion === debtVersion &&
+          stage.purpose === purpose &&
+          stage.obligationId === obligationId,
+      );
+      if (existing) return existing.promise;
+
+      // A new compatible stage is the only place that advances an identity's
+      // read generation. This invalidates every older stage, including a
+      // promise that was already started before a newer selection intent.
+      const nextReadGeneration = advanceSelectedRead(coordinator, identity);
+      const key = [identity, intentGeneration, nextReadGeneration, debtVersion ?? '-', purpose, obligationId].join('::');
+      let resolveStage!: (outcome: SelectedReadOutcome) => void;
+      const promise = new Promise<SelectedReadOutcome>((resolve) => {
+        resolveStage = resolve;
+      });
+      const stage: SelectedReadStage = {
+        key,
         identity,
-        readGeneration,
         intentGeneration,
-        expectedCodes: options.expectedCodes,
-        refreshDefinitions: options.refreshDefinitions,
-        rollbackOnFailure: options.rollbackOnFailure,
-        clearSelectionError: options.clearSelectionError,
+        readGeneration: nextReadGeneration,
         debtVersion,
-      });
-      coordinator.activeReads.set(identity, read);
-      coordinator.activeReadCauses.set(identity, cause);
-      void read.then(() => {
-        if (coordinator.activeReads.get(identity) === read) {
-          coordinator.activeReads.delete(identity);
-          coordinator.activeReadCauses.delete(identity);
-        }
-      });
-      if (options.followContinuation === false) return read;
-      return read.then(async (outcome) => {
+        obligationId,
+        purpose,
+        expectedCodes: options.expectedCodes,
+        debtOnly: Boolean(options.debtOnly),
+        refreshDefinitions: Boolean(options.refreshDefinitions),
+        rollbackOnFailure: options.rollbackOnFailure !== false,
+        clearSelectionError: options.clearSelectionError !== false,
+        invalidated: false,
+        promise,
+        resolve: resolveStage,
+        settled: false,
+      };
+      coordinator.stages.set(key, stage);
+      coordinator.stageQueue.push(stage);
+      drainSelectedStagesRef.current?.();
+      return promise;
+    },
+    [],
+  );
+  scheduleSelectedReadRef.current = scheduleSelectedRead;
+
+  const drainSelectedStages = useCallback(() => {
+    const coordinator = selectedCoordinatorRef.current;
+    if (coordinator.stageDrainActive) return;
+    coordinator.stageDrainActive = true;
+    while (selectedMountedRef.current && coordinator.stageQueue.length > 0) {
+      const stage = coordinator.stageQueue.shift()!;
+      if (stage.invalidated || !selectedMountedRef.current) {
+        stage.settled = true;
+        stage.resolve({ kind: 'stale' });
+        if (coordinator.stages.get(stage.key) === stage) coordinator.stages.delete(stage.key);
+        continue;
+      }
+      void (async () => {
+        const outcome = await launchSelectedRead({
+          identity: stage.identity,
+          readGeneration: stage.readGeneration,
+          intentGeneration: stage.intentGeneration,
+          expectedCodes: stage.expectedCodes,
+          debtVersion: stage.debtVersion,
+          refreshDefinitions: stage.refreshDefinitions,
+          rollbackOnFailure: stage.rollbackOnFailure,
+          clearSelectionError: stage.clearSelectionError,
+        });
+        stage.settled = true;
+        stage.resolve(outcome);
+        if (coordinator.stages.get(stage.key) === stage) coordinator.stages.delete(stage.key);
         const continuation = outcome.continuation;
         if (
           !continuation ||
           !selectedMountedRef.current ||
           coordinator.intentGeneration !== continuation.intentGeneration ||
           coordinator.desiredName !== continuation.nextIdentity
-        ) return outcome;
-        if (!coordinator.reconciliationDebt.has(continuation.nextIdentity)) return outcome;
-        const follow = scheduleSelectedReadRef.current?.(continuation.nextIdentity, {
-          expectedCodes: options.expectedCodes ?? SELECTED_DISAPPEARANCE_CODES,
-          debtOnly: true,
-          refreshDefinitions: false,
-          rollbackOnFailure: false,
-          clearSelectionError: false,
-          followContinuation: false,
-          cause: 'continuation',
-        });
-        return follow ? await follow : outcome;
-      });
-    },
-    [launchSelectedRead],
-  );
-  scheduleSelectedReadRef.current = scheduleSelectedRead;
+        ) {
+          drainSelectedStagesRef.current?.();
+          return;
+        }
+        const attempted = coordinator.obligationAttempts.get(stage.obligationId) ?? new Set<string>();
+        const nextDebt = coordinator.reconciliationDebt.get(continuation.nextIdentity);
+        // A failed/retired user selection rolls back the visible intent but
+        // does not start a passive read immediately. Reconnect or an existing
+        // mutation debt is the external edge that may reconcile the fallback.
+        if (stage.purpose === 'selection' && !nextDebt) {
+          drainSelectedStagesRef.current?.();
+          return;
+        }
+        if (!attempted.has(continuation.nextIdentity)) {
+          attempted.add(continuation.nextIdentity);
+          coordinator.obligationAttempts.set(stage.obligationId, attempted);
+          scheduleSelectedReadRef.current?.(continuation.nextIdentity, {
+            expectedCodes: stage.expectedCodes ?? SELECTED_DISAPPEARANCE_CODES,
+            debtOnly: Boolean(nextDebt),
+            refreshDefinitions: false,
+            rollbackOnFailure: false,
+            clearSelectionError: false,
+            purpose: 'continuation',
+            obligationId: stage.obligationId,
+          });
+        }
+        drainSelectedStagesRef.current?.();
+      })();
+    }
+    coordinator.stageDrainActive = false;
+  }, [launchSelectedRead]);
+  drainSelectedStagesRef.current = () => {
+    void drainSelectedStages();
+  };
 
   const beginSelectedMutation = useCallback((identity: string) => {
     const coordinator = selectedCoordinatorRef.current;
@@ -831,7 +944,7 @@ export const AgentsPage: React.FC = () => {
     const debt = coordinator.reconciliationDebt.get(identity);
     if (debt) debt.scheduled = false;
     advanceSelectedRead(coordinator, identity);
-    const operation = { id: ++coordinator.nextOperationId, batchId: batch.id, identity, sequence: batch.version };
+      const operation = { id: ++coordinator.nextOperationId, batchId: batch.id, identity, sequence: batch.version };
     batch.operations.push(operation);
     return operation;
   }, [beginResourceError]);
@@ -889,8 +1002,8 @@ export const AgentsPage: React.FC = () => {
             debtOnly: true,
             expectedCodes: SELECTED_DISAPPEARANCE_CODES,
             rollbackOnFailure: false,
-            allowSupersede: true,
-            cause: 'debt',
+            purpose: 'debt',
+            obligationId: version,
           });
           if (!drain && !currentDebt.scheduled) {
             const waiters = currentDebt.waiters.splice(0);
@@ -923,39 +1036,28 @@ export const AgentsPage: React.FC = () => {
 
   const reconcileSelected = useCallback(async (edgeEpoch?: number) => {
     const coordinator = selectedCoordinatorRef.current;
-    let transactionIntentGeneration = coordinator.intentGeneration;
-    let identity = coordinator.desiredName;
-    let preserveSelectionError = false;
-    let continueDebtOnly = false;
-    const attempted = new Set<string>();
-    while (selectedMountedRef.current && identity && !attempted.has(identity)) {
-      if (edgeEpoch !== undefined && catchUpEpochRef.current !== edgeEpoch) return;
-      if (coordinator.intentGeneration !== transactionIntentGeneration) return;
-      attempted.add(identity);
-      if (coordinator.mutations.has(identity)) return;
-      const outcome = await scheduleSelectedReadRef.current?.(identity, {
-        expectedCodes: SELECTED_DISAPPEARANCE_CODES,
-        refreshDefinitions: false,
-        clearSelectionError: !preserveSelectionError,
-        debtOnly: continueDebtOnly && Boolean(coordinator.reconciliationDebt.get(identity)),
-        followContinuation: false,
-        allowSupersede: true,
-        cause: 'reconcile',
-      });
-      if (edgeEpoch !== undefined && catchUpEpochRef.current !== edgeEpoch) return;
-      if (!outcome) return;
-      const continuation = outcome.continuation;
-      if (!continuation) return;
-      if (
-        continuation.intentGeneration !== coordinator.intentGeneration ||
-        coordinator.desiredName !== continuation.nextIdentity ||
-        attempted.has(continuation.nextIdentity)
-      ) return;
-      transactionIntentGeneration = continuation.intentGeneration;
-      identity = continuation.nextIdentity;
-      preserveSelectionError = true;
-      continueDebtOnly = true;
-    }
+    const identity = coordinator.desiredName;
+    if (!identity || coordinator.mutations.has(identity)) return;
+    if (edgeEpoch !== undefined && catchUpEpochRef.current !== edgeEpoch) return;
+    if (
+      edgeEpoch !== undefined &&
+      [...coordinator.stages.values()].some(
+        (stage) =>
+          !stage.invalidated &&
+          !stage.settled &&
+          stage.identity === identity &&
+          stage.obligationId === edgeEpoch,
+      )
+    ) return;
+    const debt = coordinator.reconciliationDebt.get(identity);
+    scheduleSelectedReadRef.current?.(identity, {
+      expectedCodes: SELECTED_DISAPPEARANCE_CODES,
+      refreshDefinitions: true,
+      clearSelectionError: true,
+      debtOnly: Boolean(debt),
+      purpose: 'reconcile',
+      obligationId: edgeEpoch ?? ++coordinator.nextObligationId,
+    });
   }, []);
 
   const reconcileGap = useCallback(async () => {
@@ -1105,7 +1207,12 @@ export const AgentsPage: React.FC = () => {
     async (name: string, openDetail = false, auto = false) => {
       beginSelectedIntent(name, { auto, openDetail, source: auto ? 'auto' : 'user' });
       clearResourceError('selection');
-      await scheduleSelectedReadRef.current?.(name, { allowSupersede: true, cause: 'selection' });
+      await scheduleSelectedReadRef.current?.(name, {
+        expectedCodes: SELECTED_DISAPPEARANCE_CODES,
+        refreshDefinitions: true,
+        purpose: auto ? 'selection' : 'selection',
+        obligationId: selectedCoordinatorRef.current.intentGeneration,
+      });
     },
     [beginSelectedIntent, clearResourceError],
   );

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -90,8 +90,10 @@ type SelectedMutationBatch = {
   version: number;
   errorGeneration: number;
   failures: unknown[];
-  waiters: Array<() => void>;
+  waiters: Array<(result: SelectedMutationResult) => void>;
 };
+
+type SelectedMutationResult = { ok: true } | { ok: false; error: unknown };
 
 type SelectedReconciliationDebt = {
   version: number;
@@ -99,6 +101,21 @@ type SelectedReconciliationDebt = {
 };
 
 type AutoSelectReason = 'initial' | 'replacement';
+
+type SelectedRetirement = {
+  retired: boolean;
+  resumedIdentity: string | null;
+  intentGeneration: number;
+};
+
+type SelectedReadOutcome =
+  | { kind: 'published' }
+  | { kind: 'failed' }
+  | { kind: 'stale' }
+  | { kind: 'expected-retired'; resumedIdentity: string; intentGeneration: number };
+
+const canonicalFieldValue = (field: 'name' | 'description' | 'model' | 'effort' | 'systemPrompt', value: string) =>
+  field === 'name' || field === 'description' || field === 'systemPrompt' ? value.trim() : value;
 
 type SelectedCoordinator = {
   desiredName: string | null;
@@ -218,6 +235,7 @@ export const AgentsPage: React.FC = () => {
   const [onboardingInventory, setOnboardingInventory] = useState<VibeAgentOnboardingResult | null>(null);
   const [onboardingExpanded, setOnboardingExpanded] = useState(false);
   const [onboardingSubmitting, setOnboardingSubmitting] = useState(false);
+  const onboardingSettlementRef = useRef<Promise<boolean> | null>(null);
   const definitionsVersionRef = useRef(createAgentRequestVersion());
   const onboardingVersionRef = useRef(createAgentRequestVersion());
   const selectedCoordinatorRef = useRef(createSelectedCoordinator());
@@ -258,19 +276,30 @@ export const AgentsPage: React.FC = () => {
     setOnboardingInventory(result?.available ? result : null);
   }, []);
 
-  const refreshOnboarding = useCallback(async () => {
-    if (!selectedMountedRef.current) return;
-    if (!canOnboardAgents) {
-      setOnboardingInventory(null);
-      return;
-    }
-    const token = onboardingVersionRef.current.begin();
-    try {
-      const result = await api.getVibeAgentOnboarding();
-      if (selectedMountedRef.current && onboardingVersionRef.current.isCurrent(token)) publishOnboarding(result);
-    } catch {
-      if (selectedMountedRef.current && onboardingVersionRef.current.isCurrent(token)) publishOnboarding(null);
-    }
+  const refreshOnboarding = useCallback(() => {
+    const request = (async () => {
+      if (!selectedMountedRef.current) return false;
+      if (!canOnboardAgents) {
+        setOnboardingInventory(null);
+        return true;
+      }
+      const token = onboardingVersionRef.current.begin();
+      try {
+        const result = await api.getVibeAgentOnboarding();
+        if (selectedMountedRef.current && onboardingVersionRef.current.isCurrent(token)) {
+          publishOnboarding(result);
+          return true;
+        }
+      } catch {
+        if (selectedMountedRef.current && onboardingVersionRef.current.isCurrent(token)) {
+          publishOnboarding(null);
+          return true;
+        }
+      }
+      return false;
+    })();
+    onboardingSettlementRef.current = request;
+    return request;
   }, [api, canOnboardAgents, publishOnboarding]);
 
   useEffect(() => {
@@ -281,16 +310,18 @@ export const AgentsPage: React.FC = () => {
       const coordinator = selectedCoordinatorRef.current;
       for (const identity of coordinator.readGenerations.keys()) advanceSelectedRead(coordinator, identity);
       for (const batch of coordinator.mutations.values()) {
-        for (const resolve of batch.waiters.splice(0)) resolve();
+        for (const resolve of batch.waiters.splice(0)) resolve({ ok: false, error: new Error('Agent page unmounted') });
       }
       coordinator.mutations.clear();
     };
   }, []);
 
   const scheduleSelectedReadRef = useRef<
-    ((identity: string, options?: { expectedCodes?: readonly string[]; debtOnly?: boolean }) => Promise<'published' | 'failed' | 'stale'> | null)
+    ((identity: string, options?: { expectedCodes?: readonly string[]; debtOnly?: boolean }) => Promise<SelectedReadOutcome> | null)
   >(null);
-  const retireSelectedIdentityRef = useRef<((identity: string, options?: { refreshDefinitions?: boolean }) => boolean) | null>(null);
+  const retireSelectedIdentityRef = useRef<
+    ((identity: string, options?: { refreshDefinitions?: boolean }) => SelectedRetirement) | null
+  >(null);
 
   const commitSelected = useCallback((agent: VibeAgentFull | null) => {
     const coordinator = selectedCoordinatorRef.current;
@@ -383,7 +414,9 @@ export const AgentsPage: React.FC = () => {
   const retireSelectedIdentity = useCallback(
     (identity: string, options: { refreshDefinitions?: boolean } = {}) => {
       const coordinator = selectedCoordinatorRef.current;
-      if (coordinator.retired.has(identity)) return false;
+      if (coordinator.retired.has(identity)) {
+        return { retired: false, resumedIdentity: null, intentGeneration: coordinator.intentGeneration };
+      }
       const acceptedIdentity = coordinator.accepted?.name ?? null;
       const pendingIdentity = coordinator.desiredName === identity;
       const acceptedCanResume = Boolean(
@@ -411,7 +444,11 @@ export const AgentsPage: React.FC = () => {
         definitionsVersionRef.current.invalidate();
         void refreshRef.current();
       }
-      return true;
+      return {
+        retired: true,
+        resumedIdentity: pendingIdentity && acceptedCanResume ? acceptedIdentity : null,
+        intentGeneration: coordinator.intentGeneration,
+      };
     },
     [clearResourceError, commitSelected],
   );
@@ -462,7 +499,7 @@ export const AgentsPage: React.FC = () => {
       intentGeneration?: number;
       expectedCodes?: readonly string[];
       debtVersion?: number;
-    }): Promise<'published' | 'failed' | 'stale'> => {
+    }): Promise<SelectedReadOutcome> => {
       const coordinator = selectedCoordinatorRef.current;
       const isCurrent = () =>
         selectedMountedRef.current &&
@@ -480,48 +517,50 @@ export const AgentsPage: React.FC = () => {
       try {
         const params = options.expectedCodes ? { cache: false, expectedCodes: options.expectedCodes } : { cache: false };
         const result = await api.getVibeAgent(options.identity, params);
-        if (!isCurrent()) return 'stale';
+        if (!isCurrent()) return { kind: 'stale' };
         if (result.ok && result.agent?.name === options.identity) {
           clearResourceError('selection');
           commitSelected(result.agent);
           finishDebt(true);
-          return 'published';
+          return { kind: 'published' };
         }
         if (
           options.expectedCodes &&
           SELECTED_DISAPPEARANCE_CODES.includes(errorCodeOf(result) as (typeof SELECTED_DISAPPEARANCE_CODES)[number])
         ) {
-          retireSelectedIdentityRef.current?.(options.identity);
+          const retirement = retireSelectedIdentityRef.current?.(options.identity);
           finishDebt(false);
-          return 'failed';
+          if (retirement?.resumedIdentity) {
+            return {
+              kind: 'expected-retired',
+              resumedIdentity: retirement.resumedIdentity,
+              intentGeneration: retirement.intentGeneration,
+            };
+          }
+          return { kind: 'failed' };
         }
-        const rollback = rollbackSelectedIntent();
+        rollbackSelectedIntent();
         setResourceError('selection', errorMessage(result) || tRef.current('errorBoundary.title'));
         finishDebt(false);
-        if (rollback.identity && rollback.identity !== options.identity) {
-          void scheduleSelectedReadRef.current?.(rollback.identity, {
-            debtOnly: true,
-            expectedCodes: options.expectedCodes ?? SELECTED_DISAPPEARANCE_CODES,
-          });
-        }
-        return 'failed';
+        return { kind: 'failed' };
       } catch (err) {
-        if (!isCurrent()) return 'stale';
+        if (!isCurrent()) return { kind: 'stale' };
         if (options.expectedCodes && SELECTED_DISAPPEARANCE_CODES.includes(errorCodeOf(err) as (typeof SELECTED_DISAPPEARANCE_CODES)[number])) {
-          retireSelectedIdentityRef.current?.(options.identity);
+          const retirement = retireSelectedIdentityRef.current?.(options.identity);
           finishDebt(false);
-          return 'failed';
+          if (retirement?.resumedIdentity) {
+            return {
+              kind: 'expected-retired',
+              resumedIdentity: retirement.resumedIdentity,
+              intentGeneration: retirement.intentGeneration,
+            };
+          }
+          return { kind: 'failed' };
         }
-        const rollback = rollbackSelectedIntent();
+        rollbackSelectedIntent();
         setResourceError('selection', errorMessage(err) || tRef.current('errorBoundary.title'));
         finishDebt(false);
-        if (rollback.identity && rollback.identity !== options.identity) {
-          void scheduleSelectedReadRef.current?.(rollback.identity, {
-            debtOnly: true,
-            expectedCodes: options.expectedCodes ?? SELECTED_DISAPPEARANCE_CODES,
-          });
-        }
-        return 'failed';
+        return { kind: 'failed' };
       }
     },
     [api, clearResourceError, commitSelected, rollbackSelectedIntent, setResourceError],
@@ -531,7 +570,7 @@ export const AgentsPage: React.FC = () => {
     (
       identity: string,
       options: { expectedCodes?: readonly string[]; debtOnly?: boolean } = {},
-    ): Promise<'published' | 'failed' | 'stale'> | null => {
+    ): Promise<SelectedReadOutcome> | null => {
       if (!selectedMountedRef.current || !identity) return null;
       const coordinator = selectedCoordinatorRef.current;
       if (coordinator.retired.has(identity) || coordinator.desiredName !== identity) return null;
@@ -555,7 +594,7 @@ export const AgentsPage: React.FC = () => {
       }).then((outcome) => {
         if (debtVersion !== undefined) {
           const currentDebt = coordinator.reconciliationDebt.get(identity);
-          if (currentDebt?.version === debtVersion && outcome !== 'published') currentDebt.scheduled = false;
+          if (currentDebt?.version === debtVersion && outcome.kind !== 'published') currentDebt.scheduled = false;
         }
         return outcome;
       });
@@ -590,15 +629,15 @@ export const AgentsPage: React.FC = () => {
   }, [beginResourceError]);
 
   const settleSelectedMutation = useCallback(
-    (operation: { id: number; identity: string }, failure?: unknown): Promise<void> => {
-      if (!selectedMountedRef.current) return Promise.resolve();
+    (operation: { id: number; identity: string }, failure?: unknown): Promise<SelectedMutationResult> => {
+      if (!selectedMountedRef.current) return Promise.resolve({ ok: false, error: new Error('Agent page unmounted') });
       const coordinator = selectedCoordinatorRef.current;
       const batch = [...coordinator.mutations.values()].find((candidate) => candidate.id === operation.id);
-      if (!batch) return Promise.resolve();
+      if (!batch) return Promise.resolve({ ok: false, error: new Error('Agent mutation is no longer current') });
       if (failure) batch.failures.push(failure);
       batch.pending = Math.max(0, batch.pending - 1);
       if (batch.pending !== 0) {
-        return new Promise<void>((resolve) => batch.waiters.push(resolve));
+        return new Promise<SelectedMutationResult>((resolve) => batch.waiters.push(resolve));
       }
 
       const identity = batch.identity;
@@ -617,20 +656,42 @@ export const AgentsPage: React.FC = () => {
         debtOnly: true,
         expectedCodes: SELECTED_DISAPPEARANCE_CODES,
       });
-      const completion = drain?.then(() => undefined) ?? Promise.resolve();
+      const completion = drain?.then((outcome) => outcome.kind === 'published'
+        ? ({ ok: true } as const)
+        : ({ ok: false, error: new Error('Agent reconciliation failed') } as const))
+        ?? Promise.resolve({ ok: failures.length === 0 } as SelectedMutationResult);
+      const resultPromise = completion.then((result) => {
+        if (failures.length > 0) return { ok: false, error: failures[0] } as const;
+        return result;
+      });
       const waiters = batch.waiters.splice(0);
-      for (const resolve of waiters) void completion.then(resolve);
-      return completion;
+      for (const resolve of waiters) void resultPromise.then(resolve);
+      return resultPromise;
     },
     [setResourceError, t],
   );
 
   const reconcileSelected = useCallback(async () => {
     const coordinator = selectedCoordinatorRef.current;
-    const identity = coordinator.desiredName;
-    if (!identity) return;
-    if (coordinator.mutations.has(identity)) return;
-    await scheduleSelectedReadRef.current?.(identity, { expectedCodes: SELECTED_DISAPPEARANCE_CODES });
+    let transactionIntentGeneration = coordinator.intentGeneration;
+    let identity = coordinator.desiredName;
+    const attempted = new Set<string>();
+    while (selectedMountedRef.current && identity && !attempted.has(identity)) {
+      if (coordinator.intentGeneration !== transactionIntentGeneration) return;
+      attempted.add(identity);
+      if (coordinator.mutations.has(identity)) return;
+      const outcome = await scheduleSelectedReadRef.current?.(identity, {
+        expectedCodes: SELECTED_DISAPPEARANCE_CODES,
+      });
+      if (!outcome || outcome.kind !== 'expected-retired') return;
+      if (
+        outcome.intentGeneration !== coordinator.intentGeneration ||
+        coordinator.desiredName !== outcome.resumedIdentity ||
+        attempted.has(outcome.resumedIdentity)
+      ) return;
+      transactionIntentGeneration = outcome.intentGeneration;
+      identity = outcome.resumedIdentity;
+    }
   }, []);
 
   useEffect(() => {
@@ -777,9 +838,18 @@ export const AgentsPage: React.FC = () => {
       beginSelectedIntent(name, { auto });
       clearResourceError('selection');
       const outcome = await scheduleSelectedReadRef.current?.(name);
+      if (outcome?.kind === 'failed') {
+        const rollbackIdentity = selectedCoordinatorRef.current.desiredName;
+        if (rollbackIdentity && rollbackIdentity !== name) {
+          void scheduleSelectedReadRef.current?.(rollbackIdentity, {
+            debtOnly: true,
+            expectedCodes: SELECTED_DISAPPEARANCE_CODES,
+          });
+        }
+      }
       // Enter the mobile drill-down only once the detail has actually loaded —
       // never optimistically, or a failed fetch hides the list with no panel.
-      if (outcome === 'published' && openDetail) setDetailOpen(true);
+      if (outcome?.kind === 'published' && openDetail) setDetailOpen(true);
     },
     [beginSelectedIntent, clearResourceError],
   );
@@ -829,11 +899,19 @@ export const AgentsPage: React.FC = () => {
     if (!selected) return;
     const name = selected.name;
     const operation = beginSelectedMutation(name);
+    let mutationSettled = false;
     try {
       const result = await api.updateVibeAgent(name, patch);
-      await settleSelectedMutation(operation, result.ok ? undefined : result);
+      const settled = await settleSelectedMutation(operation, result.ok ? undefined : result);
+      mutationSettled = true;
+      if (!settled.ok) throw settled.error;
     } catch (err) {
-      await settleSelectedMutation(operation, err);
+      if (!mutationSettled) {
+        const settled = await settleSelectedMutation(operation, err);
+        mutationSettled = true;
+        if (!settled.ok) throw settled.error;
+      }
+      throw err;
     }
   };
 
@@ -862,8 +940,9 @@ export const AgentsPage: React.FC = () => {
         throw result;
       }
       migrateSelectedIdentity(oldName, newName, selected.id);
-      await settleSelectedMutation(operation);
+      const mutationResult = await settleSelectedMutation(operation);
       settled = true;
+      if (!mutationResult.ok) throw mutationResult.error;
       void refreshOnboarding();
     } catch (err) {
       if (!settled) await settleSelectedMutation(operation, err);
@@ -937,7 +1016,14 @@ export const AgentsPage: React.FC = () => {
     } catch (err) {
       showToast(t('agents.onboarding.failed', { error: errorMessage(err) ?? String(err) }), 'error');
     } finally {
-      void refreshOnboarding();
+      let settlement = refreshOnboarding();
+      await settlement;
+      while (selectedMountedRef.current) {
+        const latest = onboardingSettlementRef.current;
+        if (!latest || latest === settlement) break;
+        settlement = latest;
+        await settlement;
+      }
       setOnboardingSubmitting(false);
     }
   };
@@ -1500,6 +1586,14 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
       effort: agent.reasoning_effort ?? 'medium',
       systemPrompt: agent.system_prompt ?? '',
     };
+    const snapshotChanged =
+      previous.id !== next.id ||
+      previous.name !== next.name ||
+      previous.description !== next.description ||
+      previous.model !== next.model ||
+      previous.effort !== next.effort ||
+      previous.systemPrompt !== next.systemPrompt;
+    if (!snapshotChanged) return;
     if (previous.id !== next.id) {
       fieldRevisionRef.current = { name: 0, description: 0, model: 0, effort: 0, systemPrompt: 0 };
       submittedRevisionRef.current = { name: 0, description: 0, model: 0, effort: 0, systemPrompt: 0 };
@@ -1517,19 +1611,16 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
       editorDirtyRef.current = false;
       setEditorSeedRevision((revision) => revision + 1);
     } else {
-      // Same-identity reconciliation follows explicit local/submitted
-      // revisions. A field with an in-flight mutation remains local until its
-      // mutation batch's authoritative drain completes; an older drain cannot
-      // overwrite a newer edit. Once no submission is pending, clean fields
-      // follow the accepted server snapshot.
-      const revisions = fieldRevisionRef.current;
-      const submitted = submittedRevisionRef.current;
+      // Same-identity reconciliation compares the current canonical value to
+      // the accepted baseline. A field that returned to that baseline is clean
+      // even if it has an older edit revision; a field with an active submission
+      // remains local until its authoritative drain settles.
       const pending = pendingRevisionRef.current;
-      if (pending.name === null && revisions.name <= submitted.name) setName(next.name);
-      if (pending.description === null && revisions.description <= submitted.description) setDescription(next.description);
-      if (pending.model === null && revisions.model <= submitted.model) setModel(next.model);
-      if (pending.effort === null && revisions.effort <= submitted.effort) setEffort(next.effort);
-      if (pending.systemPrompt === null && revisions.systemPrompt <= submitted.systemPrompt) setSystemPrompt(next.systemPrompt);
+      if (pending.name === null && canonicalFieldValue('name', name) === canonicalFieldValue('name', previous.name)) setName(next.name);
+      if (pending.description === null && canonicalFieldValue('description', description) === canonicalFieldValue('description', previous.description)) setDescription(next.description);
+      if (pending.model === null && canonicalFieldValue('model', model) === canonicalFieldValue('model', previous.model)) setModel(next.model);
+      if (pending.effort === null && canonicalFieldValue('effort', effort) === canonicalFieldValue('effort', previous.effort)) setEffort(next.effort);
+      if (pending.systemPrompt === null && canonicalFieldValue('systemPrompt', systemPrompt) === canonicalFieldValue('systemPrompt', previous.systemPrompt)) setSystemPrompt(next.systemPrompt);
       if (!editorDirtyRef.current && editorOpen) {
         editorDraftRef.current = next.systemPrompt;
         editorBaselineRef.current = next.systemPrompt;
@@ -1538,7 +1629,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
       }
     }
     serverSnapshotRef.current = next;
-  }, [agent.id, agent.name, agent.description, agent.model, agent.reasoning_effort, agent.system_prompt, editorOpen]);
+  }, [agent.id, agent.name, agent.description, agent.model, agent.reasoning_effort, agent.system_prompt, editorOpen, name, description, model, effort, systemPrompt]);
 
   // Load model catalog for the agent's backend so the Combobox can offer
   // suggestions. Keeps `allowCustomValue` so users can type a model the
@@ -1605,6 +1696,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
         submittedRevisionRef.current[field] = revision;
         if (fieldRevisionRef.current[field] !== revision) continue;
         const snapshot = serverSnapshotRef.current;
+        if (field === 'name') setName(snapshot.name);
         if (field === 'description') setDescription(snapshot.description ?? '');
         if (field === 'model') setModel(snapshot.model ?? '');
         if (field === 'effort') setEffort(snapshot.effort ?? 'medium');
@@ -1618,6 +1710,23 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
           }
         }
       }
+    }).catch((err) => {
+      // A PATCH or its authoritative drain failed. The caller must see the
+      // rejection, while the latest server snapshot owns any field without a
+      // newer local edit. Keep an open modal's private draft untouched.
+      for (const { field, revision } of revisions) {
+        if (pendingRevisionRef.current[field] !== revision) continue;
+        pendingRevisionRef.current[field] = null;
+        submittedRevisionRef.current[field] = revision;
+        if (fieldRevisionRef.current[field] !== revision) continue;
+        const snapshot = serverSnapshotRef.current;
+        if (field === 'name') setName(snapshot.name);
+        if (field === 'description') setDescription(snapshot.description ?? '');
+        if (field === 'model') setModel(snapshot.model ?? '');
+        if (field === 'effort') setEffort(snapshot.effort ?? 'medium');
+        if (field === 'systemPrompt') setSystemPrompt(snapshot.systemPrompt ?? '');
+      }
+      throw err;
     });
   };
 
@@ -1754,7 +1863,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
             onBlur={commitRename}
             onKeyDown={(e) => {
               if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
-              if (e.key === 'Escape') setName(agent.name);
+              if (e.key === 'Escape') cancelFieldEdit('name', serverSnapshotRef.current.name);
             }}
             disabled={locked || renaming}
             title={lockHint}
@@ -1775,12 +1884,15 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
             setDescription(e.target.value);
           }}
           onBlur={() => {
-            if (!locked && (description !== (agent.description ?? '') || pendingRevisionRef.current.description !== null)) {
-              const canonical = description.trim();
-              setDescription(canonical);
-              markFieldSubmitted('description');
-              submitFields({ description: canonical || null }, ['description']);
+            if (locked) return;
+            const canonical = description.trim();
+            setDescription(canonical);
+            if (canonical === serverSnapshotRef.current.description && pendingRevisionRef.current.description === null) {
+              cancelFieldEdit('description', canonical);
+              return;
             }
+            markFieldSubmitted('description');
+            void submitFields({ description: canonical || null }, ['description']).catch(() => undefined);
           }}
           disabled={locked}
           title={lockHint}
@@ -1840,7 +1952,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
                   patch.reasoning_effort = fallback;
                 }
               }
-              submitFields(patch, patch.reasoning_effort ? ['model', 'effort'] : ['model']);
+              void submitFields(patch, patch.reasoning_effort ? ['model', 'effort'] : ['model']).catch(() => undefined);
             }}
             placeholder={t('agents.detail.modelPlaceholder')}
             emptyText={t('agents.detail.modelEmpty')}
@@ -1867,7 +1979,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
                   markFieldEdit('effort');
                   markFieldSubmitted('effort');
                   setEffort(opt);
-                  submitFields({ reasoning_effort: opt }, ['effort']);
+                  void submitFields({ reasoning_effort: opt }, ['effort']).catch(() => undefined);
                 }}
                 className={clsx(
                   'truncate rounded-md px-1 py-1.5 text-[11px] capitalize transition disabled:cursor-not-allowed',
@@ -1937,12 +2049,15 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
               setSystemPrompt(e.target.value);
             }}
             onBlur={() => {
-              if (canEdit && systemPrompt !== (agent.system_prompt ?? '')) {
-                const canonical = systemPrompt.trim();
-                setSystemPrompt(canonical);
-                markFieldSubmitted('systemPrompt');
-                void submitFields({ system_prompt: canonical || null }, ['systemPrompt']);
+              if (!canEdit) return;
+              const canonical = systemPrompt.trim();
+              setSystemPrompt(canonical);
+              if (canonical === serverSnapshotRef.current.systemPrompt && pendingRevisionRef.current.systemPrompt === null) {
+                cancelFieldEdit('systemPrompt', canonical);
+                return;
               }
+              markFieldSubmitted('systemPrompt');
+              void submitFields({ system_prompt: canonical || null }, ['systemPrompt']).catch(() => undefined);
             }}
             readOnly={!canEdit}
             title={canEdit ? undefined : t('agents.remoteReadOnlyHint')}
@@ -2017,10 +2132,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
           markFieldEdit('systemPrompt');
           markFieldSubmitted('systemPrompt');
           setSystemPrompt(canonical);
-          editorDraftRef.current = canonical;
-          editorBaselineRef.current = canonical;
-          editorDirtyRef.current = false;
-          if (canonical !== (agent.system_prompt ?? '') || pendingRevisionRef.current.systemPrompt !== null) {
+          if (canonical !== serverSnapshotRef.current.systemPrompt || pendingRevisionRef.current.systemPrompt !== null) {
             return submitFields({ system_prompt: canonical || null }, ['systemPrompt']);
           }
           return;

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -88,17 +88,22 @@ type SelectedMutationBatch = {
   identity: string;
   pending: number;
   version: number;
-  errorGeneration: number;
-  failures: unknown[];
-  waiters: Array<(result: SelectedMutationResult) => void>;
+  operations: SelectedMutationOperation[];
 };
 
 type SelectedMutationResult = { ok: true } | { ok: false; error: unknown };
 
+type SelectedMutationOperation = {
+  id: number;
+  batchId: number;
+  identity: string;
+  sequence: number;
+  failure?: unknown;
+  resolve?: (result: SelectedMutationResult) => void;
+};
+
 type SelectedReconciliationWaiter = {
   resolve: (result: SelectedMutationResult) => void;
-  mutationFailure?: unknown;
-  errorGeneration?: number;
 };
 
 type SelectedReconciliationDebt = {
@@ -132,12 +137,23 @@ type SelectedCoordinator = {
   accepted: VibeAgentFull | null;
   acceptedGeneration: number;
   nextBatchId: number;
+  nextOperationId: number;
   nextMutationVersion: number;
   mutations: Map<string, SelectedMutationBatch>;
   reconciliationDebt: Map<string, SelectedReconciliationDebt>;
   retired: Set<string>;
   autoSelectReason: AutoSelectReason | null;
   autoSelectDismissed: boolean;
+};
+
+type DefinitionsBarrierWaiter = {
+  watermark: number;
+  resolve: (published: boolean) => void;
+};
+
+type DefinitionsBarrierState = {
+  publishedVersion: number;
+  waiters: DefinitionsBarrierWaiter[];
 };
 
 const createSelectedCoordinator = (): SelectedCoordinator => ({
@@ -149,6 +165,7 @@ const createSelectedCoordinator = (): SelectedCoordinator => ({
   accepted: null,
   acceptedGeneration: 0,
   nextBatchId: 0,
+  nextOperationId: 0,
   nextMutationVersion: 0,
   mutations: new Map(),
   reconciliationDebt: new Map(),
@@ -178,7 +195,7 @@ const releaseSelectedDebtWaiters = (coordinator: SelectedCoordinator, identity: 
   debt.scheduled = false;
   const waiters = debt.waiters.splice(0);
   for (const waiter of waiters) {
-    waiter.resolve(waiter.mutationFailure ? { ok: false, error: waiter.mutationFailure } : { ok: true });
+    waiter.resolve({ ok: true });
   }
 };
 
@@ -252,6 +269,7 @@ export const AgentsPage: React.FC = () => {
     selection: 0,
     mutation: 0,
   });
+  const mutationErrorSequenceRef = useRef(0);
   const [search, setSearch] = useState('');
   const [backendFilter, setBackendFilter] = useState<Backend | 'all'>('all');
   const [importing, setImporting] = useState<Backend | null>(null);
@@ -260,6 +278,7 @@ export const AgentsPage: React.FC = () => {
   const [onboardingSubmitting, setOnboardingSubmitting] = useState(false);
   const onboardingSettlementRef = useRef<Promise<boolean> | null>(null);
   const definitionsVersionRef = useRef(createAgentRequestVersion());
+  const definitionsBarrierRef = useRef<DefinitionsBarrierState>({ publishedVersion: 0, waiters: [] });
   const onboardingVersionRef = useRef(createAgentRequestVersion());
   const selectedCoordinatorRef = useRef(createSelectedCoordinator());
   const selectedMountedRef = useRef(true);
@@ -287,6 +306,15 @@ export const AgentsPage: React.FC = () => {
     if (generation !== undefined && resourceErrorGenerationRef.current[owner] !== generation) return;
     setResourceErrors((current) => ({ ...current, [owner]: message }));
   }, []);
+
+  const publishMutationError = useCallback(
+    (value: unknown, sequence: number) => {
+      if (mutationErrorSequenceRef.current > sequence) return;
+      mutationErrorSequenceRef.current = sequence;
+      setResourceError('mutation', errorMessage(value) || t('errorBoundary.title'));
+    },
+    [setResourceError, t],
+  );
 
   const clearResourceError = useCallback((owner: ResourceErrorOwner, generation?: number) => {
     if (generation !== undefined && resourceErrorGenerationRef.current[owner] !== generation) return;
@@ -330,11 +358,14 @@ export const AgentsPage: React.FC = () => {
     return () => {
       selectedMountedRef.current = false;
       definitionsVersionRef.current.invalidate();
+      for (const waiter of definitionsBarrierRef.current.waiters.splice(0)) waiter.resolve(false);
       onboardingVersionRef.current.invalidate();
       const coordinator = selectedCoordinatorRef.current;
       for (const identity of coordinator.readGenerations.keys()) advanceSelectedRead(coordinator, identity);
       for (const batch of coordinator.mutations.values()) {
-        for (const resolve of batch.waiters.splice(0)) resolve({ ok: false, error: new Error('Agent page unmounted') });
+        for (const operation of batch.operations.splice(0)) {
+          operation.resolve?.({ ok: false, error: new Error('Agent page unmounted') });
+        }
       }
       for (const debt of coordinator.reconciliationDebt.values()) {
         for (const waiter of debt.waiters.splice(0)) waiter.resolve({ ok: false, error: new Error('Agent page unmounted') });
@@ -414,7 +445,25 @@ export const AgentsPage: React.FC = () => {
   // reconnect snapshot with a stale cached promise.
   const refresh = useCallback(() => {
     const token = definitionsVersionRef.current.begin();
-    const request = (async (): Promise<boolean> => {
+    const barrier = new Promise<boolean>((resolve) => {
+      const state = definitionsBarrierRef.current;
+      if (state.publishedVersion >= token.version) {
+        resolve(true);
+      } else {
+        state.waiters.push({ watermark: token.version, resolve });
+      }
+    });
+    const settleBarrier = (published: boolean) => {
+      const state = definitionsBarrierRef.current;
+      if (published) state.publishedVersion = Math.max(state.publishedVersion, token.version);
+      const remaining: DefinitionsBarrierWaiter[] = [];
+      for (const waiter of state.waiters) {
+        if (waiter.watermark <= token.version) waiter.resolve(published);
+        else remaining.push(waiter);
+      }
+      state.waiters = remaining;
+    };
+    void (async (): Promise<void> => {
       setLoading(true);
       clearResourceError('definitions');
       try {
@@ -425,7 +474,7 @@ export const AgentsPage: React.FC = () => {
         // A read issued before a stream gap may finish after the catch-up read.
         // Only the latest request may publish its snapshot, so an older response
         // cannot roll the Definitions list back to pre-gap state.
-        if (!definitionsVersionRef.current.isCurrent(token)) return false;
+        if (!definitionsVersionRef.current.isCurrent(token)) return;
         setAgents(result.agents);
         setDefaultName(result.default_agent_name);
         // List omission is authoritative retirement evidence. The coordinator
@@ -444,17 +493,17 @@ export const AgentsPage: React.FC = () => {
             retireSelectedIdentityRef.current?.(identity, { refreshDefinitions: false });
           }
         }
-        return true;
+        settleBarrier(true);
       } catch (err) {
         if (definitionsVersionRef.current.isCurrent(token)) {
           setResourceError('definitions', errorMessage(err) ?? String(err));
+          settleBarrier(false);
         }
-        return false;
       } finally {
         if (definitionsVersionRef.current.isCurrent(token)) setLoading(false);
       }
     })();
-    return request;
+    return barrier;
   }, [api, clearResourceError, setResourceError]);
 
   const refreshRef = useRef(refresh);
@@ -479,7 +528,7 @@ export const AgentsPage: React.FC = () => {
       const debt = coordinator.reconciliationDebt.get(identity);
       coordinator.reconciliationDebt.delete(identity);
       for (const waiter of debt?.waiters.splice(0) ?? []) {
-        waiter.resolve({ ok: false, error: { code: 'agent_not_found', message: 'Agent is no longer available' } });
+        waiter.resolve({ ok: false, error: { code: 'agent_not_found' } });
       }
       if (pendingIdentity) {
         coordinator.intentGeneration += 1;
@@ -579,18 +628,14 @@ export const AgentsPage: React.FC = () => {
           debt.scheduled = false;
           const waiters = debt.waiters.splice(0);
           for (const waiter of waiters) {
-            waiter.resolve({ ok: false, error: waiter.mutationFailure ?? error });
+            waiter.resolve({ ok: false, error });
           }
           return;
         }
         coordinator.reconciliationDebt.delete(options.identity);
         const waiters = debt.waiters.splice(0);
         for (const waiter of waiters) {
-          if (waiter.mutationFailure) {
-            waiter.resolve({ ok: false, error: waiter.mutationFailure });
-          } else {
-            waiter.resolve({ ok: true });
-          }
+          waiter.resolve({ ok: true });
         }
       };
       const continuationFor = () => {
@@ -707,41 +752,48 @@ export const AgentsPage: React.FC = () => {
         identity,
         pending: 0,
         version: ++coordinator.nextMutationVersion,
-        errorGeneration: 0,
-        failures: [],
-        waiters: [],
+        operations: [],
       };
       coordinator.mutations.set(identity, batch);
     }
-    const errorGeneration = beginResourceError('mutation');
-    batch.errorGeneration = errorGeneration;
+    beginResourceError('mutation');
+    if (!batch.operations.length) mutationErrorSequenceRef.current = 0;
     batch.pending += 1;
     batch.version = ++coordinator.nextMutationVersion;
+    // A pre-mutation Definitions snapshot cannot publish after the detail
+    // barrier. The settled transaction starts the next list publication.
+    definitionsVersionRef.current.invalidate();
     const debt = coordinator.reconciliationDebt.get(identity);
     if (debt) debt.scheduled = false;
     advanceSelectedRead(coordinator, identity);
-    return { id: batch.id, identity, errorGeneration };
+    const operation = { id: ++coordinator.nextOperationId, batchId: batch.id, identity, sequence: batch.version };
+    batch.operations.push(operation);
+    return operation;
   }, [beginResourceError]);
 
   const settleSelectedMutation = useCallback(
-    (operation: { id: number; identity: string }, failure?: unknown): Promise<SelectedMutationResult> => {
+    (operation: SelectedMutationOperation, failure?: unknown): Promise<SelectedMutationResult> => {
       if (!selectedMountedRef.current) return Promise.resolve({ ok: false, error: new Error('Agent page unmounted') });
       const coordinator = selectedCoordinatorRef.current;
-      const batch = [...coordinator.mutations.values()].find((candidate) => candidate.id === operation.id);
+      const batch = [...coordinator.mutations.values()].find((candidate) => candidate.id === operation.batchId);
       if (!batch) return Promise.resolve({ ok: false, error: new Error('Agent mutation is no longer current') });
-      if (failure) batch.failures.push(failure);
+      if (failure) operation.failure = failure;
       batch.pending = Math.max(0, batch.pending - 1);
       if (batch.pending !== 0) {
-        return new Promise<SelectedMutationResult>((resolve) => batch.waiters.push(resolve));
+        return new Promise<SelectedMutationResult>((resolve) => {
+          operation.resolve = resolve;
+        });
       }
 
       const identity = batch.identity;
       const version = batch.version;
-      const failures = [...batch.failures];
-      const errorGeneration = batch.errorGeneration;
       coordinator.mutations.delete(identity);
-      if (failures.length > 0) {
-        setResourceError('mutation', errorMessage(failures[0]) || t('errorBoundary.title'), errorGeneration);
+      const operations = [...batch.operations];
+      const firstFailure = operations.find((candidate) => candidate.failure)?.failure;
+      for (const candidate of operations) {
+        if (candidate.failure !== undefined) {
+          publishMutationError(candidate.failure, candidate.sequence);
+        }
       }
       const priorDebt = coordinator.reconciliationDebt.get(identity);
       if (!coordinator.retired.has(identity)) {
@@ -751,50 +803,52 @@ export const AgentsPage: React.FC = () => {
           waiters: priorDebt?.waiters ?? [],
         });
       }
-      void refreshRef.current();
-      const baseResult = failures.length > 0
-        ? ({ ok: false, error: failures[0] } as const)
-        : ({ ok: true } as const);
+      const baseResult: SelectedMutationResult = firstFailure
+        ? { ok: false, error: firstFailure }
+        : { ok: true };
       const currentDebt = coordinator.reconciliationDebt.get(identity);
       const shouldDrain = Boolean(
         currentDebt &&
           coordinator.desiredName === identity &&
           !coordinator.retired.has(identity),
       );
-      let resultPromise: Promise<SelectedMutationResult>;
-      if (!shouldDrain || !currentDebt) {
-        resultPromise = Promise.resolve(baseResult);
-      } else {
-        const completion = new Promise<SelectedMutationResult>((resolve) => {
-          currentDebt.waiters.push({
-            mutationFailure: failures[0],
-            errorGeneration,
-            resolve: (result) => {
-              if (!result.ok && !failures.length) {
-                setResourceError('mutation', errorMessage(result.error) || t('errorBoundary.title'), errorGeneration);
-              }
-              resolve(result);
-            },
+      const transaction = (async (): Promise<SelectedMutationResult> => {
+        let detailResult: SelectedMutationResult = baseResult;
+        if (shouldDrain && currentDebt) {
+          const completion = new Promise<SelectedMutationResult>((resolve) => {
+            currentDebt.waiters.push({ resolve });
           });
-        });
-        const drain = scheduleSelectedReadRef.current?.(identity, {
-          debtOnly: true,
-          expectedCodes: SELECTED_DISAPPEARANCE_CODES,
-          rollbackOnFailure: false,
-        });
-        if (!drain) {
-          const waiters = currentDebt.waiters.splice(0);
-          for (const waiter of waiters) waiter.resolve(baseResult);
-          resultPromise = Promise.resolve(baseResult);
-        } else {
-          resultPromise = completion;
+          const drain = scheduleSelectedReadRef.current?.(identity, {
+            debtOnly: true,
+            expectedCodes: SELECTED_DISAPPEARANCE_CODES,
+            rollbackOnFailure: false,
+          });
+          if (!drain && !currentDebt.scheduled) {
+            const waiters = currentDebt.waiters.splice(0);
+            for (const waiter of waiters) waiter.resolve(baseResult);
+          }
+          detailResult = await completion;
         }
+        // A brief list captured before the authoritative detail drain must not
+        // publish after that detail. The barrier joins any newer list request.
+        await refreshRef.current();
+        return detailResult;
+      })();
+      const resultFor = (candidate: SelectedMutationOperation): Promise<SelectedMutationResult> => transaction.then((detailResult) => {
+        if (candidate.failure !== undefined) {
+          return { ok: false, error: candidate.failure };
+        }
+        if (!detailResult.ok) {
+          publishMutationError(detailResult.error, candidate.sequence);
+        }
+        return detailResult;
+      });
+      for (const candidate of operations) {
+        if (candidate.resolve) void resultFor(candidate).then(candidate.resolve);
       }
-      const waiters = batch.waiters.splice(0);
-      for (const resolve of waiters) void resultPromise.then(resolve);
-      return resultPromise;
+      return resultFor(operation);
     },
-    [setResourceError, t],
+    [publishMutationError],
   );
 
   const reconcileSelected = useCallback(async (edgeEpoch?: number) => {
@@ -1186,7 +1240,6 @@ export const AgentsPage: React.FC = () => {
               void refresh();
               void refreshOnboarding();
             }}
-            disabled={loading}
           >
             <RefreshCw className={clsx('size-3.5', loading && 'animate-spin')} />
             {t('common.refresh')}
@@ -1898,7 +1951,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
       if (fieldRevisionRef.current.name === revision) setName(trimmed);
       showToast(t('agents.renameSuccess'), 'success');
     } catch (err) {
-      showToast(errorMessage(err) ?? String(err), 'error');
+      showToast(errorMessage(err) ?? t('errorBoundary.title'), 'error');
       cancelFieldEdit('name', serverSnapshotRef.current.name);
     } finally {
       setRenaming(false);

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -118,6 +118,8 @@ export const AgentsPage: React.FC = () => {
   const [onboardingExpanded, setOnboardingExpanded] = useState(false);
   const [onboardingSubmitting, setOnboardingSubmitting] = useState(false);
   const refreshRequestRef = useRef(0);
+  const selectedRef = useRef<VibeAgentFull | null>(null);
+  const selectedRefreshRequestRef = useRef(0);
   // Mobile drill-down: a row tap opens the detail full-screen. The agent
   // auto-selected on mount stays in the list view until the user drills in.
   const [detailOpen, setDetailOpen] = useState(false);
@@ -143,32 +145,69 @@ export const AgentsPage: React.FC = () => {
     }
   }, [api, canOnboardAgents]);
 
-  const refresh = useCallback(async (options?: { cache?: boolean }) => {
+  // Definitions refreshes are explicit reconciliation reads. They must always
+  // bypass the five-second client cache so a normal refresh cannot supersede a
+  // reconnect snapshot with a stale cached promise.
+  const refresh = useCallback(() => {
     const requestId = ++refreshRequestRef.current;
-    setLoading(true);
-    setError(null);
-    try {
-      const result = await api.listVibeAgents({
-        includeDisabled: true,
-        ...(options?.cache === undefined ? {} : { cache: options.cache }),
-      });
-      // A read issued before a stream gap may finish after the catch-up read.
-      // Only the latest request may publish its snapshot, so an older response
-      // cannot roll the Definitions list back to pre-gap state.
-      if (requestId !== refreshRequestRef.current) return;
-      setAgents(result.agents);
-      setDefaultName(result.default_agent_name);
-      // Keep the currently-selected agent fresh after edits / refreshes.
-      if (selected) {
-        const fresh = result.agents.find((a) => a.name === selected.name);
-        if (!fresh) setSelected(null);
+    const request = (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await api.listVibeAgents({
+          includeDisabled: true,
+          cache: false,
+        });
+        // A read issued before a stream gap may finish after the catch-up read.
+        // Only the latest request may publish its snapshot, so an older response
+        // cannot roll the Definitions list back to pre-gap state.
+        if (requestId !== refreshRequestRef.current) return;
+        setAgents(result.agents);
+        setDefaultName(result.default_agent_name);
+        // Keep the currently-selected agent present after edits / refreshes.
+        const currentSelected = selectedRef.current;
+        if (currentSelected) {
+          const fresh = result.agents.find((a) => a.name === currentSelected.name);
+          if (!fresh) {
+            selectedRef.current = null;
+            setSelected(null);
+          }
+        }
+      } catch (err) {
+        if (requestId === refreshRequestRef.current) setError(errorMessage(err) ?? String(err));
+      } finally {
+        if (requestId === refreshRequestRef.current) setLoading(false);
       }
-    } catch (err) {
-      if (requestId === refreshRequestRef.current) setError(errorMessage(err) ?? String(err));
-    } finally {
-      if (requestId === refreshRequestRef.current) setLoading(false);
+    })();
+    return request;
+  }, [api]);
+
+  const refreshRef = useRef(refresh);
+  refreshRef.current = refresh;
+
+  const refreshSelected = useCallback(async () => {
+    const current = selectedRef.current;
+    if (!current) return;
+    const requestId = ++selectedRefreshRequestRef.current;
+    try {
+      const result = await api.getVibeAgent(current.name, { cache: false });
+      if (
+        result.ok &&
+        requestId === selectedRefreshRequestRef.current &&
+        selectedRef.current?.name === current.name
+      ) {
+        selectedRef.current = result.agent;
+        setSelected(result.agent);
+      }
+    } catch {
+      // The list catch-up remains authoritative even if the selected detail
+      // cannot be re-read during a transient reconnect.
     }
-  }, [api, selected]);
+  }, [api]);
+
+  useEffect(() => {
+    selectedRef.current = selected;
+  }, [selected]);
 
   useEffect(() => {
     refresh();
@@ -233,7 +272,9 @@ export const AgentsPage: React.FC = () => {
       // The bridge report is only the indicator's level: it comes with its own
       // `onConnected`, and refetching from both would pay twice for one gap.
       onConnected: () => {
-        void refresh({ cache: false });
+        void refreshRef.current();
+        void refreshSelected();
+        void refreshOnboarding();
         void fetchRunningActiveCount();
       },
       onEventBridgeStatus: ({ connected }) => setEventBridgeConnected(connected),
@@ -242,9 +283,12 @@ export const AgentsPage: React.FC = () => {
       onTurnStart: () => fetchRunningActiveCount(),
       onTurnEnd: () => fetchRunningActiveCount(),
       onSessionStatus: () => fetchRunningActiveCount(),
-      onAuthorizationChanged: () => void refresh(),
+      onAuthorizationChanged: () => {
+        void refreshRef.current();
+        void refreshSelected();
+      },
     });
-  }, [api, capabilities.can_use_agents, fetchRunningActiveCount, refresh]);
+  }, [api, capabilities.can_use_agents, fetchRunningActiveCount, refreshOnboarding, refreshSelected]);
 
   useEffect(() => {
     if (!capabilities.can_use_agents) return;
@@ -298,6 +342,7 @@ export const AgentsPage: React.FC = () => {
       try {
         const result = await api.getVibeAgent(name);
         if (result.ok) {
+          selectedRef.current = result.agent;
           setSelected(result.agent);
           // Enter the mobile drill-down only once the detail has actually loaded —
           // never optimistically, or a failed fetch hides the list with no panel.
@@ -335,7 +380,10 @@ export const AgentsPage: React.FC = () => {
   }, [filtered]);
 
   const onCreated = (agent: VibeAgentFull) => {
-    refresh().then(() => setSelected(agent));
+    refresh().then(() => {
+      selectedRef.current = agent;
+      setSelected(agent);
+    });
     void refreshOnboarding();
   };
 
@@ -345,6 +393,7 @@ export const AgentsPage: React.FC = () => {
     try {
       const result = await api.updateVibeAgent(selected.name, patch);
       if (result.ok) {
+        selectedRef.current = result.agent;
         setSelected(result.agent);
         refresh();
       }
@@ -377,6 +426,7 @@ export const AgentsPage: React.FC = () => {
     try {
       const result = await api.removeVibeAgent(selected.name);
       if (result.ok) {
+        selectedRef.current = null;
         setSelected(null);
         refresh();
         void refreshOnboarding();
@@ -634,7 +684,11 @@ export const AgentsPage: React.FC = () => {
               onSetDefault={onSetDefault}
               onRenamed={onRenamed}
               onDelete={onDelete}
-              onClose={() => { setSelected(null); setDetailOpen(false); }}
+              onClose={() => {
+                selectedRef.current = null;
+                setSelected(null);
+                setDetailOpen(false);
+              }}
             />
           </div>
         )}
@@ -959,7 +1013,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
     setSystemPrompt(agent.system_prompt ?? '');
     setSystemPromptOpen(false);
     setEditorOpen(false);
-  }, [agent.id]);
+  }, [agent.id, agent.name, agent.description, agent.model, agent.reasoning_effort, agent.system_prompt]);
 
   // Load model catalog for the agent's backend so the Combobox can offer
   // suggestions. Keeps `allowCustomValue` so users can type a model the

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -114,9 +114,6 @@ type SelectedReadOutcome =
   | { kind: 'stale' }
   | { kind: 'expected-retired'; resumedIdentity: string; intentGeneration: number };
 
-const canonicalFieldValue = (field: 'name' | 'description' | 'model' | 'effort' | 'systemPrompt', value: string) =>
-  field === 'name' || field === 'description' || field === 'systemPrompt' ? value.trim() : value;
-
 type SelectedCoordinator = {
   desiredName: string | null;
   intentGeneration: number;
@@ -1611,16 +1608,15 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
       editorDirtyRef.current = false;
       setEditorSeedRevision((revision) => revision + 1);
     } else {
-      // Same-identity reconciliation compares the current canonical value to
-      // the accepted baseline. A field that returned to that baseline is clean
-      // even if it has an older edit revision; a field with an active submission
-      // remains local until its authoritative drain settles.
+      // Same-identity reconciliation compares raw text drafts to the raw
+      // accepted baseline. Submit-time trimming belongs only to the blur/save
+      // boundary, so an active leading/trailing-space draft remains visible.
       const pending = pendingRevisionRef.current;
-      if (pending.name === null && canonicalFieldValue('name', name) === canonicalFieldValue('name', previous.name)) setName(next.name);
-      if (pending.description === null && canonicalFieldValue('description', description) === canonicalFieldValue('description', previous.description)) setDescription(next.description);
-      if (pending.model === null && canonicalFieldValue('model', model) === canonicalFieldValue('model', previous.model)) setModel(next.model);
-      if (pending.effort === null && canonicalFieldValue('effort', effort) === canonicalFieldValue('effort', previous.effort)) setEffort(next.effort);
-      if (pending.systemPrompt === null && canonicalFieldValue('systemPrompt', systemPrompt) === canonicalFieldValue('systemPrompt', previous.systemPrompt)) setSystemPrompt(next.systemPrompt);
+      if (pending.name === null && name === previous.name) setName(next.name);
+      if (pending.description === null && description === previous.description) setDescription(next.description);
+      if (pending.model === null && model === previous.model) setModel(next.model);
+      if (pending.effort === null && effort === previous.effort) setEffort(next.effort);
+      if (pending.systemPrompt === null && systemPrompt === previous.systemPrompt) setSystemPrompt(next.systemPrompt);
       if (!editorDirtyRef.current && editorOpen) {
         editorDraftRef.current = next.systemPrompt;
         editorBaselineRef.current = next.systemPrompt;
@@ -1809,7 +1805,9 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
         </div>
         <Switch
           checked={agent.enabled}
-          onCheckedChange={(next) => onChange({ enabled: next })}
+          onCheckedChange={(next) => {
+            void onChange({ enabled: next }).catch(() => undefined);
+          }}
           disabled={!canEdit}
           title={canEdit ? undefined : t('agents.remoteReadOnlyHint')}
           label={t('agents.detail.enabled')}

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import {
@@ -117,6 +117,7 @@ export const AgentsPage: React.FC = () => {
   const [onboardingInventory, setOnboardingInventory] = useState<VibeAgentOnboardingResult | null>(null);
   const [onboardingExpanded, setOnboardingExpanded] = useState(false);
   const [onboardingSubmitting, setOnboardingSubmitting] = useState(false);
+  const refreshRequestRef = useRef(0);
   // Mobile drill-down: a row tap opens the detail full-screen. The agent
   // auto-selected on mount stays in the list view until the user drills in.
   const [detailOpen, setDetailOpen] = useState(false);
@@ -142,11 +143,19 @@ export const AgentsPage: React.FC = () => {
     }
   }, [api, canOnboardAgents]);
 
-  const refresh = useCallback(async () => {
+  const refresh = useCallback(async (options?: { cache?: boolean }) => {
+    const requestId = ++refreshRequestRef.current;
     setLoading(true);
     setError(null);
     try {
-      const result = await api.listVibeAgents({ includeDisabled: true });
+      const result = await api.listVibeAgents({
+        includeDisabled: true,
+        ...(options?.cache === undefined ? {} : { cache: options.cache }),
+      });
+      // A read issued before a stream gap may finish after the catch-up read.
+      // Only the latest request may publish its snapshot, so an older response
+      // cannot roll the Definitions list back to pre-gap state.
+      if (requestId !== refreshRequestRef.current) return;
       setAgents(result.agents);
       setDefaultName(result.default_agent_name);
       // Keep the currently-selected agent fresh after edits / refreshes.
@@ -155,9 +164,9 @@ export const AgentsPage: React.FC = () => {
         if (!fresh) setSelected(null);
       }
     } catch (err) {
-      setError(errorMessage(err) ?? String(err));
+      if (requestId === refreshRequestRef.current) setError(errorMessage(err) ?? String(err));
     } finally {
-      setLoading(false);
+      if (requestId === refreshRequestRef.current) setLoading(false);
     }
   }, [api, selected]);
 
@@ -223,7 +232,10 @@ export const AgentsPage: React.FC = () => {
       // Every gap ends here, whichever leg it was on, so this is the catch-up.
       // The bridge report is only the indicator's level: it comes with its own
       // `onConnected`, and refetching from both would pay twice for one gap.
-      onConnected: () => fetchRunningActiveCount(),
+      onConnected: () => {
+        void refresh({ cache: false });
+        void fetchRunningActiveCount();
+      },
       onEventBridgeStatus: ({ connected }) => setEventBridgeConnected(connected),
       onError: () => setEventBridgeConnected(false),
       onRunsUpdated: () => fetchRunningActiveCount(),

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -90,12 +90,15 @@ type SelectedMutationBatch = {
   version: number;
   errorGeneration: number;
   failures: unknown[];
+  waiters: Array<() => void>;
 };
 
 type SelectedReconciliationDebt = {
   version: number;
   scheduled: boolean;
 };
+
+type AutoSelectReason = 'initial' | 'replacement';
 
 type SelectedCoordinator = {
   desiredName: string | null;
@@ -108,6 +111,8 @@ type SelectedCoordinator = {
   mutations: Map<string, SelectedMutationBatch>;
   reconciliationDebt: Map<string, SelectedReconciliationDebt>;
   retired: Set<string>;
+  autoSelectReason: AutoSelectReason | null;
+  autoSelectDismissed: boolean;
 };
 
 const createSelectedCoordinator = (): SelectedCoordinator => ({
@@ -121,6 +126,8 @@ const createSelectedCoordinator = (): SelectedCoordinator => ({
   mutations: new Map(),
   reconciliationDebt: new Map(),
   retired: new Set(),
+  autoSelectReason: 'initial',
+  autoSelectDismissed: false,
 });
 
 const advanceSelectedRead = (coordinator: SelectedCoordinator, identity: string): number => {
@@ -214,6 +221,7 @@ export const AgentsPage: React.FC = () => {
   const definitionsVersionRef = useRef(createAgentRequestVersion());
   const onboardingVersionRef = useRef(createAgentRequestVersion());
   const selectedCoordinatorRef = useRef(createSelectedCoordinator());
+  const selectedMountedRef = useRef(true);
   // Mobile drill-down: a row tap opens the detail full-screen. The agent
   // auto-selected on mount stays in the list view until the user drills in.
   const [detailOpen, setDetailOpen] = useState(false);
@@ -251,6 +259,7 @@ export const AgentsPage: React.FC = () => {
   }, []);
 
   const refreshOnboarding = useCallback(async () => {
+    if (!selectedMountedRef.current) return;
     if (!canOnboardAgents) {
       setOnboardingInventory(null);
       return;
@@ -258,11 +267,25 @@ export const AgentsPage: React.FC = () => {
     const token = onboardingVersionRef.current.begin();
     try {
       const result = await api.getVibeAgentOnboarding();
-      if (onboardingVersionRef.current.isCurrent(token)) publishOnboarding(result);
+      if (selectedMountedRef.current && onboardingVersionRef.current.isCurrent(token)) publishOnboarding(result);
     } catch {
-      if (onboardingVersionRef.current.isCurrent(token)) publishOnboarding(null);
+      if (selectedMountedRef.current && onboardingVersionRef.current.isCurrent(token)) publishOnboarding(null);
     }
   }, [api, canOnboardAgents, publishOnboarding]);
+
+  useEffect(() => {
+    return () => {
+      selectedMountedRef.current = false;
+      definitionsVersionRef.current.invalidate();
+      onboardingVersionRef.current.invalidate();
+      const coordinator = selectedCoordinatorRef.current;
+      for (const identity of coordinator.readGenerations.keys()) advanceSelectedRead(coordinator, identity);
+      for (const batch of coordinator.mutations.values()) {
+        for (const resolve of batch.waiters.splice(0)) resolve();
+      }
+      coordinator.mutations.clear();
+    };
+  }, []);
 
   const scheduleSelectedReadRef = useRef<
     ((identity: string, options?: { expectedCodes?: readonly string[]; debtOnly?: boolean }) => Promise<'published' | 'failed' | 'stale'> | null)
@@ -286,7 +309,11 @@ export const AgentsPage: React.FC = () => {
       advanceSelectedRead(coordinator, coordinator.desiredName);
     }
     if (identity) advanceSelectedRead(coordinator, identity);
-    if (identity && !options.auto) coordinator.retired.delete(identity);
+    if (identity && !options.auto) {
+      coordinator.retired.delete(identity);
+      coordinator.autoSelectDismissed = false;
+      coordinator.autoSelectReason = null;
+    }
     const debt = identity ? coordinator.reconciliationDebt.get(identity) : null;
     if (debt) debt.scheduled = false;
     coordinator.intentGeneration += 1;
@@ -365,6 +392,9 @@ export const AgentsPage: React.FC = () => {
         coordinator.desiredName = null;
       }
       if (coordinator.accepted?.name === identity) commitSelected(null);
+      if (!coordinator.desiredName && !coordinator.accepted && !coordinator.autoSelectDismissed) {
+        coordinator.autoSelectReason = 'replacement';
+      }
       clearResourceError('selection');
       if (options.refreshDefinitions !== false) {
         definitionsVersionRef.current.invalidate();
@@ -386,6 +416,7 @@ export const AgentsPage: React.FC = () => {
     }): Promise<'published' | 'failed' | 'stale'> => {
       const coordinator = selectedCoordinatorRef.current;
       const isCurrent = () =>
+        selectedMountedRef.current &&
         selectedReadIsCurrent(coordinator, options.identity, options.readGeneration) &&
         coordinator.desiredName === options.identity &&
         !coordinator.retired.has(options.identity) &&
@@ -407,13 +438,15 @@ export const AgentsPage: React.FC = () => {
           finishDebt(true);
           return 'published';
         }
-        rollbackSelectedIntent();
+        const rollback = rollbackSelectedIntent();
         setResourceError('selection', errorMessage(result) || tRef.current('errorBoundary.title'));
         finishDebt(false);
-        void scheduleSelectedReadRef.current?.(coordinator.desiredName ?? '', {
-          debtOnly: true,
-          expectedCodes: options.expectedCodes ?? SELECTED_DISAPPEARANCE_CODES,
-        });
+        if (rollback.identity && rollback.identity !== options.identity) {
+          void scheduleSelectedReadRef.current?.(rollback.identity, {
+            debtOnly: true,
+            expectedCodes: options.expectedCodes ?? SELECTED_DISAPPEARANCE_CODES,
+          });
+        }
         return 'failed';
       } catch (err) {
         if (!isCurrent()) return 'stale';
@@ -422,13 +455,15 @@ export const AgentsPage: React.FC = () => {
           finishDebt(false);
           return 'failed';
         }
-        rollbackSelectedIntent();
+        const rollback = rollbackSelectedIntent();
         setResourceError('selection', errorMessage(err) || tRef.current('errorBoundary.title'));
         finishDebt(false);
-        void scheduleSelectedReadRef.current?.(coordinator.desiredName ?? '', {
-          debtOnly: true,
-          expectedCodes: options.expectedCodes ?? SELECTED_DISAPPEARANCE_CODES,
-        });
+        if (rollback.identity && rollback.identity !== options.identity) {
+          void scheduleSelectedReadRef.current?.(rollback.identity, {
+            debtOnly: true,
+            expectedCodes: options.expectedCodes ?? SELECTED_DISAPPEARANCE_CODES,
+          });
+        }
         return 'failed';
       }
     },
@@ -440,7 +475,7 @@ export const AgentsPage: React.FC = () => {
       identity: string,
       options: { expectedCodes?: readonly string[]; debtOnly?: boolean } = {},
     ): Promise<'published' | 'failed' | 'stale'> | null => {
-      if (!identity) return null;
+      if (!selectedMountedRef.current || !identity) return null;
       const coordinator = selectedCoordinatorRef.current;
       if (coordinator.retired.has(identity) || coordinator.desiredName !== identity) return null;
       // User selection is an explicit intent and may read immediately even
@@ -483,6 +518,7 @@ export const AgentsPage: React.FC = () => {
         version: ++coordinator.nextMutationVersion,
         errorGeneration: 0,
         failures: [],
+        waiters: [],
       };
       coordinator.mutations.set(identity, batch);
     }
@@ -497,13 +533,16 @@ export const AgentsPage: React.FC = () => {
   }, [beginResourceError]);
 
   const settleSelectedMutation = useCallback(
-    (operation: { id: number; identity: string }, failure?: unknown) => {
+    (operation: { id: number; identity: string }, failure?: unknown): Promise<void> => {
+      if (!selectedMountedRef.current) return Promise.resolve();
       const coordinator = selectedCoordinatorRef.current;
       const batch = coordinator.mutations.get(operation.identity);
-      if (!batch || batch.id !== operation.id) return;
+      if (!batch || batch.id !== operation.id) return Promise.resolve();
       if (failure) batch.failures.push(failure);
       batch.pending = Math.max(0, batch.pending - 1);
-      if (batch.pending !== 0) return;
+      if (batch.pending !== 0) {
+        return new Promise<void>((resolve) => batch.waiters.push(resolve));
+      }
 
       const identity = operation.identity;
       const version = batch.version;
@@ -517,7 +556,14 @@ export const AgentsPage: React.FC = () => {
         coordinator.reconciliationDebt.set(identity, { version, scheduled: false });
       }
       void refreshRef.current();
-      void scheduleSelectedReadRef.current?.(identity, { debtOnly: true, expectedCodes: SELECTED_DISAPPEARANCE_CODES });
+      const drain = scheduleSelectedReadRef.current?.(identity, {
+        debtOnly: true,
+        expectedCodes: SELECTED_DISAPPEARANCE_CODES,
+      });
+      const completion = drain?.then(() => undefined) ?? Promise.resolve();
+      const waiters = batch.waiters.splice(0);
+      for (const resolve of waiters) void completion.then(resolve);
+      return completion;
     },
     [setResourceError, t],
   );
@@ -526,10 +572,12 @@ export const AgentsPage: React.FC = () => {
     const coordinator = selectedCoordinatorRef.current;
     const identity = coordinator.desiredName;
     if (!identity) return;
+    if (coordinator.mutations.has(identity)) return;
     await scheduleSelectedReadRef.current?.(identity, { expectedCodes: SELECTED_DISAPPEARANCE_CODES });
   }, []);
 
   useEffect(() => {
+    selectedMountedRef.current = true;
     refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -543,9 +591,17 @@ export const AgentsPage: React.FC = () => {
   // that confused users on first visit.
   useEffect(() => {
     const coordinator = selectedCoordinatorRef.current;
-    if (selected || coordinator.accepted || coordinator.desiredName || agents.length === 0) return;
+    if (
+      !coordinator.autoSelectReason ||
+      coordinator.autoSelectDismissed ||
+      selected ||
+      coordinator.accepted ||
+      coordinator.desiredName ||
+      agents.length === 0
+    ) return;
     const available = agents.filter((agent) => !coordinator.retired.has(agent.name));
     const target = (defaultName && available.find((a) => a.name === defaultName)) || available[0];
+    coordinator.autoSelectReason = null;
     if (target) void selectAgent(target.name, false, true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultName, agents]);
@@ -671,6 +727,15 @@ export const AgentsPage: React.FC = () => {
     [beginSelectedIntent, clearResourceError],
   );
 
+  const dismissSelected = useCallback(() => {
+    const coordinator = selectedCoordinatorRef.current;
+    beginSelectedIntent(null);
+    coordinator.autoSelectDismissed = true;
+    coordinator.autoSelectReason = null;
+    commitSelected(null);
+    setDetailOpen(false);
+  }, [beginSelectedIntent, commitSelected]);
+
   // Apply text search + backend filter; backend grouping is a layout
   // concern that operates on the filtered set.
   const filtered = useMemo(() => {
@@ -703,15 +768,15 @@ export const AgentsPage: React.FC = () => {
   };
 
 
-  const updateField = async (patch: VibeAgentUpdatePayload) => {
+  const updateField = async (patch: VibeAgentUpdatePayload): Promise<void> => {
     if (!selected) return;
     const name = selected.name;
     const operation = beginSelectedMutation(name);
     try {
       const result = await api.updateVibeAgent(name, patch);
-      settleSelectedMutation(operation, result.ok ? undefined : result);
+      await settleSelectedMutation(operation, result.ok ? undefined : result);
     } catch (err) {
-      settleSelectedMutation(operation, err);
+      await settleSelectedMutation(operation, err);
     }
   };
 
@@ -999,11 +1064,7 @@ export const AgentsPage: React.FC = () => {
               onSetDefault={onSetDefault}
               onRenamed={onRenamed}
               onDelete={onDelete}
-              onClose={() => {
-                beginSelectedIntent(null);
-                commitSelected(null);
-                setDetailOpen(false);
-              }}
+              onClose={dismissSelected}
             />
           </div>
         )}
@@ -1276,7 +1337,7 @@ interface DetailProps {
   isDefault: boolean;
   /** False on remote instances, where every mutating control is unavailable. */
   canEdit: boolean;
-  onChange: (patch: VibeAgentUpdatePayload) => void;
+  onChange: (patch: VibeAgentUpdatePayload) => Promise<void>;
   onSetDefault: () => Promise<void>;
   onRenamed: (newName: string) => void;
   onDelete: () => void;
@@ -1308,6 +1369,16 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
   const [editorSeedRevision, setEditorSeedRevision] = useState(0);
   const editorDraftRef = useRef(agent.system_prompt ?? '');
   const editorDirtyRef = useRef(false);
+  const editorBaselineRef = useRef(agent.system_prompt ?? '');
+  type EditableField = 'description' | 'model' | 'effort' | 'systemPrompt';
+  const fieldRevisionRef = useRef<Record<EditableField, number>>({ description: 0, model: 0, effort: 0, systemPrompt: 0 });
+  const submittedRevisionRef = useRef<Record<EditableField, number>>({ description: 0, model: 0, effort: 0, systemPrompt: 0 });
+  const pendingRevisionRef = useRef<Record<EditableField, number | null>>({
+    description: null,
+    model: null,
+    effort: null,
+    systemPrompt: null,
+  });
   const [modelCatalogs, setModelCatalogs] = useState<
     Record<
       string,
@@ -1343,6 +1414,9 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
       systemPrompt: agent.system_prompt ?? '',
     };
     if (previous.id !== next.id) {
+      fieldRevisionRef.current = { description: 0, model: 0, effort: 0, systemPrompt: 0 };
+      submittedRevisionRef.current = { description: 0, model: 0, effort: 0, systemPrompt: 0 };
+      pendingRevisionRef.current = { description: null, model: null, effort: null, systemPrompt: null };
       setName(next.name);
       setDescription(next.description);
       setModel(next.model);
@@ -1351,24 +1425,31 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
       setSystemPromptOpen(false);
       setEditorOpen(false);
       editorDraftRef.current = next.systemPrompt;
+      editorBaselineRef.current = next.systemPrompt;
       editorDirtyRef.current = false;
       setEditorSeedRevision((revision) => revision + 1);
     } else {
-      // Same-identity reconciliation updates clean inline fields while leaving
-      // dirty work and the modal's private draft untouched.
-      if (name === previous.name) setName(next.name);
-      if (description === previous.description) setDescription(next.description);
-      if (model === previous.model) setModel(next.model);
-      if (effort === previous.effort) setEffort(next.effort);
-      if (systemPrompt === previous.systemPrompt || systemPrompt === next.systemPrompt) setSystemPrompt(next.systemPrompt);
-      if (editorDraftRef.current === previous.systemPrompt || editorDraftRef.current === next.systemPrompt) {
+      // Same-identity reconciliation follows explicit local/submitted
+      // revisions. A field with an in-flight mutation remains local until its
+      // mutation batch's authoritative drain completes; an older drain cannot
+      // overwrite a newer edit. Once no submission is pending, clean fields
+      // follow the accepted server snapshot.
+      const revisions = fieldRevisionRef.current;
+      const submitted = submittedRevisionRef.current;
+      const pending = pendingRevisionRef.current;
+      if (pending.description === null && revisions.description <= submitted.description) setDescription(next.description);
+      if (pending.model === null && revisions.model <= submitted.model) setModel(next.model);
+      if (pending.effort === null && revisions.effort <= submitted.effort) setEffort(next.effort);
+      if (pending.systemPrompt === null && revisions.systemPrompt <= submitted.systemPrompt) setSystemPrompt(next.systemPrompt);
+      if (!editorDirtyRef.current && editorOpen) {
         editorDraftRef.current = next.systemPrompt;
+        editorBaselineRef.current = next.systemPrompt;
         editorDirtyRef.current = false;
-        if (editorOpen) setEditorSeedRevision((revision) => revision + 1);
+        setEditorSeedRevision((revision) => revision + 1);
       }
     }
     serverSnapshotRef.current = next;
-  }, [agent.id, agent.name, agent.description, agent.model, agent.reasoning_effort, agent.system_prompt, description, effort, model, name, systemPrompt, editorOpen]);
+  }, [agent.id, agent.name, agent.description, agent.model, agent.reasoning_effort, agent.system_prompt, editorOpen]);
 
   // Load model catalog for the agent's backend so the Combobox can offer
   // suggestions. Keeps `allowCustomValue` so users can type a model the
@@ -1403,6 +1484,41 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
   const systemPromptTokens = estimateTokens(systemPrompt);
   // Effort options follow the backend + selected model when the catalog provides them.
   const effortOptions = resolveEffortOptions(agent.backend, model, reasoningOptions);
+  const markFieldEdit = (field: keyof typeof fieldRevisionRef.current) => {
+    fieldRevisionRef.current[field] += 1;
+    return fieldRevisionRef.current[field];
+  };
+  const markFieldSubmitted = (field: keyof typeof submittedRevisionRef.current) => {
+    submittedRevisionRef.current[field] = fieldRevisionRef.current[field];
+  };
+  const submitFields = (patch: VibeAgentUpdatePayload, fields: EditableField[]) => {
+    const revisions = fields.map((field) => {
+      const revision = fieldRevisionRef.current[field];
+      pendingRevisionRef.current[field] = revision;
+      return { field, revision };
+    });
+    void onChange(patch).then(() => {
+      for (const { field, revision } of revisions) {
+        if (pendingRevisionRef.current[field] !== revision) continue;
+        pendingRevisionRef.current[field] = null;
+        submittedRevisionRef.current[field] = revision;
+        if (fieldRevisionRef.current[field] !== revision) continue;
+        const snapshot = serverSnapshotRef.current;
+        if (field === 'description') setDescription(snapshot.description ?? '');
+        if (field === 'model') setModel(snapshot.model ?? '');
+        if (field === 'effort') setEffort(snapshot.effort ?? 'medium');
+        if (field === 'systemPrompt') {
+          const value = snapshot.systemPrompt ?? '';
+          setSystemPrompt(value);
+          if (!editorDirtyRef.current && editorOpen) {
+            editorDraftRef.current = value;
+            editorBaselineRef.current = value;
+            setEditorSeedRevision((seed) => seed + 1);
+          }
+        }
+      }
+    });
+  };
 
   // Only user Agents can be renamed; the backend moves every durable name
   // reference in the same transaction.
@@ -1546,12 +1662,16 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
       <Field label={t('agents.detail.description')}>
         <Textarea
           value={description}
-          onChange={(e) => setDescription(e.target.value)}
+          onChange={(e) => {
+            markFieldEdit('description');
+            setDescription(e.target.value);
+          }}
           onBlur={() => {
-            if (!locked && description !== (agent.description ?? '')) {
+            if (!locked && (description !== (agent.description ?? '') || pendingRevisionRef.current.description !== null)) {
               const canonical = description.trim();
               setDescription(canonical);
-              onChange({ description: canonical || null });
+              markFieldSubmitted('description');
+              submitFields({ description: canonical || null }, ['description']);
             }
           }}
           disabled={locked}
@@ -1595,6 +1715,8 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
             onValueChange={(next) => {
               const value = next.trim();
               if (!value) return;
+              markFieldEdit('model');
+              markFieldSubmitted('model');
               setModel(value);
               const patch: Partial<VibeAgentFull> = { model: value };
               // If the new model can't use the current effort, fall back to a
@@ -1604,11 +1726,13 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
               if (effort && !opts.includes(effort)) {
                 const fallback = opts.includes('medium') ? 'medium' : opts[0];
                 if (fallback) {
+                  markFieldEdit('effort');
+                  markFieldSubmitted('effort');
                   setEffort(fallback);
                   patch.reasoning_effort = fallback;
                 }
               }
-              onChange(patch);
+              submitFields(patch, patch.reasoning_effort ? ['model', 'effort'] : ['model']);
             }}
             placeholder={t('agents.detail.modelPlaceholder')}
             emptyText={t('agents.detail.modelEmpty')}
@@ -1632,8 +1756,10 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
                 disabled={!canEdit}
                 title={canEdit ? undefined : t('agents.remoteReadOnlyHint')}
                 onClick={() => {
+                  markFieldEdit('effort');
+                  markFieldSubmitted('effort');
                   setEffort(opt);
-                  onChange({ reasoning_effort: opt });
+                  submitFields({ reasoning_effort: opt }, ['effort']);
                 }}
                 className={clsx(
                   'truncate rounded-md px-1 py-1.5 text-[11px] capitalize transition disabled:cursor-not-allowed',
@@ -1692,11 +1818,15 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
         {systemPromptOpen && (
           <Textarea
             value={systemPrompt}
-            onChange={(e) => setSystemPrompt(e.target.value)}
+            onChange={(e) => {
+              markFieldEdit('systemPrompt');
+              setSystemPrompt(e.target.value);
+            }}
             onBlur={() => {
               if (canEdit && systemPrompt !== (agent.system_prompt ?? '')) {
                 const canonical = systemPrompt.trim();
                 setSystemPrompt(canonical);
+                markFieldSubmitted('systemPrompt');
                 onChange({ system_prompt: canonical || null });
               }
             }}
@@ -1752,23 +1882,35 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
       <EditorDialog
         key={`${agent.id}:${editorSeedRevision}`}
         open={canEdit && editorOpen}
-        onClose={() => setEditorOpen(false)}
+        onClose={() => {
+          editorDraftRef.current = systemPrompt;
+          editorBaselineRef.current = systemPrompt;
+          editorDirtyRef.current = false;
+          setEditorOpen(false);
+        }}
         title={t('agents.detail.systemPrompt')}
         description={t('agents.detail.systemPromptEditorHint')}
         value={systemPrompt}
         placeholder={t('agents.create.systemPromptPlaceholder')}
         footerHint={(draft) => {
+          if (draft !== editorDraftRef.current) {
+            markFieldEdit('systemPrompt');
+            editorDraftRef.current = draft;
+            editorDirtyRef.current = true;
+          }
           editorDraftRef.current = draft;
-          editorDirtyRef.current = draft !== systemPrompt;
           return t('agents.detail.systemPromptCount', { count: estimateTokens(draft) });
         }}
         onSave={(next) => {
           const canonical = next.trim();
+            markFieldEdit('systemPrompt');
+            markFieldSubmitted('systemPrompt');
           setSystemPrompt(canonical);
           editorDraftRef.current = canonical;
+          editorBaselineRef.current = canonical;
           editorDirtyRef.current = false;
-          if (canonical !== (agent.system_prompt ?? '')) {
-            onChange({ system_prompt: canonical || null });
+          if (canonical !== (agent.system_prompt ?? '') || pendingRevisionRef.current.systemPrompt !== null) {
+            submitFields({ system_prompt: canonical || null }, ['systemPrompt']);
           }
         }}
       />

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -83,6 +83,16 @@ type AgentRequestVersion = {
   isCurrent: (token: AgentRequestToken) => boolean;
 };
 
+type SelectedMutationBatch = {
+  id: number;
+  identity: string;
+  pending: number;
+  drainGeneration: number;
+  draining: boolean;
+  intentGeneration: number;
+  failures: unknown[];
+};
+
 // A tiny per-resource epoch owner. Every asynchronous read captures a token;
 // any committed mutation or identity change advances the epoch and makes older
 // responses inert without relying on timing or a name comparison alone.
@@ -148,9 +158,11 @@ export const AgentsPage: React.FC = () => {
   const definitionsVersionRef = useRef(createAgentRequestVersion());
   const onboardingVersionRef = useRef(createAgentRequestVersion());
   const selectedRef = useRef<VibeAgentFull | null>(null);
-  const selectedVersionRef = useRef(createAgentRequestVersion());
-  const selectedIntentRef = useRef(0);
-  const selectedMutationVersionRef = useRef(0);
+  const selectedIntentRef = useRef({ generation: 0, desiredName: null as string | null });
+  const selectedAcceptedGenerationRef = useRef(0);
+  const selectedPassiveReadRef = useRef(0);
+  const selectedMutationBatchesRef = useRef(new Map<string, SelectedMutationBatch>());
+  const selectedMutationBatchIdRef = useRef(0);
   const onboardingMutationRef = useRef(0);
   // Mobile drill-down: a row tap opens the detail full-screen. The agent
   // auto-selected on mount stays in the list view until the user drills in.
@@ -184,14 +196,17 @@ export const AgentsPage: React.FC = () => {
   }, [api, canOnboardAgents, publishOnboarding]);
 
   const commitSelected = useCallback((agent: VibeAgentFull | null) => {
-    selectedVersionRef.current.invalidate();
+    selectedAcceptedGenerationRef.current += 1;
+    selectedPassiveReadRef.current += 1;
     selectedRef.current = agent;
     setSelected(agent);
   }, []);
 
   const beginSelectedIntent = useCallback((identity: string | null) => {
-    const intent = ++selectedIntentRef.current;
-    return { intent, token: selectedVersionRef.current.begin(identity) };
+    const generation = ++selectedIntentRef.current.generation;
+    selectedIntentRef.current.desiredName = identity;
+    selectedPassiveReadRef.current += 1;
+    return { generation, identity };
   }, []);
 
 
@@ -218,8 +233,11 @@ export const AgentsPage: React.FC = () => {
         const currentSelected = selectedRef.current;
         if (currentSelected) {
           const fresh = result.agents.find((a) => a.name === currentSelected.name);
-          if (!fresh) {
-            beginSelectedIntent(null);
+          if (
+            !fresh &&
+            selectedIntentRef.current.desiredName === currentSelected.name &&
+            !selectedMutationBatchesRef.current.has(currentSelected.name)
+          ) {
             commitSelected(null);
           }
         }
@@ -230,39 +248,145 @@ export const AgentsPage: React.FC = () => {
       }
     })();
     return request;
-  }, [api, beginSelectedIntent, commitSelected]);
+  }, [api, commitSelected]);
 
   const refreshRef = useRef(refresh);
   refreshRef.current = refresh;
 
+  const beginSelectedMutation = useCallback((identity: string) => {
+    let batch = selectedMutationBatchesRef.current.get(identity);
+    if (!batch) {
+      batch = {
+        id: ++selectedMutationBatchIdRef.current,
+        identity,
+        pending: 0,
+        drainGeneration: 0,
+        draining: false,
+        intentGeneration: selectedIntentRef.current.generation,
+        failures: [],
+      };
+      selectedMutationBatchesRef.current.set(identity, batch);
+    }
+    batch.pending += 1;
+    batch.drainGeneration += 1;
+    batch.draining = false;
+    selectedPassiveReadRef.current += 1;
+    return { id: batch.id, identity };
+  }, []);
+
+  const settleSelectedMutation = useCallback(
+    (operation: { id: number; identity: string }, failure?: unknown) => {
+      const batch = selectedMutationBatchesRef.current.get(operation.identity);
+      if (!batch || batch.id !== operation.id) return;
+      if (failure) batch.failures.push(failure);
+      batch.pending = Math.max(0, batch.pending - 1);
+      if (batch.pending !== 0 || batch.draining) return;
+
+      batch.draining = true;
+      const drainGeneration = ++batch.drainGeneration;
+      const intentGeneration = batch.intentGeneration;
+      const acceptedGeneration = selectedAcceptedGenerationRef.current;
+      const passiveRead = ++selectedPassiveReadRef.current;
+      const identity = operation.identity;
+
+      void (async () => {
+        let result: Awaited<ReturnType<typeof api.getVibeAgent>> | null = null;
+        let readError: unknown = null;
+        try {
+          result = await api.getVibeAgent(identity, {
+            cache: false,
+            expectedCodes: SELECTED_DISAPPEARANCE_CODES,
+          });
+        } catch (err) {
+          readError = err;
+        }
+
+        const currentBatch = selectedMutationBatchesRef.current.get(identity);
+        if (
+          !currentBatch ||
+          currentBatch.id !== operation.id ||
+          currentBatch.drainGeneration !== drainGeneration ||
+          currentBatch.pending !== 0
+        ) {
+          return;
+        }
+
+        const canPublish =
+          selectedIntentRef.current.generation === intentGeneration &&
+          selectedIntentRef.current.desiredName === identity &&
+          selectedRef.current?.name === identity &&
+          selectedAcceptedGenerationRef.current === acceptedGeneration &&
+          selectedPassiveReadRef.current === passiveRead;
+        const failures = currentBatch.failures;
+
+        if (canPublish && result?.ok) commitSelected(result.agent);
+        if (canPublish && readError) {
+          if (SELECTED_DISAPPEARANCE_CODES.includes(errorCodeOf(readError) as (typeof SELECTED_DISAPPEARANCE_CODES)[number])) {
+            commitSelected(null);
+          }
+        }
+        // The settled mutation batch owns the Definitions refresh even when the
+        // user has already selected another Agent; the full-detail publication
+        // remains conditional on the selected intent above.
+        void refreshRef.current();
+        if (canPublish && readError && !SELECTED_DISAPPEARANCE_CODES.includes(errorCodeOf(readError) as (typeof SELECTED_DISAPPEARANCE_CODES)[number])) {
+          setError(errorMessage(readError) ?? String(readError));
+        }
+        if (canPublish && failures.length > 0) {
+          setError(errorMessage(failures[0]) ?? String(failures[0]));
+        }
+        if (selectedMutationBatchesRef.current.get(identity) === currentBatch) {
+          selectedMutationBatchesRef.current.delete(identity);
+        }
+      })();
+    },
+    [api, commitSelected],
+  );
+
   const refreshSelected = useCallback(async () => {
     const current = selectedRef.current;
     if (!current) return;
-    const intent = selectedIntentRef.current;
-    const token = selectedVersionRef.current.begin(current.name);
+    const batch = selectedMutationBatchesRef.current.get(current.name);
+    if (batch) return;
+    const intentGeneration = selectedIntentRef.current.generation;
+    const desiredIdentity = selectedIntentRef.current.desiredName;
+    const acceptedGeneration = selectedAcceptedGenerationRef.current;
+    const passiveRead = ++selectedPassiveReadRef.current;
+    const identity = current.name;
     try {
-      const result = await api.getVibeAgent(current.name, {
+      const result = await api.getVibeAgent(identity, {
         cache: false,
         expectedCodes: SELECTED_DISAPPEARANCE_CODES,
       });
       if (
         result.ok &&
-        selectedVersionRef.current.isCurrent(token) &&
-        selectedIntentRef.current === intent &&
-        selectedRef.current?.name === token.identity
+        selectedPassiveReadRef.current === passiveRead &&
+        selectedAcceptedGenerationRef.current === acceptedGeneration &&
+        selectedIntentRef.current.generation === intentGeneration &&
+        selectedIntentRef.current.desiredName === desiredIdentity &&
+        desiredIdentity === identity &&
+        selectedRef.current?.name === identity &&
+        !selectedMutationBatchesRef.current.has(identity)
       ) {
         commitSelected(result.agent);
       }
     } catch (err) {
-      if (!selectedVersionRef.current.isCurrent(token) || selectedIntentRef.current !== intent) return;
+      if (
+        selectedPassiveReadRef.current !== passiveRead ||
+        selectedAcceptedGenerationRef.current !== acceptedGeneration ||
+        selectedIntentRef.current.generation !== intentGeneration ||
+        selectedIntentRef.current.desiredName !== desiredIdentity ||
+        desiredIdentity !== identity ||
+        selectedRef.current?.name !== identity ||
+        selectedMutationBatchesRef.current.has(identity)
+      ) return;
       if (SELECTED_DISAPPEARANCE_CODES.includes(errorCodeOf(err) as (typeof SELECTED_DISAPPEARANCE_CODES)[number])) {
-        beginSelectedIntent(null);
         commitSelected(null);
         return;
       }
       setError(errorMessage(err) ?? String(err));
     }
-  }, [api, beginSelectedIntent, commitSelected]);
+  }, [api, commitSelected]);
 
   useEffect(() => {
     refresh();
@@ -394,17 +518,24 @@ export const AgentsPage: React.FC = () => {
 
   const selectAgent = useCallback(
     async (name: string, openDetail = false) => {
-      const { intent, token } = beginSelectedIntent(name);
+      const { generation, identity } = beginSelectedIntent(name);
       try {
-        const result = await api.getVibeAgent(name);
-        if (result.ok && selectedIntentRef.current === intent && selectedVersionRef.current.isCurrent(token)) {
+        const result = await api.getVibeAgent(name, { cache: false });
+        if (
+          result.ok &&
+          selectedIntentRef.current.generation === generation &&
+          selectedIntentRef.current.desiredName === identity
+        ) {
           commitSelected(result.agent);
           // Enter the mobile drill-down only once the detail has actually loaded —
           // never optimistically, or a failed fetch hides the list with no panel.
           if (openDetail) setDetailOpen(true);
         }
       } catch (err) {
-        if (selectedIntentRef.current === intent && selectedVersionRef.current.isCurrent(token)) {
+        if (
+          selectedIntentRef.current.generation === generation &&
+          selectedIntentRef.current.desiredName === identity
+        ) {
           setError(errorMessage(err) ?? String(err));
         }
       }
@@ -447,26 +578,12 @@ export const AgentsPage: React.FC = () => {
   const updateField = async (patch: VibeAgentUpdatePayload) => {
     if (!selected) return;
     const name = selected.name;
-    const intent = selectedIntentRef.current;
-    const mutationToken = selectedVersionRef.current.begin(name);
-    selectedMutationVersionRef.current = mutationToken.version;
+    const operation = beginSelectedMutation(name);
     try {
       const result = await api.updateVibeAgent(name, patch);
-      if (
-        result.ok &&
-        selectedIntentRef.current === intent &&
-        selectedRef.current?.name === name &&
-        selectedMutationVersionRef.current === mutationToken.version
-      ) {
-        // Publishing the mutation result advances the same epoch, invalidating
-        // any read that started while the PATCH was in flight.
-        commitSelected(result.agent);
-        refresh();
-      }
+      settleSelectedMutation(operation, result.ok ? undefined : result);
     } catch (err) {
-      if (selectedIntentRef.current === intent && selectedRef.current?.name === name) {
-        setError(errorMessage(err) ?? String(err));
-      }
+      settleSelectedMutation(operation, err);
     }
   };
 

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -95,9 +95,16 @@ type SelectedMutationBatch = {
 
 type SelectedMutationResult = { ok: true } | { ok: false; error: unknown };
 
+type SelectedReconciliationWaiter = {
+  resolve: (result: SelectedMutationResult) => void;
+  mutationFailure?: unknown;
+  errorGeneration?: number;
+};
+
 type SelectedReconciliationDebt = {
   version: number;
   scheduled: boolean;
+  waiters: SelectedReconciliationWaiter[];
 };
 
 type AutoSelectReason = 'initial' | 'replacement';
@@ -108,11 +115,13 @@ type SelectedRetirement = {
   intentGeneration: number;
 };
 
+type SelectedReadContinuation = { nextIdentity: string; intentGeneration: number };
+
 type SelectedReadOutcome =
   | { kind: 'published' }
-  | { kind: 'failed' }
+  | { kind: 'failed'; error?: unknown; continuation?: SelectedReadContinuation }
   | { kind: 'stale' }
-  | { kind: 'expected-retired'; resumedIdentity: string; intentGeneration: number };
+  | { kind: 'expected-retired'; continuation: SelectedReadContinuation };
 
 type SelectedCoordinator = {
   desiredName: string | null;
@@ -159,6 +168,19 @@ const selectedReadIsCurrent = (
   identity: string,
   generation: number,
 ): boolean => coordinator.readGenerations.get(identity) === generation;
+
+const releaseSelectedDebtWaiters = (coordinator: SelectedCoordinator, identity: string) => {
+  const debt = coordinator.reconciliationDebt.get(identity);
+  if (!debt || debt.waiters.length === 0) return;
+  // Leaving an identity supersedes its in-flight read. The mutation itself is
+  // already terminal, so settle callers now; any retained debt is evidence for
+  // the next authoritative read when the identity is selected again.
+  debt.scheduled = false;
+  const waiters = debt.waiters.splice(0);
+  for (const waiter of waiters) {
+    waiter.resolve(waiter.mutationFailure ? { ok: false, error: waiter.mutationFailure } : { ok: true });
+  }
+};
 
 type ResourceErrorOwner = 'definitions' | 'selection' | 'mutation';
 type ResourceErrors = Record<ResourceErrorOwner, string | null>;
@@ -314,12 +336,22 @@ export const AgentsPage: React.FC = () => {
       for (const batch of coordinator.mutations.values()) {
         for (const resolve of batch.waiters.splice(0)) resolve({ ok: false, error: new Error('Agent page unmounted') });
       }
+      for (const debt of coordinator.reconciliationDebt.values()) {
+        for (const waiter of debt.waiters.splice(0)) waiter.resolve({ ok: false, error: new Error('Agent page unmounted') });
+      }
+      coordinator.reconciliationDebt.clear();
       coordinator.mutations.clear();
     };
   }, []);
 
   const scheduleSelectedReadRef = useRef<
-    ((identity: string, options?: { expectedCodes?: readonly string[]; debtOnly?: boolean; refreshDefinitions?: boolean }) => Promise<SelectedReadOutcome> | null)
+    ((identity: string, options?: {
+      expectedCodes?: readonly string[];
+      debtOnly?: boolean;
+      refreshDefinitions?: boolean;
+      rollbackOnFailure?: boolean;
+      clearSelectionError?: boolean;
+    }) => Promise<SelectedReadOutcome> | null)
   >(null);
   const retireSelectedIdentityRef = useRef<
     ((identity: string, options?: { refreshDefinitions?: boolean }) => SelectedRetirement) | null
@@ -346,6 +378,7 @@ export const AgentsPage: React.FC = () => {
     ) => {
       const coordinator = selectedCoordinatorRef.current;
       if (coordinator.desiredName && coordinator.desiredName !== identity) {
+        releaseSelectedDebtWaiters(coordinator, coordinator.desiredName);
         advanceSelectedRead(coordinator, coordinator.desiredName);
       }
       if (identity) advanceSelectedRead(coordinator, identity);
@@ -443,7 +476,11 @@ export const AgentsPage: React.FC = () => {
       );
       coordinator.retired.add(identity);
       advanceSelectedRead(coordinator, identity);
+      const debt = coordinator.reconciliationDebt.get(identity);
       coordinator.reconciliationDebt.delete(identity);
+      for (const waiter of debt?.waiters.splice(0) ?? []) {
+        waiter.resolve({ ok: false, error: { code: 'agent_not_found', message: 'Agent is no longer available' } });
+      }
       if (pendingIdentity) {
         coordinator.intentGeneration += 1;
         // A pending selection can disappear without invalidating the accepted
@@ -524,6 +561,8 @@ export const AgentsPage: React.FC = () => {
       expectedCodes?: readonly string[];
       debtVersion?: number;
       refreshDefinitions?: boolean;
+      rollbackOnFailure?: boolean;
+      clearSelectionError?: boolean;
     }): Promise<SelectedReadOutcome> => {
       const coordinator = selectedCoordinatorRef.current;
       const isCurrent = () =>
@@ -532,19 +571,41 @@ export const AgentsPage: React.FC = () => {
         coordinator.desiredName === options.identity &&
         !coordinator.retired.has(options.identity) &&
         (options.intentGeneration === undefined || coordinator.intentGeneration === options.intentGeneration);
-      const finishDebt = (published: boolean) => {
+      const finishDebt = (published: boolean, error?: unknown) => {
         if (options.debtVersion === undefined) return;
         const debt = coordinator.reconciliationDebt.get(options.identity);
         if (!debt || debt.version !== options.debtVersion) return;
-        if (published) coordinator.reconciliationDebt.delete(options.identity);
-        else debt.scheduled = false;
+        if (!published) {
+          debt.scheduled = false;
+          const waiters = debt.waiters.splice(0);
+          for (const waiter of waiters) {
+            waiter.resolve({ ok: false, error: waiter.mutationFailure ?? error });
+          }
+          return;
+        }
+        coordinator.reconciliationDebt.delete(options.identity);
+        const waiters = debt.waiters.splice(0);
+        for (const waiter of waiters) {
+          if (waiter.mutationFailure) {
+            waiter.resolve({ ok: false, error: waiter.mutationFailure });
+          } else {
+            waiter.resolve({ ok: true });
+          }
+        }
+      };
+      const continuationFor = () => {
+        if (options.rollbackOnFailure === false) return undefined;
+        const rollback = rollbackSelectedIntent();
+        return rollback.identity && rollback.identity !== options.identity
+          ? { nextIdentity: rollback.identity, intentGeneration: rollback.intentGeneration }
+          : undefined;
       };
       try {
         const params = options.expectedCodes ? { cache: false, expectedCodes: options.expectedCodes } : { cache: false };
         const result = await api.getVibeAgent(options.identity, params);
         if (!isCurrent()) return { kind: 'stale' };
         if (result.ok && result.agent?.name === options.identity) {
-          clearResourceError('selection');
+          if (options.clearSelectionError !== false) clearResourceError('selection');
           commitSelected(result.agent);
           finishDebt(true);
           return { kind: 'published' };
@@ -556,40 +617,42 @@ export const AgentsPage: React.FC = () => {
           const retirement = retireSelectedIdentityRef.current?.(options.identity, {
             refreshDefinitions: options.refreshDefinitions !== false,
           });
-          finishDebt(false);
           if (retirement?.resumedIdentity) {
             return {
               kind: 'expected-retired',
-              resumedIdentity: retirement.resumedIdentity,
-              intentGeneration: retirement.intentGeneration,
+              continuation: {
+                nextIdentity: retirement.resumedIdentity,
+                intentGeneration: retirement.intentGeneration,
+              },
             };
           }
           return { kind: 'failed' };
         }
-        rollbackSelectedIntent();
+        const continuation = continuationFor();
         setResourceError('selection', errorMessage(result) || tRef.current('errorBoundary.title'));
-        finishDebt(false);
-        return { kind: 'failed' };
+        finishDebt(false, result);
+        return { kind: 'failed', error: result, continuation };
       } catch (err) {
         if (!isCurrent()) return { kind: 'stale' };
         if (options.expectedCodes && SELECTED_DISAPPEARANCE_CODES.includes(errorCodeOf(err) as (typeof SELECTED_DISAPPEARANCE_CODES)[number])) {
           const retirement = retireSelectedIdentityRef.current?.(options.identity, {
             refreshDefinitions: options.refreshDefinitions !== false,
           });
-          finishDebt(false);
           if (retirement?.resumedIdentity) {
             return {
               kind: 'expected-retired',
-              resumedIdentity: retirement.resumedIdentity,
-              intentGeneration: retirement.intentGeneration,
+              continuation: {
+                nextIdentity: retirement.resumedIdentity,
+                intentGeneration: retirement.intentGeneration,
+              },
             };
           }
           return { kind: 'failed' };
         }
-        rollbackSelectedIntent();
+        const continuation = continuationFor();
         setResourceError('selection', errorMessage(err) || tRef.current('errorBoundary.title'));
-        finishDebt(false);
-        return { kind: 'failed' };
+        finishDebt(false, err);
+        return { kind: 'failed', error: err, continuation };
       }
     },
     [api, clearResourceError, commitSelected, rollbackSelectedIntent, setResourceError],
@@ -598,7 +661,13 @@ export const AgentsPage: React.FC = () => {
   const scheduleSelectedRead = useCallback(
     (
       identity: string,
-      options: { expectedCodes?: readonly string[]; debtOnly?: boolean; refreshDefinitions?: boolean } = {},
+      options: {
+        expectedCodes?: readonly string[];
+        debtOnly?: boolean;
+        refreshDefinitions?: boolean;
+        rollbackOnFailure?: boolean;
+        clearSelectionError?: boolean;
+      } = {},
     ): Promise<SelectedReadOutcome> | null => {
       if (!selectedMountedRef.current || !identity) return null;
       const coordinator = selectedCoordinatorRef.current;
@@ -620,13 +689,9 @@ export const AgentsPage: React.FC = () => {
         intentGeneration,
         expectedCodes: options.expectedCodes,
         refreshDefinitions: options.refreshDefinitions,
+        rollbackOnFailure: options.rollbackOnFailure,
+        clearSelectionError: options.clearSelectionError,
         debtVersion,
-      }).then((outcome) => {
-        if (debtVersion !== undefined) {
-          const currentDebt = coordinator.reconciliationDebt.get(identity);
-          if (currentDebt?.version === debtVersion && outcome.kind !== 'published') currentDebt.scheduled = false;
-        }
-        return outcome;
       });
     },
     [launchSelectedRead],
@@ -678,22 +743,53 @@ export const AgentsPage: React.FC = () => {
       if (failures.length > 0) {
         setResourceError('mutation', errorMessage(failures[0]) || t('errorBoundary.title'), errorGeneration);
       }
+      const priorDebt = coordinator.reconciliationDebt.get(identity);
       if (!coordinator.retired.has(identity)) {
-        coordinator.reconciliationDebt.set(identity, { version, scheduled: false });
+        coordinator.reconciliationDebt.set(identity, {
+          version,
+          scheduled: false,
+          waiters: priorDebt?.waiters ?? [],
+        });
       }
       void refreshRef.current();
-      const drain = scheduleSelectedReadRef.current?.(identity, {
-        debtOnly: true,
-        expectedCodes: SELECTED_DISAPPEARANCE_CODES,
-      });
-      const completion = drain?.then((outcome) => outcome.kind === 'published'
-        ? ({ ok: true } as const)
-        : ({ ok: false, error: new Error('Agent reconciliation failed') } as const))
-        ?? Promise.resolve({ ok: failures.length === 0 } as SelectedMutationResult);
-      const resultPromise = completion.then((result) => {
-        if (failures.length > 0) return { ok: false, error: failures[0] } as const;
-        return result;
-      });
+      const baseResult = failures.length > 0
+        ? ({ ok: false, error: failures[0] } as const)
+        : ({ ok: true } as const);
+      const currentDebt = coordinator.reconciliationDebt.get(identity);
+      const shouldDrain = Boolean(
+        currentDebt &&
+          coordinator.desiredName === identity &&
+          !coordinator.retired.has(identity),
+      );
+      let resultPromise: Promise<SelectedMutationResult>;
+      if (!shouldDrain || !currentDebt) {
+        resultPromise = Promise.resolve(baseResult);
+      } else {
+        const completion = new Promise<SelectedMutationResult>((resolve) => {
+          currentDebt.waiters.push({
+            mutationFailure: failures[0],
+            errorGeneration,
+            resolve: (result) => {
+              if (!result.ok && !failures.length) {
+                setResourceError('mutation', errorMessage(result.error) || t('errorBoundary.title'), errorGeneration);
+              }
+              resolve(result);
+            },
+          });
+        });
+        const drain = scheduleSelectedReadRef.current?.(identity, {
+          debtOnly: true,
+          expectedCodes: SELECTED_DISAPPEARANCE_CODES,
+          rollbackOnFailure: false,
+        });
+        if (!drain) {
+          const waiters = currentDebt.waiters.splice(0);
+          for (const waiter of waiters) waiter.resolve(baseResult);
+          resultPromise = Promise.resolve(baseResult);
+        } else {
+          resultPromise = completion;
+        }
+      }
       const waiters = batch.waiters.splice(0);
       for (const resolve of waiters) void resultPromise.then(resolve);
       return resultPromise;
@@ -705,6 +801,7 @@ export const AgentsPage: React.FC = () => {
     const coordinator = selectedCoordinatorRef.current;
     let transactionIntentGeneration = coordinator.intentGeneration;
     let identity = coordinator.desiredName;
+    let preserveSelectionError = false;
     const attempted = new Set<string>();
     while (selectedMountedRef.current && identity && !attempted.has(identity)) {
       if (edgeEpoch !== undefined && catchUpEpochRef.current !== edgeEpoch) return;
@@ -714,16 +811,22 @@ export const AgentsPage: React.FC = () => {
       const outcome = await scheduleSelectedReadRef.current?.(identity, {
         expectedCodes: SELECTED_DISAPPEARANCE_CODES,
         refreshDefinitions: false,
+        clearSelectionError: !preserveSelectionError,
       });
       if (edgeEpoch !== undefined && catchUpEpochRef.current !== edgeEpoch) return;
-      if (!outcome || outcome.kind !== 'expected-retired') return;
+      if (!outcome) return;
+      const continuation = outcome.kind === 'expected-retired' || outcome.kind === 'failed'
+        ? outcome.continuation
+        : undefined;
+      if (!continuation) return;
       if (
-        outcome.intentGeneration !== coordinator.intentGeneration ||
-        coordinator.desiredName !== outcome.resumedIdentity ||
-        attempted.has(outcome.resumedIdentity)
+        continuation.intentGeneration !== coordinator.intentGeneration ||
+        coordinator.desiredName !== continuation.nextIdentity ||
+        attempted.has(continuation.nextIdentity)
       ) return;
-      transactionIntentGeneration = outcome.intentGeneration;
-      identity = outcome.resumedIdentity;
+      transactionIntentGeneration = continuation.intentGeneration;
+      identity = continuation.nextIdentity;
+      preserveSelectionError = true;
     }
   }, []);
 

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -87,10 +87,14 @@ type SelectedMutationBatch = {
   id: number;
   identity: string;
   pending: number;
-  drainGeneration: number;
-  draining: boolean;
+  version: number;
   errorGeneration: number;
   failures: unknown[];
+};
+
+type SelectedReconciliationDebt = {
+  version: number;
+  scheduled: boolean;
 };
 
 type SelectedCoordinator = {
@@ -100,7 +104,10 @@ type SelectedCoordinator = {
   accepted: VibeAgentFull | null;
   acceptedGeneration: number;
   nextBatchId: number;
+  nextMutationVersion: number;
   mutations: Map<string, SelectedMutationBatch>;
+  reconciliationDebt: Map<string, SelectedReconciliationDebt>;
+  retired: Set<string>;
 };
 
 const createSelectedCoordinator = (): SelectedCoordinator => ({
@@ -110,7 +117,10 @@ const createSelectedCoordinator = (): SelectedCoordinator => ({
   accepted: null,
   acceptedGeneration: 0,
   nextBatchId: 0,
+  nextMutationVersion: 0,
   mutations: new Map(),
+  reconciliationDebt: new Map(),
+  retired: new Set(),
 });
 
 const advanceSelectedRead = (coordinator: SelectedCoordinator, identity: string): number => {
@@ -254,6 +264,11 @@ export const AgentsPage: React.FC = () => {
     }
   }, [api, canOnboardAgents, publishOnboarding]);
 
+  const scheduleSelectedReadRef = useRef<
+    ((identity: string, options?: { expectedCodes?: readonly string[]; debtOnly?: boolean }) => Promise<'published' | 'failed' | 'stale'> | null)
+  >(null);
+  const retireSelectedIdentityRef = useRef<((identity: string, options?: { refreshDefinitions?: boolean }) => boolean) | null>(null);
+
   const commitSelected = useCallback((agent: VibeAgentFull | null) => {
     const coordinator = selectedCoordinatorRef.current;
     const previousIdentity = coordinator.accepted?.name;
@@ -261,15 +276,19 @@ export const AgentsPage: React.FC = () => {
     if (agent?.name) advanceSelectedRead(coordinator, agent.name);
     coordinator.acceptedGeneration += 1;
     coordinator.accepted = agent;
+    if (agent?.name) coordinator.retired.delete(agent.name);
     setSelected(agent);
   }, []);
 
-  const beginSelectedIntent = useCallback((identity: string | null) => {
+  const beginSelectedIntent = useCallback((identity: string | null, options: { auto?: boolean } = {}) => {
     const coordinator = selectedCoordinatorRef.current;
     if (coordinator.desiredName && coordinator.desiredName !== identity) {
       advanceSelectedRead(coordinator, coordinator.desiredName);
     }
     if (identity) advanceSelectedRead(coordinator, identity);
+    if (identity && !options.auto) coordinator.retired.delete(identity);
+    const debt = identity ? coordinator.reconciliationDebt.get(identity) : null;
+    if (debt) debt.scheduled = false;
     coordinator.intentGeneration += 1;
     coordinator.desiredName = identity;
     return { intentGeneration: coordinator.intentGeneration, identity };
@@ -278,10 +297,9 @@ export const AgentsPage: React.FC = () => {
   const rollbackSelectedIntent = useCallback(() => {
     const coordinator = selectedCoordinatorRef.current;
     if (coordinator.desiredName) advanceSelectedRead(coordinator, coordinator.desiredName);
-    coordinator.intentGeneration += 1;
-    coordinator.desiredName = coordinator.accepted?.name ?? null;
-    if (coordinator.desiredName) advanceSelectedRead(coordinator, coordinator.desiredName);
-  }, []);
+    const acceptedIdentity = coordinator.accepted?.name ?? null;
+    return beginSelectedIntent(acceptedIdentity && !coordinator.retired.has(acceptedIdentity) ? acceptedIdentity : null);
+  }, [beginSelectedIntent]);
 
 
   // Definitions refreshes are explicit reconciliation reads. They must always
@@ -303,35 +321,23 @@ export const AgentsPage: React.FC = () => {
         if (!definitionsVersionRef.current.isCurrent(token)) return;
         setAgents(result.agents);
         setDefaultName(result.default_agent_name);
-        // Reconcile identity outcomes from the same authoritative list snapshot.
-        // A missing desired identity invalidates only that pending intent; a
-        // missing accepted identity clears the rendered snapshot without
-        // cancelling a different desired selection that is still loading.
+        // List omission is authoritative retirement evidence. The coordinator
+        // owns all desired/accepted transitions; stale list responses cannot
+        // re-select an identity after retirement because the retired set is
+        // updated before the next render.
         const coordinator = selectedCoordinatorRef.current;
-        const acceptedIdentity = coordinator.accepted?.name ?? null;
-        const desiredIdentity = coordinator.desiredName;
-        const acceptedMissing = acceptedIdentity
-          ? !result.agents.some((agent) => agent.name === acceptedIdentity)
-          : false;
-        const desiredMissing = desiredIdentity
-          ? !result.agents.some((agent) => agent.name === desiredIdentity)
-          : false;
-
-        if (desiredIdentity && desiredMissing && !coordinator.mutations.has(desiredIdentity)) {
-          advanceSelectedRead(coordinator, desiredIdentity);
-          coordinator.intentGeneration += 1;
-          clearResourceError('selection');
-          if (desiredIdentity === acceptedIdentity) {
-            coordinator.desiredName = null;
-            commitSelected(null);
-          } else if (acceptedIdentity && !acceptedMissing) {
-            coordinator.desiredName = acceptedIdentity;
-          } else {
-            coordinator.desiredName = null;
-            if (acceptedIdentity) commitSelected(null);
+        const currentIdentities = [coordinator.accepted?.name, coordinator.desiredName].filter(
+          (identity): identity is string => Boolean(identity),
+        );
+        const retired = currentIdentities.filter(
+          (identity) => !result.agents.some((agent) => agent.name === identity) && !coordinator.mutations.has(identity),
+        );
+        if (retired.length > 0) {
+          for (const identity of retired) {
+            retireSelectedIdentityRef.current?.(identity, { refreshDefinitions: false });
           }
-        } else if (acceptedMissing && acceptedIdentity && !coordinator.mutations.has(acceptedIdentity)) {
-          commitSelected(null);
+          definitionsVersionRef.current.invalidate();
+          void refreshRef.current();
         }
       } catch (err) {
         if (definitionsVersionRef.current.isCurrent(token)) {
@@ -342,10 +348,33 @@ export const AgentsPage: React.FC = () => {
       }
     })();
     return request;
-  }, [api, clearResourceError, commitSelected, setResourceError]);
+  }, [api, clearResourceError, setResourceError]);
 
   const refreshRef = useRef(refresh);
   refreshRef.current = refresh;
+
+  const retireSelectedIdentity = useCallback(
+    (identity: string, options: { refreshDefinitions?: boolean } = {}) => {
+      const coordinator = selectedCoordinatorRef.current;
+      if (coordinator.retired.has(identity)) return false;
+      coordinator.retired.add(identity);
+      advanceSelectedRead(coordinator, identity);
+      coordinator.reconciliationDebt.delete(identity);
+      if (coordinator.desiredName === identity) {
+        coordinator.intentGeneration += 1;
+        coordinator.desiredName = null;
+      }
+      if (coordinator.accepted?.name === identity) commitSelected(null);
+      clearResourceError('selection');
+      if (options.refreshDefinitions !== false) {
+        definitionsVersionRef.current.invalidate();
+        void refreshRef.current();
+      }
+      return true;
+    },
+    [clearResourceError, commitSelected],
+  );
+  retireSelectedIdentityRef.current = retireSelectedIdentity;
 
   const launchSelectedRead = useCallback(
     async (options: {
@@ -353,12 +382,21 @@ export const AgentsPage: React.FC = () => {
       readGeneration: number;
       intentGeneration?: number;
       expectedCodes?: readonly string[];
+      debtVersion?: number;
     }): Promise<'published' | 'failed' | 'stale'> => {
       const coordinator = selectedCoordinatorRef.current;
       const isCurrent = () =>
         selectedReadIsCurrent(coordinator, options.identity, options.readGeneration) &&
         coordinator.desiredName === options.identity &&
+        !coordinator.retired.has(options.identity) &&
         (options.intentGeneration === undefined || coordinator.intentGeneration === options.intentGeneration);
+      const finishDebt = (published: boolean) => {
+        if (options.debtVersion === undefined) return;
+        const debt = coordinator.reconciliationDebt.get(options.identity);
+        if (!debt || debt.version !== options.debtVersion) return;
+        if (published) coordinator.reconciliationDebt.delete(options.identity);
+        else debt.scheduled = false;
+      };
       try {
         const params = options.expectedCodes ? { cache: false, expectedCodes: options.expectedCodes } : { cache: false };
         const result = await api.getVibeAgent(options.identity, params);
@@ -366,29 +404,73 @@ export const AgentsPage: React.FC = () => {
         if (result.ok && result.agent?.name === options.identity) {
           clearResourceError('selection');
           commitSelected(result.agent);
+          finishDebt(true);
           return 'published';
         }
         rollbackSelectedIntent();
         setResourceError('selection', errorMessage(result) || tRef.current('errorBoundary.title'));
+        finishDebt(false);
+        void scheduleSelectedReadRef.current?.(coordinator.desiredName ?? '', {
+          debtOnly: true,
+          expectedCodes: options.expectedCodes ?? SELECTED_DISAPPEARANCE_CODES,
+        });
         return 'failed';
       } catch (err) {
         if (!isCurrent()) return 'stale';
         if (options.expectedCodes && SELECTED_DISAPPEARANCE_CODES.includes(errorCodeOf(err) as (typeof SELECTED_DISAPPEARANCE_CODES)[number])) {
-          const acceptedIdentity = coordinator.accepted?.name ?? null;
-          advanceSelectedRead(coordinator, options.identity);
-          coordinator.desiredName = acceptedIdentity;
-          coordinator.intentGeneration += 1;
-          clearResourceError('selection');
-          if (acceptedIdentity === options.identity) commitSelected(null);
+          retireSelectedIdentityRef.current?.(options.identity);
+          finishDebt(false);
           return 'failed';
         }
         rollbackSelectedIntent();
         setResourceError('selection', errorMessage(err) || tRef.current('errorBoundary.title'));
+        finishDebt(false);
+        void scheduleSelectedReadRef.current?.(coordinator.desiredName ?? '', {
+          debtOnly: true,
+          expectedCodes: options.expectedCodes ?? SELECTED_DISAPPEARANCE_CODES,
+        });
         return 'failed';
       }
     },
     [api, clearResourceError, commitSelected, rollbackSelectedIntent, setResourceError],
   );
+
+  const scheduleSelectedRead = useCallback(
+    (
+      identity: string,
+      options: { expectedCodes?: readonly string[]; debtOnly?: boolean } = {},
+    ): Promise<'published' | 'failed' | 'stale'> | null => {
+      if (!identity) return null;
+      const coordinator = selectedCoordinatorRef.current;
+      if (coordinator.retired.has(identity) || coordinator.desiredName !== identity) return null;
+      // User selection is an explicit intent and may read immediately even
+      // while that identity has a pending mutation. Passive/debt drains wait
+      // for acknowledgements so they cannot publish an intermediate snapshot.
+      if (coordinator.mutations.has(identity) && options.debtOnly) return null;
+      const debt = coordinator.reconciliationDebt.get(identity);
+      if (options.debtOnly && !debt) return null;
+      if (debt && options.debtOnly && debt.scheduled) return null;
+      const debtVersion = debt?.version;
+      if (debt) debt.scheduled = true;
+      const readGeneration = advanceSelectedRead(coordinator, identity);
+      const intentGeneration = coordinator.intentGeneration;
+      return launchSelectedRead({
+        identity,
+        readGeneration,
+        intentGeneration,
+        expectedCodes: options.expectedCodes,
+        debtVersion,
+      }).then((outcome) => {
+        if (debtVersion !== undefined) {
+          const currentDebt = coordinator.reconciliationDebt.get(identity);
+          if (currentDebt?.version === debtVersion && outcome !== 'published') currentDebt.scheduled = false;
+        }
+        return outcome;
+      });
+    },
+    [launchSelectedRead],
+  );
+  scheduleSelectedReadRef.current = scheduleSelectedRead;
 
   const beginSelectedMutation = useCallback((identity: string) => {
     const coordinator = selectedCoordinatorRef.current;
@@ -398,8 +480,7 @@ export const AgentsPage: React.FC = () => {
         id: ++coordinator.nextBatchId,
         identity,
         pending: 0,
-        drainGeneration: 0,
-        draining: false,
+        version: ++coordinator.nextMutationVersion,
         errorGeneration: 0,
         failures: [],
       };
@@ -408,8 +489,9 @@ export const AgentsPage: React.FC = () => {
     const errorGeneration = beginResourceError('mutation');
     batch.errorGeneration = errorGeneration;
     batch.pending += 1;
-    batch.drainGeneration += 1;
-    batch.draining = false;
+    batch.version = ++coordinator.nextMutationVersion;
+    const debt = coordinator.reconciliationDebt.get(identity);
+    if (debt) debt.scheduled = false;
     advanceSelectedRead(coordinator, identity);
     return { id: batch.id, identity, errorGeneration };
   }, [beginResourceError]);
@@ -421,57 +503,31 @@ export const AgentsPage: React.FC = () => {
       if (!batch || batch.id !== operation.id) return;
       if (failure) batch.failures.push(failure);
       batch.pending = Math.max(0, batch.pending - 1);
-      if (batch.pending !== 0 || batch.draining) return;
+      if (batch.pending !== 0) return;
 
-      batch.draining = true;
-      const drainGeneration = ++batch.drainGeneration;
       const identity = operation.identity;
-      const intentGeneration = coordinator.intentGeneration;
-      const readGeneration = advanceSelectedRead(coordinator, identity);
-      const shouldDrain = coordinator.desiredName === identity;
-
-      void (async () => {
-        if (shouldDrain) {
-          await launchSelectedRead({
-            identity,
-            readGeneration,
-            intentGeneration,
-            expectedCodes: SELECTED_DISAPPEARANCE_CODES,
-          });
-        }
-        const currentBatch = coordinator.mutations.get(identity);
-        if (
-          !currentBatch ||
-          currentBatch.id !== operation.id ||
-          currentBatch.drainGeneration !== drainGeneration ||
-          currentBatch.pending !== 0
-        ) {
-          return;
-        }
-        if (currentBatch.failures.length > 0) {
-          setResourceError(
-            'mutation',
-            errorMessage(currentBatch.failures[0]) || t('errorBoundary.title'),
-            currentBatch.errorGeneration,
-          );
-        }
-        void refreshRef.current();
-        coordinator.mutations.delete(identity);
-      })();
+      const version = batch.version;
+      const failures = [...batch.failures];
+      const errorGeneration = batch.errorGeneration;
+      coordinator.mutations.delete(identity);
+      if (failures.length > 0) {
+        setResourceError('mutation', errorMessage(failures[0]) || t('errorBoundary.title'), errorGeneration);
+      }
+      if (!coordinator.retired.has(identity)) {
+        coordinator.reconciliationDebt.set(identity, { version, scheduled: false });
+      }
+      void refreshRef.current();
+      void scheduleSelectedReadRef.current?.(identity, { debtOnly: true, expectedCodes: SELECTED_DISAPPEARANCE_CODES });
     },
-    [launchSelectedRead, setResourceError, t],
+    [setResourceError, t],
   );
 
   const reconcileSelected = useCallback(async () => {
     const coordinator = selectedCoordinatorRef.current;
     const identity = coordinator.desiredName;
     if (!identity) return;
-    const batch = coordinator.mutations.get(identity);
-    if (batch) return;
-    const intentGeneration = coordinator.intentGeneration;
-    const readGeneration = advanceSelectedRead(coordinator, identity);
-    await launchSelectedRead({ identity, readGeneration, intentGeneration, expectedCodes: SELECTED_DISAPPEARANCE_CODES });
-  }, [launchSelectedRead]);
+    await scheduleSelectedReadRef.current?.(identity, { expectedCodes: SELECTED_DISAPPEARANCE_CODES });
+  }, []);
 
   useEffect(() => {
     refresh();
@@ -486,9 +542,11 @@ export const AgentsPage: React.FC = () => {
   // something to show — eliminates the empty "select an agent" state
   // that confused users on first visit.
   useEffect(() => {
-    if (selected || agents.length === 0) return;
-    const target = (defaultName && agents.find((a) => a.name === defaultName)) || agents[0];
-    if (target) selectAgent(target.name);
+    const coordinator = selectedCoordinatorRef.current;
+    if (selected || coordinator.accepted || coordinator.desiredName || agents.length === 0) return;
+    const available = agents.filter((agent) => !coordinator.retired.has(agent.name));
+    const target = (defaultName && available.find((a) => a.name === defaultName)) || available[0];
+    if (target) void selectAgent(target.name, false, true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultName, agents]);
 
@@ -602,18 +660,15 @@ export const AgentsPage: React.FC = () => {
   }, [capabilities.can_use_agents, eventBridgeConnected, fetchRunningActiveCount]);
 
   const selectAgent = useCallback(
-    async (name: string, openDetail = false) => {
-      const coordinator = selectedCoordinatorRef.current;
-      const { intentGeneration: generation } = beginSelectedIntent(name);
-      const identity = name;
+    async (name: string, openDetail = false, auto = false) => {
+      beginSelectedIntent(name, { auto });
       clearResourceError('selection');
-      const readGeneration = advanceSelectedRead(coordinator, identity);
-      const outcome = await launchSelectedRead({ identity, readGeneration, intentGeneration: generation });
+      const outcome = await scheduleSelectedReadRef.current?.(name);
       // Enter the mobile drill-down only once the detail has actually loaded —
       // never optimistically, or a failed fetch hides the list with no panel.
       if (outcome === 'published' && openDetail) setDetailOpen(true);
     },
-    [beginSelectedIntent, clearResourceError, launchSelectedRead],
+    [beginSelectedIntent, clearResourceError],
   );
 
   // Apply text search + backend filter; backend grouping is a layout
@@ -683,17 +738,11 @@ export const AgentsPage: React.FC = () => {
     const confirmed = window.confirm(t('agents.deleteConfirm', { name: selected.name }));
     if (!confirmed) return;
     const name = selected.name;
-    const coordinator = selectedCoordinatorRef.current;
     const errorGeneration = beginResourceError('mutation');
-    if (coordinator.desiredName === name) advanceSelectedRead(coordinator, name);
     try {
       const result = await api.removeVibeAgent(name);
       if (result.ok) {
-        if (coordinator.desiredName === name && coordinator.accepted?.name === name) {
-          beginSelectedIntent(null);
-          commitSelected(null);
-        }
-        refresh();
+        retireSelectedIdentityRef.current?.(name);
         void refreshOnboarding();
       } else {
         setResourceError('mutation', errorMessage(result) || t('errorBoundary.title'), errorGeneration);

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -89,9 +89,44 @@ type SelectedMutationBatch = {
   pending: number;
   drainGeneration: number;
   draining: boolean;
-  intentGeneration: number;
+  errorGeneration: number;
   failures: unknown[];
 };
+
+type SelectedCoordinator = {
+  desiredName: string | null;
+  intentGeneration: number;
+  readGenerations: Map<string, number>;
+  accepted: VibeAgentFull | null;
+  acceptedGeneration: number;
+  nextBatchId: number;
+  mutations: Map<string, SelectedMutationBatch>;
+};
+
+const createSelectedCoordinator = (): SelectedCoordinator => ({
+  desiredName: null,
+  intentGeneration: 0,
+  readGenerations: new Map(),
+  accepted: null,
+  acceptedGeneration: 0,
+  nextBatchId: 0,
+  mutations: new Map(),
+});
+
+const advanceSelectedRead = (coordinator: SelectedCoordinator, identity: string): number => {
+  const next = (coordinator.readGenerations.get(identity) ?? 0) + 1;
+  coordinator.readGenerations.set(identity, next);
+  return next;
+};
+
+const selectedReadIsCurrent = (
+  coordinator: SelectedCoordinator,
+  identity: string,
+  generation: number,
+): boolean => coordinator.readGenerations.get(identity) === generation;
+
+type ResourceErrorOwner = 'definitions' | 'selection' | 'mutation';
+type ResourceErrors = Record<ResourceErrorOwner, string | null>;
 
 // A tiny per-resource epoch owner. Every asynchronous read captures a token;
 // any committed mutation or identity change advances the epoch and makes older
@@ -115,6 +150,8 @@ const errorCodeOf = (error: unknown): string | null => {
 
 export const AgentsPage: React.FC = () => {
   const { t } = useTranslation();
+  const tRef = useRef(t);
+  tRef.current = t;
   const api = useApi();
   const { showToast } = useToast();
   const {
@@ -148,7 +185,16 @@ export const AgentsPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [showNew, setShowNew] = useState(false);
   const [showGlobalPrompts, setShowGlobalPrompts] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [resourceErrors, setResourceErrors] = useState<ResourceErrors>({
+    definitions: null,
+    selection: null,
+    mutation: null,
+  });
+  const resourceErrorGenerationRef = useRef<Record<ResourceErrorOwner, number>>({
+    definitions: 0,
+    selection: 0,
+    mutation: 0,
+  });
   const [search, setSearch] = useState('');
   const [backendFilter, setBackendFilter] = useState<Backend | 'all'>('all');
   const [importing, setImporting] = useState<Backend | null>(null);
@@ -157,13 +203,7 @@ export const AgentsPage: React.FC = () => {
   const [onboardingSubmitting, setOnboardingSubmitting] = useState(false);
   const definitionsVersionRef = useRef(createAgentRequestVersion());
   const onboardingVersionRef = useRef(createAgentRequestVersion());
-  const selectedRef = useRef<VibeAgentFull | null>(null);
-  const selectedIntentRef = useRef({ generation: 0, desiredName: null as string | null });
-  const selectedAcceptedGenerationRef = useRef(0);
-  const selectedPassiveReadRef = useRef(0);
-  const selectedMutationBatchesRef = useRef(new Map<string, SelectedMutationBatch>());
-  const selectedMutationBatchIdRef = useRef(0);
-  const onboardingMutationRef = useRef(0);
+  const selectedCoordinatorRef = useRef(createSelectedCoordinator());
   // Mobile drill-down: a row tap opens the detail full-screen. The agent
   // auto-selected on mount stays in the list view until the user drills in.
   const [detailOpen, setDetailOpen] = useState(false);
@@ -176,8 +216,27 @@ export const AgentsPage: React.FC = () => {
   // a member's page load into an owner-only GET and surfaced the 403 as a toast.
   const canOnboardAgents = capabilities.is_instance_owner;
 
+  const beginResourceError = useCallback((owner: ResourceErrorOwner) => {
+    const generation = resourceErrorGenerationRef.current[owner] + 1;
+    resourceErrorGenerationRef.current[owner] = generation;
+    setResourceErrors((current) => (current[owner] === null ? current : { ...current, [owner]: null }));
+    return generation;
+  }, []);
+
+  const setResourceError = useCallback((owner: ResourceErrorOwner, message: string, generation?: number) => {
+    if (generation !== undefined && resourceErrorGenerationRef.current[owner] !== generation) return;
+    setResourceErrors((current) => ({ ...current, [owner]: message }));
+  }, []);
+
+  const clearResourceError = useCallback((owner: ResourceErrorOwner, generation?: number) => {
+    if (generation !== undefined && resourceErrorGenerationRef.current[owner] !== generation) return;
+    resourceErrorGenerationRef.current[owner] += 1;
+    setResourceErrors((current) => (current[owner] === null ? current : { ...current, [owner]: null }));
+  }, []);
+
+  const error = resourceErrors.mutation ?? resourceErrors.selection ?? resourceErrors.definitions;
+
   const publishOnboarding = useCallback((result: VibeAgentOnboardingResult | null) => {
-    onboardingVersionRef.current.invalidate();
     setOnboardingInventory(result?.available ? result : null);
   }, []);
 
@@ -196,17 +255,32 @@ export const AgentsPage: React.FC = () => {
   }, [api, canOnboardAgents, publishOnboarding]);
 
   const commitSelected = useCallback((agent: VibeAgentFull | null) => {
-    selectedAcceptedGenerationRef.current += 1;
-    selectedPassiveReadRef.current += 1;
-    selectedRef.current = agent;
+    const coordinator = selectedCoordinatorRef.current;
+    const previousIdentity = coordinator.accepted?.name;
+    if (previousIdentity) advanceSelectedRead(coordinator, previousIdentity);
+    if (agent?.name) advanceSelectedRead(coordinator, agent.name);
+    coordinator.acceptedGeneration += 1;
+    coordinator.accepted = agent;
     setSelected(agent);
   }, []);
 
   const beginSelectedIntent = useCallback((identity: string | null) => {
-    const generation = ++selectedIntentRef.current.generation;
-    selectedIntentRef.current.desiredName = identity;
-    selectedPassiveReadRef.current += 1;
-    return { generation, identity };
+    const coordinator = selectedCoordinatorRef.current;
+    if (coordinator.desiredName && coordinator.desiredName !== identity) {
+      advanceSelectedRead(coordinator, coordinator.desiredName);
+    }
+    if (identity) advanceSelectedRead(coordinator, identity);
+    coordinator.intentGeneration += 1;
+    coordinator.desiredName = identity;
+    return { intentGeneration: coordinator.intentGeneration, identity };
+  }, []);
+
+  const rollbackSelectedIntent = useCallback(() => {
+    const coordinator = selectedCoordinatorRef.current;
+    if (coordinator.desiredName) advanceSelectedRead(coordinator, coordinator.desiredName);
+    coordinator.intentGeneration += 1;
+    coordinator.desiredName = coordinator.accepted?.name ?? null;
+    if (coordinator.desiredName) advanceSelectedRead(coordinator, coordinator.desiredName);
   }, []);
 
 
@@ -217,7 +291,7 @@ export const AgentsPage: React.FC = () => {
     const token = definitionsVersionRef.current.begin();
     const request = (async () => {
       setLoading(true);
-      setError(null);
+      clearResourceError('definitions');
       try {
         const result = await api.listVibeAgents({
           includeDisabled: true,
@@ -229,54 +303,121 @@ export const AgentsPage: React.FC = () => {
         if (!definitionsVersionRef.current.isCurrent(token)) return;
         setAgents(result.agents);
         setDefaultName(result.default_agent_name);
-        // Keep the currently-selected agent present after edits / refreshes.
-        const currentSelected = selectedRef.current;
-        if (currentSelected) {
-          const fresh = result.agents.find((a) => a.name === currentSelected.name);
-          if (
-            !fresh &&
-            selectedIntentRef.current.desiredName === currentSelected.name &&
-            !selectedMutationBatchesRef.current.has(currentSelected.name)
-          ) {
+        // Reconcile identity outcomes from the same authoritative list snapshot.
+        // A missing desired identity invalidates only that pending intent; a
+        // missing accepted identity clears the rendered snapshot without
+        // cancelling a different desired selection that is still loading.
+        const coordinator = selectedCoordinatorRef.current;
+        const acceptedIdentity = coordinator.accepted?.name ?? null;
+        const desiredIdentity = coordinator.desiredName;
+        const acceptedMissing = acceptedIdentity
+          ? !result.agents.some((agent) => agent.name === acceptedIdentity)
+          : false;
+        const desiredMissing = desiredIdentity
+          ? !result.agents.some((agent) => agent.name === desiredIdentity)
+          : false;
+
+        if (desiredIdentity && desiredMissing && !coordinator.mutations.has(desiredIdentity)) {
+          advanceSelectedRead(coordinator, desiredIdentity);
+          coordinator.intentGeneration += 1;
+          clearResourceError('selection');
+          if (desiredIdentity === acceptedIdentity) {
+            coordinator.desiredName = null;
             commitSelected(null);
+          } else if (acceptedIdentity && !acceptedMissing) {
+            coordinator.desiredName = acceptedIdentity;
+          } else {
+            coordinator.desiredName = null;
+            if (acceptedIdentity) commitSelected(null);
           }
+        } else if (acceptedMissing && acceptedIdentity && !coordinator.mutations.has(acceptedIdentity)) {
+          commitSelected(null);
         }
       } catch (err) {
-        if (definitionsVersionRef.current.isCurrent(token)) setError(errorMessage(err) ?? String(err));
+        if (definitionsVersionRef.current.isCurrent(token)) {
+          setResourceError('definitions', errorMessage(err) ?? String(err));
+        }
       } finally {
         if (definitionsVersionRef.current.isCurrent(token)) setLoading(false);
       }
     })();
     return request;
-  }, [api, commitSelected]);
+  }, [api, clearResourceError, commitSelected, setResourceError]);
 
   const refreshRef = useRef(refresh);
   refreshRef.current = refresh;
 
+  const launchSelectedRead = useCallback(
+    async (options: {
+      identity: string;
+      readGeneration: number;
+      intentGeneration?: number;
+      expectedCodes?: readonly string[];
+    }): Promise<'published' | 'failed' | 'stale'> => {
+      const coordinator = selectedCoordinatorRef.current;
+      const isCurrent = () =>
+        selectedReadIsCurrent(coordinator, options.identity, options.readGeneration) &&
+        coordinator.desiredName === options.identity &&
+        (options.intentGeneration === undefined || coordinator.intentGeneration === options.intentGeneration);
+      try {
+        const params = options.expectedCodes ? { cache: false, expectedCodes: options.expectedCodes } : { cache: false };
+        const result = await api.getVibeAgent(options.identity, params);
+        if (!isCurrent()) return 'stale';
+        if (result.ok && result.agent?.name === options.identity) {
+          clearResourceError('selection');
+          commitSelected(result.agent);
+          return 'published';
+        }
+        rollbackSelectedIntent();
+        setResourceError('selection', errorMessage(result) || tRef.current('errorBoundary.title'));
+        return 'failed';
+      } catch (err) {
+        if (!isCurrent()) return 'stale';
+        if (options.expectedCodes && SELECTED_DISAPPEARANCE_CODES.includes(errorCodeOf(err) as (typeof SELECTED_DISAPPEARANCE_CODES)[number])) {
+          const acceptedIdentity = coordinator.accepted?.name ?? null;
+          advanceSelectedRead(coordinator, options.identity);
+          coordinator.desiredName = acceptedIdentity;
+          coordinator.intentGeneration += 1;
+          clearResourceError('selection');
+          if (acceptedIdentity === options.identity) commitSelected(null);
+          return 'failed';
+        }
+        rollbackSelectedIntent();
+        setResourceError('selection', errorMessage(err) || tRef.current('errorBoundary.title'));
+        return 'failed';
+      }
+    },
+    [api, clearResourceError, commitSelected, rollbackSelectedIntent, setResourceError],
+  );
+
   const beginSelectedMutation = useCallback((identity: string) => {
-    let batch = selectedMutationBatchesRef.current.get(identity);
+    const coordinator = selectedCoordinatorRef.current;
+    let batch = coordinator.mutations.get(identity);
     if (!batch) {
       batch = {
-        id: ++selectedMutationBatchIdRef.current,
+        id: ++coordinator.nextBatchId,
         identity,
         pending: 0,
         drainGeneration: 0,
         draining: false,
-        intentGeneration: selectedIntentRef.current.generation,
+        errorGeneration: 0,
         failures: [],
       };
-      selectedMutationBatchesRef.current.set(identity, batch);
+      coordinator.mutations.set(identity, batch);
     }
+    const errorGeneration = beginResourceError('mutation');
+    batch.errorGeneration = errorGeneration;
     batch.pending += 1;
     batch.drainGeneration += 1;
     batch.draining = false;
-    selectedPassiveReadRef.current += 1;
-    return { id: batch.id, identity };
-  }, []);
+    advanceSelectedRead(coordinator, identity);
+    return { id: batch.id, identity, errorGeneration };
+  }, [beginResourceError]);
 
   const settleSelectedMutation = useCallback(
     (operation: { id: number; identity: string }, failure?: unknown) => {
-      const batch = selectedMutationBatchesRef.current.get(operation.identity);
+      const coordinator = selectedCoordinatorRef.current;
+      const batch = coordinator.mutations.get(operation.identity);
       if (!batch || batch.id !== operation.id) return;
       if (failure) batch.failures.push(failure);
       batch.pending = Math.max(0, batch.pending - 1);
@@ -284,24 +425,21 @@ export const AgentsPage: React.FC = () => {
 
       batch.draining = true;
       const drainGeneration = ++batch.drainGeneration;
-      const intentGeneration = batch.intentGeneration;
-      const acceptedGeneration = selectedAcceptedGenerationRef.current;
-      const passiveRead = ++selectedPassiveReadRef.current;
       const identity = operation.identity;
+      const intentGeneration = coordinator.intentGeneration;
+      const readGeneration = advanceSelectedRead(coordinator, identity);
+      const shouldDrain = coordinator.desiredName === identity;
 
       void (async () => {
-        let result: Awaited<ReturnType<typeof api.getVibeAgent>> | null = null;
-        let readError: unknown = null;
-        try {
-          result = await api.getVibeAgent(identity, {
-            cache: false,
+        if (shouldDrain) {
+          await launchSelectedRead({
+            identity,
+            readGeneration,
+            intentGeneration,
             expectedCodes: SELECTED_DISAPPEARANCE_CODES,
           });
-        } catch (err) {
-          readError = err;
         }
-
-        const currentBatch = selectedMutationBatchesRef.current.get(identity);
+        const currentBatch = coordinator.mutations.get(identity);
         if (
           !currentBatch ||
           currentBatch.id !== operation.id ||
@@ -310,83 +448,30 @@ export const AgentsPage: React.FC = () => {
         ) {
           return;
         }
-
-        const canPublish =
-          selectedIntentRef.current.generation === intentGeneration &&
-          selectedIntentRef.current.desiredName === identity &&
-          selectedRef.current?.name === identity &&
-          selectedAcceptedGenerationRef.current === acceptedGeneration &&
-          selectedPassiveReadRef.current === passiveRead;
-        const failures = currentBatch.failures;
-
-        if (canPublish && result?.ok) commitSelected(result.agent);
-        if (canPublish && readError) {
-          if (SELECTED_DISAPPEARANCE_CODES.includes(errorCodeOf(readError) as (typeof SELECTED_DISAPPEARANCE_CODES)[number])) {
-            commitSelected(null);
-          }
+        if (currentBatch.failures.length > 0) {
+          setResourceError(
+            'mutation',
+            errorMessage(currentBatch.failures[0]) || t('errorBoundary.title'),
+            currentBatch.errorGeneration,
+          );
         }
-        // The settled mutation batch owns the Definitions refresh even when the
-        // user has already selected another Agent; the full-detail publication
-        // remains conditional on the selected intent above.
         void refreshRef.current();
-        if (canPublish && readError && !SELECTED_DISAPPEARANCE_CODES.includes(errorCodeOf(readError) as (typeof SELECTED_DISAPPEARANCE_CODES)[number])) {
-          setError(errorMessage(readError) ?? String(readError));
-        }
-        if (canPublish && failures.length > 0) {
-          setError(errorMessage(failures[0]) ?? String(failures[0]));
-        }
-        if (selectedMutationBatchesRef.current.get(identity) === currentBatch) {
-          selectedMutationBatchesRef.current.delete(identity);
-        }
+        coordinator.mutations.delete(identity);
       })();
     },
-    [api, commitSelected],
+    [launchSelectedRead, setResourceError, t],
   );
 
-  const refreshSelected = useCallback(async () => {
-    const current = selectedRef.current;
-    if (!current) return;
-    const batch = selectedMutationBatchesRef.current.get(current.name);
+  const reconcileSelected = useCallback(async () => {
+    const coordinator = selectedCoordinatorRef.current;
+    const identity = coordinator.desiredName;
+    if (!identity) return;
+    const batch = coordinator.mutations.get(identity);
     if (batch) return;
-    const intentGeneration = selectedIntentRef.current.generation;
-    const desiredIdentity = selectedIntentRef.current.desiredName;
-    const acceptedGeneration = selectedAcceptedGenerationRef.current;
-    const passiveRead = ++selectedPassiveReadRef.current;
-    const identity = current.name;
-    try {
-      const result = await api.getVibeAgent(identity, {
-        cache: false,
-        expectedCodes: SELECTED_DISAPPEARANCE_CODES,
-      });
-      if (
-        result.ok &&
-        selectedPassiveReadRef.current === passiveRead &&
-        selectedAcceptedGenerationRef.current === acceptedGeneration &&
-        selectedIntentRef.current.generation === intentGeneration &&
-        selectedIntentRef.current.desiredName === desiredIdentity &&
-        desiredIdentity === identity &&
-        selectedRef.current?.name === identity &&
-        !selectedMutationBatchesRef.current.has(identity)
-      ) {
-        commitSelected(result.agent);
-      }
-    } catch (err) {
-      if (
-        selectedPassiveReadRef.current !== passiveRead ||
-        selectedAcceptedGenerationRef.current !== acceptedGeneration ||
-        selectedIntentRef.current.generation !== intentGeneration ||
-        selectedIntentRef.current.desiredName !== desiredIdentity ||
-        desiredIdentity !== identity ||
-        selectedRef.current?.name !== identity ||
-        selectedMutationBatchesRef.current.has(identity)
-      ) return;
-      if (SELECTED_DISAPPEARANCE_CODES.includes(errorCodeOf(err) as (typeof SELECTED_DISAPPEARANCE_CODES)[number])) {
-        commitSelected(null);
-        return;
-      }
-      setError(errorMessage(err) ?? String(err));
-    }
-  }, [api, commitSelected]);
+    const intentGeneration = coordinator.intentGeneration;
+    const readGeneration = advanceSelectedRead(coordinator, identity);
+    await launchSelectedRead({ identity, readGeneration, intentGeneration, expectedCodes: SELECTED_DISAPPEARANCE_CODES });
+  }, [launchSelectedRead]);
 
   useEffect(() => {
     refresh();
@@ -452,7 +537,7 @@ export const AgentsPage: React.FC = () => {
       // `onConnected`, and refetching from both would pay twice for one gap.
       onConnected: () => {
         void refreshRef.current();
-        void refreshSelected();
+        void reconcileSelected();
         void refreshOnboarding();
         void fetchRunningActiveCount();
       },
@@ -464,10 +549,10 @@ export const AgentsPage: React.FC = () => {
       onSessionStatus: () => fetchRunningActiveCount(),
       onAuthorizationChanged: () => {
         void refreshRef.current();
-        void refreshSelected();
+        void reconcileSelected();
       },
     });
-  }, [api, capabilities.can_use_agents, fetchRunningActiveCount, refreshOnboarding, refreshSelected]);
+  }, [api, capabilities.can_use_agents, fetchRunningActiveCount, refreshOnboarding, reconcileSelected]);
 
   useEffect(() => {
     if (!capabilities.can_use_agents) return;
@@ -518,29 +603,17 @@ export const AgentsPage: React.FC = () => {
 
   const selectAgent = useCallback(
     async (name: string, openDetail = false) => {
-      const { generation, identity } = beginSelectedIntent(name);
-      try {
-        const result = await api.getVibeAgent(name, { cache: false });
-        if (
-          result.ok &&
-          selectedIntentRef.current.generation === generation &&
-          selectedIntentRef.current.desiredName === identity
-        ) {
-          commitSelected(result.agent);
-          // Enter the mobile drill-down only once the detail has actually loaded —
-          // never optimistically, or a failed fetch hides the list with no panel.
-          if (openDetail) setDetailOpen(true);
-        }
-      } catch (err) {
-        if (
-          selectedIntentRef.current.generation === generation &&
-          selectedIntentRef.current.desiredName === identity
-        ) {
-          setError(errorMessage(err) ?? String(err));
-        }
-      }
+      const coordinator = selectedCoordinatorRef.current;
+      const { intentGeneration: generation } = beginSelectedIntent(name);
+      const identity = name;
+      clearResourceError('selection');
+      const readGeneration = advanceSelectedRead(coordinator, identity);
+      const outcome = await launchSelectedRead({ identity, readGeneration, intentGeneration: generation });
+      // Enter the mobile drill-down only once the detail has actually loaded —
+      // never optimistically, or a failed fetch hides the list with no panel.
+      if (outcome === 'published' && openDetail) setDetailOpen(true);
     },
-    [api, beginSelectedIntent, commitSelected],
+    [beginSelectedIntent, clearResourceError, launchSelectedRead],
   );
 
   // Apply text search + backend filter; backend grouping is a layout
@@ -610,18 +683,23 @@ export const AgentsPage: React.FC = () => {
     const confirmed = window.confirm(t('agents.deleteConfirm', { name: selected.name }));
     if (!confirmed) return;
     const name = selected.name;
-    beginSelectedIntent(null);
+    const coordinator = selectedCoordinatorRef.current;
+    const errorGeneration = beginResourceError('mutation');
+    if (coordinator.desiredName === name) advanceSelectedRead(coordinator, name);
     try {
       const result = await api.removeVibeAgent(name);
       if (result.ok) {
-        commitSelected(null);
+        if (coordinator.desiredName === name && coordinator.accepted?.name === name) {
+          beginSelectedIntent(null);
+          commitSelected(null);
+        }
         refresh();
         void refreshOnboarding();
-      } else if (result.message) {
-        setError(result.message);
+      } else {
+        setResourceError('mutation', errorMessage(result) || t('errorBoundary.title'), errorGeneration);
       }
     } catch (err) {
-      setError(errorMessage(err) ?? String(err));
+      setResourceError('mutation', errorMessage(err) || t('errorBoundary.title'), errorGeneration);
     }
   };
 
@@ -660,11 +738,9 @@ export const AgentsPage: React.FC = () => {
   const onOnboardAgents = async () => {
     if (onboardingSubmitting) return;
     setOnboardingSubmitting(true);
-    const mutationId = ++onboardingMutationRef.current;
-    onboardingVersionRef.current.begin();
+    onboardingVersionRef.current.invalidate();
     try {
       const result = await api.onboardVibeAgents();
-      if (mutationId === onboardingMutationRef.current) publishOnboarding(result);
       showToast(
         result.sync?.ok === false
           ? t('agents.onboarding.savedPending')
@@ -674,6 +750,7 @@ export const AgentsPage: React.FC = () => {
     } catch (err) {
       showToast(t('agents.onboarding.failed', { error: errorMessage(err) ?? String(err) }), 'error');
     } finally {
+      void refreshOnboarding();
       setOnboardingSubmitting(false);
     }
   };
@@ -1179,6 +1256,9 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
   const [systemPrompt, setSystemPrompt] = useState(agent.system_prompt ?? '');
   const [systemPromptOpen, setSystemPromptOpen] = useState(false);
   const [editorOpen, setEditorOpen] = useState(false);
+  const [editorSeedRevision, setEditorSeedRevision] = useState(0);
+  const editorDraftRef = useRef(agent.system_prompt ?? '');
+  const editorDirtyRef = useRef(false);
   const [modelCatalogs, setModelCatalogs] = useState<
     Record<
       string,
@@ -1221,6 +1301,9 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
       setSystemPrompt(next.systemPrompt);
       setSystemPromptOpen(false);
       setEditorOpen(false);
+      editorDraftRef.current = next.systemPrompt;
+      editorDirtyRef.current = false;
+      setEditorSeedRevision((revision) => revision + 1);
     } else {
       // Same-identity reconciliation updates clean inline fields while leaving
       // dirty work and the modal's private draft untouched.
@@ -1228,10 +1311,15 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
       if (description === previous.description) setDescription(next.description);
       if (model === previous.model) setModel(next.model);
       if (effort === previous.effort) setEffort(next.effort);
-      if (systemPrompt === previous.systemPrompt) setSystemPrompt(next.systemPrompt);
+      if (systemPrompt === previous.systemPrompt || systemPrompt === next.systemPrompt) setSystemPrompt(next.systemPrompt);
+      if (editorDraftRef.current === previous.systemPrompt || editorDraftRef.current === next.systemPrompt) {
+        editorDraftRef.current = next.systemPrompt;
+        editorDirtyRef.current = false;
+        if (editorOpen) setEditorSeedRevision((revision) => revision + 1);
+      }
     }
     serverSnapshotRef.current = next;
-  }, [agent.id, agent.name, agent.description, agent.model, agent.reasoning_effort, agent.system_prompt, description, effort, model, name, systemPrompt]);
+  }, [agent.id, agent.name, agent.description, agent.model, agent.reasoning_effort, agent.system_prompt, description, effort, model, name, systemPrompt, editorOpen]);
 
   // Load model catalog for the agent's backend so the Combobox can offer
   // suggestions. Keeps `allowCustomValue` so users can type a model the
@@ -1412,7 +1500,9 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
           onChange={(e) => setDescription(e.target.value)}
           onBlur={() => {
             if (!locked && description !== (agent.description ?? '')) {
-              onChange({ description: description.trim() || null });
+              const canonical = description.trim();
+              setDescription(canonical);
+              onChange({ description: canonical || null });
             }
           }}
           disabled={locked}
@@ -1556,7 +1646,9 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
             onChange={(e) => setSystemPrompt(e.target.value)}
             onBlur={() => {
               if (canEdit && systemPrompt !== (agent.system_prompt ?? '')) {
-                onChange({ system_prompt: systemPrompt.trim() || null });
+                const canonical = systemPrompt.trim();
+                setSystemPrompt(canonical);
+                onChange({ system_prompt: canonical || null });
               }
             }}
             readOnly={!canEdit}
@@ -1609,17 +1701,25 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
       {/* Full-screen system-prompt editor — large input + Markdown preview.
           Opening from collapsed or expanded both jump straight here. */}
       <EditorDialog
+        key={`${agent.id}:${editorSeedRevision}`}
         open={canEdit && editorOpen}
         onClose={() => setEditorOpen(false)}
         title={t('agents.detail.systemPrompt')}
         description={t('agents.detail.systemPromptEditorHint')}
         value={systemPrompt}
         placeholder={t('agents.create.systemPromptPlaceholder')}
-        footerHint={(draft) => t('agents.detail.systemPromptCount', { count: estimateTokens(draft) })}
+        footerHint={(draft) => {
+          editorDraftRef.current = draft;
+          editorDirtyRef.current = draft !== systemPrompt;
+          return t('agents.detail.systemPromptCount', { count: estimateTokens(draft) });
+        }}
         onSave={(next) => {
-          setSystemPrompt(next);
-          if (next !== (agent.system_prompt ?? '')) {
-            onChange({ system_prompt: next.trim() || null });
+          const canonical = next.trim();
+          setSystemPrompt(canonical);
+          editorDraftRef.current = canonical;
+          editorDirtyRef.current = false;
+          if (canonical !== (agent.system_prompt ?? '')) {
+            onChange({ system_prompt: canonical || null });
           }
         }}
       />

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -384,12 +384,23 @@ export const AgentsPage: React.FC = () => {
     (identity: string, options: { refreshDefinitions?: boolean } = {}) => {
       const coordinator = selectedCoordinatorRef.current;
       if (coordinator.retired.has(identity)) return false;
+      const acceptedIdentity = coordinator.accepted?.name ?? null;
+      const pendingIdentity = coordinator.desiredName === identity;
+      const acceptedCanResume = Boolean(
+        acceptedIdentity &&
+          acceptedIdentity !== identity &&
+          !coordinator.retired.has(acceptedIdentity) &&
+          !coordinator.autoSelectDismissed,
+      );
       coordinator.retired.add(identity);
       advanceSelectedRead(coordinator, identity);
       coordinator.reconciliationDebt.delete(identity);
-      if (coordinator.desiredName === identity) {
+      if (pendingIdentity) {
         coordinator.intentGeneration += 1;
-        coordinator.desiredName = null;
+        // A pending selection can disappear without invalidating the accepted
+        // entity. Keep that accepted entity eligible for reconnect/debt
+        // reconciliation instead of leaving visible A with no desired A.
+        coordinator.desiredName = acceptedCanResume ? acceptedIdentity : null;
       }
       if (coordinator.accepted?.name === identity) commitSelected(null);
       if (!coordinator.desiredName && !coordinator.accepted && !coordinator.autoSelectDismissed) {
@@ -405,6 +416,44 @@ export const AgentsPage: React.FC = () => {
     [clearResourceError, commitSelected],
   );
   retireSelectedIdentityRef.current = retireSelectedIdentity;
+
+  // A successful rename keeps the stable entity id while changing the
+  // transport key used by every read and mutation. Migrate all coordinator
+  // state in one transition so an old-name response can never republish.
+  const migrateSelectedIdentity = useCallback(
+    (oldName: string, newName: string, stableId: string) => {
+      if (!oldName || !newName || oldName === newName) return;
+      const coordinator = selectedCoordinatorRef.current;
+      const accepted = coordinator.accepted;
+      const acceptedMatches = accepted?.id === stableId && accepted.name === oldName;
+      const desiredMatches = coordinator.desiredName === oldName;
+      if (!acceptedMatches && !desiredMatches) return;
+
+      coordinator.retired.add(oldName);
+      advanceSelectedRead(coordinator, oldName);
+
+      const oldDebt = coordinator.reconciliationDebt.get(oldName);
+      coordinator.reconciliationDebt.delete(oldName);
+      if (oldDebt) {
+        coordinator.reconciliationDebt.set(newName, { ...oldDebt, scheduled: false });
+      }
+
+      const oldBatch = coordinator.mutations.get(oldName);
+      if (oldBatch) {
+        coordinator.mutations.delete(oldName);
+        oldBatch.identity = newName;
+        coordinator.mutations.set(newName, oldBatch);
+      }
+
+      coordinator.intentGeneration += 1;
+      if (desiredMatches) coordinator.desiredName = newName;
+      if (acceptedMatches && accepted) {
+        commitSelected({ ...accepted, name: newName, display_name: newName });
+      }
+      advanceSelectedRead(coordinator, newName);
+    },
+    [commitSelected],
+  );
 
   const launchSelectedRead = useCallback(
     async (options: {
@@ -437,6 +486,14 @@ export const AgentsPage: React.FC = () => {
           commitSelected(result.agent);
           finishDebt(true);
           return 'published';
+        }
+        if (
+          options.expectedCodes &&
+          SELECTED_DISAPPEARANCE_CODES.includes(errorCodeOf(result) as (typeof SELECTED_DISAPPEARANCE_CODES)[number])
+        ) {
+          retireSelectedIdentityRef.current?.(options.identity);
+          finishDebt(false);
+          return 'failed';
         }
         const rollback = rollbackSelectedIntent();
         setResourceError('selection', errorMessage(result) || tRef.current('errorBoundary.title'));
@@ -536,15 +593,15 @@ export const AgentsPage: React.FC = () => {
     (operation: { id: number; identity: string }, failure?: unknown): Promise<void> => {
       if (!selectedMountedRef.current) return Promise.resolve();
       const coordinator = selectedCoordinatorRef.current;
-      const batch = coordinator.mutations.get(operation.identity);
-      if (!batch || batch.id !== operation.id) return Promise.resolve();
+      const batch = [...coordinator.mutations.values()].find((candidate) => candidate.id === operation.id);
+      if (!batch) return Promise.resolve();
       if (failure) batch.failures.push(failure);
       batch.pending = Math.max(0, batch.pending - 1);
       if (batch.pending !== 0) {
         return new Promise<void>((resolve) => batch.waiters.push(resolve));
       }
 
-      const identity = operation.identity;
+      const identity = batch.identity;
       const version = batch.version;
       const failures = [...batch.failures];
       const errorGeneration = batch.errorGeneration;
@@ -790,12 +847,28 @@ export const AgentsPage: React.FC = () => {
     refresh();
   };
 
-  // After a rename (clone-then-delete) the list is stale: the old name lingers
-  // and the new one is missing. Refresh and re-select the renamed agent.
-  const onRenamed = (newName: string) => {
-    beginSelectedIntent(newName);
-    void refresh().then(() => selectAgent(newName));
-    void refreshOnboarding();
+  // Rename is a selected mutation too: migrate the stable entity before the
+  // batch settles so its authoritative drain routes through the new name.
+  const onRename = async (newName: string) => {
+    if (!selected) return;
+    const oldName = selected.name;
+    const operation = beginSelectedMutation(oldName);
+    let settled = false;
+    try {
+      const result = await api.updateVibeAgent(oldName, { name: newName });
+      if (!result.ok) {
+        await settleSelectedMutation(operation, result);
+        settled = true;
+        throw result;
+      }
+      migrateSelectedIdentity(oldName, newName, selected.id);
+      await settleSelectedMutation(operation);
+      settled = true;
+      void refreshOnboarding();
+    } catch (err) {
+      if (!settled) await settleSelectedMutation(operation, err);
+      throw err;
+    }
   };
 
   const onDelete = async () => {
@@ -1062,7 +1135,7 @@ export const AgentsPage: React.FC = () => {
               canEdit={canEditAgents}
               onChange={updateField}
               onSetDefault={onSetDefault}
-              onRenamed={onRenamed}
+              onRename={onRename}
               onDelete={onDelete}
               onClose={dismissSelected}
             />
@@ -1339,7 +1412,7 @@ interface DetailProps {
   canEdit: boolean;
   onChange: (patch: VibeAgentUpdatePayload) => Promise<void>;
   onSetDefault: () => Promise<void>;
-  onRenamed: (newName: string) => void;
+  onRename: (newName: string) => Promise<void>;
   onDelete: () => void;
   onClose: () => void;
 }
@@ -1350,7 +1423,7 @@ interface DetailProps {
 // for user agents. The backend renames the row and its references atomically;
 // system agents keep their locked identity. On a remote instance `canEdit` is
 // false and the panel degrades to a read-only view of the same fields.
-const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, onChange, onSetDefault, onRenamed, onDelete, onClose }) => {
+const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, onChange, onSetDefault, onRename, onDelete, onClose }) => {
   const { t } = useTranslation();
   const api = useApi();
   const { showToast } = useToast();
@@ -1369,11 +1442,25 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
   const [editorSeedRevision, setEditorSeedRevision] = useState(0);
   const editorDraftRef = useRef(agent.system_prompt ?? '');
   const editorDirtyRef = useRef(false);
+  const editorClosingRef = useRef(false);
   const editorBaselineRef = useRef(agent.system_prompt ?? '');
-  type EditableField = 'description' | 'model' | 'effort' | 'systemPrompt';
-  const fieldRevisionRef = useRef<Record<EditableField, number>>({ description: 0, model: 0, effort: 0, systemPrompt: 0 });
-  const submittedRevisionRef = useRef<Record<EditableField, number>>({ description: 0, model: 0, effort: 0, systemPrompt: 0 });
+  type EditableField = 'name' | 'description' | 'model' | 'effort' | 'systemPrompt';
+  const fieldRevisionRef = useRef<Record<EditableField, number>>({
+    name: 0,
+    description: 0,
+    model: 0,
+    effort: 0,
+    systemPrompt: 0,
+  });
+  const submittedRevisionRef = useRef<Record<EditableField, number>>({
+    name: 0,
+    description: 0,
+    model: 0,
+    effort: 0,
+    systemPrompt: 0,
+  });
   const pendingRevisionRef = useRef<Record<EditableField, number | null>>({
+    name: null,
     description: null,
     model: null,
     effort: null,
@@ -1414,9 +1501,9 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
       systemPrompt: agent.system_prompt ?? '',
     };
     if (previous.id !== next.id) {
-      fieldRevisionRef.current = { description: 0, model: 0, effort: 0, systemPrompt: 0 };
-      submittedRevisionRef.current = { description: 0, model: 0, effort: 0, systemPrompt: 0 };
-      pendingRevisionRef.current = { description: null, model: null, effort: null, systemPrompt: null };
+      fieldRevisionRef.current = { name: 0, description: 0, model: 0, effort: 0, systemPrompt: 0 };
+      submittedRevisionRef.current = { name: 0, description: 0, model: 0, effort: 0, systemPrompt: 0 };
+      pendingRevisionRef.current = { name: null, description: null, model: null, effort: null, systemPrompt: null };
       setName(next.name);
       setDescription(next.description);
       setModel(next.model);
@@ -1424,6 +1511,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
       setSystemPrompt(next.systemPrompt);
       setSystemPromptOpen(false);
       setEditorOpen(false);
+      editorClosingRef.current = false;
       editorDraftRef.current = next.systemPrompt;
       editorBaselineRef.current = next.systemPrompt;
       editorDirtyRef.current = false;
@@ -1437,6 +1525,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
       const revisions = fieldRevisionRef.current;
       const submitted = submittedRevisionRef.current;
       const pending = pendingRevisionRef.current;
+      if (pending.name === null && revisions.name <= submitted.name) setName(next.name);
       if (pending.description === null && revisions.description <= submitted.description) setDescription(next.description);
       if (pending.model === null && revisions.model <= submitted.model) setModel(next.model);
       if (pending.effort === null && revisions.effort <= submitted.effort) setEffort(next.effort);
@@ -1491,13 +1580,25 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
   const markFieldSubmitted = (field: keyof typeof submittedRevisionRef.current) => {
     submittedRevisionRef.current[field] = fieldRevisionRef.current[field];
   };
-  const submitFields = (patch: VibeAgentUpdatePayload, fields: EditableField[]) => {
+  const cancelFieldEdit = (field: EditableField, value: string) => {
+    const revision = fieldRevisionRef.current[field];
+    pendingRevisionRef.current[field] = null;
+    submittedRevisionRef.current[field] = revision;
+    if (fieldRevisionRef.current[field] === revision) {
+      if (field === 'name') setName(value);
+      if (field === 'description') setDescription(value);
+      if (field === 'model') setModel(value);
+      if (field === 'effort') setEffort(value);
+      if (field === 'systemPrompt') setSystemPrompt(value);
+    }
+  };
+  const submitFields = (patch: VibeAgentUpdatePayload, fields: EditableField[]): Promise<void> => {
     const revisions = fields.map((field) => {
       const revision = fieldRevisionRef.current[field];
       pendingRevisionRef.current[field] = revision;
       return { field, revision };
     });
-    void onChange(patch).then(() => {
+    return onChange(patch).then(() => {
       for (const { field, revision } of revisions) {
         if (pendingRevisionRef.current[field] !== revision) continue;
         pendingRevisionRef.current[field] = null;
@@ -1525,21 +1626,25 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
   const commitRename = async () => {
     const trimmed = name.trim();
     if (!trimmed || trimmed === agent.name) {
-      setName(agent.name);
+      cancelFieldEdit('name', serverSnapshotRef.current.name);
       return;
     }
     if (locked) {
-      setName(agent.name);
+      cancelFieldEdit('name', serverSnapshotRef.current.name);
       return;
     }
+    const revision = fieldRevisionRef.current.name;
+    pendingRevisionRef.current.name = revision;
+    submittedRevisionRef.current.name = revision;
     setRenaming(true);
     try {
-      await api.updateVibeAgent(agent.name, { name: trimmed });
+      await onRename(trimmed);
+      pendingRevisionRef.current.name = null;
+      if (fieldRevisionRef.current.name === revision) setName(trimmed);
       showToast(t('agents.renameSuccess'), 'success');
-      onRenamed(trimmed);
     } catch (err) {
       showToast(errorMessage(err) ?? String(err), 'error');
-      setName(agent.name);
+      cancelFieldEdit('name', serverSnapshotRef.current.name);
     } finally {
       setRenaming(false);
     }
@@ -1642,7 +1747,10 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
         <div className="flex items-center gap-2 rounded-lg border border-border-strong bg-surface-2 px-3 py-2">
           <input
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            onChange={(e) => {
+              markFieldEdit('name');
+              setName(e.target.value);
+            }}
             onBlur={commitRename}
             onKeyDown={(e) => {
               if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
@@ -1807,7 +1915,13 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
               variant="ghost"
               size="icon"
               className="size-9 shrink-0 text-muted hover:text-foreground"
-              onClick={() => setEditorOpen(true)}
+              onClick={() => {
+                editorClosingRef.current = false;
+                editorDirtyRef.current = false;
+                editorDraftRef.current = systemPrompt;
+                editorBaselineRef.current = systemPrompt;
+                setEditorOpen(true);
+              }}
               aria-label={t('agents.detail.systemPromptExpand')}
               title={t('agents.detail.systemPromptExpand')}
             >
@@ -1827,7 +1941,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
                 const canonical = systemPrompt.trim();
                 setSystemPrompt(canonical);
                 markFieldSubmitted('systemPrompt');
-                onChange({ system_prompt: canonical || null });
+                void submitFields({ system_prompt: canonical || null }, ['systemPrompt']);
               }
             }}
             readOnly={!canEdit}
@@ -1883,6 +1997,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
         key={`${agent.id}:${editorSeedRevision}`}
         open={canEdit && editorOpen}
         onClose={() => {
+          editorClosingRef.current = true;
           editorDraftRef.current = systemPrompt;
           editorBaselineRef.current = systemPrompt;
           editorDirtyRef.current = false;
@@ -1893,25 +2008,22 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
         value={systemPrompt}
         placeholder={t('agents.create.systemPromptPlaceholder')}
         footerHint={(draft) => {
-          if (draft !== editorDraftRef.current) {
-            markFieldEdit('systemPrompt');
-            editorDraftRef.current = draft;
-            editorDirtyRef.current = true;
-          }
+          if (!editorClosingRef.current) editorDirtyRef.current = draft !== editorBaselineRef.current;
           editorDraftRef.current = draft;
           return t('agents.detail.systemPromptCount', { count: estimateTokens(draft) });
         }}
         onSave={(next) => {
           const canonical = next.trim();
-            markFieldEdit('systemPrompt');
-            markFieldSubmitted('systemPrompt');
+          markFieldEdit('systemPrompt');
+          markFieldSubmitted('systemPrompt');
           setSystemPrompt(canonical);
           editorDraftRef.current = canonical;
           editorBaselineRef.current = canonical;
           editorDirtyRef.current = false;
           if (canonical !== (agent.system_prompt ?? '') || pendingRevisionRef.current.systemPrompt !== null) {
-            submitFields({ system_prompt: canonical || null }, ['systemPrompt']);
+            return submitFields({ system_prompt: canonical || null }, ['systemPrompt']);
           }
+          return;
         }}
       />
     </div>

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -75,6 +75,34 @@ function isSystemAgent(agent: { source: string }): boolean {
   return agent.source === 'builtin' || agent.source === 'system';
 }
 
+type AgentRequestToken = { version: number; identity: string | null };
+
+type AgentRequestVersion = {
+  begin: (identity?: string | null) => AgentRequestToken;
+  invalidate: () => number;
+  isCurrent: (token: AgentRequestToken) => boolean;
+};
+
+// A tiny per-resource epoch owner. Every asynchronous read captures a token;
+// any committed mutation or identity change advances the epoch and makes older
+// responses inert without relying on timing or a name comparison alone.
+const createAgentRequestVersion = (): AgentRequestVersion => {
+  let version = 0;
+  return {
+    begin: (identity = null) => ({ version: ++version, identity }),
+    invalidate: () => ++version,
+    isCurrent: (token) => token.version === version,
+  };
+};
+
+const SELECTED_DISAPPEARANCE_CODES = ['agent_not_found', 'agent_access_forbidden'] as const;
+
+const errorCodeOf = (error: unknown): string | null => {
+  if (!error || typeof error !== 'object') return null;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' ? code : null;
+};
+
 export const AgentsPage: React.FC = () => {
   const { t } = useTranslation();
   const api = useApi();
@@ -117,9 +145,13 @@ export const AgentsPage: React.FC = () => {
   const [onboardingInventory, setOnboardingInventory] = useState<VibeAgentOnboardingResult | null>(null);
   const [onboardingExpanded, setOnboardingExpanded] = useState(false);
   const [onboardingSubmitting, setOnboardingSubmitting] = useState(false);
-  const refreshRequestRef = useRef(0);
+  const definitionsVersionRef = useRef(createAgentRequestVersion());
+  const onboardingVersionRef = useRef(createAgentRequestVersion());
   const selectedRef = useRef<VibeAgentFull | null>(null);
-  const selectedRefreshRequestRef = useRef(0);
+  const selectedVersionRef = useRef(createAgentRequestVersion());
+  const selectedIntentRef = useRef(0);
+  const selectedMutationVersionRef = useRef(0);
+  const onboardingMutationRef = useRef(0);
   // Mobile drill-down: a row tap opens the detail full-screen. The agent
   // auto-selected on mount stays in the list view until the user drills in.
   const [detailOpen, setDetailOpen] = useState(false);
@@ -132,24 +164,42 @@ export const AgentsPage: React.FC = () => {
   // a member's page load into an owner-only GET and surfaced the 403 as a toast.
   const canOnboardAgents = capabilities.is_instance_owner;
 
+  const publishOnboarding = useCallback((result: VibeAgentOnboardingResult | null) => {
+    onboardingVersionRef.current.invalidate();
+    setOnboardingInventory(result?.available ? result : null);
+  }, []);
+
   const refreshOnboarding = useCallback(async () => {
     if (!canOnboardAgents) {
       setOnboardingInventory(null);
       return;
     }
+    const token = onboardingVersionRef.current.begin();
     try {
       const result = await api.getVibeAgentOnboarding();
-      setOnboardingInventory(result.available ? result : null);
+      if (onboardingVersionRef.current.isCurrent(token)) publishOnboarding(result);
     } catch {
-      setOnboardingInventory(null);
+      if (onboardingVersionRef.current.isCurrent(token)) publishOnboarding(null);
     }
-  }, [api, canOnboardAgents]);
+  }, [api, canOnboardAgents, publishOnboarding]);
+
+  const commitSelected = useCallback((agent: VibeAgentFull | null) => {
+    selectedVersionRef.current.invalidate();
+    selectedRef.current = agent;
+    setSelected(agent);
+  }, []);
+
+  const beginSelectedIntent = useCallback((identity: string | null) => {
+    const intent = ++selectedIntentRef.current;
+    return { intent, token: selectedVersionRef.current.begin(identity) };
+  }, []);
+
 
   // Definitions refreshes are explicit reconciliation reads. They must always
   // bypass the five-second client cache so a normal refresh cannot supersede a
   // reconnect snapshot with a stale cached promise.
   const refresh = useCallback(() => {
-    const requestId = ++refreshRequestRef.current;
+    const token = definitionsVersionRef.current.begin();
     const request = (async () => {
       setLoading(true);
       setError(null);
@@ -161,7 +211,7 @@ export const AgentsPage: React.FC = () => {
         // A read issued before a stream gap may finish after the catch-up read.
         // Only the latest request may publish its snapshot, so an older response
         // cannot roll the Definitions list back to pre-gap state.
-        if (requestId !== refreshRequestRef.current) return;
+        if (!definitionsVersionRef.current.isCurrent(token)) return;
         setAgents(result.agents);
         setDefaultName(result.default_agent_name);
         // Keep the currently-selected agent present after edits / refreshes.
@@ -169,18 +219,18 @@ export const AgentsPage: React.FC = () => {
         if (currentSelected) {
           const fresh = result.agents.find((a) => a.name === currentSelected.name);
           if (!fresh) {
-            selectedRef.current = null;
-            setSelected(null);
+            beginSelectedIntent(null);
+            commitSelected(null);
           }
         }
       } catch (err) {
-        if (requestId === refreshRequestRef.current) setError(errorMessage(err) ?? String(err));
+        if (definitionsVersionRef.current.isCurrent(token)) setError(errorMessage(err) ?? String(err));
       } finally {
-        if (requestId === refreshRequestRef.current) setLoading(false);
+        if (definitionsVersionRef.current.isCurrent(token)) setLoading(false);
       }
     })();
     return request;
-  }, [api]);
+  }, [api, beginSelectedIntent, commitSelected]);
 
   const refreshRef = useRef(refresh);
   refreshRef.current = refresh;
@@ -188,26 +238,31 @@ export const AgentsPage: React.FC = () => {
   const refreshSelected = useCallback(async () => {
     const current = selectedRef.current;
     if (!current) return;
-    const requestId = ++selectedRefreshRequestRef.current;
+    const intent = selectedIntentRef.current;
+    const token = selectedVersionRef.current.begin(current.name);
     try {
-      const result = await api.getVibeAgent(current.name, { cache: false });
+      const result = await api.getVibeAgent(current.name, {
+        cache: false,
+        expectedCodes: SELECTED_DISAPPEARANCE_CODES,
+      });
       if (
         result.ok &&
-        requestId === selectedRefreshRequestRef.current &&
-        selectedRef.current?.name === current.name
+        selectedVersionRef.current.isCurrent(token) &&
+        selectedIntentRef.current === intent &&
+        selectedRef.current?.name === token.identity
       ) {
-        selectedRef.current = result.agent;
-        setSelected(result.agent);
+        commitSelected(result.agent);
       }
-    } catch {
-      // The list catch-up remains authoritative even if the selected detail
-      // cannot be re-read during a transient reconnect.
+    } catch (err) {
+      if (!selectedVersionRef.current.isCurrent(token) || selectedIntentRef.current !== intent) return;
+      if (SELECTED_DISAPPEARANCE_CODES.includes(errorCodeOf(err) as (typeof SELECTED_DISAPPEARANCE_CODES)[number])) {
+        beginSelectedIntent(null);
+        commitSelected(null);
+        return;
+      }
+      setError(errorMessage(err) ?? String(err));
     }
-  }, [api]);
-
-  useEffect(() => {
-    selectedRef.current = selected;
-  }, [selected]);
+  }, [api, beginSelectedIntent, commitSelected]);
 
   useEffect(() => {
     refresh();
@@ -339,20 +394,22 @@ export const AgentsPage: React.FC = () => {
 
   const selectAgent = useCallback(
     async (name: string, openDetail = false) => {
+      const { intent, token } = beginSelectedIntent(name);
       try {
         const result = await api.getVibeAgent(name);
-        if (result.ok) {
-          selectedRef.current = result.agent;
-          setSelected(result.agent);
+        if (result.ok && selectedIntentRef.current === intent && selectedVersionRef.current.isCurrent(token)) {
+          commitSelected(result.agent);
           // Enter the mobile drill-down only once the detail has actually loaded —
           // never optimistically, or a failed fetch hides the list with no panel.
           if (openDetail) setDetailOpen(true);
         }
       } catch (err) {
-        setError(errorMessage(err) ?? String(err));
+        if (selectedIntentRef.current === intent && selectedVersionRef.current.isCurrent(token)) {
+          setError(errorMessage(err) ?? String(err));
+        }
       }
     },
-    [api],
+    [api, beginSelectedIntent, commitSelected],
   );
 
   // Apply text search + backend filter; backend grouping is a layout
@@ -380,25 +437,36 @@ export const AgentsPage: React.FC = () => {
   }, [filtered]);
 
   const onCreated = (agent: VibeAgentFull) => {
-    refresh().then(() => {
-      selectedRef.current = agent;
-      setSelected(agent);
-    });
+    beginSelectedIntent(agent.name);
+    commitSelected(agent);
+    void refresh();
     void refreshOnboarding();
   };
 
 
   const updateField = async (patch: VibeAgentUpdatePayload) => {
     if (!selected) return;
+    const name = selected.name;
+    const intent = selectedIntentRef.current;
+    const mutationToken = selectedVersionRef.current.begin(name);
+    selectedMutationVersionRef.current = mutationToken.version;
     try {
-      const result = await api.updateVibeAgent(selected.name, patch);
-      if (result.ok) {
-        selectedRef.current = result.agent;
-        setSelected(result.agent);
+      const result = await api.updateVibeAgent(name, patch);
+      if (
+        result.ok &&
+        selectedIntentRef.current === intent &&
+        selectedRef.current?.name === name &&
+        selectedMutationVersionRef.current === mutationToken.version
+      ) {
+        // Publishing the mutation result advances the same epoch, invalidating
+        // any read that started while the PATCH was in flight.
+        commitSelected(result.agent);
         refresh();
       }
     } catch (err) {
-      setError(errorMessage(err) ?? String(err));
+      if (selectedIntentRef.current === intent && selectedRef.current?.name === name) {
+        setError(errorMessage(err) ?? String(err));
+      }
     }
   };
 
@@ -415,7 +483,8 @@ export const AgentsPage: React.FC = () => {
   // After a rename (clone-then-delete) the list is stale: the old name lingers
   // and the new one is missing. Refresh and re-select the renamed agent.
   const onRenamed = (newName: string) => {
-    refresh().then(() => selectAgent(newName));
+    beginSelectedIntent(newName);
+    void refresh().then(() => selectAgent(newName));
     void refreshOnboarding();
   };
 
@@ -423,11 +492,12 @@ export const AgentsPage: React.FC = () => {
     if (!selected || isSystemAgent(selected)) return;
     const confirmed = window.confirm(t('agents.deleteConfirm', { name: selected.name }));
     if (!confirmed) return;
+    const name = selected.name;
+    beginSelectedIntent(null);
     try {
-      const result = await api.removeVibeAgent(selected.name);
+      const result = await api.removeVibeAgent(name);
       if (result.ok) {
-        selectedRef.current = null;
-        setSelected(null);
+        commitSelected(null);
         refresh();
         void refreshOnboarding();
       } else if (result.message) {
@@ -473,9 +543,11 @@ export const AgentsPage: React.FC = () => {
   const onOnboardAgents = async () => {
     if (onboardingSubmitting) return;
     setOnboardingSubmitting(true);
+    const mutationId = ++onboardingMutationRef.current;
+    onboardingVersionRef.current.begin();
     try {
       const result = await api.onboardVibeAgents();
-      setOnboardingInventory(result);
+      if (mutationId === onboardingMutationRef.current) publishOnboarding(result);
       showToast(
         result.sync?.ok === false
           ? t('agents.onboarding.savedPending')
@@ -685,8 +757,8 @@ export const AgentsPage: React.FC = () => {
               onRenamed={onRenamed}
               onDelete={onDelete}
               onClose={() => {
-                selectedRef.current = null;
-                setSelected(null);
+                beginSelectedIntent(null);
+                commitSelected(null);
                 setDetailOpen(false);
               }}
             />
@@ -1001,19 +1073,48 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
   >({});
   const [running, setRunning] = useState(false);
 
+  const serverSnapshotRef = useRef({
+    id: agent.id,
+    name: agent.name,
+    description: agent.description ?? '',
+    model: agent.model ?? '',
+    effort: agent.reasoning_effort ?? 'medium',
+    systemPrompt: agent.system_prompt ?? '',
+  });
+
   const activeModelCatalog = modelCatalogs[agent.backend];
   const modelOptions = activeModelCatalog?.modelOptions ?? [];
   const reasoningOptions = activeModelCatalog?.reasoningOptions ?? {};
 
   useEffect(() => {
-    setName(agent.name);
-    setDescription(agent.description ?? '');
-    setModel(agent.model ?? '');
-    setEffort(agent.reasoning_effort ?? 'medium');
-    setSystemPrompt(agent.system_prompt ?? '');
-    setSystemPromptOpen(false);
-    setEditorOpen(false);
-  }, [agent.id, agent.name, agent.description, agent.model, agent.reasoning_effort, agent.system_prompt]);
+    const previous = serverSnapshotRef.current;
+    const next = {
+      id: agent.id,
+      name: agent.name,
+      description: agent.description ?? '',
+      model: agent.model ?? '',
+      effort: agent.reasoning_effort ?? 'medium',
+      systemPrompt: agent.system_prompt ?? '',
+    };
+    if (previous.id !== next.id) {
+      setName(next.name);
+      setDescription(next.description);
+      setModel(next.model);
+      setEffort(next.effort);
+      setSystemPrompt(next.systemPrompt);
+      setSystemPromptOpen(false);
+      setEditorOpen(false);
+    } else {
+      // Same-identity reconciliation updates clean inline fields while leaving
+      // dirty work and the modal's private draft untouched.
+      if (name === previous.name) setName(next.name);
+      if (description === previous.description) setDescription(next.description);
+      if (model === previous.model) setModel(next.model);
+      if (effort === previous.effort) setEffort(next.effort);
+      if (systemPrompt === previous.systemPrompt) setSystemPrompt(next.systemPrompt);
+    }
+    serverSnapshotRef.current = next;
+  }, [agent.id, agent.name, agent.description, agent.model, agent.reasoning_effort, agent.system_prompt, description, effort, model, name, systemPrompt]);
 
   // Load model catalog for the agent's backend so the Combobox can offer
   // suggestions. Keeps `allowCustomValue` so users can type a model the

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -80,6 +80,7 @@ type AgentRequestToken = { version: number; identity: string | null };
 type AgentRequestVersion = {
   begin: (identity?: string | null) => AgentRequestToken;
   invalidate: () => number;
+  current: () => number;
   isCurrent: (token: AgentRequestToken) => boolean;
 };
 
@@ -99,6 +100,7 @@ type SelectedMutationOperation = {
   identity: string;
   sequence: number;
   failure?: unknown;
+  joinedDetailBarrier?: boolean;
   resolve?: (result: SelectedMutationResult) => void;
 };
 
@@ -123,10 +125,10 @@ type SelectedRetirement = {
 type SelectedReadContinuation = { nextIdentity: string; intentGeneration: number };
 
 type SelectedReadOutcome =
-  | { kind: 'published' }
+  | { kind: 'published'; continuation?: SelectedReadContinuation }
   | { kind: 'failed'; error?: unknown; continuation?: SelectedReadContinuation }
-  | { kind: 'stale' }
-  | { kind: 'expected-retired'; continuation: SelectedReadContinuation };
+  | { kind: 'stale'; continuation?: SelectedReadContinuation }
+  | { kind: 'expected-retired'; continuation?: SelectedReadContinuation };
 
 type SelectedCoordinator = {
   desiredName: string | null;
@@ -136,12 +138,15 @@ type SelectedCoordinator = {
   readGenerations: Map<string, number>;
   accepted: VibeAgentFull | null;
   acceptedGeneration: number;
+  activeReads: Map<string, Promise<SelectedReadOutcome>>;
+  activeReadCauses: Map<string, 'selection' | 'reconcile' | 'continuation' | 'debt'>;
   nextBatchId: number;
   nextOperationId: number;
   nextMutationVersion: number;
   mutations: Map<string, SelectedMutationBatch>;
   reconciliationDebt: Map<string, SelectedReconciliationDebt>;
   retired: Set<string>;
+  retiredAtDefinitionsVersion: Map<string, number>;
   autoSelectReason: AutoSelectReason | null;
   autoSelectDismissed: boolean;
 };
@@ -164,12 +169,15 @@ const createSelectedCoordinator = (): SelectedCoordinator => ({
   readGenerations: new Map(),
   accepted: null,
   acceptedGeneration: 0,
+  activeReads: new Map(),
+  activeReadCauses: new Map(),
   nextBatchId: 0,
   nextOperationId: 0,
   nextMutationVersion: 0,
   mutations: new Map(),
   reconciliationDebt: new Map(),
   retired: new Set(),
+  retiredAtDefinitionsVersion: new Map(),
   autoSelectReason: 'initial',
   autoSelectDismissed: false,
 });
@@ -210,6 +218,7 @@ const createAgentRequestVersion = (): AgentRequestVersion => {
   return {
     begin: (identity = null) => ({ version: ++version, identity }),
     invalidate: () => ++version,
+    current: () => version,
     isCurrent: (token) => token.version === version,
   };
 };
@@ -382,10 +391,13 @@ export const AgentsPage: React.FC = () => {
       refreshDefinitions?: boolean;
       rollbackOnFailure?: boolean;
       clearSelectionError?: boolean;
+      followContinuation?: boolean;
+      allowSupersede?: boolean;
+      cause?: 'selection' | 'reconcile' | 'continuation' | 'debt';
     }) => Promise<SelectedReadOutcome> | null)
   >(null);
   const retireSelectedIdentityRef = useRef<
-    ((identity: string, options?: { refreshDefinitions?: boolean }) => SelectedRetirement) | null
+    ((identity: string, options?: { refreshDefinitions?: boolean; cause?: unknown }) => SelectedRetirement) | null
   >(null);
 
   const commitSelected = useCallback((agent: VibeAgentFull | null) => {
@@ -395,7 +407,15 @@ export const AgentsPage: React.FC = () => {
     if (agent?.name) advanceSelectedRead(coordinator, agent.name);
     coordinator.acceptedGeneration += 1;
     coordinator.accepted = agent;
-    if (agent?.name) coordinator.retired.delete(agent.name);
+    if (agent?.name) {
+      coordinator.retired.delete(agent.name);
+      coordinator.retiredAtDefinitionsVersion.delete(agent.name);
+      if (coordinator.desiredSource === 'auto' && coordinator.desiredName === agent.name) {
+        // Auto-selection is consumed only by an authoritative publication. A
+        // failed attempt leaves the reason pending for the next external edge.
+        coordinator.autoSelectReason = null;
+      }
+    }
     setSelected(agent);
     if (agent && coordinator.desiredName === agent.name && coordinator.desiredOpenDetail) {
       setDetailOpen(true);
@@ -415,6 +435,7 @@ export const AgentsPage: React.FC = () => {
       if (identity) advanceSelectedRead(coordinator, identity);
       if (identity && !options.auto) {
         coordinator.retired.delete(identity);
+        coordinator.retiredAtDefinitionsVersion.delete(identity);
         coordinator.autoSelectDismissed = false;
         coordinator.autoSelectReason = null;
       }
@@ -475,13 +496,23 @@ export const AgentsPage: React.FC = () => {
         // Only the latest request may publish its snapshot, so an older response
         // cannot roll the Definitions list back to pre-gap state.
         if (!definitionsVersionRef.current.isCurrent(token)) return;
-        setAgents(result.agents);
+        const coordinator = selectedCoordinatorRef.current;
+        const visibleAgents = result.agents.filter((agent) => {
+          const retiredAt = coordinator.retiredAtDefinitionsVersion.get(agent.name);
+          if (retiredAt === undefined) return true;
+          if (token.version > retiredAt) {
+            coordinator.retired.delete(agent.name);
+            coordinator.retiredAtDefinitionsVersion.delete(agent.name);
+            return true;
+          }
+          return false;
+        });
+        setAgents(visibleAgents);
         setDefaultName(result.default_agent_name);
         // List omission is authoritative retirement evidence. The coordinator
         // owns all desired/accepted transitions; stale list responses cannot
         // re-select an identity after retirement because the retired set is
         // updated before the next render.
-        const coordinator = selectedCoordinatorRef.current;
         const currentIdentities = [coordinator.accepted?.name, coordinator.desiredName].filter(
           (identity): identity is string => Boolean(identity),
         );
@@ -510,7 +541,7 @@ export const AgentsPage: React.FC = () => {
   refreshRef.current = refresh;
 
   const retireSelectedIdentity = useCallback(
-    (identity: string, options: { refreshDefinitions?: boolean } = {}) => {
+    (identity: string, options: { refreshDefinitions?: boolean; cause?: unknown } = {}) => {
       const coordinator = selectedCoordinatorRef.current;
       if (coordinator.retired.has(identity)) {
         return { retired: false, resumedIdentity: null, intentGeneration: coordinator.intentGeneration };
@@ -524,11 +555,16 @@ export const AgentsPage: React.FC = () => {
           !coordinator.autoSelectDismissed,
       );
       coordinator.retired.add(identity);
+      coordinator.retiredAtDefinitionsVersion.set(identity, definitionsVersionRef.current.current());
       advanceSelectedRead(coordinator, identity);
+      // A detail-level tombstone is Definitions evidence too. Remove the row
+      // in the same transition, while the retirement watermark prevents an
+      // older in-flight list response from resurrecting it.
+      setAgents((current) => current.filter((agent) => agent.name !== identity));
       const debt = coordinator.reconciliationDebt.get(identity);
       coordinator.reconciliationDebt.delete(identity);
       for (const waiter of debt?.waiters.splice(0) ?? []) {
-        waiter.resolve({ ok: false, error: { code: 'agent_not_found' } });
+        waiter.resolve({ ok: false, error: options.cause ?? { code: 'agent_not_found' } });
       }
       if (pendingIdentity) {
         coordinator.intentGeneration += 1;
@@ -645,59 +681,48 @@ export const AgentsPage: React.FC = () => {
           ? { nextIdentity: rollback.identity, intentGeneration: rollback.intentGeneration }
           : undefined;
       };
-      try {
-        const params = options.expectedCodes ? { cache: false, expectedCodes: options.expectedCodes } : { cache: false };
-        const result = await api.getVibeAgent(options.identity, params);
+      // All selected-read terminal states pass through this one owner. The
+      // executor only obtains a server result; retirement, debt completion,
+      // rollback and error publication are decided here for both transport
+      // shapes (HTTP ok:false and rejected requests).
+      const finalizeSelectedRead = (value: unknown): SelectedReadOutcome => {
         if (!isCurrent()) return { kind: 'stale' };
-        if (result.ok && result.agent?.name === options.identity) {
+        const result = value as {
+          ok?: boolean;
+          agent?: VibeAgentFull;
+        } | null;
+        if (result?.ok && result.agent?.name === options.identity) {
           if (options.clearSelectionError !== false) clearResourceError('selection');
           commitSelected(result.agent);
           finishDebt(true);
           return { kind: 'published' };
         }
-        if (
-          options.expectedCodes &&
-          SELECTED_DISAPPEARANCE_CODES.includes(errorCodeOf(result) as (typeof SELECTED_DISAPPEARANCE_CODES)[number])
-        ) {
+        const code = errorCodeOf(value);
+        if (options.expectedCodes?.includes(code ?? '')) {
           const retirement = retireSelectedIdentityRef.current?.(options.identity, {
-            refreshDefinitions: options.refreshDefinitions !== false,
+            refreshDefinitions: options.refreshDefinitions === true,
+            cause: value,
           });
-          if (retirement?.resumedIdentity) {
-            return {
-              kind: 'expected-retired',
-              continuation: {
-                nextIdentity: retirement.resumedIdentity,
-                intentGeneration: retirement.intentGeneration,
-              },
-            };
-          }
-          return { kind: 'failed' };
+          return {
+            kind: 'expected-retired',
+            continuation: retirement?.resumedIdentity
+              ? {
+                  nextIdentity: retirement.resumedIdentity,
+                  intentGeneration: retirement.intentGeneration,
+                }
+              : undefined,
+          };
         }
         const continuation = continuationFor();
-        setResourceError('selection', errorMessage(result) || tRef.current('errorBoundary.title'));
-        finishDebt(false, result);
-        return { kind: 'failed', error: result, continuation };
+        setResourceError('selection', errorMessage(value) || tRef.current('errorBoundary.title'));
+        finishDebt(false, value);
+        return { kind: 'failed', error: value, continuation };
+      };
+      try {
+        const params = options.expectedCodes ? { cache: false, expectedCodes: options.expectedCodes } : { cache: false };
+        return finalizeSelectedRead(await api.getVibeAgent(options.identity, params));
       } catch (err) {
-        if (!isCurrent()) return { kind: 'stale' };
-        if (options.expectedCodes && SELECTED_DISAPPEARANCE_CODES.includes(errorCodeOf(err) as (typeof SELECTED_DISAPPEARANCE_CODES)[number])) {
-          const retirement = retireSelectedIdentityRef.current?.(options.identity, {
-            refreshDefinitions: options.refreshDefinitions !== false,
-          });
-          if (retirement?.resumedIdentity) {
-            return {
-              kind: 'expected-retired',
-              continuation: {
-                nextIdentity: retirement.resumedIdentity,
-                intentGeneration: retirement.intentGeneration,
-              },
-            };
-          }
-          return { kind: 'failed' };
-        }
-        const continuation = continuationFor();
-        setResourceError('selection', errorMessage(err) || tRef.current('errorBoundary.title'));
-        finishDebt(false, err);
-        return { kind: 'failed', error: err, continuation };
+        return finalizeSelectedRead(err);
       }
     },
     [api, clearResourceError, commitSelected, rollbackSelectedIntent, setResourceError],
@@ -712,11 +737,20 @@ export const AgentsPage: React.FC = () => {
         refreshDefinitions?: boolean;
         rollbackOnFailure?: boolean;
         clearSelectionError?: boolean;
+        followContinuation?: boolean;
+        allowSupersede?: boolean;
+        cause?: 'selection' | 'reconcile' | 'continuation' | 'debt';
       } = {},
     ): Promise<SelectedReadOutcome> | null => {
       if (!selectedMountedRef.current || !identity) return null;
       const coordinator = selectedCoordinatorRef.current;
       if (coordinator.retired.has(identity) || coordinator.desiredName !== identity) return null;
+      const activeRead = coordinator.activeReads.get(identity);
+      const cause = options.cause ?? 'selection';
+      if (
+        activeRead &&
+        !(options.allowSupersede === true && !(cause === 'reconcile' && coordinator.activeReadCauses.get(identity) === 'continuation'))
+      ) return activeRead;
       // User selection is an explicit intent and may read immediately even
       // while that identity has a pending mutation. Passive/debt drains wait
       // for acknowledgements so they cannot publish an intermediate snapshot.
@@ -728,7 +762,7 @@ export const AgentsPage: React.FC = () => {
       if (debt) debt.scheduled = true;
       const readGeneration = advanceSelectedRead(coordinator, identity);
       const intentGeneration = coordinator.intentGeneration;
-      return launchSelectedRead({
+      const read = launchSelectedRead({
         identity,
         readGeneration,
         intentGeneration,
@@ -737,6 +771,35 @@ export const AgentsPage: React.FC = () => {
         rollbackOnFailure: options.rollbackOnFailure,
         clearSelectionError: options.clearSelectionError,
         debtVersion,
+      });
+      coordinator.activeReads.set(identity, read);
+      coordinator.activeReadCauses.set(identity, cause);
+      void read.then(() => {
+        if (coordinator.activeReads.get(identity) === read) {
+          coordinator.activeReads.delete(identity);
+          coordinator.activeReadCauses.delete(identity);
+        }
+      });
+      if (options.followContinuation === false) return read;
+      return read.then(async (outcome) => {
+        const continuation = outcome.continuation;
+        if (
+          !continuation ||
+          !selectedMountedRef.current ||
+          coordinator.intentGeneration !== continuation.intentGeneration ||
+          coordinator.desiredName !== continuation.nextIdentity
+        ) return outcome;
+        if (!coordinator.reconciliationDebt.has(continuation.nextIdentity)) return outcome;
+        const follow = scheduleSelectedReadRef.current?.(continuation.nextIdentity, {
+          expectedCodes: options.expectedCodes ?? SELECTED_DISAPPEARANCE_CODES,
+          debtOnly: true,
+          refreshDefinitions: false,
+          rollbackOnFailure: false,
+          clearSelectionError: false,
+          followContinuation: false,
+          cause: 'continuation',
+        });
+        return follow ? await follow : outcome;
       });
     },
     [launchSelectedRead],
@@ -757,9 +820,11 @@ export const AgentsPage: React.FC = () => {
       coordinator.mutations.set(identity, batch);
     }
     beginResourceError('mutation');
-    if (!batch.operations.length) mutationErrorSequenceRef.current = 0;
     batch.pending += 1;
     batch.version = ++coordinator.nextMutationVersion;
+    // Keep the error watermark monotonic across batches. A delayed drain from
+    // older work must never republish after this operation has begun.
+    mutationErrorSequenceRef.current = Math.max(mutationErrorSequenceRef.current, batch.version);
     // A pre-mutation Definitions snapshot cannot publish after the detail
     // barrier. The settled transaction starts the next list publication.
     definitionsVersionRef.current.invalidate();
@@ -789,10 +854,12 @@ export const AgentsPage: React.FC = () => {
       const version = batch.version;
       coordinator.mutations.delete(identity);
       const operations = [...batch.operations];
-      const firstFailure = operations.find((candidate) => candidate.failure)?.failure;
       for (const candidate of operations) {
         if (candidate.failure !== undefined) {
-          publishMutationError(candidate.failure, candidate.sequence);
+          // The batch is one publication edge, so expose a PATCH failure at
+          // the batch watermark even when that operation started before a
+          // sibling. Caller completion still uses the operation's own error.
+          publishMutationError(candidate.failure, batch.version);
         }
       }
       const priorDebt = coordinator.reconciliationDebt.get(identity);
@@ -803,17 +870,17 @@ export const AgentsPage: React.FC = () => {
           waiters: priorDebt?.waiters ?? [],
         });
       }
-      const baseResult: SelectedMutationResult = firstFailure
-        ? { ok: false, error: firstFailure }
-        : { ok: true };
       const currentDebt = coordinator.reconciliationDebt.get(identity);
       const shouldDrain = Boolean(
         currentDebt &&
           coordinator.desiredName === identity &&
           !coordinator.retired.has(identity),
       );
+      for (const candidate of operations) {
+        candidate.joinedDetailBarrier = shouldDrain && candidate.failure === undefined;
+      }
       const transaction = (async (): Promise<SelectedMutationResult> => {
-        let detailResult: SelectedMutationResult = baseResult;
+        let detailResult: SelectedMutationResult = { ok: true };
         if (shouldDrain && currentDebt) {
           const completion = new Promise<SelectedMutationResult>((resolve) => {
             currentDebt.waiters.push({ resolve });
@@ -822,10 +889,12 @@ export const AgentsPage: React.FC = () => {
             debtOnly: true,
             expectedCodes: SELECTED_DISAPPEARANCE_CODES,
             rollbackOnFailure: false,
+            allowSupersede: true,
+            cause: 'debt',
           });
           if (!drain && !currentDebt.scheduled) {
             const waiters = currentDebt.waiters.splice(0);
-            for (const waiter of waiters) waiter.resolve(baseResult);
+            for (const waiter of waiters) waiter.resolve({ ok: true });
           }
           detailResult = await completion;
         }
@@ -838,10 +907,11 @@ export const AgentsPage: React.FC = () => {
         if (candidate.failure !== undefined) {
           return { ok: false, error: candidate.failure };
         }
-        if (!detailResult.ok) {
+        if (candidate.joinedDetailBarrier && !detailResult.ok) {
           publishMutationError(detailResult.error, candidate.sequence);
+          return detailResult;
         }
-        return detailResult;
+        return { ok: true };
       });
       for (const candidate of operations) {
         if (candidate.resolve) void resultFor(candidate).then(candidate.resolve);
@@ -856,6 +926,7 @@ export const AgentsPage: React.FC = () => {
     let transactionIntentGeneration = coordinator.intentGeneration;
     let identity = coordinator.desiredName;
     let preserveSelectionError = false;
+    let continueDebtOnly = false;
     const attempted = new Set<string>();
     while (selectedMountedRef.current && identity && !attempted.has(identity)) {
       if (edgeEpoch !== undefined && catchUpEpochRef.current !== edgeEpoch) return;
@@ -866,12 +937,14 @@ export const AgentsPage: React.FC = () => {
         expectedCodes: SELECTED_DISAPPEARANCE_CODES,
         refreshDefinitions: false,
         clearSelectionError: !preserveSelectionError,
+        debtOnly: continueDebtOnly && Boolean(coordinator.reconciliationDebt.get(identity)),
+        followContinuation: false,
+        allowSupersede: true,
+        cause: 'reconcile',
       });
       if (edgeEpoch !== undefined && catchUpEpochRef.current !== edgeEpoch) return;
       if (!outcome) return;
-      const continuation = outcome.kind === 'expected-retired' || outcome.kind === 'failed'
-        ? outcome.continuation
-        : undefined;
+      const continuation = outcome.continuation;
       if (!continuation) return;
       if (
         continuation.intentGeneration !== coordinator.intentGeneration ||
@@ -881,6 +954,7 @@ export const AgentsPage: React.FC = () => {
       transactionIntentGeneration = continuation.intentGeneration;
       identity = continuation.nextIdentity;
       preserveSelectionError = true;
+      continueDebtOnly = true;
     }
   }, []);
 
@@ -916,7 +990,6 @@ export const AgentsPage: React.FC = () => {
     ) return;
     const available = agents.filter((agent) => !coordinator.retired.has(agent.name));
     const target = (defaultName && available.find((a) => a.name === defaultName)) || available[0];
-    coordinator.autoSelectReason = null;
     if (target) void selectAgent(target.name, false, true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultName, agents]);
@@ -1032,16 +1105,7 @@ export const AgentsPage: React.FC = () => {
     async (name: string, openDetail = false, auto = false) => {
       beginSelectedIntent(name, { auto, openDetail, source: auto ? 'auto' : 'user' });
       clearResourceError('selection');
-      const outcome = await scheduleSelectedReadRef.current?.(name);
-      if (outcome?.kind === 'failed') {
-        const rollbackIdentity = selectedCoordinatorRef.current.desiredName;
-        if (rollbackIdentity && rollbackIdentity !== name) {
-          void scheduleSelectedReadRef.current?.(rollbackIdentity, {
-            debtOnly: true,
-            expectedCodes: SELECTED_DISAPPEARANCE_CODES,
-          });
-        }
-      }
+      await scheduleSelectedReadRef.current?.(name, { allowSupersede: true, cause: 'selection' });
     },
     [beginSelectedIntent, clearResourceError],
   );
@@ -1151,7 +1215,7 @@ export const AgentsPage: React.FC = () => {
     try {
       const result = await api.removeVibeAgent(name);
       if (result.ok) {
-        retireSelectedIdentityRef.current?.(name);
+        retireSelectedIdentityRef.current?.(name, { refreshDefinitions: true });
         void refreshOnboarding();
       } else {
         setResourceError('mutation', errorMessage(result) || t('errorBoundary.title'), errorGeneration);

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -116,6 +116,8 @@ type SelectedReadOutcome =
 
 type SelectedCoordinator = {
   desiredName: string | null;
+  desiredOpenDetail: boolean;
+  desiredSource: 'user' | 'auto' | 'passive';
   intentGeneration: number;
   readGenerations: Map<string, number>;
   accepted: VibeAgentFull | null;
@@ -131,6 +133,8 @@ type SelectedCoordinator = {
 
 const createSelectedCoordinator = (): SelectedCoordinator => ({
   desiredName: null,
+  desiredOpenDetail: false,
+  desiredSource: 'passive',
   intentGeneration: 0,
   readGenerations: new Map(),
   accepted: null,
@@ -237,6 +241,7 @@ export const AgentsPage: React.FC = () => {
   const onboardingVersionRef = useRef(createAgentRequestVersion());
   const selectedCoordinatorRef = useRef(createSelectedCoordinator());
   const selectedMountedRef = useRef(true);
+  const catchUpEpochRef = useRef(0);
   // Mobile drill-down: a row tap opens the detail full-screen. The agent
   // auto-selected on mount stays in the list view until the user drills in.
   const [detailOpen, setDetailOpen] = useState(false);
@@ -314,7 +319,7 @@ export const AgentsPage: React.FC = () => {
   }, []);
 
   const scheduleSelectedReadRef = useRef<
-    ((identity: string, options?: { expectedCodes?: readonly string[]; debtOnly?: boolean }) => Promise<SelectedReadOutcome> | null)
+    ((identity: string, options?: { expectedCodes?: readonly string[]; debtOnly?: boolean; refreshDefinitions?: boolean }) => Promise<SelectedReadOutcome> | null)
   >(null);
   const retireSelectedIdentityRef = useRef<
     ((identity: string, options?: { refreshDefinitions?: boolean }) => SelectedRetirement) | null
@@ -329,31 +334,45 @@ export const AgentsPage: React.FC = () => {
     coordinator.accepted = agent;
     if (agent?.name) coordinator.retired.delete(agent.name);
     setSelected(agent);
+    if (agent && coordinator.desiredName === agent.name && coordinator.desiredOpenDetail) {
+      setDetailOpen(true);
+    }
   }, []);
 
-  const beginSelectedIntent = useCallback((identity: string | null, options: { auto?: boolean } = {}) => {
-    const coordinator = selectedCoordinatorRef.current;
-    if (coordinator.desiredName && coordinator.desiredName !== identity) {
-      advanceSelectedRead(coordinator, coordinator.desiredName);
-    }
-    if (identity) advanceSelectedRead(coordinator, identity);
-    if (identity && !options.auto) {
-      coordinator.retired.delete(identity);
-      coordinator.autoSelectDismissed = false;
-      coordinator.autoSelectReason = null;
-    }
-    const debt = identity ? coordinator.reconciliationDebt.get(identity) : null;
-    if (debt) debt.scheduled = false;
-    coordinator.intentGeneration += 1;
-    coordinator.desiredName = identity;
-    return { intentGeneration: coordinator.intentGeneration, identity };
-  }, []);
+  const beginSelectedIntent = useCallback(
+    (
+      identity: string | null,
+      options: { auto?: boolean; openDetail?: boolean; source?: 'user' | 'auto' | 'passive' } = {},
+    ) => {
+      const coordinator = selectedCoordinatorRef.current;
+      if (coordinator.desiredName && coordinator.desiredName !== identity) {
+        advanceSelectedRead(coordinator, coordinator.desiredName);
+      }
+      if (identity) advanceSelectedRead(coordinator, identity);
+      if (identity && !options.auto) {
+        coordinator.retired.delete(identity);
+        coordinator.autoSelectDismissed = false;
+        coordinator.autoSelectReason = null;
+      }
+      const debt = identity ? coordinator.reconciliationDebt.get(identity) : null;
+      if (debt) debt.scheduled = false;
+      coordinator.intentGeneration += 1;
+      coordinator.desiredName = identity;
+      coordinator.desiredOpenDetail = Boolean(identity && options.openDetail);
+      coordinator.desiredSource = options.source ?? (options.auto ? 'auto' : 'user');
+      return { intentGeneration: coordinator.intentGeneration, identity };
+    },
+    [],
+  );
 
   const rollbackSelectedIntent = useCallback(() => {
     const coordinator = selectedCoordinatorRef.current;
     if (coordinator.desiredName) advanceSelectedRead(coordinator, coordinator.desiredName);
     const acceptedIdentity = coordinator.accepted?.name ?? null;
-    return beginSelectedIntent(acceptedIdentity && !coordinator.retired.has(acceptedIdentity) ? acceptedIdentity : null);
+    return beginSelectedIntent(
+      acceptedIdentity && !coordinator.retired.has(acceptedIdentity) ? acceptedIdentity : null,
+      { source: 'passive', openDetail: false },
+    );
   }, [beginSelectedIntent]);
 
 
@@ -362,7 +381,7 @@ export const AgentsPage: React.FC = () => {
   // reconnect snapshot with a stale cached promise.
   const refresh = useCallback(() => {
     const token = definitionsVersionRef.current.begin();
-    const request = (async () => {
+    const request = (async (): Promise<boolean> => {
       setLoading(true);
       clearResourceError('definitions');
       try {
@@ -373,7 +392,7 @@ export const AgentsPage: React.FC = () => {
         // A read issued before a stream gap may finish after the catch-up read.
         // Only the latest request may publish its snapshot, so an older response
         // cannot roll the Definitions list back to pre-gap state.
-        if (!definitionsVersionRef.current.isCurrent(token)) return;
+        if (!definitionsVersionRef.current.isCurrent(token)) return false;
         setAgents(result.agents);
         setDefaultName(result.default_agent_name);
         // List omission is authoritative retirement evidence. The coordinator
@@ -391,13 +410,13 @@ export const AgentsPage: React.FC = () => {
           for (const identity of retired) {
             retireSelectedIdentityRef.current?.(identity, { refreshDefinitions: false });
           }
-          definitionsVersionRef.current.invalidate();
-          void refreshRef.current();
         }
+        return true;
       } catch (err) {
         if (definitionsVersionRef.current.isCurrent(token)) {
           setResourceError('definitions', errorMessage(err) ?? String(err));
         }
+        return false;
       } finally {
         if (definitionsVersionRef.current.isCurrent(token)) setLoading(false);
       }
@@ -431,8 +450,16 @@ export const AgentsPage: React.FC = () => {
         // entity. Keep that accepted entity eligible for reconnect/debt
         // reconciliation instead of leaving visible A with no desired A.
         coordinator.desiredName = acceptedCanResume ? acceptedIdentity : null;
+        // A vanished pending selection must not transfer its mobile drill-down
+        // request to the fallback identity.
+        coordinator.desiredOpenDetail = false;
+        coordinator.desiredSource = 'passive';
       }
-      if (coordinator.accepted?.name === identity) commitSelected(null);
+      if (coordinator.accepted?.name === identity) {
+        coordinator.desiredOpenDetail = false;
+        coordinator.desiredSource = 'passive';
+        commitSelected(null);
+      }
       if (!coordinator.desiredName && !coordinator.accepted && !coordinator.autoSelectDismissed) {
         coordinator.autoSelectReason = 'replacement';
       }
@@ -496,6 +523,7 @@ export const AgentsPage: React.FC = () => {
       intentGeneration?: number;
       expectedCodes?: readonly string[];
       debtVersion?: number;
+      refreshDefinitions?: boolean;
     }): Promise<SelectedReadOutcome> => {
       const coordinator = selectedCoordinatorRef.current;
       const isCurrent = () =>
@@ -525,7 +553,9 @@ export const AgentsPage: React.FC = () => {
           options.expectedCodes &&
           SELECTED_DISAPPEARANCE_CODES.includes(errorCodeOf(result) as (typeof SELECTED_DISAPPEARANCE_CODES)[number])
         ) {
-          const retirement = retireSelectedIdentityRef.current?.(options.identity);
+          const retirement = retireSelectedIdentityRef.current?.(options.identity, {
+            refreshDefinitions: options.refreshDefinitions !== false,
+          });
           finishDebt(false);
           if (retirement?.resumedIdentity) {
             return {
@@ -543,7 +573,9 @@ export const AgentsPage: React.FC = () => {
       } catch (err) {
         if (!isCurrent()) return { kind: 'stale' };
         if (options.expectedCodes && SELECTED_DISAPPEARANCE_CODES.includes(errorCodeOf(err) as (typeof SELECTED_DISAPPEARANCE_CODES)[number])) {
-          const retirement = retireSelectedIdentityRef.current?.(options.identity);
+          const retirement = retireSelectedIdentityRef.current?.(options.identity, {
+            refreshDefinitions: options.refreshDefinitions !== false,
+          });
           finishDebt(false);
           if (retirement?.resumedIdentity) {
             return {
@@ -566,7 +598,7 @@ export const AgentsPage: React.FC = () => {
   const scheduleSelectedRead = useCallback(
     (
       identity: string,
-      options: { expectedCodes?: readonly string[]; debtOnly?: boolean } = {},
+      options: { expectedCodes?: readonly string[]; debtOnly?: boolean; refreshDefinitions?: boolean } = {},
     ): Promise<SelectedReadOutcome> | null => {
       if (!selectedMountedRef.current || !identity) return null;
       const coordinator = selectedCoordinatorRef.current;
@@ -587,6 +619,7 @@ export const AgentsPage: React.FC = () => {
         readGeneration,
         intentGeneration,
         expectedCodes: options.expectedCodes,
+        refreshDefinitions: options.refreshDefinitions,
         debtVersion,
       }).then((outcome) => {
         if (debtVersion !== undefined) {
@@ -668,18 +701,21 @@ export const AgentsPage: React.FC = () => {
     [setResourceError, t],
   );
 
-  const reconcileSelected = useCallback(async () => {
+  const reconcileSelected = useCallback(async (edgeEpoch?: number) => {
     const coordinator = selectedCoordinatorRef.current;
     let transactionIntentGeneration = coordinator.intentGeneration;
     let identity = coordinator.desiredName;
     const attempted = new Set<string>();
     while (selectedMountedRef.current && identity && !attempted.has(identity)) {
+      if (edgeEpoch !== undefined && catchUpEpochRef.current !== edgeEpoch) return;
       if (coordinator.intentGeneration !== transactionIntentGeneration) return;
       attempted.add(identity);
       if (coordinator.mutations.has(identity)) return;
       const outcome = await scheduleSelectedReadRef.current?.(identity, {
         expectedCodes: SELECTED_DISAPPEARANCE_CODES,
+        refreshDefinitions: false,
       });
+      if (edgeEpoch !== undefined && catchUpEpochRef.current !== edgeEpoch) return;
       if (!outcome || outcome.kind !== 'expected-retired') return;
       if (
         outcome.intentGeneration !== coordinator.intentGeneration ||
@@ -690,6 +726,13 @@ export const AgentsPage: React.FC = () => {
       identity = outcome.resumedIdentity;
     }
   }, []);
+
+  const reconcileGap = useCallback(async () => {
+    const edgeEpoch = ++catchUpEpochRef.current;
+    const applied = await refreshRef.current();
+    if (!applied || !selectedMountedRef.current || catchUpEpochRef.current !== edgeEpoch) return;
+    await reconcileSelected(edgeEpoch);
+  }, [reconcileSelected]);
 
   useEffect(() => {
     selectedMountedRef.current = true;
@@ -765,8 +808,7 @@ export const AgentsPage: React.FC = () => {
       // The bridge report is only the indicator's level: it comes with its own
       // `onConnected`, and refetching from both would pay twice for one gap.
       onConnected: () => {
-        void refreshRef.current();
-        void reconcileSelected();
+        void reconcileGap();
         void refreshOnboarding();
         void fetchRunningActiveCount();
       },
@@ -777,11 +819,10 @@ export const AgentsPage: React.FC = () => {
       onTurnEnd: () => fetchRunningActiveCount(),
       onSessionStatus: () => fetchRunningActiveCount(),
       onAuthorizationChanged: () => {
-        void refreshRef.current();
-        void reconcileSelected();
+        void reconcileGap();
       },
     });
-  }, [api, capabilities.can_use_agents, fetchRunningActiveCount, refreshOnboarding, reconcileSelected]);
+  }, [api, capabilities.can_use_agents, fetchRunningActiveCount, reconcileGap, refreshOnboarding]);
 
   useEffect(() => {
     if (!capabilities.can_use_agents) return;
@@ -832,7 +873,7 @@ export const AgentsPage: React.FC = () => {
 
   const selectAgent = useCallback(
     async (name: string, openDetail = false, auto = false) => {
-      beginSelectedIntent(name, { auto });
+      beginSelectedIntent(name, { auto, openDetail, source: auto ? 'auto' : 'user' });
       clearResourceError('selection');
       const outcome = await scheduleSelectedReadRef.current?.(name);
       if (outcome?.kind === 'failed') {
@@ -844,9 +885,6 @@ export const AgentsPage: React.FC = () => {
           });
         }
       }
-      // Enter the mobile drill-down only once the detail has actually loaded —
-      // never optimistically, or a failed fetch hides the list with no panel.
-      if (outcome?.kind === 'published' && openDetail) setDetailOpen(true);
     },
     [beginSelectedIntent, clearResourceError],
   );
@@ -1213,6 +1251,7 @@ export const AgentsPage: React.FC = () => {
         {selected && (
           <div className={clsx('self-start rounded-2xl border border-border-strong bg-surface p-5', !detailOpen && 'max-lg:hidden')}>
             <AgentDetailPanel
+              key={selected.id}
               agent={selected}
               isDefault={defaultName === selected.name}
               canEdit={canEditAgents}
@@ -1726,6 +1765,14 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
     });
   };
 
+  // Inline controls are background mutations: the coordinator records and
+  // renders failures, while this single owner consumes the rejection so JSX
+  // callbacks never create unhandled promises. The modal save intentionally
+  // bypasses this helper so EditorDialog can keep a failed draft open.
+  const consumeBackgroundMutation = (operation: Promise<unknown>) => {
+    void operation.catch(() => undefined);
+  };
+
   // Only user Agents can be renamed; the backend moves every durable name
   // reference in the same transaction.
   const commitRename = async () => {
@@ -1806,7 +1853,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
         <Switch
           checked={agent.enabled}
           onCheckedChange={(next) => {
-            void onChange({ enabled: next }).catch(() => undefined);
+            consumeBackgroundMutation(onChange({ enabled: next }));
           }}
           disabled={!canEdit}
           title={canEdit ? undefined : t('agents.remoteReadOnlyHint')}
@@ -1890,7 +1937,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
               return;
             }
             markFieldSubmitted('description');
-            void submitFields({ description: canonical || null }, ['description']).catch(() => undefined);
+              consumeBackgroundMutation(submitFields({ description: canonical || null }, ['description']));
           }}
           disabled={locked}
           title={lockHint}
@@ -1950,7 +1997,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
                   patch.reasoning_effort = fallback;
                 }
               }
-              void submitFields(patch, patch.reasoning_effort ? ['model', 'effort'] : ['model']).catch(() => undefined);
+              consumeBackgroundMutation(submitFields(patch, patch.reasoning_effort ? ['model', 'effort'] : ['model']));
             }}
             placeholder={t('agents.detail.modelPlaceholder')}
             emptyText={t('agents.detail.modelEmpty')}
@@ -1977,7 +2024,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
                   markFieldEdit('effort');
                   markFieldSubmitted('effort');
                   setEffort(opt);
-                  void submitFields({ reasoning_effort: opt }, ['effort']).catch(() => undefined);
+                  consumeBackgroundMutation(submitFields({ reasoning_effort: opt }, ['effort']));
                 }}
                 className={clsx(
                   'truncate rounded-md px-1 py-1.5 text-[11px] capitalize transition disabled:cursor-not-allowed',
@@ -2055,7 +2102,7 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, canEdit, on
                 return;
               }
               markFieldSubmitted('systemPrompt');
-              void submitFields({ system_prompt: canonical || null }, ['systemPrompt']).catch(() => undefined);
+              consumeBackgroundMutation(submitFields({ system_prompt: canonical || null }, ['systemPrompt']));
             }}
             readOnly={!canEdit}
             title={canEdit ? undefined : t('agents.remoteReadOnlyHint')}

--- a/ui/src/context/ApiContext.agents.test.tsx
+++ b/ui/src/context/ApiContext.agents.test.tsx
@@ -1,0 +1,89 @@
+/* @vitest-environment jsdom */
+
+import { useEffect } from 'react';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiFetch = vi.hoisted(() => vi.fn());
+
+vi.mock('../lib/apiFetch', () => ({ apiFetch }));
+vi.mock('./ToastContext', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { ApiProvider, useApi } from './ApiContext';
+
+let capturedApi: ReturnType<typeof useApi> | null = null;
+
+const CaptureApi = () => {
+  const api = useApi();
+  useEffect(() => {
+    capturedApi = api;
+  }, [api]);
+  return null;
+};
+
+const response = (payload: unknown) => new Response(JSON.stringify(payload), {
+  status: 200,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+const fullAgent = (systemPrompt: string) => ({
+  ok: true,
+  default_agent_name: 'agent-a',
+  agent: {
+    id: 'agent-a-id',
+    name: 'agent-a',
+    display_name: 'agent-a',
+    description: 'Agent A',
+    backend: 'codex',
+    model: 'gpt-5',
+    reasoning_effort: 'medium',
+    system_prompt: systemPrompt,
+    enabled: true,
+    archived: false,
+    archived_at: null,
+    source: 'custom',
+    created_at: '2026-08-21T00:00:00Z',
+    updated_at: '2026-08-21T00:00:00Z',
+    metadata: {},
+  },
+});
+
+beforeEach(() => {
+  capturedApi = null;
+  window.localStorage.clear();
+  apiFetch.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});
+
+describe('ApiProvider agent detail transport', () => {
+  it('bypasses the cached in-flight detail read when explicitly requested', async () => {
+    render(<ApiProvider><CaptureApi /></ApiProvider>);
+    await waitFor(() => expect(capturedApi).not.toBeNull());
+
+    let resolveCached!: (value: Response) => void;
+    const cachedRead = new Promise<Response>((resolve) => {
+      resolveCached = resolve;
+    });
+    apiFetch.mockReturnValueOnce(cachedRead).mockResolvedValueOnce(response(fullAgent('fresh')));
+
+    const cached = capturedApi!.getVibeAgent('agent-a');
+    const fresh = capturedApi!.getVibeAgent('agent-a', { cache: false });
+
+    await expect(fresh).resolves.toMatchObject({ agent: { system_prompt: 'fresh' } });
+    resolveCached(response(fullAgent('stale')));
+    await expect(cached).resolves.toMatchObject({ agent: { system_prompt: 'stale' } });
+
+    expect(apiFetch).toHaveBeenCalledTimes(2);
+    expect(apiFetch.mock.calls.map(([path]) => path)).toEqual([
+      '/api/agents/agent-a',
+      '/api/agents/agent-a',
+    ]);
+  });
+});

--- a/ui/src/context/ApiContext.agents.test.tsx
+++ b/ui/src/context/ApiContext.agents.test.tsx
@@ -115,4 +115,16 @@ describe('ApiProvider agent detail transport', () => {
     })).rejects.toMatchObject({ code: 'agent_access_forbidden' });
     expect(showToast).toHaveBeenCalledTimes(1);
   });
+
+  it('passes handleError through the real uncached request path', async () => {
+    render(<ApiProvider><CaptureApi /></ApiProvider>);
+    await waitFor(() => expect(capturedApi).not.toBeNull());
+
+    apiFetch.mockResolvedValueOnce(response({ ok: false, code: 'agent_backend_unavailable', message: 'offline' }, 503));
+    await expect(capturedApi!.getVibeAgent('agent-a', { cache: false, handleError: false })).resolves.toMatchObject({
+      ok: false,
+      code: 'agent_backend_unavailable',
+    });
+    expect(showToast).not.toHaveBeenCalled();
+  });
 });

--- a/ui/src/context/ApiContext.agents.test.tsx
+++ b/ui/src/context/ApiContext.agents.test.tsx
@@ -5,9 +5,10 @@ import { cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const apiFetch = vi.hoisted(() => vi.fn());
+const showToast = vi.hoisted(() => vi.fn());
 
 vi.mock('../lib/apiFetch', () => ({ apiFetch }));
-vi.mock('./ToastContext', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('./ToastContext', () => ({ useToast: () => ({ showToast }) }));
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
@@ -24,8 +25,8 @@ const CaptureApi = () => {
   return null;
 };
 
-const response = (payload: unknown) => new Response(JSON.stringify(payload), {
-  status: 200,
+const response = (payload: unknown, status = 200) => new Response(JSON.stringify(payload), {
+  status,
   headers: { 'Content-Type': 'application/json' },
 });
 
@@ -55,6 +56,7 @@ beforeEach(() => {
   capturedApi = null;
   window.localStorage.clear();
   apiFetch.mockReset();
+  showToast.mockReset();
 });
 
 afterEach(() => {
@@ -85,5 +87,32 @@ describe('ApiProvider agent detail transport', () => {
       '/api/agents/agent-a',
       '/api/agents/agent-a',
     ]);
+  });
+
+  it('passes expected disappearance codes through the uncached error boundary', async () => {
+    render(<ApiProvider><CaptureApi /></ApiProvider>);
+    await waitFor(() => expect(capturedApi).not.toBeNull());
+
+    apiFetch.mockResolvedValueOnce(response({
+      ok: false,
+      code: 'agent_not_found',
+      message: 'agent disappeared',
+    }, 404));
+    await expect(capturedApi!.getVibeAgent('agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found'],
+    })).rejects.toMatchObject({ code: 'agent_not_found' });
+    expect(showToast).not.toHaveBeenCalled();
+
+    apiFetch.mockResolvedValueOnce(response({
+      ok: false,
+      code: 'agent_access_forbidden',
+      message: 'agent forbidden',
+    }, 403));
+    await expect(capturedApi!.getVibeAgent('agent-a', {
+      cache: false,
+      expectedCodes: ['agent_not_found'],
+    })).rejects.toMatchObject({ code: 'agent_access_forbidden' });
+    expect(showToast).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -794,7 +794,7 @@ export type ApiContextType = {
   }) => Promise<{ ok: boolean; agents: VibeAgentBrief[]; default_agent_name: string | null }>;
   getVibeAgentOnboarding: () => Promise<VibeAgentOnboardingResult>;
   onboardVibeAgents: () => Promise<VibeAgentOnboardingResult>;
-  getVibeAgent: (name: string) => Promise<{ ok: boolean; agent: VibeAgentFull; default_agent_name: string | null }>;
+  getVibeAgent: (name: string, params?: { cache?: boolean }) => Promise<{ ok: boolean; agent: VibeAgentFull; default_agent_name: string | null }>;
   createVibeAgent: (payload: VibeAgentCreatePayload) => Promise<{ ok: boolean; agent: VibeAgentFull }>;
   updateVibeAgent: (name: string, payload: VibeAgentUpdatePayload) => Promise<{ ok: boolean; agent: VibeAgentFull }>;
   setDefaultVibeAgent: (name: string) => Promise<{ ok: boolean; default_agent_name: string; agent: VibeAgentBrief }>;
@@ -4118,7 +4118,10 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     },
     getVibeAgentOnboarding: () => getJson('/api/agent-onboarding'),
     onboardVibeAgents: () => postJson('/api/agent-onboarding', {}),
-    getVibeAgent: (name) => getCachedJson(`/api/agents/${encodeURIComponent(name)}`, 5_000),
+    getVibeAgent: (name, params) => {
+      const path = `/api/agents/${encodeURIComponent(name)}`;
+      return params?.cache === false ? getJson(path) : getCachedJson(path, 5_000);
+    },
     createVibeAgent: (payload) => postJson('/api/agents', payload),
     updateVibeAgent: async (name, payload) => {
       const { payloadJson } = await requestJson(`/api/agents/${encodeURIComponent(name)}`, {

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -796,7 +796,7 @@ export type ApiContextType = {
   onboardVibeAgents: () => Promise<VibeAgentOnboardingResult>;
   getVibeAgent: (
     name: string,
-    params?: { cache?: boolean; expectedCodes?: readonly string[] },
+    params?: { cache?: boolean; handleError?: boolean; expectedCodes?: readonly string[] },
   ) => Promise<{ ok: boolean; agent: VibeAgentFull; default_agent_name: string | null }>;
   createVibeAgent: (payload: VibeAgentCreatePayload) => Promise<{ ok: boolean; agent: VibeAgentFull }>;
   updateVibeAgent: (name: string, payload: VibeAgentUpdatePayload) => Promise<{ ok: boolean; agent: VibeAgentFull }>;
@@ -4124,8 +4124,8 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     getVibeAgent: (name, params) => {
       const path = `/api/agents/${encodeURIComponent(name)}`;
       return params?.cache === false
-        ? getJson(path, { expectedCodes: params.expectedCodes })
-        : getCachedJson(path, 5_000);
+        ? getJson(path, { handleError: params.handleError, expectedCodes: params.expectedCodes })
+        : getCachedJson(path, 5_000, { handleError: params?.handleError });
     },
     createVibeAgent: (payload) => postJson('/api/agents', payload),
     updateVibeAgent: async (name, payload) => {

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -794,7 +794,10 @@ export type ApiContextType = {
   }) => Promise<{ ok: boolean; agents: VibeAgentBrief[]; default_agent_name: string | null }>;
   getVibeAgentOnboarding: () => Promise<VibeAgentOnboardingResult>;
   onboardVibeAgents: () => Promise<VibeAgentOnboardingResult>;
-  getVibeAgent: (name: string, params?: { cache?: boolean }) => Promise<{ ok: boolean; agent: VibeAgentFull; default_agent_name: string | null }>;
+  getVibeAgent: (
+    name: string,
+    params?: { cache?: boolean; expectedCodes?: readonly string[] },
+  ) => Promise<{ ok: boolean; agent: VibeAgentFull; default_agent_name: string | null }>;
   createVibeAgent: (payload: VibeAgentCreatePayload) => Promise<{ ok: boolean; agent: VibeAgentFull }>;
   updateVibeAgent: (name: string, payload: VibeAgentUpdatePayload) => Promise<{ ok: boolean; agent: VibeAgentFull }>;
   setDefaultVibeAgent: (name: string) => Promise<{ ok: boolean; default_agent_name: string; agent: VibeAgentBrief }>;
@@ -4120,7 +4123,9 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     onboardVibeAgents: () => postJson('/api/agent-onboarding', {}),
     getVibeAgent: (name, params) => {
       const path = `/api/agents/${encodeURIComponent(name)}`;
-      return params?.cache === false ? getJson(path) : getCachedJson(path, 5_000);
+      return params?.cache === false
+        ? getJson(path, { expectedCodes: params.expectedCodes })
+        : getCachedJson(path, 5_000);
     },
     createVibeAgent: (payload) => postJson('/api/agents', payload),
     updateVibeAgent: async (name, payload) => {


### PR DESCRIPTION
## P0-10

Fixes the Avibe P0-10 Agent definition reconciliation gap observed at candidate head 594c94a4a2c1b78024c6854c67be746072cd3187 (3.0.13rc3+master.594c94a4). After an SSE/controller offline -> online gap, the mounted Agents page now reconciles every server-backed definition it displays before treating it as current.

## Root cause and ownership model

The original reconnect edge refreshed /api/running-agents but did not perform an authoritative /api/agents?include_disabled=1 read. Subsequent fixes exposed the broader cause: Definitions, selected full detail, mutation acknowledgements, onboarding inventory, and editable drafts had competing publication owners. This head consolidates those responsibilities in one bounded page-local reconciliation stage scheduler.

- Definitions reads are cache-bypassing and latest-only. Superseded callers join the newer publication barrier, reconnect stages Definitions before selected detail, and causal retirement follow-up is bounded.
- The selected coordinator owns desired/accepted identity epochs, stable-ID rename routing, mobile presentation intent, uncached physical detail producers, compatible selection/reconnect/debt consumers, retirement tombstones, and per-identity mutation debt. Invalidated or lower-floor stages cannot satisfy newer obligations; PATCH responses are acknowledgements, and each mutation operation keeps its own outcome.
- AgentDetailPanel is keyed by stable Agent ID. The five editable fields track raw authoritative baselines and local submission provenance; whitespace remains part of an active draft, trim occurs only at submit/blur/save, and modal save remains an awaited/rejecting path.
- Auto-selection uses explicit consumable initialization/replacement reasons, dismissal stays closed across reconnect publication, onboarding publishes only ordered GET snapshots, and resource-owned errors are localized at the final UI boundary.

## Evidence

- Base: origin/master 251f40d338aada3f7be07d5904e200f0f71a19bd.
- Candidate failing head: 594c94a4a2c1b78024c6854c67be746072cd3187.
- Current implementation head: 4447d2887798d99fe254aaa2607bd6ab015dc970.
- Focused Vitest + Testing Library: 88 AgentsPage tests plus 15 real ApiProvider transport and stream-liveness tests (103 passing). Coverage includes list/detail stage ordering, identity-epoch and compatible-consumer joins, invalidated/lower-floor stage suppression, direct stale-row retirement, mobile presentation intent, stable-ID field isolation, one-shot debt/unmount behavior, expected disappearance and localized errors, per-operation mutation outcomes, raw-whitespace and clean-baseline fields, prompt save failure, explicit dismissal, enabled background failure consumption, onboarding settlement locking, and stale inventory ordering.
- Changed-surface ESLint has no errors, tsc --noEmit passes, and npm run build passes. Build output retains only existing dependency annotation and chunk-size warnings.
- No dependency, backend/API contract, locale, runtime, service, or acceptance-environment changes.

Residual risk is the requested manual Chrome/mobile verification of a real controller/SSE offline -> online gap, including full-detail fields and responsive rendering. Ports 5100/5190 and the acceptance runtime were not used. Do not merge from this PR.
