### PR TITLE
fix(ui): stack the Show Page Access section and fill its audience row

### DIFF
--- a/ui/src/components/workbench/ShowPageSharingSettings.test.tsx
+++ b/ui/src/components/workbench/ShowPageSharingSettings.test.tsx
@@ -151,6 +151,40 @@ describe('ShowPageSharingSettings', () => {
     expect(screen.queryByRole('button', { name: 'Apply' })).toBeNull();
   });
 
+  it('stacks Access as title, select, then status, and lets the audience row fill the panel', async () => {
+    api.getShowAccessSettings.mockResolvedValue({
+      show_access: showAccess({
+        access_mode: 'limited',
+        normalized_emails: ['guest@example.com'],
+      }),
+    });
+    getPermissions.mockResolvedValue(ORGANIZATION);
+    renderSettings();
+
+    const trigger = await screen.findByRole('button', { name: 'Access: Limited' });
+    const title = screen.getByText('Access');
+    const status = screen.getByRole('status');
+    // One vertical stack: the title, the mode select, and the autosave status
+    // are siblings in that order -- no label-left/control-right row.
+    const stack = trigger.parentElement;
+    expect(title.parentElement).toBe(stack);
+    expect(status.parentElement).toBe(stack);
+    expect(Array.from(stack?.children ?? [])).toEqual([title, trigger, status]);
+    expect(status.textContent).toContain('Changes save automatically');
+    // The select stays its own fixed width instead of stretching to the panel.
+    expect(trigger.className).toContain('w-40');
+
+    // The audience field, by contrast, adapts to the container: the input takes
+    // the free space and the add button ends the row at its right edge.
+    const input = await audience();
+    const add = screen.getByRole('button', { name: 'Add email' });
+    const row = add.parentElement;
+    expect(input.parentElement?.className).toContain('flex-1');
+    expect(row?.lastElementChild).toBe(add);
+    expect(row?.parentElement?.className).toContain('w-full');
+    expect(row?.parentElement?.className).not.toMatch(/max-w-/);
+  });
+
   it('starts an Organization page as Private with no audience field', async () => {
     api.getShowAccessSettings.mockResolvedValue({ show_access: showAccess() });
     getPermissions.mockResolvedValue(ORGANIZATION);

--- a/ui/src/components/workbench/ShowPageSharingSettings.tsx
+++ b/ui/src/components/workbench/ShowPageSharingSettings.tsx
@@ -89,8 +89,11 @@ function AccessModeSelect({
           <ChevronDown className="size-4 shrink-0 text-muted" />
         </button>
       </PopoverTrigger>
+      {/* Anchored to the trigger's leading edge: the trigger is left-aligned in
+          the panel, and a 16rem list hung off the right edge of a 10rem trigger
+          would reach past the panel and rely on collision shifting. */}
       <PopoverContent
-        align="end"
+        align="start"
         sideOffset={4}
         role="listbox"
         aria-label={t('chat.showPage.sharingAccess')}
@@ -220,7 +223,7 @@ function AudienceCombobox({
   return (
     <div
       ref={containerRef}
-      className="relative w-full max-w-[17.5rem]"
+      className="relative w-full"
       onBlur={(event) => {
         if (containerRef.current?.contains(event.relatedTarget as Node | null)) return;
         setFocused(false);
@@ -700,29 +703,30 @@ export function ShowPageSharingSettings({
             aria-label={t('chat.showPage.sharingAccess')}
             className={clsx('space-y-2.5', sharedMode && 'border-t border-border pt-3')}
           >
-            <div className="flex items-center justify-between gap-3">
-              <div className="min-w-0">
-                <div className="text-sm font-medium">{t('chat.showPage.sharingAccess')}</div>
-                <div className="mt-0.5 flex items-center gap-1 text-[11px] text-muted" role="status">
-                  {saving ? (
-                    <>
-                      <Loader2 className="size-3 animate-spin" />
-                      {t('common.saving')}
-                    </>
-                  ) : (
-                    <>
-                      <Check className="size-3 text-mint-ink" />
-                      {t('chat.showPage.sharingAutoSave')}
-                    </>
-                  )}
-                </div>
-              </div>
+            {/* Title, then control, then status — the same vertical rhythm the
+                Custom link section above uses, so the panel reads as one
+                stack of labelled fields instead of one stack plus one row. */}
+            <div className="space-y-1.5">
+              <div className="text-sm font-medium">{t('chat.showPage.sharingAccess')}</div>
               <AccessModeSelect
                 value={mode}
                 disabled={!editable}
                 onChange={changeMode}
                 ownerWindowId={ownerWindowId}
               />
+              <div className="flex items-center gap-1 text-[11px] text-muted" role="status">
+                {saving ? (
+                  <>
+                    <Loader2 className="size-3 animate-spin" />
+                    {t('common.saving')}
+                  </>
+                ) : (
+                  <>
+                    <Check className="size-3 text-mint-ink" />
+                    {t('chat.showPage.sharingAutoSave')}
+                  </>
+                )}
+              </div>
             </div>
 
             {mode === 'limited' ? (


### PR DESCRIPTION
## Capability

Show Page **Share panel layout** — the Access section and the "People with access" row in `ShowPageSharingSettings`. UI-only; no behavior, logic, copy, or i18n-key changes.

## What changed

1. **Access becomes a vertical field, like Custom link above it.** The title is on its own line, the access-mode select sits on the next line left-aligned, and it keeps its existing fixed width (`w-40`) rather than stretching to the panel.
2. **The "Changes save automatically" status** (`chat.showPage.sharingAutoSave`, unchanged key and copy) moved to its own line *below* the select. It keeps `role="status"`, so the saving/saved swap is still announced.
3. **The audience row adapts to its container.** The combobox dropped its `max-w-[17.5rem]` cap, so the search input takes the free width and the `+` add button ends the row at the panel's right edge — the same shape as the share-URL row at the top of the panel. The "Saved" indicator beside the "People with access" heading is untouched.

One consequence of (1), included because the layout change causes it: the mode list now anchors `align="start"` instead of `align="end"`. A 16rem list hung off the right edge of a 10rem trigger that now sits at the panel's left edge would reach past the panel and depend on Radix collision shifting to stay on screen.

All `aria-label`s, roles, and the `data-access-icon` hooks are unchanged.

## Evidence

- **Unit** — `ui/src/components/workbench/ShowPageSharingSettings.test.tsx`: added one case asserting the layout as properties rather than a class snapshot — the title, select, and status are siblings of one stack *in that order*, the status still carries the autosave copy, the select still carries `w-40`, and the audience row's input is `flex-1` with the add button as the row's last child inside a container that is `w-full` with no `max-w-*`. Verified discriminating: it fails against `master`'s component and passes with the change. Full file: 30/30 pass. Broader run over `src/components/workbench` + `ShowPagesPage`: 432/432 pass.
- **Build** — `cd ui && npm run build` passes (`validate:imports` + `tsc -b` + `vite build`); `npm run lint` baseline clean, no drift.
- **Manual / visual** — rendered the real component markup against the built Tailwind bundle and screenshotted `master` vs this branch side by side; all three requirements confirmed in the rendered pixels.
- **Contract / scenario** — none applicable: no catalog covers this panel's layout, and no cross-boundary shape changed.

## Residual manual checks

Deferred to the integration pass: the panel in its two real hosts — the Workbench share popover (`ShowPageShareControl`, 23rem) and the Show Pages settings card (`ShowPagesPage`, 420px) — plus a narrow-viewport / mobile check, since the audience row is now container-driven rather than capped.
