### PR TITLE
fix(ui): align mobile Show Page actions

### DIFF
--- a/ui/src/components/apps/ShowPageRoute.test.tsx
+++ b/ui/src/components/apps/ShowPageRoute.test.tsx
@@ -69,4 +69,24 @@ describe('mobile Show Page app route', () => {
     fireEvent.click(screen.getByRole('button', { name: 'chat.showPage.backToChat' }));
     expect(screen.getByTestId('location').textContent).toBe('/chat/session-1?view=chat');
   });
+
+  it('keeps action controls out of the missing-session placeholder', async () => {
+    api.getSession.mockResolvedValue(null);
+
+    render(
+      <MemoryRouter initialEntries={['/apps/show/session-1']}>
+        <Routes>
+          <Route path="/apps/show/:sessionId" element={<ShowPageRoute />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const header = await screen.findByRole('banner');
+    expect(await screen.findByText('apps.showPage.missingTitle')).toBeTruthy();
+    expect(header.querySelectorAll('button')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'common.back' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'chat.showPage.annotate.unavailable' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'chat.showPage.backToChat' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'chat.showPage.share' })).toBeNull();
+  });
 });

--- a/ui/src/components/apps/ShowPageRoute.test.tsx
+++ b/ui/src/components/apps/ShowPageRoute.test.tsx
@@ -1,13 +1,15 @@
 /* @vitest-environment jsdom */
 
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 
 import { ShowPageRoute } from './ShowPageRoute';
 
 const api = vi.hoisted(() => ({
   getSession: vi.fn(),
+  getShowPages: vi.fn(),
+  connectWorkbenchEvents: vi.fn(),
 }));
 
 vi.mock('../../context/ApiContext', () => ({ useApi: () => api }));
@@ -15,8 +17,16 @@ vi.mock('../../context/DockContext', () => ({ useDock: () => ({ unpin: vi.fn() }
 vi.mock('../../context/WindowManagerContext', () => ({
   useWindowManager: () => ({ windows: [], openApp: vi.fn(), focus: vi.fn(), restore: vi.fn() }),
 }));
+vi.mock('../../context/showPageDrag', () => ({
+  useShowPageDrag: () => ({ active: false, begin: vi.fn(), end: vi.fn(), dropToDock: vi.fn() }),
+}));
 vi.mock('../../lib/useIsDesktop', () => ({ useIsDesktop: () => false }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+const LocationProbe = () => {
+  const location = useLocation();
+  return <output data-testid="location">{location.pathname}{location.search}</output>;
+};
 
 afterEach(() => {
   cleanup();
@@ -24,23 +34,29 @@ afterEach(() => {
 });
 
 describe('mobile Show Page app route', () => {
-  it('uses one full-width header with only back, title, and annotation controls', async () => {
+  it('uses one full-width header with back, annotation, chat, and share controls', async () => {
     api.getSession.mockResolvedValue({ id: 'session-1', status: 'active', title: 'Release dashboard' });
+    api.getShowPages.mockResolvedValue({ pages: [] });
+    api.connectWorkbenchEvents.mockReturnValue(vi.fn());
 
     render(
       <MemoryRouter initialEntries={['/apps/show/session-1']}>
         <Routes>
           <Route path="/apps/show/:sessionId" element={<ShowPageRoute />} />
+          <Route path="/chat/:sessionId" element={null} />
         </Routes>
+        <LocationProbe />
       </MemoryRouter>,
     );
 
     expect(await screen.findByText('Release dashboard')).toBeTruthy();
     const header = screen.getByRole('banner');
-    expect(header.querySelectorAll('button')).toHaveLength(2);
+    expect(header.querySelectorAll('button')).toHaveLength(4);
     expect(header.querySelector('a')).toBeNull();
     expect(screen.getByRole('button', { name: 'common.back' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'chat.showPage.annotate.unavailable' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'chat.showPage.backToChat' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'chat.showPage.share' })).toBeTruthy();
 
     const surface = header.parentElement;
     expect(surface?.className).toContain('h-full');
@@ -49,5 +65,8 @@ describe('mobile Show Page app route', () => {
     expect(surface?.className).not.toContain('rounded');
     expect(surface?.className).not.toContain('border border-border');
     expect(screen.getByTitle('chat.showPage.title').getAttribute('src')).toBe('/show/session-1/?vibe-embed=1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'chat.showPage.backToChat' }));
+    expect(screen.getByTestId('location').textContent).toBe('/chat/session-1?view=chat');
   });
 });

--- a/ui/src/components/apps/ShowPageRoute.test.tsx
+++ b/ui/src/components/apps/ShowPageRoute.test.tsx
@@ -11,9 +11,13 @@ const api = vi.hoisted(() => ({
   getShowPages: vi.fn(),
   connectWorkbenchEvents: vi.fn(),
 }));
+const shareControl = vi.hoisted(() => ({ canManageInstance: undefined as boolean | undefined }));
 
 vi.mock('../../context/ApiContext', () => ({ useApi: () => api }));
 vi.mock('../../context/DockContext', () => ({ useDock: () => ({ unpin: vi.fn() }) }));
+vi.mock('../../context/InstanceAuthorizationContext', () => ({
+  useInstanceAuthorization: () => ({ capabilities: { can_manage_instance: true } }),
+}));
 vi.mock('../../context/WindowManagerContext', () => ({
   useWindowManager: () => ({ windows: [], openApp: vi.fn(), focus: vi.fn(), restore: vi.fn() }),
 }));
@@ -22,6 +26,12 @@ vi.mock('../../context/showPageDrag', () => ({
 }));
 vi.mock('../../lib/useIsDesktop', () => ({ useIsDesktop: () => false }));
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../workbench/ShowPageShareControl', () => ({
+  ShowPageShareControl: ({ canManageInstance }: { canManageInstance?: boolean }) => {
+    shareControl.canManageInstance = canManageInstance;
+    return <button type="button" aria-label="chat.showPage.share" />;
+  },
+}));
 
 const LocationProbe = () => {
   const location = useLocation();
@@ -31,6 +41,7 @@ const LocationProbe = () => {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  shareControl.canManageInstance = undefined;
 });
 
 describe('mobile Show Page app route', () => {
@@ -57,6 +68,7 @@ describe('mobile Show Page app route', () => {
     expect(screen.getByRole('button', { name: 'chat.showPage.annotate.unavailable' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'chat.showPage.backToChat' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'chat.showPage.share' })).toBeTruthy();
+    expect(shareControl.canManageInstance).toBe(true);
 
     const surface = header.parentElement;
     expect(surface?.className).toContain('h-full');

--- a/ui/src/components/apps/ShowPageRoute.tsx
+++ b/ui/src/components/apps/ShowPageRoute.tsx
@@ -6,10 +6,12 @@ import { ArrowLeft, MonitorX, PinOff } from 'lucide-react';
 import { useApi } from '../../context/ApiContext';
 import { useDock } from '../../context/DockContext';
 import { useWindowManager } from '../../context/WindowManagerContext';
-import { showPageEmbeddedPath, showPagePrivatePath } from '../../apps/showPageAvatar';
+import { sessionChatPath, showPageEmbeddedPath, showPagePrivatePath } from '../../apps/showPageAvatar';
 import { useIsDesktop } from '../../lib/useIsDesktop';
 import { Button } from '../ui/button';
 import { ShowPageAnnotateControl } from '../workbench/ShowPageAnnotateControl';
+import { ShowPageLaunchControl } from '../workbench/ShowPageLaunchControl';
+import { ShowPageShareControl } from '../workbench/ShowPageShareControl';
 import { useShowPageAnnotation } from '../workbench/useShowPageAnnotation';
 
 // The `/apps/show/:sessionId` route — a pinned Show Page opened as an app on the
@@ -62,6 +64,7 @@ const MobileShowPage: React.FC<{ sessionId: string }> = ({ sessionId }) => {
   const [state, setState] = useState<'loading' | 'ready' | 'missing'>(sessionId ? 'loading' : 'missing');
   const [title, setTitle] = useState('');
   const [annotateOpen, setAnnotateOpen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
 
   // Read the session once (error-suppressed — a gone session must NOT toast) to
   // upgrade the header to the LIVE title and to detect missing/archived, exactly
@@ -115,13 +118,27 @@ const MobileShowPage: React.FC<{ sessionId: string }> = ({ sessionId }) => {
           <ArrowLeft className="size-3.5" />
         </Button>
         <span className="min-w-0 flex-1 truncate text-[14px] font-semibold text-foreground">{label}</span>
-        <ShowPageAnnotateControl
-          state={annotationState}
-          onEnable={enableAnnotation}
-          onDisable={disableAnnotation}
-          onSetMode={setAnnotationMode}
-          onPopoverOpenChange={setAnnotateOpen}
-        />
+        <div className="ml-auto flex shrink-0 items-center gap-1.5">
+          <ShowPageAnnotateControl
+            state={annotationState}
+            onEnable={enableAnnotation}
+            onDisable={disableAnnotation}
+            onSetMode={setAnnotationMode}
+            onPopoverOpenChange={setAnnotateOpen}
+          />
+          <ShowPageLaunchControl
+            sessionId={sessionId}
+            title={title || null}
+            showPageMode
+            busy={false}
+            onToggle={() => navigate(sessionChatPath(sessionId, { showChat: true }))}
+            onPrepareLaunch={async () => true}
+          />
+          <ShowPageShareControl
+            sessionId={sessionId}
+            onOpenChange={setShareOpen}
+          />
+        </div>
       </header>
 
       {missing ? (
@@ -159,7 +176,7 @@ const MobileShowPage: React.FC<{ sessionId: string }> = ({ sessionId }) => {
           src={src ?? undefined}
           sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals allow-downloads"
           allow="clipboard-write"
-          className={`min-h-0 w-full flex-1 border-0 bg-background${annotateOpen ? ' pointer-events-none' : ''}`}
+          className={`min-h-0 w-full flex-1 border-0 bg-background${annotateOpen || shareOpen ? ' pointer-events-none' : ''}`}
         />
       )}
     </div>

--- a/ui/src/components/apps/ShowPageRoute.tsx
+++ b/ui/src/components/apps/ShowPageRoute.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, MonitorX, PinOff } from 'lucide-react';
 
 import { useApi } from '../../context/ApiContext';
 import { useDock } from '../../context/DockContext';
+import { useInstanceAuthorization } from '../../context/InstanceAuthorizationContext';
 import { useWindowManager } from '../../context/WindowManagerContext';
 import { sessionChatPath, showPageEmbeddedPath, showPagePrivatePath } from '../../apps/showPageAvatar';
 import { useIsDesktop } from '../../lib/useIsDesktop';
@@ -60,6 +61,7 @@ const MobileShowPage: React.FC<{ sessionId: string }> = ({ sessionId }) => {
   const api = useApi();
   const navigate = useNavigate();
   const { unpin } = useDock();
+  const { capabilities } = useInstanceAuthorization();
 
   const [state, setState] = useState<'loading' | 'ready' | 'missing'>(sessionId ? 'loading' : 'missing');
   const [title, setTitle] = useState('');
@@ -137,6 +139,7 @@ const MobileShowPage: React.FC<{ sessionId: string }> = ({ sessionId }) => {
             />
             <ShowPageShareControl
               sessionId={sessionId}
+              canManageInstance={capabilities.can_manage_instance}
               onOpenChange={setShareOpen}
             />
           </div>

--- a/ui/src/components/apps/ShowPageRoute.tsx
+++ b/ui/src/components/apps/ShowPageRoute.tsx
@@ -118,27 +118,29 @@ const MobileShowPage: React.FC<{ sessionId: string }> = ({ sessionId }) => {
           <ArrowLeft className="size-3.5" />
         </Button>
         <span className="min-w-0 flex-1 truncate text-[14px] font-semibold text-foreground">{label}</span>
-        <div className="ml-auto flex shrink-0 items-center gap-1.5">
-          <ShowPageAnnotateControl
-            state={annotationState}
-            onEnable={enableAnnotation}
-            onDisable={disableAnnotation}
-            onSetMode={setAnnotationMode}
-            onPopoverOpenChange={setAnnotateOpen}
-          />
-          <ShowPageLaunchControl
-            sessionId={sessionId}
-            title={title || null}
-            showPageMode
-            busy={false}
-            onToggle={() => navigate(sessionChatPath(sessionId, { showChat: true }))}
-            onPrepareLaunch={async () => true}
-          />
-          <ShowPageShareControl
-            sessionId={sessionId}
-            onOpenChange={setShareOpen}
-          />
-        </div>
+        {state === 'ready' && (
+          <div className="ml-auto flex shrink-0 items-center gap-1.5">
+            <ShowPageAnnotateControl
+              state={annotationState}
+              onEnable={enableAnnotation}
+              onDisable={disableAnnotation}
+              onSetMode={setAnnotationMode}
+              onPopoverOpenChange={setAnnotateOpen}
+            />
+            <ShowPageLaunchControl
+              sessionId={sessionId}
+              title={title || null}
+              showPageMode
+              busy={false}
+              onToggle={() => navigate(sessionChatPath(sessionId, { showChat: true }))}
+              onPrepareLaunch={async () => true}
+            />
+            <ShowPageShareControl
+              sessionId={sessionId}
+              onOpenChange={setShareOpen}
+            />
+          </div>
+        )}
       </header>
 
       {missing ? (


### PR DESCRIPTION
## Summary

- Match the mobile Show Page header actions with Chat's visual mode: annotation, back to chat, and share.
- Keep the mobile header controls icon-only and route back to the owning chat with `?view=chat`.
- Shield the embedded Show Page while annotation or share popovers are open.

## Validation

- `npm run test -- --run src/components/apps/ShowPageRoute.test.tsx src/components/workbench/ShowPageAnnotateControl.test.tsx src/components/workbench/ShowPageShareControl.test.tsx`
- `npm run build`
- Targeted ESLint on the changed files
