### PR TITLE
fix(ui): prevent activity interruption flash on chat switch

### DIFF
--- a/ui/src/components/workbench/ChatPage.hydration.test.tsx
+++ b/ui/src/components/workbench/ChatPage.hydration.test.tsx
@@ -2,7 +2,7 @@
 
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 
 const mocks = vi.hoisted(() => ({
   api: {
@@ -164,6 +164,11 @@ const projectedMessage = (id: string, text: string) => ({
   delivered_at: '2026-08-15T00:00:01Z',
   read_at: null,
 });
+
+const SessionSwitcher = () => {
+  const navigate = useNavigate();
+  return <button type="button" onClick={() => navigate('/chat/session-running')}>switch chat</button>;
+};
 
 describe('ChatPage transcript hydration', () => {
   let sessionRow: Deferred<{ id: string }>;
@@ -416,5 +421,74 @@ describe('ChatPage transcript hydration', () => {
     await waitFor(() => expect(mocks.api.getSessionActivity).toHaveBeenCalledTimes(1));
     expect(screen.getByText('first active step')).toBeTruthy();
     expect(screen.getByText('second active step')).toBeTruthy();
+  });
+
+  it('does not render an open activity group as interrupted before the switched chat turn state is known', async () => {
+    const openGroup = {
+      id: 'open-turn',
+      anchor_message_id: null,
+      anchor_position: 'after' as const,
+      open: true,
+      status: 'interrupted' as const,
+      steps: 1,
+      duration_ms: null,
+    };
+    const runningBootstrap = deferred<ReturnType<typeof bootstrapPayload>>();
+    const unknownActivity = deferred<{ groups: typeof openGroup[] }>();
+    const runningActivity = deferred<{ groups: typeof openGroup[] }>();
+    mocks.api.getSession.mockResolvedValue({ id: 'session-running' });
+    mocks.api.getSessionBootstrap
+      .mockReset()
+      .mockResolvedValueOnce({
+        ...bootstrapPayload('session-old'),
+        config: { ui: { show_agent_activity: true } },
+      })
+      .mockReturnValueOnce(runningBootstrap.promise);
+    let runningActivityReads = 0;
+    mocks.api.getSessionActivity.mockImplementation((sessionId: string) => {
+      if (sessionId !== 'session-running') return Promise.resolve({ groups: [] });
+      runningActivityReads += 1;
+      return runningActivityReads === 1 ? unknownActivity.promise : runningActivity.promise;
+    });
+    mocks.api.getSessionActivityGroup.mockResolvedValue({
+      ...openGroup,
+      rows: [{
+        id: 'active-step',
+        kind: 'assistant',
+        text: 'still working',
+        created_at: '2026-08-21T00:00:00Z',
+      }],
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/chat/session-old']}>
+        <SessionSwitcher />
+        <Routes>
+          <Route path="/chat/:sessionId" element={<ChatPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(mocks.api.getSessionActivity).toHaveBeenCalledWith('session-old'));
+    act(() => screen.getByRole('button', { name: 'switch chat' }).click());
+    await waitFor(() => expect(mocks.api.getSessionBootstrap).toHaveBeenCalledTimes(2));
+
+    act(() => mocks.events?.onConnected());
+    await waitFor(() => expect(mocks.api.getSessionActivity).toHaveBeenCalledWith('session-running'));
+
+    await act(async () => runningBootstrap.resolve({
+      ...bootstrapPayload('session-running'),
+      config: { ui: { show_agent_activity: true } },
+      turn_state: { ...idleTurnState, foreground: 'running', in_flight: true },
+    }));
+
+    await act(async () => unknownActivity.resolve({ groups: [openGroup] }));
+    await waitFor(() => expect(runningActivityReads).toBe(2));
+    expect(screen.queryByText('chat.agentActivity.interrupted')).toBeNull();
+
+    await act(async () => runningActivity.resolve({ groups: [openGroup] }));
+
+    await waitFor(() => expect(screen.getByText('chat.agentActivity.running')).toBeTruthy());
+    expect(screen.queryByText('chat.agentActivity.interrupted')).toBeNull();
   });
 });

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -131,12 +131,14 @@ import type { MentionReference } from '../../lib/mentions';
 import { QuickReplies } from './QuickReplies';
 import { ActivityCard, ActivityChip } from './AgentActivityGroup';
 import {
+  activityGroupsForForeground,
   activityRowFromMessage,
   groupFromWire,
   initialLiveActivity,
   isActivityMessageType,
   liveActivityReducer,
   shouldShowRunningCard,
+  type ActivityForeground,
   type ActivityGroup,
   type ActivityRow,
   type LiveActivityEvent,
@@ -651,11 +653,14 @@ export const ChatPage: React.FC = () => {
   // settle fetch schedules exactly one bounded retry (the next settle also rebuilds).
   const activityRefreshInFlightRef = useRef(false);
   const activityRefreshPendingRef = useRef(false);
-  const activityRunningRef = useRef(false);
+  // The controller-owned state used to interpret an open durable group. This is
+  // deliberately tri-state: a route switch starts unknown, so an early activity
+  // read cannot turn "not hydrated yet" into a visible interrupted result.
+  const activityForegroundRef = useRef<ActivityForeground>('unknown');
   const activityRetryTimerRef = useRef<number | null>(null);
   // Latest ``scheduleActivityRefresh`` (assigned below) so its own async resolution
   // can re-enter for the trailing / retry pass without a definition cycle.
-  const scheduleActivityRefreshRef = useRef<(running: boolean, isRetry?: boolean) => void>(() => {});
+  const scheduleActivityRefreshRef = useRef<(isRetry?: boolean) => void>(() => {});
   // Advance the live-buffer state machine + mirror it into render state. The ref is
   // updated synchronously so same-tick reads (generation, settled) are current.
   const dispatchLive = useCallback((event: LiveActivityEvent) => {
@@ -686,6 +691,7 @@ export const ChatPage: React.FC = () => {
   const markWorking = useCallback(() => {
     turnEpochRef.current += 1;
     workingSetAtRef.current = Date.now();
+    activityForegroundRef.current = 'running';
     workingRef.current = true;
     setWorking(true);
   }, []);
@@ -705,7 +711,7 @@ export const ChatPage: React.FC = () => {
   // is only touched when the resolution is still for the CURRENT generation (a newer
   // turn.start bumped it → a late resolution is a structural no-op).
   const refreshActivity = useCallback(
-    async (running: boolean, issuedGen: number): Promise<boolean> => {
+    async (issuedGen: number): Promise<boolean> => {
       const sid = sessionIdRef.current;
       if (!sid || !showAgentActivityRef.current) return true;
       let res: { groups: TurnActivityGroupWire[] };
@@ -716,12 +722,12 @@ export const ChatPage: React.FC = () => {
       }
       if (sid !== sessionIdRef.current) return true;
       const fetched = (res.groups ?? []).map(groupFromWire);
-      // The last un-terminated turn is the ``open`` group. While a turn is running it
-      // IS that turn — promote it into the live card (re-hydrate) rather than render
-      // it as a chip; otherwise it renders as an interrupted chip after its trigger.
-      const inflightIdx = running ? fetched.findIndex((g) => g.open) : -1;
-      const inflight = inflightIdx >= 0 ? fetched[inflightIdx] : null;
-      const groups = inflight ? fetched.filter((_, i) => i !== inflightIdx) : fetched;
+      // Interpret an open group against the LATEST controller state, not the state
+      // from when this request started. A chat switch can hydrate ``running`` while
+      // an earlier unknown-state request is in flight; committing the stale boolean
+      // is the orange interrupted-chip flash this boundary prevents.
+      const foreground = activityForegroundRef.current;
+      const { settled: groups, inflight } = activityGroupsForForeground(fetched, foreground);
       // Settled groups are always safe to replace (storage is authoritative);
       // preserve already-loaded rows so a resync doesn't force a re-fetch on expand.
       setActivityGroups((prev) => {
@@ -735,6 +741,7 @@ export const ChatPage: React.FC = () => {
           try {
             const wire = await api.getSessionActivityGroup(sid, inflight.id);
             if (sid !== sessionIdRef.current) return true;
+            if (activityForegroundRef.current !== 'running') return true;
             const rows = groupFromWire(wire).rows ?? [];
             if (rows.length > 0) {
               const startMs = Date.parse(rows[0].created_at);
@@ -749,38 +756,37 @@ export const ChatPage: React.FC = () => {
             /* re-hydrate is best-effort; live streaming still fills the card */
           }
         }
-      } else {
-        // No in-flight turn: clear the finished buffer so the card swaps to its chip
-        // — but only if still the same generation (a newer turn's rows are kept).
+      } else if (foreground === 'idle') {
+        // Authoritative idle: clear the finished buffer so the card swaps to its
+        // chip, but only if still the same generation (newer rows are kept).
         dispatchLive({ type: 'clear_for_gen', gen: issuedGen });
       }
       return true;
     },
     [api, dispatchLive],
   );
-  // Coalesce settle-triggered refreshes: one in-flight + at most one trailing (with
-  // the latest ``running`` and the current generation), never N fetches for a settle
-  // burst. On a transient fetch failure schedule exactly one bounded retry (the next
-  // settle also rebuilds). No fetch when the toggle is off (strict no-op).
+  // Coalesce settle-triggered refreshes: one in-flight + at most one trailing for
+  // the current generation, never N fetches for a settle burst. Each response is
+  // interpreted against the latest controller foreground state at commit time. On
+  // a transient failure schedule one bounded retry (the next settle also rebuilds).
   const scheduleActivityRefresh = useCallback(
-    (running: boolean, isRetry = false) => {
+    (isRetry = false) => {
       if (!showAgentActivityRef.current) return;
-      activityRunningRef.current = running;
       if (activityRefreshInFlightRef.current) {
         activityRefreshPendingRef.current = true;
         return;
       }
       activityRefreshInFlightRef.current = true;
       const issuedGen = liveStateRef.current.gen;
-      void refreshActivity(activityRunningRef.current, issuedGen).then((ok) => {
+      void refreshActivity(issuedGen).then((ok) => {
         activityRefreshInFlightRef.current = false;
         if (activityRefreshPendingRef.current) {
           activityRefreshPendingRef.current = false;
-          scheduleActivityRefreshRef.current(activityRunningRef.current, false);
+          scheduleActivityRefreshRef.current(false);
         } else if (ok === false && !isRetry && activityRetryTimerRef.current === null) {
           activityRetryTimerRef.current = window.setTimeout(() => {
             activityRetryTimerRef.current = null;
-            scheduleActivityRefreshRef.current(activityRunningRef.current, true);
+            scheduleActivityRefreshRef.current(true);
           }, 1500);
         }
       });
@@ -1160,7 +1166,7 @@ export const ChatPage: React.FC = () => {
     // Resync activity too: an SSE gap can drop the terminal/turn.end, so rebuild
     // settled groups from storage (a recovered turn gets its chip; a still-running
     // turn keeps/re-hydrates its card). Coalesced + no-op when the toggle is off.
-    scheduleActivityRefresh(workingRef.current);
+    scheduleActivityRefresh();
   }, [api, sessionId, scheduleActivityRefresh, beginTranscriptSnapshotRead]);
 
   // The send-while-busy queue (pending messages shown above the composer).
@@ -1230,7 +1236,7 @@ export const ChatPage: React.FC = () => {
       // Returning to the live tail from a historical window: activity ingestion was
       // suppressed while scrolled away, so resync groups from storage — a turn that
       // finished in history still gets its chip without a full reload.
-      scheduleActivityRefresh(workingRef.current);
+      scheduleActivityRefresh();
       return true;
     } catch {
       return false;
@@ -1292,6 +1298,7 @@ export const ChatPage: React.FC = () => {
         // overlapping sync whose idle response lands AFTER this one can't clear
         // the Stop we just confirmed live — its captured epoch is now stale (P2).
         markWorking();
+        scheduleActivityRefresh();
         return;
       }
       // Idle snapshot — clear the stale indicator, but only when it's safe:
@@ -1304,6 +1311,7 @@ export const ChatPage: React.FC = () => {
       const sinceSet = Date.now() - workingSetAtRef.current;
       if (sinceSet > WORKING_SETTLE_GRACE_MS) {
         const recoveredDroppedTurnEnd = workingRef.current;
+        activityForegroundRef.current = 'idle';
         workingRef.current = false;
         setWorking(false);
         // Agent Activity: the idle poll recovering a dropped terminal/turn.end is a
@@ -1313,7 +1321,7 @@ export const ChatPage: React.FC = () => {
         // The card is already hidden by the working gate; this produces the chip.
         if (showAgentActivityRef.current) {
           dispatchLive({ type: 'settle' });
-          scheduleActivityRefresh(false);
+          scheduleActivityRefresh();
         }
         if (recoveredDroppedTurnEnd) void refreshSessionRow();
       } else if (graceResyncRef.current === null) {
@@ -1401,11 +1409,12 @@ export const ChatPage: React.FC = () => {
       }
       setHydratedTranscriptSessionId(sessionId);
       setFailedBootstrapSessionId(null);
+      activityForegroundRef.current = bootstrap.turn_state.foreground;
       // Chat Activity chips for past turns: resync the per-turn summary (row text
       // lazy-loads on expand). If a turn is in flight, the refresh re-hydrates the
       // running card instead of showing it as interrupted.
       if (activityEnabled) {
-        scheduleActivityRefresh(bootstrap.turn_state.foreground === 'running');
+        scheduleActivityRefresh();
       } else {
         setActivityGroups([]);
       }
@@ -1417,7 +1426,10 @@ export const ChatPage: React.FC = () => {
       // syncTurnState idle response can't clear it; an idle load is authoritative
       // for the fresh page, so clear directly (Codex P2).
       if (bootstrap.turn_state.foreground === 'running') markWorking();
-      else if (bootstrap.turn_state.foreground === 'idle') setWorking(false);
+      else if (bootstrap.turn_state.foreground === 'idle') {
+        workingRef.current = false;
+        setWorking(false);
+      }
     } catch (err) {
       // A superseded failure must not stamp an error onto the newer request's
       // loading state, even when both requests belong to the same route.
@@ -1471,6 +1483,7 @@ export const ChatPage: React.FC = () => {
       window.clearTimeout(highlightTimerRef.current);
       highlightTimerRef.current = null;
     }
+    workingRef.current = false;
     setWorking(false);
     setRuntimeState(emptyRuntimeState());
     setQueue([]);
@@ -1478,6 +1491,7 @@ export const ChatPage: React.FC = () => {
     // Clear all Agent Activity state so the previous session's groups / live buffer
     // never leak into the new chat (refresh re-reads the toggle + summary).
     setActivityGroups([]);
+    activityForegroundRef.current = 'unknown';
     liveStateRef.current = initialLiveActivity();
     setLiveRows([]);
     setLiveStartedAt(null);
@@ -1552,7 +1566,7 @@ export const ChatPage: React.FC = () => {
         // detached completion. Only a terminal reply owns this live generation.
         if (showAgentActivityRef.current && shouldRefreshAgentActivityForMessage(msg)) {
           if (isTerminalAgentMessage(msg)) dispatchLive({ type: 'settle' });
-          scheduleActivityRefresh(workingRef.current);
+          scheduleActivityRefresh();
         }
         // Don't clear ``working`` from a result row here: with the queue, a
         // result can belong to an EARLIER turn while a newer queued turn is
@@ -1578,17 +1592,17 @@ export const ChatPage: React.FC = () => {
         // or user cancel) — the authoritative end of the working state. There is
         // no turn-duration timeout, so this only fires on a REAL terminal signal.
         if (data.session_id === sessionIdRef.current) {
+          activityForegroundRef.current = 'idle';
           setRuntimeState((current) => ({ ...current, in_flight: false, foreground: 'idle' }));
           workingRef.current = false;
           setWorking(false);
           // Agent Activity: the turn settled (result / error / interrupt) → mark the
-          // generation settled and rebuild from storage. running=false so a trailing
-          // (no-terminal) turn renders as its interrupted chip and the finished
-          // card's buffer clears — the interrupt case is covered structurally, with
-          // no client-side snapshot or grace timer.
+          // generation settled and rebuild from storage. Authoritative idle makes a
+          // trailing open group render as interrupted and clears the finished card's
+          // buffer — the interrupt case needs no client-side snapshot or grace timer.
           if (showAgentActivityRef.current) {
             dispatchLive({ type: 'settle' });
-            scheduleActivityRefresh(false);
+            scheduleActivityRefresh();
           }
           // Turn start can materialize an inherited route even on an already-
           // bound legacy session. Reload the authoritative row on every settle

--- a/ui/src/lib/agentActivity.test.ts
+++ b/ui/src/lib/agentActivity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { WorkbenchMessage } from '../context/ApiContext';
 import {
+  activityGroupsForForeground,
   activityDurationParts,
   activityRowFromMessage,
   filterActivityRows,
@@ -291,6 +292,48 @@ describe('groupFromWire', () => {
     expect(group.open).toBe(true);
     expect(group.durationMs).toBeNull();
     expect(group.rows).toBeUndefined();
+  });
+});
+
+describe('activityGroupsForForeground', () => {
+  const settled = groupFromWire({
+    id: 'settled',
+    anchor_message_id: 'result',
+    anchor_position: 'before',
+    open: false,
+    status: 'done',
+    steps: 2,
+    duration_ms: 1000,
+  });
+  const open = groupFromWire({
+    id: 'open',
+    anchor_message_id: 'prompt',
+    anchor_position: 'after',
+    open: true,
+    status: 'interrupted',
+    steps: 1,
+    duration_ms: null,
+  });
+
+  it('withholds open groups while foreground state is unknown', () => {
+    expect(activityGroupsForForeground([settled, open], 'unknown')).toEqual({
+      settled: [settled],
+      inflight: null,
+    });
+  });
+
+  it('promotes the latest open group only while the turn is running', () => {
+    expect(activityGroupsForForeground([settled, open], 'running')).toEqual({
+      settled: [settled],
+      inflight: open,
+    });
+  });
+
+  it('renders an open group as settled only after authoritative idle', () => {
+    expect(activityGroupsForForeground([settled, open], 'idle')).toEqual({
+      settled: [settled, open],
+      inflight: null,
+    });
   });
 });
 

--- a/ui/src/lib/agentActivity.ts
+++ b/ui/src/lib/agentActivity.ts
@@ -34,6 +34,30 @@ export type ActivityGroup = {
   rows?: ActivityRow[];
 };
 
+export type ActivityForeground = 'idle' | 'running' | 'unknown';
+
+/** Interpret durable groups only after the controller's foreground state is known.
+ * An open group is not interrupted evidence by itself: while state is unknown it
+ * stays hidden, while running it becomes the live card, and only authoritative
+ * idle lets its stored interrupted status render as a settled chip. */
+export const activityGroupsForForeground = (
+  groups: ActivityGroup[],
+  foreground: ActivityForeground,
+): { settled: ActivityGroup[]; inflight: ActivityGroup | null } => {
+  if (foreground === 'idle') return { settled: groups, inflight: null };
+
+  let inflight: ActivityGroup | null = null;
+  if (foreground === 'running') {
+    for (let i = groups.length - 1; i >= 0; i -= 1) {
+      if (groups[i].open) {
+        inflight = groups[i];
+        break;
+      }
+    }
+  }
+  return { settled: groups.filter((group) => !group.open), inflight };
+};
+
 // Wire shape from GET /api/sessions/<id>/activity (summary group + optional rows).
 export type TurnActivityGroupWire = {
   id: string;


### PR DESCRIPTION
## Summary

- interpret open Agent Activity groups against the controller-owned `unknown | running | idle` foreground state
- hide an open group while a newly selected chat is still hydrating, and only render it as interrupted after authoritative idle
- add a controlled async race regression for switching into a running chat

## Evidence

- Unit: `agentActivity.test.ts` covers all three foreground states
- Component/contract: `ChatPage.hydration.test.tsx` reproduces an unknown-state activity response landing after a running bootstrap; 45 focused tests pass
- Scenario catalog: not applicable; no Agent Activity session-switch scenario catalog exists
- Regression: isolated local Incus worktree environment built and reached healthy/running state; the same 45 focused tests pass inside it
- UI lint and production build pass

## Residual manual check

- Rapid switching against a credentialed live backend was not repeated manually; the controlled component race fixes and locks the exact response ordering that caused the flash.
