### PR TITLE
fix(show-runtime): classify explicit child exits by owner

### DIFF
--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -1380,6 +1380,7 @@ class ShowRuntimeManager:
         runtime_evidence = ShowRuntimeFailureEvidence(
             ShowRuntimeFailureDimension.RUNTIME,
             runtime_reason,
+            provenance="configured" if self._command_explicit else None,
         )
         runtime_failure_class = classify_show_runtime_failure(runtime_evidence) if runtime_reason else None
         availability = replace(

--- a/core/show_runtime_failures.py
+++ b/core/show_runtime_failures.py
@@ -92,6 +92,15 @@ _FAILURE_DECLARATION_ROWS = (
         ShowRuntimeRecoveryAction.REPAIR,
     ),
     ShowRuntimeFailureDeclaration(
+        "runtime_start_process_unavailable",
+        ShowRuntimeFailureDimension.RUNTIME,
+        "explicit-runtime-command",
+        ShowRuntimeFailureClass.CONFIGURED,
+        ShowRuntimeRecoveryAction.CHANGE_SETTING,
+        user_owned=True,
+        provenance="configured",
+    ),
+    ShowRuntimeFailureDeclaration(
         "runtime_start_health_timeout",
         ShowRuntimeFailureDimension.RUNTIME,
         "runtime-start",

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -8,11 +8,13 @@ import io
 import json
 import os
 import re
+import shlex
 import shutil
 import socket
 import ssl
 import struct
 import subprocess
+import sys
 import tarfile
 import textwrap
 import threading
@@ -6616,6 +6618,28 @@ def test_show_runtime_failure_classification(dimension, reason, expected):
 @pytest.mark.parametrize(
     ("provenance", "expected_class", "expected_action"),
     (
+        (None, ShowRuntimeFailureClass.UNCLASSIFIED, ShowRuntimeRecoveryAction.REPAIR),
+        ("configured", ShowRuntimeFailureClass.CONFIGURED, ShowRuntimeRecoveryAction.CHANGE_SETTING),
+    ),
+)
+def test_runtime_child_exit_classification_uses_command_owner(
+    provenance,
+    expected_class,
+    expected_action,
+):
+    evidence = ShowRuntimeFailureEvidence(
+        ShowRuntimeFailureDimension.RUNTIME,
+        "runtime_start_process_unavailable",
+        provenance,
+    )
+
+    assert classify_show_runtime_failure(evidence) is expected_class
+    assert show_runtime_recovery_action(evidence) is expected_action
+
+
+@pytest.mark.parametrize(
+    ("provenance", "expected_class", "expected_action"),
+    (
         ("configured", ShowRuntimeFailureClass.CONFIGURED, ShowRuntimeRecoveryAction.CHANGE_SETTING),
         ("packaged", ShowRuntimeFailureClass.UNCLASSIFIED, ShowRuntimeRecoveryAction.REPAIR),
     ),
@@ -8006,6 +8030,31 @@ def test_show_runtime_manager_reports_url_timeout_separately(monkeypatch, tmp_pa
 
     assert result.available is False
     assert result.reason == "runtime_start_url_timeout"
+
+
+def test_explicit_runtime_child_exit_publishes_configured_recovery_evidence(monkeypatch, tmp_path):
+    started = tmp_path / "configured-runtime-started"
+    runtime_script = tmp_path / "configured-runtime.py"
+    runtime_script.write_text(
+        "from pathlib import Path\n"
+        "from time import sleep\n"
+        f"Path({str(started)!r}).touch()\n"
+        "sleep(0.05)\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("VIBE_SHOW_RUNTIME_BIN", shlex.join([sys.executable, str(runtime_script)]))
+    manager = ShowRuntimeManager(
+        workspace_root=tmp_path / "show",
+        runtime_dir=tmp_path / "runtime",
+    )
+    monkeypatch.setattr(manager, "_sweep_orphan_runtime_servers", lambda: None)
+
+    result = asyncio.run(manager.ensure())
+
+    assert started.exists()
+    assert result.reason == "runtime_start_process_unavailable"
+    assert result.failure_class is ShowRuntimeFailureClass.CONFIGURED
+    assert result.recovery_action is ShowRuntimeRecoveryAction.CHANGE_SETTING
 
 
 def test_show_runtime_manager_rejects_process_that_exits_before_health(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- preserve the configured-command owner when Show Runtime publishes runtime failure evidence
- classify an explicitly configured child that exits before publishing a URL as configured/change-setting evidence
- keep the managed-runtime child-exit path on its existing unclassified/repair evidence

Closes #1659

## Evidence

- Unit: a real command supplied through `VIBE_SHOW_RUNTIME_BIN` writes a startup sentinel, exits without publishing a URL, and produces configured/change-setting evidence
- Contract: owner-sensitive failure declarations cover both configured and managed child exits
- Red before green: the new behavior test failed on `origin/master` because the result was unclassified/repair, then passed on this branch
- Scenario: no Show Runtime scenario catalog entry exists for this serve-side classification path
- Full suite: all 6 CI unit-test shards passed, covering 384 test files in per-file isolation
- Residual manual check: no Incus regression was run; end-to-end user-surface verification is deferred to the orchestrator's integration pass

## Dependencies

None.

## Known by design

- Only the explicit child-exit evidence is reclassified. Managed child exits and other runtime-start reasons retain their existing declarations unless they publish distinct owner evidence.
