### PR TITLE
docs(show-runtime): record inherited automatic-recovery constraints

### DIFF
--- a/docs/plans/show-runtime-availability.md
+++ b/docs/plans/show-runtime-availability.md
@@ -1257,6 +1257,14 @@ as a rule because the reduced signal looked adequate each time.
   only from a manager-owned admission signal, never from a browser counter. Its
   design remains open in #1637 rather than being implied by PR #1640.
 
+The delivery record moves three resolved PR #1640 threads with that scope:
+[polling state must survive document replacement](https://github.com/avibe-bot/avibe/pull/1640#discussion_r3833946834),
+[a failed browser fetch cannot consume manager-owned confirmation](https://github.com/avibe-bot/avibe/pull/1640#discussion_r3835632885),
+and [a terminal response cannot trigger another automatic Runtime request](https://github.com/avibe-bot/avibe/pull/1640#discussion_r3835792302).
+Their resolution on PR #1640 records the split, not discharge of the behavior:
+the successor owns their consuming tests and exact-head close-out together with
+the manager-owned admission constraint above.
+
 **A probe proves only the state it was calibrated for.** The first attempt at the
 fix above reused `_healthy()` exactly as the already-running path calls it: one
 request, `connect=0.5s`, `read=2.0s`, no retry. That budget was chosen for a


### PR DESCRIPTION
## Summary

- record in the PRD the three PR #1640 review threads whose behavior moved rather than being discharged
- retire this branch as a successor placeholder: no automatic request recovery is implemented here

## What this actually lands

Eight lines in `docs/plans/show-runtime-availability.md`, immediately after the paragraph stating that
bounded retry admission must come from a manager-owned signal rather than a browser counter. Docs only,
no code.

This PR was opened as the declared successor to merged PR #1640 — the one PR that would reintroduce the
automatic browser poller and request-level retry record that #1640 deliberately removed. Implementation
never started. Its design dependency, #1637, is frozen behind the managed-runtime install convergence,
and the recorded conclusion for the automatic-recovery mechanism was deletion rather than perfection.
So the placeholder is being retired and only its durable content is landing.

The fuller contract that lived in this description — the five request-owner constraints distilled from
PR #1640's fifth-head review, plus the inherited thread links and the standing ruling that satisfying
them is necessary and not sufficient — now lives on #1637, which owns that design:
https://github.com/avibe-bot/avibe/issues/1637#issuecomment-5419724553

Nothing in this repository referenced this PR.

## Verification

- `git diff --check`
- the eight added lines exist nowhere else on `master`; without this commit the three thread links are
  recoverable only from a closed PR description
