### PR TITLE
fix(ui): surface provider key cleanup warning

### DIFF
--- a/ui/src/components/settings/providers/ClaudeProviderConfig.tsx
+++ b/ui/src/components/settings/providers/ClaudeProviderConfig.tsx
@@ -23,6 +23,7 @@ import { BackendRuntimeCard } from '../shared/BackendRuntimeCard';
 import { BackendSupplyModeCard } from '../models/BackendSupplyModeCard';
 import { useModelHubCapability } from '../models/useModelHubCapability';
 import { SegmentedRadio } from '../shared/SegmentedRadio';
+import { surfaceBackendNotices } from '../shared/surfaceBackendNotices';
 import { useBackendRuntime } from '../shared/useBackendRuntime';
 import { useOAuthFlowLock } from '../shared/useOAuthFlowLock';
 import { useApi } from '@/context/ApiContext';
@@ -180,6 +181,7 @@ export const ClaudeProviderConfig: React.FC<{
       } else {
         showToast(t('settings.backends.claudeApiKeyRemoved'), 'success');
       }
+      surfaceBackendNotices(result.notices, showToast, t);
     } catch (err) {
       showToast(
         t('settings.backends.claudeApiKeyRemoveFailed', { detail: errorMessage(err) || 'unknown' }),

--- a/ui/src/components/settings/shared/surfaceBackendNotices.test.ts
+++ b/ui/src/components/settings/shared/surfaceBackendNotices.test.ts
@@ -1,0 +1,79 @@
+import { createInstance, type TFunction } from 'i18next';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import en from '@/i18n/en.json';
+import zh from '@/i18n/zh.json';
+import type { BackendNotice } from '@/context/ApiContext';
+
+import { surfaceBackendNotices } from './surfaceBackendNotices';
+
+const resources = {
+  en: { translation: en },
+  zh: { translation: zh },
+};
+
+const translate = new Map<'en' | 'zh', TFunction>();
+
+beforeAll(async () => {
+  for (const language of ['en', 'zh'] as const) {
+    const instance = createInstance();
+    await instance.init({
+      lng: language,
+      fallbackLng: 'en',
+      resources,
+      interpolation: { escapeValue: false },
+    });
+    translate.set(language, instance.t);
+  }
+});
+
+describe('surfaceBackendNotices', () => {
+  it.each(['en', 'zh'] as const)(
+    'explains that the key was removed while settings may be stale in %s',
+    (language) => {
+      const showToast = vi.fn();
+      const notice: BackendNotice = {
+        code: 'v2_clear_failed',
+        detail: 'disk full',
+      };
+
+      surfaceBackendNotices([notice], showToast, translate.get(language)!);
+
+      expect(showToast).toHaveBeenCalledWith(
+        expect.stringContaining('disk full'),
+        'warning',
+      );
+      const message = showToast.mock.calls[0]?.[0] as string;
+      expect(message).not.toContain('v2_clear_failed');
+      expect(message).toMatch(language === 'en' ? /API key removed/i : /API Key 已删除/);
+      expect(message).toMatch(language === 'en' ? /settings.*stale/i : /设置.*未更新/);
+    },
+  );
+
+  it('keeps existing relay and unknown notice rendering intact', () => {
+    const showToast = vi.fn();
+    surfaceBackendNotices(
+      [
+        {
+          code: 'cleared_custom_relay_pointer',
+          provider_id: 'Relay',
+          base_url: 'https://relay.example/v1',
+        },
+        { code: 'future_notice' },
+      ],
+      showToast,
+      translate.get('en')!,
+    );
+
+    expect(showToast).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('https://relay.example/v1'),
+      'warning',
+    );
+    expect(showToast).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('future_notice'),
+      'warning',
+    );
+  });
+});

--- a/ui/src/components/settings/shared/surfaceBackendNotices.ts
+++ b/ui/src/components/settings/shared/surfaceBackendNotices.ts
@@ -9,12 +9,10 @@ export type ShowToast = (
 
 /**
  * Surface server-side ``notices`` (from a save / remove response) as
- * warning toasts. Today the only code-driven notice is
- * ``cleared_custom_relay_pointer`` (Codex relay-URL cleanup when
- * switching to OAuth), but the helper is shaped to accept arbitrary
- * future codes — unknown codes fall through to a generic
- * ``codexNoticeGeneric``-style toast so the user at least sees that
- * the server reported a notable side-effect.
+ * warning toasts. Known notices get user-facing copy here so every
+ * provider page presents the same meaning; unknown codes fall through to
+ * a generic ``codexNoticeGeneric``-style toast so the user at least sees
+ * that the server reported a notable side-effect.
  *
  * Previously each provider page duplicated this switch inline.
  */
@@ -25,6 +23,15 @@ export function surfaceBackendNotices(
 ): void {
   if (!notices || notices.length === 0) return;
   for (const notice of notices) {
+    if (notice.code === 'v2_clear_failed') {
+      showToast(
+        t('settings.backends.backendNoticeV2ClearFailed', {
+          detail: notice.detail || t('settings.backends.backendNoticeDetailUnknown'),
+        }),
+        'warning',
+      );
+      continue;
+    }
     if (notice.code === 'cleared_custom_relay_pointer') {
       showToast(
         t('settings.backends.codexNoticeClearedRelayPointer', {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -480,6 +480,8 @@
       "codexApiKeyRemoveConfirm": "Remove the stored OpenAI API key from auth.json? Codex will fall back to OAuth tokens if present, or sit unconfigured if not.",
       "codexApiKeyRemoved": "Stored OpenAI API key removed.",
       "codexApiKeyRemoveFailed": "Could not remove API key: {{detail}}",
+      "backendNoticeV2ClearFailed": "API key removed, but saved settings may still be stale: {{detail}}",
+      "backendNoticeDetailUnknown": "the settings save did not complete",
       "codexNoticeClearedRelayPointer": "Cleared the custom relay pointer ({{provider}} → {{url}}) because OAuth tokens won't validate against a custom base URL. Codex will now use OpenAI's default endpoint. To switch back, re-add an API key or edit ~/.codex/config.toml manually.",
       "codexNoticeGeneric": "Config notice: {{code}}",
       "opencodeProviderSignIn": "Sign in",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -480,6 +480,8 @@
       "codexApiKeyRemoveConfirm": "确定要从 auth.json 移除已保存的 OpenAI API Key 吗？如果有 OAuth 凭据，Codex 会回落到 OAuth；否则会变成未配置状态。",
       "codexApiKeyRemoved": "已移除 OpenAI API Key。",
       "codexApiKeyRemoveFailed": "移除 API Key 失败：{{detail}}",
+      "backendNoticeV2ClearFailed": "API Key 已删除，但保存的设置可能仍未更新：{{detail}}",
+      "backendNoticeDetailUnknown": "设置保存未完成",
       "codexNoticeClearedRelayPointer": "已清除自定义中继指向（{{provider}} → {{url}}）：OAuth 凭据无法被自定义 base_url 验证，Codex 将改为使用 OpenAI 官方端点。如需切回，请重新添加 API Key 或手动编辑 ~/.codex/config.toml。",
       "codexNoticeGeneric": "配置提示：{{code}}",
       "opencodeProviderSignIn": "登录",


### PR DESCRIPTION
## Changed capability

Provider Settings now renders the existing `v2_clear_failed` notice returned by `remove_backend_api_key` in both the Claude and Codex pages. The warning is localized in English and Chinese and tells the user that the API key was removed while the saved settings may still be stale. Existing success, failure, restart, relay-pointer, and generic notice messages remain unchanged.

## Affected scenario IDs

None. This is a local Provider UI rendering change and does not alter a scenario contract.

## Evidence layers

- Unit: focused `surfaceBackendNotices` tests cover the `v2_clear_failed` warning in `en` and `zh`, including the detail, plus existing relay and unknown notice behavior.
- Contract: no backend or cloud contract changes; the UI consumes the existing optional `notices[].code/detail` response fields.
- Scenario: no scenario catalog update; Model Hub and cloud control-plane behavior are out of scope.
- Residual manual: verify a simulated `v2_clear_failed` remove response on both Provider pages in both locales through the local Settings UI.

## Dependencies

None.

## Known-by-design ledger

None.
