### PR TITLE
fix(show-runtime): narrow managed install identity

### DIFF
--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -1824,6 +1824,14 @@ class ShowRuntimeManager:
             node,
         )
         if verified_existing_command and not self.force_install:
+            verified_install_dir = next(
+                iter(self._manifest_install_dirs_for_command(verified_existing_command)),
+                None,
+            )
+            if verified_install_dir is None:
+                self._install_reason = "runtime_install_failed"
+                return None
+            self._write_current_manifest_pointer(manifest, archive, verified_install_dir)
             self._install_reason = None
             return verified_existing_command
         archive_path = self._resolve_manifest_archive(archive)

--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -698,9 +698,15 @@ class ShowRuntimeManager:
             archive = manifest.archives.get(platform_tag)
             if archive:
                 installed_dir = self._manifest_install_dir(manifest, archive)
-                installed_matches = self._manifest_install_matches(installed_dir, manifest, archive)
-                if installed_matches and node and node_supported is not False:
-                    installed_command = self._manifest_runtime_command(installed_dir, node)
+                for candidate in self._manifest_install_candidates(manifest, archive):
+                    if not self._manifest_install_matches(candidate, manifest, archive):
+                        continue
+                    installed_dir = candidate
+                    installed_matches = True
+                    if node and node_supported is not False:
+                        installed_command = self._manifest_runtime_command(candidate, node)
+                        if installed_command:
+                            break
         elif not configured_command and self.runtime_source == _RUNTIME_SOURCE_ARCHIVE:
             installed_dir = self._archive_install_dir()
             installed_command = self._archive_runtime_command(installed_dir, node or ["node"])
@@ -1635,11 +1641,7 @@ class ShowRuntimeManager:
         archive = self._manifest_archive_for_platform(manifest)
         if not archive:
             return None
-        install_dir = self._manifest_install_dir(manifest, archive)
-        command = self._verified_manifest_runtime_command(install_dir, manifest, archive, node)
-        if command:
-            return command
-        return self._verified_manifest_runtime_command(self._legacy_manifest_install_dir(manifest, archive), manifest, archive, node)
+        return self._verified_manifest_runtime_command_for_manifest(manifest, archive, node)
 
     @contextlib.contextmanager
     def _install_guard_locked(self, *, timeout_seconds: float = 0.0):
@@ -1797,11 +1799,7 @@ class ShowRuntimeManager:
             archive = self._manifest_archive_for_platform(manifest)
             if not archive:
                 return None
-            install_dir = self._manifest_install_dir(manifest, archive)
-            command = self._verified_manifest_runtime_command(install_dir, manifest, archive, node)
-            if not command:
-                legacy_install_dir = self._legacy_manifest_install_dir(manifest, archive)
-                command = self._verified_manifest_runtime_command(legacy_install_dir, manifest, archive, node)
+            command = self._verified_manifest_runtime_command_for_manifest(manifest, archive, node)
             return self._reuse_existing_archive_runtime(command)
         except Exception:
             return None
@@ -1820,10 +1818,11 @@ class ShowRuntimeManager:
         if not archive:
             return None
         install_dir = self._manifest_install_dir(manifest, archive)
-        verified_existing_command = self._verified_manifest_runtime_command(install_dir, manifest, archive, node)
-        if not verified_existing_command:
-            legacy_install_dir = self._legacy_manifest_install_dir(manifest, archive)
-            verified_existing_command = self._verified_manifest_runtime_command(legacy_install_dir, manifest, archive, node)
+        verified_existing_command = self._verified_manifest_runtime_command_for_manifest(
+            manifest,
+            archive,
+            node,
+        )
         if verified_existing_command and not self.force_install:
             self._install_reason = None
             return verified_existing_command
@@ -1981,7 +1980,9 @@ class ShowRuntimeManager:
         return True
 
     def _manifest_install_dir(self, manifest: ShowRuntimeManifest, archive: ShowRuntimeArchive) -> Path:
-        fingerprint = hashlib.sha256(f"{manifest.digest}:{archive.sha256}".encode("utf-8")).hexdigest()[:16]
+        fingerprint = hashlib.sha256(
+            f"{manifest.runtime_version}:{archive.platform}:{archive.sha256}".encode("utf-8")
+        ).hexdigest()[:16]
         return (
             self.runtime_dir
             / "versions"
@@ -1992,6 +1993,40 @@ class ShowRuntimeManager:
 
     def _legacy_manifest_install_dir(self, manifest: ShowRuntimeManifest, archive: ShowRuntimeArchive) -> Path:
         return self.runtime_dir / "versions" / _safe_path_part(manifest.runtime_version) / _safe_path_part(archive.platform)
+
+    def _manifest_install_candidates(
+        self,
+        manifest: ShowRuntimeManifest,
+        archive: ShowRuntimeArchive,
+    ) -> Iterator[Path]:
+        install_dir = self._manifest_install_dir(manifest, archive)
+        legacy_install_dir = self._legacy_manifest_install_dir(manifest, archive)
+        yield install_dir
+        yield legacy_install_dir
+
+        # Releases before the platform-scoped identity used the manifest digest
+        # in this child directory's fingerprint. Metadata proves that layout.
+        try:
+            candidates = sorted(legacy_install_dir.iterdir(), key=lambda path: path.name)
+        except OSError:
+            return
+        for candidate in candidates:
+            if candidate == install_dir:
+                continue
+            try:
+                payload = json.loads(self._manifest_metadata_path(candidate).read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            previous_manifest_sha256 = payload.get("manifest_sha256")
+            if not isinstance(previous_manifest_sha256, str) or not _CONTENT_ADDRESSED_ARCHIVE_RE.fullmatch(
+                f"{previous_manifest_sha256}.tgz"
+            ):
+                continue
+            previous_fingerprint = hashlib.sha256(
+                f"{previous_manifest_sha256}:{archive.sha256}".encode("utf-8")
+            ).hexdigest()[:16]
+            if candidate.name == previous_fingerprint:
+                yield candidate
 
     def _manifest_metadata_path(self, install_dir: Path) -> Path:
         return install_dir / ".vibe-show-runtime.json"
@@ -2008,6 +2043,18 @@ class ShowRuntimeManager:
             return command
         return None
 
+    def _verified_manifest_runtime_command_for_manifest(
+        self,
+        manifest: ShowRuntimeManifest,
+        archive: ShowRuntimeArchive,
+        node: list[str],
+    ) -> list[str] | None:
+        for install_dir in self._manifest_install_candidates(manifest, archive):
+            command = self._verified_manifest_runtime_command(install_dir, manifest, archive, node)
+            if command:
+                return command
+        return None
+
     def _manifest_install_matches(self, install_dir: Path, manifest: ShowRuntimeManifest, archive: ShowRuntimeArchive) -> bool:
         try:
             payload = json.loads(self._manifest_metadata_path(install_dir).read_text(encoding="utf-8"))
@@ -2015,7 +2062,6 @@ class ShowRuntimeManager:
             return False
         return (
             payload.get("provider") == _RUNTIME_SOURCE_MANIFEST
-            and payload.get("manifest_sha256") == manifest.digest
             and payload.get("runtime_version") == manifest.runtime_version
             and payload.get("platform") == archive.platform
             and payload.get("archive_sha256") == archive.sha256

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -6654,7 +6654,6 @@ def test_show_runtime_manager_adopts_previous_fingerprint_and_preserves_gc_prote
     previous_cli.parent.mkdir(parents=True)
     previous_cli.write_text("previous fingerprint runtime\n", encoding="utf-8")
     previous_manager._write_manifest_install_metadata(previous_install_dir, previous_manifest, archive)
-    previous_manager._write_current_manifest_pointer(previous_manifest, archive, previous_install_dir)
 
     downloads_dir = runtime_dir / "downloads"
     downloads_dir.mkdir(parents=True)
@@ -6681,6 +6680,19 @@ def test_show_runtime_manager_adopts_previous_fingerprint_and_preserves_gc_prote
     stale_archive = downloads_dir / f"{stale_sha256}.tgz"
     stale_archive.write_bytes(b"stale")
     os.utime(stale_archive, (1, 1))
+    (runtime_dir / "current.json").write_text(
+        json.dumps(
+            {
+                "provider": "manifest-cache",
+                "runtime_version": "stale-runtime",
+                "platform": archive.platform,
+                "install_dir": str(stale_install_dir),
+                "manifest_sha256": "d" * 64,
+                "archive_sha256": stale_sha256,
+            }
+        ),
+        encoding="utf-8",
+    )
 
     payload = json.loads(manifest_path.read_text(encoding="utf-8"))
     payload["archives"]["other-platform"] = {
@@ -6711,6 +6723,10 @@ def test_show_runtime_manager_adopts_previous_fingerprint_and_preserves_gc_prote
     assert previous_install_dir.exists() is True
     assert manager._manifest_install_dir(current_manifest, archive).exists() is False
     assert archive.sha256 in manager._protected_archive_sha256s()
+    current_pointer = json.loads((runtime_dir / "current.json").read_text(encoding="utf-8"))
+    assert current_pointer["runtime_version"] == current_manifest.runtime_version
+    assert current_pointer["install_dir"] == str(previous_install_dir)
+    assert current_pointer["archive_sha256"] == archive.sha256
 
     clean_result = manager.clean(keep_previous=0)
 

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -6396,6 +6396,7 @@ def test_show_runtime_manager_installs_from_manifest_cache(monkeypatch, tmp_path
     assert (runtime_dir / "downloads" / f"{_sha256(archive_path)}.tgz").exists()
     metadata = json.loads((installed_cli.parents[4] / ".vibe-show-runtime.json").read_text(encoding="utf-8"))
     assert metadata["provider"] == "manifest-cache"
+    assert metadata["manifest_sha256"] == manifest.digest
     assert metadata["archive_sha256"] == _sha256(archive_path)
     status = manager.status()
     assert status["installed"] is True
@@ -6554,7 +6555,7 @@ def test_show_runtime_archive_probe_uses_body_free_head_request(monkeypatch, tmp
     assert requests[0].get_method() == "HEAD"
 
 
-def test_show_runtime_manager_manifest_install_dir_includes_manifest_and_archive_identity(monkeypatch, tmp_path):
+def test_show_runtime_manager_manifest_install_dir_includes_runtime_and_archive_identity(monkeypatch, tmp_path):
     old_archive_path = _write_runtime_archive(tmp_path / "old", text="old runtime\n")
     old_manifest_path = _write_runtime_manifest(tmp_path / "old", old_archive_path)
     runtime_dir = tmp_path / "runtime"
@@ -6584,6 +6585,140 @@ def test_show_runtime_manager_manifest_install_dir_includes_manifest_and_archive
     assert new_cli.read_text(encoding="utf-8") == "new runtime\n"
     assert old_cli.read_text(encoding="utf-8") == "old runtime\n"
     assert new_manager.status()["installed_matches_manifest"] is True
+
+
+def test_show_runtime_manager_manifest_install_identity_ignores_other_platform_edits(monkeypatch, tmp_path):
+    archive_path = _write_runtime_archive(tmp_path, text="current platform runtime\n")
+    manifest_path = _write_runtime_manifest(tmp_path, archive_path)
+    runtime_dir = tmp_path / "runtime"
+    monkeypatch.setattr("core.show_runtime._resolve_command", lambda command: ["/bin/node"] if command == "node" else None)
+
+    initial_manager = ShowRuntimeManager(
+        workspace_root=tmp_path / "show",
+        runtime_dir=runtime_dir,
+        manifest_path=manifest_path,
+    )
+    initial_result = initial_manager.prepare()
+    initial_manifest = initial_manager._load_runtime_manifest()
+    assert initial_manifest is not None
+
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["archives"]["other-platform"] = {
+        "name": "vibe-show-runtime-node-other-platform.tgz",
+        "url": "https://example.test/other-platform.tgz",
+        "sha256": "f" * 64,
+        "size": 1,
+    }
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    edited_manager = ShowRuntimeManager(
+        workspace_root=tmp_path / "show",
+        runtime_dir=runtime_dir,
+        manifest_path=manifest_path,
+        offline=True,
+    )
+    edited_manifest = edited_manager._load_runtime_manifest()
+    assert edited_manifest is not None
+    assert edited_manifest.digest != initial_manifest.digest
+
+    def _unexpected_archive_resolution(_archive):
+        raise AssertionError("an unrelated platform edit must not trigger archive resolution")
+
+    monkeypatch.setattr(edited_manager, "_resolve_manifest_archive", _unexpected_archive_resolution)
+    edited_result = edited_manager.prepare()
+
+    assert edited_result["ok"] is True
+    assert edited_result["command"] == initial_result["command"]
+    assert edited_result["status"]["installed_matches_manifest"] is True
+
+
+def test_show_runtime_manager_adopts_previous_fingerprint_and_preserves_gc_protection(monkeypatch, tmp_path):
+    archive_path = _write_runtime_archive(tmp_path, text="previous fingerprint runtime\n")
+    manifest_path = _write_runtime_manifest(tmp_path, archive_path)
+    runtime_dir = tmp_path / "runtime"
+    monkeypatch.setattr("core.show_runtime._resolve_command", lambda command: ["/bin/node"] if command == "node" else None)
+
+    previous_manager = ShowRuntimeManager(
+        workspace_root=tmp_path / "show",
+        runtime_dir=runtime_dir,
+        manifest_path=manifest_path,
+    )
+    previous_manifest = previous_manager._load_runtime_manifest()
+    assert previous_manifest is not None
+    archive = previous_manager._manifest_archive_for_platform(previous_manifest)
+    assert archive is not None
+    previous_fingerprint = hashlib.sha256(
+        f"{previous_manifest.digest}:{archive.sha256}".encode("utf-8")
+    ).hexdigest()[:16]
+    previous_install_dir = previous_manager._legacy_manifest_install_dir(previous_manifest, archive) / previous_fingerprint
+    previous_cli = previous_install_dir / "node_modules" / "@avibe" / "show-runtime" / "dist" / "cli.js"
+    previous_cli.parent.mkdir(parents=True)
+    previous_cli.write_text("previous fingerprint runtime\n", encoding="utf-8")
+    previous_manager._write_manifest_install_metadata(previous_install_dir, previous_manifest, archive)
+    previous_manager._write_current_manifest_pointer(previous_manifest, archive, previous_install_dir)
+
+    downloads_dir = runtime_dir / "downloads"
+    downloads_dir.mkdir(parents=True)
+    adopted_archive = downloads_dir / f"{archive.sha256}.tgz"
+    adopted_archive.write_bytes(archive_path.read_bytes())
+    os.utime(adopted_archive, (1, 1))
+    stale_sha256 = "e" * 64
+    stale_install_dir = runtime_dir / "versions" / "stale-runtime" / archive.platform / "stale-fingerprint"
+    stale_install_dir.mkdir(parents=True)
+    (stale_install_dir / ".vibe-show-runtime.json").write_text(
+        json.dumps(
+            {
+                "provider": "manifest-cache",
+                "manifest_sha256": "d" * 64,
+                "runtime_version": "stale-runtime",
+                "platform": archive.platform,
+                "archive_name": "stale.tgz",
+                "archive_sha256": stale_sha256,
+                "manifest_source": str(manifest_path),
+            }
+        ),
+        encoding="utf-8",
+    )
+    stale_archive = downloads_dir / f"{stale_sha256}.tgz"
+    stale_archive.write_bytes(b"stale")
+    os.utime(stale_archive, (1, 1))
+
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["archives"]["other-platform"] = {
+        "name": "vibe-show-runtime-node-other-platform.tgz",
+        "url": "https://example.test/other-platform.tgz",
+        "sha256": "f" * 64,
+        "size": 1,
+    }
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    manager = ShowRuntimeManager(
+        workspace_root=tmp_path / "show",
+        runtime_dir=runtime_dir,
+        manifest_path=manifest_path,
+        offline=True,
+    )
+    current_manifest = manager._load_runtime_manifest()
+    assert current_manifest is not None
+    assert manager._manifest_install_dir(current_manifest, archive) != previous_install_dir
+
+    def _unexpected_archive_resolution(_archive):
+        raise AssertionError("a previous-fingerprint install must be adopted without a download")
+
+    monkeypatch.setattr(manager, "_resolve_manifest_archive", _unexpected_archive_resolution)
+    result = manager.prepare()
+
+    assert result["ok"] is True
+    assert result["command"] == ["/bin/node", str(previous_cli)]
+    assert previous_install_dir.exists() is True
+    assert manager._manifest_install_dir(current_manifest, archive).exists() is False
+    assert archive.sha256 in manager._protected_archive_sha256s()
+
+    clean_result = manager.clean(keep_previous=0)
+
+    assert str(previous_install_dir) not in clean_result["removed"]
+    assert previous_install_dir.exists() is True
+    assert adopted_archive.exists() is True
+    assert stale_install_dir.exists() is False
+    assert stale_archive.exists() is False
 
 
 def test_show_runtime_clean_prunes_stale_manifest_fingerprints(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- scope managed Show Runtime install identity to `runtime_version`, platform, and archive SHA-256
- keep `manifest_sha256` in install metadata for diagnostics without making unrelated manifest content part of identity
- discover and reuse installs created by the previous manifest-digest fingerprint layout without moving or downloading them
- share the migration candidate path across status, normal reuse, install-lock fallback, and prepare
- update `current.json` to the verified install on every successful adoption so install and archive GC protect the runtime being served

## Evidence

- Unit: 349 tests passed across `test_ui_show_pages.py`, archive cleanup, manifest, and manifest packaging coverage
- Unit: all 100 `test_show_runtime_*.py` tests passed
- Lint: Ruff passed on both changed Python files
- Contract: added hermetic coverage for an unrelated-platform manifest edit, previous-fingerprint adoption without archive resolution, and adoption from a pointer naming another runtime followed by `clean(keep_previous=0)`
- Scenario catalog: none applies to this internal managed-runtime identity change
- Residual manual: no Incus regression in this PR; W2 changes filesystem identity/reuse only, while the plan's end-to-end network recovery regression belongs to W4/W5 and W3

## Dependencies

None.

## Known by design

- `manifest_sha256` remains diagnostic metadata but is no longer an equality gate.
- An install with a different runtime version, platform, or archive SHA-256 is never reused.
- Migration recognizes the exact previous fingerprint layout and leaves the adopted install in place.
- The install returned by successful adoption is always the install named by `current.json`.
