### PR TITLE
fix(ui): improve mobile built-in apps

### DIFF
--- a/ui/eslint-baseline.json
+++ b/ui/eslint-baseline.json
@@ -96,9 +96,6 @@
     "src/components/ui/vault-chat-requests.tsx": {
       "react-hooks/set-state-in-effect": 1
     },
-    "src/components/workbench/AppsEditorPage.tsx": {
-      "react-hooks/set-state-in-effect": 1
-    },
     "src/components/workbench/ChatPage.tsx": {
       "@typescript-eslint/no-explicit-any": 1,
       "react-hooks/set-state-in-effect": 3

--- a/ui/src/components/AppShell.test.tsx
+++ b/ui/src/components/AppShell.test.tsx
@@ -284,6 +284,24 @@ describe('AppShell remote Apps access', () => {
     expect(surface.parentElement?.className).not.toContain('px-4 py-5');
   });
 
+  it.each(['/apps/files', '/apps/terminal', '/apps/editor'])('gives the mobile built-in app %s the full viewport', async (path) => {
+    render(
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route element={<AppShell />}>
+            <Route path={path.slice(1)} element={<div data-testid="builtin-app-surface" />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const surface = await screen.findByTestId('builtin-app-surface');
+    expect(screen.queryByRole('banner')).toBeNull();
+    expect(document.querySelector('nav.fixed.inset-x-0.bottom-0')).toBeNull();
+    expect(surface.parentElement?.className).toContain('h-full p-0');
+    expect(surface.parentElement?.className).not.toContain('px-4 py-5');
+  });
+
   it.each([
     ['owner', true],
     ['member', false],

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -544,14 +544,15 @@ export const AppShell: React.FC = () => {
       : []),
   ];
 
-  // Chat is a full-screen detail (own composer) and Search is a full-screen
-  // focused surface (own header + back button); the wizard owns the whole
-  // viewport. These mobile surfaces render their own top chrome, so the shell's
-  // mobile brand header AND the bottom tab bar are hidden on them.
+  // Chat is a full-screen detail (own composer), Search is a full-screen focused
+  // surface (own header + back button), and built-in apps own their toolbars.
+  // These mobile surfaces render their own top chrome, so the shell's mobile
+  // brand header AND the bottom tab bar are hidden on them.
   const isChat = location.pathname.startsWith('/chat/');
   const isSearch = location.pathname === '/search';
   const isShowPageApp = location.pathname.startsWith('/apps/show/');
-  const isFullScreenMobile = isChat || isSearch || isShowPageApp;
+  const isBuiltinApp = isStandaloneAppRoutePath(location.pathname);
+  const isFullScreenMobile = isChat || isSearch || isShowPageApp || isBuiltinApp;
 
   const showBottomNav = !isFullScreenMobile && !chromeless && location.pathname !== '/setup';
 
@@ -739,7 +740,7 @@ export const AppShell: React.FC = () => {
             // Single-app tab: no sidebar offset, no scroll, no page glow — the app body
             // is the only thing in the viewport and sizes itself to this box (h-full).
             ? 'min-h-0 flex-1 overflow-hidden'
-            : isShowPageApp
+            : isFullScreenMobile
               ? 'min-h-0 flex-1 overflow-hidden md:ml-[240px] md:min-h-screen md:flex-none md:overflow-visible md:pb-0'
             : 'flex-1 min-h-0 overflow-y-auto md:ml-[240px] md:min-h-screen md:flex-none md:overflow-visible md:pb-0',
           !chromeless && (showBottomNav ? 'pb-[calc(5.5rem+env(safe-area-inset-bottom))]' : 'pb-0'),
@@ -751,7 +752,7 @@ export const AppShell: React.FC = () => {
           'w-full',
           chromeless
             ? 'h-full'
-            : isShowPageApp
+            : isFullScreenMobile
               ? 'h-full p-0 md:mx-auto md:h-auto md:px-10 md:py-8'
             : 'mx-auto px-4 py-5 md:px-10 md:py-8',
         )}>

--- a/ui/src/components/apps/MobileAppHeader.tsx
+++ b/ui/src/components/apps/MobileAppHeader.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react';
+import { ArrowLeft, type LucideIcon } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+import { hasInAppBackEntry } from '../../lib/navigationHistory';
+import { Button } from '../ui/button';
+
+/** Compact route chrome for built-in apps on phones.
+ *
+ * The shell owns navigation for ordinary pages, but an app surface needs the
+ * whole viewport. Keeping this header local gives each app a consistent back
+ * affordance without bringing the global Avibe brand bar back into the view.
+ */
+export const MobileAppHeader: React.FC<{
+  title: string;
+  icon: LucideIcon;
+  actions?: ReactNode;
+  fallback?: string;
+}> = ({ title, icon: Icon, actions, fallback = '/' }) => {
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+
+  return (
+    <header className="flex h-[calc(3rem+env(safe-area-inset-top))] shrink-0 items-center gap-2 border-b border-border bg-surface/95 px-3 pt-[env(safe-area-inset-top)] backdrop-blur">
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="size-8 shrink-0 text-muted"
+        aria-label={t('common.back')}
+        title={t('common.back')}
+        onClick={() => (hasInAppBackEntry(window.history.state) ? navigate(-1) : navigate(fallback))}
+      >
+        <ArrowLeft className="size-4" />
+      </Button>
+      <div className="flex min-w-0 items-center gap-2">
+        <Icon className="size-4 shrink-0 text-mint-ink" />
+        <span className="truncate text-[14px] font-semibold text-foreground">{title}</span>
+      </div>
+      {actions && <div className="ml-auto flex shrink-0 items-center gap-1">{actions}</div>}
+    </header>
+  );
+};

--- a/ui/src/components/workbench/AppsEditorPage.tsx
+++ b/ui/src/components/workbench/AppsEditorPage.tsx
@@ -1,19 +1,18 @@
 import { Suspense, lazy, useEffect, useMemo, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { CodeXml, FolderOpen } from 'lucide-react';
+import { CodeXml } from 'lucide-react';
 import clsx from 'clsx';
 
-import { Button } from '../ui/button';
 import { useUnsavedChanges } from '../../context/useUnsavedChanges';
 import { useStandaloneAppTab } from '../../context/StandaloneAppTabContext';
-import { FileEditorPane } from './FileEditorPane';
-import { EditorFontSizePopover } from './EditorFontSizePopover';
 import { isDesktopViewport } from '../../lib/useIsDesktop';
+import { MobileAppHeader } from '../apps/MobileAppHeader';
 
-// The Editor app as a full-page route (sibling of /apps/files and /apps/terminal). On desktop it
-// mounts the same full Editor IDE the Dock window uses; on phones — where there is no window layer —
-// it renders a slim single-file editor. Design: `dnYPx` (IDE) + `w0qoC` (welcome).
+// The Editor app as a full-page route (sibling of /apps/files and /apps/terminal). The same IDE is
+// used on desktop and phones so explorer, search, tabs, recent files, and save-as do not disappear
+// on the smaller surface. The mobile shell starts with the explorer collapsed to leave the editor
+// readable, and the activity bar can reopen it when needed. Design: `dnYPx` (IDE) + `w0qoC` (welcome).
 const EditorApp = lazy(() => import('./EditorApp').then((m) => ({ default: m.EditorApp })));
 
 // A file handed to the editor when navigating in from the File Browser (mobile) or a direct link.
@@ -79,9 +78,11 @@ export const AppsEditorPage: React.FC = () => {
   // Re-read whenever the router state changes (each navigation carries a fresh state object) so
   // opening another file while already on this route swaps the launch target.
   const launch = useMemo(() => readLaunch(location.state), [location.state]);
-  // A single-app browser tab (`?standalone=1`): the shell drops its chrome, so the editor
-  // fills the whole web area — no page header, no card border, no padding around it.
-  const fullBleed = useStandaloneAppTab();
+  const standalone = useStandaloneAppTab();
+  // The shell drops its chrome for standalone tabs. Ordinary phone routes also
+  // fill the viewport and render a compact app-local header instead.
+  const mobileRoute = !desktop && !standalone;
+  const fullBleed = standalone || !desktop;
   useUnsavedChanges(dirty ? t('apps.editor.confirmDiscardSwitch') : null);
   useUnloadWarning(dirty);
 
@@ -89,34 +90,32 @@ export const AppsEditorPage: React.FC = () => {
     <div
       className={
         fullBleed
-          ? 'flex h-full w-full flex-col bg-surface'
+          ? 'flex h-full w-full flex-col bg-surface pb-[env(safe-area-inset-bottom)]'
           : 'flex h-[calc(100dvh-7rem)] min-h-[460px] flex-col gap-3 md:h-[calc(100vh-8rem)]'
       }
     >
+      {mobileRoute && <MobileAppHeader title={t('apps.editor.label')} icon={CodeXml} />}
       {!fullBleed && (
         <div>
           <h1 className="text-[18px] font-semibold text-foreground">{t('apps.editor.label')}</h1>
           <p className="text-[12px] text-muted">{t('apps.editor.tagline')}</p>
         </div>
       )}
-      {desktop ? (
-        <DesktopEditor launch={launch} onDirtyChange={setDirty} fullBleed={fullBleed} />
-      ) : (
-        <MobileEditor launch={launch} onDirtyChange={setDirty} fullBleed={fullBleed} />
-      )}
+      <EditorSurface launch={launch} onDirtyChange={setDirty} fullBleed={fullBleed} mobile={!desktop} />
     </div>
   );
 };
 
-// Desktop / tablet: the full Editor IDE, forced dark like its Dock window (data-theme re-cascades the
-// dark token set to this subtree). No windowId, so the window-only niceties (title, close guard,
-// ⌘O/⌘N) stay inert; open/edit/save all work full-page. `useWindowCloseGuard` is a no-op without a
-// window, so the route page owns its navigation and unload guards.
-const DesktopEditor: React.FC<{
+// Full Editor IDE, forced dark like its Dock window (data-theme re-cascades the dark token set to
+// this subtree). No windowId, so the window-only niceties (title, close guard, ⌘O/⌘N) stay inert;
+// open/edit/save all work full-page. `useWindowCloseGuard` is a no-op without a window, so the route
+// page owns its navigation and unload guards.
+const EditorSurface: React.FC<{
   launch: LaunchFile | null;
   onDirtyChange: (dirty: boolean) => void;
   fullBleed?: boolean;
-}> = ({ launch, onDirtyChange, fullBleed = false }) => {
+  mobile?: boolean;
+}> = ({ launch, onDirtyChange, fullBleed = false, mobile = false }) => {
   return (
     <div
       data-theme="dark"
@@ -126,72 +125,9 @@ const DesktopEditor: React.FC<{
         <EditorApp
           onDirtyChange={onDirtyChange}
           params={launch ?? undefined}
+          mobile={mobile}
         />
       </Suspense>
-    </div>
-  );
-};
-
-// Phone single-file editor: one file at a time (no activity bar / explorer). FileEditorPane already
-// renders the filename + dirty dot + Save header and the Monaco touch accessory bar; opening/switching
-// a file reuses the File Browser (the mobile file-picking surface, which owns the editable-vs-download
-// decision). The name-only launch has no live cursor/search — that richness stays on the desktop IDE.
-const MobileEditor: React.FC<{
-  launch: LaunchFile | null;
-  onDirtyChange: (dirty: boolean) => void;
-  fullBleed?: boolean;
-}> = ({ launch, onDirtyChange, fullBleed = false }) => {
-  const { t } = useTranslation();
-  const navigate = useNavigate();
-  const [file, setFile] = useState<LaunchFile | null>(launch);
-
-  // A fresh navigation from Files swaps the open file. The router-wide blocker already confirmed
-  // before a dirty editor could leave this page to pick another.
-  useEffect(() => {
-    if (launch) {
-      setFile(launch);
-      onDirtyChange(false);
-    }
-  }, [launch, onDirtyChange]);
-
-  // This imperative navigation uses the same router-level blocker as links and browser Back.
-  const openAnother = () => navigate('/apps/files');
-
-  return (
-    <div className={clsx('flex min-h-0 flex-1 flex-col overflow-hidden bg-surface', !fullBleed && 'rounded-xl border border-border')}>
-      {file ? (
-        // Key by path so switching to a different file remounts the pane and reads it fresh —
-        // FileEditorPane treats a live path change as a rename and skips the reread otherwise, which
-        // would show the previous file's buffer under the new name.
-        <FileEditorPane
-          key={file.path}
-          path={file.path}
-          filename={file.filename}
-          mtime={file.mtime}
-          onOpenFile={openAnother}
-          headerActions={<EditorFontSizePopover trigger="mobile" />}
-          onDirtyChange={onDirtyChange}
-          reveal={file.line ? {
-            line: file.line,
-            column: file.column ?? 0,
-            endColumn: file.endColumn ?? file.column ?? 0,
-            nonce: 0,
-          } : null}
-        />
-      ) : (
-        <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
-          <span className="grid size-12 place-items-center rounded-2xl border border-violet/50 bg-violet/[0.1]">
-            <CodeXml className="size-6 text-violet-ink" />
-          </span>
-          <div className="flex flex-col gap-1">
-            <div className="text-[15px] font-semibold text-foreground">{t('apps.editor.empty')}</div>
-            <p className="max-w-[260px] text-[12.5px] text-muted">{t('apps.editor.emptyHint')}</p>
-          </div>
-          <Button type="button" variant="brand" size="sm" className="gap-1.5" onClick={() => navigate('/apps/files')}>
-            <FolderOpen className="size-4" /> {t('apps.editor.browseFiles')}
-          </Button>
-        </div>
-      )}
     </div>
   );
 };

--- a/ui/src/components/workbench/AppsEditorPage.tsx
+++ b/ui/src/components/workbench/AppsEditorPage.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 
 import { useUnsavedChanges } from '../../context/useUnsavedChanges';
 import { useStandaloneAppTab } from '../../context/StandaloneAppTabContext';
-import { isDesktopViewport } from '../../lib/useIsDesktop';
+import { useIsDesktop } from '../../lib/useIsDesktop';
 import { MobileAppHeader } from '../apps/MobileAppHeader';
 
 // The Editor app as a full-page route (sibling of /apps/files and /apps/terminal). The same IDE is
@@ -44,13 +44,6 @@ function readLaunch(state: unknown): LaunchFile | null {
   };
 }
 
-// Pick the surface ONCE at mount, deliberately NOT reactive: swapping between the mobile pane and the
-// desktop IDE on a mid-edit resize/rotate would unmount whichever holds the buffer and silently drop
-// unsaved edits. A phone that rotates keeps the surface it opened with.
-function useDesktopAtMount(): boolean {
-  return useState(isDesktopViewport)[0];
-}
-
 // Warn before a hard unload (refresh / tab close / leaving the SPA) while there are unsaved edits.
 // React Router's blocker handles in-app navigation separately.
 function useUnloadWarning(active: boolean): void {
@@ -73,7 +66,7 @@ const PaneLoading: React.FC = () => {
 export const AppsEditorPage: React.FC = () => {
   const { t } = useTranslation();
   const location = useLocation();
-  const desktop = useDesktopAtMount();
+  const desktop = useIsDesktop();
   const [dirty, setDirty] = useState(false);
   // Re-read whenever the router state changes (each navigation carries a fresh state object) so
   // opening another file while already on this route swaps the launch target.

--- a/ui/src/components/workbench/AppsFileBrowserPage.tsx
+++ b/ui/src/components/workbench/AppsFileBrowserPage.tsx
@@ -34,7 +34,7 @@ import {
   X,
   type LucideIcon,
 } from 'lucide-react';
-import { isDesktopViewport } from '../../lib/useIsDesktop';
+import { useIsDesktop } from '../../lib/useIsDesktop';
 import clsx from 'clsx';
 
 import { useWorkbenchProjectsTree } from '../../context/WorkbenchProjectsContext';
@@ -211,7 +211,8 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
   // A single-app browser tab (`?standalone=1`) frames the app exactly like a window body —
   // full-bleed, no page header or card border — since the shell drops its chrome there too.
   const standalone = useStandaloneAppTab();
-  const mobileRoute = !windowed && !standalone && !isDesktopViewport();
+  const isDesktop = useIsDesktop();
+  const mobileRoute = !windowed && !standalone && !isDesktop;
   const fullBleed = windowed || standalone || mobileRoute;
   const { projects } = useWorkbenchProjectsTree();
   const [cwd, setCwd] = useState('');
@@ -398,26 +399,26 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
   // routes correctly regardless of where it's called from.
   const openInEditor = useCallback(
     (path: string, filename: string, mtime: number | null) => {
-      if (isDesktopViewport()) {
+      if (isDesktop) {
         wm.openApp('editor', { title: filename, params: { path, filename, mtime } });
       } else {
         routerNavigate('/apps/editor', { state: { path, filename, mtime } });
       }
     },
-    [wm, routerNavigate],
+    [isDesktop, wm, routerNavigate],
   );
 
   // Preview capability is shared across breakpoints; only its presentation differs. The caller
   // supplies resolved metadata when it has already been fetched (content hits / ambiguous names).
   const openPreview = useCallback(
     (item: RowItem, entry: FsEntry = item.entry, editable = isEditableFile(entry), mtime = entry.mtime) => {
-      if (isDesktopViewport()) {
+      if (isDesktop) {
         wm.openApp('preview', { title: entry.name, params: { path: item.full, name: entry.name } });
       } else {
         setPreview({ path: item.full, name: entry.name, mtime, editable });
       }
     },
-    [wm],
+    [isDesktop, wm],
   );
 
   // Open a terminal rooted at a folder ("Open Terminal Here"): desktop opens a Terminal window
@@ -425,13 +426,13 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
   // route with the dir in router state. Mirrors openInEditor.
   const openTerminalHere = useCallback(
     (dir: string) => {
-      if (isDesktopViewport()) {
+      if (isDesktop) {
         wm.openApp('terminal', { params: { cwd: dir } });
       } else {
         routerNavigate('/apps/terminal', { state: { cwd: dir } });
       }
     },
-    [wm, routerNavigate],
+    [isDesktop, wm, routerNavigate],
   );
 
   // Open: dir → navigate (and leave search); image / PDF / Office / Markdown → the standalone Preview
@@ -530,12 +531,12 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
   // hidden, so fall back to the inline create row so a file can still be made.
   const onNewFile = useCallback(() => {
     if (!cwd) return;
-    if (isDesktopViewport()) {
+    if (isDesktop) {
       wm.openApp('editor', { title: t('apps.fileBrowser.newFile'), params: { newFileDir: cwd } });
     } else {
       startNewEntry('file');
     }
-  }, [cwd, wm, t, startNewEntry]);
+  }, [cwd, isDesktop, wm, t, startNewEntry]);
 
   // ---- Rename (inline) + Delete ----------------------------------------------------------------
   const [rename, setRename] = useState<{ full: string } | null>(null);
@@ -1794,7 +1795,10 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
       {/* MOBILE-ONLY quick-look overlay: on mobile there's no window layer, so a previewable file
           opens here in-page instead of the standalone Preview window (desktop uses the window). */}
       {preview && (
-        <div className="absolute inset-0 z-20 flex flex-col bg-surface">
+        <div className={clsx(
+          'absolute inset-x-0 bottom-0 z-20 flex flex-col bg-surface',
+          mobileRoute ? 'top-[calc(3rem+env(safe-area-inset-top))]' : 'top-0',
+        )}>
           <div className="flex items-center gap-2 border-b border-border bg-surface-2/60 px-3 py-2">
             <FileText className="size-4 shrink-0 text-muted" />
             <span className="min-w-0 flex-1 truncate text-[12.5px] font-medium text-foreground">{preview.name}</span>

--- a/ui/src/components/workbench/AppsFileBrowserPage.tsx
+++ b/ui/src/components/workbench/AppsFileBrowserPage.tsx
@@ -34,7 +34,7 @@ import {
   X,
   type LucideIcon,
 } from 'lucide-react';
-import { useIsDesktop } from '../../lib/useIsDesktop';
+import { isDesktopViewport, useIsDesktop } from '../../lib/useIsDesktop';
 import clsx from 'clsx';
 
 import { useWorkbenchProjectsTree } from '../../context/WorkbenchProjectsContext';
@@ -399,26 +399,26 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
   // routes correctly regardless of where it's called from.
   const openInEditor = useCallback(
     (path: string, filename: string, mtime: number | null) => {
-      if (isDesktop) {
+      if (isDesktopViewport()) {
         wm.openApp('editor', { title: filename, params: { path, filename, mtime } });
       } else {
         routerNavigate('/apps/editor', { state: { path, filename, mtime } });
       }
     },
-    [isDesktop, wm, routerNavigate],
+    [wm, routerNavigate],
   );
 
   // Preview capability is shared across breakpoints; only its presentation differs. The caller
   // supplies resolved metadata when it has already been fetched (content hits / ambiguous names).
   const openPreview = useCallback(
     (item: RowItem, entry: FsEntry = item.entry, editable = isEditableFile(entry), mtime = entry.mtime) => {
-      if (isDesktop) {
+      if (isDesktopViewport()) {
         wm.openApp('preview', { title: entry.name, params: { path: item.full, name: entry.name } });
       } else {
         setPreview({ path: item.full, name: entry.name, mtime, editable });
       }
     },
-    [isDesktop, wm],
+    [wm],
   );
 
   // Open a terminal rooted at a folder ("Open Terminal Here"): desktop opens a Terminal window
@@ -426,13 +426,13 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
   // route with the dir in router state. Mirrors openInEditor.
   const openTerminalHere = useCallback(
     (dir: string) => {
-      if (isDesktop) {
+      if (isDesktopViewport()) {
         wm.openApp('terminal', { params: { cwd: dir } });
       } else {
         routerNavigate('/apps/terminal', { state: { cwd: dir } });
       }
     },
-    [isDesktop, wm, routerNavigate],
+    [wm, routerNavigate],
   );
 
   // Open: dir → navigate (and leave search); image / PDF / Office / Markdown → the standalone Preview
@@ -531,12 +531,12 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
   // hidden, so fall back to the inline create row so a file can still be made.
   const onNewFile = useCallback(() => {
     if (!cwd) return;
-    if (isDesktop) {
+    if (isDesktopViewport()) {
       wm.openApp('editor', { title: t('apps.fileBrowser.newFile'), params: { newFileDir: cwd } });
     } else {
       startNewEntry('file');
     }
-  }, [cwd, isDesktop, wm, t, startNewEntry]);
+  }, [cwd, wm, t, startNewEntry]);
 
   // ---- Rename (inline) + Delete ----------------------------------------------------------------
   const [rename, setRename] = useState<{ full: string } | null>(null);

--- a/ui/src/components/workbench/AppsFileBrowserPage.tsx
+++ b/ui/src/components/workbench/AppsFileBrowserPage.tsx
@@ -78,6 +78,7 @@ import { ContextMenu, ContextMenuItem } from '../ui/context-menu';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog';
 import { FilePreview } from '../ui/file-preview';
 import { InlineNameInput } from '../ui/inline-name-input';
+import { MobileAppHeader } from '../apps/MobileAppHeader';
 import { FilePicker } from './FilePicker';
 
 // A code-file extension → its accent + glyph (mirrors design nknn2's colored type icons).
@@ -210,7 +211,8 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
   // A single-app browser tab (`?standalone=1`) frames the app exactly like a window body —
   // full-bleed, no page header or card border — since the shell drops its chrome there too.
   const standalone = useStandaloneAppTab();
-  const fullBleed = windowed || standalone;
+  const mobileRoute = !windowed && !standalone && !isDesktopViewport();
+  const fullBleed = windowed || standalone || mobileRoute;
   const { projects } = useWorkbenchProjectsTree();
   const [cwd, setCwd] = useState('');
   const [listing, setListing] = useState<FsListing | null>(null);
@@ -1327,7 +1329,8 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
     : 0;
 
   return (
-    <div className={fullBleed ? 'relative flex h-full w-full flex-col bg-surface' : 'relative flex h-[calc(100dvh-7rem)] min-h-[460px] flex-col gap-3 md:h-[calc(100vh-8rem)]'}>
+    <div className={fullBleed ? 'relative flex h-full w-full flex-col bg-surface pb-[env(safe-area-inset-bottom)]' : 'relative flex h-[calc(100dvh-7rem)] min-h-[460px] flex-col gap-3 md:h-[calc(100vh-8rem)]'}>
+      {mobileRoute && <MobileAppHeader title={t('apps.fileBrowser.label')} icon={Folder} />}
       {!fullBleed && (
         <div>
           <h1 className="text-[18px] font-semibold text-foreground">{t('apps.fileBrowser.label')}</h1>
@@ -1337,8 +1340,14 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
 
       <div className={clsx('flex min-h-0 flex-1 flex-col overflow-hidden', !fullBleed && 'rounded-xl border border-border')}>
         {/* Toolbar: breadcrumb (left) + search + New File / New Folder (right) */}
-        <div className="flex items-center gap-2 border-b border-border bg-surface-2/60 px-3 py-2">
-          <div className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto">
+        <div className={clsx(
+          'flex items-center gap-2 border-b border-border bg-surface-2/60',
+          mobileRoute ? 'flex-wrap px-2 py-2' : 'px-3 py-2',
+        )}>
+          <div className={clsx(
+            'flex min-w-0 items-center gap-0.5 overflow-x-auto',
+            mobileRoute ? 'order-1 w-full' : 'flex-1',
+          )}>
             <Button type="button" size="icon" variant="ghost" className="size-7 shrink-0 text-muted" aria-label={t('apps.fileBrowser.refresh')} onClick={() => cwd && refreshAll()}>
               <RefreshCw className={clsx('size-3.5', (loading || searchBusy) && 'animate-spin')} />
             </Button>
@@ -1362,13 +1371,19 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
               </span>
             ))}
           </div>
-          <label className="flex items-center gap-1.5 rounded-lg border border-border bg-surface px-2 py-1">
+          <label className={clsx(
+            'flex items-center gap-1.5 rounded-lg border border-border bg-surface px-2 py-1',
+            mobileRoute ? 'order-2 w-full' : 'shrink-0',
+          )}>
             {searchBusy ? <Loader2 className="size-3.5 shrink-0 animate-spin text-muted" /> : <Search className="size-3.5 shrink-0 text-muted" />}
             <input
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder={t(searchMode === 'content' ? 'apps.fileBrowser.searchContentPlaceholder' : 'apps.fileBrowser.searchPlaceholder')}
-              className="w-28 bg-transparent text-[12px] text-foreground placeholder:text-muted focus:outline-none"
+              className={clsx(
+                'min-w-0 flex-1 bg-transparent text-[12px] text-foreground placeholder:text-muted focus:outline-none',
+                !mobileRoute && 'w-28 flex-none',
+              )}
             />
             {/* Mode toggle: file/folder NAME search (default) ⇄ file CONTENT search; pressed = content. */}
             <button
@@ -1391,54 +1406,60 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
             )}
           </label>
           <input ref={uploadInputRef} type="file" multiple className="hidden" onChange={onUploadPick} />
-          {selectedItems.length > 1 || touchSelectionMode ? (
-            <div className="flex shrink-0 items-center gap-1 overflow-x-auto">
-              <Button type="button" size="sm" variant="ghost" className="h-7 gap-1.5 px-2 text-[12px]" onClick={() => copyRowsToClipboard(selectedItems)} disabled={selectedItems.length === 0}>
-                <Copy className="size-3.5" /> {t('apps.fileBrowser.copy')}
-              </Button>
-              {clipboard.length > 0 && (
-                <Button type="button" size="sm" variant="ghost" className="h-7 gap-1.5 px-2 text-[12px]" disabled={!cwd} onClick={() => void pasteRows(clipboard, cwd)}>
-                  <ClipboardPaste className="size-3.5" /> {t('apps.fileBrowser.paste')}
+          <div className={clsx(
+            'flex shrink-0 items-center gap-1 overflow-x-auto',
+            mobileRoute ? 'order-3 w-full justify-end' : 'ml-auto',
+          )}>
+            {selectedItems.length > 1 || touchSelectionMode ? (
+              <>
+                <Button type="button" size="sm" variant="ghost" title={t('apps.fileBrowser.copy')} className="h-7 gap-1.5 px-2 text-[12px]" onClick={() => copyRowsToClipboard(selectedItems)} disabled={selectedItems.length === 0}>
+                  <Copy className="size-3.5" /> <span className={mobileRoute ? 'sr-only' : undefined}>{t('apps.fileBrowser.copy')}</span>
                 </Button>
-              )}
-              <Button type="button" size="sm" variant="ghost" className="h-7 gap-1.5 px-2 text-[12px]" onClick={() => setMovePickerItems(selectedItems)} disabled={selectedItems.length === 0}>
-                <FolderInput className="size-3.5" /> {t('apps.fileBrowser.move')}
-              </Button>
-              <Button type="button" size="sm" variant="ghost" className="h-7 gap-1.5 px-2 text-[12px]" onClick={() => void downloadItems(selectedItems)} disabled={selectedItems.length === 0}>
-                <Download className="size-3.5" /> {t('apps.fileBrowser.download')}
-              </Button>
-              <Button type="button" size="sm" variant="ghost" className="h-7 gap-1.5 px-2 text-[12px] text-destructive-ink" onClick={() => removeItems(selectedItems)} disabled={selectedItems.length === 0}>
-                <Trash2 className="size-3.5" /> {t('apps.fileBrowser.delete')}
-              </Button>
-              <Button type="button" size="icon" variant="ghost" className="size-7 text-muted" aria-label={t('apps.fileBrowser.clearSelection')} onClick={clearSelection}>
-                <X className="size-4" />
-              </Button>
-            </div>
-          ) : (
-            <>
-              {clipboard.length > 0 && (
-                <Button type="button" size="sm" variant="ghost" className="h-7 shrink-0 gap-1.5 px-2 text-[12px]" disabled={!cwd} onClick={() => void pasteRows(clipboard, cwd)}>
-                  <ClipboardPaste className="size-3.5" /> {t('apps.fileBrowser.paste')}
+                {clipboard.length > 0 && (
+                  <Button type="button" size="sm" variant="ghost" title={t('apps.fileBrowser.paste')} className="h-7 gap-1.5 px-2 text-[12px]" disabled={!cwd} onClick={() => void pasteRows(clipboard, cwd)}>
+                    <ClipboardPaste className="size-3.5" /> <span className={mobileRoute ? 'sr-only' : undefined}>{t('apps.fileBrowser.paste')}</span>
+                  </Button>
+                )}
+                <Button type="button" size="sm" variant="ghost" title={t('apps.fileBrowser.move')} className="h-7 gap-1.5 px-2 text-[12px]" onClick={() => setMovePickerItems(selectedItems)} disabled={selectedItems.length === 0}>
+                  <FolderInput className="size-3.5" /> <span className={mobileRoute ? 'sr-only' : undefined}>{t('apps.fileBrowser.move')}</span>
                 </Button>
-              )}
-              <Button type="button" size="sm" variant="brand" className="h-7 shrink-0 gap-1.5 px-2.5 text-[12px]" disabled={!cwd || newEntry !== null} onClick={onNewFile}>
-                <FilePlus className="size-3.5" /> {t('apps.fileBrowser.newFile')}
-              </Button>
-              <Button type="button" size="sm" variant="outline" className="h-7 shrink-0 gap-1.5 px-2.5 text-[12px]" disabled={!cwd || newEntry !== null} onClick={() => startNewEntry('folder')}>
-                <FolderPlus className="size-3.5" /> {t('apps.fileBrowser.newFolder')}
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                className="h-7 shrink-0 gap-1.5 px-2.5 text-[12px]"
-                disabled={!cwd || uploadProgress !== null}
-                onClick={() => uploadInputRef.current?.click()}
-              >
-                {uploadProgress ? <Loader2 className="size-3.5 animate-spin" /> : <Upload className="size-3.5" />} {t('apps.fileBrowser.upload')}
-              </Button>
-            </>
-          )}
+                <Button type="button" size="sm" variant="ghost" title={t('apps.fileBrowser.download')} className="h-7 gap-1.5 px-2 text-[12px]" onClick={() => void downloadItems(selectedItems)} disabled={selectedItems.length === 0}>
+                  <Download className="size-3.5" /> <span className={mobileRoute ? 'sr-only' : undefined}>{t('apps.fileBrowser.download')}</span>
+                </Button>
+                <Button type="button" size="sm" variant="ghost" title={t('apps.fileBrowser.delete')} className="h-7 gap-1.5 px-2 text-[12px] text-destructive-ink" onClick={() => removeItems(selectedItems)} disabled={selectedItems.length === 0}>
+                  <Trash2 className="size-3.5" /> <span className={mobileRoute ? 'sr-only' : undefined}>{t('apps.fileBrowser.delete')}</span>
+                </Button>
+                <Button type="button" size="icon" variant="ghost" className="size-7 text-muted" aria-label={t('apps.fileBrowser.clearSelection')} onClick={clearSelection}>
+                  <X className="size-4" />
+                </Button>
+              </>
+            ) : (
+              <>
+                {clipboard.length > 0 && (
+                  <Button type="button" size="sm" variant="ghost" title={t('apps.fileBrowser.paste')} className="h-7 shrink-0 gap-1.5 px-2 text-[12px]" disabled={!cwd} onClick={() => void pasteRows(clipboard, cwd)}>
+                    <ClipboardPaste className="size-3.5" /> <span className={mobileRoute ? 'sr-only' : undefined}>{t('apps.fileBrowser.paste')}</span>
+                  </Button>
+                )}
+                <Button type="button" size="sm" variant="brand" title={t('apps.fileBrowser.newFile')} className="h-7 shrink-0 gap-1.5 px-2.5 text-[12px]" disabled={!cwd || newEntry !== null} onClick={onNewFile}>
+                  <FilePlus className="size-3.5" /> <span className={mobileRoute ? 'sr-only' : undefined}>{t('apps.fileBrowser.newFile')}</span>
+                </Button>
+                <Button type="button" size="sm" variant="outline" title={t('apps.fileBrowser.newFolder')} className="h-7 shrink-0 gap-1.5 px-2.5 text-[12px]" disabled={!cwd || newEntry !== null} onClick={() => startNewEntry('folder')}>
+                  <FolderPlus className="size-3.5" /> <span className={mobileRoute ? 'sr-only' : undefined}>{t('apps.fileBrowser.newFolder')}</span>
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  title={t('apps.fileBrowser.upload')}
+                  className="h-7 shrink-0 gap-1.5 px-2.5 text-[12px]"
+                  disabled={!cwd || uploadProgress !== null}
+                  onClick={() => uploadInputRef.current?.click()}
+                >
+                  {uploadProgress ? <Loader2 className="size-3.5 animate-spin" /> : <Upload className="size-3.5" />} <span className={mobileRoute ? 'sr-only' : undefined}>{t('apps.fileBrowser.upload')}</span>
+                </Button>
+              </>
+            )}
+          </div>
         </div>
 
         {/* Mobile favorites/projects strip: the rail (below) is hidden under md, so surface the same
@@ -1546,11 +1567,11 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
                 <span className="truncate">{t('apps.fileBrowser.colName')}</span>
                 {sort?.col === 'name' && (sort.dir === 'asc' ? <ChevronUp className="size-3 shrink-0" /> : <ChevronDown className="size-3 shrink-0" />)}
               </button>
-              <button type="button" onClick={() => cycleSort('size')} className={clsx('flex w-20 shrink-0 items-center justify-end gap-1 transition hover:text-foreground', sort?.col === 'size' && 'text-foreground')}>
+              <button type="button" onClick={() => cycleSort('size')} className={clsx('hidden w-20 shrink-0 items-center justify-end gap-1 transition hover:text-foreground sm:flex', sort?.col === 'size' && 'text-foreground')}>
                 {t('apps.fileBrowser.colSize')}
                 {sort?.col === 'size' && (sort.dir === 'asc' ? <ChevronUp className="size-3 shrink-0" /> : <ChevronDown className="size-3 shrink-0" />)}
               </button>
-              <button type="button" onClick={() => cycleSort('modified')} className={clsx('flex w-36 shrink-0 items-center gap-1 pl-4 transition hover:text-foreground', sort?.col === 'modified' && 'text-foreground')}>
+              <button type="button" onClick={() => cycleSort('modified')} className={clsx('hidden w-36 shrink-0 items-center gap-1 pl-4 transition hover:text-foreground sm:flex', sort?.col === 'modified' && 'text-foreground')}>
                 {t('apps.fileBrowser.colModified')}
                 {sort?.col === 'modified' && (sort.dir === 'asc' ? <ChevronUp className="size-3 shrink-0" /> : <ChevronDown className="size-3 shrink-0" />)}
               </button>
@@ -1690,8 +1711,8 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
                         </span>
                       )}
                     </span>
-                    <span className="w-20 shrink-0 text-right font-mono text-[11px] text-muted">{isDir ? '—' : formatSize(item.entry.size)}</span>
-                    <span className="w-36 shrink-0 pl-4 font-mono text-[11px] text-muted">{formatMtime(item.entry.mtime)}</span>
+                    <span className="hidden w-20 shrink-0 text-right font-mono text-[11px] text-muted sm:block">{isDir ? '—' : formatSize(item.entry.size)}</span>
+                    <span className="hidden w-36 shrink-0 pl-4 font-mono text-[11px] text-muted sm:block">{formatMtime(item.entry.mtime)}</span>
                   </button>
                 );
               })}

--- a/ui/src/components/workbench/AppsTerminalPage.tsx
+++ b/ui/src/components/workbench/AppsTerminalPage.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { SquareTerminal } from 'lucide-react';
 
 import { useStandaloneAppTab } from '../../context/StandaloneAppTabContext';
-import { isDesktopViewport } from '../../lib/useIsDesktop';
+import { useIsDesktop } from '../../lib/useIsDesktop';
 import { MobileAppHeader } from '../apps/MobileAppHeader';
 import { TerminalTabs } from './TerminalTabs';
 
@@ -34,7 +34,8 @@ export const AppsTerminalPage: React.FC<{ windowed?: boolean; windowId?: string;
   // Still the ROUTE mount, so the first tab keeps its persistent reattachable session (unlike
   // `windowed`, whose tabs are ephemeral).
   const standalone = useStandaloneAppTab();
-  const mobileRoute = !windowed && !standalone && !isDesktopViewport();
+  const isDesktop = useIsDesktop();
+  const mobileRoute = !windowed && !standalone && !isDesktop;
 
   if (windowed) {
     return (

--- a/ui/src/components/workbench/AppsTerminalPage.tsx
+++ b/ui/src/components/workbench/AppsTerminalPage.tsx
@@ -1,8 +1,11 @@
 import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { SquareTerminal } from 'lucide-react';
 
 import { useStandaloneAppTab } from '../../context/StandaloneAppTabContext';
+import { isDesktopViewport } from '../../lib/useIsDesktop';
+import { MobileAppHeader } from '../apps/MobileAppHeader';
 import { TerminalTabs } from './TerminalTabs';
 
 // A start directory handed to the terminal when navigating in from the File Browser on mobile
@@ -31,6 +34,7 @@ export const AppsTerminalPage: React.FC<{ windowed?: boolean; windowId?: string;
   // Still the ROUTE mount, so the first tab keeps its persistent reattachable session (unlike
   // `windowed`, whose tabs are ephemeral).
   const standalone = useStandaloneAppTab();
+  const mobileRoute = !windowed && !standalone && !isDesktopViewport();
 
   if (windowed) {
     return (
@@ -44,6 +48,17 @@ export const AppsTerminalPage: React.FC<{ windowed?: boolean; windowId?: string;
     return (
       <div className="flex h-full w-full overflow-hidden bg-surface">
         <TerminalTabs launchCwd={launchCwd} launchKey={launchCwd ? location.key : undefined} />
+      </div>
+    );
+  }
+
+  if (mobileRoute) {
+    return (
+      <div className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-surface pb-[env(safe-area-inset-bottom)]">
+        <MobileAppHeader title={t('apps.terminal.label')} icon={SquareTerminal} />
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          <TerminalTabs launchCwd={launchCwd} launchKey={launchCwd ? location.key : undefined} />
+        </div>
       </div>
     );
   }

--- a/ui/src/components/workbench/EditorApp.tsx
+++ b/ui/src/components/workbench/EditorApp.tsx
@@ -143,10 +143,12 @@ function languageLabel(filename: string | undefined): string | undefined {
 export const EditorApp: React.FC<{
   windowId?: string;
   params?: Record<string, unknown>;
+  /** Start with the explorer collapsed on the phone; the activity bar can reopen it. */
+  mobile?: boolean;
   /** Report whether ANY open tab has unsaved edits — the full-page route uses it for an unload guard
    *  (the window mount relies on useWindowCloseGuard instead). */
   onDirtyChange?: (dirty: boolean) => void;
-}> = ({ windowId, params, onDirtyChange }) => {
+}> = ({ windowId, params, mobile = false, onDirtyChange }) => {
   const { t } = useTranslation();
   const wm = useWindowManager();
   const [root, setRoot] = useState<string | null>(null);
@@ -621,8 +623,13 @@ export const EditorApp: React.FC<{
 
   // The left panel collapses (toggled by the active activity-bar icon) and resizes (drag its right
   // border). Width persists for the window's lifetime (state, not navigation).
-  const [explorerCollapsed, setExplorerCollapsed] = useState(false);
+  const [explorerCollapsed, setExplorerCollapsed] = useState(mobile);
   const [explorerWidth, setExplorerWidth] = useState(240);
+  // Selecting a file from the mobile explorer returns the editor to the foreground. This keeps
+  // the narrow screen useful after every open while leaving the desktop panel behavior unchanged.
+  useEffect(() => {
+    if (mobile && active) setExplorerCollapsed(true);
+  }, [active, mobile]);
   // Holds the in-flight drag's teardown so an unmount mid-drag (window closed while dragging) can
   // still remove the window listeners and restore the body cursor / user-select.
   const resizeTeardown = useRef<(() => void) | null>(null);
@@ -698,7 +705,10 @@ export const EditorApp: React.FC<{
             active activity-bar icon; drag its right border to resize. Explorer is ALWAYS present in
             Files view (design w0qoC keeps it in the welcome state). */}
         {!explorerCollapsed && (
-        <div className="relative flex shrink-0 flex-col overflow-hidden border-r border-border bg-surface-2" style={{ width: explorerWidth }}>
+        <div
+          className="relative flex shrink-0 flex-col overflow-hidden border-r border-border bg-surface-2"
+          style={{ width: mobile ? 'min(240px, 72vw)' : explorerWidth }}
+        >
           {view === 'search' ? (
             <EditorSearchView root={root} focusNonce={searchFocus} onOpenFolder={openFolder} onJump={onJump} onFilesChanged={reloadTabs} />
           ) : (
@@ -794,7 +804,7 @@ export const EditorApp: React.FC<{
                         type="button"
                         onClick={() => closeTab(tab.id)}
                         aria-label={t('common.close')}
-                        className="grid size-4 place-items-center rounded text-muted opacity-0 transition hover:bg-foreground/10 hover:text-foreground group-hover/tab:opacity-100"
+                        className="grid size-4 place-items-center rounded text-muted transition hover:bg-foreground/10 hover:text-foreground md:opacity-0 md:group-hover/tab:opacity-100"
                       >
                         <X className="size-3" strokeWidth={2.5} />
                       </button>
@@ -820,7 +830,7 @@ export const EditorApp: React.FC<{
                             path={tab.path}
                             filename={tab.name}
                             mtime={tab.mtime}
-                            chromeless
+                            chromeless={!mobile}
                             onDirtyChange={(d) => setDirty((prev) => (prev[tab.id] === d ? prev : { ...prev, [tab.id]: d }))}
                             onCursor={(line, col, indent) => setStatus((s) => ({ ...s, [tab.id]: { line, col, insertSpaces: indent.insertSpaces, tabSize: indent.tabSize } }))}
                             onSaveAs={(textValue) => saveAs(tab.id, textValue)}

--- a/ui/src/components/workbench/EditorApp.tsx
+++ b/ui/src/components/workbench/EditorApp.tsx
@@ -161,6 +161,10 @@ export const EditorApp: React.FC<{
   const [status, setStatus] = useState<Record<string, PaneStatus>>({});
   const [picker, setPicker] = useState<PickerState | null>(null);
   const [view, setView] = useState<'files' | 'search'>('files');
+  // The left panel collapses (toggled by the active activity-bar icon) and resizes (drag its right
+  // border). Width persists for the window's lifetime (state, not navigation).
+  const [explorerCollapsed, setExplorerCollapsed] = useState(mobile);
+  const [explorerWidth, setExplorerWidth] = useState(240);
   // A pending Monaco jump (from a cross-file search result), scoped to one tab. The nonce makes a
   // repeat jump to the same spot re-fire even when the tab is already open.
   const [reveal, setReveal] = useState<{ tabId: string; line: number; column: number; endColumn: number; nonce: number } | null>(null);
@@ -238,8 +242,9 @@ export const EditorApp: React.FC<{
       } catch {
         openFile(path, name, null, target);
       }
+      if (mobile) setExplorerCollapsed(true);
     },
-    [openFile],
+    [mobile, openFile],
   );
 
   // The explorer tree emits a clicked entry. Gate it like the File Browser: only a regular,
@@ -252,6 +257,7 @@ export const EditorApp: React.FC<{
       // markdown / code / json / csv stay editable (with a preview toggle inside the pane).
       if (previewOverlayKind(entry)) {
         openPreview(path, entry.name);
+        if (mobile) setExplorerCollapsed(true);
         return;
       }
       // Fetch fresh metadata (also content-sniffs `text`) and decide by CONTENT, not just the
@@ -261,6 +267,7 @@ export const EditorApp: React.FC<{
         const m = await fileMeta(path);
         if (isEditableMeta(m)) {
           openFile(path, entry.name, m.mtime);
+          if (mobile) setExplorerCollapsed(true);
         } else {
           downloadFile(path);
         }
@@ -268,12 +275,13 @@ export const EditorApp: React.FC<{
         // Metadata fetch failed — fall back to the name-only guess so a known text type still opens.
         if (isEditableFile(entry)) {
           openFile(path, entry.name, entry.mtime);
+          if (mobile) setExplorerCollapsed(true);
         } else {
           downloadFile(path);
         }
       }
     },
-    [openFile, openPreview],
+    [mobile, openFile, openPreview],
   );
 
   // After a cross-file replace/undo rewrites files on disk, reload any open, non-dirty tab for a
@@ -621,10 +629,6 @@ export const EditorApp: React.FC<{
     return () => window.removeEventListener('keydown', onKey, true);
   }, [windowId, wm.focusedId]);
 
-  // The left panel collapses (toggled by the active activity-bar icon) and resizes (drag its right
-  // border). Width persists for the window's lifetime (state, not navigation).
-  const [explorerCollapsed, setExplorerCollapsed] = useState(mobile);
-  const [explorerWidth, setExplorerWidth] = useState(240);
   // Selecting a file from the mobile explorer returns the editor to the foreground. This keeps
   // the narrow screen useful after every open while leaving the desktop panel behavior unchanged.
   useEffect(() => {
@@ -831,6 +835,7 @@ export const EditorApp: React.FC<{
                             filename={tab.name}
                             mtime={tab.mtime}
                             chromeless={!mobile}
+                            forceDark
                             onDirtyChange={(d) => setDirty((prev) => (prev[tab.id] === d ? prev : { ...prev, [tab.id]: d }))}
                             onCursor={(line, col, indent) => setStatus((s) => ({ ...s, [tab.id]: { line, col, insertSpaces: indent.insertSpaces, tabSize: indent.tabSize } }))}
                             onSaveAs={(textValue) => saveAs(tab.id, textValue)}

--- a/ui/src/components/workbench/FileEditorPane.tsx
+++ b/ui/src/components/workbench/FileEditorPane.tsx
@@ -105,6 +105,8 @@ export const FileEditorPane: React.FC<{
    * be a redundant second header. Standalone uses keep the header (default).
    */
   chromeless?: boolean;
+  /** Keep Monaco on the IDE's dark theme even when the pane header is visible on mobile. */
+  forceDark?: boolean;
   /** Live status for the IDE status bar: 1-based cursor position plus the model's resolved
    *  indentation (insertSpaces / tabSize). Forwarded straight to Monaco's onCursorChange. */
   onCursor?: (line: number, column: number, indent: { insertSpaces: boolean; tabSize: number }) => void;
@@ -123,7 +125,7 @@ export const FileEditorPane: React.FC<{
    * window-level ⌘S itself — scoped by this flag so only the foreground tab saves.
    */
   saveHotkey?: boolean;
-}> = ({ path, filename, mtime, readOnly = false, onPopOut, windowId, onOpenFile, headerActions, onDirtyChange, chromeless = false, onCursor, onSaveAs, reveal, reloadNonce, saveHotkey = false }) => {
+}> = ({ path, filename, mtime, readOnly = false, onPopOut, windowId, onOpenFile, headerActions, onDirtyChange, chromeless = false, forceDark = false, onCursor, onSaveAs, reveal, reloadNonce, saveHotkey = false }) => {
   const { t } = useTranslation();
   const { resolvedTheme } = useTheme();
   const [text, setText] = useState<string | null>(null);
@@ -488,10 +490,10 @@ export const FileEditorPane: React.FC<{
               language={language}
               path={monacoPath}
               readOnly={readOnly}
-              // Monaco is JS-themed (it can't read the window's `data-theme="dark"` CSS), so in the
-              // IDE (chromeless = the dark-locked Editor window) force the dark theme; otherwise a
-              // light global theme would leave a white Monaco slab inside the dark window (dnYPx is dark).
-              dark={chromeless || resolvedTheme === 'dark'}
+              // Monaco is JS-themed (it can't read the window's `data-theme="dark"` CSS). The
+              // mobile IDE keeps its file header visible, so the visual-header flag is separate
+              // from the theme policy that keeps the whole IDE dark.
+              dark={forceDark || chromeless || resolvedTheme === 'dark'}
               onChange={(value) => setText(value)}
               onSave={() => void save()}
               onCursorChange={onCursor}
@@ -521,7 +523,7 @@ export const FileEditorPane: React.FC<{
                   original={diskText}
                   modified={text}
                   language={language}
-                  dark={chromeless || resolvedTheme === 'dark'}
+                  dark={forceDark || chromeless || resolvedTheme === 'dark'}
                 />
               </Suspense>
             </div>

--- a/ui/src/components/workbench/TerminalTabs.tsx
+++ b/ui/src/components/workbench/TerminalTabs.tsx
@@ -250,7 +250,7 @@ export const TerminalTabs: React.FC<{
                 type="button"
                 onClick={() => closeTab(tab.key)}
                 aria-label={t('common.close')}
-                className="grid size-4 place-items-center rounded text-muted opacity-0 transition hover:bg-foreground/10 hover:text-foreground group-hover/tab:opacity-100"
+                className="grid size-4 place-items-center rounded text-muted transition hover:bg-foreground/10 hover:text-foreground md:opacity-0 md:group-hover/tab:opacity-100"
               >
                 <X className="size-3" strokeWidth={2.5} />
               </button>

--- a/ui/src/lib/useIsDesktop.test.ts
+++ b/ui/src/lib/useIsDesktop.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from 'vitest';
+// @vitest-environment jsdom
 
-import { DESKTOP_MEDIA_QUERY, isDesktopViewport } from './useIsDesktop';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DESKTOP_MEDIA_QUERY, isDesktopViewport, useIsDesktop } from './useIsDesktop';
 
 describe('isDesktopViewport', () => {
   it('uses the shell desktop breakpoint', () => {
@@ -10,5 +13,34 @@ describe('isDesktopViewport', () => {
 
     expect(isDesktopViewport(targetWindow)).toBe(true);
     expect(isDesktopViewport(null)).toBe(false);
+  });
+
+  it('updates when the viewport crosses the breakpoint', () => {
+    let matches = false;
+    const listeners = new Set<(event: MediaQueryListEvent) => void>();
+    const media = {
+      get matches() {
+        return matches;
+      },
+      addEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => listeners.add(listener),
+      removeEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => listeners.delete(listener),
+    } as unknown as MediaQueryList;
+    const matchMedia = vi.fn().mockReturnValue(media);
+    Object.defineProperty(window, 'matchMedia', { configurable: true, value: matchMedia });
+
+    try {
+      const { result } = renderHook(() => useIsDesktop());
+      expect(result.current).toBe(false);
+
+      act(() => {
+        matches = true;
+        listeners.forEach((listener) => listener({ matches: true, media: DESKTOP_MEDIA_QUERY } as MediaQueryListEvent));
+      });
+
+      expect(result.current).toBe(true);
+      expect(matchMedia).toHaveBeenCalledWith(DESKTOP_MEDIA_QUERY);
+    } finally {
+      delete (window as Window & { matchMedia?: typeof matchMedia }).matchMedia;
+    }
   });
 });


### PR DESCRIPTION
## Summary
- give Files, Terminal, and Editor mobile routes a full-viewport shell without duplicate Avibe chrome
- make Files actions and columns responsive on narrow screens
- keep the full Editor IDE available on mobile with a collapsed explorer and touch-friendly controls

## Validation
- npm run lint
- npm run build
- npm test
