### PR TITLE
feat(memory): split agent memory owner on read paths

### DIFF
--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -27,6 +27,7 @@ from core.memory.types import (
     MemoryProfile,
     MemoryProfileExplicitInfo,
     MemoryProfileTrait,
+    ProviderSearchItem,
     ProviderSessionRef,
     is_memory_error_code,
     MemoryPreflightDiagnostic,
@@ -510,7 +511,7 @@ class EverOSPort:
         session_ref: ProviderSessionRef | None = None,
         timeout_seconds: float | None = None,
         agentic_telemetry: AgenticRecallTelemetry | None = None,
-    ) -> tuple[MemoryItem, ...]:
+    ) -> tuple[ProviderSearchItem, ...]:
         response_metadata: dict[str, str] = {}
         try:
             data = await self._search_data(
@@ -1206,14 +1207,14 @@ def _map_search_items(
     *,
     principal_id: str,
     limit: int,
-) -> tuple[MemoryItem, ...]:
+) -> tuple[ProviderSearchItem, ...]:
     episodes = data.get("episodes", [])
     if not isinstance(episodes, list):
         raise MemoryProviderFailure("memory_provider_response_invalid")
     if len(episodes) > _MAX_RESPONSE_COLLECTION:
         raise MemoryProviderFailure("memory_provider_response_invalid")
 
-    items: list[MemoryItem] = []
+    items: list[ProviderSearchItem] = []
     for episode in episodes:
         if len(items) >= limit:
             break
@@ -1221,9 +1222,21 @@ def _map_search_items(
             continue
         if episode.get("user_id") != principal_id:
             continue
+        episode_id = _strict_receipt_id(episode.get("id"))
+        episode_score = _provider_score(episode)
+        episode_timestamp = _first_record_timestamp(episode)
         text = _episode_text(episode)
         if text is not None:
-            items.append(MemoryItem(kind="episode", text=text, date=_record_date(episode)))
+            items.append(
+                ProviderSearchItem(
+                    item=MemoryItem(kind="episode", text=text, date=_record_date(episode)),
+                    score=episode_score,
+                    episode_id=episode_id,
+                    timestamp=episode_timestamp,
+                    provider_rank=len(items),
+                    queried_owner=principal_id,
+                )
+            )
         if len(items) >= limit:
             break
         facts = episode.get("atomic_facts", [])
@@ -1238,8 +1251,35 @@ def _map_search_items(
                 continue
             text = _safe_text(fact.get("content"))
             if text is not None:
-                items.append(MemoryItem(kind="fact", text=text, date=_record_date(fact, episode)))
+                fact_score = _provider_score(fact)
+                items.append(
+                    ProviderSearchItem(
+                        item=MemoryItem(kind="fact", text=text, date=_record_date(fact, episode)),
+                        score=fact_score if fact_score is not None else episode_score,
+                        episode_id=episode_id,
+                        timestamp=_first_record_timestamp(fact, episode),
+                        provider_rank=len(items),
+                        queried_owner=principal_id,
+                    )
+                )
     return tuple(items)
+
+
+def _provider_score(record: dict[str, Any]) -> float | None:
+    for key in ("score", "relevance_score"):
+        value = record.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value):
+            return float(value)
+    return None
+
+
+def _first_record_timestamp(*records: dict[str, Any]) -> str | None:
+    for record in records:
+        for key in ("timestamp", "created_at", "createdAt", "date"):
+            timestamp = _record_timestamp(record.get(key))
+            if timestamp is not None:
+                return timestamp
+    return None
 
 
 def _map_episode_page(
@@ -2010,7 +2050,7 @@ class MemoryProviderPort(Protocol):
         session_ref: ProviderSessionRef | None = None,
         timeout_seconds: float | None = None,
         agentic_telemetry: AgenticRecallTelemetry | None = None,
-    ) -> tuple[MemoryItem, ...]: ...
+    ) -> tuple[ProviderSearchItem, ...]: ...
 
     async def profile(self, principal_id: str, project_id: str) -> tuple[MemoryItem, ...]: ...
 
@@ -2040,7 +2080,8 @@ class FakeMemoryProvider:
 
     healthy: bool = True
     processing_healthy_flag: bool = True
-    search_items: tuple[MemoryItem, ...] = ()
+    search_items: tuple[MemoryItem | ProviderSearchItem, ...] = ()
+    search_items_by_owner: dict[str, tuple[MemoryItem | ProviderSearchItem, ...]] = field(default_factory=dict)
     profile_items: tuple[MemoryItem, ...] = ()
     list_page: MemoryListPage = field(
         default_factory=lambda: MemoryListPage(
@@ -2064,7 +2105,10 @@ class FakeMemoryProvider:
     add_results: Deque[AddResult] = field(default_factory=deque)
     flush_results: Deque[FlushResult] = field(default_factory=deque)
     search_failure: BaseException | None = None
+    search_failures_by_owner: dict[str, BaseException] = field(default_factory=dict)
     profile_failure: BaseException | None = None
+    profile_items_by_owner: dict[str, tuple[MemoryItem, ...]] = field(default_factory=dict)
+    profile_failures_by_owner: dict[str, BaseException] = field(default_factory=dict)
     list_failure: BaseException | None = None
     health_failure: BaseException | None = None
     agentic_budget_enforced_flag: bool = False
@@ -2123,22 +2167,43 @@ class FakeMemoryProvider:
         session_ref: ProviderSessionRef | None = None,
         timeout_seconds: float | None = None,
         agentic_telemetry: AgenticRecallTelemetry | None = None,
-    ) -> tuple[MemoryItem, ...]:
+    ) -> tuple[ProviderSearchItem, ...]:
         self.search_scopes.append((principal_id, project_id))
         self.search_policies.append((method, include_profile, session_ref))
         self.search_timeouts.append(timeout_seconds)
         if method == "agentic" and agentic_telemetry is not None:
             agentic_telemetry.round = self.agentic_round
         del query, limit
-        if self.search_failure is not None:
-            raise self.search_failure
-        return self.search_items
+        failure = self.search_failures_by_owner.get(principal_id, self.search_failure)
+        if failure is not None:
+            raise failure
+        raw_items = self.search_items_by_owner.get(
+            principal_id,
+            () if principal_id.endswith("-agent") else self.search_items,
+        )
+        return tuple(
+            item
+            if isinstance(item, ProviderSearchItem)
+            else ProviderSearchItem(
+                item=item,
+                score=None,
+                episode_id=None,
+                timestamp=None,
+                provider_rank=rank,
+                queried_owner=principal_id,
+            )
+            for rank, item in enumerate(raw_items)
+        )
 
     async def profile(self, principal_id: str, project_id: str) -> tuple[MemoryItem, ...]:
         self.profile_scopes.append((principal_id, project_id))
-        if self.profile_failure is not None:
-            raise self.profile_failure
-        return self.profile_items
+        failure = self.profile_failures_by_owner.get(principal_id, self.profile_failure)
+        if failure is not None:
+            raise failure
+        return self.profile_items_by_owner.get(
+            principal_id,
+            () if principal_id.endswith("-agent") else self.profile_items,
+        )
 
     async def list_episodes(
         self,

--- a/core/memory/module.py
+++ b/core/memory/module.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import os
 import re
 import shutil
@@ -39,6 +40,8 @@ from core.memory.project_ids import (
 from core.memory.store import (
     MAX_NONTERMINAL_QUEUE_ROWS,
     MemoryStore,
+    derive_assistant_memory_owner_id,
+    is_memory_owner_id,
     is_principal_id,
 )
 from core.memory.types import (
@@ -60,6 +63,7 @@ from core.memory.types import (
     MemoryProfileTrait,
     MemoryResult,
     OperationFailed,
+    ProviderSearchItem,
     RecallItems,
     RecallPolicy,
     RecallResult,
@@ -140,6 +144,7 @@ class _CaptureReservation:
 
 logger = logging.getLogger(__name__)
 _SessionLifecycleResult = TypeVar("_SessionLifecycleResult")
+_ProviderReadResult = TypeVar("_ProviderReadResult")
 
 
 _ROOT_LIFECYCLE_LOCKS: dict[str, asyncio.Lock] = {}
@@ -898,7 +903,7 @@ class MemoryModule:
         project_id: str,
         limit: int = DEFAULT_SEARCH_LIMIT,
     ) -> MemoryResult:
-        """Compatibility wrapper for the default one-run hybrid recall policy."""
+        """Compatibility wrapper for the default hybrid recall policy."""
 
         try:
             policy = RecallPolicy(mode="hybrid", max_results=limit)
@@ -924,7 +929,7 @@ class MemoryModule:
         current_session_id: str | None = None,
         effective_mode: Literal["keyword", "vector", "hybrid", "agentic"] | None = None,
     ) -> RecallResult:
-        """Execute one capability-gated recall decision and at most one search."""
+        """Execute one capability-gated, dual-owner recall decision."""
 
         if not self._is_enabled():
             return OperationFailed(error="memory_disabled")
@@ -1018,16 +1023,28 @@ class MemoryModule:
                 return OperationFailed(error="memory_store_unavailable")
             if meta.clear_in_progress:
                 return OperationFailed(error="memory_clear_failed")
-            session_ref = None
+            owner_ids = (
+                principal_id,
+                derive_assistant_memory_owner_id(principal_id),
+            )
+            session_refs = [None, None]
             if policy.include_current_session:
                 if not isinstance(current_session_id, str) or not current_session_id.strip():
                     return OperationFailed(error="memory_invalid_input")
                 try:
-                    session_ref = await self._store_call(
-                        self._store.provider_session_ref,
-                        principal_id=principal_id,
-                        project_ref=project_id,
-                        session_id=current_session_id.strip(),
+                    session_refs = list(
+                        await asyncio.gather(
+                            *(
+                                self._store_call(
+                                    self._store.provider_session_ref,
+                                    principal_id=principal_id,
+                                    project_ref=project_id,
+                                    session_id=current_session_id.strip(),
+                                    memory_owner_id=owner_id,
+                                )
+                                for owner_id in owner_ids
+                            )
+                        )
                     )
                 except ValueError:
                     return OperationFailed(error="memory_access_denied")
@@ -1062,30 +1079,69 @@ class MemoryModule:
                 provider_timeout = _remaining_timeout(agentic_deadline)
             else:
                 provider_timeout = None
-            result = await self._provider_read(
-                lambda: self._provider.search(
-                    principal_id,
-                    project_id,
-                    normalized_query,
-                    policy.max_results,
-                    method=effective_mode,
-                    include_profile=policy.include_profile,
-                    session_ref=session_ref,
-                    timeout_seconds=provider_timeout,
-                    agentic_telemetry=agentic_telemetry,
-                ),
-                timeout_seconds=provider_timeout,
+            leg_methods = (
+                effective_mode,
+                "hybrid" if effective_mode == "agentic" else effective_mode,
             )
-        if isinstance(result, OperationFailed):
-            return result
-        bounded = self._bounded_items(result, limit=policy.max_results)
-        if isinstance(bounded, OperationFailed):
-            return bounded
+            results = await asyncio.gather(
+                *(
+                    self._provider_read(
+                        lambda owner_id=owner_id, method=method, session_ref=session_ref, index=index: self._provider.search(
+                            owner_id,
+                            project_id,
+                            normalized_query,
+                            policy.max_results,
+                            method=method,
+                            include_profile=policy.include_profile,
+                            session_ref=session_ref,
+                            timeout_seconds=provider_timeout if index == 0 else None,
+                            agentic_telemetry=agentic_telemetry if index == 0 else None,
+                        ),
+                        timeout_seconds=provider_timeout,
+                    )
+                    for index, (owner_id, method, session_ref) in enumerate(
+                        zip(owner_ids, leg_methods, session_refs)
+                    )
+                )
+            )
+        successful: list[tuple[ProviderSearchItem, ...]] = []
+        leg_succeeded: list[bool] = []
+        first_failure: OperationFailed | None = None
+        for owner_id, result in zip(owner_ids, results):
+            if isinstance(result, OperationFailed):
+                if first_failure is None:
+                    first_failure = result
+                successful.append(())
+                leg_succeeded.append(False)
+                continue
+            bounded = self._bounded_provider_search_items(
+                result,
+                owner_id=owner_id,
+                limit=policy.max_results,
+            )
+            if isinstance(bounded, OperationFailed):
+                if first_failure is None:
+                    first_failure = bounded
+                successful.append(())
+                leg_succeeded.append(False)
+                continue
+            successful.append(bounded)
+            leg_succeeded.append(True)
+        succeeded_count = sum(leg_succeeded)
+        if succeeded_count == 0:
+            return first_failure or OperationFailed(error="memory_processing_failed")
+        merged = _merge_owner_search_items(
+            user_items=successful[0],
+            assistant_items=successful[1],
+            same_method=leg_methods[0] == leg_methods[1],
+            limit=policy.max_results,
+        )
         return RecallItems(
-            items=bounded.items,
+            items=merged,
             requested_mode=requested_mode,
             effective_mode=effective_mode,
-            current_session_overlay=session_ref is not None,
+            current_session_overlay=any(ref is not None for ref in session_refs),
+            warnings=("memory_search_partial",) if succeeded_count == 1 else (),
         )
 
     async def resolve_recall_mode(
@@ -1158,10 +1214,36 @@ class MemoryModule:
                 return OperationFailed(error="memory_store_unavailable")
             if meta.clear_in_progress:
                 return OperationFailed(error="memory_clear_failed")
-            result = await self._provider_read(lambda: self._provider.profile(principal_id, project_id))
-        return result if isinstance(result, OperationFailed) else self._bounded_items(
-            result,
-            limit=MAX_PROVIDER_RESULT_ITEMS,
+            owner_ids = (
+                principal_id,
+                derive_assistant_memory_owner_id(principal_id),
+            )
+            results = await asyncio.gather(
+                *(
+                    self._provider_read(lambda owner_id=owner_id: self._provider.profile(owner_id, project_id))
+                    for owner_id in owner_ids
+                )
+            )
+        items: list[MemoryItem] = []
+        first_failure: OperationFailed | None = None
+        succeeded = 0
+        for origin, result in zip(("user", "agent"), results):
+            if isinstance(result, OperationFailed):
+                if first_failure is None:
+                    first_failure = result
+                continue
+            bounded = self._bounded_items(result, limit=MAX_PROVIDER_RESULT_ITEMS)
+            if isinstance(bounded, OperationFailed):
+                if first_failure is None:
+                    first_failure = bounded
+                continue
+            succeeded += 1
+            items.extend(replace(item, origin=origin) for item in bounded.items)
+        if succeeded == 0:
+            return first_failure or OperationFailed(error="memory_processing_failed")
+        return MemoryItems(
+            items=tuple(items),
+            warnings=("memory_search_partial",) if succeeded == 1 else (),
         )
 
     async def list_episodes(
@@ -1349,10 +1431,10 @@ class MemoryModule:
 
     async def _provider_read(
         self,
-        operation: Callable[[], Awaitable[tuple[MemoryItem, ...]]],
+        operation: Callable[[], Awaitable[tuple[_ProviderReadResult, ...]]],
         *,
         timeout_seconds: float | None = None,
-    ) -> tuple[MemoryItem, ...] | OperationFailed:
+    ) -> tuple[_ProviderReadResult, ...] | OperationFailed:
         try:
             return await asyncio.wait_for(
                 operation(),
@@ -1364,6 +1446,49 @@ class MemoryModule:
             return OperationFailed(error=_provider_error_code(failure, "memory_processing_failed"))
         except Exception:
             return OperationFailed(error="memory_processing_failed")
+
+    def _bounded_provider_search_items(
+        self,
+        items: tuple[ProviderSearchItem, ...],
+        *,
+        owner_id: str,
+        limit: int,
+    ) -> tuple[ProviderSearchItem, ...] | OperationFailed:
+        if not isinstance(items, tuple) or len(items) > limit or not is_memory_owner_id(owner_id):
+            return OperationFailed(error="memory_provider_response_invalid")
+        bounded = self._bounded_items(tuple(item.item for item in items), limit=limit) if all(
+            isinstance(item, ProviderSearchItem) for item in items
+        ) else OperationFailed(error="memory_provider_response_invalid")
+        if isinstance(bounded, OperationFailed):
+            return bounded
+        for item in items:
+            if (
+                item.queried_owner != owner_id
+                or item.item.origin is not None
+                or isinstance(item.provider_rank, bool)
+                or not isinstance(item.provider_rank, int)
+                or item.provider_rank < 0
+                or (
+                    item.score is not None
+                    and (
+                        isinstance(item.score, bool)
+                        or not isinstance(item.score, (int, float))
+                        or not math.isfinite(item.score)
+                    )
+                )
+                or (
+                    item.episode_id is not None
+                    and (
+                        not isinstance(item.episode_id, str)
+                        or not item.episode_id
+                        or (episode_id_bytes := _utf8_bytes(item.episode_id)) is None
+                        or len(episode_id_bytes) > 256
+                    )
+                )
+                or (item.timestamp is not None and _list_timestamp_instant(item.timestamp) is None)
+            ):
+                return OperationFailed(error="memory_provider_response_invalid")
+        return items
 
     async def _provider_list_read(
         self,
@@ -1482,6 +1607,8 @@ class MemoryModule:
                 if profile_bytes is None:
                     return OperationFailed(error="memory_provider_response_invalid")
                 total_bytes += profile_bytes
+            if item.origin not in {None, "user", "agent", "both"}:
+                return OperationFailed(error="memory_provider_response_invalid")
             if total_bytes > MAX_PROVIDER_RESULT_BYTES:
                 return OperationFailed(error="memory_provider_response_invalid")
         return MemoryItems(items=items)
@@ -1614,6 +1741,81 @@ class MemoryModule:
     def _valid_identifier(value: str) -> bool:
         encoded = _utf8_bytes(value)
         return bool(value.strip()) and encoded is not None and len(encoded) <= MAX_CAPTURE_IDENTIFIER_BYTES
+
+
+def _merge_owner_search_items(
+    *,
+    user_items: tuple[ProviderSearchItem, ...],
+    assistant_items: tuple[ProviderSearchItem, ...],
+    same_method: bool,
+    limit: int,
+) -> tuple[MemoryItem, ...]:
+    if same_method:
+        ranked: list[tuple[ProviderSearchItem, Literal["user", "agent"]]] = [
+            *((item, "user") for item in user_items),
+            *((item, "agent") for item in assistant_items),
+        ]
+        ranked.sort(key=lambda value: _same_method_rank_key(value[0]))
+    else:
+        user_ranked = sorted(user_items, key=_per_leg_rank_key)
+        assistant_ranked = sorted(assistant_items, key=_per_leg_rank_key)
+        ranked = []
+        for index in range(max(len(user_ranked), len(assistant_ranked))):
+            if index < len(user_ranked):
+                ranked.append((user_ranked[index], "user"))
+            if index < len(assistant_ranked):
+                ranked.append((assistant_ranked[index], "agent"))
+
+    merged: list[MemoryItem] = []
+    seen: dict[str, int] = {}
+    for provider_item, origin in ranked:
+        item = replace(provider_item.item, origin=origin)
+        normalized_text = MemoryModule._normalize_text(item.text)
+        existing_index = seen.get(normalized_text)
+        if existing_index is not None:
+            existing = merged[existing_index]
+            if existing.origin != origin:
+                merged[existing_index] = replace(existing, origin="both")
+            continue
+        if len(merged) >= limit:
+            continue
+        seen[normalized_text] = len(merged)
+        merged.append(item)
+    return tuple(merged)
+
+
+def _same_method_rank_key(item: ProviderSearchItem) -> tuple[object, ...]:
+    timestamp = _list_timestamp_instant(item.timestamp)
+    timestamp_value = timestamp.timestamp() if timestamp is not None else float("-inf")
+    normalized_text = MemoryModule._normalize_text(item.item.text)
+    if item.score is not None:
+        return (
+            0,
+            -float(item.score),
+            -timestamp_value,
+            item.episode_id or normalized_text,
+            item.provider_rank,
+            normalized_text,
+        )
+    return (
+        1,
+        item.provider_rank,
+        -timestamp_value,
+        item.episode_id or normalized_text,
+        normalized_text,
+    )
+
+
+def _per_leg_rank_key(item: ProviderSearchItem) -> tuple[object, ...]:
+    timestamp = _list_timestamp_instant(item.timestamp)
+    timestamp_value = timestamp.timestamp() if timestamp is not None else float("-inf")
+    normalized_text = MemoryModule._normalize_text(item.item.text)
+    return (
+        item.provider_rank,
+        -timestamp_value,
+        item.episode_id or normalized_text,
+        normalized_text,
+    )
 
 
 def _profile_text_bytes(value: object) -> bytes | None:

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -2127,6 +2127,7 @@ class MemoryRuntime:
                 continue
             succeeded = True
             effective_mode = result.effective_mode
+            warnings.extend(result.warnings)
             collected.extend(
                 replace(item, project=project_id) for item in result.items
             )

--- a/core/memory/sidecar.py
+++ b/core/memory/sidecar.py
@@ -26,6 +26,7 @@ from core.memory.project_ids import (
 from core.memory.everos_insight import install_error_scrubbers, prepare_call_recorder
 from core.memory.everos_insight.patches import boundary_request
 from core.memory.modality import SUPPORTED_ATTACHMENT_EXTENSIONS
+from core.memory.store import is_memory_owner_id
 from core.memory.types import MAX_AGENTIC_TIMEOUT_SECONDS
 
 
@@ -33,7 +34,6 @@ _MAX_BODY_BYTES = 64 * 1024
 _APP_ID = "avibe"
 _AGENTIC_TIMEOUT_HEADER = "X-Avibe-Memory-Agentic-Timeout-Seconds"
 _AGENTIC_ROUND_HEADER = "X-Avibe-Memory-Agentic-Round"
-_PRINCIPAL_PATTERN = re.compile(r"u-[0-9a-f]{32}\Z")
 _SESSION_PATTERN = re.compile(r"src--[0-9a-f]{64}--e(?:0|[1-9][0-9]*)\Z")
 _AGENTIC_ROUND_STATE: contextvars.ContextVar[dict[str, str] | None] = (
     contextvars.ContextVar("avibe_memory_agentic_round", default=None)
@@ -582,7 +582,7 @@ def _validate_get(payload: dict[str, Any]) -> str | None:
 
 
 def _valid_principal(value: object) -> bool:
-    return isinstance(value, str) and _PRINCIPAL_PATTERN.fullmatch(value) is not None
+    return is_memory_owner_id(value)
 
 
 def _valid_session(value: object) -> bool:

--- a/core/memory/store.py
+++ b/core/memory/store.py
@@ -1048,11 +1048,15 @@ class MemoryStore:
         principal_id: str,
         project_ref: str,
         session_id: str,
+        memory_owner_id: str | None = None,
     ) -> ProviderSessionRef:
-        """Resolve trusted caller context into the current canonical provider identity."""
+        """Resolve trusted caller context into an owner-scoped provider identity."""
 
         if not is_principal_id(principal_id) or not is_project_id(project_ref):
             raise ValueError("invalid Memory scope")
+        owner_id = principal_id if memory_owner_id is None else memory_owner_id
+        if owner_id not in {principal_id, derive_assistant_memory_owner_id(principal_id)}:
+            raise ValueError("invalid Memory owner")
         if not isinstance(session_id, str) or not session_id or "\x00" in session_id:
             raise ValueError("invalid Memory session")
         with self._transaction() as conn:
@@ -1060,12 +1064,12 @@ class MemoryStore:
             if meta.clear_in_progress:
                 raise RuntimeError("Memory clear is in progress")
             return ProviderSessionRef(
-                principal_id=principal_id,
+                principal_id=owner_id,
                 epoch=meta.epoch,
                 project_ref=project_ref,
                 session_id=_provider_session_ref(
                     meta.scope_key,
-                    principal_id,
+                    owner_id,
                     project_ref,
                     session_id,
                     meta.epoch,
@@ -3935,6 +3939,26 @@ def is_principal_id(value: object) -> bool:
     )
 
 
+def derive_assistant_memory_owner_id(principal_id: str) -> str:
+    """Derive the server-owned assistant Memory identity for one caller."""
+
+    if not is_principal_id(principal_id):
+        raise ValueError("invalid Memory principal")
+    return f"{principal_id}-agent"
+
+
+def is_memory_owner_id(value: object) -> bool:
+    """Return whether a value is a user or derived assistant Memory owner."""
+
+    if is_principal_id(value):
+        return True
+    return (
+        isinstance(value, str)
+        and value.endswith("-agent")
+        and is_principal_id(value[:-6])
+    )
+
+
 def is_project_id(value: object) -> bool:
     """Compatibility alias for persisted project ids. Do not use on new writes."""
 
@@ -3962,9 +3986,9 @@ def _upsert_memory_project(
 
 def _provider_session_ref(
     scope_key: bytes,
-    principal_id: str,
+    memory_owner_id: str,
     project_ref: str,
     session_id: str,
     epoch: int,
 ) -> str:
-    return f"src--{_keyed_digest(scope_key, f'{principal_id}:{project_ref}:{session_id}')}--e{epoch}"
+    return f"src--{_keyed_digest(scope_key, f'{memory_owner_id}:{project_ref}:{session_id}')}--e{epoch}"

--- a/core/memory/types.py
+++ b/core/memory/types.py
@@ -110,7 +110,7 @@ class MemoryPreflightDiagnostic:
 
 @dataclass(frozen=True)
 class ProviderSessionRef:
-    """Canonical provider identity persisted by Avibe's Memory outbox."""
+    """Canonical provider identity; ``principal_id`` carries the Memory owner."""
 
     principal_id: str
     epoch: int
@@ -322,6 +322,19 @@ class MemoryItem:
     date: str | None = None
     profile: MemoryProfile | None = None
     project: str | None = None
+    origin: Literal["user", "agent", "both"] | None = None
+
+
+@dataclass(frozen=True)
+class ProviderSearchItem:
+    """Provider-only search metadata used to merge owner-scoped legs."""
+
+    item: MemoryItem
+    score: float | None
+    episode_id: str | None
+    timestamp: str | None
+    provider_rank: int
+    queried_owner: str
 
 
 def memory_profile_payload(profile: MemoryProfile) -> dict[str, Any]:
@@ -362,6 +375,8 @@ def memory_item_payload(item: MemoryItem) -> dict[str, Any]:
         payload["profile"] = memory_profile_payload(item.profile)
     if item.project is not None:
         payload["project"] = item.project
+    if item.origin is not None:
+        payload["origin"] = item.origin
     return payload
 
 

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -434,9 +434,10 @@ _MEMORY_CLI_PROMPT = """\
 Avibe Memory is enabled for this conversation. Read Memory through the scoped CLI when durable personal context would materially improve the answer, and write to it whenever the conversation produces something worth carrying forward.
 
 - `vibe memory search "<query>" --json` searches this user's default Memory project.
+- Search results label `origin` as `user`, `agent`, or `both`. Treat `user` as directly captured user context, `agent` as the Agent's own recorded memory, and `both` as an exact text match found under both owners; do not present Agent-origin text as a direct user statement.
 - `vibe memory search "<query>" --project <slug> --json` searches one named project. Slugs are lowercase `^[a-z][a-z0-9_-]{0,62}$` and cannot be `all`, `personal`, mixed case, empty, or start with `p-` / `u-`. Never use `--project all`.
 - Agentic mode is for complex, multi-hop recall only: `vibe memory search "<query>" --mode agentic --json`.
-- `vibe memory profile --json` reads the current distilled profile.
+- `vibe memory profile --json` reads separately labeled user and Agent profile blocks; never merge them into one attributed profile.
 - `vibe memory status --json` is for diagnosing Memory availability and processing state.
 - `vibe memory remember "<text>" --json` queues one durable fact in `default`.
 - `vibe memory remember "<text>" --project <slug> --json` stores the fact in that named project only when the user explicitly wants it there. The same slug rules apply.

--- a/tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_scenarios.py
+++ b/tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_scenarios.py
@@ -109,6 +109,7 @@ def test_bound_slack_dm_attachment_reaches_search_with_redacted_call_log(
             "kind": "fact",
             "text": "Captured Slack attachment screenshot.png",
             "date": None,
+            "origin": "user",
         }
     ]
 

--- a/tests/scenarios/memory_search/catalog.yaml
+++ b/tests/scenarios/memory_search/catalog.yaml
@@ -53,3 +53,21 @@ scenarios:
     kind: happy_path
     layer: contract
     test: tests/test_memory_cli.py::test_agentic_cli_builds_bounded_internal_recall_policy
+  - id: MEMORY-SEARCH-008
+    name: Derived Agent owners are stable, cross-user isolated, and session-disjoint
+    status: covered
+    kind: authorization
+    layer: contract
+    test: tests/test_memory_store.py::test_assistant_owner_derivation_and_read_session_refs_are_stable_and_disjoint
+  - id: MEMORY-SEARCH-009
+    name: Dual-owner recall labels results and exact duplicates retain both origins
+    status: covered
+    kind: happy_path
+    layer: contract
+    test: tests/test_memory_module.py::test_dual_owner_search_is_concurrent_and_merges_score_dedupe_and_origins
+  - id: MEMORY-SEARCH-010
+    name: Agentic dual-owner recall spends at most one agentic provider leg
+    status: covered
+    kind: budget
+    layer: contract
+    test: tests/test_memory_module.py::test_agentic_recall_interleaves_per_leg_rank_with_only_one_agentic_leg

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -417,6 +417,33 @@ def test_memory_cli_human_output_uses_configured_i18n(monkeypatch, capsys) -> No
     ]
 
 
+def test_memory_cli_human_labels_origins_and_preserves_legacy_items(capsys) -> None:
+    cli._print_memory_cli_human(
+        "search",
+        {
+            "items": [
+                {"kind": "fact", "text": "Direct", "date": "2026-08-21", "origin": "user"},
+                {"kind": "fact", "text": "Recorded", "date": None, "origin": "agent"},
+                {"kind": "fact", "text": "Shared", "date": None, "origin": "both"},
+                {"kind": "fact", "text": "Legacy", "date": None},
+            ]
+        },
+        language="en",
+    )
+
+    assert capsys.readouterr().out.splitlines() == [
+        "[User memory] 2026-08-21 Direct",
+        "[Agent memory] Recorded",
+        "[User + Agent] Shared",
+        "Legacy",
+    ]
+
+
+def test_memory_prompt_explains_owner_labels_and_profile_separation() -> None:
+    assert "label `origin` as `user`, `agent`, or `both`" in _MEMORY_CLI_PROMPT
+    assert "never merge them into one attributed profile" in _MEMORY_CLI_PROMPT
+
+
 def test_memory_cli_human_status_uses_localized_fallbacks_for_unknown_tokens(
     monkeypatch,
     capsys,

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -216,6 +216,38 @@ def test_memory_list_human_surfaces_truncation_warning(
     assert "2026-08-14T12:00:00Z Subject" in captured.out
 
 
+@pytest.mark.parametrize("operation", ["search", "profile"])
+@pytest.mark.parametrize(
+    ("language", "warning"),
+    [
+        (
+            "en",
+            "Some user, Agent, or project Memory sources could not be loaded. Results may be incomplete.",
+        ),
+        ("zh", "部分用户记忆、Agent 记忆或项目记忆来源未能加载，结果可能不完整。"),
+    ],
+)
+def test_memory_read_human_surfaces_partial_warning(
+    operation,
+    language,
+    warning,
+    capsys,
+) -> None:
+    cli._print_memory_cli_human(
+        operation,
+        {
+            "status": "ok",
+            "items": [{"kind": "fact", "text": "Visible result", "date": None}],
+            "warnings": ["memory_search_partial"],
+        },
+        language=language,
+    )
+
+    captured = capsys.readouterr()
+    assert warning in captured.err
+    assert "Visible result" in captured.out
+
+
 def test_memory_list_parser_defaults_match_everos_page_semantics() -> None:
     args = cli.build_parser().parse_args(["memory", "list"])
 

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -738,11 +738,85 @@ def test_search_uses_public_search_only_and_maps_episode_and_nested_fact() -> No
             },
         )
     ]
-    assert items[0].kind == "episode"
-    assert items[0].text == "Preferred language\nThe owner uses Python."
-    assert items[0].date == "2026-07-22"
-    assert items[1].kind == "fact"
-    assert items[1].text == "Uses Python for automation."
+    assert items[0].item.kind == "episode"
+    assert items[0].item.text == "Preferred language\nThe owner uses Python."
+    assert items[0].item.date == "2026-07-22"
+    assert items[0].score is None
+    assert items[0].episode_id is None
+    assert items[0].provider_rank == 0
+    assert items[0].queried_owner == PRINCIPAL
+    assert items[1].item.kind == "fact"
+    assert items[1].item.text == "Uses Python for automation."
+
+
+def test_assistant_owner_crosses_add_search_and_profile_provider_contract() -> None:
+    assistant_owner = "u-11111111111111111111111111111111-agent"
+    session_ref = ProviderSessionRef(
+        principal_id=assistant_owner,
+        epoch=0,
+        project_ref=PROJECT,
+        session_id="src--assistant-owner--e0",
+    )
+    requests: list[tuple[str, dict]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        requests.append((request.url.path, payload))
+        if request.url.path.endswith("/add"):
+            return httpx.Response(
+                200,
+                json={"request_id": "add-assistant", "data": {"status": "accumulated"}},
+            )
+        if request.url.path.endswith("/search"):
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "episodes": [
+                            {
+                                "id": "episode-agent",
+                                "user_id": assistant_owner,
+                                "summary": "Agent-owned memory",
+                                "score": 0.75,
+                                "timestamp": "2026-08-21T10:00:00Z",
+                            },
+                            {"id": "wrong-owner", "user_id": PRINCIPAL, "summary": "must not leak"},
+                        ]
+                    }
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "profiles": [
+                        {"user_id": assistant_owner, "profile_data": {"summary": "Agent profile"}},
+                        {"user_id": PRINCIPAL, "profile_data": {"summary": "must not leak"}},
+                    ]
+                }
+            },
+        )
+
+    async def run():
+        provider = EverOSPort(Path("/tmp/everos.sock"))
+        added = await provider.add(ProviderCapture(session_ref, "记住发布计划", 1_725_000_001_234))
+        searched = await provider.search(assistant_owner, PROJECT, "发布", 5)
+        profile = await provider.profile(assistant_owner, PROJECT)
+        return added, searched, profile
+
+    with _sidecar_transport(handler):
+        added, searched, profile = asyncio.run(run())
+
+    assert added == AddAck(request_id="add-assistant", status="accumulated")
+    assert requests[0][1]["messages"][0]["sender_id"] == assistant_owner
+    assert requests[1][1]["user_id"] == assistant_owner
+    assert requests[2][1]["user_id"] == assistant_owner
+    assert len(searched) == 1
+    assert searched[0].queried_owner == assistant_owner
+    assert searched[0].score == 0.75
+    assert searched[0].episode_id == "episode-agent"
+    assert searched[0].timestamp == "2026-08-21T10:00:00Z"
+    assert [item.text for item in profile] == ['{"summary":"Agent profile"}']
 
 
 def test_agentic_search_retains_allowlisted_round_metadata() -> None:

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -22,7 +22,7 @@ from core.memory.module import (
     MemoryModule,
 )
 from core.memory.provider_root import ProviderRoot, ProviderRootMetadata
-from core.memory.store import MemoryStore
+from core.memory.store import MemoryStore, derive_assistant_memory_owner_id
 from core.memory.types import (
     CLOSED_MEMORY_ERROR_CODES,
     CaptureAccepted,
@@ -40,11 +40,14 @@ from core.memory.types import (
     OperationFailed,
     RecallItems,
     RecallPolicy,
+    ProviderSearchItem,
+    memory_item_payload,
 )
 
 
 PROJECT = "default"
 PRINCIPAL = "u-11111111111111111111111111111111"
+ASSISTANT_OWNER = derive_assistant_memory_owner_id(PRINCIPAL)
 
 
 @pytest.fixture(autouse=True)
@@ -305,7 +308,7 @@ async def test_provider_replacement_updates_reads_and_claim_delivery(tmp_path: P
         "query",
         principal_id=PRINCIPAL,
         project_id=PROJECT,
-    ) == MemoryItems(items=replacement.search_items)
+    ) == MemoryItems(items=(replace(replacement.search_items[0], origin="user"),))
     assert await module.capture(_request()) == CaptureAccepted()
     assert await module.drain() == 1
     assert original.captures == []
@@ -600,13 +603,13 @@ async def test_search_and_profile_enforce_bounds_and_return_closed_errors(tmp_pa
     module, _store, _provider = _module(tmp_path, provider=provider)
 
     assert await module.search("query", principal_id=PRINCIPAL, project_id=PROJECT) == MemoryItems(
-        items=provider.search_items
+        items=(replace(provider.search_items[0], origin="user"),)
     )
     assert await module.profile(principal_id=PRINCIPAL, project_id=PROJECT) == MemoryItems(
-        items=provider.profile_items
+        items=(replace(provider.profile_items[0], origin="user"),)
     )
-    assert provider.search_scopes == [(PRINCIPAL, PROJECT)]
-    assert provider.profile_scopes == [(PRINCIPAL, PROJECT)]
+    assert provider.search_scopes == [(PRINCIPAL, PROJECT), (ASSISTANT_OWNER, PROJECT)]
+    assert provider.profile_scopes == [(PRINCIPAL, PROJECT), (ASSISTANT_OWNER, PROJECT)]
     assert await module.search(
         "x" * (MAX_QUERY_BYTES + 1),
         principal_id=PRINCIPAL,
@@ -614,8 +617,8 @@ async def test_search_and_profile_enforce_bounds_and_return_closed_errors(tmp_pa
     ) == OperationFailed(error="memory_input_too_large")
 
     provider.search_items = tuple(MemoryItem(kind="fact", text=str(index)) for index in range(9))
-    assert await module.search("query", principal_id=PRINCIPAL, project_id=PROJECT) == OperationFailed(
-        error="memory_provider_response_invalid"
+    assert await module.search("query", principal_id=PRINCIPAL, project_id=PROJECT) == MemoryItems(
+        warnings=("memory_search_partial",)
     )
     provider.search_items = ()
     provider.search_failure = RuntimeError("provider-search-body-canary")
@@ -643,18 +646,18 @@ async def test_profile_bounds_accept_structured_data_only_on_profile_items(tmp_p
     module, _store, _provider = _module(tmp_path, provider=provider)
 
     assert await module.profile(principal_id=PRINCIPAL, project_id=PROJECT) == MemoryItems(
-        items=provider.profile_items
+        items=(replace(provider.profile_items[0], origin="user"),)
     )
 
     provider.profile_items = (MemoryItem(kind="fact", text="{}", profile=profile),)
-    assert await module.profile(principal_id=PRINCIPAL, project_id=PROJECT) == OperationFailed(
-        error="memory_provider_response_invalid"
+    assert await module.profile(principal_id=PRINCIPAL, project_id=PROJECT) == MemoryItems(
+        warnings=("memory_search_partial",)
     )
     provider.profile_items = (
         MemoryItem(kind="profile", text="{}", profile=MemoryProfile(summary="bad\x00value")),
     )
-    assert await module.profile(principal_id=PRINCIPAL, project_id=PROJECT) == OperationFailed(
-        error="memory_provider_response_invalid"
+    assert await module.profile(principal_id=PRINCIPAL, project_id=PROJECT) == MemoryItems(
+        warnings=("memory_search_partial",)
     )
 
 
@@ -951,11 +954,11 @@ async def test_keyword_recall_skips_health_and_succeeds_without_embedding(tmp_pa
     )
 
     assert result == RecallItems(
-        items=provider.search_items,
+        items=(replace(provider.search_items[0], origin="user"),),
         requested_mode="keyword",
         effective_mode="keyword",
     )
-    assert provider.search_policies == [("keyword", False, None)]
+    assert provider.search_policies == [("keyword", False, None), ("keyword", False, None)]
 
 
 @pytest.mark.parametrize("mode", ["vector", "hybrid"])
@@ -1002,7 +1005,10 @@ async def test_auto_recall_selects_only_keyword_or_hybrid(
     assert isinstance(result, RecallItems)
     assert result.requested_mode == "auto"
     assert result.effective_mode == effective_mode
-    assert provider.search_policies == [(effective_mode, True, None)]
+    assert provider.search_policies == [
+        (effective_mode, True, None),
+        (effective_mode, True, None),
+    ]
 
 
 @pytest.mark.parametrize("missing_capability", ["embed", "llm", "rerank"])
@@ -1236,13 +1242,13 @@ async def test_agentic_recall_reaches_provider_with_policy_timeout(
     )
 
     assert result == RecallItems(
-        items=provider.search_items,
+        items=(replace(provider.search_items[0], origin="user"),),
         requested_mode="agentic",
         effective_mode="agentic",
     )
-    assert provider.search_policies == [("agentic", True, None)]
+    assert provider.search_policies == [("agentic", True, None), ("hybrid", True, None)]
     assert resolve_timeouts == [5.0]
-    assert provider.search_timeouts == [3.0]
+    assert provider.search_timeouts == [3.0, None]
     telemetry = [
         record.getMessage()
         for record in caplog.records
@@ -1276,7 +1282,16 @@ async def test_current_session_overlay_uses_the_trusted_canonical_reference(tmp_
 
     assert isinstance(result, RecallItems)
     assert result.current_session_overlay is True
-    assert provider.search_policies == [("keyword", True, expected_ref)]
+    assistant_ref = store.provider_session_ref(
+        principal_id=PRINCIPAL,
+        memory_owner_id=ASSISTANT_OWNER,
+        project_ref=PROJECT,
+        session_id="trusted-current-session",
+    )
+    assert provider.search_policies == [
+        ("keyword", True, expected_ref),
+        ("keyword", True, assistant_ref),
+    ]
     assert expected_ref.principal_id == PRINCIPAL
     assert expected_ref.project_ref == PROJECT
     assert expected_ref.session_id != "trusted-current-session"
@@ -1309,8 +1324,8 @@ async def test_recall_makes_one_search_and_never_falls_back(tmp_path: Path) -> N
     )
 
     assert result == OperationFailed(error="memory_processing_failed")
-    assert provider.search_scopes == [(PRINCIPAL, PROJECT)]
-    assert provider.search_policies == [("hybrid", True, None)]
+    assert provider.search_scopes == [(PRINCIPAL, PROJECT), (ASSISTANT_OWNER, PROJECT)]
+    assert provider.search_policies == [("hybrid", True, None), ("hybrid", True, None)]
 
 
 async def test_failure_log_is_a_bounded_read_without_creating_state(tmp_path: Path) -> None:
@@ -1360,6 +1375,237 @@ async def test_malformed_unicode_returns_closed_capture_and_search_errors(tmp_pa
     )
 
 
+async def test_dual_owner_search_is_concurrent_and_merges_score_dedupe_and_origins(
+    tmp_path: Path,
+) -> None:
+    """Scenario: MEMORY-SEARCH-009."""
+
+    both_started = asyncio.Event()
+
+    class ConcurrentProvider(FakeMemoryProvider):
+        started = 0
+
+        async def search(self, *args, **kwargs):
+            self.started += 1
+            if self.started == 2:
+                both_started.set()
+            await asyncio.wait_for(both_started.wait(), timeout=1)
+            return await super().search(*args, **kwargs)
+
+    provider = ConcurrentProvider(
+        search_items_by_owner={
+            PRINCIPAL: (
+                ProviderSearchItem(
+                    item=MemoryItem(kind="fact", text="release plan"),
+                    score=0.7,
+                    episode_id="user-duplicate",
+                    timestamp="2026-08-20T00:00:00Z",
+                    provider_rank=1,
+                    queried_owner=PRINCIPAL,
+                ),
+                ProviderSearchItem(
+                    item=MemoryItem(kind="fact", text="I plan to release"),
+                    score=0.9,
+                    episode_id="user-paraphrase",
+                    timestamp="2026-08-19T00:00:00Z",
+                    provider_rank=0,
+                    queried_owner=PRINCIPAL,
+                ),
+            ),
+            ASSISTANT_OWNER: (
+                ProviderSearchItem(
+                    item=MemoryItem(kind="episode", text="release plan"),
+                    score=0.8,
+                    episode_id="agent-duplicate",
+                    timestamp="2026-08-21T00:00:00Z",
+                    provider_rank=0,
+                    queried_owner=ASSISTANT_OWNER,
+                ),
+                ProviderSearchItem(
+                    item=MemoryItem(kind="fact", text="The user plans to release"),
+                    score=0.6,
+                    episode_id=None,
+                    timestamp=None,
+                    provider_rank=1,
+                    queried_owner=ASSISTANT_OWNER,
+                ),
+            ),
+        }
+    )
+    _set_embed_capability(provider, True)
+    module, _store, _provider = _module(tmp_path, provider=provider)
+
+    result = await module.search("release", principal_id=PRINCIPAL, project_id=PROJECT)
+
+    assert isinstance(result, MemoryItems)
+    assert [(item.kind, item.text, item.origin) for item in result.items] == [
+        ("fact", "I plan to release", "user"),
+        ("episode", "release plan", "both"),
+        ("fact", "The user plans to release", "agent"),
+    ]
+    assert provider.started == 2
+
+
+async def test_dual_owner_search_marks_selected_duplicate_after_merge_limit(
+    tmp_path: Path,
+) -> None:
+    def hit(
+        *, owner: str, text: str, score: float, rank: int
+    ) -> ProviderSearchItem:
+        return ProviderSearchItem(
+            item=MemoryItem(kind="fact", text=text),
+            score=score,
+            episode_id=f"{owner}-{rank}",
+            timestamp=None,
+            provider_rank=rank,
+            queried_owner=owner,
+        )
+
+    provider = FakeMemoryProvider(
+        search_items_by_owner={
+            PRINCIPAL: (
+                hit(owner=PRINCIPAL, text="shared", score=0.9, rank=0),
+                hit(owner=PRINCIPAL, text="user only", score=0.8, rank=1),
+            ),
+            ASSISTANT_OWNER: (
+                hit(owner=ASSISTANT_OWNER, text="agent only", score=0.7, rank=0),
+                hit(owner=ASSISTANT_OWNER, text="shared", score=0.6, rank=1),
+            ),
+        }
+    )
+    _set_embed_capability(provider, True)
+    module, _store, _provider = _module(tmp_path, provider=provider)
+
+    result = await module.search(
+        "shared", principal_id=PRINCIPAL, project_id=PROJECT, limit=2
+    )
+
+    assert result == MemoryItems(
+        items=(
+            MemoryItem(kind="fact", text="shared", origin="both"),
+            MemoryItem(kind="fact", text="user only", origin="user"),
+        )
+    )
+
+
+async def test_dual_owner_search_does_not_collapse_whitespace_variants(
+    tmp_path: Path,
+) -> None:
+    provider = FakeMemoryProvider(
+        search_items_by_owner={
+            PRINCIPAL: (
+                ProviderSearchItem(
+                    item=MemoryItem(kind="fact", text="shared"),
+                    score=0.9,
+                    episode_id="user-shared",
+                    timestamp=None,
+                    provider_rank=0,
+                    queried_owner=PRINCIPAL,
+                ),
+            ),
+            ASSISTANT_OWNER: (
+                ProviderSearchItem(
+                    item=MemoryItem(kind="fact", text=" shared "),
+                    score=0.8,
+                    episode_id="agent-shared",
+                    timestamp=None,
+                    provider_rank=0,
+                    queried_owner=ASSISTANT_OWNER,
+                ),
+            ),
+        }
+    )
+    _set_embed_capability(provider, True)
+    module, _store, _provider = _module(tmp_path, provider=provider)
+
+    result = await module.search("shared", principal_id=PRINCIPAL, project_id=PROJECT)
+
+    assert result == MemoryItems(
+        items=(
+            MemoryItem(kind="fact", text="shared", origin="user"),
+            MemoryItem(kind="fact", text=" shared ", origin="agent"),
+        )
+    )
+
+
+async def test_dual_owner_partial_failure_and_labeled_profiles(tmp_path: Path) -> None:
+    provider = FakeMemoryProvider(
+        search_items=(MemoryItem(kind="fact", text="user result"),),
+        search_failures_by_owner={
+            ASSISTANT_OWNER: MemoryProviderFailure("memory_processing_failed"),
+        },
+        profile_items_by_owner={
+            PRINCIPAL: (MemoryItem(kind="profile", text="user profile"),),
+            ASSISTANT_OWNER: (MemoryItem(kind="profile", text="agent profile"),),
+        },
+    )
+    module, _store, _provider = _module(tmp_path, provider=provider)
+
+    search = await module.search("query", principal_id=PRINCIPAL, project_id=PROJECT)
+    profile = await module.profile(principal_id=PRINCIPAL, project_id=PROJECT)
+
+    assert search == MemoryItems(
+        items=(MemoryItem(kind="fact", text="user result", origin="user"),),
+        warnings=("memory_search_partial",),
+    )
+    assert profile == MemoryItems(
+        items=(
+            MemoryItem(kind="profile", text="user profile", origin="user"),
+            MemoryItem(kind="profile", text="agent profile", origin="agent"),
+        )
+    )
+
+
+async def test_agentic_recall_interleaves_per_leg_rank_with_only_one_agentic_leg(
+    tmp_path: Path,
+) -> None:
+    """Scenario: MEMORY-SEARCH-010."""
+
+    def hits(owner: str, prefix: str) -> tuple[ProviderSearchItem, ...]:
+        return tuple(
+            ProviderSearchItem(
+                item=MemoryItem(kind="fact", text=f"{prefix}{rank}"),
+                score=100.0 - rank,
+                episode_id=f"{prefix}-{rank}",
+                timestamp=None,
+                provider_rank=rank,
+                queried_owner=owner,
+            )
+            for rank in range(2)
+        )
+
+    provider = FakeMemoryProvider(
+        agentic_budget_enforced_flag=True,
+        search_items_by_owner={
+            PRINCIPAL: hits(PRINCIPAL, "user-"),
+            ASSISTANT_OWNER: hits(ASSISTANT_OWNER, "agent-"),
+        },
+    )
+    module, _store, _provider = _module(tmp_path, provider=provider)
+    result = await module.recall(
+        "connect",
+        policy=RecallPolicy(
+            mode="agentic",
+            max_results=4,
+            timeout_seconds=5,
+            max_model_calls=1,
+            cost_budget_tokens=1_000,
+        ),
+        principal_id=PRINCIPAL,
+        project_id=PROJECT,
+    )
+
+    assert isinstance(result, RecallItems)
+    assert [(item.text, item.origin) for item in result.items] == [
+        ("user-0", "user"),
+        ("agent-0", "agent"),
+        ("user-1", "user"),
+        ("agent-1", "agent"),
+    ]
+    assert [method for method, _include, _session in provider.search_policies] == [
+        "agentic",
+        "hybrid",
+    ]
 async def test_capture_happy_path_uses_one_local_queue_transaction(tmp_path: Path) -> None:
     class CountingStore(MemoryStore):
         def __init__(self, path: Path) -> None:
@@ -1404,6 +1650,13 @@ def test_provider_port_is_not_part_of_the_public_memory_package() -> None:
 
     assert "MemoryProviderPort" not in memory.__all__
     assert "ProviderCapture" not in memory.__all__
+
+
+def test_memory_item_origin_is_optional_in_legacy_payloads() -> None:
+    assert "origin" not in memory_item_payload(MemoryItem(kind="fact", text="legacy"))
+    assert memory_item_payload(
+        MemoryItem(kind="fact", text="shared", origin="both")
+    )["origin"] == "both"
 
 
 def test_memory_list_result_types_are_public() -> None:

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -68,6 +68,7 @@ from core.memory.types import (
     MemoryProfile,
     MemoryProfileExplicitInfo,
     OperationFailed,
+    RecallItems,
     RecallPolicy,
     CaptureAttachment,
     CaptureRequest,
@@ -110,6 +111,35 @@ async def test_all_project_agentic_recall_is_rejected_before_project_access() ->
     )
 
     assert result == OperationFailed(error="memory_invalid_input")
+
+
+async def test_all_projects_preserves_successful_project_partial_warnings() -> None:
+    class Module:
+        async def resolve_recall_mode(self, _policy):
+            return "hybrid"
+
+        async def recall(self, _query, **kwargs):
+            return RecallItems(
+                items=(MemoryItem(kind="fact", text=kwargs["project_id"], origin="user"),),
+                requested_mode="hybrid",
+                effective_mode="hybrid",
+                warnings=("memory_search_partial",),
+            )
+
+    runtime = SimpleNamespace(
+        module=Module(),
+        list_memory_projects=lambda _principal_id: ("default", "notes"),
+    )
+    result = await MemoryRuntime._recall_all_projects(
+        runtime,
+        "query",
+        policy=RecallPolicy(mode="hybrid", max_results=8),
+        principal_id=PRINCIPAL,
+    )
+
+    assert isinstance(result, RecallItems)
+    assert [item.text for item in result.items] == ["default", "notes"]
+    assert result.warnings == ("memory_search_partial",)
 
 
 def _maintenance(runtime: MemoryRuntime) -> MemoryMaintenance:

--- a/tests/test_memory_sidecar.py
+++ b/tests/test_memory_sidecar.py
@@ -484,7 +484,7 @@ def test_sidecar_guard_allows_derived_principals_and_memory_scope() -> None:
     ).encode()
     get = json.dumps(
         {
-            "user_id": "u-22222222222222222222222222222222",
+            "user_id": principal,
             "app_id": "avibe",
             "project_id": "default",
             "memory_type": "profile",
@@ -497,6 +497,22 @@ def test_sidecar_guard_allows_derived_principals_and_memory_scope() -> None:
     assert _request_rejection("POST", "/api/v2/memory/add", payload) is None
     assert _request_rejection("POST", "/api/v2/memory/search", search) is None
     assert _request_rejection("POST", "/api/v2/memory/get", get) is None
+    assistant_owner = f"{principal}-agent".encode()
+    assert _request_rejection(
+        "POST",
+        "/api/v2/memory/add",
+        payload.replace(principal.encode(), assistant_owner),
+    ) is None
+    assert _request_rejection(
+        "POST",
+        "/api/v2/memory/search",
+        search.replace(principal.encode(), assistant_owner),
+    ) is None
+    assert _request_rejection(
+        "POST",
+        "/api/v2/memory/get",
+        get.replace(principal.encode(), assistant_owner),
+    ) is None
     assert _request_rejection("POST", "/api/v2/memory/add", payload.replace(principal.encode(), b"owner-1")) == "add"
     assert _request_rejection("POST", "/api/v2/memory/add", payload.replace(PROJECT.encode(), b"personal")) == "add"
     assert _request_rejection("POST", "/api/v1/memory/add", payload) == "route"

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import sqlite3
 import stat
@@ -26,7 +27,9 @@ from core.memory.store import (
     SystemOutage,
     TERMINAL_TOMBSTONE_RETENTION,
     derive_project_id,
+    derive_assistant_memory_owner_id,
     derive_principal_id,
+    is_memory_owner_id,
     _keyed_digest,
 )
 from core.memory.types import ProviderSessionRef
@@ -1208,6 +1211,52 @@ def test_principal_derivation_is_stable_opaque_and_user_scoped() -> None:
     assert first != derive_principal_id(bytes.fromhex("22" * 32), "slack:U123")
     assert first.startswith("u-") and len(first) == 34
     assert "U123" not in first
+
+
+def test_assistant_owner_derivation_and_read_session_refs_are_stable_and_disjoint(
+    tmp_path: Path,
+) -> None:
+    """Scenario: MEMORY-SEARCH-008."""
+
+    principal = "u-11111111111111111111111111111111"
+    other_principal = "u-22222222222222222222222222222222"
+    assistant_owner = derive_assistant_memory_owner_id(principal)
+
+    assert assistant_owner == f"{principal}-agent"
+    assert assistant_owner == derive_assistant_memory_owner_id(principal)
+    assert assistant_owner != derive_assistant_memory_owner_id(other_principal)
+    assert is_memory_owner_id(principal)
+    assert is_memory_owner_id(assistant_owner)
+    assert not is_memory_owner_id(f"{principal}-agent-agent")
+
+    store = MemoryStore(_store_path(tmp_path))
+    user_ref = store.provider_session_ref(
+        principal_id=principal,
+        project_ref=PROJECT,
+        session_id="owner-split-session",
+    )
+    explicit_user_ref = store.provider_session_ref(
+        principal_id=principal,
+        memory_owner_id=principal,
+        project_ref=PROJECT,
+        session_id="owner-split-session",
+    )
+    assistant_ref = store.provider_session_ref(
+        principal_id=principal,
+        memory_owner_id=assistant_owner,
+        project_ref=PROJECT,
+        session_id="owner-split-session",
+    )
+
+    assert explicit_user_ref == user_ref
+    assert assistant_ref.principal_id == assistant_owner
+    assert assistant_ref.session_id != user_ref.session_id
+    assert set(json.loads(assistant_ref.serialize())) == {
+        "principal_id",
+        "epoch",
+        "project_ref",
+        "session_id",
+    }
 
 
 def test_project_derivation_is_stable_opaque_and_workdir_scoped() -> None:

--- a/ui/src/components/settings/memory/MemoryProfilePanel.test.tsx
+++ b/ui/src/components/settings/memory/MemoryProfilePanel.test.tsx
@@ -2,7 +2,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
 import type { MemoryProfile } from '../../../context/ApiContext';
-import { StructuredMemoryProfile } from './MemoryProfilePanel';
+import { MemoryProfileItemBlock, StructuredMemoryProfile } from './MemoryProfilePanel';
 import { structuredProfileFromItems } from './memoryProfile';
 
 const t = (key: string) => key;
@@ -62,5 +62,19 @@ describe('MemoryProfilePanel structured text', () => {
 
     expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
     expect(html).not.toContain('<img src=x');
+  });
+
+  it('labels user and Agent profile blocks while legacy blocks still render', () => {
+    const html = renderToStaticMarkup(
+      <>
+        <MemoryProfileItemBlock item={{ kind: 'profile', text: 'User profile', date: null, origin: 'user' }} t={t} />
+        <MemoryProfileItemBlock item={{ kind: 'profile', text: 'Agent profile', date: null, origin: 'agent' }} t={t} />
+        <MemoryProfileItemBlock item={{ kind: 'profile', text: 'Legacy profile', date: null }} t={t} />
+      </>,
+    );
+
+    expect(html).toContain('memory.origin.user');
+    expect(html).toContain('memory.origin.agent');
+    expect(html).toContain('Legacy profile');
   });
 });

--- a/ui/src/components/settings/memory/MemoryProfilePanel.test.tsx
+++ b/ui/src/components/settings/memory/MemoryProfilePanel.test.tsx
@@ -1,11 +1,24 @@
+/* @vitest-environment jsdom */
+
 import { renderToStaticMarkup } from 'react-dom/server';
-import { describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { MemoryProfile } from '../../../context/ApiContext';
-import { MemoryProfileItemBlock, StructuredMemoryProfile } from './MemoryProfilePanel';
+import { MemoryProfileItemBlock, MemoryProfilePanel, StructuredMemoryProfile } from './MemoryProfilePanel';
 import { structuredProfileFromItems } from './memoryProfile';
 
 const t = (key: string) => key;
+const getMemoryProfile = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../context/ApiContext', async (loadOriginal) => {
+  const original = await loadOriginal<typeof import('../../../context/ApiContext')>();
+  return { ...original, useApi: () => ({ getMemoryProfile }) };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t }),
+}));
 
 const PROFILE: MemoryProfile = {
   summary: 'Prefers concise technical updates.',
@@ -26,6 +39,15 @@ const PROFILE: MemoryProfile = {
   ],
   updated_at: '2026-08-02T10:30:00Z',
 };
+
+beforeEach(() => {
+  getMemoryProfile.mockResolvedValue({ status: 'ok', items: [], warnings: [] });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 describe('MemoryProfilePanel structured text', () => {
   it('renders structured sections and keeps basis distinct from evidence', () => {
@@ -76,5 +98,18 @@ describe('MemoryProfilePanel structured text', () => {
     expect(html).toContain('memory.origin.user');
     expect(html).toContain('memory.origin.agent');
     expect(html).toContain('Legacy profile');
+  });
+
+  it('renders a partial warning while retaining the successful owner profile', async () => {
+    getMemoryProfile.mockResolvedValue({
+      status: 'ok',
+      items: [{ kind: 'profile', text: 'Available user profile', date: null, origin: 'user' }],
+      warnings: ['memory_search_partial'],
+    });
+
+    render(<MemoryProfilePanel enabled />);
+
+    expect(await screen.findByText('memory.profile.partial')).toBeTruthy();
+    expect(screen.getByText('Available user profile')).toBeTruthy();
   });
 });

--- a/ui/src/components/settings/memory/MemoryProfilePanel.tsx
+++ b/ui/src/components/settings/memory/MemoryProfilePanel.tsx
@@ -112,6 +112,11 @@ export const MemoryProfilePanel: React.FC<{ enabled: boolean }> = ({ enabled }) 
           {t('memory.profile.refresh')}
         </Button>
       </div>
+      {data?.warnings.includes('memory_search_partial') ? (
+        <div className="rounded-lg border border-border bg-surface px-4 py-3 text-sm text-muted">
+          {t('memory.profile.partial')}
+        </div>
+      ) : null}
       {error ? (
         <div className="rounded-xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive-ink">{error}</div>
       ) : loading && items === null ? (

--- a/ui/src/components/settings/memory/MemoryProfilePanel.tsx
+++ b/ui/src/components/settings/memory/MemoryProfilePanel.tsx
@@ -5,8 +5,9 @@ import { Loader2, RefreshCw } from 'lucide-react';
 import { Badge } from '../../ui/badge';
 import { Button } from '../../ui/button';
 import { useApi } from '../../../context/ApiContext';
-import type { MemoryItemsResult, MemoryProfile } from '../../../context/ApiContext';
+import type { MemoryItem, MemoryItemsResult, MemoryProfile } from '../../../context/ApiContext';
 import { useMemoryResource } from './useMemoryResource';
+import { memoryOriginLabelKey } from './memoryOrigin';
 
 type MemoryItemsOk = Extract<MemoryItemsResult, { status: 'ok' }>;
 type Translate = (key: string) => string;
@@ -56,6 +57,23 @@ export const StructuredMemoryProfile: React.FC<{ profile: MemoryProfile; t: Tran
         </div>
       </section>
     ) : null}
+  </div>
+);
+
+export const MemoryProfileItemBlock: React.FC<{ item: MemoryItem; t: Translate }> = ({ item, t }) => (
+  <div className="rounded-xl border border-border bg-surface px-4 py-3">
+    <div className="mb-3 flex items-center gap-2">
+      <Badge variant="secondary">{t(`memory.kind.${item.kind}`)}</Badge>
+      {memoryOriginLabelKey(item.origin) ? (
+        <Badge variant="outline">{t(memoryOriginLabelKey(item.origin)!)}</Badge>
+      ) : null}
+      {item.date ? <span className="font-mono text-[10.5px] text-muted">{item.date}</span> : null}
+    </div>
+    {item.profile ? (
+      <StructuredMemoryProfile profile={item.profile} t={t} />
+    ) : (
+      <p className="whitespace-pre-wrap text-[13px] leading-relaxed text-foreground">{item.text}</p>
+    )}
   </div>
 );
 
@@ -112,17 +130,11 @@ export const MemoryProfilePanel: React.FC<{ enabled: boolean }> = ({ enabled }) 
       ) : (
         <div className="flex flex-col gap-2">
           {items.map((item, index) => (
-            <div key={`${item.kind}:${item.date ?? ''}:${index}`} className="rounded-xl border border-border bg-surface px-4 py-3">
-              <div className="mb-3 flex items-center gap-2">
-                <Badge variant="secondary">{t(`memory.kind.${item.kind}`)}</Badge>
-                {item.date ? <span className="font-mono text-[10.5px] text-muted">{item.date}</span> : null}
-              </div>
-              {item.profile ? (
-                <StructuredMemoryProfile profile={item.profile} t={t} />
-              ) : (
-                <p className="whitespace-pre-wrap text-[13px] leading-relaxed text-foreground">{item.text}</p>
-              )}
-            </div>
+            <MemoryProfileItemBlock
+              key={`${item.kind}:${item.date ?? ''}:${index}`}
+              item={item}
+              t={t}
+            />
           ))}
           <p className="px-1 text-[11px] text-muted">{t('memory.profile.sourceNote')}</p>
         </div>

--- a/ui/src/components/settings/memory/MemorySearchPanel.test.tsx
+++ b/ui/src/components/settings/memory/MemorySearchPanel.test.tsx
@@ -380,6 +380,29 @@ describe('MemorySearchPanel browse and search modes', () => {
     expect(api.searchMemory).toHaveBeenCalledWith('release plan', 20, 'all');
   });
 
+  it('[MEMORY-SEARCH-009] labels owner origins and still renders legacy search items', async () => {
+    api.searchMemory.mockResolvedValue({
+      status: 'ok',
+      items: [
+        { kind: 'fact', text: 'User result', date: null, origin: 'user' },
+        { kind: 'fact', text: 'Agent result', date: null, origin: 'agent' },
+        { kind: 'fact', text: 'Shared result', date: null, origin: 'both' },
+        { kind: 'fact', text: 'Legacy result', date: null },
+      ],
+      warnings: [],
+    });
+    const user = userEvent.setup();
+
+    render(<MemorySearchPanel enabled />);
+    await user.type(screen.getByPlaceholderText('memory.search.placeholder'), 'owner labels');
+    await user.click(screen.getByRole('button', { name: 'memory.search.button' }));
+
+    expect(await screen.findByText('memory.origin.user')).toBeTruthy();
+    expect(screen.getByText('memory.origin.agent')).toBeTruthy();
+    expect(screen.getByText('memory.origin.both')).toBeTruthy();
+    expect(screen.getByText('Legacy result')).toBeTruthy();
+  });
+
   it('shows the Memory-closed state without issuing list calls', () => {
     render(<MemorySearchPanel enabled={false} />);
 

--- a/ui/src/components/settings/memory/MemorySearchPanel.tsx
+++ b/ui/src/components/settings/memory/MemorySearchPanel.tsx
@@ -23,6 +23,7 @@ import type {
 } from '../../../context/ApiContext';
 import { copyTextToClipboard } from '../../../lib/utils';
 import { useMemoryResource } from './useMemoryResource';
+import { memoryOriginLabelKey } from './memoryOrigin';
 
 type MemoryItemsOk = Extract<MemoryRecallResult, { status: 'ok' }>;
 type MemoryListOk = Extract<MemoryListResult, { status: 'ok' }>;
@@ -464,6 +465,9 @@ export const MemorySearchPanel: React.FC<{ enabled: boolean }> = ({ enabled }) =
                 <div key={index} className="rounded-lg border border-border bg-surface px-4 py-3">
                   <div className="mb-1 flex items-center gap-2">
                     <Badge variant="secondary">{t(`memory.kind.${item.kind}`)}</Badge>
+                    {memoryOriginLabelKey(item.origin) ? (
+                      <Badge variant="outline">{t(memoryOriginLabelKey(item.origin)!)}</Badge>
+                    ) : null}
                     {item.project && (project === 'all' || item.project !== 'default') ? (
                       <Badge variant="outline">
                         {item.project === 'default' ? t('memory.search.projectDefault') : item.project}

--- a/ui/src/components/settings/memory/memoryOrigin.ts
+++ b/ui/src/components/settings/memory/memoryOrigin.ts
@@ -1,0 +1,4 @@
+import type { MemoryItem } from '../../../context/ApiContext';
+
+export const memoryOriginLabelKey = (origin: MemoryItem['origin']): string | null =>
+  origin ? `memory.origin.${origin}` : null;

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -2078,6 +2078,7 @@ export type MemoryItem = {
   date: string | null;
   profile?: MemoryProfile;
   project?: string;
+  origin?: 'user' | 'agent' | 'both';
 };
 
 export type MemoryItemsResult =

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -4114,6 +4114,11 @@
     "title": "Memory",
     "betaTitle": "Memory · Beta",
     "subtitle": "Avibe builds a personal memory from your conversations and your Agent's work, so it understands you better over time. Review, search, or clear it here.",
+    "origin": {
+      "user": "User memory",
+      "agent": "Agent memory",
+      "both": "User + Agent"
+    },
     "setup": {
       "runtimeRequired": "Install the Memory runtime first",
       "runtimeRequiredHint": "Install or repair Memory from Dependencies. You can still disable Memory or clear stored data below."

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -4369,6 +4369,7 @@
       "loading": "Loading profile…",
       "empty": "No profile yet — keep chatting, then check back once messages have been processed.",
       "loadFailed": "Couldn't load your profile.",
+      "partial": "One profile source could not be loaded. The profile shown here may be incomplete.",
       "warningUnavailable": "A profile isn't available from this provider yet. This is expected, not an error — try Search instead, or check back later.",
       "disabledHint": "Enable Memory to view your profile.",
       "refresh": "Refresh",
@@ -4391,7 +4392,7 @@
       "projectLabel": "Memory project",
       "projectDefault": "Default",
       "projectAll": "All my projects",
-      "partial": "Some projects could not be searched. These results may be incomplete.",
+      "partial": "Some user, Agent, or project Memory sources could not be searched. These results may be incomplete.",
       "truncated": "Search stopped before every project was checked. These results may be incomplete.",
       "browse": {
         "sortLabel": "Episode order",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -4114,6 +4114,11 @@
     "title": "记忆",
     "betaTitle": "记忆 · Beta",
     "subtitle": "Avibe 会从你的对话和 Agent 的工作记录中提炼记忆，让它越来越懂你。你可以在这里查看、搜索或清除这些记忆。",
+    "origin": {
+      "user": "用户记忆",
+      "agent": "Agent 记忆",
+      "both": "用户 + Agent"
+    },
     "setup": {
       "runtimeRequired": "请先安装记忆运行时",
       "runtimeRequiredHint": "请前往依赖页面安装或修复记忆运行时。你仍可在下方停用记忆或清除已存储的数据。"

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -4369,6 +4369,7 @@
       "loading": "正在加载画像…",
       "empty": "还没有画像——继续聊天，消息处理后再来看看。",
       "loadFailed": "无法加载你的画像。",
+      "partial": "有一个画像来源未能加载，当前显示的画像可能不完整。",
       "warningUnavailable": "该提供方暂不支持画像。这是预期行为，不是错误——可以试试搜索，或稍后再来看看。",
       "disabledHint": "启用记忆后即可查看画像。",
       "refresh": "刷新",
@@ -4391,7 +4392,7 @@
       "projectLabel": "记忆项目",
       "projectDefault": "默认",
       "projectAll": "我的全部项目",
-      "partial": "部分项目未能搜索，结果可能不完整。",
+      "partial": "部分用户记忆、Agent 记忆或项目记忆来源未能搜索，结果可能不完整。",
       "truncated": "搜索在查完所有项目前停止，结果可能不完整。",
       "browse": {
         "sortLabel": "记忆片段排序",

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -558,7 +558,16 @@ def _print_memory_cli_human(operation: str, result: dict, *, language: str) -> N
         if not isinstance(text, str):
             continue
         date = item.get("date")
-        prefix = f"{date} " if isinstance(date, str) and date else ""
+        origin = item.get("origin")
+        origin_prefix = ""
+        if operation in {"search", "profile"} and origin in {"user", "agent", "both"}:
+            origin_prefix = i18n_t(
+                "memory.cli.originPrefix",
+                language,
+                origin=i18n_t(f"memory.cli.origin.{origin}", language),
+            )
+        date_prefix = f"{date} " if isinstance(date, str) and date else ""
+        prefix = f"{origin_prefix}{date_prefix}"
         print(f"{prefix}{text}")
 
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -522,10 +522,16 @@ def _print_memory_cli_human(operation: str, result: dict, *, language: str) -> N
             print(i18n_t("memory.cli.sourceReason", language, reason=reason_label))
         return
 
+    warnings = result.get("warnings")
     if operation == "list":
-        warnings = result.get("warnings")
         if isinstance(warnings, list) and "memory_list_truncated" in warnings:
             print(i18n_t("memory.cli.listWarning.truncated", language), file=sys.stderr)
+    elif (
+        operation in {"search", "profile"}
+        and isinstance(warnings, list)
+        and "memory_search_partial" in warnings
+    ):
+        print(i18n_t("memory.cli.readWarning.partial", language), file=sys.stderr)
 
     items = result.get("items")
     if not isinstance(items, list) or not items:

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -774,6 +774,12 @@
         "engine": "The Memory engine reported an internal error. Try repairing the Memory runtime."
       },
       "empty": "No memory items found.",
+      "originPrefix": "[{origin}] ",
+      "origin": {
+        "user": "User memory",
+        "agent": "Agent memory",
+        "both": "User + Agent"
+      },
       "remembered": "Memory queued.",
       "listWarning": {
         "truncated": "Memory listing reached the provider ordering limit. Later pages may be incomplete."

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -784,6 +784,9 @@
       "listWarning": {
         "truncated": "Memory listing reached the provider ordering limit. Later pages may be incomplete."
       },
+      "readWarning": {
+        "partial": "Some user, Agent, or project Memory sources could not be loaded. Results may be incomplete."
+      },
       "partialRestartWarning": "Memory Settings content is unavailable: the Web UI restarted while the service kept running,\n  and their shared Memory proof exists only inside the running processes.\n  Run 'vibe stop' and then 'vibe' to restart both together."
     }
   },

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -774,6 +774,12 @@
         "engine": "记忆引擎内部错误，可尝试修复记忆运行时。"
       },
       "empty": "未找到记忆条目。",
+      "originPrefix": "[{origin}] ",
+      "origin": {
+        "user": "用户记忆",
+        "agent": "Agent 记忆",
+        "both": "用户 + Agent"
+      },
       "remembered": "记忆已加入队列。",
       "listWarning": {
         "truncated": "记忆列表已达到服务排序上限，后续页面可能不完整。"

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -784,6 +784,9 @@
       "listWarning": {
         "truncated": "记忆列表已达到服务排序上限，后续页面可能不完整。"
       },
+      "readWarning": {
+        "partial": "部分用户记忆、Agent 记忆或项目记忆来源未能加载，结果可能不完整。"
+      },
       "partialRestartWarning": "记忆设置内容暂不可用：Web UI 已重启，但服务仍在运行，\n  两者共享的记忆访问凭证仅存在于运行中的进程内。\n  请先运行 'vibe stop'，再运行 'vibe'，以同时重启两者。"
     }
   },


### PR DESCRIPTION
## Capability

Adds dual-owner Memory read fan-out and labeled user/Agent surfaces while preserving the trusted caller principal and the existing single-owner EverOS request contract.

- derives the assistant Memory owner as `<principal>-agent` server-side
- queries user and assistant owners concurrently for search, recall, and profile
- merges same-method legs by score/timestamp/stable ID, interleaves mixed agentic/hybrid legs by per-leg rank, trims after merge, and marks exact normalized duplicates as `origin="both"`
- degrades one failed leg with `memory_search_partial`, including all-projects recall
- keeps at most one agentic provider leg and gives each owner its own current-session filter
- renders user, Agent, and shared origins in CLI, prompt guidance, and Settings Memory

PR B depends on this read contract and must preserve the frozen owner, origin, provider-result, session-ref, merge, and partial-failure shapes introduced here.

## Affected scenarios

- `MEMORY-SEARCH-008` - derived owner stability, cross-user isolation, and session-ref disjointness
- `MEMORY-SEARCH-009` - dual-owner recall labels and exact-duplicate provenance
- `MEMORY-SEARCH-010` - one-agentic-leg budget rule

## Evidence

- Unit: `uv run pytest -q tests/test_memory*.py` - 1558 passed, 7 skipped
- Contract: stub-sidecar coverage drives assistant owners through add/search/profile mapping, retains metadata-free search responses, validates queried-owner identity, and proves the four-field `ProviderSessionRef` shape
- Scenario: catalog IDs above are wired into backend and UI tests; focused Vitest coverage passed (15 tests)
- Static/build: Ruff passed on all changed Python files; `git diff --check` passed; `cd ui && npm run build` passed
- Residual manual: Incus regression is intentionally deferred to the orchestrator integration pass after PR B activates the write path

## Known by design

- `list_episodes` remains user-owner-only in PR A.
- Assistant-owner reads are dark by data until PR B routes agent-provenance writes.
- Queue minting/recovery, terminal flush, EverOS add routing, insight-reader expansion, migration, and write-path documentation remain outside this PR.
