### PR TITLE
fix(model-hub): keep Usage within narrow viewports

### DIFF
--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -288,6 +288,12 @@ scenarios:
     kind: observation
     layer: unit
     test: ui/src/components/settings/models/UsageTab.test.tsx::MH-USAGE-026
+  - id: MH-USAGE-027
+    name: The usage report stays within a narrow viewport and states every chart-axis label without clipping
+    status: covered
+    kind: observation
+    layer: unit
+    test: ui/src/components/settings/models/UsageTab.test.tsx::MH-USAGE-027
   - id: MH-RES-LIVE-001
     name: Live turn retries an eligible backup before streaming starts
     status: covered

--- a/ui/src/components/settings/models/UsageTab.test.tsx
+++ b/ui/src/components/settings/models/UsageTab.test.tsx
@@ -6,6 +6,8 @@
 // shortfall presented as spare capacity.
 import { cleanup, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { createInstance } from 'i18next';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -82,6 +84,13 @@ const bodyRows = (table: HTMLElement) =>
  * which column each of them answers.
  */
 const figures = (row: HTMLElement) => [...within(row).getAllByRole('rowheader'), ...within(row).getAllByRole('cell')];
+
+const surfaceCss = readFileSync(join(__dirname, 'modelHubSurface.css'), 'utf8');
+
+const rule = (selector: string) => {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return surfaceCss.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`))?.[1] ?? '';
+};
 
 afterEach(cleanup);
 
@@ -257,6 +266,43 @@ describe('UsageTab', () => {
       expect(stated).toHaveLength(said.length);
       stated.forEach((text, column) => expect(said[column]).toContain(text));
     });
+  });
+
+  it('MH-USAGE-027: keeps a 390px viewport within bounds and states long chart labels without clipping', () => {
+    const longPeak = counters({ input_tokens: 123_456_789_012, output_tokens: 34_567_890 });
+    const { container } = draw(readyRegion(summary({
+      from_day: '2026-08-16',
+      to_day: '2026-08-18',
+      window_days: 3,
+      totals: longPeak,
+      sources: [source({ ...longPeak, models: [model(longPeak)] })],
+      days: [{ ...longPeak, day: '2026-08-18' }],
+    })));
+
+    // A table's intrinsic columns can remain wider than the one-pixel `sr-only`
+    // box applied to the table itself. A generic paint/layout container is the
+    // boundary that keeps the complete semantic table out of visual geometry.
+    const dailyTable = screen.getByRole('table', { name: /Metered tokens and requests per day/ });
+    expect(dailyTable.classList.contains('sr-only')).toBe(false);
+    expect(dailyTable.parentElement?.classList.contains('sr-only')).toBe(true);
+    expect(dailyTable.parentElement?.classList.contains('model-hub-usage-a11y-table')).toBe(true);
+    expect(rule('.model-hub-usage-a11y-table')).toContain('contain: strict');
+
+    const axis = container.querySelector('.model-hub-usage-axis');
+    const labels = [...(axis?.querySelectorAll('.model-hub-usage-axis-label') ?? [])];
+    expect(labels).toHaveLength(3);
+    expect(labels[1].textContent).toContain('123,491,356,902');
+    expect(labels[1].textContent).toContain('Aug 18, 2026');
+    for (const label of labels) expect(label.classList.contains('truncate')).toBe(false);
+
+    // jsdom has no layout engine, so the narrow-width browser property is stated
+    // by the same min-zero fractional grid and emergency wrapping Chrome uses.
+    // No track owns an intrinsic pixel width, so this holds below and above 390px
+    // rather than special-casing the reproduced fixture width.
+    expect(rule('.model-hub-usage-axis')).toContain('grid-template-columns: var(--model-hub-usage-axis-columns)');
+    expect(rule('.model-hub-usage-axis-label')).toContain('min-width: 0');
+    expect(rule('.model-hub-usage-axis-label')).toContain('overflow-wrap: anywhere');
+    expect(rule('.model-hub-usage')).toContain('--model-hub-usage-axis-columns: minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr)');
   });
 
   it('MH-USAGE-024: every figure the report states names the row and the column it answers', () => {

--- a/ui/src/components/settings/models/UsageTab.tsx
+++ b/ui/src/components/settings/models/UsageTab.tsx
@@ -338,28 +338,34 @@ const ByDayPanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
             which is the same per-column association the Source table carries.
             Sibling of the image, never a child: inside it, it would be hidden
             along with everything else. */}
-        <table className="sr-only">
-          <caption>{t('settings.models.usage.byDay.table', { from: day(summary.from_day), to: day(summary.to_day) })}</caption>
-          <thead>
-            <tr>
-              <th scope="col">{t('settings.models.usage.byDay.col.day')}</th>
-              <th scope="col">{t('settings.models.usage.tokens.label')}</th>
-              <th scope="col">{t('settings.models.usage.requests.label')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {columns.map((column) => (
-              <tr key={column.day}>
-                <th scope="row">{day(column.day)}</th>
-                <td><TokenFigure counters={column} value={column.tokens} /></td>
-                <td>{count(column.requests)}</td>
+        {/* Apply the visually-hidden box to a generic wrapper. A table keeps its
+            intrinsic column width even when the table itself is only one pixel
+            wide; containing that layout inside the clipped wrapper keeps its
+            semantics without letting it widen the document. */}
+        <div className="model-hub-usage-a11y-table sr-only">
+          <table>
+            <caption>{t('settings.models.usage.byDay.table', { from: day(summary.from_day), to: day(summary.to_day) })}</caption>
+            <thead>
+              <tr>
+                <th scope="col">{t('settings.models.usage.byDay.col.day')}</th>
+                <th scope="col">{t('settings.models.usage.tokens.label')}</th>
+                <th scope="col">{t('settings.models.usage.requests.label')}</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-        <div className="model-hub-usage-axis flex items-baseline justify-between gap-3">
-          <span className="truncate">{day(summary.from_day)}</span>
-          <span className="model-hub-usage-peak truncate">
+            </thead>
+            <tbody>
+              {columns.map((column) => (
+                <tr key={column.day}>
+                  <th scope="row">{day(column.day)}</th>
+                  <td><TokenFigure counters={column} value={column.tokens} /></td>
+                  <td>{count(column.requests)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className="model-hub-usage-axis">
+          <span className="model-hub-usage-axis-label">{day(summary.from_day)}</span>
+          <span className="model-hub-usage-axis-label model-hub-usage-peak">
             {peak !== null
               ? t('settings.models.usage.byDay.peak', { tokens: tokenText(peak, peak.tokens), day: day(peak.day) })
               // No peak is three different windows, and the tokens cannot tell them
@@ -375,7 +381,7 @@ const ByDayPanel: React.FC<{ summary: UsageSummary }> = ({ summary }) => {
                   ? t('settings.models.usage.byDay.unreported')
                   : t('settings.models.usage.byDay.quiet')}
           </span>
-          <span className="truncate">{day(summary.to_day)}</span>
+          <span className="model-hub-usage-axis-label">{day(summary.to_day)}</span>
         </div>
       </div>
     </section>

--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -1488,6 +1488,8 @@
   --model-hub-usage-chart-height: 132px;
   --model-hub-usage-chart-gap: 3px;
   --model-hub-usage-column-radius: 2px;
+  --model-hub-usage-axis-gap: 12px;
+  --model-hub-usage-axis-columns: minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr);
   --model-hub-usage-head-fill: var(--model-hub-wash-05);
   --model-hub-usage-label-ink: var(--model-hub-ink-73);
   --model-hub-usage-note-ink: var(--model-hub-muted-b3);
@@ -1593,11 +1595,25 @@
   border-radius: var(--model-hub-usage-column-radius);
   background: var(--model-hub-usage-column-fill);
 }
+.model-hub-usage-a11y-table { contain: strict; }
 .model-hub-usage-axis {
+  display: grid;
+  grid-template-columns: var(--model-hub-usage-axis-columns);
+  gap: var(--model-hub-usage-axis-gap);
+  align-items: start;
   color: var(--model-hub-usage-note-ink);
   font-size: var(--model-hub-usage-note-size);
 }
-.model-hub-usage-peak { color: var(--model-hub-usage-label-ink); }
+.model-hub-usage-axis-label {
+  min-width: 0;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+.model-hub-usage-axis-label:last-child { text-align: right; }
+.model-hub-usage-peak {
+  color: var(--model-hub-usage-label-ink);
+  text-align: center;
+}
 
 @media (min-width: 1024px) {
   .model-hub-direct-grid {


### PR DESCRIPTION
## Summary

- contain the visually hidden daily-usage table in a generic clipped layout boundary so its intrinsic table width cannot widen the document
- replace truncating chart-axis labels with a min-zero fractional grid whose labels wrap completely at narrow widths
- add the `MH-USAGE-027` narrow-layout contract and focused regression coverage

## Changed contract

- The complete daily table remains available to assistive technology but contributes no visible document geometry.
- At narrow widths, including 390px, Usage content does not create horizontal overflow and every chart-axis label remains complete by wrapping instead of ellipsizing.
- Desktop behavior and theme-token ownership are unchanged; the layout rules are color-independent and apply in light and dark themes.

## Scenario coverage

- `MH-USAGE-027`

## Evidence

- Focused UI: 58 Vitest cases passed across `UsageTab`, Model Hub style policy, and the consuming Settings Models render suite.
- Catalog: all 25 UI citations resolve to one collected Vitest case.
- Static gates: TypeScript project build, lint baseline, import validation, and theme/token validation passed.
- Production build: Vite build passed.
- Browser geometry: isolated headless Chrome rendered a 390px Usage probe with `clientWidth == scrollWidth == 390`. The semantic table retained a 492.84px intrinsic width inside a 1px clipped/contained wrapper, while the long peak label wrapped to two lines with `clientWidth == scrollWidth == 148` and no text overflow.

## Residual manual check

- Re-run the real Settings > Models > Usage acceptance path at 390x844 light after integration to confirm the product shell and live payload together. This lane did not access the acceptance browser, ports 5100/5190, Incus, or user state.

## Dependencies

- None.

## Release boundary

- This fix is not included in the already locked `gh-v3.0.13rc3`; it is delivered from current `master` for a later integration/release decision.

## Known-by-design ledger

- None.
