### PR TITLE
fix(ui): keep chat bubble session links in-app

### DIFF
--- a/ui/src/components/ui/markdown.tsx
+++ b/ui/src/components/ui/markdown.tsx
@@ -3,12 +3,14 @@ import ReactMarkdown, { type Components, defaultUrlTransform } from 'react-markd
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import { Check, Copy } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
 import { ChatImage, LinkedImageContent, LinkedImageProvider } from '@/components/ui/chat-image';
 import { FileCard } from '@/components/ui/file-card';
 import { SecretRequestCard } from '@/components/ui/secret-request-card';
+import { inAppChatPath } from '@/lib/applicationRoutes';
 import { isProxyMediaUrl, readMediaDims } from '@/lib/mediaProxy';
 import { isAbsoluteWindowsFileHref, resolveLocalFileLink, type LocalFileLinkTarget } from '@/lib/localFileLinks';
 import {
@@ -283,6 +285,17 @@ export const Markdown: React.FC<{
           );
         }
         if (!interactive) return <span>{children}</span>;
+        const chatPath = inAppChatPath(
+          url,
+          typeof window === 'undefined' ? null : window.location.href,
+        );
+        if (chatPath) {
+          return (
+            <Link to={chatPath}>
+              <LinkedImageProvider>{children}</LinkedImageProvider>
+            </Link>
+          );
+        }
         // Wrap children so a nested ChatImage (``[![](media)](href)``) renders
         // bare — without its own download anchor inside this one.
         return (

--- a/ui/src/components/workbench/ChatArchivedReadOnly.test.tsx
+++ b/ui/src/components/workbench/ChatArchivedReadOnly.test.tsx
@@ -981,6 +981,22 @@ describe('agent-authored local file links', () => {
     expect(routeMarkup).toContain('target="_blank"');
   });
 
+  it('opens Workbench chat routes in the current document', () => {
+    const props = {
+      session: session({ workdir: '/workspace/project' }),
+      messageFontSize: 13,
+      onOpenLocalFile: () => undefined,
+    };
+    const chatMessage = {
+      ...linkedMessage('agent'),
+      text: '[open chat](/chat/session-456)',
+    } as WorkbenchMessage;
+    const markup = render(<MessageRow {...props} message={chatMessage} />);
+    expect(markup).toContain('href="/chat/session-456"');
+    expect(markup).not.toContain('target="_blank"');
+    expect(markup).not.toContain('data-local-file-link');
+  });
+
   it('lets the outer local link own clicks for a linked local image', () => {
     const linkedImageMessage = {
       ...linkedMessage('agent'),

--- a/ui/src/lib/applicationRoutes.test.ts
+++ b/ui/src/lib/applicationRoutes.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import {
   APPLICATION_DYNAMIC_ROUTE_PATHS,
   APPLICATION_ROUTE_PATHS,
+  inAppChatPath,
   isApplicationRouteHref,
 } from './applicationRoutes';
 
@@ -72,5 +73,22 @@ describe('AppShell route policy', () => {
     expect(isApplicationRouteHref('/apps/show/session-123')).toBe(true);
     expect(isApplicationRouteHref('/projects/report.md')).toBe(false);
     expect(isApplicationRouteHref('/admin/settings/custom.json')).toBe(false);
+  });
+
+  it('keeps same-origin chat destinations on the SPA path', () => {
+    expect(APPLICATION_DYNAMIC_ROUTE_PATHS).toContain('/chat/:sessionId');
+    const current = 'https://alex-app.avibe.bot/chat/session-123';
+    expect(inAppChatPath('/chat/session-456?msg=latest#reply')).toBe(
+      '/chat/session-456?msg=latest#reply',
+    );
+    expect(inAppChatPath('/chat/session-456/')).toBe('/chat/session-456');
+    expect(inAppChatPath('https://alex-app.avibe.bot/chat/session-456', current)).toBe(
+      '/chat/session-456',
+    );
+    expect(inAppChatPath('https://github.com/avibe-bot/avibe/chat/session-456', current)).toBeNull();
+    expect(inAppChatPath('/apps/files')).toBeNull();
+    expect(inAppChatPath('/chat/session-456/notes.md')).toBeNull();
+    expect(inAppChatPath('./chat/session-456')).toBeNull();
+    expect(inAppChatPath('https://alex-app.avibe.bot/chat/session-456')).toBeNull();
   });
 });

--- a/ui/src/lib/applicationRoutes.ts
+++ b/ui/src/lib/applicationRoutes.ts
@@ -73,12 +73,49 @@ const APPLICATION_ROUTE_PATTERNS = APPLICATION_DYNAMIC_ROUTE_PATHS.map((path) =>
   const pattern = path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/:[^/]+/g, '[^/]+');
   return new RegExp(`^${pattern}$`);
 });
+const CHAT_ROUTE_PATTERN = APPLICATION_ROUTE_PATTERNS[
+  APPLICATION_DYNAMIC_ROUTE_PATHS.indexOf('/chat/:sessionId')
+];
+
+function hrefPathname(href: string): string {
+  const rawPathname = href.split(/[?#]/, 1)[0];
+  return rawPathname.replace(/\/+$/, '') || '/';
+}
+
+function isAbsoluteHref(href: string): boolean {
+  return /^[a-zA-Z][a-zA-Z+\-.]*:/.test(href) || href.startsWith('//');
+}
 
 export function isApplicationRouteHref(href: string): boolean {
-  const rawPathname = href.split(/[?#]/, 1)[0];
-  const pathname = rawPathname.replace(/\/+$/, '') || '/';
+  const pathname = hrefPathname(href);
   return (
     APPLICATION_ROUTES.has(pathname) ||
     APPLICATION_ROUTE_PATTERNS.some((pattern) => pattern.test(pathname))
   );
+}
+
+export function inAppChatPath(href: string, currentHref?: string | null): string | null {
+  try {
+    if (!href) return null;
+    if (isAbsoluteHref(href)) {
+      if (!currentHref) return null;
+      const current = new URL(currentHref);
+      const target = new URL(href, current);
+      if (target.origin !== current.origin || !['http:', 'https:'].includes(target.protocol)) {
+        return null;
+      }
+      return chatPath(target.pathname, target.search, target.hash);
+    }
+    if (!href.startsWith('/') || href.startsWith('//')) return null;
+    const target = new URL(href, 'https://avibe.invalid');
+    return chatPath(target.pathname, target.search, target.hash);
+  } catch {
+    return null;
+  }
+}
+
+function chatPath(pathname: string, search: string, hash: string): string | null {
+  const normalized = hrefPathname(pathname);
+  if (!CHAT_ROUTE_PATTERN?.test(normalized)) return null;
+  return `${normalized}${search}${hash}`;
 }


### PR DESCRIPTION
## Summary

Desktop Chat bubbles currently open every ordinary Markdown link in a new tab, including same-origin `/chat/:sessionId` destinations. iOS PWA already keeps those AppShell routes in-app via React Router; desktop now does the same for chat session links only.

## Changed capability

- Same-origin `/chat/:sessionId` Markdown links (relative or absolute) render as a React Router `Link` and stay in the current document.
- Other Workbench routes such as `/apps/files` remain `_blank`.
- Cross-origin `/chat/...` URLs, nested `/chat/:id/...` paths, and local-file links are unchanged.

## Evidence

- **Unit**: `applicationRoutes` now owns `inAppChatPath()` and asserts relative, same-origin, and rejected destinations.
- **Contract**: Chat bubble Markdown rendering asserts `/chat/session-456` has no `target="_blank"`, while `/apps/files` still does.
- **Scenario**: none in catalog; this is renderer navigation policy.
- **Residual manual**: click a same-origin `/chat/:id` link in a desktop Chat bubble and confirm it switches sessions without a new tab.

## Known-by-design

- Only `/chat/:sessionId` is in-app on desktop. Broader AppShell SPA interception remains an iOS PWA concern.
