### PR TITLE
docs(memory): defer processing record simplification

### DIFF
--- a/docs/plans/memory-everos-processing-record-followup.md
+++ b/docs/plans/memory-everos-processing-record-followup.md
@@ -1,0 +1,60 @@
+# Deferred EverOS Processing Record simplification
+
+> Status: deferred decision note
+>
+> Revisit only after PR #1651 and its implementation are complete. This document
+> authorizes no change to #1651 or to current product code.
+
+## Decision
+
+EverOS remains a separately supervised process. Avibe owns installation, startup,
+health checks, wakeup, restart, and repair; Memory capture remains best effort and
+may lose data.
+
+After the best-effort writer ships, keep one user-facing **Processing Record** and
+remove **Provider Call Log**.
+
+Processing Record reads authorized EverOS-native data and shows:
+
+- bounded original message text, not only a preview;
+- run/strategy steps, status, timestamps, and errors; and
+- generated Episode, Fact, and Profile content and identifiers.
+
+Avibe does not duplicate that semantic history in its own durable observer store.
+
+Provider Call Log removal includes its recorder, database, provider instrumentation,
+raw request/response bodies, model/token/timing metadata, correlations, and unlinked
+call UI/API.
+
+## Contract
+
+- Processing history may be incomplete or absent after loss, retention, migration,
+  runtime replacement, or EverOS failure.
+- Missing data is `unavailable`, not a complete empty result.
+- Reads remain scope-authorized, bounded, and fail closed.
+- Diagnostic failure never blocks capture or an EverOS call.
+- Clear still deletes legacy call-log data, but new runtime code creates none.
+- This adds no replay, retry, correlation, gap, anomaly, or exactly-once state.
+
+## Sequencing
+
+1. Finish #1651 and its accepted-loss writer implementation.
+2. Re-audit the resulting EverOS data sources, Processing Record UI/API, and code
+   ownership; verify that message text and semantic results are available directly.
+3. Replace this estimate with measured file and test counts.
+4. Implement the removal in a separate PR without changing capture reliability.
+
+## Expected reduction
+
+The pre-implementation estimate is another 3,000-4,500 production lines beyond the
+#1651 simplification, or roughly 11,000-14,000 lines combined from the original
+Memory design. Re-measure after implementation; this estimate is not a target or an
+acceptance gate.
+
+## Acceptance
+
+- A user can inspect what was said, how EverOS processed it, and what semantic
+  result EverOS produced when that native data still exists.
+- No UI or API exposes provider HTTP audit details.
+- Avibe has no durable per-call observer state.
+- EverOS supervision and security boundaries remain intact.


### PR DESCRIPTION
## Changed capability

Adds a 60-line deferred decision note for the post-#1651 Memory simplification. It records the eventual product boundary without changing #1651 or current code: keep an authorized EverOS-native Processing Record with bounded original message text, processing steps, errors, and Episode/Fact/Profile results; remove Provider Call Log and Avibe-side per-call observer storage only after the accepted-loss writer implementation settles.

The note also preserves the remaining invariants: EverOS stays separately supervised, missing history is reported as unavailable, authorization remains fail closed, diagnostics never gate capture, and Clear removes legacy call-log data.

## Affected scenario IDs

None. This PR records a deferred follow-up and does not change a current scenario contract.

## Evidence layers

- unit: none, docs-only
- contract: explicit keep/remove boundary, sequencing, and acceptance criteria
- scenario: none, deferred follow-up only
- lint: `uv run --no-project --with pre-commit pre-commit run --files docs/plans/memory-everos-processing-record-followup.md` (Ruff skipped because no Python changed); `git diff --check` passed
- residual manual checks: re-audit EverOS data sources and re-measure code/test counts after #1651 implementation

## Dependencies

The document can land independently. Any product-code change described by it is deferred until #1651 and its implementation are complete.

## Known-by-design ledger

1. This PR changes no runtime behavior.
2. Memory capture loss remains accepted.
3. Detailed Processing Record means semantic EverOS input/processing/result data, not provider HTTP audit data.
4. The line-count estimate is provisional and must be re-measured after implementation.
