### PR TITLE
fix(show-runtime): invalidate stale WebSocket target

### DIFF
--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -170,6 +170,8 @@ class ShowRuntimeProtocolEnvelope:
 class ShowRuntimeWebSocketTarget:
     url: str
     headers: dict[str, str]
+    _base_url: str | None = None
+    _process: subprocess.Popen[str] | None = None
 
 
 @dataclass(frozen=True)
@@ -823,10 +825,7 @@ class ShowRuntimeManager:
                         f"Show Runtime request exceeded {total_timeout_seconds:g} seconds"
                     ) from exc
         except (ShowRuntimeRequestTimeoutError, httpx.RequestError) as exc:
-            async with self._lock:
-                if self._base_url == base_url and self._process is process:
-                    self._base_url = None
-                    self._clear_capability_state()
+            await self._invalidate_runtime_snapshot(base_url, process)
             if isinstance(exc, ShowRuntimeRequestTimeoutError):
                 raise
             evidence = ShowRuntimeFailureEvidence(
@@ -919,9 +918,31 @@ class ShowRuntimeManager:
         ready = await self.ensure()
         if not ready.available or not ready.base_url:
             raise self._unavailable_error(ready)
-        await self._negotiate_context_key_capability(ready.base_url)
-        url = f"{ready.base_url.replace('http://', 'ws://', 1).replace('https://', 'wss://', 1)}{path}"
-        return ShowRuntimeWebSocketTarget(url=url, headers=envelope.headers())
+        base_url = ready.base_url
+        process = self._process
+        await self._negotiate_context_key_capability(base_url)
+        url = f"{base_url.replace('http://', 'ws://', 1).replace('https://', 'wss://', 1)}{path}"
+        return ShowRuntimeWebSocketTarget(
+            url=url,
+            headers=envelope.headers(),
+            _base_url=base_url,
+            _process=process,
+        )
+
+    async def invalidate_websocket_target(self, target: ShowRuntimeWebSocketTarget) -> None:
+        if target._base_url is None:
+            return
+        await self._invalidate_runtime_snapshot(target._base_url, target._process)
+
+    async def _invalidate_runtime_snapshot(
+        self,
+        base_url: str,
+        process: subprocess.Popen[str] | None,
+    ) -> None:
+        async with self._lock:
+            if self._base_url == base_url and self._process is process:
+                self._base_url = None
+                self._clear_capability_state()
 
     def _unavailable_error(self, availability: ShowRuntimeAvailability) -> ShowRuntimeUnavailableError:
         reason = availability.reason

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -29,6 +29,7 @@ import pytest
 import core.dependency_network as dependency_network
 import core.show_runtime as show_runtime
 import core.show_runtime_failures as show_runtime_failures_module
+from aiohttp import ClientConnectionError, WSServerHandshakeError
 from starlette.websockets import WebSocketDisconnect
 
 from config import paths
@@ -7414,6 +7415,123 @@ def test_delayed_transport_failure_does_not_invalidate_replacement_process(monke
         asyncio.run(manager.request_global("GET", "/health"))
 
     assert manager._process is replacement_process
+    assert manager._base_url == base_url
+
+
+class _FailingWebSocketHandshake:
+    def __init__(self, error, *, before_failure=None):
+        self.error = error
+        self.before_failure = before_failure
+
+    async def _fail(self):
+        if self.before_failure is not None:
+            self.before_failure()
+        raise self.error
+
+    def __await__(self):
+        return self._fail().__await__()
+
+    async def __aenter__(self):
+        return await self
+
+    async def __aexit__(self, _exc_type, _exc, _traceback):
+        return False
+
+
+class _FailingWebSocketSession:
+    def __init__(self, handshake):
+        self.handshake = handshake
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, _exc_type, _exc, _traceback):
+        return False
+
+    def ws_connect(self, *_args, **_kwargs):
+        return self.handshake
+
+
+def test_websocket_transport_failure_invalidates_runtime_and_readmits(monkeypatch, tmp_path):
+    manager = _runtime_manager_with_failing_transport(monkeypatch, tmp_path)
+    set_show_runtime_manager_for_tests(manager)
+    handshake = _FailingWebSocketHandshake(ClientConnectionError("runtime connection refused"))
+    monkeypatch.setattr(ui_server, "ClientSession", lambda: _FailingWebSocketSession(handshake))
+    websocket = SimpleNamespace(url=SimpleNamespace(query=""))
+
+    with pytest.raises(ClientConnectionError):
+        asyncio.run(ui_server._proxy_show_runtime_websocket(websocket, "ses123"))
+
+    assert manager._base_url is None
+
+    admissions = []
+    replacement_process = SimpleNamespace(pid=654, poll=lambda: None)
+
+    async def admit(*, automatic=True):
+        admissions.append((automatic, manager._base_url))
+        manager._process = replacement_process
+        manager._base_url = "http://127.0.0.1:49322"
+        return manager._publish_runtime_availability(
+            ShowRuntimeServingState.SERVING,
+            manager._base_url,
+        )
+
+    monkeypatch.setattr(manager, "ensure", admit)
+
+    target = asyncio.run(
+        manager.websocket_target(
+            "/show/ses123/__vite_hmr",
+            envelope=ShowRuntimeProtocolEnvelope(ShowRuntimeContext.PRIVATE),
+        )
+    )
+
+    assert admissions == [(True, None)]
+    assert target.url == "ws://127.0.0.1:49322/show/ses123/__vite_hmr"
+
+
+def test_delayed_websocket_failure_does_not_invalidate_replacement_process(monkeypatch, tmp_path):
+    manager = _runtime_manager_with_failing_transport(monkeypatch, tmp_path)
+    set_show_runtime_manager_for_tests(manager)
+    base_url = manager._base_url
+    replacement_process = SimpleNamespace(pid=654, poll=lambda: None)
+
+    def replace_runtime():
+        manager._process = replacement_process
+        manager._base_url = base_url
+
+    handshake = _FailingWebSocketHandshake(
+        ClientConnectionError("old runtime failed late"),
+        before_failure=replace_runtime,
+    )
+    monkeypatch.setattr(ui_server, "ClientSession", lambda: _FailingWebSocketSession(handshake))
+    websocket = SimpleNamespace(url=SimpleNamespace(query=""))
+
+    with pytest.raises(ClientConnectionError):
+        asyncio.run(ui_server._proxy_show_runtime_websocket(websocket, "ses123"))
+
+    assert manager._process is replacement_process
+    assert manager._base_url == base_url
+
+
+def test_websocket_handshake_response_does_not_invalidate_runtime(monkeypatch, tmp_path):
+    manager = _runtime_manager_with_failing_transport(monkeypatch, tmp_path)
+    set_show_runtime_manager_for_tests(manager)
+    base_url = manager._base_url
+    handshake = _FailingWebSocketHandshake(
+        WSServerHandshakeError(
+            request_info=None,
+            history=(),
+            status=503,
+            message="runtime rejected websocket upgrade",
+            headers=None,
+        )
+    )
+    monkeypatch.setattr(ui_server, "ClientSession", lambda: _FailingWebSocketSession(handshake))
+    websocket = SimpleNamespace(url=SimpleNamespace(query=""))
+
+    with pytest.raises(WSServerHandshakeError):
+        asyncio.run(ui_server._proxy_show_runtime_websocket(websocket, "ses123"))
+
     assert manager._base_url == base_url
 
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any, Callable, Mapping
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlparse, urlsplit, urlunsplit
 
 import psutil
-from aiohttp import ClientSession, WSMsgType
+from aiohttp import ClientConnectionError, ClientSession, WSMsgType
 from fastapi import Request as FastAPIRequest, WebSocket, WebSocketDisconnect
 from fastapi.responses import Response as FastAPIResponse
 from starlette.datastructures import UploadFile as StarletteUploadFile
@@ -4390,17 +4390,23 @@ async def _proxy_show_runtime_websocket(
     runtime_path = f"{external_prefix.rstrip('/')}/__vite_hmr"
     if websocket.url.query:
         runtime_path = f"{runtime_path}?{websocket.url.query}"
-    upstream = await get_show_runtime_manager().websocket_target(
+    manager = get_show_runtime_manager()
+    target = await manager.websocket_target(
         runtime_path,
         envelope=ShowRuntimeProtocolEnvelope(context),
     )
     async with ClientSession() as session:
-        async with session.ws_connect(
-            upstream.url,
-            headers=upstream.headers,
-            protocols=["vite-hmr"],
-            autoping=True,
-        ) as upstream:
+        try:
+            upstream = await session.ws_connect(
+                target.url,
+                headers=target.headers,
+                protocols=["vite-hmr"],
+                autoping=True,
+            )
+        except (asyncio.TimeoutError, ClientConnectionError):
+            await manager.invalidate_websocket_target(target)
+            raise
+        async with upstream:
             async def client_to_upstream():
                 try:
                     while True:


### PR DESCRIPTION
## Capability

Invalidate a Show Runtime WebSocket target when its upstream handshake fails at the transport layer, so the next Vite HMR reconnect re-enters Runtime admission instead of dialing a stale URL indefinitely.

The manager owns invalidation and matches both the captured base URL and process object. A delayed failure from an older target therefore cannot clear a replacement Runtime that reused the same URL.

Closes #1656.

## Evidence

- Unit: the focused Show Page module passes all 423 tests.
- Contract: a hermetic manager/UI test fails on `master` because the dead URL remains cached, then passes here and proves the next `websocket_target()` call sees an empty snapshot before admission.
- Contract: delayed failure coverage proves that only the matching URL/process snapshot is invalidated.
- Contract: an application-level WebSocket handshake response does not invalidate a reachable Runtime.
- Full suite: all six `scripts/ci_unit_tests.sh` shards pass in the locked Python 3.12 environment (384 test files, each isolated as CI runs them).
- Scenario IDs: none; the Show Runtime WebSocket recovery path has no catalog entry.
- Residual manual check: sidecar crash plus live Vite HMR reconnect is deferred to the integration regression pass.

## Dependencies

None. PR #1662 changes the install-side half of `core/show_runtime.py`; this PR stays within the serve-side boundary and does not depend on it.

## Known By Design

- Only failures before `ws_connect()` returns invalidate the target. HTTP handshake responses from a reachable Runtime and post-handshake close/error frames remain application-level outcomes and do not mark the Runtime dead.
