### PR TITLE
docs(memory): plan best-effort capture delivery

### DIFF
--- a/docs/plans/memory-best-effort-capture.md
+++ b/docs/plans/memory-best-effort-capture.md
@@ -67,15 +67,16 @@ provider root.
   reservation through pinning, stale-generation reclamation, queueing, and the
   one in-flight provider call. There is no second reservation chain outside
   that process-wide bound.
-- Principal, project, epoch, `scope_key`, and `provider_root_id` are
-  byte-identical across the upgrade.
+- Principal, project, epoch, `scope_key`, `provider_root_id`, and
+  `last_success_at` are byte-identical across the upgrade.
 - Named-project catalog rows survive.
 - `last_provider_timestamp_ms` survives and remains the lower bound for
   new EverOS add timestamps, so post-upgrade writes cannot reorder against
   already-stored EverOS cells.
-- An in-progress Clear or Factory Reset is completed by the existing
-  destructive path. The capture migrator does not strip or rewrite a store
-  that those markers still own.
+- A readable marker-owned Clear or pending Factory Reset is completed by the
+  existing destructive path. The capture migrator does not strip or rewrite a
+  store that those markers still own. A fence without a readable Clear marker
+  stays blocked until an explicit Clear supplies fresh destructive authority.
 - A Clear marker that exists but cannot be read is still an open destructive
   fence. Migration and all Memory writes stay blocked until the existing
   Clear retry replaces or completes that marker.
@@ -190,31 +191,43 @@ required for this cut.
 `extracted` drops pending flush state for that provider session.
 `accumulated` refreshes one in-memory `PendingFlush(session_ref,
 raw_session_id, first_accumulated_at, last_accumulated_at, message_ids,
-attempts)`. `message_ids` is bounded by the 100-message flush limit and exists
-only to correlate any submitted flush outcome with the retained Provider Call
-Log. `raw_session_id` is the already-validated bounded capture identifier; it
-stays volatile and is never logged. The message-id list length is the volatile
-`unflushed_count`: every `accumulated`
-acknowledgement appends exactly one message id, and reaching 100 makes that
-provider session immediately due before another add for the same session can be
-submitted.
+attempts, correlation_complete)`. `message_ids` is bounded by the 100-message
+flush limit and exists only to correlate any submitted flush outcome with the
+retained Provider Call Log. `raw_session_id` is the already-validated bounded
+capture identifier; it stays volatile and is never logged. The message-id list
+length is the volatile `unflushed_count`: every `accumulated` acknowledgement
+appends exactly one message id, and reaching 100 makes that provider session
+immediately due before another add for the same session can be submitted.
 
 The map retains at most 256 provider sessions, so its 100-id per-entry limit
-also bounds total retained ids at 25,600. If an `accumulated` result would create
-a 257th entry, do not evict or mutate an existing scope: drop the new volatile
-tracking entry, increment a content-free capacity-drop counter, and leave the
-EverOS buffer untouched. A later same-session add may recreate tracking after
-capacity is available, and Repair or provider extraction may process the older
-buffer. The pending map does not survive process restart.
+also bounds total retained ids at 25,600. Every retained session has a bounded,
+content-free durable correlation guard described below. A guard written by the
+current writer instance plus its matching live `PendingFlush` means the bounded
+message-id list is complete. A guard from an older writer generation, or one
+already marked incomplete, makes any recreated tracker incomplete.
+
+If an `accumulated` result would create a 257th entry, do not evict or mutate an
+existing scope: atomically record the add provenance and set the singleton
+global-incomplete correlation guard, drop the new volatile tracking entry,
+increment a content-free capacity-drop counter, and leave the EverOS buffer
+untouched. A later same-session add may recreate tracking after capacity is
+available, but its `correlation_complete` is false; any later flush is recorded
+as unavailable correlation rather than appearing complete from only the later
+ids. Failure to persist the guard leaves the add's already-open provenance gap
+open and fails the writer generation closed. The pending map does not survive a
+writer generation or process restart, while its durable guards do.
 
 When an entry becomes due, the worker snapshots it for one flush attempt. A
 failure proven to occur before the provider coroutine can execute may retain
 that same entry for at most three total attempts. At the exact submission edge
 where the provider coroutine may execute, remove the entry from the map and
-carry its bounded message-id snapshot only in the in-flight slot. Success,
+carry its bounded message-id snapshot and completeness bit only in the in-flight
+slot. Mark its durable guard incomplete before submission. Success,
 rejection, timeout, malformed response, cancellation, and any other ambiguous
 submitted outcome all consume that snapshot permanently; none reinsert or
-reschedule it. Only a later `accumulated` add can create fresh pending state.
+reschedule it. An acknowledged flush or natural `extracted` add deletes that
+session's exact guard; every other result leaves it incomplete for later adds.
+Only a later `accumulated` add can create fresh pending state.
 
 Worker generation increments on disable, shutdown, Reset/Clear, and
 runtime-affecting configuration replacement. The old worker is cancelled, the
@@ -309,6 +322,7 @@ memory_call_provenance
   project_id
   session_id
   message_ids_json     # exact EverOS message ids, at most 100
+  correlation_complete # true for adds; flush snapshot completeness
   recorded_at_ms
 
 memory_processing_anomaly
@@ -323,6 +337,12 @@ memory_processing_anomaly
   worker_generation
   principal_id
   project_id
+
+memory_flush_correlation_guard
+  guard_key            # HMAC of provider-session ref, or one global sentinel
+  writer_instance_id   # opaque generation token; null for global sentinel
+  incomplete           # boolean; true cannot become complete by later adds
+  recorded_at_ms
 
 memory_call_provenance_gap
   gap_id               # local operation token, never sent to EverOS
@@ -341,8 +361,8 @@ that Processing Record currently reads from `memory_capture_queue` and
   `FlushRejected`, another terminal non-success, or an otherwise unclassifiable
   response whose id can still be validated
 - an add row carries its one exact `m_<session>_<provider timestamp>_000`
-  message id; a flush row carries the bounded message-id list from that
-  session's `PendingFlush`
+  message id and `correlation_complete=true`; a flush row carries the bounded
+  message-id list from that session's `PendingFlush` plus its completeness bit
 - retain at most 5,000 provenance rows and at most 14 days, matching Provider
   Call Log retention, but prune only complete request-id groups: age-prune a
   group only when its newest `recorded_at_ms` is older than the cutoff, then
@@ -354,11 +374,38 @@ that Processing Record currently reads from `memory_capture_queue` and
 - for every user-scoped read, require all rows for the request id to resolve to
   exactly one principal/project; ambiguous or missing provenance never
   broadens visibility
+- require every row in a request-id group to have `correlation_complete=true`
+  for correlation and authorization. A false flush row makes that call's
+  correlation source unavailable; its later message ids must not make an
+  incomplete request appear linked or unlinked
 - for a call reached through a linked memcell, additionally require that owned
   memcell to contain one of the recorded message ids
 - for `list_unlinked_calls` and an unlinked request-id detail, unique provenance
   scope is the authorization fact: requiring memcell membership there would
   reject the branch precisely because the call is unlinked
+
+`memory_flush_correlation_guard` is observer completeness metadata, not a flush
+schedule or delivery queue. It contains no message ids, raw session id, payload,
+count, deadline, attempt, or work item:
+
+- keep at most 256 exact session digests plus one singleton global-incomplete
+  sentinel; never evict an exact guard and thereby turn unknown correlation into
+  apparently complete correlation
+- create/update an exact guard in the same observer transaction that records the
+  first `accumulated` add for a live tracker. Its opaque writer-instance token
+  proves completeness only while the matching generation and `PendingFlush`
+  still exist
+- at generation replacement or process restart, any surviving exact guard has
+  an old token and therefore taints later recreated tracking as incomplete
+- when the exact-guard capacity or volatile pending-map capacity is exceeded,
+  set the global sentinel. While it exists every newly created tracker is
+  incomplete, including sessions not represented by an exact row
+- delete an exact guard only after a natural `extracted` add or acknowledged
+  flush proves that provider buffer crossed a boundary. Rejection, timeout,
+  malformed response, cancellation, and ambiguity retain it as incomplete
+- the global sentinel is cleared only by Clear/Factory Reset or a future
+  provider-wide operation that positively proves every unprocessed buffer empty;
+  ordinary add/flush results and sidecar restart cannot prove that
 
 `memory_processing_anomaly` replaces the sanitized failure projection that
 `MemoryStore.failure_log()` currently derives from terminal
@@ -397,11 +444,14 @@ observer state into delivery state:
    snapshot only for the bounded pre-submission retry policy above.
 2. If the result contains a valid request id, one transaction inserts every
    provenance row for that call, inserts its sanitized anomaly row when the
-   result is non-success, and deletes only that operation token's gap. This
-   applies to acknowledged, rejected, and unknown classifications. A separately
-   allowed add retry starts only after that observer transaction commits; a
-   submitted flush is terminal. A provenance/anomaly transaction failure leaves
-   the already-committed gap open and never causes a provider retry.
+   result is non-success, applies its correlation-guard transition, and deletes
+   only that operation token's gap. An acknowledged add also advances
+   `memory_meta.last_success_at` to the observation time in this transaction.
+   This applies to acknowledged, rejected, and unknown classifications. A
+   separately allowed add retry starts only after that observer transaction
+   commits; a submitted flush is terminal. A provenance/anomaly/guard transaction
+   failure leaves the already-committed gap open and never causes a provider
+   retry.
 3. If an add result has no valid request id and proves no request left Avibe, or
    a flush attempt fails before its provider coroutine can execute, close only
    that gap before any permitted retry. On the final bounded failure, insert the
@@ -436,8 +486,8 @@ oldest ranges into a wider range rather than dropping coverage. Delete a closed
 range only when it is wholly older than the Provider Call Log retention cutoff;
 an open range is never age-deleted. This may hide a good observation
 conservatively, but cannot authorize the wrong scope. Clear's `reset_for_clear`
-deletes provenance rows, anomalies, and gaps with the catalog and watermark
-reset; Factory Reset deletes them with `state/memory`.
+deletes provenance rows, anomalies, correlation guards, and gaps with the
+catalog and watermark reset; Factory Reset deletes them with `state/memory`.
 
 The independently maintained Provider Call Log is not an input to identity
 migration or writer admission. Historical migration copies every valid bounded
@@ -465,6 +515,16 @@ charge, attachment pin, or task creation. Otherwise persist the new watermark in
 the same identity transaction as the catalog upsert for named projects, charge
 the ordered slot, and only then release the critical section. That section has
 no attachment or provider await; the identity write is not an outbox.
+
+`last_success_at` also remains durable display/maintenance state. Every
+acknowledged v4 add updates it in the same observer transaction as provenance and
+gap settlement, using the later of its existing value and the observation time.
+Provenance retention never clears it. The reduced
+`has_provider_data_history()` reads this field instead of delivery rows, so
+`MemoryMaintenance.maintenance_payload().data_exists` remains true after
+provenance ages out while EverOS may still contain captured data. Clear resets it
+to null in the same identity reset transaction; migration preserves its exact
+released value.
 
 That identity transaction preserves `MAX_NAMED_MEMORY_PROJECTS`: an existing
 named-project row may be updated at the limit, but inserting a 17th distinct
@@ -524,8 +584,8 @@ default project, both provenances, attachment bundle present or absent,
 flush in_flight / idle, processing-fault columns set or null, WAL+SHM
 sidecars). After upgrade:
 
-- `scope_key`, `epoch`, `provider_root_id`, and
-  `last_provider_timestamp_ms` are unchanged
+- `scope_key`, `epoch`, `provider_root_id`, `last_provider_timestamp_ms`, and
+  `last_success_at` are unchanged
 - `memory_projects` rows are unchanged
 - no capture payload, lease, fence, settlement, or bundle row remains
 - no dropped payload is sent to EverOS
@@ -546,16 +606,21 @@ would accept captures:
    Do not read or rewrite `memory.sqlite` as an identity source; Reset
    deletes `memory` and `state/memory`.
 2. Read `state/memory/clear-intent.json` through `ClearIntentStore.load()`.
-   If it is present and readable, or `memory_meta.clear_in_progress` is set,
-   run the existing Clear reconcile. Clear already deletes queue tables and
-   bumps epoch. After it finishes, the store is empty identity at
-   `target_epoch`. Then open it as v4, creating identity tables if Clear's
-   reset still used the old schema for one boot. If the marker exists but is
-   truncated, malformed, inaccessible, oversized, symlinked, or otherwise
-   raises `ClearIntentUnreadable`, preserve `MemoryMaintenance.is_open()`
-   semantics: do not migrate, do not start the sidecar/writer, and project the
-   existing `memory_clear_marker_unreadable` retry state. Only an explicit
-   Clear re-run may replace that marker.
+   - If it is present and readable, run the existing marker-owned Clear
+     reconcile. After it finishes, the store is empty identity at
+     `target_epoch`. Then open it as v4, creating identity/observer tables if
+     Clear's reset still used the old schema for one boot.
+   - If it is absent but `memory_meta.clear_in_progress` is set, do not call
+     `reconcile_pending()` and do not assume deletion occurred. Preserve the
+     existing `orphaned-fence` / `memory_clear_failed` projection, keep
+     migration plus sidecar/writer admission blocked, and allow only an explicit
+     operator Clear to create a fresh intent and own the destructive sweep.
+   - If it is truncated, malformed, inaccessible, oversized, symlinked, or
+     otherwise raises `ClearIntentUnreadable`, preserve
+     `MemoryMaintenance.is_open()` semantics: do not migrate, do not start the
+     sidecar/writer, and project the existing
+     `memory_clear_marker_unreadable` retry state. Only an explicit Clear re-run
+     may replace that marker.
 3. Otherwise open `state/memory/memory.sqlite` through the existing confined
    path and detect its released shape without writing.
 4. Start one outer `BEGIN IMMEDIATE`. Refactor the v0→v2, v1→v2, and v2→v3
@@ -582,6 +647,11 @@ would accept captures:
      rejected adds exactly as the current projection does, map errors through the
      same closed-code sanitizer, and prune only the oldest overflow beyond the
      newest 100,000 rows, with no age cutoff
+   - for every old `memory_session_flush_state` row with an unflushed provider
+     buffer, create an incomplete exact `memory_flush_correlation_guard` using
+     only its bounded session-ref digest. If more than 256 distinct rows exist,
+     keep 256 exact guards and set the global-incomplete sentinel; never migrate
+     a schedule, count, deadline, fence, attempt, or message id
    - do not open the optional Provider Call Log; if observer-only request-id or
      timestamp data cannot be translated safely, create or widen one bounded
      `migration_unknown` gap over the retained horizon and count it without
@@ -607,7 +677,8 @@ would accept captures:
    same scrub on the next boot; never follow or manually unlink an unsafe entry.
 8. Emit one content-free structured log: discarded nonterminal count,
    discarded terminal count, migrated anomaly count, discarded bundle-row
-   count, and scrubbed confined entry count. Never log text,
+   count, migrated exact-guard count, global-incomplete-guard state, and
+   scrubbed confined entry count. Never log text,
    paths, or digests that can recover a message. Also count provenance rows
    covered by a migration gap and a busy post-commit checkpoint without treating
    either as a capture-startup failure.
@@ -726,9 +797,11 @@ labelled as volatile; it must not show a durable missed-capture backlog.
 
 Processing Record and Provider Call Log otherwise retain their current scope
 and correlation behavior through `memory_call_provenance` and
-`memory_call_provenance_gap`. The reader's capture-source availability probe and
-request-id joins move to those tables; they do not silently omit request-id call
-branches merely because the delivery tables are gone.
+`memory_call_provenance_gap`, with completeness guarded by
+`memory_flush_correlation_guard`. The reader's capture-source availability probe
+and request-id joins move to those tables; they do not silently omit request-id
+call branches merely because the delivery tables are gone or a volatile
+message-id set was lost.
 
 Processing Record's durable anomaly source moves independently to
 `memory_processing_anomaly`. `MemoryStore.failure_log()` keeps its current
@@ -762,9 +835,12 @@ only after the replacement is admitted. This is the replacement for
 `quiesce_claims()`, not an outbox drain.
 
 Clear's queue primitive becomes: identity `reset_for_clear` (epoch bump,
-catalog wipe, watermark zero, call-provenance and gap wipe) with no
+catalog wipe, watermark and `last_success_at` reset, and atomic deletion of
+`memory_call_provenance`, `memory_processing_anomaly`,
+`memory_flush_correlation_guard`, and `memory_call_provenance_gap`) with no
 capture-queue DELETE. The other three surfaces (provider root, call log,
-attachments) stay.
+attachments) stay. Replaying the same `target_epoch` is idempotent and still
+proves every observer table empty before the Clear fence may be released.
 
 Factory Reset still deletes `memory` and `state/memory`. The v4 store is just
 another file under `state/memory`.
@@ -822,13 +898,19 @@ Do not ship those doc edits in this planning PR.
 - Missing, corrupt, incompatible, or unreadable Provider Call Log state does
   not fail identity migration or block writer startup; its observer projection
   reports unavailable/warned independently.
-- `clear_in_progress` / clear-intent / factory-reset pending skip the
-  strip path and follow the existing destructive reconciler.
+- A readable clear-intent or factory-reset pending state skips the strip path
+  and follows its existing destructive reconciler. `clear_in_progress` without
+  a readable intent skips the strip path but stays blocked as an orphaned fence;
+  it never enters the destructive reconciler without fresh operator authority.
 - Every unreadable clear-intent shape keeps migration, sidecar startup, and
   writer startup blocked without modifying the marker or SQLite identity.
 - Retained add/flush request ids migrate to bounded call provenance before
   delivery tables are dropped, including rejected calls and every scope row for
   reused ids; ambiguous cross-scope request ids remain unauthorized.
+- Released unflushed-session rows migrate to incomplete, content-free
+  correlation guards without message ids or schedule state. At 256 distinct
+  exact guards the next distinct row sets the global-incomplete sentinel; a
+  later recreated tracker cannot claim complete flush provenance.
 - Across the released-fixture matrix, seed every failure form each shape can
   represent, together covering `dead`, `manual_required`, boot recovery,
   rejected add/flush, and ambiguous settlement evidence. The newest-50
@@ -876,7 +958,15 @@ Do not ship those doc edits in this planning PR.
   third failed attempt drops it without a provider call.
 - High-cardinality accumulated traffic retains at most 256 pending sessions and
   25,600 message ids. A 257th new session drops only its new volatile tracking,
-  never evicts or mutates an existing scope, and records content-free accounting.
+  never evicts or mutates an existing scope, atomically sets the durable
+  global-incomplete guard, and records content-free accounting. A later add for
+  that session may be tracked, but its flush provenance is explicitly incomplete
+  and Processing Record reports correlation unavailable.
+- Exact correlation guards from a previous writer instance/generation taint a
+  recreated tracker after restart; a global guard taints every new tracker.
+  Natural extraction or acknowledged flush clears an exact guard, while
+  rejected/ambiguous results and sidecar restart do not. No test can recover
+  complete provenance using only message ids accumulated after a guard.
 - Shutdown, disable, config replacement, Clear, and Reset drop the queue
   without drain.
 - Session barrier does not block `/new` or archive. At its ordered head it
@@ -899,6 +989,10 @@ Do not ship those doc edits in this planning PR.
   closed and its permit charged until confined cleanup succeeds; restart runs
   the mandatory empty-root scrub before reopening intake.
 - Watermark persists across writer restart and is monotonic.
+- Every acknowledged add advances durable `last_success_at` atomically with its
+  provenance/gap settlement. After all call-provenance groups age out,
+  `has_provider_data_history()` and maintenance `data_exists` remain true from
+  that timestamp; rejected/ambiguous adds do not advance it and Clear resets it.
 - With the watermark already at `MAX_PROVIDER_TIMESTAMP_MS`, the next otherwise
   valid capture returns `timestamp_invalid` without changing the watermark or
   catalog and without charging a slot, pinning, or creating a task.
@@ -939,6 +1033,14 @@ Do not ship those doc edits in this planning PR.
   operation, and resume only an admitted fresh generation.
 - Clear still resumes from `clear-intent.json` and still recreates an
   empty provider root.
+- A readable Clear intent replays, but an absent intent plus
+  `memory_meta.clear_in_progress=1` remains the existing failed
+  `orphaned-fence` projection and blocks migration, sidecar, and writer until an
+  explicit operator Clear writes new authority.
+- Clear's identity reset atomically removes provenance, anomalies, correlation
+  guards, and gaps and nulls `last_success_at` before releasing its fence. A
+  pre-Clear `failure_log()` row cannot appear under the new epoch, including on
+  idempotent replay after a crash.
 - Search, profile, list, remember admission, and agent-owner read paths
   keep their `origin/dev` contracts.
 - Agent-provenance capture writes retain the current user-principal
@@ -956,7 +1058,7 @@ Do not ship those doc edits in this planning PR.
 
 ## Implementation sequence
 
-1. Identity-and-provenance v4 schema + migrator + fixture property tests. No
+1. Identity-and-observer v4 schema + migrator + fixture property tests. No
    behavior change yet if the writer still reads v4 as empty outbox —
    prefer not to land a half-migrated store. Land migrator and writer
    together.
@@ -977,9 +1079,9 @@ after adding migrator and writer tests. Line count is not acceptance.
 - [ ] Implement v4 identity schema and released-shape migrator.
 - [ ] Implement `BestEffortMemoryWriter` and switch capture to `offer()`.
 - [ ] Replace capture-table Processing Record joins with bounded call
-      provenance, lifecycle-closed durable gaps, and sanitized anomaly rows;
-      migrate retained correlations and the current failure projection before
-      dropping the tables.
+      provenance, correlation guards, lifecycle-closed durable gaps, and
+      sanitized anomaly rows; migrate retained correlations and the current
+      failure projection before dropping the tables.
 - [ ] Replace session final-flush waits with a best-effort multi-scope session
       barrier over the bounded volatile pending-flush map.
 - [ ] Replace claim quiescence with writer pause/quiesce around Rebuild/Repair.
@@ -1007,8 +1109,10 @@ implementation PR:
 5. Session-boundary flush is a barrier enqueue, not a wait. A crash or
    a full queue can leave consecutive conversations in one EverOS accumulation
    boundary. A 257th concurrently tracked provider session also drops its new
-   volatile flush trigger; a later same-session add, Repair, or provider
-   extraction may process that buffer.
+   volatile flush trigger and sets the bounded global-incomplete guard. Later
+   flush correlation stays unavailable rather than silently omitting older
+   message ids; the global guard may conservatively hide unrelated flush
+   correlation until Clear/Factory Reset or a provider-wide empty-buffer proof.
 6. No JSON identity file is introduced. Identity stays in the existing
    SQLite file so Clear's `reset_for_clear(target_epoch=...)` and
    Factory Reset keep one authority.

--- a/docs/plans/memory-best-effort-capture.md
+++ b/docs/plans/memory-best-effort-capture.md
@@ -277,7 +277,7 @@ own `memory_meta.epoch`. A second identity format would add crash windows
 without removing the outbox.
 
 After migration, `state/memory/memory.sqlite` contains identity plus bounded,
-content-free display-provenance tables. They contain no delivery work,
+content-free display-provenance and anomaly tables. They contain no delivery work,
 retry state, flush schedule, captured text, or attachment path:
 
 ```text
@@ -310,6 +310,19 @@ memory_call_provenance
   session_id
   message_ids_json     # exact EverOS message ids, at most 100
   recorded_at_ms
+
+memory_processing_anomaly
+  anomaly_id           # stable opaque local id
+  kind                 # current closed MemoryFailureKind
+  occurred_at_ms
+  error_code           # closed Memory error code or null
+  request_id           # bounded provider id or null
+  attempts             # bounded add/flush attempt count
+  state
+  operation_kind       # add | flush
+  worker_generation
+  principal_id
+  project_id
 
 memory_call_provenance_gap
   gap_id               # local operation token, never sent to EverOS
@@ -347,30 +360,74 @@ that Processing Record currently reads from `memory_capture_queue` and
   scope is the authorization fact: requiring memcell membership there would
   reject the branch precisely because the call is unlinked
 
+`memory_processing_anomaly` replaces the sanitized failure projection that
+`MemoryStore.failure_log()` currently derives from terminal
+`memory_capture_queue` rows and `memory_flush_settlements`. It is observer state,
+not a retry or delivery ledger:
+
+- write one row for each terminal rejected or ambiguous add/flush and each
+  proven-uncommitted operation that exhausts its bounded attempts; successful
+  calls never create anomaly rows
+- preserve the current `MemoryFailureLogEntry` fields and closed values: stable
+  id, kind, occurrence time, closed error code, bounded request id, attempts,
+  state, operation, and worker generation. New ids are an HMAC of `scope_key`
+  plus the opaque local operation token; migrated rows retain the current
+  `_failure_anomaly_id` result derived from their queue/settlement namespace and
+  evidence. Principal/project columns provide authorization but are not added to
+  the user-visible anomaly payload
+- never store provider messages, raw exceptions, payload/message text, session
+  ids, source digests, attachment metadata, paths, or lease/fence tokens
+- retain the newest 100,000 rows with no age deletion, matching the current
+  terminal-tombstone count ceiling while preserving old immutable-settlement
+  anomalies that remain among the newest 50; return that newest 50 through the
+  unchanged `failure_log()` / Processing Record projection
+- order and prune deterministically by `(occurred_at_ms, anomaly_id)`, so
+  deleting only oldest overflow cannot change the current newest-50 projection
+- enforce retention after each insert and at boot; an anomaly read/schema
+  failure marks that Processing Record source unavailable rather than returning
+  an empty successful list
+
 The single ordered worker makes correlation loss restart-safe without turning
 observer state into delivery state:
 
 1. Before every EverOS add or flush attempt, the worker durably inserts one open
-   `memory_call_provenance_gap` row. It also closes any stale open row at this
-   attempt's start time. If this preflight identity transaction fails, the
-   provider is not called: an add is skipped, while a due flush retains its
+   `memory_call_provenance_gap` row for that operation token. It never closes or
+   replaces another attempt's gap. If this preflight identity transaction fails,
+   the provider is not called: an add is skipped, while a due flush retains its
    snapshot only for the bounded pre-submission retry policy above.
 2. If the result contains a valid request id, one transaction inserts every
-   provenance row for that call and deletes its open gap. This applies to
-   acknowledged, rejected, and unknown classifications. A separately allowed
-   add retry starts only after that observer transaction commits; a submitted
-   flush is terminal. A provenance transaction failure leaves the
-   already-committed gap open and never causes a provider retry.
+   provenance row for that call, inserts its sanitized anomaly row when the
+   result is non-success, and deletes only that operation token's gap. This
+   applies to acknowledged, rejected, and unknown classifications. A separately
+   allowed add retry starts only after that observer transaction commits; a
+   submitted flush is terminal. A provenance/anomaly transaction failure leaves
+   the already-committed gap open and never causes a provider retry.
 3. If an add result has no valid request id and proves no request left Avibe, or
-   a flush attempt fails before its provider coroutine can execute, close the
-   gap before any permitted retry; if closing fails, drop the item. The retry
-   opens a new gap. A timeout, truncated or malformed response, or other result
-   without a trustworthy request id after submission leaves the gap open because
-   the provider may have observed the call, and a submitted flush stays terminal.
-4. At boot, close a stale open gap at boot time. Until then an open gap covers
-   `[started_at_ms, infinity)`. A Processing Record call whose observation time
-   overlaps any gap reports the correlation source unavailable instead of
-   silently disappearing from a scoped result.
+   a flush attempt fails before its provider coroutine can execute, close only
+   that gap before any permitted retry. On the final bounded failure, insert the
+   sanitized anomaly in the same transaction that closes the gap. If the
+   transaction fails, drop the item and leave the gap open fail-closed. A retry
+   opens a new independent gap.
+4. A timeout, truncated or malformed response, cancellation, or other submitted
+   result without a trustworthy request id inserts a `result_unknown` anomaly
+   but leaves that operation's gap open because the provider may still execute.
+   Later attempts do not shorten it. If the anomaly transaction fails, the open
+   gap still makes the observation source unavailable; the provider call is not
+   retried.
+5. Close open `call_unobserved` gaps only at a provider-lifecycle upper bound:
+   intake is paused, the writer has no new submission edge, and the sidecar
+   supervisor has successfully stopped and reaped the owned provider process.
+   One transaction sets `ended_at_ms` for gaps that started before that observed
+   termination; only then may a replacement sidecar accept calls. Failed or
+   unprovable termination leaves the gaps open and intake closed. An Avibe boot
+   does not close them merely because the service restarted; it may close them
+   only after the same provider-termination proof. Until then each open gap
+   covers `[started_at_ms, infinity)`.
+
+A Processing Record call whose observation time overlaps any gap reports the
+correlation source unavailable instead of silently disappearing from a scoped
+result. Thus an older timed-out request remains covered even if a newer request
+quickly returns a valid id and settles its own gap.
 
 A gap is global observer state rather than a principal/project authorization
 fact: no scoped reader may bypass an overlapping gap. Gap metadata is also
@@ -379,8 +436,8 @@ oldest ranges into a wider range rather than dropping coverage. Delete a closed
 range only when it is wholly older than the Provider Call Log retention cutoff;
 an open range is never age-deleted. This may hide a good observation
 conservatively, but cannot authorize the wrong scope. Clear's `reset_for_clear`
-deletes provenance rows and gaps with the catalog and watermark reset; Factory
-Reset deletes them with `state/memory`.
+deletes provenance rows, anomalies, and gaps with the catalog and watermark
+reset; Factory Reset deletes them with `state/memory`.
 
 The independently maintained Provider Call Log is not an input to identity
 migration or writer admission. Historical migration copies every valid bounded
@@ -439,7 +496,7 @@ remains keyed by the 34-character user principal.
 On-disk Memory SQLite is a shipped surface. v3.0.10 (2026-08-11) released
 the #1217 foundation. `dev` already migrates those files up to schema v3
 (`5a1a8ff3` and follow-ups). This PR adds one more step: v3 →
-identity-and-provenance v4, and must still enter from every earlier released
+identity-and-observer v4, and must still enter from every earlier released
 shape.
 
 Checked-in fixtures to drive, not a closed list of "interesting" rows:
@@ -518,6 +575,13 @@ would accept captures:
      id into `memory_call_provenance`, including rejected operations and every
      scope row for a reused id; prune only complete request-id groups to the
      5,000-row / 14-day window and preserve ambiguity as fail-closed
+   - run the released-shape equivalent of the current `failure_log()` union and
+     copy every projected queue/settlement anomaly into
+     `memory_processing_anomaly` before its source tables are dropped. Preserve
+     the stable id and every sanitized `MemoryFailureLogEntry` field, deduplicate
+     rejected adds exactly as the current projection does, map errors through the
+     same closed-code sanitizer, and prune only the oldest overflow beyond the
+     newest 100,000 rows, with no age cutoff
    - do not open the optional Provider Call Log; if observer-only request-id or
      timestamp data cannot be translated safely, create or widen one bounded
      `migration_unknown` gap over the retained horizon and count it without
@@ -526,7 +590,7 @@ would accept captures:
    - rebuild `memory_meta` without requiring delivery columns if this
      PR drops them
    - `PRAGMA user_version = 4`
-   - verify identity tables and required identity columns
+   - verify identity and observer tables plus every required v4 column
 6. Commit, request `PRAGMA wal_checkpoint(FULL)` on the migration connection,
    inspect its busy result, and close every store-owned connection before
    admitting the writer. A concurrent read-only Processing Record connection
@@ -542,8 +606,8 @@ would accept captures:
    If the scrub cannot prove the root empty, keep the writer closed and retry the
    same scrub on the next boot; never follow or manually unlink an unsafe entry.
 8. Emit one content-free structured log: discarded nonterminal count,
-   discarded terminal count, discarded bundle-row count, and scrubbed confined
-   entry count. Never log text,
+   discarded terminal count, migrated anomaly count, discarded bundle-row
+   count, and scrubbed confined entry count. Never log text,
    paths, or digests that can recover a message. Also count provenance rows
    covered by a migration gap and a busy post-commit checkpoint without treating
    either as a capture-startup failure.
@@ -666,6 +730,12 @@ and correlation behavior through `memory_call_provenance` and
 request-id joins move to those tables; they do not silently omit request-id call
 branches merely because the delivery tables are gone.
 
+Processing Record's durable anomaly source moves independently to
+`memory_processing_anomaly`. `MemoryStore.failure_log()` keeps its current
+newest-50 result shape and source-availability behavior; it no longer queries a
+delivery table. Disabling Memory still permits the existing read-only retained
+anomaly projection.
+
 ## Control plane that stays
 
 The claim API goes away with the outbox, but its provider-maintenance
@@ -705,7 +775,7 @@ Likely:
 
 ```text
 core/memory/ingest.py      # BestEffortMemoryWriter
-core/memory/identity.py    # meta + projects + watermark + bounded provenance/gaps
+core/memory/identity.py    # meta + projects + watermark + bounded observer tables
                            # or store.py reduced to that surface
 core/memory/migrate_store.py  # v0..v3 recognition + v3→v4 strip
 ```
@@ -735,7 +805,7 @@ Do not ship those doc edits in this planning PR.
 ### Identity and migration
 
 - Every checked-in released fixture opens and becomes a v4
-  identity-and-provenance store.
+  identity-and-observer store.
 - Property test: seed every persistable production row shape the current
   schema allows, migrate, assert identity bytes and catalog equality,
   assert zero remaining delivery tables, assert the fake provider received
@@ -759,6 +829,14 @@ Do not ship those doc edits in this planning PR.
 - Retained add/flush request ids migrate to bounded call provenance before
   delivery tables are dropped, including rejected calls and every scope row for
   reused ids; ambiguous cross-scope request ids remain unauthorized.
+- Across the released-fixture matrix, seed every failure form each shape can
+  represent, together covering `dead`, `manual_required`, boot recovery,
+  rejected add/flush, and ambiguous settlement evidence. The newest-50
+  `failure_log()` projection is field-for-field identical before and after
+  migration (including stable ids, deduplication, closed errors, attempts,
+  operation, state, generation, and bounded request ids), while the v4 file has
+  no delivery tables. Retention keeps only the deterministically newest 100,000
+  anomaly rows, without an age cutoff and without payload or retry state.
 - Provenance age and row-count pruning deletes complete request-id groups only;
   it cannot turn a reused ambiguous id into a uniquely authorized id, including
   when one group alone exceeds the row bound.
@@ -835,12 +913,21 @@ Do not ship those doc edits in this planning PR.
   write skips an add or retains a due flush only within its bounded
   pre-submission attempts, without calling EverOS; timeout/unknown responses and
   an injected provenance-commit failure leave a gap that remains fail-closed
-  after restart and is closed at the next attempt or boot.
+  after restart. A later successful attempt settles only its own gap; the older
+  ambiguous gap stays open until a paused writer plus successful sidecar
+  stop/reap proves its termination boundary.
 - Valid bounded request ids from acknowledged, rejected, and otherwise
-  unclassifiable add/flush responses are recorded with their outcome and scope.
-  Provenance failure never causes a provider retry; a separately allowed add or
-  pre-submission flush retry first settles the old observer gap and opens a new
-  one, while a submitted flush remains terminal.
+  unclassifiable add/flush responses are recorded with their outcome and scope;
+  terminal non-success and exhausted proven-uncommitted operations also persist
+  the current sanitized `MemoryFailureLogEntry` fields in the bounded anomaly
+  table. Provenance/anomaly failure never causes a provider retry; a separately
+  allowed add or pre-submission flush retry settles only its own proven-unentered
+  gap and opens a new one, while a submitted flush remains terminal.
+- An ambiguous request A followed by a successful request B leaves A's gap open
+  after B atomically records provenance and deletes B's gap. A late Provider Call
+  Log row from A therefore overlaps unavailable correlation coverage. Only a
+  successful owned-sidecar stop/reap closes A at the observed termination time;
+  an ordinary later attempt, failed stop, or unproved boot never does.
 - Gap compaction coalesces old ranges without losing covered time, and age
   deletion removes only closed ranges wholly outside Call Log retention.
 
@@ -862,6 +949,10 @@ Do not ship those doc edits in this planning PR.
   rejected calls, linked memcell membership, unique-scope unlinked list/detail,
   restart-safe source unavailability, whole-request-id-group retention, and
   ambiguous-request-id tests.
+- Processing Record reads recent durable failures from bounded
+  `memory_processing_anomaly`, preserving its current newest-50 field shape,
+  stable migrated ids, disabled-state visibility, and unavailable-on-read-failure
+  behavior without consulting queue or settlement tables.
 
 ## Implementation sequence
 
@@ -886,7 +977,8 @@ after adding migrator and writer tests. Line count is not acceptance.
 - [ ] Implement v4 identity schema and released-shape migrator.
 - [ ] Implement `BestEffortMemoryWriter` and switch capture to `offer()`.
 - [ ] Replace capture-table Processing Record joins with bounded call
-      provenance plus durable gaps, and migrate retained correlations before
+      provenance, lifecycle-closed durable gaps, and sanitized anomaly rows;
+      migrate retained correlations and the current failure projection before
       dropping the tables.
 - [ ] Replace session final-flush waits with a best-effort multi-scope session
       barrier over the bounded volatile pending-flush map.

--- a/docs/plans/memory-best-effort-capture.md
+++ b/docs/plans/memory-best-effort-capture.md
@@ -1,0 +1,521 @@
+# Memory best-effort capture (Phase 1)
+
+> Status: implementation contract
+>
+> Scope: replace Avibe's durable Memory outbox with a process-local writer.
+> The change that lands this file is docs-only. "This PR" / "implementation"
+> below means the follow-up product-code PR after this contract is accepted.
+> That follow-up does not rename Repair, collapse Reset, add Settings Test,
+> or change EverOS.
+
+Base: `origin/dev` at `ab91b6c07` (`feat(memory): split agent memory owner on read paths (#1633)`). Implementation rebases onto current `origin/dev` before coding.
+
+This document is the implementation contract. The planning PR that lands it does not change product code. An unpublished umbrella draft considered later cuts (Repair rename, Processing Record, attachments, Settings Test); those remain out of scope here.
+
+## Background
+
+Avibe currently persists every eligible capture in SQLite
+(`state/memory/memory.sqlite`) and delivers it through claims, leases,
+generation fences, flush settlements, tombstones, and `manual_required`.
+That protocol is a second reliability system around EverOS. Ordinary chat
+does not wait for it, and processing failures no longer notify IM
+administrators (`0210f154c` / #1631).
+
+The durable outbox's real guarantee is "Avibe can replay a capture after
+this process restarts." EverOS already keeps markdown and
+`unprocessed_buffer` as its own durable sources. Replaying Avibe's queue
+after an ambiguous add also risks duplicates.
+
+This change makes capture best-effort and process-local, while preserving
+the identity that already-released installs use to reach their EverOS
+provider root.
+
+## Goals
+
+1. Automatic capture and `vibe memory remember` never wait on EverOS.
+2. Capture payloads, retries, and flush schedules do not survive an Avibe
+   process restart, disable, configuration replacement, or Reset/Clear.
+3. Ambiguous EverOS add/flush outcomes are not retried.
+4. `/new` and archive never wait for Memory.
+5. Every released Memory SQLite shape loads. Stable identity and the
+   EverOS provider root survive. Pending outbox rows are counted and
+   discarded, never replayed.
+6. Sidecar supervision, Rebuild, Repair (`cascade sync`), Clear, Factory
+   Reset, Processing Record, Provider Call Log, and attachment pinning
+   stay in place except where they exist only to serve the outbox.
+
+## Non-goals
+
+- No EverOS source, API, or data-format change.
+- No identity-file format change. Identity stays in the existing SQLite
+  file, with delivery tables removed.
+- No ephemeral attachment-lease redesign. Pins remain in-process; leftover
+  bundles after migration or crash are deleted, not recovered.
+- No Repair/Rebuild rename, no Clear/Factory-Reset collapse, no Settings
+  Test, no `cascade sync` removal.
+- No change to principal, project, epoch, or provider-session derivation.
+- No automatic rebuild, repair, or reset.
+
+## Product contract
+
+### Guarantees
+
+- Chat, `/new`, and archive do not block on Memory.
+- `offer()` / `capture()` only does bounded local work.
+- The in-memory queue has a hard bound and cannot grow without limit.
+- Principal, project, epoch, `scope_key`, and `provider_root_id` are
+  byte-identical across the upgrade.
+- Named-project catalog rows survive.
+- `last_provider_timestamp_ms` survives and remains the lower bound for
+  new EverOS add timestamps, so post-upgrade writes cannot reorder against
+  already-stored EverOS cells.
+- An in-progress Clear or Factory Reset is completed by the existing
+  destructive path. The capture migrator does not strip or rewrite a store
+  that those markers still own.
+- An in-progress Rebuild or Repair is not converted to Reset. Queue
+  discard is allowed; the provider root is not touched.
+- Credentials, configured URLs, captured text, and absolute paths stay
+  out of service logs.
+
+### Explicit non-guarantees
+
+- A successful `CaptureAccepted` means the item entered process memory.
+  It does not mean EverOS stored it.
+- Queue contents do not survive process crash or restart.
+- A provider outage is not followed by durable replay when the provider
+  recovers.
+- Ambiguous add/flush results may leave a rare duplicate if EverOS
+  committed and Avibe could not observe the ack. They are not retried.
+- Session-boundary flush is best-effort. Queue saturation or a crash may
+  leave old and new conversation content in the same EverOS accumulation
+  boundary.
+- Duplicate source-message suppression is process-local. A restart may
+  recapture the same IM or remember payload if the caller submits it
+  again.
+- Pending outbox rows present at upgrade are dropped. Users may lose
+  captures that had not reached EverOS.
+
+### `vibe memory remember`
+
+On `origin/dev` the human copy is already queued, not saved:
+`memory.cli.remembered` is "Memory queued." / "记忆已加入队列。" JSON
+success is `ok: true` with `result.status` in `{accepted, duplicate}`.
+Keep that copy. Do not change it to claim the fact is stored in EverOS.
+If product later wants a stronger disclaimer (process-local, dropped on
+restart), that is a copy tweak in the implementation PR, not a status
+machine change. Automatic capture callers keep ignoring the receipt
+after structured logging.
+
+## Current machinery this PR removes
+
+Concentrated in:
+
+- `core/memory/store.py` delivery surface: `enqueue_request`, `claim_*`,
+  `settle*`, flush FSM, `manual_required`, tombstone compaction,
+  processing-fault ACK
+- `core/memory/coordinator.py` (`SessionFlushCoordinator`)
+- `core/memory/worker.py` (`MemoryWorker`)
+- `memory_capture_queue`, `memory_session_flush_state`,
+  `memory_flush_settlements`, `memory_attachment_bundle`
+- `MemoryModule.final_flush` / `run_session_lifecycle` waits
+- `MemoryRuntime` drain loop, claim pause/resume, and boot outbox recovery
+
+Retained in the same SQLite file:
+
+- `memory_meta` identity columns listed below
+- `memory_projects`
+
+## Target writer
+
+```text
+CaptureAdmission (unchanged authorize/size/scope checks)
+        |
+        v
+optional AttachmentPinStore pin (unchanged, in-process only)
+        |
+        v
+BestEffortMemoryWriter.offer()     # put_nowait, no await on EverOS
+        |
+        v
+bounded asyncio.Queue + one ordered worker
+        |
+        v
+EverOSPort.add / flush
+```
+
+Suggested starting constants, fixed rather than user settings:
+
+- queue bound: 256 items
+- max total add attempts: 3, only for outcomes that prove the request
+  did not commit (UDS refused before send, sidecar not ready, provider
+  error classified uncommitted)
+- do not retry timeout, truncated response, malformed success, or any
+  result that may have committed
+- idle flush: 60s
+- max unflushed age: 5 minutes
+- process-local duplicate LRU: 256 source-message digests
+
+`extracted` drops pending flush state for that provider session.
+`accumulated` refreshes one in-memory `PendingFlush(session_ref,
+first_accumulated_at, last_accumulated_at)`.
+
+Worker generation increments on disable, shutdown, Reset/Clear, and
+runtime-affecting configuration replacement. The old worker is cancelled,
+the queue and flush table are discarded, and in-flight requests are not
+replayed.
+
+### Session boundary
+
+`/new` and archive enqueue an ordered flush-barrier item and return.
+They never call `final_flush` with a deadline. Existing internal routes
+may remain as adapters that enqueue the barrier; they must not wait.
+
+### Shutdown
+
+Stop intake, increment generation, cancel the worker, drop volatile
+state, then continue the existing sidecar stop. No queue drain.
+
+## Persistent identity (compatibility core)
+
+Do **not** introduce a JSON identity file in this PR. Clear, Factory
+Reset, Rebuild fencing, and `reset_for_clear(target_epoch=...)` already
+own `memory_meta.epoch`. A second identity format would add crash windows
+without removing the outbox.
+
+After migration, `state/memory/memory.sqlite` contains only identity:
+
+```text
+memory_meta
+  singleton
+  epoch
+  clear_in_progress
+  scope_key
+  provider_root_id
+  last_provider_timestamp_ms
+  missed_count          # optional; may stay as a counter, not a backlog
+  last_success_at
+  last_error
+  last_error_at
+  updated_at
+
+memory_projects
+  principal_id
+  project_id
+  created_at
+  last_written_at
+```
+
+`processing_fault_*` / `processing_alert_*` / `processing_recovery_*`
+stop being written. They may be dropped in the v4 table rebuild or left
+unused; they are not an input to retry, Repair, or IM notification.
+
+`last_provider_timestamp_ms` remains durable. Each accepted offer assigns
+`max(occurred_at_ms, last_provider_timestamp_ms + 1)` and persists the
+new watermark in the same identity transaction as the catalog upsert for
+named projects. That is a small identity write, not an outbox.
+
+Provider session derivation stays the `origin/dev` formula in
+`core/memory/store.py::_provider_session_ref`:
+
+```text
+src--<hmac-sha256(scope_key, "{memory_owner_id}:{project_ref}:{session_id}")>--e{epoch}
+```
+
+`memory_owner_id` is the user principal `u-<32 hex>` for
+`provenance="user_input"`, or `{principal}-agent` (`u-<32 hex>-agent`)
+for `provenance="agent"` (`derive_assistant_memory_owner_id`, #1633).
+`memory_projects.principal_id` remains the 34-character user principal;
+the catalog is not keyed by the `-agent` owner. Implementation copies
+these helpers. It does not change digest inputs, principal shape, or
+the catalog key. Changing them would orphan existing EverOS sessions.
+
+## Released shapes the migrator must accept
+
+On-disk Memory SQLite is a shipped surface. v3.0.10 (2026-08-11) released
+the #1217 foundation. `dev` already migrates those files up to schema v3
+(`5a1a8ff3` and follow-ups). This PR adds one more step: v3 → identity-only
+v4, and must still enter from every earlier released shape.
+
+Checked-in fixtures to drive, not a closed list of "interesting" rows:
+
+| Fixture / recognizer | `PRAGMA user_version` | What it is |
+|---|---|---|
+| `tests/fixtures/memory_initial_foundation_v0.sql` | 0 | Initial foundation (`4cc4b158`): `memory_meta` + `memory_capture_queue` without `provider_session_ref` |
+| `tests/fixtures/memory_foundation_v0.sql` | 0 | Later v0 (`a104df57` / v3.0.10): same tables with `provider_session_ref` |
+| `_recognized_v0_shape` both branches | 0 | The two nonempty v0 column sets already implemented |
+| `tests/fixtures/memory_foundation_v1.sql` | 1 | Adds bundles, flush state, settlements, recovery timestamp |
+| `tests/fixtures/memory_foundation_v2.sql` | 2 | Adds `processing_fault_generation` pair |
+| current `schema.sql` | 3 | Widened `project_ref` + `memory_projects` |
+
+Empty version-zero (no application tables) continues to install the new
+identity schema directly.
+
+Unrecognized nonempty files keep today's fail-closed rule: raise, leave
+the file untouched, do not start Memory writes. Avibe startup still
+proceeds; Memory enters the existing unavailable/blocked projection.
+
+Property, not an enumeration: seed one database of every recognized
+released shape, including rows the production code can already persist
+(pending, processing, delivered, dead, `manual_required`, named project,
+default project, both provenances, attachment bundle present or absent,
+flush in_flight / idle, processing-fault columns set or null, WAL+SHM
+sidecars). After upgrade:
+
+- `scope_key`, `epoch`, `provider_root_id`, and
+  `last_provider_timestamp_ms` are unchanged
+- `memory_projects` rows are unchanged
+- no capture payload, lease, fence, settlement, or bundle row remains
+- no dropped payload is sent to EverOS
+- the original file is not mutated if the transaction fails
+
+A shape added later that the recognizer accepts is covered by the same
+property. A shape the recognizer rejects must remain byte-identical.
+
+## Migration algorithm
+
+Boot order, before the writer starts and before sidecar activation that
+would accept captures:
+
+1. If `recovery_intent == factory_reset` (or the equivalent runtime
+   factory-reset pending flag): run the existing Factory Reset path.
+   Do not read or rewrite `memory.sqlite` as an identity source; Reset
+   deletes `memory` and `state/memory`.
+2. If `state/memory/clear-intent.json` is present and readable, or
+   `memory_meta.clear_in_progress` is set: run the existing Clear
+   reconcile. Clear already deletes queue tables and bumps epoch.
+   After it finishes, the store is empty identity at `target_epoch`.
+   Then open it as v4, creating identity tables if Clear's reset still
+   used the old schema for one boot.
+3. Otherwise open `state/memory/memory.sqlite` through the existing
+   confined path.
+4. Reuse the current v0→v2→v3 chain so the in-memory connection is a
+   recognized v3 (or empty). Do not skip that chain; v0/v1/v2 installs
+   must not have to know about v4.
+5. In one immediate transaction:
+   - count nonterminal queue rows (`pending`, `processing`,
+     `manual_required`) and terminal rows, without logging payload text
+   - collect `attachment_bundle` ids
+   - copy `memory_meta` identity columns and `memory_projects`
+   - drop delivery tables, indexes, and settlement triggers
+   - rebuild `memory_meta` without requiring delivery columns if this
+     PR drops them
+   - `PRAGMA user_version = 4`
+   - verify identity tables and required identity columns
+6. Commit, then confined-delete leftover pin bundles whose ids were
+   collected, then confined-delete WAL/SHM only after the main file
+   has the new user_version.
+7. Emit one content-free structured log: discarded nonterminal count,
+   discarded terminal count, discarded bundle count. Never log text,
+   paths, or digests that can recover a message.
+8. Start `BestEffortMemoryWriter` against the preserved watermark and
+   catalog.
+
+Crash windows:
+
+- Failure before commit: old file unchanged; next boot retries.
+- Failure after commit, before bundle delete: identity is v4; leftover
+  files under `memory/attachments/` are unreferenced and deleted on the
+  next boot by "no bundle table ⇒ delete pin root if empty-orphan".
+- Failure during Clear/Reset: existing markers remain authoritative.
+  The capture migrator does not clear those markers and does not treat
+  a pending Clear as a successful identity upgrade.
+
+Never:
+
+- replay a pending row into the new writer
+- bump `epoch` as a side effect of discarding the queue
+- rotate `scope_key` or `provider_root_id`
+- convert a pending rebuild marker into Reset
+- delete the EverOS provider root
+- delete Provider Call Log data
+
+Downgrade is unsupported. A v4 file opened by an older Avibe that only
+understands v3 is an unrecognized schema and must fail closed without
+writing, same as today's unknown `user_version` rule.
+
+## Attachments in this PR
+
+Keep `AttachmentPinStore` and IM/Workbench admission. The worker still
+pins before `offer` when the current path pins, and releases the bundle
+after a terminal in-process add (success, definite rejection, or drop).
+
+Remove only:
+
+- restart recovery of pinned bundles via queue rows
+- snapshot/restore handling that exists solely for durable delivery
+- any assumption that a bundle outlives the process
+
+After migration or crash, unreferenced pin directories are deleted.
+That is data loss of files Avibe copied for retry, not of the user's
+original chat attachments.
+
+A later PR may replace pins with ephemeral source leases. It is not
+required to land best-effort capture.
+
+## Callers and receipts
+
+Keep `CaptureRequest` and `CaptureReceipt`. Map writer outcomes:
+
+| Writer | Receipt |
+|---|---|
+| queued | `CaptureAccepted` |
+| duplicate in process-local LRU | `CaptureDuplicate` |
+| disabled / not ready / invalid / queue full | `CaptureSkipped` with the existing closed error code |
+
+Automatic capture still ignores the receipt after a content-free log.
+`/internal/memory/remember` still returns `receipt.status`. CLI copy
+stays queued, as above.
+
+Processing-fault durable notification and ACK in `MemoryStore` /
+`SessionFlushCoordinator` are deleted. IM already does not receive those
+events. Processing Record may show process-local queue depth labelled
+as volatile; it must not show a durable missed-capture backlog.
+
+## Control plane that stays
+
+Unchanged except for dropping claim-quiesce that existed only to freeze
+the outbox:
+
+- artifact install, sidecar ownership, provider-root confinement
+- `MemoryOperationLease`
+- Restart Engine
+- Rebuild (`cascade rebuild --yes`) and Repair (`cascade sync`)
+- Clear durable intent and Factory Reset
+- `ProviderRoot` recreation on Clear/Reset
+
+Clear's queue primitive becomes: identity `reset_for_clear` (epoch bump,
+catalog wipe, watermark zero) with no capture-queue DELETE. The other
+three surfaces (provider root, call log, attachments) stay.
+
+Factory Reset still deletes `memory` and `state/memory`. A v4 identity
+file is just another file under `state/memory`.
+
+## Module shape after this PR
+
+Likely:
+
+```text
+core/memory/ingest.py      # BestEffortMemoryWriter
+core/memory/identity.py    # narrow store: meta + projects + watermark
+                           # or store.py reduced to that surface
+core/memory/migrate_store.py  # v0..v3 recognition + v3→v4 strip
+```
+
+`coordinator.py` and `worker.py` go away. `store.py` may shrink in place
+rather than being renamed, if that keeps Clear/Reset call sites smaller.
+
+`MemoryRuntime` / `MemoryModule` keep the public read and maintenance
+facade. Capture becomes `offer()` after admission.
+
+## User documentation
+
+Implementation must update `docs/MEMORY.md` and `docs/MEMORY_ZH.md`:
+
+- delete the "durable capture queue / manual_required / final flush"
+  promises
+- state that capture is best-effort and dropped on restart
+- state that upgrade discards undelivered outbox rows and keeps EverOS
+  content
+- keep Rebuild / Repair / Clear / Reinitialize descriptions except where
+  they mention outbox settlement
+
+Do not ship those doc edits in this planning PR.
+
+## Validation
+
+### Identity and migration
+
+- Every checked-in released fixture opens and becomes v4 identity.
+- Property test: seed every persistable production row shape the current
+  schema allows, migrate, assert identity bytes and catalog equality,
+  assert zero remaining delivery tables, assert the fake provider received
+  no add/flush from discarded rows.
+- Unrecognized nonempty v0 remains unmodified.
+- Unknown `user_version` remains unmodified.
+- WAL/SHM sidecars do not come back as a second database.
+- `clear_in_progress` / clear-intent / factory-reset pending skip the
+  strip path and follow the existing destructive reconciler.
+- Interrupted strip (kill before commit) retries and still preserves
+  identity.
+- v4 file is refused by a v3-only opener without writes (contract test
+  with the old recognizer, or an equivalent fail-closed probe).
+
+### Writer
+
+- `offer()` does not await provider I/O.
+- Occupancy never exceeds 256.
+- Saturation returns `memory_queue_full` / `CaptureSkipped`.
+- One worker preserves accepted-item order globally.
+- At most three total attempts, and only for uncommitted failures.
+- Timeout / unknown / truncated success is not retried.
+- `accumulated` schedules idle and max-age flush in memory.
+- `extracted` removes pending flush.
+- Shutdown, disable, config replacement, Clear, and Reset drop the queue
+  without drain.
+- Session barrier does not block `/new` or archive.
+- Watermark persists across writer restart and is monotonic.
+- Named-project upsert still happens on accepted capture.
+- Logs never include captured text, credentials, or absolute paths.
+
+### Compatibility with retained surfaces
+
+- Restart Engine still replaces only the sidecar.
+- Rebuild/Repair still take the operation lease and do not start a second
+  outbox drain.
+- Clear still resumes from `clear-intent.json` and still recreates an
+  empty provider root.
+- Search, profile, list, remember admission, and agent-owner read paths
+  keep their `origin/dev` contracts.
+- Processing Record no longer requires queue settlement rows.
+
+## Implementation sequence
+
+1. Identity-only v4 schema + migrator + fixture property tests. No
+   behavior change yet if the writer still reads v4 as empty outbox —
+   prefer not to land a half-migrated store. Land migrator and writer
+   together.
+2. `BestEffortMemoryWriter` behind `MemoryModule.capture`.
+3. Delete coordinator/worker/outbox APIs and tests that only exist for
+   them.
+4. Convert `final_flush` / archive / `/new` to barriers.
+5. Keep the queued remember CLI copy; rewrite `docs/MEMORY.md` and
+   `docs/MEMORY_ZH.md` capture-delivery sections.
+6. Clear `reset_for_clear` without delivery tables.
+
+Estimated production-code net reduction: about 5,000 lines in
+`core/memory/`. Estimated test net reduction: about 7,000–9,000 lines,
+after adding migrator and writer tests. Line count is not acceptance.
+
+## Todo
+
+- [ ] Implement v4 identity schema and released-shape migrator.
+- [ ] Implement `BestEffortMemoryWriter` and switch capture to `offer()`.
+- [ ] Replace session final-flush waits with a best-effort barrier.
+- [ ] Stop writing processing-fault ACK / `manual_required` / settlements.
+- [ ] Delete leftover pin bundles after migration; keep in-process pins.
+- [ ] Keep `memory.cli.remembered` as queued; rewrite Memory user docs.
+- [ ] Shrink Clear's queue primitive to identity reset.
+- [ ] Remove coordinator, worker, and outbox-only tests.
+
+## Known-by-design
+
+These are accepted product consequences, not defects to fix in the
+implementation PR:
+
+1. Upgrade discards undelivered outbox rows (`pending`, `processing`,
+   `manual_required`, and terminal tombstones). EverOS markdown and
+   `unprocessed_buffer` are kept. Users can lose captures that had not
+   reached EverOS.
+2. `CaptureAccepted` means entered process memory, not stored by EverOS.
+3. Duplicate source-message suppression is an in-process LRU. Restart
+   may recapture the same payload.
+4. Attachment pins have no durable recovery after this cut. Leftover
+   bundles are deleted. Original chat attachments are untouched.
+5. Session-boundary flush is a barrier enqueue, not a wait. A crash or
+   a full queue can leave consecutive conversations in one EverOS
+   accumulation boundary.
+6. No JSON identity file is introduced. Identity stays in the existing
+   SQLite file so Clear's `reset_for_clear(target_epoch=...)` and
+   Factory Reset keep one authority.
+7. Pin-without-outbox is temporary debt. A later attachments PR may
+   replace pins with ephemeral source leases; it is not required here.

--- a/docs/plans/memory-best-effort-capture.md
+++ b/docs/plans/memory-best-effort-capture.md
@@ -101,8 +101,11 @@ provider root.
 - Ambiguous add/flush results may leave a rare duplicate if EverOS
   committed and Avibe could not observe the ack. They are not retried.
 - Session-boundary flush is best-effort. Admission saturation can reject a
-  barrier, and a process crash can drop volatile boundary candidates, leaving
-  old and new conversation content in the same EverOS accumulation boundary.
+  barrier. Process crash/restart, disable, graceful shutdown, runtime-affecting
+  configuration replacement, and Clear/Reset generation invalidation all drop
+  volatile boundary candidates; when the provider buffer survives the
+  transition, old and new conversation content may share one accumulation
+  boundary.
 - Duplicate source-message suppression is process-local. A restart may
   recapture the same IM or remember payload if the caller submits it
   again.
@@ -176,8 +179,10 @@ Suggested starting constants, fixed rather than user settings:
   the request did not commit (UDS refused before send, sidecar not ready,
   provider error classified uncommitted)
 - max total flush attempts: 3 (`MAX_FLUSH_ATTEMPTS`), but only before the
-  provider coroutine may have executed; a submitted flush is never retried
-  regardless of its response
+  provider coroutine may have executed **after** a durable observation gap has
+  opened. Observer-SQLite preflight failure is not a provider attempt and does
+  not consume this bound; a submitted flush is never retried regardless of its
+  response
 - do not retry timeout, truncated response, malformed success, or any
   result that may have committed
 - idle flush: 5 minutes (`SessionFlushCoordinator.IDLE_FLUSH_TIMEOUT`)
@@ -234,16 +239,20 @@ gap at that lifecycle bound, replace the sidecar, and submit this incomplete
 flush before later work. A returned but semantically unknown response with a
 valid request id can enqueue the same due flush immediately without sidecar
 replacement. `/new` and archive still return without waiting. A process crash
-may lose this volatile boundary action, but its durable guard remains
-incomplete. Failure of any required pre-submission guard/gap write skips the add
-without calling EverOS.
+or any generation-invalidating transition may lose this volatile boundary
+action, but its durable guard remains incomplete unless Clear/Reset deliberately
+deletes observer identity with the provider root. Failure of any required
+pre-submission guard/gap write skips the add without calling EverOS.
 
 When an entry becomes due, the worker snapshots it for one flush attempt. A
-failure proven to occur before the provider coroutine can execute may retain
-that same entry for at most three total attempts. At the exact submission edge
-where the provider coroutine may execute, remove the entry from the map and
-carry its bounded message-id snapshot and completeness bit only in the in-flight
-slot. Mark its durable guard incomplete before submission. Success,
+failure to commit its observer preflight does not increment `attempts`: retain
+the same due entry, schedule one delayed process-local retry, and create no
+additional slot or task. Only after the durable gap opens can a failure proven
+to occur before the provider coroutine executes consume one of at most three
+total attempts. At the exact submission edge where the provider coroutine may
+execute, remove the entry from the map and carry its bounded message-id snapshot
+and completeness bit only in the in-flight slot. Mark its durable guard
+incomplete before submission. Success,
 rejection, timeout, malformed response, cancellation, and any other ambiguous
 submitted outcome all consume that snapshot permanently; none reinsert or
 reschedule it. An acknowledged flush or natural `extracted` add deletes that
@@ -504,8 +513,9 @@ observer state into delivery state:
    volatile provisional boundary reservation above happens first and is rolled
    back if preflight fails. A gap never closes or replaces another attempt's
    gap. If preflight fails, the provider is not called: an add is skipped, while
-   a due flush retains its snapshot only for the bounded pre-submission retry
-   policy above.
+   a due flush retains the same snapshot and retries after a process-local delay
+   without incrementing its provider-attempt counter. It cannot be dropped as an
+   exhausted operation because no durable anomaly/gap authority exists yet.
 2. If a result contains a valid request id, one transaction inserts every
    provenance row for that call with the preflight provider-start time, inserts
    its source-expiring sanitized anomaly only when the logical capture/flush is
@@ -523,11 +533,11 @@ observer state into delivery state:
    ambiguously submitted provider call.
 3. If an add result proves no request left Avibe, or a flush attempt fails before
    its provider coroutine can execute, restore the add's prior boundary snapshot
-   and delete only that gap before any permitted retry. On the final bounded
-   failure, insert the queue-backed sanitized anomaly with its 90-day expiry in
-   the same transaction. If that transaction fails, drop the item and leave the
-   gap open with both source flags fail-closed. A retry opens a new independent
-   gap.
+   and delete only that already-durable gap before any permitted retry. On the
+   final bounded failure, insert the queue-backed sanitized anomaly with its
+   90-day expiry in the same transaction. If that settlement transaction fails,
+   the preflight gap remains durable with both source flags, so dropping the item
+   is fail-closed. A retry opens a new independent gap.
 4. A timeout, truncated or malformed response, cancellation, or other submitted
    result without a trustworthy request id inserts a settlement-backed
    `result_unknown` anomaly when possible and atomically clears only that gap's
@@ -567,13 +577,18 @@ most 256 ranges. When the bound would be exceeded, coalesce the oldest closed
 ranges, OR their source flags, and widen their time coverage rather than
 dropping a hole. Never merge away the exact token for an open provider attempt;
 if no closed range can make capacity, fail preflight or retention pruning before
-the provider call or provenance deletion. A closed correlation flag may retire
-only when its range is wholly older than the Provider Call Log cutoff; an open
-flag never age-deletes. Delete the row only after both source flags retire. This
-may hide a good observation conservatively, but cannot authorize or display an
-incomplete source as complete. Clear's `reset_for_clear` deletes provenance
-rows, anomalies, correlation guards, and observation gaps with the catalog and
-watermark reset; Factory Reset deletes them with `state/memory`.
+the provider call or provenance deletion. Every Processing Record call query
+applies the same `started_at_ms >= retention_cutoff_ms` predicate before joins or
+availability checks, regardless of whether background maintenance deleted older
+physical rows. A closed correlation flag may retire only when that read cutoff
+excludes its entire range **and** a read-only Call Log query proves no physical
+`provider_call` row overlaps the range. An unavailable/busy source or remaining
+stale row delays retirement but never writer admission. An open flag never
+age-deletes. Delete the row only after both source flags retire. This may hide a
+good observation conservatively, but cannot authorize or display an incomplete
+source as complete. Clear's `reset_for_clear` deletes provenance rows, anomalies,
+correlation guards, and observation gaps with the catalog and watermark reset;
+Factory Reset deletes them with `state/memory`.
 
 The independently maintained Provider Call Log is not an input to identity
 migration or writer admission. Historical migration copies every valid bounded
@@ -919,7 +934,11 @@ and correlation behavior through `memory_call_provenance` and
 and request-id joins move to those tables; they do not silently omit request-id
 call branches merely because the delivery tables are gone or a volatile
 message-id set was lost. Count-pruned provenance inside the Call Log horizon is
-covered by a correlation-only gap before deletion.
+covered by a correlation-only gap before deletion. Every Processing Record
+provider-call list/detail query also applies the recorder's current 14-day
+`started_at_ms` cutoff itself. Delayed/failed maintenance may leave older rows
+physically readable, but those rows cannot outlive provenance/gap coverage in
+the projection.
 
 Processing Record's durable anomaly source moves independently to
 `memory_processing_anomaly`. `MemoryStore.failure_log()` keeps its current
@@ -1091,8 +1110,10 @@ Do not ship those doc edits in this planning PR.
 - `extracted` removes pending flush.
 - Every submitted flush consumes its pending entry and bounded message-id
   snapshot after success, rejection, timeout, malformed response, cancellation,
-  or other ambiguity. Only a proven pre-submission failure retains it, and the
-  third failed attempt drops it without a provider call.
+  or other ambiguity. Observer preflight write failure retains it without
+  consuming an attempt. After a durable gap opens, the third proven
+  provider-preexecution failure drops it only after the final anomaly/gap
+  settlement commits or leaves that existing gap open fail-closed.
 - High-cardinality accumulated traffic retains at most 256 pending sessions and
   25,600 message ids. A capture for a 257th distinct session is skipped before
   any EverOS RPC, never evicts or mutates an existing scope, records only
@@ -1113,10 +1134,18 @@ Do not ship those doc edits in this planning PR.
   incomplete flush runs before later work; a `/new` barrier admitted meanwhile
   returns immediately, and the candidate stays barrier-visible until the
   recovery flush reaches its submission edge. If that flush cannot prove a
-  boundary, its durable guard remains incomplete. A process crash may drop the
-  volatile flush action but cannot make later correlation complete.
+  boundary, its durable guard remains incomplete. A crash/restart, disable,
+  graceful shutdown, runtime-affecting config replacement, or Clear/Reset
+  generation invalidation may drop the volatile flush action; no ordinary
+  transition can make later correlation complete.
 - Shutdown, disable, config replacement, Clear, and Reset drop the queue
   without drain.
+- A parameterized ambiguous-candidate transition test covers process restart,
+  disable/re-enable, graceful shutdown/start, and runtime config replacement:
+  each drops the volatile candidate but preserves an old/incomplete guard, so a
+  recreated tracker cannot claim complete correlation. Clear/Reset may delete
+  the guard only in the same successful operation that replaces/deletes the
+  provider root; an interrupted operation keeps its existing fence closed.
 - Session barrier does not block `/new` or archive. At its ordered head it
   resolves and flushes every retained pending scope for the raw Workbench
   session, including project switches and scopes created by an earlier capture
@@ -1159,12 +1188,15 @@ Do not ship those doc edits in this planning PR.
   and cleanup entry charged until confined deletion succeeds.
 - Logs never include captured text, credentials, or absolute paths.
 - Every provider attempt durably opens a two-source observation gap before the
-  RPC. A failed preflight write skips an add or retains a due flush only within
-  its bounded pre-submission attempts, without calling EverOS;
-  timeout/unknown responses and an injected observer-commit failure leave both
-  correlation and anomaly unavailable after restart. A later successful attempt
-  settles only its own gap; the older ambiguous gap stays open until a paused
-  writer plus successful sidecar stop/reap proves its termination boundary.
+  RPC. A failed preflight write skips an add; a due flush retains its exact
+  snapshot, consumes no provider attempt, and has at most one delayed retry
+  scheduled, without calling EverOS. Three consecutive preflight failures still
+  retain one snapshot; after storage recovers, the gap commits before the first
+  counted provider attempt. Timeout/unknown responses and an injected
+  observer-commit failure leave both correlation and anomaly unavailable after
+  restart. A later successful attempt settles only its own gap; the older
+  ambiguous gap stays open until a paused writer plus successful sidecar
+  stop/reap proves its termination boundary.
 - Valid bounded request ids from acknowledged, rejected, and otherwise
   unclassifiable add/flush responses are recorded with their outcome and scope;
   only final logical non-success and exhausted proven-uncommitted operations
@@ -1183,9 +1215,17 @@ Do not ship those doc edits in this planning PR.
   retention. A failed stop or unproved boot admits no B provider submission.
 - Observation-gap compaction coalesces old ranges with the union of their source
   flags and without losing covered time. Correlation flags retire only outside
-  Call Log retention; anomaly flags retire only after 100 newer non-expiring
-  known anomalies make the interval irrelevant to every supported newest-N
-  result. Expiring newer rows may disappear and therefore never retire a gap.
+  the cutoff enforced by every Processing Record call query and after a
+  read-only Call Log probe proves no covered physical row remains; anomaly flags
+  retire only after 100 newer non-expiring known anomalies make the interval
+  irrelevant to every supported newest-N result. Expiring newer rows may
+  disappear and therefore never retire a gap.
+- With Call Log maintenance forced to fail while an older physical row remains,
+  every calls list/detail query excludes that row at the 14-day start cutoff;
+  the matching closed correlation gap does not retire until a later read-only
+  probe proves the row was deleted. A query that cannot enforce the cutoff
+  reports the calls source unavailable, while a failed retirement probe only
+  retains conservative coverage.
 - A closed anomaly gap followed by 100 newer expiring rows remains unavailable
   before and after those rows expire; 100 newer non-expiring settlement rows
   permit retirement and preserve the newest-100 projection.
@@ -1273,13 +1313,15 @@ implementation PR:
    may recapture the same payload.
 4. Attachment pins have no durable recovery after this cut. Leftover
    bundles are deleted. Original chat attachments are untouched.
-5. Session-boundary flush is a barrier enqueue, not a wait. A crash or
-   a full admission queue can leave consecutive conversations in one EverOS
-   accumulation boundary. A 257th distinct pending session is skipped before
-   EverOS, while an ambiguous submitted add retains a best-effort in-process due
-   boundary candidate; only a process crash may lose that candidate. Its durable
-   guard still keeps later flush correlation unavailable rather than silently
-   omitting older message ids.
+5. Session-boundary flush is a barrier enqueue, not a wait. A full admission
+   queue can reject it. A crash/restart, disable, graceful shutdown,
+   runtime-affecting configuration replacement, or Clear/Reset generation
+   invalidation drops volatile due candidates; when the provider buffer survives
+   the transition, consecutive conversations may share one EverOS accumulation
+   boundary. A 257th distinct pending session is skipped before EverOS. Durable
+   guards keep later correlation unavailable rather than silently omitting older
+   message ids; successful Clear/Reset instead replaces the provider root and
+   observer identity together.
 6. No JSON identity file is introduced. Identity stays in the existing
    SQLite file so Clear's `reset_for_clear(target_epoch=...)` and
    Factory Reset keep one authority.

--- a/docs/plans/memory-best-effort-capture.md
+++ b/docs/plans/memory-best-effort-capture.md
@@ -176,9 +176,12 @@ required for this cut.
 `accumulated` refreshes one in-memory `PendingFlush(session_ref,
 first_accumulated_at, last_accumulated_at, message_ids)`. `message_ids` is
 bounded by the 100-message flush limit and exists only to correlate a
-successful flush with the retained Provider Call Log. The pending table does
-not survive process restart; EverOS still holds the buffer until a later
-same-session add, Repair, or provider extraction.
+successful flush with the retained Provider Call Log. Its length is the
+volatile `unflushed_count`: every `accumulated` acknowledgement appends exactly
+one message id, and reaching 100 makes that provider session immediately due
+without waiting for either timer. The pending table does not survive process
+restart; EverOS still holds the buffer until a later same-session add, Repair,
+or provider extraction.
 
 Worker generation increments on disable, shutdown, Reset/Clear, and
 runtime-affecting configuration replacement. The old worker is cancelled,
@@ -362,12 +365,16 @@ would accept captures:
    semantics: do not migrate, do not start the sidecar/writer, and project the
    existing `memory_clear_marker_unreadable` retry state. Only an explicit
    Clear re-run may replace that marker.
-3. Otherwise open `state/memory/memory.sqlite` through the existing
-   confined path.
-4. Reuse the current v0→v2→v3 chain so the in-memory connection is a
-   recognized v3 (or empty). Do not skip that chain; v0/v1/v2 installs
-   must not have to know about v4.
-5. In one immediate transaction:
+3. Otherwise open `state/memory/memory.sqlite` through the existing confined
+   path and detect its released shape without writing.
+4. Start one outer `BEGIN IMMEDIATE`. Refactor the v0→v2, v1→v2, and v2→v3
+   transforms into composable helpers that accept this transaction and never
+   issue their current inner `BEGIN` / `COMMIT` / `ROLLBACK`. Standalone v3
+   migration may keep a wrapper that owns a transaction, but the v4 boot path
+   runs every required released-shape transform under this one owner. There is
+   no committed v2 or v3 intermediate.
+5. In that same outer transaction, once the connection is recognized v3 (or
+   the detected v0 file was empty):
    - count nonterminal queue rows (`pending`, `processing`,
      `manual_required`) and terminal rows, without logging payload text
    - collect `attachment_bundle` ids
@@ -421,6 +428,22 @@ registers the exact-session FIFO reservation before pinning, pins before
 in-process add (success, definite rejection, or drop). Closing a reservation
 as skipped releases its successor, so one failed pin cannot strand a later
 barrier.
+
+Retain the current single text-only degradation for a valid nonempty caption:
+
+- if pinned-attachment verification fails before provider submission with the
+  existing positively classified `AttachmentBundleInvalidError`, release the
+  pin and offer the same capture once without attachments
+- if EverOS returns an attachment rejection for which
+  `attachment_add_rejection_proves_no_write()` is true, release the pin and
+  offer the same capture once without attachments
+
+This is a modality fallback, not replay after ambiguity. It counts toward the
+same three-total-attempt bound and is forbidden for timeouts, unknown/truncated
+responses, generic provider rejection, or any outcome that may have written.
+If the caption is empty, close as skipped instead. Preserve
+`MEMORY-IM-ATTACH-009` and `MEMORY-IM-ATTACH-011` rather than deleting them with
+the durable worker tests.
 
 Remove only:
 
@@ -533,6 +556,10 @@ Do not ship those doc edits in this planning PR.
   schema allows, migrate, assert identity bytes and catalog equality,
   assert zero remaining delivery tables, assert the fake provider received
   no add/flush from discarded rows.
+- Inject a failure after every composed v0/v1/v2/v3 transform and during the
+  v4 strip; every case rolls back the one outer transaction, preserves the
+  original `user_version`, schema, and rows, and retries from the same released
+  shape on the next boot. No test may observe a committed v2/v3 intermediate.
 - Unrecognized nonempty v0 remains unmodified.
 - Unknown `user_version` remains unmodified.
 - WAL/SHM sidecars do not come back as a second database.
@@ -558,6 +585,9 @@ Do not ship those doc edits in this planning PR.
 - Timeout / unknown / truncated success is not retried.
 - `accumulated` schedules idle (5m), max-age (30m), and
   message-count (100) flush in memory, matching today's coordinator.
+- 99 accumulated acknowledgements do not satisfy the count boundary; the
+  100th makes the session immediately due, and extraction/generation drop
+  clears both the bounded message-id list and its count.
 - `extracted` removes pending flush.
 - Shutdown, disable, config replacement, Clear, and Reset drop the queue
   without drain.
@@ -568,6 +598,9 @@ Do not ship those doc edits in this planning PR.
 - Named-project upsert still happens on accepted capture; the current
   16-project test still rejects the 17th distinct slug and accepts reuse at
   the limit without advancing rejected-capture state.
+- `MEMORY-IM-ATTACH-009` and `MEMORY-IM-ATTACH-011` still perform exactly one
+  safe text-only degradation, while ambiguous or unclassified attachment
+  failures never resubmit the caption.
 - Logs never include captured text, credentials, or absolute paths.
 
 ### Compatibility with retained surfaces

--- a/docs/plans/memory-best-effort-capture.md
+++ b/docs/plans/memory-best-effort-capture.md
@@ -64,9 +64,9 @@ provider root.
 - `offer()` / `capture()` reserves or rejects one process-local slot without
   waiting on attachment pinning or EverOS.
 - One 256-slot admission window bounds every retained capture/barrier from
-  reservation through pinning, stale-generation reclamation, queueing, and the
-  one in-flight provider call. There is no second reservation chain outside
-  that process-wide bound.
+  reservation through pinning, current- or stale-generation bundle reclamation,
+  queueing, and the one in-flight provider call. There is no second reservation
+  or terminal-cleanup chain outside that process-wide bound.
 - Principal, project, epoch, `scope_key`, `provider_root_id`, and
   `last_success_at` are byte-identical across the upgrade.
 - Named-project catalog rows survive.
@@ -170,7 +170,8 @@ Suggested starting constants, fixed rather than user settings:
 
 - process-wide admission-window bound: 256 total permits across
   reserved/unready, pinning (including stale work from an older generation),
-  ready/queued, and the current in-flight add or barrier
+  ready/queued, the current in-flight add or barrier, and terminal bundle
+  cleanup whose confined deletion has not yet succeeded
 - max total add attempts: 3 (`MAX_ADD_ATTEMPTS`), only for outcomes that prove
   the request did not commit (UDS refused before send, sidecar not ready,
   provider error classified uncommitted)
@@ -254,7 +255,9 @@ runtime-affecting configuration replacement. The old worker is cancelled, the
 ordered queue and pending-flush map are invalidated immediately, and in-flight
 provider requests are not replayed. A synchronous pin that is already running
 becomes stale cleanup work under the process-wide admission bound described
-below; the generation transition does not wait for it.
+below; current-generation terminal release work is transferred to that same
+process-wide registry. Neither cleanup owner is generation-local, and the
+generation transition does not wait for it.
 
 ### Session boundary
 
@@ -280,11 +283,12 @@ complete ordered tuple of logical per-scope barriers.
 Use one fixed-capacity ordered admission window, not a queue plus an unbounded
 reservation chain. `offer()` synchronously and non-blockingly reserves the next
 sequence slot before any deferred attachment work. That permit remains charged
-while the slot is unready, pinning, ready, queued, or in flight. A normal slot
-releases it when consumed or skipped; a stale pin keeps the permit and source
-lease until late-completion reclamation finishes. At most 256 slot payloads,
-attachment leases, and owned or stale pin tasks therefore exist process-wide,
-including across generation replacement.
+while the slot is unready, pinning, ready, queued, in flight, or reclaiming a
+terminal bundle. A slot with no bundle releases it when consumed or skipped; any
+successful pin keeps the same permit and source lease until confined deletion
+succeeds. At most 256 slot payloads, attachment leases, pin tasks, and terminal
+cleanup owners therefore exist process-wide, including across generation
+replacement.
 
 A barrier reserves the same kind of slot and is ready immediately. The worker
 consumes only from the head, so an accepted barrier cannot overtake any earlier
@@ -293,14 +297,18 @@ and lets the worker advance. When all 256 permits are charged, captures and
 barriers are rejected with the existing queue-full outcome before starting a
 pin, retaining a payload, advancing the watermark/catalog, or creating another
 task. `/new` and archive return without waiting. Generation drop marks pinning
-slots skipped for ordering and releases every non-pinning permit immediately;
-it does not cancel the underlying synchronous pin, release its source lease, or
-return its permit before the late-pin reaper settles it.
+slots skipped for ordering and releases queue permits that own neither a pin nor
+terminal bundle cleanup; it does not cancel the underlying synchronous pin,
+release a bundle's source lease, or return its permit before the reaper proves
+confined deletion.
 
 ### Shutdown
 
-Stop intake, increment generation, cancel the worker, drop volatile
-state, then continue the existing sidecar stop. No queue drain.
+Stop intake, increment generation, cancel the worker, and drop volatile queue /
+pending-flush state, then continue the existing sidecar stop. The process-wide
+pin/release registry retains its charged cleanup owners until deletion succeeds
+or the process exits; a later v4 boot scrubs leftovers before intake. No queue
+drain.
 
 ## Persistent identity and display provenance
 
@@ -325,6 +333,7 @@ memory_meta
   last_success_at
   last_error
   last_error_at
+  next_anomaly_sequence # checked monotonic observer-order allocator
   updated_at
 
 memory_projects
@@ -343,6 +352,7 @@ memory_call_provenance
   session_id
   message_ids_json     # exact EverOS message ids, at most 100
   correlation_complete # true for adds; flush snapshot completeness
+  provider_started_at_ms # preflight time at the provider-submission edge
   recorded_at_ms
 
 memory_processing_anomaly
@@ -357,6 +367,7 @@ memory_processing_anomaly
   worker_generation
   principal_id
   project_id
+  order_sequence       # local, order-preserving tie breaker; never displayed
   expires_at_ms        # queue-backed abandonment + 90 days; null for settlement evidence
 
 memory_flush_correlation_guard
@@ -385,14 +396,18 @@ that Processing Record currently reads from `memory_capture_queue` and
   response whose id can still be validated
 - an add row carries its one exact `m_<session>_<provider timestamp>_000`
   message id and `correlation_complete=true`; a flush row carries the bounded
-  message-id list from that session's `PendingFlush` plus its completeness bit
+  message-id list from that session's `PendingFlush` plus its completeness bit.
+  Both carry the operation's preflight `provider_started_at_ms`, captured before
+  the provider coroutine can execute
 - retain at most 5,000 provenance rows and at most 14 days, matching Provider
   Call Log retention, but prune only complete request-id groups. Before
   row-count pruning any group that can still overlap retained Call Log rows,
   create or widen a closed correlation-only `retention_pruned` observation gap
-  over the deleted groups' full observation-time range in the same transaction.
-  A group wholly older than the Call Log cutoff needs no new coverage; then
-  delete oldest whole groups until the row count is at most 5,000
+  from the minimum deleted `provider_started_at_ms` through the maximum
+  `recorded_at_ms` in the same transaction. This covers Call Log rows timestamped
+  at request start rather than response observation. A group wholly older than
+  the Call Log cutoff needs no new coverage; then delete oldest whole groups
+  until the row count is at most 5,000
 - never retain a subset of a request-id group. If one reused group alone exceeds
   the row limit, delete that whole group; missing provenance remains fail-closed
 - enforce both bounds after each provenance write and at boot with the same
@@ -442,9 +457,12 @@ count, deadline, attempt, or work item:
 `memory_capture_queue` rows and `memory_flush_settlements`. It is observer state,
 not a retry or delivery ledger:
 
-- write one row for each terminal rejected or ambiguous add/flush and each
-  proven-uncommitted operation that exhausts its bounded attempts; successful
-  calls never create anomaly rows
+- write one row only when a logical capture or flush terminates rejected or
+  ambiguous, or when a proven-uncommitted logical operation exhausts its bounded
+  attempts. A positively classified attachment rejection that enters the one
+  allowed text-only fallback is nonterminal: record its call provenance and
+  settle its observation gap, but create no anomaly unless the fallback itself
+  terminates unsuccessfully
 - preserve the current `MemoryFailureLogEntry` fields and closed values: stable
   id, kind, occurrence time, closed error code, bounded request id, attempts,
   state, operation, and worker generation. New ids are an HMAC of `scope_key`
@@ -459,13 +477,19 @@ not a retry or delivery ledger:
   removes, and null for settlement-backed rejected/ambiguous evidence that the
   current immutable settlement table retains. Migration derives this from the
   source side of the released `failure_log()` union, not from `kind` alone
-- delete expired rows first, then retain the deterministically newest 100,000
-  unexpired rows. This preserves every source-specific age contract and every
-  immutable-settlement anomaly that can still appear among the newest 50;
-  return that newest 50 through the unchanged `failure_log()` / Processing
-  Record projection
-- order and prune deterministically by `(occurred_at_ms, anomaly_id)`, so
-  deleting only oldest overflow cannot change the current newest-50 projection
+- delete expired rows first, then apply independent caps: retain the newest
+  100,000 expiring rows and the newest 100,000 non-expiring rows. Newer expiring
+  evidence can never evict permanent settlement evidence that must reappear
+  after those temporary rows expire; within the expiring class, an older row
+  also expires no later than every newer row that displaced it. The table is
+  therefore bounded to 200,000 rows total
+- allocate `order_sequence` monotonically in the anomaly insert transaction and
+  order/prune by `(occurred_at_ms, order_sequence)`. Migration assigns sequences
+  in the released projection's existing `(occurred_at, sort_key)` order, where
+  queue digests and zero-padded settlement ids are used only while reading the
+  old tables and are not copied. This preserves the exact newest-50 tie order
+  without retaining source digests; return that newest 50 through the unchanged
+  `failure_log()` / Processing Record projection
 - enforce expiry/count retention after each insert and at boot; an anomaly
   read/schema failure marks that Processing Record source unavailable rather
   than returning an empty successful list
@@ -483,16 +507,20 @@ observer state into delivery state:
    a due flush retains its snapshot only for the bounded pre-submission retry
    policy above.
 2. If a result contains a valid request id, one transaction inserts every
-   provenance row for that call, inserts its source-expiring sanitized anomaly
-   when the result is non-success, applies the guard and provisional-boundary
+   provenance row for that call with the preflight provider-start time, inserts
+   its source-expiring sanitized anomaly only when the logical capture/flush is
+   now terminal and unsuccessful, applies the guard and provisional-boundary
    transition, and deletes only that operation token's gap. An acknowledged add
    also advances `memory_meta.last_success_at` to the observation time in this
    transaction. This applies to acknowledged, rejected, and semantically unknown
-   classifications. A separately allowed add retry starts only after that
-   observer transaction commits; a submitted flush is terminal. Transaction
-   failure leaves the preflight gap carrying both source flags, keeps any
-   possible add boundary candidate incomplete and due, closes later provider
-   submission, and never retries the provider call.
+   classifications. A positive attachment rejection that starts text fallback
+   records provenance and deletes its gap without an anomaly; the fallback opens
+   a new gap and only its final logical outcome can create one. Any separately
+   allowed add retry starts only after that observer transaction commits; a
+   submitted flush is terminal. Transaction failure leaves the preflight gap
+   carrying both source flags, keeps any possible add boundary candidate
+   incomplete and due, closes later provider submission, and never retries an
+   ambiguously submitted provider call.
 3. If an add result proves no request left Avibe, or a flush attempt fails before
    its provider coroutine can execute, restore the add's prior boundary snapshot
    and delete only that gap before any permitted retry. On the final bounded
@@ -525,11 +553,13 @@ or row-count-pruned provenance group remains covered even if newer observations
 settle successfully.
 
 The anomaly projection is unavailable when an `anomaly_incomplete` gap is open,
-or when fewer than the maximum supported failure-log limit (100) of unexpired
-anomaly rows are strictly newer than a closed gap's `ended_at_ms`. Once 100
-newer known rows exist, no missing event in that older interval can affect any
-supported newest-N result, so the anomaly flag may be retired. Lifecycle close
-alone never turns a missing anomaly into a complete successful projection.
+or when fewer than the maximum supported failure-log limit (100) of
+**non-expiring** anomaly rows are strictly newer than a closed gap's
+`ended_at_ms`. Expiring queue-backed rows never retire a gap: they can disappear
+later and expose missing permanent evidence again. Once 100 newer permanent rows
+exist, no missing event in that older interval can affect any supported newest-N
+result, so the anomaly flag may be retired. Lifecycle close alone never turns a
+missing anomaly into a complete successful projection.
 
 An observation gap is global observer state rather than a principal/project
 authorization fact: no scoped reader may bypass an affected source. Keep at
@@ -549,9 +579,11 @@ The independently maintained Provider Call Log is not an input to identity
 migration or writer admission. Historical migration copies every valid bounded
 add/flush request id from the released Memory store, including rejected rows and
 every scope row for a reused id, then applies the same whole-group 5,000-row /
-14-day policy using capture/settlement observation times, including
-correlation-only coverage for count-pruned groups that can still overlap the
-Call Log window. It does not open or filter against the call-log database. Any
+14-day policy. Because released rows have only capture/settlement observation
+times, migration assigns the Call Log retention cutoff as their conservative
+provider start; count-pruned coverage therefore still reaches every retained
+call that could precede its response. It does not open or filter against the
+call-log database. Any
 observer source that cannot be translated safely creates or widens a
 `migration_unknown` observation gap with the affected source flags over the
 retained observation horizon instead of being silently skipped. An absent,
@@ -697,19 +729,25 @@ would accept captures:
    - copy `memory_meta` identity columns and `memory_projects`
    - before dropping delivery tables, copy every valid bounded add/flush request
      id into `memory_call_provenance`, including rejected operations and every
-     scope row for a reused id; prune only complete request-id groups to the
-     5,000-row / 14-day window, create correlation-only `retention_pruned`
-     coverage before count-pruning groups still inside the Call Log horizon,
-     and preserve ambiguity as fail-closed
+     scope row for a reused id. Released rows have no provider-start field, so
+     set their conservative `provider_started_at_ms` to the migration instant's
+     Call Log retention cutoff without opening that optional database. Prune
+     only complete request-id groups to the 5,000-row / 14-day window, create
+     correlation-only `retention_pruned` coverage from the earliest provider
+     start through latest observation before count-pruning groups still inside
+     the Call Log horizon, and preserve ambiguity as fail-closed
    - run the released-shape equivalent of the current `failure_log()` union and
      copy every projected queue/settlement anomaly into
      `memory_processing_anomaly` before its source tables are dropped. Preserve
      the stable id and every sanitized `MemoryFailureLogEntry` field, deduplicate
-     rejected adds exactly as the current projection does, map errors through the
-     same closed-code sanitizer, set 90-day expiry only for queue-backed
-     abandonment rows, keep settlement-backed expiry null, delete rows already
-     expired at migration time, and prune only the oldest overflow beyond the
-     newest 100,000 remaining rows
+     rejected adds exactly as the current projection does, and enumerate the
+     released union in ascending `(occurred_at, sort_key)` order to assign local
+     `order_sequence` values before discarding the old queue digest / settlement
+     id sort evidence. Map errors through the same closed-code sanitizer, set
+     90-day expiry only for queue-backed abandonment rows, keep
+     settlement-backed expiry null, delete rows already expired at migration
+     time, and prune each expiry class independently beyond its newest 100,000
+     rows. Set `next_anomaly_sequence` after the largest assigned value
    - for every old `memory_session_flush_state` row with an unflushed provider
      buffer, create an incomplete exact `memory_flush_correlation_guard` using
      only its bounded session-ref digest. If more than 256 distinct rows exist,
@@ -781,34 +819,48 @@ writing, same as today's unknown `user_version` rule.
 Keep `AttachmentPinStore` and IM/Workbench admission. `offer()` charges one
 ordered admission-window slot before pinning and starts at most one owned pin
 task inside that permit. The worker does not consume that slot until pinning
-marks it ready or skipped, and releases the bundle after a terminal in-process
-add (success, definite rejection, or drop). Marking a slot skipped lets the
-worker advance, so one failed pin cannot strand a later barrier.
+marks it ready or skipped. After a terminal in-process add (success, definite
+rejection, or drop), it transfers any bundle plus the same permit and source
+lease to the process-wide cleanup registry before advancing. Marking the ordered
+slot consumed or skipped does not release that ownership, so one failed release
+cannot become an unbounded orphan and one failed pin cannot strand a later
+barrier.
+
+Each charged permit has one owner with separate logical-slot-terminal and
+bundle-deleted completion bits. A positive attachment rejection may transfer the
+bundle to cleanup and continue its text fallback under that same permit; the
+permit and source lease return only after both bits are true. The registry holds
+at most one cleanup entry per permit and one shared reaper services those
+entries, so fallback does not create a second task/reservation chain.
 
 Do not cancel an asyncio wrapper and assume the synchronous
 `AttachmentPinStore.pin()` stopped. The writer keeps a strong reference to every
-pin task in a process-wide late-pin registry. A generation change atomically
-marks its slot stale and ordering-skipped, but leaves its admission permit and
-source lease charged without awaiting completion. When the blocking call
-settles, one completion path checks the captured generation before exposing the
-result:
+pin task and terminal-release entry in one process-wide cleanup registry. A
+generation change atomically marks its slot stale and ordering-skipped, but
+leaves its admission permit and source lease charged without awaiting completion.
+When the blocking call settles, one completion path checks the captured
+generation before exposing the result:
 
 - a current successful pin marks its original slot ready
 - a stale successful pin immediately calls the confined, idempotent
   `AttachmentPinStore.release(bundle_id)` and never enters a new generation
 - a stale failure is consumed as cleanup, without text-only resubmission
-- every branch releases the source lease and admission permit only after result
-  handling and confined reclamation finish
+- every current or stale terminal bundle enters the same idempotent confined
+  release loop; only successful deletion releases the source lease and admission
+  permit
 
-The reaper consumes task exceptions and stays bounded by those unreleased
-process-wide permits, so repeated configuration changes cannot accumulate more
-than 256 blocking pins. Clear/Reset cleanup and the late reaper serialize through
-the same `AttachmentPinStore` confinement/lock; a bundle published after logical
-generation invalidation is still reclaimed. If release cannot prove deletion,
-fail the replacement writer generation closed, keep that permit charged, and
-retry confined cleanup rather than losing ownership of the orphan. If the
-process exits before a callback runs, the mandatory empty-root scrub on the next
-v4 boot removes both published and staging leftovers before accepting captures.
+The reaper consumes task exceptions and retries every current- or
+stale-generation release while keeping its strong owner and original permit. It
+stays bounded by those unreleased process-wide permits, so repeated terminal
+release failures or configuration changes cannot accumulate more than 256 pins
+and cleanup tasks. Clear/Reset cleanup and the reaper serialize through the same
+`AttachmentPinStore` confinement/lock; a bundle published after logical
+generation invalidation is still reclaimed. If stale release cannot prove
+deletion, fail the replacement writer generation closed; every release failure
+keeps its permit charged and retries confined cleanup rather than losing
+ownership of the orphan. If the process exits before a callback runs, the
+mandatory empty-root scrub on the next v4 boot removes both published and
+staging leftovers before accepting captures.
 
 Retain the current single text-only degradation for a valid nonempty caption:
 
@@ -817,7 +869,8 @@ Retain the current single text-only degradation for a valid nonempty caption:
   pin and mark the same ordered slot ready once without attachments
 - if EverOS returns an attachment rejection for which
   `attachment_add_rejection_proves_no_write()` is true, release the pin and
-  retry the same in-flight slot once without attachments
+  retry the same in-flight slot once without attachments; the same permit owns
+  both the fallback and any still-pending confined release
 
 This is a modality fallback, not replay after ambiguity. It counts toward the
 same three-total-attempt bound, never reserves a second slot, and is forbidden
@@ -973,7 +1026,9 @@ Do not ship those doc edits in this planning PR.
   writer startup blocked without modifying the marker or SQLite identity.
 - Retained add/flush request ids migrate to bounded call provenance before
   delivery tables are dropped, including rejected calls and every scope row for
-  reused ids; ambiguous cross-scope request ids remain unauthorized.
+  reused ids; ambiguous cross-scope request ids remain unauthorized. Migrated
+  rows receive the Call Log cutoff as their conservative provider-start time,
+  while new rows retain the exact preflight start.
 - Released unflushed-session rows migrate to incomplete, content-free
   correlation guards without message ids or schedule state. At 256 distinct
   exact guards the next distinct row sets the global-incomplete sentinel; a
@@ -986,14 +1041,22 @@ Do not ship those doc edits in this planning PR.
   operation, state, generation, and bounded request ids), while the v4 file has
   no delivery tables. Queue-backed abandoned rows receive their exact 90-day
   expiry, settlement-backed rows remain unexpired, rows already expired at the
-  migration instant disappear, and count retention keeps only the
-  deterministically newest 100,000 remaining rows without payload or retry
-  state.
+  migration instant disappear, and count retention keeps the independently
+  newest 100,000 rows in each expiry class without payload or retry state. More
+  than 50 queue and settlement rows sharing one occurrence timestamp retain the
+  released digest / zero-padded-ID tie order through local sequences, without
+  copying either old sort key.
+- An old non-expiring settlement anomaly followed by 100,001 newer expiring
+  queue anomalies survives the independent permanent cap. After the clock moves
+  past every queue expiry, that settlement row re-enters the newest-50 result in
+  its original order.
 - Provenance age and row-count pruning deletes complete request-id groups only;
   it cannot turn a reused ambiguous id into a uniquely authorized id, including
   when one group alone exceeds the row bound. Count-pruning a group still inside
-  the Call Log horizon atomically creates correlation-only coverage first; an
-  overlapping retained call reports unavailable rather than disappearing.
+  the Call Log horizon atomically creates correlation-only coverage from the
+  earliest provider start, not merely the response observation; a retained call
+  that started earlier than `recorded_at_ms` still reports unavailable rather
+  than disappearing.
 - A malformed observer correlation or anomaly creates a bounded retained-horizon
   migration observation gap with the exact affected source flags; after
   restart, each overlapping/affected Processing Record source still reports
@@ -1012,8 +1075,9 @@ Do not ship those doc edits in this planning PR.
 
 - `offer()` does not await attachment pinning or provider I/O.
 - Total occupancy never exceeds 256 across unready reservations, current and
-  stale pin tasks, ready/queued slots, and the in-flight slot, even through
-  repeated generation changes; there is no out-of-window predecessor chain.
+  stale pin tasks, current/stale terminal cleanup entries, ready/queued slots,
+  and the in-flight slot, even through repeated generation changes; there is no
+  out-of-window predecessor or cleanup chain.
 - Saturation returns `memory_queue_full` / `CaptureSkipped`.
 - One worker preserves accepted-item order globally.
 - At most three total attempts per operation, and only for proven-uncommitted adds or
@@ -1069,9 +1133,11 @@ Do not ship those doc edits in this planning PR.
   marks the slot skipped without waiting, keeps its process-wide permit and
   source lease charged, reclaims the late bundle through confinement, and only
   then releases both. A replacement generation cannot exceed the same 256 cap.
-- An injected late-bundle release failure keeps the replacement generation
-  closed and its permit charged until confined cleanup succeeds; restart runs
-  the mandatory empty-root scrub before reopening intake.
+- An injected current-generation terminal bundle-release failure transfers to
+  the strong cleanup registry, keeps its original permit and source lease
+  charged, retries confined deletion, and cannot accumulate a 257th cleanup
+  owner. The same late-bundle failure keeps a replacement generation closed;
+  restart runs the mandatory empty-root scrub before reopening intake.
 - Watermark persists across writer restart and is monotonic.
 - Every acknowledged add advances durable `last_success_at` atomically with its
   provenance/observation-gap settlement. After all call-provenance groups age
@@ -1086,7 +1152,11 @@ Do not ship those doc edits in this planning PR.
   the limit without advancing rejected-capture state.
 - `MEMORY-IM-ATTACH-009` and `MEMORY-IM-ATTACH-011` still perform exactly one
   safe text-only degradation, while ambiguous or unclassified attachment
-  failures never resubmit the caption.
+  failures never resubmit the caption. The positively rejected attachment call
+  records provenance but no terminal anomaly when its text fallback succeeds;
+  only an unsuccessful final logical outcome enters `failure_log()`. An injected
+  bundle-release failure during that successful fallback leaves the same permit
+  and cleanup entry charged until confined deletion succeeds.
 - Logs never include captured text, credentials, or absolute paths.
 - Every provider attempt durably opens a two-source observation gap before the
   RPC. A failed preflight write skips an add or retains a due flush only within
@@ -1097,14 +1167,15 @@ Do not ship those doc edits in this planning PR.
   writer plus successful sidecar stop/reap proves its termination boundary.
 - Valid bounded request ids from acknowledged, rejected, and otherwise
   unclassifiable add/flush responses are recorded with their outcome and scope;
-  terminal non-success and exhausted proven-uncommitted operations also persist
-  the current sanitized `MemoryFailureLogEntry` fields and source-specific
-  expiry in the bounded anomaly table. Observer failure never causes a provider
-  retry; its preflight anomaly flag makes `failure_log()` unavailable even after
-  lifecycle close until enough newer known rows exclude the hole from every
-  supported newest-N result. A separately allowed add or pre-submission flush
-  retry settles only its own proven-unentered gap and opens a new one, while a
-  submitted flush remains terminal.
+  only final logical non-success and exhausted proven-uncommitted operations
+  also persist the current sanitized `MemoryFailureLogEntry` fields and
+  source-specific expiry in the bounded anomaly table. Observer failure never
+  causes an ambiguous provider retry; its preflight anomaly flag makes
+  `failure_log()` unavailable even after lifecycle close until 100 newer
+  non-expiring known rows exclude the hole from every supported newest-N result.
+  Expiring rows never retire that flag. A separately allowed add or
+  pre-submission flush retry settles only its own proven-unentered gap and opens
+  a new one, while a submitted flush remains terminal.
 - An ambiguous request A prevents request B from reaching the provider until a
   successful owned-sidecar stop/reap closes A's interval. The replacement then
   flushes A's incomplete candidate before B can submit and delete only B's gap;
@@ -1112,8 +1183,12 @@ Do not ship those doc edits in this planning PR.
   retention. A failed stop or unproved boot admits no B provider submission.
 - Observation-gap compaction coalesces old ranges with the union of their source
   flags and without losing covered time. Correlation flags retire only outside
-  Call Log retention; anomaly flags retire only after 100 newer unexpired known
-  anomalies make the interval irrelevant to every supported newest-N result.
+  Call Log retention; anomaly flags retire only after 100 newer non-expiring
+  known anomalies make the interval irrelevant to every supported newest-N
+  result. Expiring newer rows may disappear and therefore never retire a gap.
+- A closed anomaly gap followed by 100 newer expiring rows remains unavailable
+  before and after those rows expire; 100 newer non-expiring settlement rows
+  permit retirement and preserve the newest-100 projection.
 
 ### Compatibility with retained surfaces
 
@@ -1178,7 +1253,8 @@ after adding migrator and writer tests. Line count is not acceptance.
 - [ ] Replace claim quiescence with writer pause/quiesce around Rebuild/Repair.
 - [ ] Stop writing processing-fault ACK / `manual_required` / settlements.
 - [ ] Scrub the entire confined pin root before every v4 writer start and reap
-      stale-generation pin completions under the process-wide admission bound.
+      stale pin completions plus every current/stale terminal release under the
+      process-wide admission bound.
 - [ ] Keep `memory.cli.remembered` as queued; rewrite Memory user docs.
 - [ ] Shrink Clear's queue primitive to identity reset.
 - [ ] Remove coordinator, worker, and outbox-only tests.

--- a/docs/plans/memory-best-effort-capture.md
+++ b/docs/plans/memory-best-effort-capture.md
@@ -100,9 +100,9 @@ provider root.
   recovers.
 - Ambiguous add/flush results may leave a rare duplicate if EverOS
   committed and Avibe could not observe the ack. They are not retried.
-- Session-boundary flush is best-effort. Queue saturation, a crash, or dropping
-  a 257th pending-session tracker may leave old and new conversation content in
-  the same EverOS accumulation boundary.
+- Session-boundary flush is best-effort. Admission saturation can reject a
+  barrier, and a process crash can drop volatile boundary candidates, leaving
+  old and new conversation content in the same EverOS accumulation boundary.
 - Duplicate source-message suppression is process-local. A restart may
   recapture the same IM or remember payload if the caller submits it
   again.
@@ -154,7 +154,10 @@ BestEffortMemoryWriter.offer()
 one ordered worker consumes the ready head slot
         |
         v
-durably open one content-free provider-call gap
+reserve one bounded session-boundary candidate and mark its guard incomplete
+        |
+        v
+durably open one content-free multi-source observation gap
         |
         v
 EverOSPort.add / flush
@@ -200,22 +203,39 @@ appends exactly one message id, and reaching 100 makes that provider session
 immediately due before another add for the same session can be submitted.
 
 The map retains at most 256 provider sessions, so its 100-id per-entry limit
-also bounds total retained ids at 25,600. Every retained session has a bounded,
-content-free durable correlation guard described below. A guard written by the
-current writer instance plus its matching live `PendingFlush` means the bounded
-message-id list is complete. A guard from an older writer generation, or one
-already marked incomplete, makes any recreated tracker incomplete.
+also bounds total retained ids at 25,600. Before an add can cross the provider
+submission edge, reserve or refresh that session's `PendingFlush`, append the
+deterministic message id provisionally, retain the previous tracker snapshot in
+the single in-flight slot, and durably mark its content-free correlation guard
+incomplete. A guard written by the current writer instance plus its matching
+live tracker can become complete only when the same add returns an observed
+`accumulated` acknowledgement and the prior snapshot was complete. A guard from
+an older writer generation, the global guard, or an already incomplete prior
+snapshot keeps the tracker incomplete.
 
-If an `accumulated` result would create a 257th entry, do not evict or mutate an
-existing scope: atomically record the add provenance and set the singleton
-global-incomplete correlation guard, drop the new volatile tracking entry,
-increment a content-free capacity-drop counter, and leave the EverOS buffer
-untouched. A later same-session add may recreate tracking after capacity is
-available, but its `correlation_complete` is false; any later flush is recorded
-as unavailable correlation rather than appearing complete from only the later
-ids. Failure to persist the guard leaves the add's already-open provenance gap
-open and fails the writer generation closed. The pending map does not survive a
-writer generation or process restart, while its durable guards do.
+If a new provider session would create a 257th map entry, skip that add before
+calling EverOS, release its admission slot, increment a content-free capacity
+counter, and do not create provider-call provenance. Never submit a call whose
+possible `unprocessed_buffer` write has no retained raw-session boundary
+candidate. This removes the previous capacity case that could leave an EverOS
+buffer with neither a flush trigger nor a safe correlation state.
+
+An observed `accumulated` result commits the provisional id and its restored
+completeness; `extracted` clears the whole tracker and guard because it proves a
+natural boundary. A rejection or failure proven before provider execution
+restores the prior snapshot (and removes a newly created empty tracker). An
+ambiguous submitted add keeps the provisional id, marks the
+tracker incomplete and immediately due, and is never retried. If the ambiguity
+is a timeout, cancellation, transport loss, or another result without a
+trustworthy response boundary, pause all later provider submissions without
+invalidating the map, stop and reap the owned sidecar, close the observation
+gap at that lifecycle bound, replace the sidecar, and submit this incomplete
+flush before later work. A returned but semantically unknown response with a
+valid request id can enqueue the same due flush immediately without sidecar
+replacement. `/new` and archive still return without waiting. A process crash
+may lose this volatile boundary action, but its durable guard remains
+incomplete. Failure of any required pre-submission guard/gap write skips the add
+without calling EverOS.
 
 When an entry becomes due, the worker snapshots it for one flush attempt. A
 failure proven to occur before the provider coroutine can execute may retain
@@ -290,8 +310,8 @@ own `memory_meta.epoch`. A second identity format would add crash windows
 without removing the outbox.
 
 After migration, `state/memory/memory.sqlite` contains identity plus bounded,
-content-free display-provenance and anomaly tables. They contain no delivery work,
-retry state, flush schedule, captured text, or attachment path:
+content-free observer tables. They contain no delivery work, retry state, flush
+schedule, captured text, or attachment path:
 
 ```text
 memory_meta
@@ -337,6 +357,7 @@ memory_processing_anomaly
   worker_generation
   principal_id
   project_id
+  expires_at_ms        # queue-backed abandonment + 90 days; null for settlement evidence
 
 memory_flush_correlation_guard
   guard_key            # HMAC of provider-session ref, or one global sentinel
@@ -344,12 +365,14 @@ memory_flush_correlation_guard
   incomplete           # boolean; true cannot become complete by later adds
   recorded_at_ms
 
-memory_call_provenance_gap
+memory_observation_gap
   gap_id               # local operation token, never sent to EverOS
   started_at_ms
   ended_at_ms          # null while the outcome is still unknown
   operation_kind       # add | flush | migration
-  reason               # call_unobserved | migration_unknown
+  correlation_incomplete # boolean source-availability flag
+  anomaly_incomplete   # boolean source-availability flag
+  reason               # call_unobserved | migration_unknown | retention_pruned
 ```
 
 `memory_call_provenance` replaces the correlation and authorization facts
@@ -364,13 +387,17 @@ that Processing Record currently reads from `memory_capture_queue` and
   message id and `correlation_complete=true`; a flush row carries the bounded
   message-id list from that session's `PendingFlush` plus its completeness bit
 - retain at most 5,000 provenance rows and at most 14 days, matching Provider
-  Call Log retention, but prune only complete request-id groups: age-prune a
-  group only when its newest `recorded_at_ms` is older than the cutoff, then
-  delete the oldest whole groups until the row count is at most 5,000
+  Call Log retention, but prune only complete request-id groups. Before
+  row-count pruning any group that can still overlap retained Call Log rows,
+  create or widen a closed correlation-only `retention_pruned` observation gap
+  over the deleted groups' full observation-time range in the same transaction.
+  A group wholly older than the Call Log cutoff needs no new coverage; then
+  delete oldest whole groups until the row count is at most 5,000
 - never retain a subset of a request-id group. If one reused group alone exceeds
   the row limit, delete that whole group; missing provenance remains fail-closed
 - enforce both bounds after each provenance write and at boot with the same
-  policy values
+  policy values. If coverage cannot be committed, do not prune; a failed
+  provider-observation transaction leaves its preflight gap open
 - for every user-scoped read, require all rows for the request id to resolve to
   exactly one principal/project; ambiguous or missing provenance never
   broadens visibility
@@ -391,17 +418,20 @@ count, deadline, attempt, or work item:
 - keep at most 256 exact session digests plus one singleton global-incomplete
   sentinel; never evict an exact guard and thereby turn unknown correlation into
   apparently complete correlation
-- create/update an exact guard in the same observer transaction that records the
-  first `accumulated` add for a live tracker. Its opaque writer-instance token
+- create/update an exact guard in the pre-submission transaction for every add
+  that has reserved a live boundary candidate. Its opaque writer-instance token
   proves completeness only while the matching generation and `PendingFlush`
-  still exist
+  still exist; the same observed `accumulated` settlement may restore the prior
+  complete state, but a later unrelated add cannot
 - at generation replacement or process restart, any surviving exact guard has
   an old token and therefore taints later recreated tracking as incomplete
-- when the exact-guard capacity or volatile pending-map capacity is exceeded,
-  set the global sentinel. While it exists every newly created tracker is
-  incomplete, including sessions not represented by an exact row
+- when exact-guard capacity is exceeded by retained old-generation rows, set the
+  global sentinel. While it exists every newly created tracker is incomplete,
+  including sessions not represented by an exact row. Pending-map capacity is
+  handled separately by skipping a new-session add before its provider RPC
 - delete an exact guard only after a natural `extracted` add or acknowledged
-  flush proves that provider buffer crossed a boundary. Rejection, timeout,
+  flush proves that provider buffer crossed a boundary. A rejection or
+  proven-uncommitted failure restores the pre-add guard snapshot; timeout,
   malformed response, cancellation, and ambiguity retain it as incomplete
 - the global sentinel is cleared only by Clear/Factory Reset or a future
   provider-wide operation that positively proves every unprocessed buffer empty;
@@ -424,78 +454,106 @@ not a retry or delivery ledger:
   the user-visible anomaly payload
 - never store provider messages, raw exceptions, payload/message text, session
   ids, source digests, attachment metadata, paths, or lease/fence tokens
-- retain the newest 100,000 rows with no age deletion, matching the current
-  terminal-tombstone count ceiling while preserving old immutable-settlement
-  anomalies that remain among the newest 50; return that newest 50 through the
-  unchanged `failure_log()` / Processing Record projection
+- set `expires_at_ms = occurred_at_ms + 90 days` for queue-backed
+  `delivery_abandoned` rows that the current terminal-tombstone compactor
+  removes, and null for settlement-backed rejected/ambiguous evidence that the
+  current immutable settlement table retains. Migration derives this from the
+  source side of the released `failure_log()` union, not from `kind` alone
+- delete expired rows first, then retain the deterministically newest 100,000
+  unexpired rows. This preserves every source-specific age contract and every
+  immutable-settlement anomaly that can still appear among the newest 50;
+  return that newest 50 through the unchanged `failure_log()` / Processing
+  Record projection
 - order and prune deterministically by `(occurred_at_ms, anomaly_id)`, so
   deleting only oldest overflow cannot change the current newest-50 projection
-- enforce retention after each insert and at boot; an anomaly read/schema
-  failure marks that Processing Record source unavailable rather than returning
-  an empty successful list
+- enforce expiry/count retention after each insert and at boot; an anomaly
+  read/schema failure marks that Processing Record source unavailable rather
+  than returning an empty successful list
 
-The single ordered worker makes correlation loss restart-safe without turning
+The single ordered worker makes every observer loss explicit without turning
 observer state into delivery state:
 
-1. Before every EverOS add or flush attempt, the worker durably inserts one open
-   `memory_call_provenance_gap` row for that operation token. It never closes or
-   replaces another attempt's gap. If this preflight identity transaction fails,
-   the provider is not called: an add is skipped, while a due flush retains its
-   snapshot only for the bounded pre-submission retry policy above.
-2. If the result contains a valid request id, one transaction inserts every
-   provenance row for that call, inserts its sanitized anomaly row when the
-   result is non-success, applies its correlation-guard transition, and deletes
-   only that operation token's gap. An acknowledged add also advances
-   `memory_meta.last_success_at` to the observation time in this transaction.
-   This applies to acknowledged, rejected, and unknown classifications. A
-   separately allowed add retry starts only after that observer transaction
-   commits; a submitted flush is terminal. A provenance/anomaly/guard transaction
-   failure leaves the already-committed gap open and never causes a provider
-   retry.
-3. If an add result has no valid request id and proves no request left Avibe, or
-   a flush attempt fails before its provider coroutine can execute, close only
-   that gap before any permitted retry. On the final bounded failure, insert the
-   sanitized anomaly in the same transaction that closes the gap. If the
-   transaction fails, drop the item and leave the gap open fail-closed. A retry
-   opens a new independent gap.
+1. Before every EverOS add or flush attempt, one preflight transaction marks the
+   exact correlation guard incomplete and inserts one open
+   `memory_observation_gap` for that operation token with both
+   `correlation_incomplete` and `anomaly_incomplete` set. For an add, the
+   volatile provisional boundary reservation above happens first and is rolled
+   back if preflight fails. A gap never closes or replaces another attempt's
+   gap. If preflight fails, the provider is not called: an add is skipped, while
+   a due flush retains its snapshot only for the bounded pre-submission retry
+   policy above.
+2. If a result contains a valid request id, one transaction inserts every
+   provenance row for that call, inserts its source-expiring sanitized anomaly
+   when the result is non-success, applies the guard and provisional-boundary
+   transition, and deletes only that operation token's gap. An acknowledged add
+   also advances `memory_meta.last_success_at` to the observation time in this
+   transaction. This applies to acknowledged, rejected, and semantically unknown
+   classifications. A separately allowed add retry starts only after that
+   observer transaction commits; a submitted flush is terminal. Transaction
+   failure leaves the preflight gap carrying both source flags, keeps any
+   possible add boundary candidate incomplete and due, closes later provider
+   submission, and never retries the provider call.
+3. If an add result proves no request left Avibe, or a flush attempt fails before
+   its provider coroutine can execute, restore the add's prior boundary snapshot
+   and delete only that gap before any permitted retry. On the final bounded
+   failure, insert the queue-backed sanitized anomaly with its 90-day expiry in
+   the same transaction. If that transaction fails, drop the item and leave the
+   gap open with both source flags fail-closed. A retry opens a new independent
+   gap.
 4. A timeout, truncated or malformed response, cancellation, or other submitted
-   result without a trustworthy request id inserts a `result_unknown` anomaly
-   but leaves that operation's gap open because the provider may still execute.
-   Later attempts do not shorten it. If the anomaly transaction fails, the open
-   gap still makes the observation source unavailable; the provider call is not
-   retried.
-5. Close open `call_unobserved` gaps only at a provider-lifecycle upper bound:
-   intake is paused, the writer has no new submission edge, and the sidecar
-   supervisor has successfully stopped and reaped the owned provider process.
-   One transaction sets `ended_at_ms` for gaps that started before that observed
-   termination; only then may a replacement sidecar accept calls. Failed or
-   unprovable termination leaves the gaps open and intake closed. An Avibe boot
-   does not close them merely because the service restarted; it may close them
-   only after the same provider-termination proof. Until then each open gap
-   covers `[started_at_ms, infinity)`.
+   result without a trustworthy request id inserts a settlement-backed
+   `result_unknown` anomaly when possible and atomically clears only that gap's
+   `anomaly_incomplete` flag, but leaves its correlation flag and interval open
+   because the provider may still execute. The add's provisional boundary stays
+   incomplete and due as described above. Later attempts do not shorten the gap
+   and the provider call is never retried. Failure to insert the anomaly leaves
+   both preflight flags set rather than returning a successful empty list.
+5. Set `ended_at_ms` on open `call_unobserved` gaps only at a
+   provider-lifecycle upper bound: intake is paused, the writer has no new
+   submission edge, and the sidecar supervisor has successfully stopped and
+   reaped the owned provider process. Only then may a replacement sidecar accept
+   calls and the retained ambiguous-add boundary flush run before later work.
+   Failed or unprovable termination leaves gaps open and intake closed. An Avibe
+   boot does not close them merely because the service restarted; it may close
+   them only after the same provider-termination proof. Closing a gap bounds its
+   interval; it does not clear either missing-source flag.
 
-A Processing Record call whose observation time overlaps any gap reports the
-correlation source unavailable instead of silently disappearing from a scoped
-result. Thus an older timed-out request remains covered even if a newer request
-quickly returns a valid id and settles its own gap.
+A Processing Record call whose observation time overlaps a
+`correlation_incomplete` gap reports the correlation source unavailable instead
+of silently disappearing from a scoped result. Thus an older timed-out request
+or row-count-pruned provenance group remains covered even if newer observations
+settle successfully.
 
-A gap is global observer state rather than a principal/project authorization
-fact: no scoped reader may bypass an overlapping gap. Gap metadata is also
-bounded to 14 days and 256 ranges. When it exceeds the count bound, coalesce the
-oldest ranges into a wider range rather than dropping coverage. Delete a closed
-range only when it is wholly older than the Provider Call Log retention cutoff;
-an open range is never age-deleted. This may hide a good observation
-conservatively, but cannot authorize the wrong scope. Clear's `reset_for_clear`
-deletes provenance rows, anomalies, correlation guards, and gaps with the
-catalog and watermark reset; Factory Reset deletes them with `state/memory`.
+The anomaly projection is unavailable when an `anomaly_incomplete` gap is open,
+or when fewer than the maximum supported failure-log limit (100) of unexpired
+anomaly rows are strictly newer than a closed gap's `ended_at_ms`. Once 100
+newer known rows exist, no missing event in that older interval can affect any
+supported newest-N result, so the anomaly flag may be retired. Lifecycle close
+alone never turns a missing anomaly into a complete successful projection.
+
+An observation gap is global observer state rather than a principal/project
+authorization fact: no scoped reader may bypass an affected source. Keep at
+most 256 ranges. When the bound would be exceeded, coalesce the oldest closed
+ranges, OR their source flags, and widen their time coverage rather than
+dropping a hole. Never merge away the exact token for an open provider attempt;
+if no closed range can make capacity, fail preflight or retention pruning before
+the provider call or provenance deletion. A closed correlation flag may retire
+only when its range is wholly older than the Provider Call Log cutoff; an open
+flag never age-deletes. Delete the row only after both source flags retire. This
+may hide a good observation conservatively, but cannot authorize or display an
+incomplete source as complete. Clear's `reset_for_clear` deletes provenance
+rows, anomalies, correlation guards, and observation gaps with the catalog and
+watermark reset; Factory Reset deletes them with `state/memory`.
 
 The independently maintained Provider Call Log is not an input to identity
 migration or writer admission. Historical migration copies every valid bounded
 add/flush request id from the released Memory store, including rejected rows and
 every scope row for a reused id, then applies the same whole-group 5,000-row /
-14-day policy using capture/settlement observation times. It does not open or
-filter against the call-log database. Any observer-only correlation that cannot
-be translated safely creates or widens a `migration_unknown` gap over the
+14-day policy using capture/settlement observation times, including
+correlation-only coverage for count-pruned groups that can still overlap the
+Call Log window. It does not open or filter against the call-log database. Any
+observer source that cannot be translated safely creates or widens a
+`migration_unknown` observation gap with the affected source flags over the
 retained observation horizon instead of being silently skipped. An absent,
 corrupt, incompatible, or unreadable call log therefore makes the Processing
 Record calls section unavailable/warned through its existing projection, but
@@ -518,7 +576,8 @@ no attachment or provider await; the identity write is not an outbox.
 
 `last_success_at` also remains durable display/maintenance state. Every
 acknowledged v4 add updates it in the same observer transaction as provenance and
-gap settlement, using the later of its existing value and the observation time.
+observation-gap settlement, using the later of its existing value and the
+observation time.
 Provenance retention never clears it. The reduced
 `has_provider_data_history()` reads this field instead of delivery rows, so
 `MemoryMaintenance.maintenance_payload().data_exists` remains true after
@@ -639,23 +698,27 @@ would accept captures:
    - before dropping delivery tables, copy every valid bounded add/flush request
      id into `memory_call_provenance`, including rejected operations and every
      scope row for a reused id; prune only complete request-id groups to the
-     5,000-row / 14-day window and preserve ambiguity as fail-closed
+     5,000-row / 14-day window, create correlation-only `retention_pruned`
+     coverage before count-pruning groups still inside the Call Log horizon,
+     and preserve ambiguity as fail-closed
    - run the released-shape equivalent of the current `failure_log()` union and
      copy every projected queue/settlement anomaly into
      `memory_processing_anomaly` before its source tables are dropped. Preserve
      the stable id and every sanitized `MemoryFailureLogEntry` field, deduplicate
      rejected adds exactly as the current projection does, map errors through the
-     same closed-code sanitizer, and prune only the oldest overflow beyond the
-     newest 100,000 rows, with no age cutoff
+     same closed-code sanitizer, set 90-day expiry only for queue-backed
+     abandonment rows, keep settlement-backed expiry null, delete rows already
+     expired at migration time, and prune only the oldest overflow beyond the
+     newest 100,000 remaining rows
    - for every old `memory_session_flush_state` row with an unflushed provider
      buffer, create an incomplete exact `memory_flush_correlation_guard` using
      only its bounded session-ref digest. If more than 256 distinct rows exist,
      keep 256 exact guards and set the global-incomplete sentinel; never migrate
      a schedule, count, deadline, fence, attempt, or message id
    - do not open the optional Provider Call Log; if observer-only request-id or
-     timestamp data cannot be translated safely, create or widen one bounded
-     `migration_unknown` gap over the retained horizon and count it without
-     storing source data
+     anomaly data cannot be translated safely, create or widen one bounded
+     `migration_unknown` observation gap with the affected source flags over the
+     retained horizon and count it without storing source data
    - drop delivery tables, indexes, and settlement triggers
    - rebuild `memory_meta` without requiring delivery columns if this
      PR drops them
@@ -680,8 +743,9 @@ would accept captures:
    count, migrated exact-guard count, global-incomplete-guard state, and
    scrubbed confined entry count. Never log text,
    paths, or digests that can recover a message. Also count provenance rows
-   covered by a migration gap and a busy post-commit checkpoint without treating
-   either as a capture-startup failure.
+   covered by retention/migration observation gaps, source-specific expired
+   anomaly rows, and a busy post-commit checkpoint without treating any as a
+   capture-startup failure.
 9. Start `BestEffortMemoryWriter` against the preserved watermark and
    catalog.
 
@@ -797,17 +861,20 @@ labelled as volatile; it must not show a durable missed-capture backlog.
 
 Processing Record and Provider Call Log otherwise retain their current scope
 and correlation behavior through `memory_call_provenance` and
-`memory_call_provenance_gap`, with completeness guarded by
+`memory_observation_gap`, with completeness guarded by
 `memory_flush_correlation_guard`. The reader's capture-source availability probe
 and request-id joins move to those tables; they do not silently omit request-id
 call branches merely because the delivery tables are gone or a volatile
-message-id set was lost.
+message-id set was lost. Count-pruned provenance inside the Call Log horizon is
+covered by a correlation-only gap before deletion.
 
 Processing Record's durable anomaly source moves independently to
 `memory_processing_anomaly`. `MemoryStore.failure_log()` keeps its current
-newest-50 result shape and source-availability behavior; it no longer queries a
-delivery table. Disabling Memory still permits the existing read-only retained
-anomaly projection.
+newest-50 result shape, source-specific expiry, and source-availability
+behavior; it no longer queries a delivery table. Any observation gap that could
+change the requested newest-N result makes that source unavailable instead of
+returning an incomplete list. Disabling Memory still permits the existing
+read-only retained anomaly projection.
 
 ## Control plane that stays
 
@@ -837,7 +904,7 @@ only after the replacement is admitted. This is the replacement for
 Clear's queue primitive becomes: identity `reset_for_clear` (epoch bump,
 catalog wipe, watermark and `last_success_at` reset, and atomic deletion of
 `memory_call_provenance`, `memory_processing_anomaly`,
-`memory_flush_correlation_guard`, and `memory_call_provenance_gap`) with no
+`memory_flush_correlation_guard`, and `memory_observation_gap`) with no
 capture-queue DELETE. The other three surfaces (provider root, call log,
 attachments) stay. Replaying the same `target_epoch` is idempotent and still
 proves every observer table empty before the Clear fence may be released.
@@ -917,14 +984,20 @@ Do not ship those doc edits in this planning PR.
   `failure_log()` projection is field-for-field identical before and after
   migration (including stable ids, deduplication, closed errors, attempts,
   operation, state, generation, and bounded request ids), while the v4 file has
-  no delivery tables. Retention keeps only the deterministically newest 100,000
-  anomaly rows, without an age cutoff and without payload or retry state.
+  no delivery tables. Queue-backed abandoned rows receive their exact 90-day
+  expiry, settlement-backed rows remain unexpired, rows already expired at the
+  migration instant disappear, and count retention keeps only the
+  deterministically newest 100,000 remaining rows without payload or retry
+  state.
 - Provenance age and row-count pruning deletes complete request-id groups only;
   it cannot turn a reused ambiguous id into a uniquely authorized id, including
-  when one group alone exceeds the row bound.
-- A malformed observer correlation creates a bounded retained-horizon migration
-  gap; after restart, overlapping Processing Record observations still report
-  correlation unavailable rather than silently disappearing.
+  when one group alone exceeds the row bound. Count-pruning a group still inside
+  the Call Log horizon atomically creates correlation-only coverage first; an
+  overlapping retained call reports unavailable rather than disappearing.
+- A malformed observer correlation or anomaly creates a bounded retained-horizon
+  migration observation gap with the exact affected source flags; after
+  restart, each overlapping/affected Processing Record source still reports
+  unavailable rather than silently succeeding with omissions.
 - Migration and later-v4-boot tests seed represented bundles, an unrepresented
   valid published bundle, staging leftovers, and safely confined unrecognized
   entries, then prove the empty-reference scrub removes all of them before
@@ -957,16 +1030,27 @@ Do not ship those doc edits in this planning PR.
   or other ambiguity. Only a proven pre-submission failure retains it, and the
   third failed attempt drops it without a provider call.
 - High-cardinality accumulated traffic retains at most 256 pending sessions and
-  25,600 message ids. A 257th new session drops only its new volatile tracking,
-  never evicts or mutates an existing scope, atomically sets the durable
-  global-incomplete guard, and records content-free accounting. A later add for
-  that session may be tracked, but its flush provenance is explicitly incomplete
-  and Processing Record reports correlation unavailable.
+  25,600 message ids. A capture for a 257th distinct session is skipped before
+  any EverOS RPC, never evicts or mutates an existing scope, records only
+  content-free accounting, and cannot create an untracked provider buffer.
 - Exact correlation guards from a previous writer instance/generation taint a
   recreated tracker after restart; a global guard taints every new tracker.
-  Natural extraction or acknowledged flush clears an exact guard, while
-  rejected/ambiguous results and sidecar restart do not. No test can recover
-  complete provenance using only message ids accumulated after a guard.
+  Natural extraction or acknowledged flush clears an exact guard; rejection or
+  proven-uncommitted failure restores the prior snapshot; ambiguous results and
+  sidecar restart do not make it complete. No test can recover complete
+  provenance using only message ids accumulated after an incomplete guard.
+- Before every submitted add, the deterministic message id is provisionally
+  present in a barrier-visible tracker and the durable guard is incomplete. An
+  accumulated ack commits it, extraction clears the boundary, and rejection or
+  proven-uncommitted failure restores the exact prior snapshot.
+- A timed-out/transport-ambiguous submitted add retains that provisional tracker
+  incomplete and due, blocks all later provider submissions, and survives the
+  sidecar stop/reap operation in process. After the lifecycle upper bound, its
+  incomplete flush runs before later work; a `/new` barrier admitted meanwhile
+  returns immediately, and the candidate stays barrier-visible until the
+  recovery flush reaches its submission edge. If that flush cannot prove a
+  boundary, its durable guard remains incomplete. A process crash may drop the
+  volatile flush action but cannot make later correlation complete.
 - Shutdown, disable, config replacement, Clear, and Reset drop the queue
   without drain.
 - Session barrier does not block `/new` or archive. At its ordered head it
@@ -990,9 +1074,10 @@ Do not ship those doc edits in this planning PR.
   the mandatory empty-root scrub before reopening intake.
 - Watermark persists across writer restart and is monotonic.
 - Every acknowledged add advances durable `last_success_at` atomically with its
-  provenance/gap settlement. After all call-provenance groups age out,
-  `has_provider_data_history()` and maintenance `data_exists` remain true from
-  that timestamp; rejected/ambiguous adds do not advance it and Clear resets it.
+  provenance/observation-gap settlement. After all call-provenance groups age
+  out, `has_provider_data_history()` and maintenance `data_exists` remain true
+  from that timestamp; rejected/ambiguous adds do not advance it and Clear
+  resets it.
 - With the watermark already at `MAX_PROVIDER_TIMESTAMP_MS`, the next otherwise
   valid capture returns `timestamp_invalid` without changing the watermark or
   catalog and without charging a slot, pinning, or creating a task.
@@ -1003,27 +1088,32 @@ Do not ship those doc edits in this planning PR.
   safe text-only degradation, while ambiguous or unclassified attachment
   failures never resubmit the caption.
 - Logs never include captured text, credentials, or absolute paths.
-- Every provider attempt durably opens a gap before the RPC. A failed preflight
-  write skips an add or retains a due flush only within its bounded
-  pre-submission attempts, without calling EverOS; timeout/unknown responses and
-  an injected provenance-commit failure leave a gap that remains fail-closed
-  after restart. A later successful attempt settles only its own gap; the older
-  ambiguous gap stays open until a paused writer plus successful sidecar
-  stop/reap proves its termination boundary.
+- Every provider attempt durably opens a two-source observation gap before the
+  RPC. A failed preflight write skips an add or retains a due flush only within
+  its bounded pre-submission attempts, without calling EverOS;
+  timeout/unknown responses and an injected observer-commit failure leave both
+  correlation and anomaly unavailable after restart. A later successful attempt
+  settles only its own gap; the older ambiguous gap stays open until a paused
+  writer plus successful sidecar stop/reap proves its termination boundary.
 - Valid bounded request ids from acknowledged, rejected, and otherwise
   unclassifiable add/flush responses are recorded with their outcome and scope;
   terminal non-success and exhausted proven-uncommitted operations also persist
-  the current sanitized `MemoryFailureLogEntry` fields in the bounded anomaly
-  table. Provenance/anomaly failure never causes a provider retry; a separately
-  allowed add or pre-submission flush retry settles only its own proven-unentered
-  gap and opens a new one, while a submitted flush remains terminal.
-- An ambiguous request A followed by a successful request B leaves A's gap open
-  after B atomically records provenance and deletes B's gap. A late Provider Call
-  Log row from A therefore overlaps unavailable correlation coverage. Only a
-  successful owned-sidecar stop/reap closes A at the observed termination time;
-  an ordinary later attempt, failed stop, or unproved boot never does.
-- Gap compaction coalesces old ranges without losing covered time, and age
-  deletion removes only closed ranges wholly outside Call Log retention.
+  the current sanitized `MemoryFailureLogEntry` fields and source-specific
+  expiry in the bounded anomaly table. Observer failure never causes a provider
+  retry; its preflight anomaly flag makes `failure_log()` unavailable even after
+  lifecycle close until enough newer known rows exclude the hole from every
+  supported newest-N result. A separately allowed add or pre-submission flush
+  retry settles only its own proven-unentered gap and opens a new one, while a
+  submitted flush remains terminal.
+- An ambiguous request A prevents request B from reaching the provider until a
+  successful owned-sidecar stop/reap closes A's interval. The replacement then
+  flushes A's incomplete candidate before B can submit and delete only B's gap;
+  A's closed correlation flag still covers late Provider Call Log rows until
+  retention. A failed stop or unproved boot admits no B provider submission.
+- Observation-gap compaction coalesces old ranges with the union of their source
+  flags and without losing covered time. Correlation flags retire only outside
+  Call Log retention; anomaly flags retire only after 100 newer unexpired known
+  anomalies make the interval irrelevant to every supported newest-N result.
 
 ### Compatibility with retained surfaces
 
@@ -1038,23 +1128,24 @@ Do not ship those doc edits in this planning PR.
   `orphaned-fence` projection and blocks migration, sidecar, and writer until an
   explicit operator Clear writes new authority.
 - Clear's identity reset atomically removes provenance, anomalies, correlation
-  guards, and gaps and nulls `last_success_at` before releasing its fence. A
-  pre-Clear `failure_log()` row cannot appear under the new epoch, including on
-  idempotent replay after a crash.
+  guards, and observation gaps and nulls `last_success_at` before releasing its
+  fence. A pre-Clear `failure_log()` row cannot appear under the new epoch,
+  including on idempotent replay after a crash.
 - Search, profile, list, remember admission, and agent-owner read paths
   keep their `origin/dev` contracts.
 - Agent-provenance capture writes retain the current user-principal
   `ProviderSessionRef` and provider-session digest; no `-agent` write owner is
   introduced by this cut.
 - Processing Record authorizes and correlates historical migrated calls and
-  new add/flush calls through bounded provenance and gap metadata, including
-  rejected calls, linked memcell membership, unique-scope unlinked list/detail,
-  restart-safe source unavailability, whole-request-id-group retention, and
-  ambiguous-request-id tests.
+  new add/flush calls through bounded provenance and observation-gap metadata,
+  including rejected calls, linked memcell membership, unique-scope unlinked
+  list/detail, restart-safe source unavailability, count-prune coverage,
+  whole-request-id-group retention, and ambiguous-request-id tests.
 - Processing Record reads recent durable failures from bounded
   `memory_processing_anomaly`, preserving its current newest-50 field shape,
-  stable migrated ids, disabled-state visibility, and unavailable-on-read-failure
-  behavior without consulting queue or settlement tables.
+  stable migrated ids, queue-backed 90-day expiry, settlement-backed persistence,
+  disabled-state visibility, and unavailable-on-read-or-gap behavior without
+  consulting queue or settlement tables.
 
 ## Implementation sequence
 
@@ -1079,9 +1170,9 @@ after adding migrator and writer tests. Line count is not acceptance.
 - [ ] Implement v4 identity schema and released-shape migrator.
 - [ ] Implement `BestEffortMemoryWriter` and switch capture to `offer()`.
 - [ ] Replace capture-table Processing Record joins with bounded call
-      provenance, correlation guards, lifecycle-closed durable gaps, and
-      sanitized anomaly rows; migrate retained correlations and the current
-      failure projection before dropping the tables.
+      provenance, correlation guards, source-flagged durable observation gaps,
+      and source-expiring sanitized anomaly rows; migrate retained correlations
+      and the current failure projection before dropping the tables.
 - [ ] Replace session final-flush waits with a best-effort multi-scope session
       barrier over the bounded volatile pending-flush map.
 - [ ] Replace claim quiescence with writer pause/quiesce around Rebuild/Repair.
@@ -1107,12 +1198,12 @@ implementation PR:
 4. Attachment pins have no durable recovery after this cut. Leftover
    bundles are deleted. Original chat attachments are untouched.
 5. Session-boundary flush is a barrier enqueue, not a wait. A crash or
-   a full queue can leave consecutive conversations in one EverOS accumulation
-   boundary. A 257th concurrently tracked provider session also drops its new
-   volatile flush trigger and sets the bounded global-incomplete guard. Later
-   flush correlation stays unavailable rather than silently omitting older
-   message ids; the global guard may conservatively hide unrelated flush
-   correlation until Clear/Factory Reset or a provider-wide empty-buffer proof.
+   a full admission queue can leave consecutive conversations in one EverOS
+   accumulation boundary. A 257th distinct pending session is skipped before
+   EverOS, while an ambiguous submitted add retains a best-effort in-process due
+   boundary candidate; only a process crash may lose that candidate. Its durable
+   guard still keeps later flush correlation unavailable rather than silently
+   omitting older message ids.
 6. No JSON identity file is introduced. Identity stays in the existing
    SQLite file so Clear's `reset_for_clear(target_epoch=...)` and
    Factory Reset keep one authority.

--- a/docs/plans/memory-best-effort-capture.md
+++ b/docs/plans/memory-best-effort-capture.md
@@ -61,8 +61,11 @@ provider root.
 ### Guarantees
 
 - Chat, `/new`, and archive do not block on Memory.
-- `offer()` / `capture()` only does bounded local work.
-- The in-memory queue has a hard bound and cannot grow without limit.
+- `offer()` / `capture()` reserves or rejects one process-local slot without
+  waiting on attachment pinning or EverOS.
+- One 256-slot admission window bounds every retained capture/barrier from
+  reservation through pinning, queueing, and the one in-flight provider call.
+  There is no second reservation chain outside that bound.
 - Principal, project, epoch, `scope_key`, and `provider_root_id` are
   byte-identical across the upgrade.
 - Named-project catalog rows survive.
@@ -78,9 +81,9 @@ provider root.
 - An in-progress Rebuild or Repair is not converted to Reset. Queue
   discard is allowed; the provider root is not touched. The writer cannot
   call EverOS concurrently with either maintenance child.
-- Captures that reserve an exact-session admission slot before `/new` or
-  archive reserve their slot are offered before that session's flush barrier,
-  even when attachment pinning completes later.
+- Captures admitted before `/new` or archive reserve their ordered slot are
+  consumed before that session's flush barrier, even when attachment pinning
+  completes later.
 - The existing per-principal limit of 16 named projects remains enforced.
   Reusing an existing named project is still allowed at the limit.
 - Credentials, configured URLs, captured text, and absolute paths stay
@@ -140,16 +143,13 @@ Retained in the same SQLite file:
 CaptureAdmission (unchanged authorize/size/scope checks)
         |
         v
-exact-session FIFO reservation      # registered before deferred pinning
+BestEffortMemoryWriter.offer()
+  # non-blocking reserve in one 256-slot ordered admission window
         |
+        +--> capture slot: bounded deferred pin task -> ready or skipped
+        +--> barrier slot: ready immediately
         v
-optional AttachmentPinStore pin (unchanged, in-process only)
-        |
-        v
-BestEffortMemoryWriter.offer()     # put_nowait, no await on EverOS
-        |
-        v
-bounded asyncio.Queue + one ordered worker
+one ordered worker consumes the ready head slot
         |
         v
 EverOSPort.add / flush
@@ -157,7 +157,8 @@ EverOSPort.add / flush
 
 Suggested starting constants, fixed rather than user settings:
 
-- queue bound: 256 items
+- admission-window bound: 256 total slots across reserved/unready, pinning,
+  ready/queued, and the current in-flight add or barrier
 - max total add attempts: 3, only for outcomes that prove the request
   did not commit (UDS refused before send, sidecar not ready, provider
   error classified uncommitted)
@@ -194,14 +195,21 @@ replayed.
 They never call `final_flush` with a deadline. Existing internal routes
 may remain as adapters that enqueue the barrier; they must not wait.
 
-Keep the current O(1) exact-session FIFO reservation, or an equivalent
-sequencer. A capture registers its reservation synchronously before its first
-deferred step, including attachment pinning. A barrier registers after the
-current tail and schedules its queue offer only after every predecessor has
-either offered its add item or closed as skipped. Registering the barrier is
-non-blocking, so `/new` and archive return without waiting for pins, provider
-I/O, or the worker. Queue saturation may reject the barrier, but a barrier
-that is accepted must never overtake already-started capture work.
+Use one fixed-capacity ordered admission window, not a queue plus an unbounded
+reservation chain. `offer()` synchronously and non-blockingly reserves the next
+sequence slot before any deferred attachment work. That permit remains charged
+while the slot is unready, pinning, ready, queued, or in flight, and is released
+only when the worker consumes or skips the slot. At most 256 slot payloads,
+attachment leases, and owned pin tasks therefore exist in one generation.
+
+A barrier reserves the same kind of slot and is ready immediately. The worker
+consumes only from the head, so an accepted barrier cannot overtake any earlier
+admitted capture even if its pin is slow; a failed pin marks its slot skipped
+and lets the worker advance. When all 256 permits are charged, captures and
+barriers are rejected with the existing queue-full outcome before starting a
+pin, retaining a payload, advancing the watermark/catalog, or creating another
+task. `/new` and archive return without waiting. Generation drop cancels the
+bounded pin tasks, releases their leases, and clears every charged permit.
 
 ### Shutdown
 
@@ -260,16 +268,30 @@ that Processing Record currently reads from `memory_capture_queue` and
 - retain at most 5,000 provenance rows and at most 14 days, matching Provider
   Call Log retention; enforce both bounds after each provenance write and at
   boot with the same policy values
-- for a user-scoped read, authorize a request id only when all of its
-  provenance rows resolve to exactly one principal/project and the memcell
-  contains one of the recorded message ids; ambiguous or missing provenance
-  never broadens visibility
+- for every user-scoped read, require all rows for the request id to resolve to
+  exactly one principal/project; ambiguous or missing provenance never
+  broadens visibility
+- for a call reached through a linked memcell, additionally require that owned
+  memcell to contain one of the recorded message ids
+- for `list_unlinked_calls` and an unlinked request-id detail, unique provenance
+  scope is the authorization fact: requiring memcell membership there would
+  reject the branch precisely because the call is unlinked
 
 A provenance write failure never retries an EverOS add or flush. It marks the
 Processing Record capture-correlation source unavailable for that observation
 and emits content-free diagnostics; ordinary capture remains best-effort.
 Clear's `reset_for_clear` deletes every provenance row with the catalog and
 watermark reset; Factory Reset deletes it with `state/memory`.
+
+The independently maintained Provider Call Log is not an input to identity
+migration or writer admission. Historical migration copies non-null,
+unambiguous add/flush correlations from the released Memory store and applies
+the same 5,000-row / 14-day limits using their capture/settlement observation
+times; it does not open or filter against the call-log database. A malformed
+observer-only correlation or timestamp is skipped with a content-free count.
+An absent, corrupt, incompatible, or unreadable call log therefore makes the
+Processing Record calls section unavailable/warned through its existing
+projection, but cannot block v4 migration or capture startup.
 
 `processing_fault_*` / `processing_alert_*` / `processing_recovery_*`
 stop being written. They may be dropped in the v4 table rebuild or left
@@ -294,13 +316,16 @@ Provider session derivation stays the `origin/dev` formula in
 src--<hmac-sha256(scope_key, "{memory_owner_id}:{project_ref}:{session_id}")>--e{epoch}
 ```
 
-`memory_owner_id` is the user principal `u-<32 hex>` for
-`provenance="user_input"`, or `{principal}-agent` (`u-<32 hex>-agent`)
-for `provenance="agent"` (`derive_assistant_memory_owner_id`, #1633).
-`memory_projects.principal_id` remains the 34-character user principal;
-the catalog is not keyed by the `-agent` owner. Implementation copies
-these helpers. It does not change digest inputs, principal shape, or
-the catalog key. Changing them would orphan existing EverOS sessions.
+For capture writes, `memory_owner_id` remains the 34-character user principal
+`u-<32 hex>` for both `provenance="user_input"` and `provenance="agent"`, exactly
+as current `MemoryStore.enqueue_request()` calls `_provider_session_ref` and
+constructs `ProviderSessionRef.principal_id`. Provenance remains payload-origin
+metadata; this PR does not route agent-origin captures to `{principal}-agent`.
+The owner-scoped helper and `derive_assistant_memory_owner_id` added for #1633
+remain available to the existing read paths but do not change this write path.
+Changing capture ownership requires a separate migration contract because it
+would orphan the current EverOS sessions. `memory_projects.principal_id` also
+remains keyed by the 34-character user principal.
 
 ## Released shapes the migrator must accept
 
@@ -340,7 +365,9 @@ sidecars). After upgrade:
 - `memory_projects` rows are unchanged
 - no capture payload, lease, fence, settlement, or bundle row remains
 - no dropped payload is sent to EverOS
-- the original file is not mutated if the transaction fails
+- a failed recognized-shape migration leaves `user_version`, logical schema,
+  identity, catalog, and delivery rows unchanged; SQLite may create or update
+  its own transaction sidecars while rolling back
 
 A shape added later that the recognizer accepts is covered by the same
 property. A shape the recognizer rejects must remain byte-identical.
@@ -379,27 +406,37 @@ would accept captures:
      `manual_required`) and terminal rows, without logging payload text
    - collect `attachment_bundle` ids
    - copy `memory_meta` identity columns and `memory_projects`
-   - before dropping delivery tables, copy add/flush request correlation into
-     `memory_call_provenance`, bounded to retained Provider Call Log request
-     ids and its 5,000-row / 14-day window; preserve the current fail-closed
+   - before dropping delivery tables, copy non-null add/flush request
+     correlation into `memory_call_provenance`, independently bounded to its
+     5,000-row / 14-day window; do not open the optional Provider Call Log, skip
+     malformed observer-only rows with a count, and preserve the fail-closed
      rule for request ids that resolve to more than one scope
    - drop delivery tables, indexes, and settlement triggers
    - rebuild `memory_meta` without requiring delivery columns if this
      PR drops them
    - `PRAGMA user_version = 4`
    - verify identity tables and required identity columns
-6. Commit, then confined-delete leftover pin bundles whose ids were
-   collected, then confined-delete WAL/SHM only after the main file
-   has the new user_version.
+6. Commit, request `PRAGMA wal_checkpoint(FULL)` on the migration connection,
+   inspect its busy result, and close every store-owned connection before
+   admitting the writer. A concurrent read-only Processing Record connection
+   may keep the checkpoint busy; that is safe because committed pages remain in
+   SQLite's WAL and are recovered on reopen. Never unlink `-wal`, `-shm`, or
+   `-journal` directly. Reopen normally and verify v4, then confined-delete the
+   collected leftover pin bundles.
 7. Emit one content-free structured log: discarded nonterminal count,
    discarded terminal count, discarded bundle count. Never log text,
-   paths, or digests that can recover a message.
+   paths, or digests that can recover a message. Also count skipped malformed
+   provenance rows and a busy post-commit checkpoint without treating either
+   as a capture-startup failure.
 8. Start `BestEffortMemoryWriter` against the preserved watermark and
    catalog.
 
 Crash windows:
 
-- Failure before commit: old file unchanged; next boot retries.
+- Failure before commit: logical schema and rows are unchanged; next boot
+  retries, and SQLite owns any rollback journal/WAL artifacts.
+- Failure after commit, before checkpoint/close: SQLite recovers the committed
+  v4 transaction from its WAL. No cleanup code removes those pages.
 - Failure after commit, before bundle delete: the store is v4; leftover
   files under `memory/attachments/` are unreferenced and deleted on the
   next boot by "no bundle table ⇒ delete pin root if empty-orphan".
@@ -415,6 +452,7 @@ Never:
 - convert a pending rebuild marker into Reset
 - delete the EverOS provider root
 - delete Provider Call Log data
+- unlink SQLite WAL/SHM/journal files outside SQLite's own lifecycle
 
 Downgrade is unsupported. A v4 file opened by an older Avibe that only
 understands v3 is an unrecognized schema and must fail closed without
@@ -422,28 +460,28 @@ writing, same as today's unknown `user_version` rule.
 
 ## Attachments in this PR
 
-Keep `AttachmentPinStore` and IM/Workbench admission. The worker still
-registers the exact-session FIFO reservation before pinning, pins before
-`offer` when the current path pins, and releases the bundle after a terminal
-in-process add (success, definite rejection, or drop). Closing a reservation
-as skipped releases its successor, so one failed pin cannot strand a later
-barrier.
+Keep `AttachmentPinStore` and IM/Workbench admission. `offer()` charges one
+ordered admission-window slot before pinning and starts at most one owned pin
+task inside that permit. The worker does not consume that slot until pinning
+marks it ready or skipped, and releases the bundle after a terminal in-process
+add (success, definite rejection, or drop). Marking a slot skipped lets the
+worker advance, so one failed pin cannot strand a later barrier.
 
 Retain the current single text-only degradation for a valid nonempty caption:
 
 - if pinned-attachment verification fails before provider submission with the
   existing positively classified `AttachmentBundleInvalidError`, release the
-  pin and offer the same capture once without attachments
+  pin and mark the same ordered slot ready once without attachments
 - if EverOS returns an attachment rejection for which
   `attachment_add_rejection_proves_no_write()` is true, release the pin and
-  offer the same capture once without attachments
+  retry the same in-flight slot once without attachments
 
 This is a modality fallback, not replay after ambiguity. It counts toward the
-same three-total-attempt bound and is forbidden for timeouts, unknown/truncated
-responses, generic provider rejection, or any outcome that may have written.
-If the caption is empty, close as skipped instead. Preserve
-`MEMORY-IM-ATTACH-009` and `MEMORY-IM-ATTACH-011` rather than deleting them with
-the durable worker tests.
+same three-total-attempt bound, never reserves a second slot, and is forbidden
+for timeouts, unknown/truncated responses, generic provider rejection, or any
+outcome that may have written. If the caption is empty, mark the slot skipped
+instead. Preserve `MEMORY-IM-ATTACH-009` and `MEMORY-IM-ATTACH-011` rather than
+deleting them with the durable worker tests.
 
 Remove only:
 
@@ -464,7 +502,7 @@ Keep `CaptureRequest` and `CaptureReceipt`. Map writer outcomes:
 
 | Writer | Receipt |
 |---|---|
-| queued | `CaptureAccepted` |
+| ordered slot admitted | `CaptureAccepted` |
 | duplicate in process-local LRU | `CaptureDuplicate` |
 | disabled / not ready / invalid / named-project limit / queue full | `CaptureSkipped` with the existing closed error code |
 
@@ -474,8 +512,8 @@ stays queued, as above.
 
 Processing-fault durable notification and ACK in `MemoryStore` /
 `SessionFlushCoordinator` are deleted. IM already does not receive those
-events. Processing Record may show process-local queue depth labelled
-as volatile; it must not show a durable missed-capture backlog.
+events. Processing Record may show process-local admission-window occupancy
+labelled as volatile; it must not show a durable missed-capture backlog.
 
 Processing Record and Provider Call Log otherwise retain their current
 scope and correlation behavior through `memory_call_provenance`. The reader's
@@ -562,7 +600,12 @@ Do not ship those doc edits in this planning PR.
   shape on the next boot. No test may observe a committed v2/v3 intermediate.
 - Unrecognized nonempty v0 remains unmodified.
 - Unknown `user_version` remains unmodified.
-- WAL/SHM sidecars do not come back as a second database.
+- A committed v4 store reopens correctly from either checkpointed main pages or
+  a retained WAL. A concurrent Processing Record reader may keep WAL/SHM alive;
+  migration closes owned connections and never deletes SQLite sidecars.
+- Missing, corrupt, incompatible, or unreadable Provider Call Log state does
+  not fail identity migration or block writer startup; its observer projection
+  reports unavailable/warned independently.
 - `clear_in_progress` / clear-intent / factory-reset pending skip the
   strip path and follow the existing destructive reconciler.
 - Every unreadable clear-intent shape keeps migration, sidecar startup, and
@@ -577,8 +620,10 @@ Do not ship those doc edits in this planning PR.
 
 ### Writer
 
-- `offer()` does not await provider I/O.
-- Occupancy never exceeds 256.
+- `offer()` does not await attachment pinning or provider I/O.
+- Total occupancy never exceeds 256 across unready reservations, pinning tasks,
+  ready/queued slots, and the in-flight slot; there is no out-of-window
+  predecessor chain.
 - Saturation returns `memory_queue_full` / `CaptureSkipped`.
 - One worker preserves accepted-item order globally.
 - At most three total attempts, and only for uncommitted failures.
@@ -594,6 +639,10 @@ Do not ship those doc edits in this planning PR.
 - Session barrier does not block `/new` or archive, and a capture delayed in
   attachment pinning after reserving admission is still offered before the
   later barrier.
+- With the head pin stalled, filling all 256 permits creates at most 256 slot
+  payloads/tasks/leases; the next capture and barrier are rejected before pin
+  or identity mutation. An already accepted barrier remains ordered after all
+  earlier slots and before every later accepted slot.
 - Watermark persists across writer restart and is monotonic.
 - Named-project upsert still happens on accepted capture; the current
   16-project test still rejects the 17th distinct slug and accepts reuse at
@@ -613,10 +662,13 @@ Do not ship those doc edits in this planning PR.
   empty provider root.
 - Search, profile, list, remember admission, and agent-owner read paths
   keep their `origin/dev` contracts.
+- Agent-provenance capture writes retain the current user-principal
+  `ProviderSessionRef` and provider-session digest; no `-agent` write owner is
+  introduced by this cut.
 - Processing Record authorizes and correlates historical migrated calls and
   new add/flush calls through bounded `memory_call_provenance`, including
-  scoped list/detail, unlinked-call, source-availability, retention, and
-  ambiguous-request-id tests.
+  linked memcell membership, unique-scope unlinked list/detail,
+  source-availability, retention, and ambiguous-request-id tests.
 
 ## Implementation sequence
 

--- a/docs/plans/memory-best-effort-capture.md
+++ b/docs/plans/memory-best-effort-capture.md
@@ -72,8 +72,17 @@ provider root.
 - An in-progress Clear or Factory Reset is completed by the existing
   destructive path. The capture migrator does not strip or rewrite a store
   that those markers still own.
+- A Clear marker that exists but cannot be read is still an open destructive
+  fence. Migration and all Memory writes stay blocked until the existing
+  Clear retry replaces or completes that marker.
 - An in-progress Rebuild or Repair is not converted to Reset. Queue
-  discard is allowed; the provider root is not touched.
+  discard is allowed; the provider root is not touched. The writer cannot
+  call EverOS concurrently with either maintenance child.
+- Captures that reserve an exact-session admission slot before `/new` or
+  archive reserve their slot are offered before that session's flush barrier,
+  even when attachment pinning completes later.
+- The existing per-principal limit of 16 named projects remains enforced.
+  Reusing an existing named project is still allowed at the limit.
 - Credentials, configured URLs, captured text, and absolute paths stay
   out of service logs.
 
@@ -131,6 +140,9 @@ Retained in the same SQLite file:
 CaptureAdmission (unchanged authorize/size/scope checks)
         |
         v
+exact-session FIFO reservation      # registered before deferred pinning
+        |
+        v
 optional AttachmentPinStore pin (unchanged, in-process only)
         |
         v
@@ -162,8 +174,10 @@ required for this cut.
 
 `extracted` drops pending flush state for that provider session.
 `accumulated` refreshes one in-memory `PendingFlush(session_ref,
-first_accumulated_at, last_accumulated_at)`. The pending table does not
-survive process restart; EverOS still holds the buffer until a later
+first_accumulated_at, last_accumulated_at, message_ids)`. `message_ids` is
+bounded by the 100-message flush limit and exists only to correlate a
+successful flush with the retained Provider Call Log. The pending table does
+not survive process restart; EverOS still holds the buffer until a later
 same-session add, Repair, or provider extraction.
 
 Worker generation increments on disable, shutdown, Reset/Clear, and
@@ -177,19 +191,30 @@ replayed.
 They never call `final_flush` with a deadline. Existing internal routes
 may remain as adapters that enqueue the barrier; they must not wait.
 
+Keep the current O(1) exact-session FIFO reservation, or an equivalent
+sequencer. A capture registers its reservation synchronously before its first
+deferred step, including attachment pinning. A barrier registers after the
+current tail and schedules its queue offer only after every predecessor has
+either offered its add item or closed as skipped. Registering the barrier is
+non-blocking, so `/new` and archive return without waiting for pins, provider
+I/O, or the worker. Queue saturation may reject the barrier, but a barrier
+that is accepted must never overtake already-started capture work.
+
 ### Shutdown
 
 Stop intake, increment generation, cancel the worker, drop volatile
 state, then continue the existing sidecar stop. No queue drain.
 
-## Persistent identity (compatibility core)
+## Persistent identity and display provenance
 
 Do **not** introduce a JSON identity file in this PR. Clear, Factory
 Reset, Rebuild fencing, and `reset_for_clear(target_epoch=...)` already
 own `memory_meta.epoch`. A second identity format would add crash windows
 without removing the outbox.
 
-After migration, `state/memory/memory.sqlite` contains only identity:
+After migration, `state/memory/memory.sqlite` contains identity plus one
+bounded, content-free display-provenance table. It contains no delivery work,
+retry state, flush schedule, captured text, or attachment path:
 
 ```text
 memory_meta
@@ -210,7 +235,38 @@ memory_projects
   project_id
   created_at
   last_written_at
+
+memory_call_provenance
+  request_id
+  operation_kind       # add | flush
+  principal_id
+  project_id
+  session_id
+  message_ids_json     # exact EverOS message ids, at most 100
+  recorded_at_ms
 ```
+
+`memory_call_provenance` replaces the correlation and authorization facts
+that Processing Record currently reads from `memory_capture_queue` and
+`memory_flush_settlements`. It is observer metadata, not an outbox:
+
+- after an acknowledged add, write the returned request id with its one exact
+  `m_<session>_<provider timestamp>_000` message id
+- after an acknowledged flush, write the returned request id with the bounded
+  message-id list from that session's `PendingFlush`
+- retain at most 5,000 provenance rows and at most 14 days, matching Provider
+  Call Log retention; enforce both bounds after each provenance write and at
+  boot with the same policy values
+- for a user-scoped read, authorize a request id only when all of its
+  provenance rows resolve to exactly one principal/project and the memcell
+  contains one of the recorded message ids; ambiguous or missing provenance
+  never broadens visibility
+
+A provenance write failure never retries an EverOS add or flush. It marks the
+Processing Record capture-correlation source unavailable for that observation
+and emits content-free diagnostics; ordinary capture remains best-effort.
+Clear's `reset_for_clear` deletes every provenance row with the catalog and
+watermark reset; Factory Reset deletes it with `state/memory`.
 
 `processing_fault_*` / `processing_alert_*` / `processing_recovery_*`
 stop being written. They may be dropped in the v4 table rebuild or left
@@ -220,6 +276,13 @@ unused; they are not an input to retry, Repair, or IM notification.
 `max(occurred_at_ms, last_provider_timestamp_ms + 1)` and persists the
 new watermark in the same identity transaction as the catalog upsert for
 named projects. That is a small identity write, not an outbox.
+
+That identity transaction preserves `MAX_NAMED_MEMORY_PROJECTS`: an existing
+named-project row may be updated at the limit, but inserting a 17th distinct
+named project for one principal returns the existing `project_limit` outcome,
+mapped to `memory_invalid_input`. The rejected capture does not advance the
+watermark, enter the writer queue, or leave a pin. The default project does not
+count toward the cap.
 
 Provider session derivation stays the `origin/dev` formula in
 `core/memory/store.py::_provider_session_ref`:
@@ -240,8 +303,9 @@ the catalog key. Changing them would orphan existing EverOS sessions.
 
 On-disk Memory SQLite is a shipped surface. v3.0.10 (2026-08-11) released
 the #1217 foundation. `dev` already migrates those files up to schema v3
-(`5a1a8ff3` and follow-ups). This PR adds one more step: v3 → identity-only
-v4, and must still enter from every earlier released shape.
+(`5a1a8ff3` and follow-ups). This PR adds one more step: v3 →
+identity-and-provenance v4, and must still enter from every earlier released
+shape.
 
 Checked-in fixtures to drive, not a closed list of "interesting" rows:
 
@@ -287,12 +351,17 @@ would accept captures:
    factory-reset pending flag): run the existing Factory Reset path.
    Do not read or rewrite `memory.sqlite` as an identity source; Reset
    deletes `memory` and `state/memory`.
-2. If `state/memory/clear-intent.json` is present and readable, or
-   `memory_meta.clear_in_progress` is set: run the existing Clear
-   reconcile. Clear already deletes queue tables and bumps epoch.
-   After it finishes, the store is empty identity at `target_epoch`.
-   Then open it as v4, creating identity tables if Clear's reset still
-   used the old schema for one boot.
+2. Read `state/memory/clear-intent.json` through `ClearIntentStore.load()`.
+   If it is present and readable, or `memory_meta.clear_in_progress` is set,
+   run the existing Clear reconcile. Clear already deletes queue tables and
+   bumps epoch. After it finishes, the store is empty identity at
+   `target_epoch`. Then open it as v4, creating identity tables if Clear's
+   reset still used the old schema for one boot. If the marker exists but is
+   truncated, malformed, inaccessible, oversized, symlinked, or otherwise
+   raises `ClearIntentUnreadable`, preserve `MemoryMaintenance.is_open()`
+   semantics: do not migrate, do not start the sidecar/writer, and project the
+   existing `memory_clear_marker_unreadable` retry state. Only an explicit
+   Clear re-run may replace that marker.
 3. Otherwise open `state/memory/memory.sqlite` through the existing
    confined path.
 4. Reuse the current v0→v2→v3 chain so the in-memory connection is a
@@ -303,6 +372,10 @@ would accept captures:
      `manual_required`) and terminal rows, without logging payload text
    - collect `attachment_bundle` ids
    - copy `memory_meta` identity columns and `memory_projects`
+   - before dropping delivery tables, copy add/flush request correlation into
+     `memory_call_provenance`, bounded to retained Provider Call Log request
+     ids and its 5,000-row / 14-day window; preserve the current fail-closed
+     rule for request ids that resolve to more than one scope
    - drop delivery tables, indexes, and settlement triggers
    - rebuild `memory_meta` without requiring delivery columns if this
      PR drops them
@@ -320,7 +393,7 @@ would accept captures:
 Crash windows:
 
 - Failure before commit: old file unchanged; next boot retries.
-- Failure after commit, before bundle delete: identity is v4; leftover
+- Failure after commit, before bundle delete: the store is v4; leftover
   files under `memory/attachments/` are unreferenced and deleted on the
   next boot by "no bundle table ⇒ delete pin root if empty-orphan".
 - Failure during Clear/Reset: existing markers remain authoritative.
@@ -343,8 +416,11 @@ writing, same as today's unknown `user_version` rule.
 ## Attachments in this PR
 
 Keep `AttachmentPinStore` and IM/Workbench admission. The worker still
-pins before `offer` when the current path pins, and releases the bundle
-after a terminal in-process add (success, definite rejection, or drop).
+registers the exact-session FIFO reservation before pinning, pins before
+`offer` when the current path pins, and releases the bundle after a terminal
+in-process add (success, definite rejection, or drop). Closing a reservation
+as skipped releases its successor, so one failed pin cannot strand a later
+barrier.
 
 Remove only:
 
@@ -367,7 +443,7 @@ Keep `CaptureRequest` and `CaptureReceipt`. Map writer outcomes:
 |---|---|
 | queued | `CaptureAccepted` |
 | duplicate in process-local LRU | `CaptureDuplicate` |
-| disabled / not ready / invalid / queue full | `CaptureSkipped` with the existing closed error code |
+| disabled / not ready / invalid / named-project limit / queue full | `CaptureSkipped` with the existing closed error code |
 
 Automatic capture still ignores the receipt after a content-free log.
 `/internal/memory/remember` still returns `receipt.status`. CLI copy
@@ -378,10 +454,17 @@ Processing-fault durable notification and ACK in `MemoryStore` /
 events. Processing Record may show process-local queue depth labelled
 as volatile; it must not show a durable missed-capture backlog.
 
+Processing Record and Provider Call Log otherwise retain their current
+scope and correlation behavior through `memory_call_provenance`. The reader's
+capture-source availability probe and request-id joins move to that table;
+they do not silently omit request-id call branches merely because the
+delivery tables are gone.
+
 ## Control plane that stays
 
-Unchanged except for dropping claim-quiesce that existed only to freeze
-the outbox:
+The claim API goes away with the outbox, but its provider-maintenance
+exclusion does not. `BestEffortMemoryWriter` exposes pause/quiesce/resume for
+the existing control plane:
 
 - artifact install, sidecar ownership, provider-root confinement
 - `MemoryOperationLease`
@@ -390,12 +473,24 @@ the outbox:
 - Clear durable intent and Factory Reset
 - `ProviderRoot` recreation on Clear/Reset
 
-Clear's queue primitive becomes: identity `reset_for_clear` (epoch bump,
-catalog wipe, watermark zero) with no capture-queue DELETE. The other
-three surfaces (provider root, call log, attachments) stay.
+Before Rebuild or Repair launches `cascade rebuild` / `cascade sync`, it
+synchronously closes writer intake, increments the writer generation, drops
+unsubmitted queue and pending-flush state, and waits until no add/flush RPC is
+in flight. New captures during that interval return
+`memory_operation_in_progress`. If quiescence cannot be proved, maintenance
+fails before launching its child and keeps the writer fail-closed; it never
+runs concurrently with a provider call. Repair opens a fresh writer generation
+only after its child exits and the existing sidecar is still authoritative.
+Rebuild keeps the writer paused through sidecar/root replacement and resumes
+only after the replacement is admitted. This is the replacement for
+`quiesce_claims()`, not an outbox drain.
 
-Factory Reset still deletes `memory` and `state/memory`. A v4 identity
-file is just another file under `state/memory`.
+Clear's queue primitive becomes: identity `reset_for_clear` (epoch bump,
+catalog wipe, watermark zero, call-provenance wipe) with no capture-queue
+DELETE. The other three surfaces (provider root, call log, attachments) stay.
+
+Factory Reset still deletes `memory` and `state/memory`. The v4 store is just
+another file under `state/memory`.
 
 ## Module shape after this PR
 
@@ -403,7 +498,7 @@ Likely:
 
 ```text
 core/memory/ingest.py      # BestEffortMemoryWriter
-core/memory/identity.py    # narrow store: meta + projects + watermark
+core/memory/identity.py    # meta + projects + watermark + bounded call provenance
                            # or store.py reduced to that surface
 core/memory/migrate_store.py  # v0..v3 recognition + v3→v4 strip
 ```
@@ -432,7 +527,8 @@ Do not ship those doc edits in this planning PR.
 
 ### Identity and migration
 
-- Every checked-in released fixture opens and becomes v4 identity.
+- Every checked-in released fixture opens and becomes a v4
+  identity-and-provenance store.
 - Property test: seed every persistable production row shape the current
   schema allows, migrate, assert identity bytes and catalog equality,
   assert zero remaining delivery tables, assert the fake provider received
@@ -442,6 +538,11 @@ Do not ship those doc edits in this planning PR.
 - WAL/SHM sidecars do not come back as a second database.
 - `clear_in_progress` / clear-intent / factory-reset pending skip the
   strip path and follow the existing destructive reconciler.
+- Every unreadable clear-intent shape keeps migration, sidecar startup, and
+  writer startup blocked without modifying the marker or SQLite identity.
+- Retained add/flush request ids migrate to bounded call provenance before
+  delivery tables are dropped; ambiguous cross-scope request ids remain
+  unauthorized.
 - Interrupted strip (kill before commit) retries and still preserves
   identity.
 - v4 file is refused by a v3-only opener without writes (contract test
@@ -460,25 +561,33 @@ Do not ship those doc edits in this planning PR.
 - `extracted` removes pending flush.
 - Shutdown, disable, config replacement, Clear, and Reset drop the queue
   without drain.
-- Session barrier does not block `/new` or archive.
+- Session barrier does not block `/new` or archive, and a capture delayed in
+  attachment pinning after reserving admission is still offered before the
+  later barrier.
 - Watermark persists across writer restart and is monotonic.
-- Named-project upsert still happens on accepted capture.
+- Named-project upsert still happens on accepted capture; the current
+  16-project test still rejects the 17th distinct slug and accepts reuse at
+  the limit without advancing rejected-capture state.
 - Logs never include captured text, credentials, or absolute paths.
 
 ### Compatibility with retained surfaces
 
 - Restart Engine still replaces only the sidecar.
-- Rebuild/Repair still take the operation lease and do not start a second
-  outbox drain.
+- Rebuild/Repair still take the operation lease, prove the writer has no
+  in-flight provider RPC before launching a child, keep intake closed for the
+  operation, and resume only an admitted fresh generation.
 - Clear still resumes from `clear-intent.json` and still recreates an
   empty provider root.
 - Search, profile, list, remember admission, and agent-owner read paths
   keep their `origin/dev` contracts.
-- Processing Record no longer requires queue settlement rows.
+- Processing Record authorizes and correlates historical migrated calls and
+  new add/flush calls through bounded `memory_call_provenance`, including
+  scoped list/detail, unlinked-call, source-availability, retention, and
+  ambiguous-request-id tests.
 
 ## Implementation sequence
 
-1. Identity-only v4 schema + migrator + fixture property tests. No
+1. Identity-and-provenance v4 schema + migrator + fixture property tests. No
    behavior change yet if the writer still reads v4 as empty outbox —
    prefer not to land a half-migrated store. Land migrator and writer
    together.
@@ -498,7 +607,10 @@ after adding migrator and writer tests. Line count is not acceptance.
 
 - [ ] Implement v4 identity schema and released-shape migrator.
 - [ ] Implement `BestEffortMemoryWriter` and switch capture to `offer()`.
+- [ ] Replace capture-table Processing Record joins with bounded call
+      provenance and migrate retained correlations before dropping the tables.
 - [ ] Replace session final-flush waits with a best-effort barrier.
+- [ ] Replace claim quiescence with writer pause/quiesce around Rebuild/Repair.
 - [ ] Stop writing processing-fault ACK / `manual_required` / settlements.
 - [ ] Delete leftover pin bundles after migration; keep in-process pins.
 - [ ] Keep `memory.cli.remembered` as queued; rewrite Memory user docs.

--- a/docs/plans/memory-best-effort-capture.md
+++ b/docs/plans/memory-best-effort-capture.md
@@ -152,7 +152,13 @@ BestEffortMemoryWriter.offer()
 one ordered worker consumes the ready head slot
         |
         v
+durably open one content-free provider-call gap
+        |
+        v
 EverOSPort.add / flush
+        |
+        v
+record every valid request id and close that gap atomically
 ```
 
 Suggested starting constants, fixed rather than user settings:
@@ -223,8 +229,8 @@ Reset, Rebuild fencing, and `reset_for_clear(target_epoch=...)` already
 own `memory_meta.epoch`. A second identity format would add crash windows
 without removing the outbox.
 
-After migration, `state/memory/memory.sqlite` contains identity plus one
-bounded, content-free display-provenance table. It contains no delivery work,
+After migration, `state/memory/memory.sqlite` contains identity plus bounded,
+content-free display-provenance tables. They contain no delivery work,
 retry state, flush schedule, captured text, or attachment path:
 
 ```text
@@ -248,26 +254,43 @@ memory_projects
   last_written_at
 
 memory_call_provenance
+  provenance_id        # local row key; request_id is deliberately non-unique
   request_id
   operation_kind       # add | flush
+  outcome_class        # acknowledged | rejected | unknown
   principal_id
   project_id
   session_id
   message_ids_json     # exact EverOS message ids, at most 100
   recorded_at_ms
+
+memory_call_provenance_gap
+  gap_id               # local operation token, never sent to EverOS
+  started_at_ms
+  ended_at_ms          # null while the outcome is still unknown
+  operation_kind       # add | flush | migration
+  reason               # call_unobserved | migration_unknown
 ```
 
 `memory_call_provenance` replaces the correlation and authorization facts
 that Processing Record currently reads from `memory_capture_queue` and
 `memory_flush_settlements`. It is observer metadata, not an outbox:
 
-- after an acknowledged add, write the returned request id with its one exact
-  `m_<session>_<provider timestamp>_000` message id
-- after an acknowledged flush, write the returned request id with the bounded
-  message-id list from that session's `PendingFlush`
+- record every syntactically valid, bounded request id observed in an EverOS
+  response, whether its result is an acknowledged add/flush, `AddRejected`,
+  `FlushRejected`, another terminal non-success, or an otherwise unclassifiable
+  response whose id can still be validated
+- an add row carries its one exact `m_<session>_<provider timestamp>_000`
+  message id; a flush row carries the bounded message-id list from that
+  session's `PendingFlush`
 - retain at most 5,000 provenance rows and at most 14 days, matching Provider
-  Call Log retention; enforce both bounds after each provenance write and at
-  boot with the same policy values
+  Call Log retention, but prune only complete request-id groups: age-prune a
+  group only when its newest `recorded_at_ms` is older than the cutoff, then
+  delete the oldest whole groups until the row count is at most 5,000
+- never retain a subset of a request-id group. If one reused group alone exceeds
+  the row limit, delete that whole group; missing provenance remains fail-closed
+- enforce both bounds after each provenance write and at boot with the same
+  policy values
 - for every user-scoped read, require all rows for the request id to resolve to
   exactly one principal/project; ambiguous or missing provenance never
   broadens visibility
@@ -277,30 +300,65 @@ that Processing Record currently reads from `memory_capture_queue` and
   scope is the authorization fact: requiring memcell membership there would
   reject the branch precisely because the call is unlinked
 
-A provenance write failure never retries an EverOS add or flush. It marks the
-Processing Record capture-correlation source unavailable for that observation
-and emits content-free diagnostics; ordinary capture remains best-effort.
-Clear's `reset_for_clear` deletes every provenance row with the catalog and
-watermark reset; Factory Reset deletes it with `state/memory`.
+The single ordered worker makes correlation loss restart-safe without turning
+observer state into delivery state:
+
+1. Before every EverOS add or flush attempt, the worker durably inserts one open
+   `memory_call_provenance_gap` row. It also closes any stale open row at this
+   attempt's start time. If this preflight identity transaction fails, the
+   best-effort item is skipped and EverOS is not called.
+2. If the result contains a valid request id, one transaction inserts every
+   provenance row for that call and deletes its open gap. This applies to
+   acknowledged, rejected, and unknown classifications; any separately allowed
+   uncommitted retry starts only after that observer transaction commits. A
+   provenance transaction failure leaves the already-committed gap open and
+   never causes a provider retry.
+3. If a result has no valid request id and proves no request left Avibe, close
+   the gap before any permitted retry; if closing fails, drop the item. The retry
+   opens a new gap. A timeout, truncated or malformed response, or other result
+   without a trustworthy request id leaves the gap open because the provider may
+   have observed the call.
+4. At boot, close a stale open gap at boot time. Until then an open gap covers
+   `[started_at_ms, infinity)`. A Processing Record call whose observation time
+   overlaps any gap reports the correlation source unavailable instead of
+   silently disappearing from a scoped result.
+
+A gap is global observer state rather than a principal/project authorization
+fact: no scoped reader may bypass an overlapping gap. Gap metadata is also
+bounded to 14 days and 256 ranges. When it exceeds the count bound, coalesce the
+oldest ranges into a wider range rather than dropping coverage. Delete a closed
+range only when it is wholly older than the Provider Call Log retention cutoff;
+an open range is never age-deleted. This may hide a good observation
+conservatively, but cannot authorize the wrong scope. Clear's `reset_for_clear`
+deletes provenance rows and gaps with the catalog and watermark reset; Factory
+Reset deletes them with `state/memory`.
 
 The independently maintained Provider Call Log is not an input to identity
-migration or writer admission. Historical migration copies non-null,
-unambiguous add/flush correlations from the released Memory store and applies
-the same 5,000-row / 14-day limits using their capture/settlement observation
-times; it does not open or filter against the call-log database. A malformed
-observer-only correlation or timestamp is skipped with a content-free count.
-An absent, corrupt, incompatible, or unreadable call log therefore makes the
-Processing Record calls section unavailable/warned through its existing
-projection, but cannot block v4 migration or capture startup.
+migration or writer admission. Historical migration copies every valid bounded
+add/flush request id from the released Memory store, including rejected rows and
+every scope row for a reused id, then applies the same whole-group 5,000-row /
+14-day policy using capture/settlement observation times. It does not open or
+filter against the call-log database. Any observer-only correlation that cannot
+be translated safely creates or widens a `migration_unknown` gap over the
+retained observation horizon instead of being silently skipped. An absent,
+corrupt, incompatible, or unreadable call log therefore makes the Processing
+Record calls section unavailable/warned through its existing projection, but
+cannot block v4 migration or capture startup.
 
 `processing_fault_*` / `processing_alert_*` / `processing_recovery_*`
 stop being written. They may be dropped in the v4 table rebuild or left
 unused; they are not an input to retry, Repair, or IM notification.
 
-`last_provider_timestamp_ms` remains durable. Each accepted offer assigns
-`max(occurred_at_ms, last_provider_timestamp_ms + 1)` and persists the
-new watermark in the same identity transaction as the catalog upsert for
-named projects. That is a small identity write, not an outbox.
+`last_provider_timestamp_ms` remains durable. Under the short process-local
+admission critical section, a capture first proves that capacity is available,
+reads the current watermark, and computes
+`max(occurred_at_ms, last_provider_timestamp_ms + 1)` with a checked upper
+bound. If the candidate exceeds `MAX_PROVIDER_TIMESTAMP_MS`, return the existing
+`timestamp_invalid` outcome before catalog upsert, watermark mutation, slot
+charge, attachment pin, or task creation. Otherwise persist the new watermark in
+the same identity transaction as the catalog upsert for named projects, charge
+the ordered slot, and only then release the critical section. That section has
+no attachment or provider await; the identity write is not an outbox.
 
 That identity transaction preserves `MAX_NAMED_MEMORY_PROJECTS`: an existing
 named-project row may be updated at the limit, but inserting a 17th distinct
@@ -406,11 +464,14 @@ would accept captures:
      `manual_required`) and terminal rows, without logging payload text
    - collect `attachment_bundle` ids
    - copy `memory_meta` identity columns and `memory_projects`
-   - before dropping delivery tables, copy non-null add/flush request
-     correlation into `memory_call_provenance`, independently bounded to its
-     5,000-row / 14-day window; do not open the optional Provider Call Log, skip
-     malformed observer-only rows with a count, and preserve the fail-closed
-     rule for request ids that resolve to more than one scope
+   - before dropping delivery tables, copy every valid bounded add/flush request
+     id into `memory_call_provenance`, including rejected operations and every
+     scope row for a reused id; prune only complete request-id groups to the
+     5,000-row / 14-day window and preserve ambiguity as fail-closed
+   - do not open the optional Provider Call Log; if observer-only request-id or
+     timestamp data cannot be translated safely, create or widen one bounded
+     `migration_unknown` gap over the retained horizon and count it without
+     storing source data
    - drop delivery tables, indexes, and settlement triggers
    - rebuild `memory_meta` without requiring delivery columns if this
      PR drops them
@@ -425,9 +486,9 @@ would accept captures:
    collected leftover pin bundles.
 7. Emit one content-free structured log: discarded nonterminal count,
    discarded terminal count, discarded bundle count. Never log text,
-   paths, or digests that can recover a message. Also count skipped malformed
-   provenance rows and a busy post-commit checkpoint without treating either
-   as a capture-startup failure.
+   paths, or digests that can recover a message. Also count provenance rows
+   covered by a migration gap and a busy post-commit checkpoint without treating
+   either as a capture-startup failure.
 8. Start `BestEffortMemoryWriter` against the preserved watermark and
    catalog.
 
@@ -515,11 +576,11 @@ Processing-fault durable notification and ACK in `MemoryStore` /
 events. Processing Record may show process-local admission-window occupancy
 labelled as volatile; it must not show a durable missed-capture backlog.
 
-Processing Record and Provider Call Log otherwise retain their current
-scope and correlation behavior through `memory_call_provenance`. The reader's
-capture-source availability probe and request-id joins move to that table;
-they do not silently omit request-id call branches merely because the
-delivery tables are gone.
+Processing Record and Provider Call Log otherwise retain their current scope
+and correlation behavior through `memory_call_provenance` and
+`memory_call_provenance_gap`. The reader's capture-source availability probe and
+request-id joins move to those tables; they do not silently omit request-id call
+branches merely because the delivery tables are gone.
 
 ## Control plane that stays
 
@@ -547,8 +608,9 @@ only after the replacement is admitted. This is the replacement for
 `quiesce_claims()`, not an outbox drain.
 
 Clear's queue primitive becomes: identity `reset_for_clear` (epoch bump,
-catalog wipe, watermark zero, call-provenance wipe) with no capture-queue
-DELETE. The other three surfaces (provider root, call log, attachments) stay.
+catalog wipe, watermark zero, call-provenance and gap wipe) with no
+capture-queue DELETE. The other three surfaces (provider root, call log,
+attachments) stay.
 
 Factory Reset still deletes `memory` and `state/memory`. The v4 store is just
 another file under `state/memory`.
@@ -559,7 +621,7 @@ Likely:
 
 ```text
 core/memory/ingest.py      # BestEffortMemoryWriter
-core/memory/identity.py    # meta + projects + watermark + bounded call provenance
+core/memory/identity.py    # meta + projects + watermark + bounded provenance/gaps
                            # or store.py reduced to that surface
 core/memory/migrate_store.py  # v0..v3 recognition + v3→v4 strip
 ```
@@ -611,8 +673,14 @@ Do not ship those doc edits in this planning PR.
 - Every unreadable clear-intent shape keeps migration, sidecar startup, and
   writer startup blocked without modifying the marker or SQLite identity.
 - Retained add/flush request ids migrate to bounded call provenance before
-  delivery tables are dropped; ambiguous cross-scope request ids remain
-  unauthorized.
+  delivery tables are dropped, including rejected calls and every scope row for
+  reused ids; ambiguous cross-scope request ids remain unauthorized.
+- Provenance age and row-count pruning deletes complete request-id groups only;
+  it cannot turn a reused ambiguous id into a uniquely authorized id, including
+  when one group alone exceeds the row bound.
+- A malformed observer correlation creates a bounded retained-horizon migration
+  gap; after restart, overlapping Processing Record observations still report
+  correlation unavailable rather than silently disappearing.
 - Interrupted strip (kill before commit) retries and still preserves
   identity.
 - v4 file is refused by a v3-only opener without writes (contract test
@@ -644,6 +712,9 @@ Do not ship those doc edits in this planning PR.
   or identity mutation. An already accepted barrier remains ordered after all
   earlier slots and before every later accepted slot.
 - Watermark persists across writer restart and is monotonic.
+- With the watermark already at `MAX_PROVIDER_TIMESTAMP_MS`, the next otherwise
+  valid capture returns `timestamp_invalid` without changing the watermark or
+  catalog and without charging a slot, pinning, or creating a task.
 - Named-project upsert still happens on accepted capture; the current
   16-project test still rejects the 17th distinct slug and accepts reuse at
   the limit without advancing rejected-capture state.
@@ -651,6 +722,17 @@ Do not ship those doc edits in this planning PR.
   safe text-only degradation, while ambiguous or unclassified attachment
   failures never resubmit the caption.
 - Logs never include captured text, credentials, or absolute paths.
+- Every provider attempt durably opens a gap before the RPC. A failed preflight
+  write skips the item without calling EverOS; timeout/unknown responses and an
+  injected provenance-commit failure leave a gap that remains fail-closed after
+  restart and is closed at the next attempt or boot.
+- Valid bounded request ids from acknowledged, rejected, and otherwise
+  unclassifiable add/flush responses are recorded with their outcome and scope.
+  Provenance failure never causes a provider retry, while a separately allowed
+  proven-uncommitted retry first settles the old observer gap and opens a new
+  one.
+- Gap compaction coalesces old ranges without losing covered time, and age
+  deletion removes only closed ranges wholly outside Call Log retention.
 
 ### Compatibility with retained surfaces
 
@@ -666,9 +748,10 @@ Do not ship those doc edits in this planning PR.
   `ProviderSessionRef` and provider-session digest; no `-agent` write owner is
   introduced by this cut.
 - Processing Record authorizes and correlates historical migrated calls and
-  new add/flush calls through bounded `memory_call_provenance`, including
-  linked memcell membership, unique-scope unlinked list/detail,
-  source-availability, retention, and ambiguous-request-id tests.
+  new add/flush calls through bounded provenance and gap metadata, including
+  rejected calls, linked memcell membership, unique-scope unlinked list/detail,
+  restart-safe source unavailability, whole-request-id-group retention, and
+  ambiguous-request-id tests.
 
 ## Implementation sequence
 
@@ -693,7 +776,8 @@ after adding migrator and writer tests. Line count is not acceptance.
 - [ ] Implement v4 identity schema and released-shape migrator.
 - [ ] Implement `BestEffortMemoryWriter` and switch capture to `offer()`.
 - [ ] Replace capture-table Processing Record joins with bounded call
-      provenance and migrate retained correlations before dropping the tables.
+      provenance plus durable gaps, and migrate retained correlations before
+      dropping the tables.
 - [ ] Replace session final-flush waits with a best-effort barrier.
 - [ ] Replace claim quiescence with writer pause/quiesce around Rebuild/Repair.
 - [ ] Stop writing processing-fault ACK / `manual_required` / settlements.

--- a/docs/plans/memory-best-effort-capture.md
+++ b/docs/plans/memory-best-effort-capture.md
@@ -64,8 +64,9 @@ provider root.
 - `offer()` / `capture()` reserves or rejects one process-local slot without
   waiting on attachment pinning or EverOS.
 - One 256-slot admission window bounds every retained capture/barrier from
-  reservation through pinning, queueing, and the one in-flight provider call.
-  There is no second reservation chain outside that bound.
+  reservation through pinning, stale-generation reclamation, queueing, and the
+  one in-flight provider call. There is no second reservation chain outside
+  that process-wide bound.
 - Principal, project, epoch, `scope_key`, and `provider_root_id` are
   byte-identical across the upgrade.
 - Named-project catalog rows survive.
@@ -98,9 +99,9 @@ provider root.
   recovers.
 - Ambiguous add/flush results may leave a rare duplicate if EverOS
   committed and Avibe could not observe the ack. They are not retried.
-- Session-boundary flush is best-effort. Queue saturation or a crash may
-  leave old and new conversation content in the same EverOS accumulation
-  boundary.
+- Session-boundary flush is best-effort. Queue saturation, a crash, or dropping
+  a 257th pending-session tracker may leave old and new conversation content in
+  the same EverOS accumulation boundary.
 - Duplicate source-message suppression is process-local. A restart may
   recapture the same IM or remember payload if the caller submits it
   again.
@@ -163,16 +164,23 @@ record every valid request id and close that gap atomically
 
 Suggested starting constants, fixed rather than user settings:
 
-- admission-window bound: 256 total slots across reserved/unready, pinning,
+- process-wide admission-window bound: 256 total permits across
+  reserved/unready, pinning (including stale work from an older generation),
   ready/queued, and the current in-flight add or barrier
-- max total add attempts: 3, only for outcomes that prove the request
-  did not commit (UDS refused before send, sidecar not ready, provider
-  error classified uncommitted)
+- max total add attempts: 3 (`MAX_ADD_ATTEMPTS`), only for outcomes that prove
+  the request did not commit (UDS refused before send, sidecar not ready,
+  provider error classified uncommitted)
+- max total flush attempts: 3 (`MAX_FLUSH_ATTEMPTS`), but only before the
+  provider coroutine may have executed; a submitted flush is never retried
+  regardless of its response
 - do not retry timeout, truncated response, malformed success, or any
   result that may have committed
 - idle flush: 5 minutes (`SessionFlushCoordinator.IDLE_FLUSH_TIMEOUT`)
 - max unflushed age: 30 minutes (`MAX_UNFLUSHED_AGE`)
 - message-count flush: 100 (`MAX_UNFLUSHED_MESSAGES`)
+- pending-flush bound: 256 provider sessions
+  (`MAX_PENDING_FLUSH_SESSIONS`) / 25,600 retained message ids
+  (`MAX_PENDING_FLUSH_MESSAGE_IDS`)
 - process-local duplicate LRU: 256 source-message digests
 
 These flush timers are recall-freshness, not durability. An `accumulated`
@@ -181,32 +189,69 @@ required for this cut.
 
 `extracted` drops pending flush state for that provider session.
 `accumulated` refreshes one in-memory `PendingFlush(session_ref,
-first_accumulated_at, last_accumulated_at, message_ids)`. `message_ids` is
-bounded by the 100-message flush limit and exists only to correlate a
-successful flush with the retained Provider Call Log. Its length is the
-volatile `unflushed_count`: every `accumulated` acknowledgement appends exactly
-one message id, and reaching 100 makes that provider session immediately due
-without waiting for either timer. The pending table does not survive process
-restart; EverOS still holds the buffer until a later same-session add, Repair,
-or provider extraction.
+raw_session_id, first_accumulated_at, last_accumulated_at, message_ids,
+attempts)`. `message_ids` is bounded by the 100-message flush limit and exists
+only to correlate any submitted flush outcome with the retained Provider Call
+Log. `raw_session_id` is the already-validated bounded capture identifier; it
+stays volatile and is never logged. The message-id list length is the volatile
+`unflushed_count`: every `accumulated`
+acknowledgement appends exactly one message id, and reaching 100 makes that
+provider session immediately due before another add for the same session can be
+submitted.
+
+The map retains at most 256 provider sessions, so its 100-id per-entry limit
+also bounds total retained ids at 25,600. If an `accumulated` result would create
+a 257th entry, do not evict or mutate an existing scope: drop the new volatile
+tracking entry, increment a content-free capacity-drop counter, and leave the
+EverOS buffer untouched. A later same-session add may recreate tracking after
+capacity is available, and Repair or provider extraction may process the older
+buffer. The pending map does not survive process restart.
+
+When an entry becomes due, the worker snapshots it for one flush attempt. A
+failure proven to occur before the provider coroutine can execute may retain
+that same entry for at most three total attempts. At the exact submission edge
+where the provider coroutine may execute, remove the entry from the map and
+carry its bounded message-id snapshot only in the in-flight slot. Success,
+rejection, timeout, malformed response, cancellation, and any other ambiguous
+submitted outcome all consume that snapshot permanently; none reinsert or
+reschedule it. Only a later `accumulated` add can create fresh pending state.
 
 Worker generation increments on disable, shutdown, Reset/Clear, and
-runtime-affecting configuration replacement. The old worker is cancelled,
-the queue and flush table are discarded, and in-flight requests are not
-replayed.
+runtime-affecting configuration replacement. The old worker is cancelled, the
+ordered queue and pending-flush map are invalidated immediately, and in-flight
+provider requests are not replayed. A synchronous pin that is already running
+becomes stale cleanup work under the process-wide admission bound described
+below; the generation transition does not wait for it.
 
 ### Session boundary
 
-`/new` and archive enqueue an ordered flush-barrier item and return.
-They never call `final_flush` with a deadline. Existing internal routes
+`/new` and archive enqueue one ordered `SessionBarrier(raw_session_id)` slot and
+return. They never call `final_flush` with a deadline. Existing internal routes
 may remain as adapters that enqueue the barrier; they must not wait.
+
+The worker resolves the barrier only when it reaches the head, after every
+earlier admitted capture has either updated or skipped pending state. It selects
+every `PendingFlush` whose `raw_session_id` matches, including all principal /
+project scopes accumulated by one Workbench session after project switches,
+sorts their provider-session refs deterministically, and executes one logical
+flush barrier for each inside the same charged admission slot. Later captures
+cannot pass the batch. A scope with no retained pending entry needs no flush;
+the explicit pending-capacity and restart non-guarantees still apply.
+
+This head-time expansion is the barrier adapter's multi-scope replacement for
+`resolve_current_session_scopes()`: resolving at adapter-call time would miss an
+earlier admitted capture whose pin has not completed yet. The single batch slot
+therefore carries only the trusted raw session id until it can produce the
+complete ordered tuple of logical per-scope barriers.
 
 Use one fixed-capacity ordered admission window, not a queue plus an unbounded
 reservation chain. `offer()` synchronously and non-blockingly reserves the next
 sequence slot before any deferred attachment work. That permit remains charged
-while the slot is unready, pinning, ready, queued, or in flight, and is released
-only when the worker consumes or skips the slot. At most 256 slot payloads,
-attachment leases, and owned pin tasks therefore exist in one generation.
+while the slot is unready, pinning, ready, queued, or in flight. A normal slot
+releases it when consumed or skipped; a stale pin keeps the permit and source
+lease until late-completion reclamation finishes. At most 256 slot payloads,
+attachment leases, and owned or stale pin tasks therefore exist process-wide,
+including across generation replacement.
 
 A barrier reserves the same kind of slot and is ready immediately. The worker
 consumes only from the head, so an accepted barrier cannot overtake any earlier
@@ -214,8 +259,10 @@ admitted capture even if its pin is slow; a failed pin marks its slot skipped
 and lets the worker advance. When all 256 permits are charged, captures and
 barriers are rejected with the existing queue-full outcome before starting a
 pin, retaining a payload, advancing the watermark/catalog, or creating another
-task. `/new` and archive return without waiting. Generation drop cancels the
-bounded pin tasks, releases their leases, and clears every charged permit.
+task. `/new` and archive return without waiting. Generation drop marks pinning
+slots skipped for ordering and releases every non-pinning permit immediately;
+it does not cancel the underlying synchronous pin, release its source lease, or
+return its permit before the late-pin reaper settles it.
 
 ### Shutdown
 
@@ -306,18 +353,20 @@ observer state into delivery state:
 1. Before every EverOS add or flush attempt, the worker durably inserts one open
    `memory_call_provenance_gap` row. It also closes any stale open row at this
    attempt's start time. If this preflight identity transaction fails, the
-   best-effort item is skipped and EverOS is not called.
+   provider is not called: an add is skipped, while a due flush retains its
+   snapshot only for the bounded pre-submission retry policy above.
 2. If the result contains a valid request id, one transaction inserts every
    provenance row for that call and deletes its open gap. This applies to
-   acknowledged, rejected, and unknown classifications; any separately allowed
-   uncommitted retry starts only after that observer transaction commits. A
-   provenance transaction failure leaves the already-committed gap open and
-   never causes a provider retry.
-3. If a result has no valid request id and proves no request left Avibe, close
-   the gap before any permitted retry; if closing fails, drop the item. The retry
+   acknowledged, rejected, and unknown classifications. A separately allowed
+   add retry starts only after that observer transaction commits; a submitted
+   flush is terminal. A provenance transaction failure leaves the
+   already-committed gap open and never causes a provider retry.
+3. If an add result has no valid request id and proves no request left Avibe, or
+   a flush attempt fails before its provider coroutine can execute, close the
+   gap before any permitted retry; if closing fails, drop the item. The retry
    opens a new gap. A timeout, truncated or malformed response, or other result
-   without a trustworthy request id leaves the gap open because the provider may
-   have observed the call.
+   without a trustworthy request id after submission leaves the gap open because
+   the provider may have observed the call, and a submitted flush stays terminal.
 4. At boot, close a stale open gap at boot time. Until then an open gap covers
    `[started_at_ms, infinity)`. A Processing Record call whose observation time
    overlaps any gap reports the correlation source unavailable instead of
@@ -462,7 +511,8 @@ would accept captures:
    the detected v0 file was empty):
    - count nonterminal queue rows (`pending`, `processing`,
      `manual_required`) and terminal rows, without logging payload text
-   - collect `attachment_bundle` ids
+   - count `memory_attachment_bundle` rows for content-free discard diagnostics;
+     do not treat that table as a complete filesystem inventory
    - copy `memory_meta` identity columns and `memory_projects`
    - before dropping delivery tables, copy every valid bounded add/flush request
      id into `memory_call_provenance`, including rejected operations and every
@@ -482,14 +532,22 @@ would accept captures:
    admitting the writer. A concurrent read-only Processing Record connection
    may keep the checkpoint busy; that is safe because committed pages remain in
    SQLite's WAL and are recovered on reopen. Never unlink `-wal`, `-shm`, or
-   `-journal` directly. Reopen normally and verify v4, then confined-delete the
-   collected leftover pin bundles.
-7. Emit one content-free structured log: discarded nonterminal count,
-   discarded terminal count, discarded bundle count. Never log text,
+   `-journal` directly. Reopen normally and verify v4.
+7. Before writer admission on this migration boot and every later v4 boot, run
+   `AttachmentPinStore.clear_all()` (extended to return a content-free removed
+   entry count) against the confined pin root. After the outbox table is gone,
+   the authoritative reference set is empty, so inventory and remove every
+   staging and bundle entry, including valid published bundles with no old table
+   row and safely confined entries with unrecognized names.
+   If the scrub cannot prove the root empty, keep the writer closed and retry the
+   same scrub on the next boot; never follow or manually unlink an unsafe entry.
+8. Emit one content-free structured log: discarded nonterminal count,
+   discarded terminal count, discarded bundle-row count, and scrubbed confined
+   entry count. Never log text,
    paths, or digests that can recover a message. Also count provenance rows
    covered by a migration gap and a busy post-commit checkpoint without treating
    either as a capture-startup failure.
-8. Start `BestEffortMemoryWriter` against the preserved watermark and
+9. Start `BestEffortMemoryWriter` against the preserved watermark and
    catalog.
 
 Crash windows:
@@ -499,8 +557,8 @@ Crash windows:
 - Failure after commit, before checkpoint/close: SQLite recovers the committed
   v4 transaction from its WAL. No cleanup code removes those pages.
 - Failure after commit, before bundle delete: the store is v4; leftover
-  files under `memory/attachments/` are unreferenced and deleted on the
-  next boot by "no bundle table ⇒ delete pin root if empty-orphan".
+  files under `memory/attachments/` are unreferenced and the mandatory empty-root
+  scrub runs again before writer admission on the next boot.
 - Failure during Clear/Reset: existing markers remain authoritative.
   The capture migrator does not clear those markers and does not treat
   a pending Clear as a successful identity upgrade.
@@ -528,6 +586,31 @@ marks it ready or skipped, and releases the bundle after a terminal in-process
 add (success, definite rejection, or drop). Marking a slot skipped lets the
 worker advance, so one failed pin cannot strand a later barrier.
 
+Do not cancel an asyncio wrapper and assume the synchronous
+`AttachmentPinStore.pin()` stopped. The writer keeps a strong reference to every
+pin task in a process-wide late-pin registry. A generation change atomically
+marks its slot stale and ordering-skipped, but leaves its admission permit and
+source lease charged without awaiting completion. When the blocking call
+settles, one completion path checks the captured generation before exposing the
+result:
+
+- a current successful pin marks its original slot ready
+- a stale successful pin immediately calls the confined, idempotent
+  `AttachmentPinStore.release(bundle_id)` and never enters a new generation
+- a stale failure is consumed as cleanup, without text-only resubmission
+- every branch releases the source lease and admission permit only after result
+  handling and confined reclamation finish
+
+The reaper consumes task exceptions and stays bounded by those unreleased
+process-wide permits, so repeated configuration changes cannot accumulate more
+than 256 blocking pins. Clear/Reset cleanup and the late reaper serialize through
+the same `AttachmentPinStore` confinement/lock; a bundle published after logical
+generation invalidation is still reclaimed. If release cannot prove deletion,
+fail the replacement writer generation closed, keep that permit charged, and
+retry confined cleanup rather than losing ownership of the orphan. If the
+process exits before a callback runs, the mandatory empty-root scrub on the next
+v4 boot removes both published and staging leftovers before accepting captures.
+
 Retain the current single text-only degradation for a valid nonempty caption:
 
 - if pinned-attachment verification fails before provider submission with the
@@ -550,7 +633,8 @@ Remove only:
 - snapshot/restore handling that exists solely for durable delivery
 - any assumption that a bundle outlives the process
 
-After migration or crash, unreferenced pin directories are deleted.
+After migration or crash, every confined staging/bundle entry is deleted before
+the v4 writer starts, whether or not the old table recorded it.
 That is data loss of files Avibe copied for retry, not of the user's
 original chat attachments.
 
@@ -681,6 +765,11 @@ Do not ship those doc edits in this planning PR.
 - A malformed observer correlation creates a bounded retained-horizon migration
   gap; after restart, overlapping Processing Record observations still report
   correlation unavailable rather than silently disappearing.
+- Migration and later-v4-boot tests seed represented bundles, an unrepresented
+  valid published bundle, staging leftovers, and safely confined unrecognized
+  entries, then prove the empty-reference scrub removes all of them before
+  writer admission. An injected scrub failure keeps the writer closed and the
+  next boot retries without relying on the removed table.
 - Interrupted strip (kill before commit) retries and still preserves
   identity.
 - v4 file is refused by a v3-only opener without writes (contract test
@@ -689,12 +778,13 @@ Do not ship those doc edits in this planning PR.
 ### Writer
 
 - `offer()` does not await attachment pinning or provider I/O.
-- Total occupancy never exceeds 256 across unready reservations, pinning tasks,
-  ready/queued slots, and the in-flight slot; there is no out-of-window
-  predecessor chain.
+- Total occupancy never exceeds 256 across unready reservations, current and
+  stale pin tasks, ready/queued slots, and the in-flight slot, even through
+  repeated generation changes; there is no out-of-window predecessor chain.
 - Saturation returns `memory_queue_full` / `CaptureSkipped`.
 - One worker preserves accepted-item order globally.
-- At most three total attempts, and only for uncommitted failures.
+- At most three total attempts per operation, and only for proven-uncommitted adds or
+  pre-submission flush failures.
 - Timeout / unknown / truncated success is not retried.
 - `accumulated` schedules idle (5m), max-age (30m), and
   message-count (100) flush in memory, matching today's coordinator.
@@ -702,15 +792,34 @@ Do not ship those doc edits in this planning PR.
   100th makes the session immediately due, and extraction/generation drop
   clears both the bounded message-id list and its count.
 - `extracted` removes pending flush.
+- Every submitted flush consumes its pending entry and bounded message-id
+  snapshot after success, rejection, timeout, malformed response, cancellation,
+  or other ambiguity. Only a proven pre-submission failure retains it, and the
+  third failed attempt drops it without a provider call.
+- High-cardinality accumulated traffic retains at most 256 pending sessions and
+  25,600 message ids. A 257th new session drops only its new volatile tracking,
+  never evicts or mutates an existing scope, and records content-free accounting.
 - Shutdown, disable, config replacement, Clear, and Reset drop the queue
   without drain.
-- Session barrier does not block `/new` or archive, and a capture delayed in
-  attachment pinning after reserving admission is still offered before the
-  later barrier.
+- Session barrier does not block `/new` or archive. At its ordered head it
+  resolves and flushes every retained pending scope for the raw Workbench
+  session, including project switches and scopes created by an earlier capture
+  whose pin completed after barrier admission.
+- A Workbench project-switch archive test accumulates at least two scopes for
+  one raw session and observes one ordered submitted flush per retained scope;
+  the same assertion holds when the first scope's pin finishes after barrier
+  admission.
 - With the head pin stalled, filling all 256 permits creates at most 256 slot
   payloads/tasks/leases; the next capture and barrier are rejected before pin
   or identity mutation. An already accepted barrier remains ordered after all
   earlier slots and before every later accepted slot.
+- Generation cancellation after bundle publication but before `pin()` returns
+  marks the slot skipped without waiting, keeps its process-wide permit and
+  source lease charged, reclaims the late bundle through confinement, and only
+  then releases both. A replacement generation cannot exceed the same 256 cap.
+- An injected late-bundle release failure keeps the replacement generation
+  closed and its permit charged until confined cleanup succeeds; restart runs
+  the mandatory empty-root scrub before reopening intake.
 - Watermark persists across writer restart and is monotonic.
 - With the watermark already at `MAX_PROVIDER_TIMESTAMP_MS`, the next otherwise
   valid capture returns `timestamp_invalid` without changing the watermark or
@@ -723,14 +832,15 @@ Do not ship those doc edits in this planning PR.
   failures never resubmit the caption.
 - Logs never include captured text, credentials, or absolute paths.
 - Every provider attempt durably opens a gap before the RPC. A failed preflight
-  write skips the item without calling EverOS; timeout/unknown responses and an
-  injected provenance-commit failure leave a gap that remains fail-closed after
-  restart and is closed at the next attempt or boot.
+  write skips an add or retains a due flush only within its bounded
+  pre-submission attempts, without calling EverOS; timeout/unknown responses and
+  an injected provenance-commit failure leave a gap that remains fail-closed
+  after restart and is closed at the next attempt or boot.
 - Valid bounded request ids from acknowledged, rejected, and otherwise
   unclassifiable add/flush responses are recorded with their outcome and scope.
-  Provenance failure never causes a provider retry, while a separately allowed
-  proven-uncommitted retry first settles the old observer gap and opens a new
-  one.
+  Provenance failure never causes a provider retry; a separately allowed add or
+  pre-submission flush retry first settles the old observer gap and opens a new
+  one, while a submitted flush remains terminal.
 - Gap compaction coalesces old ranges without losing covered time, and age
   deletion removes only closed ranges wholly outside Call Log retention.
 
@@ -778,10 +888,12 @@ after adding migrator and writer tests. Line count is not acceptance.
 - [ ] Replace capture-table Processing Record joins with bounded call
       provenance plus durable gaps, and migrate retained correlations before
       dropping the tables.
-- [ ] Replace session final-flush waits with a best-effort barrier.
+- [ ] Replace session final-flush waits with a best-effort multi-scope session
+      barrier over the bounded volatile pending-flush map.
 - [ ] Replace claim quiescence with writer pause/quiesce around Rebuild/Repair.
 - [ ] Stop writing processing-fault ACK / `manual_required` / settlements.
-- [ ] Delete leftover pin bundles after migration; keep in-process pins.
+- [ ] Scrub the entire confined pin root before every v4 writer start and reap
+      stale-generation pin completions under the process-wide admission bound.
 - [ ] Keep `memory.cli.remembered` as queued; rewrite Memory user docs.
 - [ ] Shrink Clear's queue primitive to identity reset.
 - [ ] Remove coordinator, worker, and outbox-only tests.
@@ -801,8 +913,10 @@ implementation PR:
 4. Attachment pins have no durable recovery after this cut. Leftover
    bundles are deleted. Original chat attachments are untouched.
 5. Session-boundary flush is a barrier enqueue, not a wait. A crash or
-   a full queue can leave consecutive conversations in one EverOS
-   accumulation boundary.
+   a full queue can leave consecutive conversations in one EverOS accumulation
+   boundary. A 257th concurrently tracked provider session also drops its new
+   volatile flush trigger; a later same-session add, Repair, or provider
+   extraction may process that buffer.
 6. No JSON identity file is introduced. Identity stays in the existing
    SQLite file so Clear's `reset_for_clear(target_epoch=...)` and
    Factory Reset keep one authority.

--- a/docs/plans/memory-best-effort-capture.md
+++ b/docs/plans/memory-best-effort-capture.md
@@ -151,13 +151,20 @@ Suggested starting constants, fixed rather than user settings:
   error classified uncommitted)
 - do not retry timeout, truncated response, malformed success, or any
   result that may have committed
-- idle flush: 60s
-- max unflushed age: 5 minutes
+- idle flush: 5 minutes (`SessionFlushCoordinator.IDLE_FLUSH_TIMEOUT`)
+- max unflushed age: 30 minutes (`MAX_UNFLUSHED_AGE`)
+- message-count flush: 100 (`MAX_UNFLUSHED_MESSAGES`)
 - process-local duplicate LRU: 256 source-message digests
+
+These flush timers are recall-freshness, not durability. An `accumulated`
+add is already in EverOS `unprocessed_buffer`. Speeding them up is not
+required for this cut.
 
 `extracted` drops pending flush state for that provider session.
 `accumulated` refreshes one in-memory `PendingFlush(session_ref,
-first_accumulated_at, last_accumulated_at)`.
+first_accumulated_at, last_accumulated_at)`. The pending table does not
+survive process restart; EverOS still holds the buffer until a later
+same-session add, Repair, or provider extraction.
 
 Worker generation increments on disable, shutdown, Reset/Clear, and
 runtime-affecting configuration replacement. The old worker is cancelled,
@@ -448,7 +455,8 @@ Do not ship those doc edits in this planning PR.
 - One worker preserves accepted-item order globally.
 - At most three total attempts, and only for uncommitted failures.
 - Timeout / unknown / truncated success is not retried.
-- `accumulated` schedules idle and max-age flush in memory.
+- `accumulated` schedules idle (5m), max-age (30m), and
+  message-count (100) flush in memory, matching today's coordinator.
 - `extracted` removes pending flush.
 - Shutdown, disable, config replacement, Clear, and Reset drop the queue
   without drain.


### PR DESCRIPTION
## Changed capability

Plan document only: `docs/plans/memory-best-effort-capture.md` — the implementation contract for replacing Avibe's durable Memory outbox (claim / lease / fence / settlement / tombstone / `manual_required`) with a process-local `BestEffortMemoryWriter`.

This PR does not change product code. Implementation is a follow-up after the contract is accepted.

Key decisions locked in the plan:

- Capture is best-effort and process-local. `CaptureAccepted` means the item entered process memory, not that EverOS stored it. One ordered 256-permit process-wide admission window bounds reservation, current and stale pinning, queued work, the in-flight item, and current/stale terminal bundle reclamation across generation changes; contents do not survive restart.
- Pending flush tracking is bounded to 256 provider sessions / 25,600 message IDs. Every submitted flush consumes its state and is never retried; only a failure after a durable gap opens and proven before provider execution consumes the three-attempt bound. Observer-SQLite preflight failure retains the same snapshot with one delayed retry and consumes no provider attempt. Before each add RPC, the writer reserves a bounded boundary candidate and marks its exact guard incomplete. A 257th distinct pending session is skipped before EverOS. Ambiguous submitted adds remain due, close later provider submissions until stop/reap bounds the call, and flush before later work; they are never retried.
- `/new` and archive enqueue one ordered raw-session barrier and return. At queue head it expands across every retained principal/project scope for that Workbench session; they never wait on Memory.
- Identity stays in the existing SQLite file. No JSON identity file. After upgrade, `state/memory/memory.sqlite` keeps `memory_meta`, `memory_projects`, bounded content-free `memory_call_provenance`, `memory_processing_anomaly`, `memory_flush_correlation_guard`, and source-flagged `memory_observation_gap` observer metadata (`PRAGMA user_version = 4`); no delivery state survives. Durable exact/global guards are written before add submission, so ambiguous adds retain a boundary candidate and incomplete correlation; a 257th pending session is skipped before EverOS. Every attempt opens an independent two-source gap; lifecycle close only bounds its interval, and correlation/anomaly availability stays fail-closed until each source-specific retirement rule is met. Provenance records the provider-submission start, and count pruning covers the full start-to-observation interval. Anomalies retain source-specific expiry (90 days for queue-backed abandonment, none for settlement evidence), preserve released tie ordering through local sequences, and cap expiring/non-expiring rows independently; only 100 newer permanent rows retire an anomaly gap. Every Processing Record call read enforces the 14-day start cutoff, and a correlation gap retires only after a read-only probe also proves no covered physical Call Log row remains. Valid request IDs and the sanitized newest-50 failure projection migrate before delivery tables are dropped. Acknowledged adds advance durable `last_success_at`, which survives provenance pruning and drives provider-data history until Clear resets it. Timestamp overflow is rejected before catalog, watermark, or admission mutation. All released-shape transforms and the v4 strip share one transaction; migration checkpoints and closes owned SQLite connections and never unlinks SQLite sidecars.
- Every released Memory SQLite shape (v0 two variants, v1, v2, v3) loads. `scope_key`, `provider_root_id`, `epoch`, named-project catalog, `last_provider_timestamp_ms`, and `last_success_at` are byte-identical. Pending outbox rows are counted and discarded, never replayed.
- A readable marker-owned Clear or pending Factory Reset follows the existing destructive path. An absent marker with `clear_in_progress=1` remains a blocked orphan fence until an explicit Clear supplies fresh authority. Clear atomically resets all observer tables and `last_success_at`. A pending Rebuild/Repair is not converted to Reset.
- Provider-session derivation is unchanged from `origin/dev`: both user-input and agent-provenance capture writes use the 34-character user principal exactly as current `MemoryStore.enqueue_request`; the `#1633` assistant owner remains read-path support only.
- `vibe memory remember` copy stays queued (`memory.cli.remembered` is already "Memory queued." / "记忆已加入队列。"). It must not claim the fact is stored.
- Sidecar supervision, Rebuild, Repair (`cascade sync`), Clear, Factory Reset, Processing Record, Provider Call Log, and in-process attachment pins stay. The optional Call Log never gates identity migration or writer startup; unlinked calls use unique provenance scope, while linked reads also require memcell membership. The attachment text-only fallback records rejected call provenance but creates no anomaly unless the logical capture ultimately fails. Every v4 boot scrubs the full confined pin root before writer admission; one process-wide cleanup registry retains the original permit/source lease for current and stale terminal releases and retries confined deletion under the same 256-permit bound.

## Affected scenario IDs

None changed in this PR. Implementation will keep existing Memory scenario IDs unless a catalog row currently asserts durable queue replay.

## Evidence layers

- unit / contract / scenario: none in this PR (docs only); the plan defines them for the implementation PR
- residual manual checks: none required for a plan document

## Dependencies

None. This PR precedes the implementation PR described in the plan. It does not depend on the unpublished umbrella simplification draft.

## Known-by-design ledger

Copied from the plan so review re-flags can point here:

1. Upgrade discards undelivered outbox rows (`pending`, `processing`, `manual_required`, and terminal tombstones). EverOS markdown and `unprocessed_buffer` are kept. Users can lose captures that had not reached EverOS.
2. `CaptureAccepted` means entered process memory, not stored by EverOS.
3. Duplicate source-message suppression is an in-process LRU. Restart may recapture the same payload.
4. Attachment pins have no durable recovery after this cut. Every v4 boot deletes all safely confined published and staging leftovers before writer admission, including entries absent from the old table. Original chat attachments are untouched.
5. Session-boundary flush is a multi-scope barrier enqueue, not a wait. A full admission queue can reject it. Crash/restart, disable, graceful shutdown, runtime config replacement, and Clear/Reset generation invalidation drop volatile due candidates; when the provider buffer survives, consecutive conversations may share one accumulation boundary. A 257th distinct pending session is skipped before EverOS. Durable guards preserve correlation incompleteness; successful Clear/Reset replaces the provider root and observer identity together.
6. No JSON identity file is introduced. Identity stays in the existing SQLite file so Clear's `reset_for_clear(target_epoch=...)` and Factory Reset keep one authority.
7. Pin-without-outbox is temporary debt. A later attachments PR may replace pins with ephemeral source leases; it is not required here.