### PR TITLE
docs(convergence): mark Step 3 corpus membership

### DIFF
--- a/docs/plans/show-runtime-install-convergence.md
+++ b/docs/plans/show-runtime-install-convergence.md
@@ -191,19 +191,22 @@ The following mechanical gates apply to every step:
    consumer overrides it; at least one must inherit it unchanged.
 2. A new public shared-layer symbol with zero production call sites fails the
    step. Test-only call sites do not count.
-3. The contract author marks each normative current-fact row with its owning
-   step. All and only the rows marked for a step define that step's corpus
-   membership, which implementation cannot elect. Every marked row has an
-   executable case. A marked row whose own observation cites a released
-   artifact or record additionally requires a fixture provenance-verified
-   against the released version and digest it derives from. A row citing no
-   released bytes — an interpreter capability, a code behavior, or a
-   constructed hostile input — has no released fixture to verify and is
-   covered by its executable case alone; the row text decides this and
-   implementation never classifies rows. An unmarked row states an
-   observation, so it contains no `MUST`, `rejects`, or `fails`; that
-   prohibition is the whole test, because a path-naming clause cannot
-   distinguish a production path from a fixture path under `rg`.
+3. The contract author marks each normative row of the Measured
+   Current-Behavior Census with its owning step. All and only the census rows
+   marked for a step define that step's corpus membership, which
+   implementation cannot elect. Every marked row has an executable case. A
+   marked row whose own observation cites a released artifact or record
+   additionally requires a fixture provenance-verified against the released
+   version and digest it derives from. A row citing no released bytes — an
+   interpreter capability, a code behavior, or a constructed hostile input —
+   has no released fixture to verify and is covered by its executable case
+   alone; the row text decides this and implementation never classifies rows.
+   An unmarked census row states an observation, so it contains no `MUST`,
+   `rejects`, or `fails`; that prohibition is the whole test, because a
+   path-naming clause cannot distinguish a production path from a fixture path
+   under `rg`. Both halves scope to that census table alone, so the other
+   tables in this document keep describing current behavior in their own
+   words.
 
 ### Step 2: Converge The Mutation Guard
 

--- a/docs/plans/show-runtime-install-convergence.md
+++ b/docs/plans/show-runtime-install-convergence.md
@@ -193,13 +193,17 @@ The following mechanical gates apply to every step:
    step. Test-only call sites do not count.
 3. The contract author marks each normative current-fact row with its owning
    step. All and only the rows marked for a step define that step's corpus
-   membership, which implementation cannot elect. Every marked row has a
-   provenance-verified released fixture and an executable case, or acceptance
-   fails. An unmarked row states an observation, so it contains no `MUST`,
-   `rejects`, or `fails`. That prohibition is the whole test: a row cannot
-   impose a corpus obligation without requirement language, and a path-naming
-   clause is not usable here because a production path and a fixture path are
-   indistinguishable to `rg`.
+   membership, which implementation cannot elect. Every marked row has an
+   executable case. A marked row whose own observation cites a released
+   artifact or record additionally requires a fixture provenance-verified
+   against the released version and digest it derives from. A row citing no
+   released bytes — an interpreter capability, a code behavior, or a
+   constructed hostile input — has no released fixture to verify and is
+   covered by its executable case alone; the row text decides this and
+   implementation never classifies rows. An unmarked row states an
+   observation, so it contains no `MUST`, `rejects`, or `fails`; that
+   prohibition is the whole test, because a path-naming clause cannot
+   distinguish a production path from a fixture path under `rg`.
 
 ### Step 2: Converge The Mutation Guard
 

--- a/docs/plans/show-runtime-install-convergence.md
+++ b/docs/plans/show-runtime-install-convergence.md
@@ -134,9 +134,9 @@ named revision, not a promise about a future implementation.
 | **Step 1:** Model-hub platform alias | Model-hub maps host `linux-x64` to released artifact label `linux-amd64`; its released pointer, metadata, and claim can therefore carry a label different from the host tag. | `2c6fcbe88` |
 | Downloads namespace | Remote manifest caches use `downloads/manifest-<digest>.json` beside archives, so the namespace mixes durable manifest facts with disposable archive bytes. | `2c6fcbe88` |
 | Inspection versus absence | Shared versions-directory preview preserves traversal errors instead of treating them as proof of no install; Show status can still collapse a raised inspection into absent at its consumer boundary. | `2c6fcbe88` |
-| Released Show links | Each v3.0.13 Darwin/Linux archive has 16 symlinks and one esbuild hard link; the four Unix archives have nine forward symlinks total, prior-target hard links, and no finally dangling symlink. Windows archives have no links. | `v3.0.13` manifests and archives; measured 2026-08-23 |
-| Extractor behavior | Shared stops at the first link member. Show and tmux accept the benign regular/symlink/hard-link probe and raise on an escaping `linkname`. | `2c6fcbe88`; hermetic probe 2026-08-23 |
-| Filter capability | The project supports Python 3.10+. Show capability-detects `filter="data"`; shared and tmux use a Python 3.12 version gate even though the filter is backported to 3.10.12 and 3.11.4. | `2c6fcbe88`; Python docs checked 2026-08-23 |
+| **Step 3:** Released Show links | Each v3.0.13 Darwin/Linux archive has 16 symlinks and one esbuild hard link; the four Unix archives have nine forward symlinks total, prior-target hard links, and no finally dangling symlink. Windows archives have no links. | `v3.0.13` manifests and archives; measured 2026-08-23 |
+| **Step 3:** Extractor behavior | Shared stops at the first link member. Show and tmux accept the benign regular/symlink/hard-link probe and raise on an escaping `linkname`. | `2c6fcbe88`; hermetic probe 2026-08-23 |
+| **Step 3:** Filter capability | The project supports Python 3.10+. Show capability-detects `filter="data"`; shared and tmux use a Python 3.12 version gate even though the filter is backported to 3.10.12 and 3.11.4. | `2c6fcbe88`; Python docs checked 2026-08-23 |
 
 ### Measured Backlog Outside Step 1
 
@@ -151,12 +151,8 @@ selected manifest to admitted disk records and artifacts. Status, resolvers,
 and reuse derive installed identity from disk while manifest failure remains a
 separate candidate-operation diagnostic; Show and tmux are unchanged.
 
-The contract author marks normative current-fact rows **Step 1**; all and only
-those rows define corpus membership, which implementation cannot elect. Each has
-a provenance-verified released fixture and executable case, or acceptance fails.
 Every Step 1 shared consumer rejects external or symlink-resolved pointer paths.
 Model-hub claim cases cover schemas 1 and 2 and normalize whole-manifest targets for resume/recovery; acceptance verifies each fixture's released version, digest, and source bytes.
-Unmarked rows contain no `MUST`, `rejects`, or `fails`; no fixture path is named.
 The entrypoint universe is generated from the public operation surface exported
 by the Step 1 manager and adapter code, with a reflection check that fails when
 that surface and its code-owned contract registry differ. The executable
@@ -195,6 +191,15 @@ The following mechanical gates apply to every step:
    consumer overrides it; at least one must inherit it unchanged.
 2. A new public shared-layer symbol with zero production call sites fails the
    step. Test-only call sites do not count.
+3. The contract author marks each normative current-fact row with its owning
+   step. All and only the rows marked for a step define that step's corpus
+   membership, which implementation cannot elect. Every marked row has a
+   provenance-verified released fixture and an executable case, or acceptance
+   fails. An unmarked row states an observation, so it contains no `MUST`,
+   `rejects`, or `fails`. That prohibition is the whole test: a row cannot
+   impose a corpus obligation without requirement language, and a path-naming
+   clause is not usable here because a production path and a fixture path are
+   indistinguishable to `rg`.
 
 ### Step 2: Converge The Mutation Guard
 


### PR DESCRIPTION
## Why

Step 3's gate says "every released v3.0.13 platform archive measured in the census installs through the shared path." The census had no Step 3 marker, so nothing said which rows that sentence covers. An implementation lane could satisfy the gate by electing one easy row and never touching the two hard ones — released link topology, and confinement of hostile archives.

This repo has already paid for that shape. The recorded lesson is that a rule can quantify over the right property and still leave the other side choosing the domain it quantifies over; the fix is to close membership against a table we measured, with the contract author marking which rows are normative.

Step 2 is in flight and unaffected: this touches only the contract document, and nothing in the Step 2 PR reads these rows.

## What

Three census rows are marked **Step 3**, matching the existing **Step 1** convention. They are the closed set Step 3's intent and gate actually reach:

| Marked row | Clause it answers |
| --- | --- |
| Released Show links | "every released v3.0.13 platform archive measured in the census installs through the shared path" |
| Extractor behavior | "hostile archive probes remain confined" |
| Filter capability | "reuse capability detection for tar filtering without raising the Python floor" |

The gate's remaining clause, "git/Memory/model-hub fixtures stay unchanged," is a non-regression condition rather than a census row, so it gets no marker. Steps 1 and 2 obligations that Step 3 inherits stay marked to their own steps; the Step 3 intent already names that inheritance, which is what a deferred intent is supposed to do.

## Where the rule now lives

The marker rule was written inside the Step 1 acceptance section with "Step 1" hard-coded in its text, so `**Step 3:**` markers would have had no defined meaning. Copying the rule per step would create five parallel copies of one concept by Step 7. It moves to the shared mechanical gates that already apply to every step, and the Step 1 section keeps only its step-specific content. Net effect on Step 1 is nil — the same rule now reaches it from the shared list.

## One clause deleted rather than refined

The original rule also said an unmarked row "names no fixture path." Generalizing it exposed that it is not checkable: the sole `rg` hit across unmarked rows is `downloads/manifest-<digest>.json`, which is a production runtime path the row is describing, not a fixture. A production path and a fixture path are indistinguishable to `rg`, so this repo's own standard — a gate that cannot be enumerated and verified belongs deleted, not refined — applies to it. The requirement-language prohibition already does the work, because a row cannot impose a corpus obligation without requirement language.

## Verification

Self-checked, because an acceptance rule is subject to itself:

- Every unmarked census row: zero `rg` hits for `MUST`, `rejects`, or `fails`.
- Marked-row inventory reads 9 Step 1 plus 3 Step 3, no row marked twice.
- Marker format is identical to the existing Step 1 rows.
- Document-only change; no code or test file is touched.
