### PR TITLE
fix(ui): streamline mobile Show Page navigation

### DIFF
--- a/ui/src/components/AppShell.test.tsx
+++ b/ui/src/components/AppShell.test.tsx
@@ -265,6 +265,24 @@ describe('AppShell Permissions navigation', () => {
 });
 
 describe('AppShell remote Apps access', () => {
+  it('gives the mobile Show Page app the full viewport without duplicate shell chrome', async () => {
+    render(
+      <MemoryRouter initialEntries={['/apps/show/session-1']}>
+        <Routes>
+          <Route element={<AppShell />}>
+            <Route path="apps/show/:sessionId" element={<div data-testid="show-page-surface" />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const surface = await screen.findByTestId('show-page-surface');
+    expect(screen.queryByRole('banner')).toBeNull();
+    expect(document.querySelector('nav.fixed.inset-x-0.bottom-0')).toBeNull();
+    expect(surface.parentElement?.className).toContain('h-full p-0');
+    expect(surface.parentElement?.className).not.toContain('px-4 py-5');
+  });
+
   it.each([
     ['owner', true],
     ['member', false],

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -550,7 +550,8 @@ export const AppShell: React.FC = () => {
   // mobile brand header AND the bottom tab bar are hidden on them.
   const isChat = location.pathname.startsWith('/chat/');
   const isSearch = location.pathname === '/search';
-  const isFullScreenMobile = isChat || isSearch;
+  const isShowPageApp = location.pathname.startsWith('/apps/show/');
+  const isFullScreenMobile = isChat || isSearch || isShowPageApp;
 
   const showBottomNav = !isFullScreenMobile && !chromeless && location.pathname !== '/setup';
 
@@ -738,6 +739,8 @@ export const AppShell: React.FC = () => {
             // Single-app tab: no sidebar offset, no scroll, no page glow — the app body
             // is the only thing in the viewport and sizes itself to this box (h-full).
             ? 'min-h-0 flex-1 overflow-hidden'
+            : isShowPageApp
+              ? 'min-h-0 flex-1 overflow-hidden md:ml-[240px] md:min-h-screen md:flex-none md:overflow-visible md:pb-0'
             : 'flex-1 min-h-0 overflow-y-auto md:ml-[240px] md:min-h-screen md:flex-none md:overflow-visible md:pb-0',
           !chromeless && (showBottomNav ? 'pb-[calc(5.5rem+env(safe-area-inset-bottom))]' : 'pb-0'),
           !chromeless &&
@@ -748,6 +751,8 @@ export const AppShell: React.FC = () => {
           'w-full',
           chromeless
             ? 'h-full'
+            : isShowPageApp
+              ? 'h-full p-0 md:mx-auto md:h-auto md:px-10 md:py-8'
             : 'mx-auto px-4 py-5 md:px-10 md:py-8',
         )}>
           {/* A crashing page only replaces the content area — the sidebar + chrome stay usable, and

--- a/ui/src/components/apps/ShowPageRoute.test.tsx
+++ b/ui/src/components/apps/ShowPageRoute.test.tsx
@@ -1,0 +1,52 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { ShowPageRoute } from './ShowPageRoute';
+
+const api = vi.hoisted(() => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock('../../context/ApiContext', () => ({ useApi: () => api }));
+vi.mock('../../context/DockContext', () => ({ useDock: () => ({ unpin: vi.fn() }) }));
+vi.mock('../../context/WindowManagerContext', () => ({
+  useWindowManager: () => ({ windows: [], openApp: vi.fn(), focus: vi.fn(), restore: vi.fn() }),
+}));
+vi.mock('../../lib/useIsDesktop', () => ({ useIsDesktop: () => false }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('mobile Show Page app route', () => {
+  it('uses one full-width header with only back, title, and annotation controls', async () => {
+    api.getSession.mockResolvedValue({ id: 'session-1', status: 'active', title: 'Release dashboard' });
+
+    render(
+      <MemoryRouter initialEntries={['/apps/show/session-1']}>
+        <Routes>
+          <Route path="/apps/show/:sessionId" element={<ShowPageRoute />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Release dashboard')).toBeTruthy();
+    const header = screen.getByRole('banner');
+    expect(header.querySelectorAll('button')).toHaveLength(2);
+    expect(header.querySelector('a')).toBeNull();
+    expect(screen.getByRole('button', { name: 'common.back' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'chat.showPage.annotate.unavailable' })).toBeTruthy();
+
+    const surface = header.parentElement;
+    expect(surface?.className).toContain('h-full');
+    expect(surface?.className).toContain('w-full');
+    expect(surface?.className).not.toContain('rounded');
+    expect(surface?.className).not.toContain('border border-border');
+    expect(screen.getByTitle('chat.showPage.title').getAttribute('src')).toBe('/show/session-1/');
+  });
+});

--- a/ui/src/components/apps/ShowPageRoute.test.tsx
+++ b/ui/src/components/apps/ShowPageRoute.test.tsx
@@ -45,8 +45,9 @@ describe('mobile Show Page app route', () => {
     const surface = header.parentElement;
     expect(surface?.className).toContain('h-full');
     expect(surface?.className).toContain('w-full');
+    expect(surface?.className).toContain('pb-[env(safe-area-inset-bottom)]');
     expect(surface?.className).not.toContain('rounded');
     expect(surface?.className).not.toContain('border border-border');
-    expect(screen.getByTitle('chat.showPage.title').getAttribute('src')).toBe('/show/session-1/');
+    expect(screen.getByTitle('chat.showPage.title').getAttribute('src')).toBe('/show/session-1/?vibe-embed=1');
   });
 });

--- a/ui/src/components/apps/ShowPageRoute.tsx
+++ b/ui/src/components/apps/ShowPageRoute.tsx
@@ -6,7 +6,7 @@ import { ArrowLeft, MonitorX, PinOff } from 'lucide-react';
 import { useApi } from '../../context/ApiContext';
 import { useDock } from '../../context/DockContext';
 import { useWindowManager } from '../../context/WindowManagerContext';
-import { showPagePrivatePath } from '../../apps/showPageAvatar';
+import { showPageEmbeddedPath, showPagePrivatePath } from '../../apps/showPageAvatar';
 import { useIsDesktop } from '../../lib/useIsDesktop';
 import { Button } from '../ui/button';
 import { ShowPageAnnotateControl } from '../workbench/ShowPageAnnotateControl';
@@ -91,7 +91,7 @@ const MobileShowPage: React.FC<{ sessionId: string }> = ({ sessionId }) => {
 
   const label = title || t('apps.showPage.label');
   const missing = !sessionId || state === 'missing';
-  const src = missing ? null : showPagePrivatePath(sessionId);
+  const src = missing ? null : showPageEmbeddedPath(showPagePrivatePath(sessionId));
   const {
     state: annotationState,
     setIframe,
@@ -102,7 +102,7 @@ const MobileShowPage: React.FC<{ sessionId: string }> = ({ sessionId }) => {
   } = useShowPageAnnotation(src);
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background pt-[env(safe-area-inset-top)]">
+    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)]">
       <header className="flex shrink-0 items-center gap-3 border-b border-border bg-surface/70 px-4 py-2.5 backdrop-blur">
         <Button
           type="button"

--- a/ui/src/components/apps/ShowPageRoute.tsx
+++ b/ui/src/components/apps/ShowPageRoute.tsx
@@ -1,15 +1,16 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, ExternalLink, MonitorX, PinOff } from 'lucide-react';
+import { ArrowLeft, MonitorX, PinOff } from 'lucide-react';
 
 import { useApi } from '../../context/ApiContext';
 import { useDock } from '../../context/DockContext';
 import { useWindowManager } from '../../context/WindowManagerContext';
-import { appTabHref } from '../../apps/appLaunch';
-import { showPageAvatar, showPagePrivatePath } from '../../apps/showPageAvatar';
-import { ShowPageAvatarContent } from '../../apps/showPageAvatarTile';
+import { showPagePrivatePath } from '../../apps/showPageAvatar';
 import { useIsDesktop } from '../../lib/useIsDesktop';
+import { Button } from '../ui/button';
+import { ShowPageAnnotateControl } from '../workbench/ShowPageAnnotateControl';
+import { useShowPageAnnotation } from '../workbench/useShowPageAnnotation';
 
 // The `/apps/show/:sessionId` route — a pinned Show Page opened as an app on the
 // current surface. Desktop keeps windows (mirrors LibraryRoute): focus an
@@ -50,9 +51,8 @@ export const ShowPageRoute: React.FC = () => {
   return <MobileShowPage key={sessionId} sessionId={sessionId} />;
 };
 
-// Full-screen mobile body: a back-affordance header over the framed Show Page.
-// Sized like the mobile Library route so it fits within the AppShell header +
-// bottom-nav chrome (100dvh − header − tab bar).
+// Full-screen mobile body: it owns the viewport below the safe-area inset, so
+// AppShell withdraws its brand header, page padding, and bottom navigation.
 const MobileShowPage: React.FC<{ sessionId: string }> = ({ sessionId }) => {
   const { t } = useTranslation();
   const api = useApi();
@@ -61,6 +61,7 @@ const MobileShowPage: React.FC<{ sessionId: string }> = ({ sessionId }) => {
 
   const [state, setState] = useState<'loading' | 'ready' | 'missing'>(sessionId ? 'loading' : 'missing');
   const [title, setTitle] = useState('');
+  const [annotateOpen, setAnnotateOpen] = useState(false);
 
   // Read the session once (error-suppressed — a gone session must NOT toast) to
   // upgrade the header to the LIVE title and to detect missing/archived, exactly
@@ -88,52 +89,39 @@ const MobileShowPage: React.FC<{ sessionId: string }> = ({ sessionId }) => {
     };
   }, [sessionId, api]);
 
-  const avatar = sessionId ? showPageAvatar(sessionId, title) : null;
   const label = title || t('apps.showPage.label');
   const missing = !sessionId || state === 'missing';
-  const externalHref = appTabHref({ appId: 'showpage', sessionId });
+  const src = missing ? null : showPagePrivatePath(sessionId);
+  const {
+    state: annotationState,
+    setIframe,
+    handleIframeLoad,
+    enable: enableAnnotation,
+    disable: disableAnnotation,
+    setMode: setAnnotationMode,
+  } = useShowPageAnnotation(src);
 
   return (
-    <div className="flex h-[calc(100dvh-9.5rem)] min-h-[420px] flex-col overflow-hidden rounded-xl border border-border bg-surface">
-      <header className="flex shrink-0 items-center gap-2 border-b border-border px-2 py-2">
-        <button
+    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background pt-[env(safe-area-inset-top)]">
+      <header className="flex shrink-0 items-center gap-3 border-b border-border bg-surface/70 px-4 py-2.5 backdrop-blur">
+        <Button
           type="button"
+          variant="outline"
+          size="icon"
           onClick={() => navigate(-1)}
           aria-label={t('common.back')}
-          className="grid size-9 shrink-0 place-items-center rounded-lg text-muted transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+          className="size-7 shrink-0"
         >
-          <ArrowLeft className="size-[18px]" />
-        </button>
-        {avatar && (
-          <span
-            aria-hidden
-            // §7.1k sweep: borderless — the per-session accent border removed. Keep the 16%
-            // tint + accent letter color and the header's existing 12px radius. Routes the
-            // avatar through the shared ShowPageAvatarContent chokepoint (letter-only here:
-            // this header loads the session, not the icon inventory, so it has no favicon
-            // — §7.1f — but it now shares the one render path if that changes).
-            className="grid size-7 shrink-0 place-items-center overflow-hidden rounded-lg text-[13px] font-bold leading-none"
-            style={{
-              color: `var(${avatar.accentVar})`,
-              backgroundColor: `color-mix(in srgb, var(${avatar.accentVar}) 16%, transparent)`,
-            }}
-          >
-            <ShowPageAvatarContent iconUrl={null} letter={avatar.letter} />
-          </span>
-        )}
+          <ArrowLeft className="size-3.5" />
+        </Button>
         <span className="min-w-0 flex-1 truncate text-[14px] font-semibold text-foreground">{label}</span>
-        {state === 'ready' && externalHref && (
-          <a
-            href={externalHref}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label={t('apps.window.openInNewTab')}
-            title={t('apps.window.openInNewTab')}
-            className="grid size-9 shrink-0 place-items-center rounded-lg text-muted transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
-          >
-            <ExternalLink className="size-[17px]" />
-          </a>
-        )}
+        <ShowPageAnnotateControl
+          state={annotationState}
+          onEnable={enableAnnotation}
+          onDisable={disableAnnotation}
+          onSetMode={setAnnotationMode}
+          onPopoverOpenChange={setAnnotateOpen}
+        />
       </header>
 
       {missing ? (
@@ -165,11 +153,13 @@ const MobileShowPage: React.FC<{ sessionId: string }> = ({ sessionId }) => {
         // Sandbox copied verbatim from the desktop Show Page window / ChatPage: the
         // workbench Show Page frame is intentionally same-origin-trusted — not hardened.
         <iframe
+          ref={setIframe}
+          onLoad={handleIframeLoad}
           title={t('chat.showPage.title')}
-          src={showPagePrivatePath(sessionId)}
+          src={src ?? undefined}
           sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals allow-downloads"
           allow="clipboard-write"
-          className="min-h-0 w-full flex-1 border-0 bg-background"
+          className={`min-h-0 w-full flex-1 border-0 bg-background${annotateOpen ? ' pointer-events-none' : ''}`}
         />
       )}
     </div>

--- a/ui/src/lib/pwaNavigation.test.ts
+++ b/ui/src/lib/pwaNavigation.test.ts
@@ -141,14 +141,14 @@ describe('PWA navigation', () => {
 describe('internalPwaLinkTarget', () => {
   const current = 'https://alex-app.avibe.bot/chat/session-123';
 
-  it('keeps private Show Pages inside the AppShell route', () => {
+  it('opens private Show Pages at their literal document route', () => {
     expect(internalPwaLinkTarget('/show/ses_123/', current)).toEqual({
-      path: '/apps/show/ses_123',
-      navigation: 'spa',
+      path: '/show/ses_123/',
+      navigation: 'document',
     });
     expect(internalPwaLinkTarget('https://alex-app.avibe.bot/show/a%20b%2Fc/', current)).toEqual({
-      path: '/apps/show/a%20b%2Fc',
-      navigation: 'spa',
+      path: '/show/a%20b%2Fc/',
+      navigation: 'document',
     });
   });
 

--- a/ui/src/lib/pwaNavigation.ts
+++ b/ui/src/lib/pwaNavigation.ts
@@ -42,12 +42,11 @@ export function shouldBlockPwaLoopbackLink(href: string, currentHref: string): b
  * Resolve a same-origin `_blank` navigation to the target the installed iOS
  * PWA should open in its current browsing context.
  *
- * A private Show Page root uses the in-shell app route so the user keeps Avibe
- * chrome and back navigation. Canonical AppShell routes stay on the SPA path,
- * avoiding a reload and another auth pass. Every other same-origin destination
- * uses a current-context document navigation so WebKit never creates the
- * secondary context that iOS may incorrectly restore after process eviction.
- * Callers exclude download anchors before using this resolver.
+ * Canonical AppShell routes stay on the SPA path, avoiding a reload and another
+ * auth pass. Show Pages and every other same-origin document keep their literal
+ * destination in the current context so WebKit never creates the secondary
+ * context that iOS may incorrectly restore after process eviction. Callers
+ * exclude download anchors before using this resolver.
  */
 export interface InternalPwaLinkTarget {
   path: string;
@@ -62,11 +61,6 @@ export function internalPwaLinkTarget(
     const current = new URL(currentHref);
     const target = new URL(href, current);
     if (target.origin !== current.origin || !['http:', 'https:'].includes(target.protocol)) return null;
-
-    const privateShowRoot = /^\/show\/([^/]+)\/?$/.exec(target.pathname);
-    if (privateShowRoot && !target.search && !target.hash) {
-      return { path: `/apps/show/${privateShowRoot[1]}`, navigation: 'spa' };
-    }
 
     return {
       path: `${target.pathname}${target.search}${target.hash}`,


### PR DESCRIPTION
## Summary

- Preserve literal `/show/:sessionId/` document navigation when an installed mobile PWA opens an Agent-provided Show Page link.
- Give the mobile Show Page app the full viewport with no AppShell side padding, brand header, or bottom navigation.
- Replace the old framed app header with the compact chat-style back/title/annotation bar.

## Evidence

- Unit/component: 42 focused Vitest cases passed, including PWA routing, AppShell chrome, and the mobile Show Page header.
- Static/build: UI lint baseline and production build passed.
- Scenario: local Incus worktree regression at 390x844 confirmed a 390px-wide shell and iframe, 49px header, two controls, and no duplicate brand or bottom chrome.
- Residual manual check: physical iOS installed-PWA link interception remains for the integration acceptance pass.

Scenario IDs: none (no matching catalog entry).

Dependencies: none.

Known-by-design ledger: none.
