### PR TITLE
fix(model-hub): cover CLIProxyAPI cold starts

### DIFF
--- a/docs/plans/model-hub.md
+++ b/docs/plans/model-hub.md
@@ -1565,12 +1565,13 @@ both health surfaces in 7.4 seconds. It adds bounded cold-start margin without
 claiming an unobserved internal engine phase or introducing a retry loop. If
 readiness is not established, Avibe terminates the child and preserves the
 existing runtime failure contract.
-During that window Avibe continuously drains combined child output to prevent a
-full pipe from blocking startup. It exact-redacts known runtime and upstream
-secrets before bounded tail retention, discards any partial leading line created
-at the remaining pattern-redaction boundary, and emits only a compact, bounded,
-redacted diagnostic to the service log. Raw child output is never persisted by
-the supervisor.
+CLIProxyAPI stdout and stderr are directed to the operating system's null sink
+when the process is created. Child bytes therefore never enter Avibe's Python
+memory or service logs and cannot create pipe backpressure. Startup diagnostics
+contain only bounded supervisor-owned structured fields: outcome, managed
+version, exit code when applicable, elapsed time, readiness budget, and the
+existing error contract. Avibe does not retain, inspect, redact, or publish child
+output.
 
 **v3 routing requires no new engine policy.** Failover is ours, not the engine's: the engine
 runs as a single global instance with its own cooling and request-retry disabled

--- a/docs/plans/model-hub.md
+++ b/docs/plans/model-hub.md
@@ -1557,6 +1557,19 @@ binary): pinned version + SHA256, 127.0.0.1-only listener, random management
 key and gateway token, lifecycle owned by Avibe. Its YAML/auth files/manage
 UI are **not** product surface.
 
+An explicit start has one bounded 30-second readiness budget; it succeeds only
+after both the gateway model endpoint and management config endpoint respond.
+The operational budget is based on local live evidence: the first process was
+still alive when the former 10-second window ended, while the next start reached
+both health surfaces in 7.4 seconds. It adds bounded cold-start margin without
+claiming an unobserved internal engine phase or introducing a retry loop. If
+readiness is not established, Avibe terminates the child and preserves the
+existing runtime failure contract.
+During that window Avibe continuously drains combined child output to prevent a
+full pipe from blocking startup, retains only a bounded tail in memory, and emits
+only a compact, bounded, redacted diagnostic to the service log. Raw child output
+is never persisted by the supervisor.
+
 **v3 routing requires no new engine policy.** Failover is ours, not the engine's: the engine
 runs as a single global instance with its own cooling and request-retry disabled
 (`vibe/model_hub_runtime/config.py`), model prefixes pin the source, and Python

--- a/docs/plans/model-hub.md
+++ b/docs/plans/model-hub.md
@@ -1566,9 +1566,11 @@ claiming an unobserved internal engine phase or introducing a retry loop. If
 readiness is not established, Avibe terminates the child and preserves the
 existing runtime failure contract.
 During that window Avibe continuously drains combined child output to prevent a
-full pipe from blocking startup, retains only a bounded tail in memory, and emits
-only a compact, bounded, redacted diagnostic to the service log. Raw child output
-is never persisted by the supervisor.
+full pipe from blocking startup. It exact-redacts known runtime and upstream
+secrets before bounded tail retention, discards any partial leading line created
+at the remaining pattern-redaction boundary, and emits only a compact, bounded,
+redacted diagnostic to the service log. Raw child output is never persisted by
+the supervisor.
 
 **v3 routing requires no new engine policy.** Failover is ours, not the engine's: the engine
 runs as a single global instance with its own cooling and request-retry disabled

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -139,11 +139,11 @@ scenarios:
     layer: unit
     test: tests/test_model_hub_runtime.py::test_mh_runtime_005_first_cold_start_waits_for_readiness_within_bounded_budget
   - id: MH-RUNTIME-006
-    name: CLIProxyAPI readiness timeout stops the child and leaves bounded redacted diagnostics
+    name: CLIProxyAPI readiness timeout stops the child, discards its output, and leaves bounded structured diagnostics
     status: covered
     kind: timeout_cancel
     layer: unit
-    test: tests/test_model_hub_runtime.py::test_mh_runtime_006_timeout_stops_engine_with_bounded_redacted_diagnostics
+    test: tests/test_model_hub_runtime.py::test_mh_runtime_006_timeout_stops_engine_with_bounded_structured_diagnostics
   - id: MH-USAGE-001
     name: Tokens an upstream reported before the turn ended are still metered
     status: covered

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -132,6 +132,18 @@ scenarios:
     kind: concurrency
     layer: unit
     test: tests/test_opencode_server.py::test_mh_runtime_004_overlay_reservation_promotes_atomically_to_active_run
+  - id: MH-RUNTIME-005
+    name: First CLIProxyAPI cold start remains pending until both health surfaces are ready
+    status: covered
+    kind: recovery
+    layer: unit
+    test: tests/test_model_hub_runtime.py::test_mh_runtime_005_first_cold_start_waits_for_readiness_within_bounded_budget
+  - id: MH-RUNTIME-006
+    name: CLIProxyAPI readiness timeout stops the child and leaves bounded redacted diagnostics
+    status: covered
+    kind: timeout_cancel
+    layer: unit
+    test: tests/test_model_hub_runtime.py::test_mh_runtime_006_timeout_stops_engine_with_bounded_redacted_diagnostics
   - id: MH-USAGE-001
     name: Tokens an upstream reported before the turn ended are still metered
     status: covered

--- a/tests/scenarios/model_hub/observations.yaml
+++ b/tests/scenarios/model_hub/observations.yaml
@@ -28,3 +28,9 @@ observations:
     affects:
       - MH-AC29-001
       - MH-MIG-001
+  - id: MH-OBS-005
+    source: local-incus-cold-start-2026-08-23
+    summary: A first CLIProxyAPI process remained alive when Avibe ended the fixed 10-second readiness window; the next start reached both health surfaces in 7.4 seconds.
+    affects:
+      - MH-RUNTIME-005
+      - MH-RUNTIME-006

--- a/tests/test_model_hub_runtime.py
+++ b/tests/test_model_hub_runtime.py
@@ -57,6 +57,7 @@ from vibe.model_hub_runtime.state import (
 )
 from vibe.model_hub_runtime.supervisor import (
     MODEL_HUB_STARTUP_TIMEOUT_SECONDS,
+    _BoundedStartupOutput,
     EngineSupervisor,
     EngineUnavailableError,
 )
@@ -1337,10 +1338,12 @@ def _write_mock_engine(
     startup_delay: float = 0.0,
     startup_output: str = "",
     echo_runtime_secrets: bool = False,
+    split_runtime_secret_after_ready: bool = False,
 ) -> None:
     script = f"""#!{sys.executable}
 import json
 import sys
+import threading
 import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -1356,7 +1359,14 @@ if startup_output:
     print(startup_output, file=sys.stderr, flush=True)
 if {echo_runtime_secrets!r}:
     print(f'management-key={{management}} gateway-token={{gateway}}', file=sys.stderr, flush=True)
+split_runtime_secret_after_ready = {split_runtime_secret_after_ready!r}
+if split_runtime_secret_after_ready:
+    secret_midpoint = len(management) // 2
+    print(management[:secret_midpoint], end='', file=sys.stderr, flush=True)
+    time.sleep(0.1)
 time.sleep({startup_delay!r})
+health_surfaces = set()
+health_complete = threading.Event()
 
 class Handler(BaseHTTPRequestHandler):
     def log_message(self, *args):
@@ -1372,9 +1382,15 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         if self.path == '/v1/models' and self.headers.get('Authorization') == f'Bearer {{gateway}}':
+            health_surfaces.add('gateway')
+            if len(health_surfaces) == 2:
+                health_complete.set()
             self._json(200, {{'object': 'list', 'data': []}})
             return
         if self.path == '/v0/management/config' and self.headers.get('X-Management-Key') == management:
+            health_surfaces.add('management')
+            if len(health_surfaces) == 2:
+                health_complete.set()
             self._json(200, {{'host': config['host']}})
             return
         if self.path.startswith('/v0/management/auth-files/models'):
@@ -1455,7 +1471,17 @@ class Handler(BaseHTTPRequestHandler):
             return
         self._json(200, {{'id': 'response-1', 'model': payload['model']}})
 
-HTTPServer((config['host'], config['port']), Handler).serve_forever()
+server = HTTPServer((config['host'], config['port']), Handler)
+if split_runtime_secret_after_ready:
+    def finish_secret_output():
+        health_complete.wait()
+        time.sleep(0.75)
+        print(management[secret_midpoint:], file=sys.stderr, flush=True)
+        with open('split-secret-output-complete', 'w', encoding='utf-8') as handle:
+            handle.write('complete')
+
+    threading.Thread(target=finish_secret_output, daemon=True).start()
+server.serve_forever()
 """
     path.write_text(script, encoding="utf-8")
     path.chmod(0o755)
@@ -1505,6 +1531,7 @@ def _fixture_supervisor(
     startup_delay: float = 0.0,
     startup_output: str = "",
     echo_runtime_secrets: bool = False,
+    split_runtime_secret_after_ready: bool = False,
 ) -> tuple[EngineSupervisor, EngineStateStore]:
     tmp_path.mkdir(parents=True, exist_ok=True)
     binary = tmp_path / "mock-engine"
@@ -1513,6 +1540,7 @@ def _fixture_supervisor(
         startup_delay=startup_delay,
         startup_output=startup_output,
         echo_runtime_secrets=echo_runtime_secrets,
+        split_runtime_secret_after_ready=split_runtime_secret_after_ready,
     )
     installer = _FixtureInstaller(binary, tmp_path / "versions" / "install-1")
     store = EngineStateStore(tmp_path / "state")
@@ -1662,22 +1690,73 @@ def test_mh_runtime_005_first_cold_start_waits_for_readiness_within_bounded_budg
 
     assert MODEL_HUB_STARTUP_TIMEOUT_SECONDS == 30.0
     caplog.set_level(logging.INFO, logger="vibe.model_hub_runtime.supervisor")
-    supervisor, _ = _fixture_supervisor(
+    safe_diagnostic = "cold-start phase=loading-runtime " + "safe-context " * 12
+    supervisor, store = _fixture_supervisor(
         tmp_path,
         startup_timeout=3.0,
         startup_delay=0.25,
-        startup_output="cold-start phase=loading-runtime",
+        startup_output=safe_diagnostic,
+        split_runtime_secret_after_ready=True,
     )
 
     started_at = time.monotonic()
     connection = supervisor.ensure_running()
     elapsed = time.monotonic() - started_at
+    runtime_secrets = store.prepare_instance("install-1", rotate=False)[1]
+    secret_midpoint = len(runtime_secrets.management_key) // 2
+    split_output_marker = store.root / "instances" / "install-1" / "split-secret-output-complete"
+    ready_log = next(
+        record.getMessage()
+        for record in caplog.records
+        if "startup outcome=ready" in record.getMessage()
+    )
 
     assert connection.base_url.startswith("http://127.0.0.1:")
     assert 0.2 <= elapsed < 3.0
-    assert "startup outcome=ready" in caplog.text
-    assert "cold-start phase=loading-runtime" in caplog.text
+    assert "cold-start phase=loading-runtime" in ready_log
+    assert runtime_secrets.management_key[:secret_midpoint] not in ready_log
+    assert runtime_secrets.management_key[secret_midpoint:] not in ready_log
+    assert not split_output_marker.exists()
+    marker_deadline = time.monotonic() + 2.0
+    while not split_output_marker.exists() and time.monotonic() < marker_deadline:
+        time.sleep(0.01)
+    assert split_output_marker.read_text(encoding="utf-8") == "complete"
     supervisor.stop()
+
+
+def test_terminal_snapshot_without_observed_eof_discards_unproven_secret_prefix() -> None:
+    """A stopped or joined reader cannot authorize a final flush without pipe EOF."""
+
+    exact_secret = "arbitrary-property-secret-with-two-distinct-halves-0123456789"
+    prefix = exact_secret[: len(exact_secret) // 2].encode()
+    reader_blocked = threading.Event()
+    release_reader = threading.Event()
+
+    class BlockingStream:
+        reads = 0
+
+        def read(self, _size: int) -> bytes:
+            self.reads += 1
+            if self.reads == 1:
+                return prefix
+            reader_blocked.set()
+            release_reader.wait(timeout=2)
+            return b""
+
+    output = _BoundedStartupOutput(
+        BlockingStream(),
+        exact_values=(exact_secret,),
+    )
+    try:
+        assert reader_blocked.wait(timeout=1)
+        output.join(timeout=0.01)
+        tail, _truncated, _partial_line = output.snapshot_terminal()
+    finally:
+        release_reader.set()
+        output.join(timeout=1)
+
+    assert prefix not in tail
+    assert tail == b""
 
 
 def test_mh_runtime_006_timeout_stops_engine_with_bounded_redacted_diagnostics(

--- a/tests/test_model_hub_runtime.py
+++ b/tests/test_model_hub_runtime.py
@@ -57,7 +57,6 @@ from vibe.model_hub_runtime.state import (
 )
 from vibe.model_hub_runtime.supervisor import (
     MODEL_HUB_STARTUP_TIMEOUT_SECONDS,
-    _BoundedStartupOutput,
     EngineSupervisor,
     EngineUnavailableError,
 )
@@ -1336,14 +1335,14 @@ def _write_mock_engine(
     path: Path,
     *,
     startup_delay: float = 0.0,
-    startup_output: str = "",
+    startup_output: bytes = b"",
+    startup_output_repeat: int = 1,
     echo_runtime_secrets: bool = False,
-    split_runtime_secret_after_ready: bool = False,
+    exit_before_ready: int | None = None,
 ) -> None:
     script = f"""#!{sys.executable}
 import json
 import sys
-import threading
 import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -1354,19 +1353,30 @@ with open(config_path, encoding='utf-8') as handle:
     config = yaml.safe_load(handle)
 gateway = config['api-keys'][0]
 management = config['remote-management']['secret-key']
-startup_output = {startup_output!r}
+startup_output = {startup_output!r} * {startup_output_repeat!r}
 if startup_output:
-    print(startup_output, file=sys.stderr, flush=True)
+    sys.stdout.buffer.write(startup_output)
+    sys.stdout.buffer.flush()
+    sys.stderr.buffer.write(startup_output)
+    sys.stderr.buffer.flush()
 if {echo_runtime_secrets!r}:
-    print(f'management-key={{management}} gateway-token={{gateway}}', file=sys.stderr, flush=True)
-split_runtime_secret_after_ready = {split_runtime_secret_after_ready!r}
-if split_runtime_secret_after_ready:
-    secret_midpoint = len(management) // 2
-    print(management[:secret_midpoint], end='', file=sys.stderr, flush=True)
-    time.sleep(0.1)
+    sys.stderr.buffer.write(
+        f'management-key={{management}} gateway-token={{gateway}}'.encode()
+    )
+    sys.stderr.buffer.flush()
+with open('startup-output-complete', 'w', encoding='utf-8') as handle:
+    handle.write(str(len(startup_output) * 2))
+exit_before_ready = {exit_before_ready!r}
+if exit_before_ready is not None:
+    raise SystemExit(exit_before_ready)
 time.sleep({startup_delay!r})
 health_surfaces = set()
-health_complete = threading.Event()
+
+def mark_health_surface(surface):
+    health_surfaces.add(surface)
+    if len(health_surfaces) == 2:
+        with open('health-surfaces-complete', 'w', encoding='utf-8') as handle:
+            handle.write(','.join(sorted(health_surfaces)))
 
 class Handler(BaseHTTPRequestHandler):
     def log_message(self, *args):
@@ -1382,15 +1392,11 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         if self.path == '/v1/models' and self.headers.get('Authorization') == f'Bearer {{gateway}}':
-            health_surfaces.add('gateway')
-            if len(health_surfaces) == 2:
-                health_complete.set()
+            mark_health_surface('gateway')
             self._json(200, {{'object': 'list', 'data': []}})
             return
         if self.path == '/v0/management/config' and self.headers.get('X-Management-Key') == management:
-            health_surfaces.add('management')
-            if len(health_surfaces) == 2:
-                health_complete.set()
+            mark_health_surface('management')
             self._json(200, {{'host': config['host']}})
             return
         if self.path.startswith('/v0/management/auth-files/models'):
@@ -1471,17 +1477,7 @@ class Handler(BaseHTTPRequestHandler):
             return
         self._json(200, {{'id': 'response-1', 'model': payload['model']}})
 
-server = HTTPServer((config['host'], config['port']), Handler)
-if split_runtime_secret_after_ready:
-    def finish_secret_output():
-        health_complete.wait()
-        time.sleep(0.75)
-        print(management[secret_midpoint:], file=sys.stderr, flush=True)
-        with open('split-secret-output-complete', 'w', encoding='utf-8') as handle:
-            handle.write('complete')
-
-    threading.Thread(target=finish_secret_output, daemon=True).start()
-server.serve_forever()
+HTTPServer((config['host'], config['port']), Handler).serve_forever()
 """
     path.write_text(script, encoding="utf-8")
     path.chmod(0o755)
@@ -1529,9 +1525,10 @@ def _fixture_supervisor(
     process_factory=subprocess.Popen,
     startup_timeout: float = 5,
     startup_delay: float = 0.0,
-    startup_output: str = "",
+    startup_output: bytes = b"",
+    startup_output_repeat: int = 1,
     echo_runtime_secrets: bool = False,
-    split_runtime_secret_after_ready: bool = False,
+    exit_before_ready: int | None = None,
 ) -> tuple[EngineSupervisor, EngineStateStore]:
     tmp_path.mkdir(parents=True, exist_ok=True)
     binary = tmp_path / "mock-engine"
@@ -1539,8 +1536,9 @@ def _fixture_supervisor(
         binary,
         startup_delay=startup_delay,
         startup_output=startup_output,
+        startup_output_repeat=startup_output_repeat,
         echo_runtime_secrets=echo_runtime_secrets,
-        split_runtime_secret_after_ready=split_runtime_secret_after_ready,
+        exit_before_ready=exit_before_ready,
     )
     installer = _FixtureInstaller(binary, tmp_path / "versions" / "install-1")
     store = EngineStateStore(tmp_path / "state")
@@ -1647,9 +1645,11 @@ def test_supervisor_starts_checks_health_and_stops_mock_engine(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured_env: dict[str, str] = {}
+    captured_stdio: dict[str, int] = {}
 
     def spawn(*args, **kwargs):
         captured_env.update(kwargs["env"])
+        captured_stdio.update(stdout=kwargs["stdout"], stderr=kwargs["stderr"])
         return subprocess.Popen(*args, **kwargs)
 
     monkeypatch.setenv("MANAGEMENT_PASSWORD", "untrusted-management-secret")
@@ -1668,6 +1668,10 @@ def test_supervisor_starts_checks_health_and_stops_mock_engine(
     assert "GITHUB_TOKEN" not in captured_env
     assert "HTTP_PROXY" not in captured_env
     assert captured_env == engine_subprocess_environment()
+    assert captured_stdio == {
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+    }
     assert supervisor.status()["status"]["health"] == "ok"
     config_path = store.root / "instances" / "install-1" / "config.yaml"
     first_config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
@@ -1682,6 +1686,58 @@ def test_supervisor_starts_checks_health_and_stops_mock_engine(
     supervisor.stop()
 
 
+def _assert_supervisor_owned_startup_log(
+    message: str,
+    *,
+    outcome: str,
+    exit_code: int | None = None,
+    readiness_budget: float | None = None,
+) -> None:
+    prefix = "Model Hub engine startup "
+    assert message.startswith(prefix)
+    tokens = message.removeprefix(prefix).split()
+    assert all("=" in token for token in tokens)
+    fields = dict(token.split("=", 1) for token in tokens)
+    assert len(fields) == len(tokens)
+
+    expected_fields = {
+        "outcome",
+        "managed_version",
+        "elapsed_seconds",
+        "child_output_retained",
+    }
+    if readiness_budget is not None:
+        expected_fields.update({"exit_code", "readiness_budget_seconds"})
+    assert set(fields) == expected_fields
+    assert fields["outcome"] == outcome
+    assert fields["managed_version"] == "v7.2.95"
+    assert float(fields["elapsed_seconds"]) >= 0
+    assert fields["child_output_retained"] == "false"
+    if readiness_budget is not None:
+        assert fields["exit_code"] == str(exit_code)
+        assert float(fields["readiness_budget_seconds"]) == readiness_budget
+    assert len(message.encode("utf-8")) < 512
+
+
+def _assert_child_payload_absent(log_text: str, payload: bytes) -> None:
+    printable_run = bytearray()
+    candidates: list[bytes] = []
+    for byte in payload + b"\x00":
+        if 32 <= byte <= 126:
+            printable_run.append(byte)
+            continue
+        if len(printable_run) >= 8:
+            if len(printable_run) <= 128:
+                candidates.append(bytes(printable_run))
+            else:
+                candidates.extend((bytes(printable_run[:64]), bytes(printable_run[-64:])))
+        printable_run.clear()
+
+    assert candidates
+    assert all(candidate.decode("ascii") not in log_text for candidate in candidates)
+    assert "\ufffd" not in log_text
+
+
 def test_mh_runtime_005_first_cold_start_waits_for_readiness_within_bounded_budget(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
@@ -1690,21 +1746,28 @@ def test_mh_runtime_005_first_cold_start_waits_for_readiness_within_bounded_budg
 
     assert MODEL_HUB_STARTUP_TIMEOUT_SECONDS == 30.0
     caplog.set_level(logging.INFO, logger="vibe.model_hub_runtime.supervisor")
-    safe_diagnostic = "cold-start phase=loading-runtime " + "safe-context " * 12
+    child_payload = b"\n".join(
+        (
+            b"cold-start-safe-diagnostic-marker",
+            b'id_token="opaque-id-token-value"',
+            b'private_key="opaque-private-key-value"',
+            b'future_unknown_auth_material="opaque-unknown-value"',
+            b"binary-boundary-before-\xff\xfe-binary-boundary-after",
+        )
+    )
     supervisor, store = _fixture_supervisor(
         tmp_path,
         startup_timeout=3.0,
         startup_delay=0.25,
-        startup_output=safe_diagnostic,
-        split_runtime_secret_after_ready=True,
+        startup_output=child_payload,
+        echo_runtime_secrets=True,
     )
 
     started_at = time.monotonic()
     connection = supervisor.ensure_running()
     elapsed = time.monotonic() - started_at
     runtime_secrets = store.prepare_instance("install-1", rotate=False)[1]
-    secret_midpoint = len(runtime_secrets.management_key) // 2
-    split_output_marker = store.root / "instances" / "install-1" / "split-secret-output-complete"
+    instance_dir = store.root / "instances" / "install-1"
     ready_log = next(
         record.getMessage()
         for record in caplog.records
@@ -1713,136 +1776,129 @@ def test_mh_runtime_005_first_cold_start_waits_for_readiness_within_bounded_budg
 
     assert connection.base_url.startswith("http://127.0.0.1:")
     assert 0.2 <= elapsed < 3.0
-    assert "cold-start phase=loading-runtime" in ready_log
-    assert runtime_secrets.management_key[:secret_midpoint] not in ready_log
-    assert runtime_secrets.management_key[secret_midpoint:] not in ready_log
-    assert not split_output_marker.exists()
-    marker_deadline = time.monotonic() + 2.0
-    while not split_output_marker.exists() and time.monotonic() < marker_deadline:
-        time.sleep(0.01)
-    assert split_output_marker.read_text(encoding="utf-8") == "complete"
+    _assert_supervisor_owned_startup_log(ready_log, outcome="ready")
+    _assert_child_payload_absent(caplog.text, child_payload)
+    for secret in (runtime_secrets.management_key, runtime_secrets.gateway_token):
+        midpoint = len(secret) // 2
+        assert secret[:midpoint] not in caplog.text
+        assert secret[midpoint:] not in caplog.text
+    assert (instance_dir / "startup-output-complete").read_text(encoding="utf-8") == str(
+        len(child_payload) * 2
+    )
+    assert (instance_dir / "health-surfaces-complete").read_text(encoding="utf-8") == (
+        "gateway,management"
+    )
     supervisor.stop()
 
 
-def test_terminal_snapshot_without_observed_eof_discards_unproven_secret_prefix() -> None:
-    """A stopped or joined reader cannot authorize a final flush without pipe EOF."""
-
-    exact_secret = "arbitrary-property-secret-with-two-distinct-halves-0123456789"
-    prefix = exact_secret[: len(exact_secret) // 2].encode()
-    reader_blocked = threading.Event()
-    release_reader = threading.Event()
-
-    class BlockingStream:
-        reads = 0
-
-        def read(self, _size: int) -> bytes:
-            self.reads += 1
-            if self.reads == 1:
-                return prefix
-            reader_blocked.set()
-            release_reader.wait(timeout=2)
-            return b""
-
-    output = _BoundedStartupOutput(
-        BlockingStream(),
-        exact_values=(exact_secret,),
-    )
-    try:
-        assert reader_blocked.wait(timeout=1)
-        output.join(timeout=0.01)
-        tail, _truncated, _partial_line = output.snapshot_terminal()
-    finally:
-        release_reader.set()
-        output.join(timeout=1)
-
-    assert prefix not in tail
-    assert tail == b""
-
-
-def test_mh_runtime_006_timeout_stops_engine_with_bounded_redacted_diagnostics(
+def test_supervisor_process_exit_discards_all_child_output(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """MH-RUNTIME-006: readiness timeout is terminal, bounded, and safely diagnosable."""
-
+    child_payload = b"\n".join(
+        (
+            b"process-exit-safe-diagnostic-marker",
+            b'id_token="process-exit-oauth-secret"',
+            b'private_key="process-exit-private-key"',
+            b'unknown_field="process-exit-opaque-value"',
+            b"process-exit-binary-before-\xff-process-exit-binary-after",
+        )
+    )
     caplog.set_level(logging.WARNING, logger="vibe.model_hub_runtime.supervisor")
-    boundary_secret = "boundary-secret-" + "z" * 9_000
-    visible_secret = "visible-upstream-test-secret"
-    json_secret = "unprefixed-json-secret"
     supervisor, store = _fixture_supervisor(
         tmp_path,
         startup_timeout=2.0,
-        startup_delay=60.0,
-        startup_output=(
-            f"raw-value={boundary_secret}\n"
-            + "discarded-prefix "
-            + "x" * 12_000
-            + "\n"
-            + f"Authorization: Bearer {visible_secret} api-key={visible_secret}"
-            + f' raw-value={visible_secret} {{"token":"{json_secret}"}} tail-marker'
-        ),
+        startup_output=child_payload,
         echo_runtime_secrets=True,
+        exit_before_ready=23,
     )
-    credential_ref = store.store_api_key(
-        boundary_secret,
-        vendor="custom",
-        protocol="openai_chat",
-        base_url="https://timeout.example.test/v1",
+
+    with pytest.raises(EngineUnavailableError, match="models.engine.health_failed") as exc_info:
+        supervisor.ensure_running()
+
+    runtime_secrets = store.prepare_instance("install-1", rotate=False)[1]
+    instance_dir = store.root / "instances" / "install-1"
+    warning = next(
+        record.getMessage()
+        for record in caplog.records
+        if "startup outcome=process_exit" in record.getMessage()
     )
-    visible_credential_ref = store.store_api_key(
-        visible_secret,
-        vendor="custom",
-        protocol="openai_chat",
-        base_url="https://timeout.example.test/v1",
+    assert exc_info.value.error_key == "models.engine.health_failed"
+    assert supervisor.status()["status"]["health"] == "down"
+    _assert_supervisor_owned_startup_log(
+        warning,
+        outcome="process_exit",
+        exit_code=23,
+        readiness_budget=2.0,
     )
-    store.replace_sources(
-        [
-            SourceRecord(
-                source_id="src_timeout01",
-                vendor="custom",
-                protocol="openai_chat",
-                base_url="https://timeout.example.test/v1",
-                credential_ref=credential_ref,
-                allowed_origins=("codex",),
-                model_ids=("model-a",),
-                prefix="timeout",
-            ),
-            SourceRecord(
-                source_id="src_timeout02",
-                vendor="custom",
-                protocol="openai_chat",
-                base_url="https://timeout.example.test/v1",
-                credential_ref=visible_credential_ref,
-                allowed_origins=("codex",),
-                model_ids=("model-a",),
-                prefix="timeout2",
-            ),
-        ]
+    _assert_child_payload_absent(caplog.text, child_payload)
+    for secret in (runtime_secrets.management_key, runtime_secrets.gateway_token):
+        midpoint = len(secret) // 2
+        assert secret[:midpoint] not in caplog.text
+        assert secret[midpoint:] not in caplog.text
+    assert (instance_dir / "startup-output-complete").read_text(encoding="utf-8") == str(
+        len(child_payload) * 2
+    )
+    assert not (instance_dir / "health-surfaces-complete").exists()
+
+
+def test_mh_runtime_006_timeout_stops_engine_with_bounded_structured_diagnostics(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """MH-RUNTIME-006: readiness timeout is terminal with bounded diagnostics."""
+
+    caplog.set_level(logging.WARNING, logger="vibe.model_hub_runtime.supervisor")
+    child_payload = b"\n".join(
+        (
+            b"timeout-safe-diagnostic-marker",
+            b'id_token="timeout-oauth-secret"',
+            b'private_key="timeout-private-key"',
+            b'future_unknown_field="timeout-opaque-value"',
+            b"oversized-child-output-" + b"x" * 4_096,
+            b"timeout-binary-before-\xff\xfe-timeout-binary-after",
+        )
+    )
+    output_repeat = 256
+    supervisor, store = _fixture_supervisor(
+        tmp_path,
+        startup_timeout=1.0,
+        startup_delay=60.0,
+        startup_output=child_payload,
+        startup_output_repeat=output_repeat,
+        echo_runtime_secrets=True,
     )
 
     started_at = time.monotonic()
-    with pytest.raises(EngineUnavailableError, match="models.engine.health_failed"):
+    with pytest.raises(EngineUnavailableError, match="models.engine.health_failed") as exc_info:
         supervisor.ensure_running()
     elapsed = time.monotonic() - started_at
     runtime_secrets = store.prepare_instance("install-1", rotate=False)[1]
+    instance_dir = store.root / "instances" / "install-1"
     warning = next(
         record.getMessage()
         for record in caplog.records
         if "startup outcome=timeout" in record.getMessage()
     )
 
-    assert elapsed < 3.5
+    assert exc_info.value.error_key == "models.engine.health_failed"
+    assert elapsed < 2.5
     assert supervisor.status()["status"]["health"] == "down"
-    assert "startup_output_truncated=true" in warning
-    assert "tail-marker" in warning
-    assert "[REDACTED]" in warning
-    assert "z" * 64 not in warning
-    assert visible_secret not in warning
-    assert json_secret not in warning
-    assert runtime_secrets.management_key not in warning
-    assert runtime_secrets.gateway_token not in warning
-    assert "discarded-prefix" not in warning
-    assert len(warning.encode("utf-8")) < 5 * 1024
+    _assert_supervisor_owned_startup_log(
+        warning,
+        outcome="timeout",
+        readiness_budget=1.0,
+    )
+    _assert_child_payload_absent(caplog.text, child_payload)
+    for secret in (runtime_secrets.management_key, runtime_secrets.gateway_token):
+        midpoint = len(secret) // 2
+        assert secret[:midpoint] not in caplog.text
+        assert secret[midpoint:] not in caplog.text
+    observed_output_bytes = int(
+        (instance_dir / "startup-output-complete").read_text(encoding="utf-8")
+    )
+    assert observed_output_bytes == len(child_payload) * output_repeat * 2
+    assert observed_output_bytes > 512 * 1024
 
 
 def test_mh_runtime_001_service_restart_reports_installed_engine_as_not_started(

--- a/tests/test_model_hub_runtime.py
+++ b/tests/test_model_hub_runtime.py
@@ -1687,6 +1687,7 @@ def test_mh_runtime_006_timeout_stops_engine_with_bounded_redacted_diagnostics(
     """MH-RUNTIME-006: readiness timeout is terminal, bounded, and safely diagnosable."""
 
     caplog.set_level(logging.WARNING, logger="vibe.model_hub_runtime.supervisor")
+    boundary_secret = "boundary-secret-" + "z" * 9_000
     visible_secret = "visible-upstream-test-secret"
     json_secret = "unprefixed-json-secret"
     supervisor, store = _fixture_supervisor(
@@ -1694,14 +1695,22 @@ def test_mh_runtime_006_timeout_stops_engine_with_bounded_redacted_diagnostics(
         startup_timeout=2.0,
         startup_delay=60.0,
         startup_output=(
-            "discarded-prefix "
+            f"raw-value={boundary_secret}\n"
+            + "discarded-prefix "
             + "x" * 12_000
-            + f" Authorization: Bearer {visible_secret} api-key={visible_secret}"
+            + "\n"
+            + f"Authorization: Bearer {visible_secret} api-key={visible_secret}"
             + f' raw-value={visible_secret} {{"token":"{json_secret}"}} tail-marker'
         ),
         echo_runtime_secrets=True,
     )
     credential_ref = store.store_api_key(
+        boundary_secret,
+        vendor="custom",
+        protocol="openai_chat",
+        base_url="https://timeout.example.test/v1",
+    )
+    visible_credential_ref = store.store_api_key(
         visible_secret,
         vendor="custom",
         protocol="openai_chat",
@@ -1718,7 +1727,17 @@ def test_mh_runtime_006_timeout_stops_engine_with_bounded_redacted_diagnostics(
                 allowed_origins=("codex",),
                 model_ids=("model-a",),
                 prefix="timeout",
-            )
+            ),
+            SourceRecord(
+                source_id="src_timeout02",
+                vendor="custom",
+                protocol="openai_chat",
+                base_url="https://timeout.example.test/v1",
+                credential_ref=visible_credential_ref,
+                allowed_origins=("codex",),
+                model_ids=("model-a",),
+                prefix="timeout2",
+            ),
         ]
     )
 
@@ -1738,6 +1757,7 @@ def test_mh_runtime_006_timeout_stops_engine_with_bounded_redacted_diagnostics(
     assert "startup_output_truncated=true" in warning
     assert "tail-marker" in warning
     assert "[REDACTED]" in warning
+    assert "z" * 64 not in warning
     assert visible_secret not in warning
     assert json_secret not in warning
     assert runtime_secrets.management_key not in warning

--- a/tests/test_model_hub_runtime.py
+++ b/tests/test_model_hub_runtime.py
@@ -55,7 +55,11 @@ from vibe.model_hub_runtime.state import (
     EngineStateStore,
     SourceRecord,
 )
-from vibe.model_hub_runtime.supervisor import EngineSupervisor, EngineUnavailableError
+from vibe.model_hub_runtime.supervisor import (
+    MODEL_HUB_STARTUP_TIMEOUT_SECONDS,
+    EngineSupervisor,
+    EngineUnavailableError,
+)
 
 
 MODEL_HUB_FIXTURES = Path(__file__).parent / "fixtures" / "model_hub"
@@ -1327,7 +1331,13 @@ def test_adapter_provisions_probes_and_revokes_credential(tmp_path: Path) -> Non
         asyncio.run(run(base_url, handler))
 
 
-def _write_mock_engine(path: Path) -> None:
+def _write_mock_engine(
+    path: Path,
+    *,
+    startup_delay: float = 0.0,
+    startup_output: str = "",
+    echo_runtime_secrets: bool = False,
+) -> None:
     script = f"""#!{sys.executable}
 import json
 import sys
@@ -1341,6 +1351,12 @@ with open(config_path, encoding='utf-8') as handle:
     config = yaml.safe_load(handle)
 gateway = config['api-keys'][0]
 management = config['remote-management']['secret-key']
+startup_output = {startup_output!r}
+if startup_output:
+    print(startup_output, file=sys.stderr, flush=True)
+if {echo_runtime_secrets!r}:
+    print(f'management-key={{management}} gateway-token={{gateway}}', file=sys.stderr, flush=True)
+time.sleep({startup_delay!r})
 
 class Handler(BaseHTTPRequestHandler):
     def log_message(self, *args):
@@ -1485,17 +1501,26 @@ def _fixture_supervisor(
     tmp_path: Path,
     *,
     process_factory=subprocess.Popen,
+    startup_timeout: float = 5,
+    startup_delay: float = 0.0,
+    startup_output: str = "",
+    echo_runtime_secrets: bool = False,
 ) -> tuple[EngineSupervisor, EngineStateStore]:
     tmp_path.mkdir(parents=True, exist_ok=True)
     binary = tmp_path / "mock-engine"
-    _write_mock_engine(binary)
+    _write_mock_engine(
+        binary,
+        startup_delay=startup_delay,
+        startup_output=startup_output,
+        echo_runtime_secrets=echo_runtime_secrets,
+    )
     installer = _FixtureInstaller(binary, tmp_path / "versions" / "install-1")
     store = EngineStateStore(tmp_path / "state")
     return (
         EngineSupervisor(
             installer=installer,
             state_store=store,
-            startup_timeout=5,
+            startup_timeout=startup_timeout,
             process_factory=process_factory,
         ),
         store,
@@ -1627,6 +1652,98 @@ def test_supervisor_starts_checks_health_and_stops_mock_engine(
     assert second.gateway_token == first.gateway_token
     assert second.management_key == first.management_key
     supervisor.stop()
+
+
+def test_mh_runtime_005_first_cold_start_waits_for_readiness_within_bounded_budget(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """MH-RUNTIME-005: first cold start waits past an early probe and becomes ready."""
+
+    assert MODEL_HUB_STARTUP_TIMEOUT_SECONDS == 30.0
+    caplog.set_level(logging.INFO, logger="vibe.model_hub_runtime.supervisor")
+    supervisor, _ = _fixture_supervisor(
+        tmp_path,
+        startup_timeout=3.0,
+        startup_delay=0.25,
+        startup_output="cold-start phase=loading-runtime",
+    )
+
+    started_at = time.monotonic()
+    connection = supervisor.ensure_running()
+    elapsed = time.monotonic() - started_at
+
+    assert connection.base_url.startswith("http://127.0.0.1:")
+    assert 0.2 <= elapsed < 3.0
+    assert "startup outcome=ready" in caplog.text
+    assert "cold-start phase=loading-runtime" in caplog.text
+    supervisor.stop()
+
+
+def test_mh_runtime_006_timeout_stops_engine_with_bounded_redacted_diagnostics(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """MH-RUNTIME-006: readiness timeout is terminal, bounded, and safely diagnosable."""
+
+    caplog.set_level(logging.WARNING, logger="vibe.model_hub_runtime.supervisor")
+    visible_secret = "visible-upstream-test-secret"
+    json_secret = "unprefixed-json-secret"
+    supervisor, store = _fixture_supervisor(
+        tmp_path,
+        startup_timeout=2.0,
+        startup_delay=60.0,
+        startup_output=(
+            "discarded-prefix "
+            + "x" * 12_000
+            + f" Authorization: Bearer {visible_secret} api-key={visible_secret}"
+            + f' raw-value={visible_secret} {{"token":"{json_secret}"}} tail-marker'
+        ),
+        echo_runtime_secrets=True,
+    )
+    credential_ref = store.store_api_key(
+        visible_secret,
+        vendor="custom",
+        protocol="openai_chat",
+        base_url="https://timeout.example.test/v1",
+    )
+    store.replace_sources(
+        [
+            SourceRecord(
+                source_id="src_timeout01",
+                vendor="custom",
+                protocol="openai_chat",
+                base_url="https://timeout.example.test/v1",
+                credential_ref=credential_ref,
+                allowed_origins=("codex",),
+                model_ids=("model-a",),
+                prefix="timeout",
+            )
+        ]
+    )
+
+    started_at = time.monotonic()
+    with pytest.raises(EngineUnavailableError, match="models.engine.health_failed"):
+        supervisor.ensure_running()
+    elapsed = time.monotonic() - started_at
+    runtime_secrets = store.prepare_instance("install-1", rotate=False)[1]
+    warning = next(
+        record.getMessage()
+        for record in caplog.records
+        if "startup outcome=timeout" in record.getMessage()
+    )
+
+    assert elapsed < 3.5
+    assert supervisor.status()["status"]["health"] == "down"
+    assert "startup_output_truncated=true" in warning
+    assert "tail-marker" in warning
+    assert "[REDACTED]" in warning
+    assert visible_secret not in warning
+    assert json_secret not in warning
+    assert runtime_secrets.management_key not in warning
+    assert runtime_secrets.gateway_token not in warning
+    assert "discarded-prefix" not in warning
+    assert len(warning.encode("utf-8")) < 5 * 1024
 
 
 def test_mh_runtime_001_service_restart_reports_installed_engine_as_not_started(

--- a/vibe/model_hub_runtime/supervisor.py
+++ b/vibe/model_hub_runtime/supervisor.py
@@ -109,6 +109,7 @@ class _BoundedStartupOutput:
         self._source_exceeded_limit = False
         self._tail_truncated = False
         self._retaining = True
+        self._eof_observed = False
         self._lock = threading.Lock()
         self._thread = threading.Thread(
             target=self._drain,
@@ -123,6 +124,10 @@ class _BoundedStartupOutput:
             while True:
                 chunk = reader(4096)
                 if not chunk:
+                    with self._lock:
+                        self._eof_observed = True
+                        if self._retaining:
+                            self._flush_pending_locked(final=True)
                     return
                 if not isinstance(chunk, bytes):
                     chunk = str(chunk).encode("utf-8", "replace")
@@ -156,15 +161,29 @@ class _BoundedStartupOutput:
             self._tail_truncated = True
         self._tail.extend(redacted)
 
-    def snapshot(self) -> tuple[bytes, bool, bool]:
+    def snapshot_live(self) -> tuple[bytes, bool, bool]:
+        """Freeze a live stream without publishing unproven overlap bytes."""
+
         with self._lock:
-            self._flush_pending_locked(final=True)
+            self._pending.clear()
             self._retaining = False
-            return (
-                bytes(self._tail),
-                self._source_exceeded_limit or self._tail_truncated,
-                self._tail_truncated,
-            )
+            return self._snapshot_locked()
+
+    def snapshot_terminal(self) -> tuple[bytes, bool, bool]:
+        """Freeze a stopped stream; only the drain may commit bytes at EOF."""
+
+        with self._lock:
+            if not self._eof_observed:
+                self._pending.clear()
+            self._retaining = False
+            return self._snapshot_locked()
+
+    def _snapshot_locked(self) -> tuple[bytes, bool, bool]:
+        return (
+            bytes(self._tail),
+            self._source_exceeded_limit or self._tail_truncated,
+            self._tail_truncated,
+        )
 
     def join(self, timeout: float = 1.0) -> None:
         self._thread.join(timeout=timeout)
@@ -412,7 +431,7 @@ class EngineSupervisor:
                     self._stop_locked()
                     raise EngineUnavailableError("models.engine.unsafe_permissions") from exc
                 self._last_check = _utc_now()
-                raw_output, output_truncated, partial_line = output.snapshot()
+                raw_output, output_truncated, partial_line = output.snapshot_live()
                 diagnostic, output_truncated = _sanitize_startup_output(
                     raw_output,
                     exact_values=startup_redaction_values,
@@ -430,7 +449,7 @@ class EngineSupervisor:
                 return connection
             time.sleep(min(_STARTUP_POLL_INTERVAL_SECONDS, max(0.0, deadline - time.monotonic())))
         self._stop_locked()
-        raw_output, output_truncated, partial_line = output.snapshot()
+        raw_output, output_truncated, partial_line = output.snapshot_terminal()
         diagnostic, output_truncated = _sanitize_startup_output(
             raw_output,
             exact_values=startup_redaction_values,

--- a/vibe/model_hub_runtime/supervisor.py
+++ b/vibe/model_hub_runtime/supervisor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import atexit
 import logging
+import re
 import signal
 import socket
 import subprocess
@@ -23,6 +24,95 @@ from vibe.model_hub_runtime.state import EngineStateStore
 logger = logging.getLogger(__name__)
 
 
+MODEL_HUB_STARTUP_TIMEOUT_SECONDS = 30.0
+_STARTUP_OUTPUT_TAIL_BYTES = 8 * 1024
+_STARTUP_LOG_BYTES = 4 * 1024
+_STARTUP_POLL_INTERVAL_SECONDS = 0.05
+_REDACTED = "[REDACTED]"
+_STARTUP_SECRET_RE = re.compile(
+    r"(?i)([\"']?\b(?:api[-_ ]?keys?|access[-_ ]?token|auth[-_ ]?token|refresh[-_ ]?token|"
+    r"gateway[-_ ]?token|management[-_ ]?(?:key|secret)|authorization|password|"
+    r"secret(?:[-_ ]?key)?|token)\b[\"']?\s*[:=]\s*)"
+    r"(?:bearer\s+)?(?:\[[^\]\r\n]*\]|\"[^\"\r\n]*\"|'[^'\r\n]*'|[^\s,;]+)"
+)
+_STARTUP_BEARER_RE = re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+")
+_STARTUP_QUERY_SECRET_RE = re.compile(
+    r"(?i)([?&](?:api[-_]?key|access[-_]?token|refresh[-_]?token|password|secret|token)=)[^&\s]+"
+)
+_STARTUP_PREFIXED_KEY_RE = re.compile(
+    r"(?<![A-Za-z0-9])(?:sk|rk|pk|api)-[A-Za-z0-9_-]{8,}"
+)
+
+
+class _BoundedStartupOutput:
+    """Drain a child pipe continuously while retaining only its startup tail."""
+
+    def __init__(self, stream: Any, *, limit: int = _STARTUP_OUTPUT_TAIL_BYTES) -> None:
+        self._stream = stream
+        self._limit = limit
+        self._tail = bytearray()
+        self._truncated = False
+        self._retaining = True
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(
+            target=self._drain,
+            name="model-hub-startup-output",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def _drain(self) -> None:
+        try:
+            reader = getattr(self._stream, "read1", self._stream.read)
+            while True:
+                chunk = reader(4096)
+                if not chunk:
+                    return
+                if not isinstance(chunk, bytes):
+                    chunk = str(chunk).encode("utf-8", "replace")
+                with self._lock:
+                    if not self._retaining:
+                        continue
+                    overflow = len(self._tail) + len(chunk) - self._limit
+                    if overflow > 0:
+                        del self._tail[:overflow]
+                        self._truncated = True
+                    self._tail.extend(chunk)
+        except Exception:
+            logger.debug("Model Hub startup output drain stopped")
+
+    def snapshot(self) -> tuple[bytes, bool]:
+        with self._lock:
+            self._retaining = False
+            return bytes(self._tail), self._truncated
+
+    def join(self, timeout: float = 1.0) -> None:
+        self._thread.join(timeout=timeout)
+
+
+def _sanitize_startup_output(
+    raw: bytes,
+    *,
+    exact_values: tuple[str, ...],
+    truncated: bool,
+) -> tuple[str, bool]:
+    text = raw.decode("utf-8", "replace")
+    text = "".join(character if character.isprintable() or character.isspace() else " " for character in text)
+    for value in sorted((item for item in exact_values if item), key=len, reverse=True):
+        text = text.replace(value, _REDACTED)
+    text = _STARTUP_SECRET_RE.sub(lambda match: match.group(1) + _REDACTED, text)
+    text = _STARTUP_BEARER_RE.sub("Bearer " + _REDACTED, text)
+    text = _STARTUP_QUERY_SECRET_RE.sub(lambda match: match.group(1) + _REDACTED, text)
+    text = _STARTUP_PREFIXED_KEY_RE.sub(_REDACTED, text)
+    compact = " ".join(text.split())
+    encoded = compact.encode("utf-8")
+    if len(encoded) > _STARTUP_LOG_BYTES:
+        encoded = encoded[-_STARTUP_LOG_BYTES:]
+        compact = encoded.decode("utf-8", "ignore")
+        truncated = True
+    return compact or "<none>", truncated
+
+
 class EngineUnavailableError(RuntimeError):
     """The Hub path is unavailable; callers may use explicitly configured Direct mode."""
 
@@ -41,7 +131,7 @@ class EngineSupervisor:
         *,
         installer: EngineRuntimeManager | Any | None = None,
         state_store: EngineStateStore | None = None,
-        startup_timeout: float = 10.0,
+        startup_timeout: float = MODEL_HUB_STARTUP_TIMEOUT_SECONDS,
         process_factory: Callable[..., subprocess.Popen[bytes]] = subprocess.Popen,
         port_allocator: Callable[[], int] | None = None,
     ) -> None:
@@ -53,6 +143,7 @@ class EngineSupervisor:
         self._lock = threading.RLock()
         self._process: subprocess.Popen[bytes] | None = None
         self._connection: EngineConnection | None = None
+        self._startup_output: _BoundedStartupOutput | None = None
         self._last_check: str | None = None
         self._start_attempted = False
 
@@ -166,14 +257,29 @@ class EngineSupervisor:
         )
         port = self._port_allocator()
         config_path = instance_dir / "config.yaml"
+        sources = self.state_store.list_sources()
+        upstream_api_keys = tuple(
+            value
+            for source in sources
+            for value in (self.state_store.credential_metadata(source.credential_ref).get("value"),)
+            if isinstance(value, str) and value
+        )
         write_engine_config(
             config_path,
             host="127.0.0.1",
             port=port,
             auth_dir=self.state_store.auth_dir,
             runtime_secrets=runtime_secrets,
-            sources=self.state_store.list_sources(),
+            sources=sources,
             state_store=self.state_store,
+        )
+        startup_redaction_values = (
+            runtime_secrets.management_key,
+            runtime_secrets.gateway_token,
+            *upstream_api_keys,
+            str(binary),
+            str(instance_dir),
+            str(config_path),
         )
         connection = EngineConnection(
             base_url=f"http://127.0.0.1:{port}",
@@ -186,8 +292,8 @@ class EngineSupervisor:
                 cwd=instance_dir,
                 env=engine_subprocess_environment(),
                 stdin=subprocess.DEVNULL,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
                 umask=0o077,
                 **isolated_subprocess_kwargs(),
             )
@@ -195,11 +301,22 @@ class EngineSupervisor:
             raise EngineUnavailableError("models.engine.start_failed") from exc
         self._process = process
         self._connection = connection
-        deadline = time.monotonic() + self.startup_timeout
-        client = EngineClient(connection, timeout=1.0)
-        while time.monotonic() < deadline:
-            if process.poll() is not None:
+        if process.stdout is None:
+            self._stop_locked()
+            raise EngineUnavailableError("models.engine.start_failed")
+        output = _BoundedStartupOutput(process.stdout)
+        self._startup_output = output
+        started_at = time.monotonic()
+        deadline = started_at + self.startup_timeout
+        exit_code: int | None = None
+        while True:
+            exit_code = process.poll()
+            if exit_code is not None:
                 break
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            client = EngineClient(connection, timeout=min(1.0, remaining / 2))
             if client.health():
                 try:
                     self.state_store.audit_auth_permissions()
@@ -207,13 +324,41 @@ class EngineSupervisor:
                     self._stop_locked()
                     raise EngineUnavailableError("models.engine.unsafe_permissions") from exc
                 self._last_check = _utc_now()
+                raw_output, output_truncated = output.snapshot()
+                diagnostic, output_truncated = _sanitize_startup_output(
+                    raw_output,
+                    exact_values=startup_redaction_values,
+                    truncated=output_truncated,
+                )
                 logger.info(
-                    "Model Hub engine started on 127.0.0.1 with managed version %s",
+                    "Model Hub engine startup outcome=ready managed_version=%s "
+                    "elapsed_seconds=%.3f startup_output_truncated=%s startup_output=%s",
                     managed.get("version"),
+                    time.monotonic() - started_at,
+                    str(output_truncated).lower(),
+                    diagnostic,
                 )
                 return connection
-            time.sleep(0.05)
+            time.sleep(min(_STARTUP_POLL_INTERVAL_SECONDS, max(0.0, deadline - time.monotonic())))
         self._stop_locked()
+        raw_output, output_truncated = output.snapshot()
+        diagnostic, output_truncated = _sanitize_startup_output(
+            raw_output,
+            exact_values=startup_redaction_values,
+            truncated=output_truncated,
+        )
+        logger.warning(
+            "Model Hub engine startup outcome=%s managed_version=%s exit_code=%s "
+            "elapsed_seconds=%.3f readiness_budget_seconds=%.3f "
+            "startup_output_truncated=%s startup_output=%s",
+            "process_exit" if exit_code is not None else "timeout",
+            managed.get("version"),
+            exit_code,
+            time.monotonic() - started_at,
+            self.startup_timeout,
+            str(output_truncated).lower(),
+            diagnostic,
+        )
         raise EngineUnavailableError("models.engine.health_failed")
 
     def _healthy_locked(self) -> bool:
@@ -228,16 +373,24 @@ class EngineSupervisor:
 
     def _stop_locked(self) -> None:
         process = self._process
+        output = self._startup_output
         self._process = None
         self._connection = None
+        self._startup_output = None
         if process is None or process.poll() is not None:
+            if output is not None:
+                output.join()
             return
-        signal_process_tree(process, signal.SIGTERM, logger, "Model Hub engine")
         try:
-            process.wait(timeout=3)
-        except subprocess.TimeoutExpired:
-            signal_process_tree(process, KILL_SIGNAL, logger, "Model Hub engine")
-            process.wait(timeout=3)
+            signal_process_tree(process, signal.SIGTERM, logger, "Model Hub engine")
+            try:
+                process.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                signal_process_tree(process, KILL_SIGNAL, logger, "Model Hub engine")
+                process.wait(timeout=3)
+        finally:
+            if output is not None:
+                output.join()
 
 
 def _allocate_loopback_port() -> int:

--- a/vibe/model_hub_runtime/supervisor.py
+++ b/vibe/model_hub_runtime/supervisor.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import atexit
 import logging
-import re
 import signal
 import socket
 import subprocess
@@ -25,196 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 MODEL_HUB_STARTUP_TIMEOUT_SECONDS = 30.0
-_STARTUP_OUTPUT_TAIL_BYTES = 8 * 1024
-_STARTUP_LOG_BYTES = 4 * 1024
 _STARTUP_POLL_INTERVAL_SECONDS = 0.05
-_REDACTED = "[REDACTED]"
-_STARTUP_SECRET_RE = re.compile(
-    r"(?i)([\"']?\b(?:api[-_ ]?keys?|access[-_ ]?token|auth[-_ ]?token|refresh[-_ ]?token|"
-    r"gateway[-_ ]?token|management[-_ ]?(?:key|secret)|authorization|password|"
-    r"secret(?:[-_ ]?key)?|token)\b[\"']?\s*[:=]\s*)"
-    r"(?:bearer\s+)?(?:\[[^\]\r\n]*\]|\"[^\"\r\n]*\"|'[^'\r\n]*'|[^\s,;]+)"
-)
-_STARTUP_BEARER_RE = re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+")
-_STARTUP_QUERY_SECRET_RE = re.compile(
-    r"(?i)([?&](?:api[-_]?key|access[-_]?token|refresh[-_]?token|password|secret|token)=)[^&\s]+"
-)
-_STARTUP_PREFIXED_KEY_RE = re.compile(
-    r"(?<![A-Za-z0-9])(?:sk|rk|pk|api)-[A-Za-z0-9_-]{8,}"
-)
-_REDACTED_BYTES = _REDACTED.encode("ascii")
-
-
-def _redact_exact_prefix(
-    data: bytes,
-    safe_length: int,
-    exact_values: tuple[bytes, ...],
-) -> tuple[bytes, bytes]:
-    if not exact_values:
-        return data[:safe_length], data[safe_length:]
-    spans: list[tuple[int, int]] = []
-    for value in exact_values:
-        search_from = 0
-        while True:
-            position = data.find(value, search_from)
-            if position < 0 or position >= safe_length:
-                break
-            spans.append((position, position + len(value)))
-            search_from = position + 1
-    if not spans:
-        return data[:safe_length], data[safe_length:]
-    spans.sort()
-    merged_spans: list[tuple[int, int]] = []
-    for start, end in spans:
-        if merged_spans and start <= merged_spans[-1][1]:
-            previous_start, previous_end = merged_spans[-1]
-            merged_spans[-1] = (previous_start, max(previous_end, end))
-        else:
-            merged_spans.append((start, end))
-    redacted = bytearray()
-    cursor = 0
-    for start, end in merged_spans:
-        redacted.extend(data[cursor:start])
-        redacted.extend(_REDACTED_BYTES)
-        cursor = end
-    if cursor < safe_length:
-        redacted.extend(data[cursor:safe_length])
-        cursor = safe_length
-    return bytes(redacted), data[cursor:]
-
-
-class _BoundedStartupOutput:
-    """Drain a child pipe while retaining an exact-redacted startup tail."""
-
-    def __init__(
-        self,
-        stream: Any,
-        *,
-        exact_values: tuple[str, ...],
-        limit: int = _STARTUP_OUTPUT_TAIL_BYTES,
-    ) -> None:
-        self._stream = stream
-        self._limit = limit
-        self._exact_values = tuple(
-            sorted(
-                {value.encode("utf-8") for value in exact_values if value},
-                key=len,
-                reverse=True,
-            )
-        )
-        self._overlap = max((len(value) for value in self._exact_values), default=1) - 1
-        self._pending = bytearray()
-        self._tail = bytearray()
-        self._observed_bytes = 0
-        self._source_exceeded_limit = False
-        self._tail_truncated = False
-        self._retaining = True
-        self._eof_observed = False
-        self._lock = threading.Lock()
-        self._thread = threading.Thread(
-            target=self._drain,
-            name="model-hub-startup-output",
-            daemon=True,
-        )
-        self._thread.start()
-
-    def _drain(self) -> None:
-        try:
-            reader = getattr(self._stream, "read1", self._stream.read)
-            while True:
-                chunk = reader(4096)
-                if not chunk:
-                    with self._lock:
-                        self._eof_observed = True
-                        if self._retaining:
-                            self._flush_pending_locked(final=True)
-                    return
-                if not isinstance(chunk, bytes):
-                    chunk = str(chunk).encode("utf-8", "replace")
-                with self._lock:
-                    if not self._retaining:
-                        continue
-                    self._observed_bytes += len(chunk)
-                    self._source_exceeded_limit = self._observed_bytes > self._limit
-                    self._pending.extend(chunk)
-                    self._flush_pending_locked(final=False)
-        except Exception:
-            logger.debug("Model Hub startup output drain stopped")
-
-    def _flush_pending_locked(self, *, final: bool) -> None:
-        safe_length = (
-            len(self._pending)
-            if final
-            else max(0, len(self._pending) - self._overlap)
-        )
-        if safe_length == 0:
-            return
-        redacted, pending = _redact_exact_prefix(
-            bytes(self._pending),
-            safe_length,
-            self._exact_values,
-        )
-        self._pending = bytearray(pending)
-        overflow = len(self._tail) + len(redacted) - self._limit
-        if overflow > 0:
-            del self._tail[:overflow]
-            self._tail_truncated = True
-        self._tail.extend(redacted)
-
-    def snapshot_live(self) -> tuple[bytes, bool, bool]:
-        """Freeze a live stream without publishing unproven overlap bytes."""
-
-        with self._lock:
-            self._pending.clear()
-            self._retaining = False
-            return self._snapshot_locked()
-
-    def snapshot_terminal(self) -> tuple[bytes, bool, bool]:
-        """Freeze a stopped stream; only the drain may commit bytes at EOF."""
-
-        with self._lock:
-            if not self._eof_observed:
-                self._pending.clear()
-            self._retaining = False
-            return self._snapshot_locked()
-
-    def _snapshot_locked(self) -> tuple[bytes, bool, bool]:
-        return (
-            bytes(self._tail),
-            self._source_exceeded_limit or self._tail_truncated,
-            self._tail_truncated,
-        )
-
-    def join(self, timeout: float = 1.0) -> None:
-        self._thread.join(timeout=timeout)
-
-
-def _sanitize_startup_output(
-    raw: bytes,
-    *,
-    exact_values: tuple[str, ...],
-    truncated: bool,
-    partial_line: bool,
-) -> tuple[str, bool]:
-    if partial_line:
-        _partial_line, separator, raw = raw.partition(b"\n")
-        if not separator:
-            raw = b""
-    text = raw.decode("utf-8", "replace")
-    text = "".join(character if character.isprintable() or character.isspace() else " " for character in text)
-    for value in sorted((item for item in exact_values if item), key=len, reverse=True):
-        text = text.replace(value, _REDACTED)
-    text = _STARTUP_SECRET_RE.sub(lambda match: match.group(1) + _REDACTED, text)
-    text = _STARTUP_BEARER_RE.sub("Bearer " + _REDACTED, text)
-    text = _STARTUP_QUERY_SECRET_RE.sub(lambda match: match.group(1) + _REDACTED, text)
-    text = _STARTUP_PREFIXED_KEY_RE.sub(_REDACTED, text)
-    compact = " ".join(text.split())
-    encoded = compact.encode("utf-8")
-    if len(encoded) > _STARTUP_LOG_BYTES:
-        encoded = encoded[-_STARTUP_LOG_BYTES:]
-        compact = encoded.decode("utf-8", "ignore")
-        truncated = True
-    return compact or "<none>", truncated
 
 
 class EngineUnavailableError(RuntimeError):
@@ -247,7 +57,6 @@ class EngineSupervisor:
         self._lock = threading.RLock()
         self._process: subprocess.Popen[bytes] | None = None
         self._connection: EngineConnection | None = None
-        self._startup_output: _BoundedStartupOutput | None = None
         self._last_check: str | None = None
         self._start_attempted = False
 
@@ -361,29 +170,14 @@ class EngineSupervisor:
         )
         port = self._port_allocator()
         config_path = instance_dir / "config.yaml"
-        sources = self.state_store.list_sources()
-        upstream_api_keys = tuple(
-            value
-            for source in sources
-            for value in (self.state_store.credential_metadata(source.credential_ref).get("value"),)
-            if isinstance(value, str) and value
-        )
         write_engine_config(
             config_path,
             host="127.0.0.1",
             port=port,
             auth_dir=self.state_store.auth_dir,
             runtime_secrets=runtime_secrets,
-            sources=sources,
+            sources=self.state_store.list_sources(),
             state_store=self.state_store,
-        )
-        startup_redaction_values = (
-            runtime_secrets.management_key,
-            runtime_secrets.gateway_token,
-            *upstream_api_keys,
-            str(binary),
-            str(instance_dir),
-            str(config_path),
         )
         connection = EngineConnection(
             base_url=f"http://127.0.0.1:{port}",
@@ -396,8 +190,8 @@ class EngineSupervisor:
                 cwd=instance_dir,
                 env=engine_subprocess_environment(),
                 stdin=subprocess.DEVNULL,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
                 umask=0o077,
                 **isolated_subprocess_kwargs(),
             )
@@ -405,14 +199,6 @@ class EngineSupervisor:
             raise EngineUnavailableError("models.engine.start_failed") from exc
         self._process = process
         self._connection = connection
-        if process.stdout is None:
-            self._stop_locked()
-            raise EngineUnavailableError("models.engine.start_failed")
-        output = _BoundedStartupOutput(
-            process.stdout,
-            exact_values=startup_redaction_values,
-        )
-        self._startup_output = output
         started_at = time.monotonic()
         deadline = started_at + self.startup_timeout
         exit_code: int | None = None
@@ -431,42 +217,24 @@ class EngineSupervisor:
                     self._stop_locked()
                     raise EngineUnavailableError("models.engine.unsafe_permissions") from exc
                 self._last_check = _utc_now()
-                raw_output, output_truncated, partial_line = output.snapshot_live()
-                diagnostic, output_truncated = _sanitize_startup_output(
-                    raw_output,
-                    exact_values=startup_redaction_values,
-                    truncated=output_truncated,
-                    partial_line=partial_line,
-                )
                 logger.info(
                     "Model Hub engine startup outcome=ready managed_version=%s "
-                    "elapsed_seconds=%.3f startup_output_truncated=%s startup_output=%s",
+                    "elapsed_seconds=%.3f child_output_retained=false",
                     managed.get("version"),
                     time.monotonic() - started_at,
-                    str(output_truncated).lower(),
-                    diagnostic,
                 )
                 return connection
             time.sleep(min(_STARTUP_POLL_INTERVAL_SECONDS, max(0.0, deadline - time.monotonic())))
         self._stop_locked()
-        raw_output, output_truncated, partial_line = output.snapshot_terminal()
-        diagnostic, output_truncated = _sanitize_startup_output(
-            raw_output,
-            exact_values=startup_redaction_values,
-            truncated=output_truncated,
-            partial_line=partial_line,
-        )
         logger.warning(
             "Model Hub engine startup outcome=%s managed_version=%s exit_code=%s "
             "elapsed_seconds=%.3f readiness_budget_seconds=%.3f "
-            "startup_output_truncated=%s startup_output=%s",
+            "child_output_retained=false",
             "process_exit" if exit_code is not None else "timeout",
             managed.get("version"),
             exit_code,
             time.monotonic() - started_at,
             self.startup_timeout,
-            str(output_truncated).lower(),
-            diagnostic,
         )
         raise EngineUnavailableError("models.engine.health_failed")
 
@@ -482,24 +250,16 @@ class EngineSupervisor:
 
     def _stop_locked(self) -> None:
         process = self._process
-        output = self._startup_output
         self._process = None
         self._connection = None
-        self._startup_output = None
         if process is None or process.poll() is not None:
-            if output is not None:
-                output.join()
             return
+        signal_process_tree(process, signal.SIGTERM, logger, "Model Hub engine")
         try:
-            signal_process_tree(process, signal.SIGTERM, logger, "Model Hub engine")
-            try:
-                process.wait(timeout=3)
-            except subprocess.TimeoutExpired:
-                signal_process_tree(process, KILL_SIGNAL, logger, "Model Hub engine")
-                process.wait(timeout=3)
-        finally:
-            if output is not None:
-                output.join()
+            process.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            signal_process_tree(process, KILL_SIGNAL, logger, "Model Hub engine")
+            process.wait(timeout=3)
 
 
 def _allocate_loopback_port() -> int:

--- a/vibe/model_hub_runtime/supervisor.py
+++ b/vibe/model_hub_runtime/supervisor.py
@@ -42,16 +42,72 @@ _STARTUP_QUERY_SECRET_RE = re.compile(
 _STARTUP_PREFIXED_KEY_RE = re.compile(
     r"(?<![A-Za-z0-9])(?:sk|rk|pk|api)-[A-Za-z0-9_-]{8,}"
 )
+_REDACTED_BYTES = _REDACTED.encode("ascii")
+
+
+def _redact_exact_prefix(
+    data: bytes,
+    safe_length: int,
+    exact_values: tuple[bytes, ...],
+) -> tuple[bytes, bytes]:
+    if not exact_values:
+        return data[:safe_length], data[safe_length:]
+    spans: list[tuple[int, int]] = []
+    for value in exact_values:
+        search_from = 0
+        while True:
+            position = data.find(value, search_from)
+            if position < 0 or position >= safe_length:
+                break
+            spans.append((position, position + len(value)))
+            search_from = position + 1
+    if not spans:
+        return data[:safe_length], data[safe_length:]
+    spans.sort()
+    merged_spans: list[tuple[int, int]] = []
+    for start, end in spans:
+        if merged_spans and start <= merged_spans[-1][1]:
+            previous_start, previous_end = merged_spans[-1]
+            merged_spans[-1] = (previous_start, max(previous_end, end))
+        else:
+            merged_spans.append((start, end))
+    redacted = bytearray()
+    cursor = 0
+    for start, end in merged_spans:
+        redacted.extend(data[cursor:start])
+        redacted.extend(_REDACTED_BYTES)
+        cursor = end
+    if cursor < safe_length:
+        redacted.extend(data[cursor:safe_length])
+        cursor = safe_length
+    return bytes(redacted), data[cursor:]
 
 
 class _BoundedStartupOutput:
-    """Drain a child pipe continuously while retaining only its startup tail."""
+    """Drain a child pipe while retaining an exact-redacted startup tail."""
 
-    def __init__(self, stream: Any, *, limit: int = _STARTUP_OUTPUT_TAIL_BYTES) -> None:
+    def __init__(
+        self,
+        stream: Any,
+        *,
+        exact_values: tuple[str, ...],
+        limit: int = _STARTUP_OUTPUT_TAIL_BYTES,
+    ) -> None:
         self._stream = stream
         self._limit = limit
+        self._exact_values = tuple(
+            sorted(
+                {value.encode("utf-8") for value in exact_values if value},
+                key=len,
+                reverse=True,
+            )
+        )
+        self._overlap = max((len(value) for value in self._exact_values), default=1) - 1
+        self._pending = bytearray()
         self._tail = bytearray()
-        self._truncated = False
+        self._observed_bytes = 0
+        self._source_exceeded_limit = False
+        self._tail_truncated = False
         self._retaining = True
         self._lock = threading.Lock()
         self._thread = threading.Thread(
@@ -73,18 +129,42 @@ class _BoundedStartupOutput:
                 with self._lock:
                     if not self._retaining:
                         continue
-                    overflow = len(self._tail) + len(chunk) - self._limit
-                    if overflow > 0:
-                        del self._tail[:overflow]
-                        self._truncated = True
-                    self._tail.extend(chunk)
+                    self._observed_bytes += len(chunk)
+                    self._source_exceeded_limit = self._observed_bytes > self._limit
+                    self._pending.extend(chunk)
+                    self._flush_pending_locked(final=False)
         except Exception:
             logger.debug("Model Hub startup output drain stopped")
 
-    def snapshot(self) -> tuple[bytes, bool]:
+    def _flush_pending_locked(self, *, final: bool) -> None:
+        safe_length = (
+            len(self._pending)
+            if final
+            else max(0, len(self._pending) - self._overlap)
+        )
+        if safe_length == 0:
+            return
+        redacted, pending = _redact_exact_prefix(
+            bytes(self._pending),
+            safe_length,
+            self._exact_values,
+        )
+        self._pending = bytearray(pending)
+        overflow = len(self._tail) + len(redacted) - self._limit
+        if overflow > 0:
+            del self._tail[:overflow]
+            self._tail_truncated = True
+        self._tail.extend(redacted)
+
+    def snapshot(self) -> tuple[bytes, bool, bool]:
         with self._lock:
+            self._flush_pending_locked(final=True)
             self._retaining = False
-            return bytes(self._tail), self._truncated
+            return (
+                bytes(self._tail),
+                self._source_exceeded_limit or self._tail_truncated,
+                self._tail_truncated,
+            )
 
     def join(self, timeout: float = 1.0) -> None:
         self._thread.join(timeout=timeout)
@@ -95,7 +175,12 @@ def _sanitize_startup_output(
     *,
     exact_values: tuple[str, ...],
     truncated: bool,
+    partial_line: bool,
 ) -> tuple[str, bool]:
+    if partial_line:
+        _partial_line, separator, raw = raw.partition(b"\n")
+        if not separator:
+            raw = b""
     text = raw.decode("utf-8", "replace")
     text = "".join(character if character.isprintable() or character.isspace() else " " for character in text)
     for value in sorted((item for item in exact_values if item), key=len, reverse=True):
@@ -304,7 +389,10 @@ class EngineSupervisor:
         if process.stdout is None:
             self._stop_locked()
             raise EngineUnavailableError("models.engine.start_failed")
-        output = _BoundedStartupOutput(process.stdout)
+        output = _BoundedStartupOutput(
+            process.stdout,
+            exact_values=startup_redaction_values,
+        )
         self._startup_output = output
         started_at = time.monotonic()
         deadline = started_at + self.startup_timeout
@@ -324,11 +412,12 @@ class EngineSupervisor:
                     self._stop_locked()
                     raise EngineUnavailableError("models.engine.unsafe_permissions") from exc
                 self._last_check = _utc_now()
-                raw_output, output_truncated = output.snapshot()
+                raw_output, output_truncated, partial_line = output.snapshot()
                 diagnostic, output_truncated = _sanitize_startup_output(
                     raw_output,
                     exact_values=startup_redaction_values,
                     truncated=output_truncated,
+                    partial_line=partial_line,
                 )
                 logger.info(
                     "Model Hub engine startup outcome=ready managed_version=%s "
@@ -341,11 +430,12 @@ class EngineSupervisor:
                 return connection
             time.sleep(min(_STARTUP_POLL_INTERVAL_SECONDS, max(0.0, deadline - time.monotonic())))
         self._stop_locked()
-        raw_output, output_truncated = output.snapshot()
+        raw_output, output_truncated, partial_line = output.snapshot()
         diagnostic, output_truncated = _sanitize_startup_output(
             raw_output,
             exact_values=startup_redaction_values,
             truncated=output_truncated,
+            partial_line=partial_line,
         )
         logger.warning(
             "Model Hub engine startup outcome=%s managed_version=%s exit_code=%s "


### PR DESCRIPTION
## Summary

- extend the single Model Hub engine readiness window from 10 to a bounded 30 seconds, with each two-surface health probe constrained by the remaining budget
- direct CLIProxyAPI stdout and stderr to the operating system null sink so child bytes cannot enter Avibe's Python memory or service logs or create pipe backpressure
- keep bounded supervisor-owned startup diagnostics for `ready`, `process_exit`, and `timeout`, while preserving the existing `models.engine.health_failed` contract and no-retry behavior

## Root cause

Local Incus evidence showed that the first CLIProxyAPI child was still alive when Avibe ended the fixed 10-second readiness window and sent `SIGTERM`. The start request returned 503 after 21.705 seconds, including teardown. The next start reached both health surfaces and returned 200 in 7.390 seconds. The evidence supports a larger bounded readiness budget; it does not identify an internal engine phase or justify retries.

The initial diagnostic-tail implementation could not prove opaque third-party output safe across arbitrary byte boundaries, unbounded exact secret lengths, and engine-owned OAuth schemas. The final contract therefore retains no child text. Startup logs contain only supervisor-owned structured fields such as outcome, managed version, exit code when applicable, elapsed time, readiness budget, and `child_output_retained=false`.

## Scenarios

- `MH-RUNTIME-005`: first cold start remains pending until both gateway and management health surfaces are ready within the bounded budget; arbitrary child output remains absent from logs
- `MH-RUNTIME-006`: readiness timeout stops the child after output larger than a pipe buffer, discards all child output, and leaves bounded structured diagnostics

## Evidence

- Unit: delayed real-subprocess cold-start success, exact `DEVNULL` process contract, process-exit handling, timeout termination, both health surfaces, binary/schema-like/runtime-secret child output exclusion, and oversized dual-stream output without pipe deadlock
- Contract: one bounded readiness budget, dual-surface health, existing runtime error key, process stop behavior, and no-retry behavior remain unchanged
- Scenario: Model Hub plan/catalog and local Incus observation cover `MH-RUNTIME-005`, `MH-RUNTIME-006`, and `MH-OBS-005`
- Validation: 416 focused Model Hub runtime/API/catalog tests passed; direct startup-property and structure-guard tests passed; Ruff passed on changed Python files
- Residual manual check: a fresh local worktree Incus instance did not finish its own `cloud-init`/service provisioning, so no live end-to-end result is claimed; the temporary instance and project were deleted with the regression runner
