### PR TITLE
fix(runtime): support composite managed artifacts

### DIFF
--- a/core/managed_runtime.py
+++ b/core/managed_runtime.py
@@ -10,7 +10,6 @@ import platform
 import re
 import shutil
 import stat
-import sys
 import tarfile
 import tempfile
 import threading
@@ -267,7 +266,7 @@ class ManagedRuntimeManager:
                     install_dir = replacement
                 shutil.move(str(staging_dir), str(install_dir))
                 candidate_install_dir = install_dir
-                installed_binary = install_dir / archive.bin_path
+                installed_binary = (install_dir / archive.bin_path).resolve(strict=True)
                 self._write_manifest_install_metadata(
                     install_dir,
                     manifest,
@@ -1036,8 +1035,16 @@ class ManagedRuntimeManager:
         bin_path = metadata.get("bin_path", self.spec.default_bin_path)
         if not isinstance(bin_path, str) or archive_path_is_unsafe(bin_path):
             return None
-        binary = install_dir / bin_path
-        if not binary.is_file() or not os.access(binary, os.X_OK):
+        try:
+            install_dir_resolved = install_dir.resolve(strict=True)
+            binary = (install_dir_resolved / bin_path).resolve(strict=True)
+        except (OSError, RuntimeError):
+            return None
+        if (
+            install_dir_resolved not in binary.parents
+            or not binary.is_file()
+            or not os.access(binary, os.X_OK)
+        ):
             return None
         target = self._install_target_identity(manifest, archive)
         target_platform = target.pop("platform")
@@ -1311,16 +1318,32 @@ def install_lock_for(runtime_id: str) -> threading.Lock:
 def safe_extract_tar(archive: tarfile.TarFile, destination: Path) -> None:
     destination_resolved = destination.resolve()
     for member in archive.getmembers():
-        if not (member.isfile() or member.isdir()):
+        if not (member.isfile() or member.isdir() or member.issym() or member.islnk()):
             raise ValueError(f"Unsupported managed runtime archive member: {member.name}")
         if archive_path_is_unsafe(member.name):
             raise ValueError(f"Unsafe managed runtime archive path: {member.name}")
         target = (destination / member.name).resolve()
         if target != destination_resolved and destination_resolved not in target.parents:
             raise ValueError(f"Unsafe managed runtime archive path: {member.name}")
-    if sys.version_info >= (3, 12):
+        if member.issym():
+            link_target = (destination / member.name).parent / member.linkname
+            link_target_resolved = link_target.resolve()
+            if (
+                link_target_resolved != destination_resolved
+                and destination_resolved not in link_target_resolved.parents
+            ):
+                raise ValueError(f"Unsafe managed runtime archive link target: {member.name}")
+        elif member.islnk():
+            link_target = destination / member.linkname
+            link_target_resolved = link_target.resolve()
+            if (
+                link_target_resolved != destination_resolved
+                and destination_resolved not in link_target_resolved.parents
+            ):
+                raise ValueError(f"Unsafe managed runtime archive link target: {member.name}")
+    try:
         archive.extractall(destination, filter="data")
-    else:
+    except TypeError:
         archive.extractall(destination)
 
 

--- a/core/managed_runtime.py
+++ b/core/managed_runtime.py
@@ -1316,6 +1316,7 @@ def install_lock_for(runtime_id: str) -> threading.Lock:
 
 
 def safe_extract_tar(archive: tarfile.TarFile, destination: Path) -> None:
+    supports_data_filter = hasattr(tarfile, "data_filter")
     destination_resolved = destination.resolve()
     for member in archive.getmembers():
         if not (member.isfile() or member.isdir() or member.issym() or member.islnk()):
@@ -1325,6 +1326,10 @@ def safe_extract_tar(archive: tarfile.TarFile, destination: Path) -> None:
         target = (destination / member.name).resolve()
         if target != destination_resolved and destination_resolved not in target.parents:
             raise ValueError(f"Unsafe managed runtime archive path: {member.name}")
+        if (member.issym() or member.islnk()) and not supports_data_filter:
+            raise ValueError(
+                f"Managed runtime archive link requires tarfile.data_filter: {member.name}"
+            )
         if member.issym():
             link_target = (destination / member.name).parent / member.linkname
             link_target_resolved = link_target.resolve()
@@ -1341,9 +1346,9 @@ def safe_extract_tar(archive: tarfile.TarFile, destination: Path) -> None:
                 and destination_resolved not in link_target_resolved.parents
             ):
                 raise ValueError(f"Unsafe managed runtime archive link target: {member.name}")
-    try:
+    if supports_data_filter:
         archive.extractall(destination, filter="data")
-    except TypeError:
+    else:
         archive.extractall(destination)
 
 

--- a/core/tmux_runtime.py
+++ b/core/tmux_runtime.py
@@ -612,9 +612,9 @@ def _safe_extract_tar(tar: tarfile.TarFile, destination: Path) -> None:
             resolved_link = (destination / link_target).resolve()
             if resolved_link != destination_resolved and destination_resolved not in resolved_link.parents:
                 raise ValueError(f"Unsafe tmux archive link target: {member.name}")
-    if sys.version_info >= (3, 12):
+    try:
         tar.extractall(destination, filter="data")
-    else:
+    except TypeError:
         tar.extractall(destination)
 
 

--- a/core/tmux_runtime.py
+++ b/core/tmux_runtime.py
@@ -591,6 +591,7 @@ def _tmux_binary_version(binary: Path | None) -> str | None:
 
 
 def _safe_extract_tar(tar: tarfile.TarFile, destination: Path) -> None:
+    supports_data_filter = hasattr(tarfile, "data_filter")
     destination_resolved = destination.resolve()
     for member in tar.getmembers():
         if not (member.isfile() or member.isdir() or member.issym() or member.islnk()):
@@ -612,9 +613,9 @@ def _safe_extract_tar(tar: tarfile.TarFile, destination: Path) -> None:
             resolved_link = (destination / link_target).resolve()
             if resolved_link != destination_resolved and destination_resolved not in resolved_link.parents:
                 raise ValueError(f"Unsafe tmux archive link target: {member.name}")
-    try:
+    if supports_data_filter:
         tar.extractall(destination, filter="data")
-    except TypeError:
+    else:
         tar.extractall(destination)
 
 

--- a/tests/fixtures/show_runtime/v3.0.13/README.md
+++ b/tests/fixtures/show_runtime/v3.0.13/README.md
@@ -1,0 +1,21 @@
+# Show Runtime v3.0.13 Composite Artifact Fixture
+
+`show-runtime-manifest.json` is the byte-for-byte release asset from Avibe
+`v3.0.13`. `composite_artifacts.json` was measured from the six archives named
+and digested by that manifest.
+
+Each link row contains, in order:
+
+1. archive member index;
+2. `symlink` or `hardlink`;
+3. member name;
+4. raw `linkname`;
+5. immediate target member index, or `null` when another archive symlink is
+   required to reach it;
+6. fully resolved target member index;
+7. fully resolved target name;
+8. fully resolved target type.
+
+The executable acceptance test verifies the release-manifest digest and binds
+every platform record to its released archive name, size, and SHA-256 before
+replaying its link topology through the shared manager.

--- a/tests/fixtures/show_runtime/v3.0.13/composite_artifacts.json
+++ b/tests/fixtures/show_runtime/v3.0.13/composite_artifacts.json
@@ -1,0 +1,110 @@
+{
+  "schema_version": 1,
+  "release": {"manifest_name":"show-runtime-manifest.json","manifest_sha256":"500b10c76738214b1221f09fd98649b3d3aec9f45c95bd1795bd27510004c38f","runtime_version":"64e2e610e4107304bdc8ce2f2d387d76be6f0a0b","tag":"v3.0.13"},
+  "archives": {
+    "darwin-arm64": {
+      "provenance": {"member_count":8376,"name":"vibe-show-runtime-node-darwin-arm64.tgz","sha256":"5899da2bb7ff25ae16657fb6bae45298a0a140bc54757a36e398349959da5669","size":22310544},
+      "entrypoints": {"cli_path":[null,"node_modules/@avibe/show-runtime/dist/cli.js"],"cli_source":[72,"packages/runtime/dist/cli.js"],"esbuild_bin":[8197,"node_modules/.bin/esbuild"],"esbuild_package":[1838,"node_modules/esbuild/bin/esbuild"],"esbuild_platform":[212,"node_modules/@esbuild/darwin-arm64/bin/esbuild"]},
+      "links": [
+        [1838,"hardlink","node_modules/esbuild/bin/esbuild","node_modules/@esbuild/darwin-arm64/bin/esbuild",212,212,"node_modules/@esbuild/darwin-arm64/bin/esbuild","file"],
+        [3811,"symlink","node_modules/@avibe/show-ui","../../packages/ui",3,3,"packages/ui","directory"],
+        [3812,"symlink","node_modules/@avibe/show-sdk","../../packages/sdk",5,5,"packages/sdk","directory"],
+        [3813,"symlink","node_modules/@avibe/show-runtime","../../packages/runtime",4,4,"packages/runtime","directory"],
+        [8185,"symlink","node_modules/.bin/jsesc","../jsesc/bin/jsesc",8278,8278,"node_modules/jsesc/bin/jsesc","file"],
+        [8186,"symlink","node_modules/.bin/browserslist","../browserslist/cli.js",8206,8206,"node_modules/browserslist/cli.js","file"],
+        [8187,"symlink","node_modules/.bin/jiti","../jiti/lib/jiti-cli.mjs",8148,8148,"node_modules/jiti/lib/jiti-cli.mjs","file"],
+        [8188,"symlink","node_modules/.bin/nanoid","../nanoid/bin/nanoid.cjs",7965,7965,"node_modules/nanoid/bin/nanoid.cjs","file"],
+        [8189,"symlink","node_modules/.bin/avibe-show-runtime","../@avibe/show-runtime/dist/cli.js",null,72,"packages/runtime/dist/cli.js","file"],
+        [8190,"symlink","node_modules/.bin/baseline-browser-mapping","../baseline-browser-mapping/dist/cli.cjs",7787,7787,"node_modules/baseline-browser-mapping/dist/cli.cjs","file"],
+        [8191,"symlink","node_modules/.bin/parser","../@babel/parser/bin/babel-parser.js",2559,2559,"node_modules/@babel/parser/bin/babel-parser.js","file"],
+        [8192,"symlink","node_modules/.bin/semver","../semver/bin/semver.js",3065,3065,"node_modules/semver/bin/semver.js","file"],
+        [8193,"symlink","node_modules/.bin/vite","../vite/bin/vite.js",3044,3044,"node_modules/vite/bin/vite.js","file"],
+        [8194,"symlink","node_modules/.bin/rollup","../rollup/dist/bin/rollup",1904,1904,"node_modules/rollup/dist/bin/rollup","file"],
+        [8195,"symlink","node_modules/.bin/json5","../json5/lib/cli.js",1866,1866,"node_modules/json5/lib/cli.js","file"],
+        [8196,"symlink","node_modules/.bin/update-browserslist-db","../update-browserslist-db/cli.js",1848,1848,"node_modules/update-browserslist-db/cli.js","file"],
+        [8197,"symlink","node_modules/.bin/esbuild","../esbuild/bin/esbuild",1838,1838,"node_modules/esbuild/bin/esbuild","hardlink"]
+      ]
+    },
+    "darwin-x64": {
+      "provenance": {"member_count":8376,"name":"vibe-show-runtime-node-darwin-x64.tgz","sha256":"15429f0aa181ddef692faeaa9589f680f8ecf44d0f0a543f3e80fe5ab0ae7b99","size":23215818},
+      "entrypoints": {"cli_path":[null,"node_modules/@avibe/show-runtime/dist/cli.js"],"cli_source":[72,"packages/runtime/dist/cli.js"],"esbuild_bin":[8197,"node_modules/.bin/esbuild"],"esbuild_package":[1838,"node_modules/esbuild/bin/esbuild"],"esbuild_platform":[212,"node_modules/@esbuild/darwin-x64/bin/esbuild"]},
+      "links": [
+        [1838,"hardlink","node_modules/esbuild/bin/esbuild","node_modules/@esbuild/darwin-x64/bin/esbuild",212,212,"node_modules/@esbuild/darwin-x64/bin/esbuild","file"],
+        [3815,"symlink","node_modules/@avibe/show-ui","../../packages/ui",3,3,"packages/ui","directory"],
+        [3816,"symlink","node_modules/@avibe/show-sdk","../../packages/sdk",5,5,"packages/sdk","directory"],
+        [3817,"symlink","node_modules/@avibe/show-runtime","../../packages/runtime",4,4,"packages/runtime","directory"],
+        [8185,"symlink","node_modules/.bin/jsesc","../jsesc/bin/jsesc",8278,8278,"node_modules/jsesc/bin/jsesc","file"],
+        [8186,"symlink","node_modules/.bin/browserslist","../browserslist/cli.js",8206,8206,"node_modules/browserslist/cli.js","file"],
+        [8187,"symlink","node_modules/.bin/jiti","../jiti/lib/jiti-cli.mjs",8148,8148,"node_modules/jiti/lib/jiti-cli.mjs","file"],
+        [8188,"symlink","node_modules/.bin/nanoid","../nanoid/bin/nanoid.cjs",7969,7969,"node_modules/nanoid/bin/nanoid.cjs","file"],
+        [8189,"symlink","node_modules/.bin/avibe-show-runtime","../@avibe/show-runtime/dist/cli.js",null,72,"packages/runtime/dist/cli.js","file"],
+        [8190,"symlink","node_modules/.bin/baseline-browser-mapping","../baseline-browser-mapping/dist/cli.cjs",7791,7791,"node_modules/baseline-browser-mapping/dist/cli.cjs","file"],
+        [8191,"symlink","node_modules/.bin/parser","../@babel/parser/bin/babel-parser.js",2559,2559,"node_modules/@babel/parser/bin/babel-parser.js","file"],
+        [8192,"symlink","node_modules/.bin/semver","../semver/bin/semver.js",3069,3069,"node_modules/semver/bin/semver.js","file"],
+        [8193,"symlink","node_modules/.bin/vite","../vite/bin/vite.js",3044,3044,"node_modules/vite/bin/vite.js","file"],
+        [8194,"symlink","node_modules/.bin/rollup","../rollup/dist/bin/rollup",1904,1904,"node_modules/rollup/dist/bin/rollup","file"],
+        [8195,"symlink","node_modules/.bin/json5","../json5/lib/cli.js",1866,1866,"node_modules/json5/lib/cli.js","file"],
+        [8196,"symlink","node_modules/.bin/update-browserslist-db","../update-browserslist-db/cli.js",1848,1848,"node_modules/update-browserslist-db/cli.js","file"],
+        [8197,"symlink","node_modules/.bin/esbuild","../esbuild/bin/esbuild",1838,1838,"node_modules/esbuild/bin/esbuild","hardlink"]
+      ]
+    },
+    "linux-arm64": {
+      "provenance": {"member_count":8376,"name":"vibe-show-runtime-node-linux-arm64.tgz","sha256":"69026d325f84bee8a96ed41522d59f248b1ad5621377d88746b0aa1f80f89e6b","size":22308471},
+      "entrypoints": {"cli_path":[null,"node_modules/@avibe/show-runtime/dist/cli.js"],"cli_source":[113,"packages/runtime/dist/cli.js"],"esbuild_bin":[7189,"node_modules/.bin/esbuild"],"esbuild_package":[6310,"node_modules/esbuild/bin/esbuild"],"esbuild_platform":[6390,"node_modules/@esbuild/linux-arm64/bin/esbuild"]},
+      "links": [
+        [6347,"symlink","node_modules/@avibe/show-ui","../../packages/ui",3,3,"packages/ui","directory"],
+        [6348,"symlink","node_modules/@avibe/show-sdk","../../packages/sdk",51,51,"packages/sdk","directory"],
+        [6349,"symlink","node_modules/@avibe/show-runtime","../../packages/runtime",70,70,"packages/runtime","directory"],
+        [6390,"hardlink","node_modules/@esbuild/linux-arm64/bin/esbuild","node_modules/esbuild/bin/esbuild",6310,6310,"node_modules/esbuild/bin/esbuild","file"],
+        [7186,"symlink","node_modules/.bin/jsesc","../jsesc/bin/jsesc",595,595,"node_modules/jsesc/bin/jsesc","file"],
+        [7187,"symlink","node_modules/.bin/baseline-browser-mapping","../baseline-browser-mapping/dist/cli.cjs",1603,1603,"node_modules/baseline-browser-mapping/dist/cli.cjs","file"],
+        [7188,"symlink","node_modules/.bin/json5","../json5/lib/cli.js",6023,6023,"node_modules/json5/lib/cli.js","file"],
+        [7189,"symlink","node_modules/.bin/esbuild","../esbuild/bin/esbuild",6310,6310,"node_modules/esbuild/bin/esbuild","file"],
+        [7190,"symlink","node_modules/.bin/avibe-show-runtime","../@avibe/show-runtime/dist/cli.js",null,113,"packages/runtime/dist/cli.js","file"],
+        [7191,"symlink","node_modules/.bin/browserslist","../browserslist/cli.js",6399,6399,"node_modules/browserslist/cli.js","file"],
+        [7192,"symlink","node_modules/.bin/rollup","../rollup/dist/bin/rollup",6460,6460,"node_modules/rollup/dist/bin/rollup","file"],
+        [7193,"symlink","node_modules/.bin/jiti","../jiti/lib/jiti-cli.mjs",6717,6717,"node_modules/jiti/lib/jiti-cli.mjs","file"],
+        [7194,"symlink","node_modules/.bin/nanoid","../nanoid/bin/nanoid.cjs",7095,7095,"node_modules/nanoid/bin/nanoid.cjs","file"],
+        [7195,"symlink","node_modules/.bin/update-browserslist-db","../update-browserslist-db/cli.js",7118,7118,"node_modules/update-browserslist-db/cli.js","file"],
+        [7196,"symlink","node_modules/.bin/parser","../@babel/parser/bin/babel-parser.js",7838,7838,"node_modules/@babel/parser/bin/babel-parser.js","file"],
+        [7197,"symlink","node_modules/.bin/semver","../semver/bin/semver.js",8151,8151,"node_modules/semver/bin/semver.js","file"],
+        [7198,"symlink","node_modules/.bin/vite","../vite/bin/vite.js",8298,8298,"node_modules/vite/bin/vite.js","file"]
+      ]
+    },
+    "linux-x64": {
+      "provenance": {"member_count":8376,"name":"vibe-show-runtime-node-linux-x64.tgz","sha256":"808d1fe357b9468e2445f023a35ca9e12652d1a6b239f870812d5dd4b905eda8","size":23256781},
+      "entrypoints": {"cli_path":[null,"node_modules/@avibe/show-runtime/dist/cli.js"],"cli_source":[134,"packages/runtime/dist/cli.js"],"esbuild_bin":[8077,"node_modules/.bin/esbuild"],"esbuild_package":[338,"node_modules/esbuild/bin/esbuild"],"esbuild_platform":[7767,"node_modules/@esbuild/linux-x64/bin/esbuild"]},
+      "links": [
+        [3059,"symlink","node_modules/@avibe/show-sdk","../../packages/sdk",51,51,"packages/sdk","directory"],
+        [3060,"symlink","node_modules/@avibe/show-ui","../../packages/ui",3,3,"packages/ui","directory"],
+        [3061,"symlink","node_modules/@avibe/show-runtime","../../packages/runtime",70,70,"packages/runtime","directory"],
+        [7767,"hardlink","node_modules/@esbuild/linux-x64/bin/esbuild","node_modules/esbuild/bin/esbuild",338,338,"node_modules/esbuild/bin/esbuild","file"],
+        [8076,"symlink","node_modules/.bin/parser","../@babel/parser/bin/babel-parser.js",456,456,"node_modules/@babel/parser/bin/babel-parser.js","file"],
+        [8077,"symlink","node_modules/.bin/esbuild","../esbuild/bin/esbuild",338,338,"node_modules/esbuild/bin/esbuild","file"],
+        [8078,"symlink","node_modules/.bin/browserslist","../browserslist/cli.js",398,398,"node_modules/browserslist/cli.js","file"],
+        [8079,"symlink","node_modules/.bin/baseline-browser-mapping","../baseline-browser-mapping/dist/cli.cjs",426,426,"node_modules/baseline-browser-mapping/dist/cli.cjs","file"],
+        [8080,"symlink","node_modules/.bin/avibe-show-runtime","../@avibe/show-runtime/dist/cli.js",null,134,"packages/runtime/dist/cli.js","file"],
+        [8081,"symlink","node_modules/.bin/json5","../json5/lib/cli.js",3351,3351,"node_modules/json5/lib/cli.js","file"],
+        [8082,"symlink","node_modules/.bin/rollup","../rollup/dist/bin/rollup",3371,3371,"node_modules/rollup/dist/bin/rollup","file"],
+        [8083,"symlink","node_modules/.bin/vite","../vite/bin/vite.js",7822,7822,"node_modules/vite/bin/vite.js","file"],
+        [8084,"symlink","node_modules/.bin/update-browserslist-db","../update-browserslist-db/cli.js",7872,7872,"node_modules/update-browserslist-db/cli.js","file"],
+        [8085,"symlink","node_modules/.bin/nanoid","../nanoid/bin/nanoid.cjs",7889,7889,"node_modules/nanoid/bin/nanoid.cjs","file"],
+        [8086,"symlink","node_modules/.bin/jsesc","../jsesc/bin/jsesc",7908,7908,"node_modules/jsesc/bin/jsesc","file"],
+        [8087,"symlink","node_modules/.bin/jiti","../jiti/lib/jiti-cli.mjs",8342,8342,"node_modules/jiti/lib/jiti-cli.mjs","file"],
+        [8088,"symlink","node_modules/.bin/semver","../semver/bin/semver.js",8371,8371,"node_modules/semver/bin/semver.js","file"]
+      ]
+    },
+    "win32-arm64": {
+      "provenance": {"member_count":8530,"name":"vibe-show-runtime-node-win32-arm64.tgz","sha256":"56f4a7b38e84ebfa9a1f7398b6113edbc30464615c1c6539effc4d04b14ef8c3","size":22220122},
+      "entrypoints": {"cli_path":[8440,"node_modules/@avibe/show-runtime/dist/cli.js"],"cli_source":[84,"packages/runtime/dist/cli.js"],"esbuild_bin":[8500,"node_modules/.bin/esbuild"],"esbuild_package":[5957,"node_modules/esbuild/bin/esbuild"],"esbuild_platform":[7467,"node_modules/@esbuild/win32-arm64/esbuild.exe"]},
+      "links": [
+      ]
+    },
+    "win32-x64": {
+      "provenance": {"member_count":8534,"name":"vibe-show-runtime-node-win32-x64.tgz","sha256":"c7be802e7ef0a06a36df101cbbaf451610ab121841d87aa444687718997ffa89","size":24138106},
+      "entrypoints": {"cli_path":[8444,"node_modules/@avibe/show-runtime/dist/cli.js"],"cli_source":[84,"packages/runtime/dist/cli.js"],"esbuild_bin":[8504,"node_modules/.bin/esbuild"],"esbuild_package":[5957,"node_modules/esbuild/bin/esbuild"],"esbuild_platform":[7471,"node_modules/@esbuild/win32-x64/esbuild.exe"]},
+      "links": [
+      ]
+    }
+  }
+}

--- a/tests/fixtures/show_runtime/v3.0.13/show-runtime-manifest.json
+++ b/tests/fixtures/show_runtime/v3.0.13/show-runtime-manifest.json
@@ -1,0 +1,47 @@
+{
+  "archives": {
+    "darwin-arm64": {
+      "name": "vibe-show-runtime-node-darwin-arm64.tgz",
+      "sha256": "5899da2bb7ff25ae16657fb6bae45298a0a140bc54757a36e398349959da5669",
+      "size": 22310544,
+      "url": "https://github.com/avibe-bot/avibe/releases/download/v3.0.13/vibe-show-runtime-node-darwin-arm64.tgz"
+    },
+    "darwin-x64": {
+      "name": "vibe-show-runtime-node-darwin-x64.tgz",
+      "sha256": "15429f0aa181ddef692faeaa9589f680f8ecf44d0f0a543f3e80fe5ab0ae7b99",
+      "size": 23215818,
+      "url": "https://github.com/avibe-bot/avibe/releases/download/v3.0.13/vibe-show-runtime-node-darwin-x64.tgz"
+    },
+    "linux-arm64": {
+      "name": "vibe-show-runtime-node-linux-arm64.tgz",
+      "sha256": "69026d325f84bee8a96ed41522d59f248b1ad5621377d88746b0aa1f80f89e6b",
+      "size": 22308471,
+      "url": "https://github.com/avibe-bot/avibe/releases/download/v3.0.13/vibe-show-runtime-node-linux-arm64.tgz"
+    },
+    "linux-x64": {
+      "name": "vibe-show-runtime-node-linux-x64.tgz",
+      "sha256": "808d1fe357b9468e2445f023a35ca9e12652d1a6b239f870812d5dd4b905eda8",
+      "size": 23256781,
+      "url": "https://github.com/avibe-bot/avibe/releases/download/v3.0.13/vibe-show-runtime-node-linux-x64.tgz"
+    },
+    "win32-arm64": {
+      "name": "vibe-show-runtime-node-win32-arm64.tgz",
+      "sha256": "56f4a7b38e84ebfa9a1f7398b6113edbc30464615c1c6539effc4d04b14ef8c3",
+      "size": 22220122,
+      "url": "https://github.com/avibe-bot/avibe/releases/download/v3.0.13/vibe-show-runtime-node-win32-arm64.tgz"
+    },
+    "win32-x64": {
+      "name": "vibe-show-runtime-node-win32-x64.tgz",
+      "sha256": "c7be802e7ef0a06a36df101cbbaf451610ab121841d87aa444687718997ffa89",
+      "size": 24138106,
+      "url": "https://github.com/avibe-bot/avibe/releases/download/v3.0.13/vibe-show-runtime-node-win32-x64.tgz"
+    }
+  },
+  "minimum_node": "^20.19.0 || >=22.12.0",
+  "runtime_source": {
+    "ref": "64e2e610e4107304bdc8ce2f2d387d76be6f0a0b",
+    "repo": "avibe-bot/vibe-show-runtime"
+  },
+  "runtime_version": "64e2e610e4107304bdc8ce2f2d387d76be6f0a0b",
+  "schema_version": 1
+}

--- a/tests/test_managed_runtime_composite_artifacts.py
+++ b/tests/test_managed_runtime_composite_artifacts.py
@@ -269,17 +269,27 @@ def test_order_dependent_link_target_stays_confined(
     outside.write_bytes(b"outside\n")
     outside_stat = outside.stat()
 
+    extraction_error = None
     with tarfile.open(archive_path) as archive:
-        with pytest.raises(tarfile.LinkOutsideDestinationError):
+        try:
             extractor(archive, destination)
+        except (KeyError, tarfile.LinkOutsideDestinationError) as error:
+            extraction_error = error
 
     assert outside.read_bytes() == b"outside\n"
     assert outside.stat().st_ino == outside_stat.st_ino
     assert outside.stat().st_nlink == outside_stat.st_nlink
     assert (destination / "outside").read_bytes() == b"archive-inside\n"
-    assert not (destination / "inside-hard").exists()
     assert (destination / "pivot").is_symlink()
-    assert sorted(path.name for path in destination.iterdir()) == ["outside", "pivot"]
+    extracted_hardlink = destination / "inside-hard"
+    if extraction_error is None:
+        assert extracted_hardlink.stat().st_ino == (destination / "outside").stat().st_ino
+        assert extracted_hardlink.stat().st_ino != outside.stat().st_ino
+        expected_members = ["inside-hard", "outside", "pivot"]
+    else:
+        assert not extracted_hardlink.exists()
+        expected_members = ["outside", "pivot"]
+    assert sorted(path.name for path in destination.iterdir()) == expected_members
 
 
 @pytest.mark.parametrize(("_name", "extractor"), EXTRACTORS, ids=[item[0] for item in EXTRACTORS])

--- a/tests/test_managed_runtime_composite_artifacts.py
+++ b/tests/test_managed_runtime_composite_artifacts.py
@@ -245,6 +245,79 @@ def _write_ordering_probe(path: Path) -> None:
         archive.addfile(hardlink)
 
 
+def _write_fallback_escape_probe(path: Path) -> None:
+    with tarfile.open(path, "w") as archive:
+        directory_link = tarfile.TarInfo("a")
+        directory_link.type = tarfile.SYMTYPE
+        directory_link.linkname = "."
+        archive.addfile(directory_link)
+        escaping_link = tarfile.TarInfo("a/x")
+        escaping_link.type = tarfile.SYMTYPE
+        escaping_link.linkname = "../victim"
+        archive.addfile(escaping_link)
+        payload = b"OVERWRITTEN\n"
+        regular = tarfile.TarInfo("x")
+        regular.size = len(payload)
+        archive.addfile(regular, io.BytesIO(payload))
+
+
+def test_shared_fallback_refuses_links_before_extraction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive_path = tmp_path / "fallback-escape.tar"
+    _write_fallback_escape_probe(archive_path)
+    case = tmp_path / "fallback"
+    case.mkdir()
+    destination = case / "destination"
+    victim = case / "victim"
+    victim.write_bytes(b"ORIGINAL\n")
+    victim_stat = victim.stat()
+    monkeypatch.delattr(tarfile, "data_filter", raising=False)
+
+    with tarfile.open(archive_path) as archive:
+        with pytest.raises(
+            ValueError,
+            match=r"^Managed runtime archive link requires tarfile\.data_filter: a$",
+        ):
+            managed_runtime.safe_extract_tar(archive, destination)
+
+    assert victim.read_bytes() == b"ORIGINAL\n"
+    assert victim.stat().st_ino == victim_stat.st_ino
+    assert victim.stat().st_nlink == victim_stat.st_nlink
+    assert not destination.exists()
+
+
+def test_shared_fallback_refuses_hardlinks_before_extraction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive_path = tmp_path / "fallback-hardlink.tar"
+    with tarfile.open(archive_path, "w") as archive:
+        payload = b"payload\n"
+        regular = tarfile.TarInfo("root/regular")
+        regular.size = len(payload)
+        archive.addfile(regular, io.BytesIO(payload))
+        hardlink = tarfile.TarInfo("root/hardlink")
+        hardlink.type = tarfile.LNKTYPE
+        hardlink.linkname = "root/regular"
+        archive.addfile(hardlink)
+    destination = tmp_path / "fallback-hardlink"
+    monkeypatch.delattr(tarfile, "data_filter", raising=False)
+
+    with tarfile.open(archive_path) as archive:
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"^Managed runtime archive link requires "
+                r"tarfile\.data_filter: root/hardlink$"
+            ),
+        ):
+            managed_runtime.safe_extract_tar(archive, destination)
+
+    assert not destination.exists()
+
+
 @pytest.mark.parametrize(
     ("_name", "extractor"),
     (
@@ -292,13 +365,21 @@ def test_order_dependent_link_target_stays_confined(
     assert sorted(path.name for path in destination.iterdir()) == expected_members
 
 
-@pytest.mark.parametrize(("_name", "extractor"), EXTRACTORS, ids=[item[0] for item in EXTRACTORS])
+@pytest.mark.parametrize(
+    ("_name", "extractor", "detects_before_extract"),
+    (
+        ("shared", managed_runtime.safe_extract_tar, True),
+        ("show", show_runtime._safe_extract_tar, False),
+        ("tmux", tmux_runtime._safe_extract_tar, False),
+    ),
+)
 @pytest.mark.parametrize("supports_filter", (True, False), ids=("available", "unavailable"))
-def test_filter_capability_is_detected_by_calling_extractall(
+def test_filter_capability_path(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     _name: str,
     extractor: Extractor,
+    detects_before_extract: bool,
     supports_filter: bool,
 ) -> None:
     archive_path = tmp_path / f"{_name}-{supports_filter}.tar"
@@ -308,6 +389,12 @@ def test_filter_capability_is_detected_by_calling_extractall(
         member.size = len(payload)
         archive.addfile(member, io.BytesIO(payload))
     destination = tmp_path / f"{_name}-{supports_filter}"
+    actual_filter_available = hasattr(tarfile, "data_filter")
+    if detects_before_extract:
+        if supports_filter:
+            monkeypatch.setattr(tarfile, "data_filter", object(), raising=False)
+        else:
+            monkeypatch.delattr(tarfile, "data_filter", raising=False)
     calls: list[object] = []
 
     with tarfile.open(archive_path) as archive:
@@ -315,7 +402,7 @@ def test_filter_capability_is_detected_by_calling_extractall(
 
         def capture_extractall(path, members=None, *, numeric_owner=False, filter=None):
             calls.append(filter)
-            if filter is not None and not supports_filter:
+            if filter is not None and not supports_filter and not detects_before_extract:
                 raise TypeError("filter is unavailable")
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", DeprecationWarning)
@@ -323,11 +410,21 @@ def test_filter_capability_is_detected_by_calling_extractall(
                     path,
                     members=members,
                     numeric_owner=numeric_owner,
-                    **({"filter": filter} if filter is not None else {}),
+                    **(
+                        {"filter": filter}
+                        if filter is not None and actual_filter_available
+                        else {}
+                    ),
                 )
 
         monkeypatch.setattr(archive, "extractall", capture_extractall)
         extractor(archive, destination)
 
-    assert calls == (["data"] if supports_filter else ["data", None])
+    if supports_filter:
+        expected_calls = ["data"]
+    elif detects_before_extract:
+        expected_calls = [None]
+    else:
+        expected_calls = ["data", None]
+    assert calls == expected_calls
     assert (destination / "payload").read_bytes() == payload

--- a/tests/test_managed_runtime_composite_artifacts.py
+++ b/tests/test_managed_runtime_composite_artifacts.py
@@ -370,7 +370,7 @@ def test_order_dependent_link_target_stays_confined(
     (
         ("shared", managed_runtime.safe_extract_tar, True),
         ("show", show_runtime._safe_extract_tar, False),
-        ("tmux", tmux_runtime._safe_extract_tar, False),
+        ("tmux", tmux_runtime._safe_extract_tar, True),
     ),
 )
 @pytest.mark.parametrize("supports_filter", (True, False), ids=("available", "unavailable"))

--- a/tests/test_managed_runtime_composite_artifacts.py
+++ b/tests/test_managed_runtime_composite_artifacts.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import tarfile
+import warnings
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from core import managed_runtime, show_runtime, tmux_runtime
+from core.managed_runtime import ManagedRuntimeManager, ManagedRuntimeSpec
+
+
+FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "show_runtime" / "v3.0.13"
+CLI_PAYLOAD = b"#!/usr/bin/env node\n"
+ESBUILD_PAYLOAD = b"fixture-esbuild\n"
+Extractor = Callable[[tarfile.TarFile, Path], None]
+EXTRACTORS: tuple[tuple[str, Extractor], ...] = (
+    ("shared", managed_runtime.safe_extract_tar),
+    ("show", show_runtime._safe_extract_tar),
+    ("tmux", tmux_runtime._safe_extract_tar),
+)
+
+
+class _CompositeFixtureManager(ManagedRuntimeManager):
+    def __init__(self, *, spec: ManagedRuntimeSpec, runtime_dir: Path, manifest_path: Path, version: str) -> None:
+        super().__init__(spec=spec, runtime_dir=runtime_dir, manifest_path=manifest_path)
+        self._version = version
+
+    def _binary_version(self, binary: Path | None) -> str | None:
+        return self._version if binary and binary.is_file() else None
+
+
+def _released_fixture() -> dict[str, Any]:
+    return json.loads((FIXTURE_ROOT / "composite_artifacts.json").read_text(encoding="utf-8"))
+
+
+def _payload_for(name: str) -> bytes:
+    if name.endswith("dist/cli.js"):
+        return CLI_PAYLOAD
+    if "esbuild" in name:
+        return ESBUILD_PAYLOAD
+    return f"released-shape:{name}\n".encode()
+
+
+def _write_released_shape_archive(tmp_path: Path, platform: str, fixture: dict[str, Any]) -> Path:
+    links = fixture["links"]
+    link_names = {row[2] for row in links}
+    members: dict[str, tuple[int, str]] = {}
+
+    for row in links:
+        resolved_index, resolved_name, resolved_type = row[5:8]
+        if resolved_name not in link_names:
+            members[resolved_name] = (resolved_index, resolved_type)
+    for index, name in fixture["entrypoints"].values():
+        if index is not None and name not in link_names:
+            members[name] = (index, "file")
+
+    events: list[tuple[int, int, str, Any]] = []
+    events.extend((index, 0, name, member_type) for name, (index, member_type) in members.items())
+    events.extend((row[0], 1, row[2], row) for row in links)
+    archive_path = tmp_path / f"{platform}.tar.gz"
+    with tarfile.open(archive_path, "w:gz") as archive:
+        for _index, event_type, name, details in sorted(events):
+            member = tarfile.TarInfo(name)
+            if event_type == 0 and details == "directory":
+                member.type = tarfile.DIRTYPE
+                member.mode = 0o755
+                archive.addfile(member)
+            elif event_type == 0:
+                payload = _payload_for(name)
+                member.size = len(payload)
+                member.mode = 0o755
+                archive.addfile(member, io.BytesIO(payload))
+            else:
+                member.type = tarfile.SYMTYPE if details[1] == "symlink" else tarfile.LNKTYPE
+                member.linkname = details[3]
+                member.mode = 0o755
+                archive.addfile(member)
+    return archive_path
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected_forward_symlinks"),
+    (
+        ("darwin-arm64", 2),
+        ("darwin-x64", 2),
+        ("linux-arm64", 3),
+        ("linux-x64", 2),
+        ("win32-arm64", 0),
+        ("win32-x64", 0),
+    ),
+)
+def test_released_show_links_install_through_shared_manager(
+    tmp_path: Path,
+    platform: str,
+    expected_forward_symlinks: int,
+) -> None:
+    fixture = _released_fixture()
+    release = fixture["release"]
+    released_manifest_bytes = (FIXTURE_ROOT / release["manifest_name"]).read_bytes()
+    assert hashlib.sha256(released_manifest_bytes).hexdigest() == release["manifest_sha256"]
+    released_manifest = json.loads(released_manifest_bytes)
+    assert release["tag"] == "v3.0.13"
+    assert released_manifest["runtime_version"] == release["runtime_version"]
+
+    archive_fixture = fixture["archives"][platform]
+    provenance = archive_fixture["provenance"]
+    released_archive = released_manifest["archives"][platform]
+    assert {
+        "name": released_archive["name"],
+        "sha256": released_archive["sha256"],
+        "size": released_archive["size"],
+    } == {key: provenance[key] for key in ("name", "sha256", "size")}
+
+    links = archive_fixture["links"]
+    symlinks = [row for row in links if row[1] == "symlink"]
+    hardlinks = [row for row in links if row[1] == "hardlink"]
+    assert all(
+        0 <= index < provenance["member_count"]
+        for row in links
+        for index in (row[0], row[5])
+    )
+    if platform.startswith("win32"):
+        assert links == []
+    else:
+        assert len(symlinks) == 16
+        assert len(hardlinks) == 1
+        assert all(row[4] is not None and row[4] < row[0] for row in hardlinks)
+    assert sum(row[4] is not None and row[4] > row[0] for row in symlinks) == expected_forward_symlinks
+
+    archive_path = _write_released_shape_archive(tmp_path, platform, archive_fixture)
+    entrypoints = archive_fixture["entrypoints"]
+    cli_path = entrypoints["cli_path"][1]
+    manifest_payload = {
+        "schema_version": 1,
+        "runtime_version": release["runtime_version"],
+        "source": f"released-shape:{release['tag']}",
+        "archives": {
+            platform: {
+                "name": archive_path.name,
+                "url": archive_path.as_uri(),
+                "sha256": hashlib.sha256(archive_path.read_bytes()).hexdigest(),
+                "binary_sha256": hashlib.sha256(CLI_PAYLOAD).hexdigest(),
+                "size": archive_path.stat().st_size,
+                "bin_path": cli_path,
+            }
+        },
+    }
+    manifest_path = tmp_path / f"{platform}-manifest.json"
+    manifest_path.write_text(json.dumps(manifest_payload), encoding="utf-8")
+    manager = _CompositeFixtureManager(
+        spec=ManagedRuntimeSpec(
+            runtime_id=f"show-fixture-{platform}",
+            manifest_resource="unused.json",
+            version_field="runtime_version",
+            default_bin_path=cli_path,
+            platform_aliases=((managed_runtime.runtime_platform_tag(), platform),),
+        ),
+        runtime_dir=tmp_path / f"runtime-{platform}",
+        manifest_path=manifest_path,
+        version=release["runtime_version"],
+    )
+
+    result = manager.ensure()
+
+    assert result["ok"] is True
+    install_dir = Path(result["install_dir"])
+    assert (install_dir / cli_path).read_bytes() == CLI_PAYLOAD
+    assert manager.resolve_binary() == (install_dir / cli_path).resolve()
+    for key in ("esbuild_bin", "esbuild_package", "esbuild_platform"):
+        assert (install_dir / entrypoints[key][1]).read_bytes() == ESBUILD_PAYLOAD
+    for row in symlinks:
+        assert (install_dir / row[2]).is_symlink()
+        assert (install_dir / row[2]).exists()
+    for row in hardlinks:
+        assert (install_dir / row[2]).stat().st_ino == (install_dir / row[6]).stat().st_ino
+
+
+def _write_link_probe(path: Path, *, escaping: bool = False) -> None:
+    with tarfile.open(path, "w") as archive:
+        if escaping:
+            link = tarfile.TarInfo("root/escape")
+            link.type = tarfile.SYMTYPE
+            link.linkname = "../../outside"
+            archive.addfile(link)
+            return
+        payload = b"composite\n"
+        regular = tarfile.TarInfo("root/regular")
+        regular.size = len(payload)
+        regular.mode = 0o644
+        archive.addfile(regular, io.BytesIO(payload))
+        symlink = tarfile.TarInfo("root/symlink")
+        symlink.type = tarfile.SYMTYPE
+        symlink.linkname = "regular"
+        archive.addfile(symlink)
+        hardlink = tarfile.TarInfo("root/hardlink")
+        hardlink.type = tarfile.LNKTYPE
+        hardlink.linkname = "root/regular"
+        archive.addfile(hardlink)
+
+
+@pytest.mark.parametrize(("_name", "extractor"), EXTRACTORS, ids=[item[0] for item in EXTRACTORS])
+def test_extractor_behavior_accepts_composite_members_and_rejects_escape(
+    tmp_path: Path,
+    _name: str,
+    extractor: Extractor,
+) -> None:
+    benign = tmp_path / "benign.tar"
+    _write_link_probe(benign)
+    destination = tmp_path / "benign"
+    with tarfile.open(benign) as archive:
+        extractor(archive, destination)
+    assert (destination / "root/symlink").read_bytes() == b"composite\n"
+    assert (destination / "root/hardlink").stat().st_ino == (destination / "root/regular").stat().st_ino
+
+    escaping = tmp_path / "escaping.tar"
+    _write_link_probe(escaping, escaping=True)
+    escaped_destination = tmp_path / "escaping"
+    with tarfile.open(escaping) as archive:
+        with pytest.raises((ValueError, tarfile.FilterError)):
+            extractor(archive, escaped_destination)
+    assert not escaped_destination.exists()
+    assert not (tmp_path / "outside").exists()
+
+
+def _write_ordering_probe(path: Path) -> None:
+    with tarfile.open(path, "w") as archive:
+        directory_link = tarfile.TarInfo("pivot")
+        directory_link.type = tarfile.SYMTYPE
+        directory_link.linkname = "."
+        archive.addfile(directory_link)
+        hardlink = tarfile.TarInfo("inside-hard")
+        hardlink.type = tarfile.LNKTYPE
+        hardlink.linkname = "pivot/../outside"
+        archive.addfile(hardlink)
+
+
+@pytest.mark.parametrize(
+    ("_name", "extractor"),
+    (
+        ("shared", managed_runtime.safe_extract_tar),
+        ("show", show_runtime._safe_extract_tar),
+        ("tarfile", lambda archive, destination: archive.extractall(destination, filter="data")),
+    ),
+)
+def test_order_dependent_link_target_stays_confined(
+    tmp_path: Path,
+    _name: str,
+    extractor: Extractor,
+) -> None:
+    if not hasattr(tarfile, "data_filter"):
+        pytest.skip("data filter unavailable on this deferred fallback interpreter")
+    archive_path = tmp_path / "ordering.tar"
+    _write_ordering_probe(archive_path)
+    case = tmp_path / _name
+    destination = case / "destination"
+    destination.mkdir(parents=True)
+    outside = case / "outside"
+    outside.write_bytes(b"outside\n")
+    outside_stat = outside.stat()
+
+    with tarfile.open(archive_path) as archive:
+        with pytest.raises(tarfile.LinkOutsideDestinationError):
+            extractor(archive, destination)
+
+    assert outside.read_bytes() == b"outside\n"
+    assert outside.stat().st_ino == outside_stat.st_ino
+    assert outside.stat().st_nlink == outside_stat.st_nlink
+    assert not (destination / "inside-hard").exists()
+    assert (destination / "pivot").is_symlink()
+    assert list(destination.iterdir()) == [destination / "pivot"]
+
+
+@pytest.mark.parametrize(("_name", "extractor"), EXTRACTORS, ids=[item[0] for item in EXTRACTORS])
+@pytest.mark.parametrize("supports_filter", (True, False), ids=("available", "unavailable"))
+def test_filter_capability_is_detected_by_calling_extractall(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _name: str,
+    extractor: Extractor,
+    supports_filter: bool,
+) -> None:
+    archive_path = tmp_path / f"{_name}-{supports_filter}.tar"
+    payload = b"filtered\n"
+    with tarfile.open(archive_path, "w") as archive:
+        member = tarfile.TarInfo("payload")
+        member.size = len(payload)
+        archive.addfile(member, io.BytesIO(payload))
+    destination = tmp_path / f"{_name}-{supports_filter}"
+    calls: list[object] = []
+
+    with tarfile.open(archive_path) as archive:
+        original_extractall = archive.extractall
+
+        def capture_extractall(path, members=None, *, numeric_owner=False, filter=None):
+            calls.append(filter)
+            if filter is not None and not supports_filter:
+                raise TypeError("filter is unavailable")
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                return original_extractall(
+                    path,
+                    members=members,
+                    numeric_owner=numeric_owner,
+                    **({"filter": filter} if filter is not None else {}),
+                )
+
+        monkeypatch.setattr(archive, "extractall", capture_extractall)
+        extractor(archive, destination)
+
+    assert calls == (["data"] if supports_filter else ["data", None])
+    assert (destination / "payload").read_bytes() == payload

--- a/tests/test_managed_runtime_composite_artifacts.py
+++ b/tests/test_managed_runtime_composite_artifacts.py
@@ -230,6 +230,11 @@ def test_extractor_behavior_accepts_composite_members_and_rejects_escape(
 
 def _write_ordering_probe(path: Path) -> None:
     with tarfile.open(path, "w") as archive:
+        payload = b"archive-inside\n"
+        regular = tarfile.TarInfo("outside")
+        regular.size = len(payload)
+        regular.mode = 0o644
+        archive.addfile(regular, io.BytesIO(payload))
         directory_link = tarfile.TarInfo("pivot")
         directory_link.type = tarfile.SYMTYPE
         directory_link.linkname = "."
@@ -271,9 +276,10 @@ def test_order_dependent_link_target_stays_confined(
     assert outside.read_bytes() == b"outside\n"
     assert outside.stat().st_ino == outside_stat.st_ino
     assert outside.stat().st_nlink == outside_stat.st_nlink
+    assert (destination / "outside").read_bytes() == b"archive-inside\n"
     assert not (destination / "inside-hard").exists()
     assert (destination / "pivot").is_symlink()
-    assert list(destination.iterdir()) == [destination / "pivot"]
+    assert sorted(path.name for path in destination.iterdir()) == ["outside", "pivot"]
 
 
 @pytest.mark.parametrize(("_name", "extractor"), EXTRACTORS, ids=[item[0] for item in EXTRACTORS])

--- a/tests/test_tmux_runtime.py
+++ b/tests/test_tmux_runtime.py
@@ -238,7 +238,7 @@ def test_macos_codesign_path_is_used(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert calls[0][4].endswith("/tmux")
 
 
-def test_safe_extract_tar_falls_back_when_data_filter_is_unavailable(
+def test_safe_extract_tar_omits_filter_when_data_filter_is_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -246,14 +246,13 @@ def test_safe_extract_tar_falls_back_when_data_filter_is_unavailable(
     destination = tmp_path / "extract"
     destination.mkdir()
     calls: list[object] = []
+    monkeypatch.delattr(tarfile, "data_filter", raising=False)
 
     with tarfile.open(archive, "r:gz") as tar:
         original_extractall = tar.extractall
 
         def capture_extractall(path, members=None, *, numeric_owner=False, filter=None):
             calls.append(filter)
-            if filter is not None:
-                raise TypeError("filter is unavailable")
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", DeprecationWarning)
                 return original_extractall(path, members=members, numeric_owner=numeric_owner)
@@ -261,11 +260,11 @@ def test_safe_extract_tar_falls_back_when_data_filter_is_unavailable(
         monkeypatch.setattr(tar, "extractall", capture_extractall)
         tmux_runtime._safe_extract_tar(tar, destination)
 
-    assert calls == ["data", None]
+    assert calls == [None]
     assert (destination / "tmux").is_file()
 
 
-def test_safe_extract_tar_uses_available_data_filter_before_python_312(
+def test_safe_extract_tar_uses_available_data_filter(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -273,6 +272,7 @@ def test_safe_extract_tar_uses_available_data_filter_before_python_312(
     destination = tmp_path / "extract"
     destination.mkdir()
     calls: list[object] = []
+    monkeypatch.setattr(tarfile, "data_filter", object(), raising=False)
 
     with tarfile.open(archive, "r:gz") as tar:
         original_extractall = tar.extractall
@@ -281,7 +281,6 @@ def test_safe_extract_tar_uses_available_data_filter_before_python_312(
             calls.append(filter)
             return original_extractall(path, members=members, numeric_owner=numeric_owner, filter=filter)
 
-        monkeypatch.setattr(tmux_runtime.sys, "version_info", (3, 10, 12))
         monkeypatch.setattr(tar, "extractall", capture_extractall)
         tmux_runtime._safe_extract_tar(tar, destination)
 
@@ -343,7 +342,10 @@ def test_safe_extract_tar_rejects_root_escaping_hard_link(tmp_path: Path) -> Non
     assert victim.stat().st_nlink == original_victim_stat.st_nlink
 
 
-def test_safe_extract_tar_allows_root_relative_in_tree_hard_link(tmp_path: Path) -> None:
+def test_safe_extract_tar_allows_root_relative_in_tree_hard_link(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     source = tmp_path / "source"
     source.mkdir()
     binary = source / "tmux-real"
@@ -352,6 +354,7 @@ def test_safe_extract_tar_allows_root_relative_in_tree_hard_link(tmp_path: Path)
     archive = tmp_path / "tmux-hardlink-safe.tar.gz"
     destination = tmp_path / "extract"
     destination.mkdir()
+    monkeypatch.delattr(tarfile, "data_filter", raising=False)
 
     with tarfile.open(archive, "w:gz") as tar:
         tar.add(binary, arcname="tmux-real")
@@ -366,7 +369,9 @@ def test_safe_extract_tar_allows_root_relative_in_tree_hard_link(tmp_path: Path)
         tar.addfile(hard_link)
 
     with tarfile.open(archive, "r:gz") as tar:
-        tmux_runtime._safe_extract_tar(tar, destination)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            tmux_runtime._safe_extract_tar(tar, destination)
 
     installed = destination / "sub" / "tmux"
     assert installed.read_text(encoding="utf-8") == "#!/bin/sh\necho tmux 3.6b\n"

--- a/tests/test_tmux_runtime.py
+++ b/tests/test_tmux_runtime.py
@@ -6,6 +6,7 @@ import stat
 import io
 import tarfile
 import urllib.error
+import warnings
 from pathlib import Path
 
 import pytest
@@ -237,40 +238,41 @@ def test_macos_codesign_path_is_used(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert calls[0][4].endswith("/tmux")
 
 
-def test_safe_extract_tar_omits_filter_before_python_312(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_safe_extract_tar_falls_back_when_data_filter_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     archive = _write_tmux_archive(tmp_path)
     destination = tmp_path / "extract"
     destination.mkdir()
     calls: list[object] = []
-
-    class VersionInfo(tuple):
-        major = 3
-        minor = 11
 
     with tarfile.open(archive, "r:gz") as tar:
         original_extractall = tar.extractall
 
         def capture_extractall(path, members=None, *, numeric_owner=False, filter=None):
             calls.append(filter)
-            return original_extractall(path, members=members, numeric_owner=numeric_owner)
+            if filter is not None:
+                raise TypeError("filter is unavailable")
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                return original_extractall(path, members=members, numeric_owner=numeric_owner)
 
-        monkeypatch.setattr(tmux_runtime.sys, "version_info", VersionInfo((3, 11, 0)))
         monkeypatch.setattr(tar, "extractall", capture_extractall)
         tmux_runtime._safe_extract_tar(tar, destination)
 
-    assert calls == [None]
+    assert calls == ["data", None]
     assert (destination / "tmux").is_file()
 
 
-def test_safe_extract_tar_uses_data_filter_on_python_312_plus(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_safe_extract_tar_uses_available_data_filter_before_python_312(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     archive = _write_tmux_archive(tmp_path)
     destination = tmp_path / "extract"
     destination.mkdir()
     calls: list[object] = []
-
-    class VersionInfo(tuple):
-        major = 3
-        minor = 12
 
     with tarfile.open(archive, "r:gz") as tar:
         original_extractall = tar.extractall
@@ -279,7 +281,7 @@ def test_safe_extract_tar_uses_data_filter_on_python_312_plus(tmp_path: Path, mo
             calls.append(filter)
             return original_extractall(path, members=members, numeric_owner=numeric_owner, filter=filter)
 
-        monkeypatch.setattr(tmux_runtime.sys, "version_info", VersionInfo((3, 12, 0)))
+        monkeypatch.setattr(tmux_runtime.sys, "version_info", (3, 10, 12))
         monkeypatch.setattr(tar, "extractall", capture_extractall)
         tmux_runtime._safe_extract_tar(tar, destination)
 


### PR DESCRIPTION
## Changed capability

- Allow the shared managed-runtime installer to extract composite directory artifacts containing confined symlinks and hard links while preserving the existing binary path.
- Resolve and re-admit a managed entrypoint reached through an internal archive symlink.
- Capability-detect `tarfile`'s `data` filter in shared and tmux extraction instead of gating it on Python 3.12.
- Decide the shared and tmux filter paths before extraction. The shared no-filter branch declines link-bearing archives before any member is written; tmux preserves its existing confined-link behavior.

Base: `31692465e269b2e7add2738c83c8e006148a6d06`. No rebase. No dependency on another open PR.

## Defects closed

The shared extractor previously caught `TypeError` around the full filtered extraction call. A `TypeError` from inside extraction could therefore retry the archive unfiltered after a partial result, and an interpreter without filter support admitted link members directly to the unfiltered path.

The tmux extractor had the same call-result decision after its version gate was removed: rejection of the filtered call triggered a second unfiltered extraction. It now captures `hasattr(tarfile, "data_filter")` before validation and makes exactly one extraction call on either branch. Its member-type, member-name, `linkname`, and target-confinement predicates are byte-unchanged, and its no-filter branch continues to accept confined links.

Shared filter availability is likewise fixed once through `hasattr(tarfile, "data_filter")`. Link members require that capability; the filtered call is no longer wrapped by a fallback catch. CPython source tags verify that the capability and call signature move together: both are absent in 3.10.11 and 3.11.3, and both are present in 3.10.12 and 3.11.4.

The settling fixture drives the capability signal directly on a filter-capable interpreter. It proves that the shared extractor refuses the hostile link-order archive before extraction and leaves a sibling file unchanged in content, inode, and link count. A separate case covers hard-link refusal. Removing the exact refusal block produces `1 failed` (`DID NOT RAISE`); restoring it produces `1 passed`. The same capability fixture asserts tmux call sequences of `["data"]` and `[None]`, while its confined hard-link fixture runs with the filter capability absent.

## Step 3 acceptance corpus

| Census row | Executable evidence | Released fixture |
| --- | --- | --- |
| Released Show links | All six v3.0.13 platform shapes install through `ManagedRuntimeManager`; Unix asserts 16 symlinks, one prior-target esbuild hard link, nine forward symlinks across the four archives, no final dangling link, and CLI/esbuild entrypoints. | Byte-exact v3.0.13 manifest plus per-archive link/member topology bound to the manifest's archive name, size, and SHA-256. |
| Extractor behavior | Shared, Show, and tmux accept regular/symlink/hard-link probes and reject escaping `linkname`; shared, Show, and raw filtered extraction also exercise the order-dependent confinement probe. The shared no-filter branch refuses links before extraction; the tmux no-filter branch still accepts confined links. | Not applicable: this row cites synthesized behavior, not released bytes. |
| Filter capability | Shared and tmux select their branch from `tarfile.data_filter` before extraction; Show retains its call-based capability path. Link-free shared archives exercise both branches, link-bearing shared archives require the filter, and tmux makes one extraction call in each branch. | Not applicable: this row cites interpreter capability, not released bytes. |

No scenario catalog IDs apply. These three named census rows are the closed acceptance corpus; none was added, dropped, or reinterpreted.

## Predicate mapping

### Shared `safe_extract_tar`

| Pre-change condition | Post-change counterpart | Disposition |
| --- | --- | --- |
| Iterate every member from `archive.getmembers()` before extraction. | The same complete pre-extraction loop remains. | Unchanged. |
| Reject unless `member.isfile() or member.isdir()`. | Reject unless file, directory, symlink, or hard link. | Intentionally widened only for the two composite link types required by released Show archives. |
| Reject when `archive_path_is_unsafe(member.name)`. | Identical predicate remains before any target calculation. | Unchanged. |
| Compute `(destination / member.name).resolve()` and require destination equality or ancestry. | Identical computation and confinement predicate remain. | Unchanged. |
| No link-target predicate because links were rejected. | Symlinks resolve from their containing directory; hard links resolve from the destination; both retain the same destination equality/ancestry test. | New conditions required by the widened member-type predicate. `archive_path_is_unsafe` is not applied to `linkname`, preserving released bundle links. |
| At the prior PR head, call `filter="data"` and retry unfiltered after any `TypeError`. | Capture `hasattr(tarfile, "data_filter")` once. Without it, reject the first link member with its name and capability reason; link-free archives extract unfiltered. With it, make one filtered extraction call. | Replaces a fail-open extraction-body catch with a preflight capability decision. |

### `ManagedRuntimeManager.ensure`

| Pre-change condition | Post-change counterpart | Disposition |
| --- | --- | --- |
| Before commit, require the staged `archive.bin_path` to be a file, prepare it, verify its digest, and verify it matches the manifest. | Identical staged predicates remain. | Unchanged. |
| After moving staging into the install directory, report `install_dir / archive.bin_path` lexically. | Resolve that path with `strict=True` before metadata and pointer commit. | Required for a released entrypoint reached through an internal symlink; a missing post-move target now aborts the transaction. |

### `ManagedRuntimeManager._verified_manifest_binary`

| Pre-change condition | Post-change counterpart | Disposition |
| --- | --- | --- |
| Require `bin_path` to be a safe relative string. | Identical predicate remains. | Unchanged. |
| Form `install_dir / bin_path`, then require file type and executable access. | Strictly resolve the install directory and binary; resolution failure returns no admitted binary. Require the resolved binary to be below the resolved install directory, then retain file and executable checks. | Adds symlink-aware confinement while admitting internal symlink entrypoints. |
| Require provider/runtime/target/platform/bin-path metadata and the binary digest to match. | Identical predicate set remains, evaluated against the resolved target bytes. | Unchanged. |

### Tmux `_safe_extract_tar`

| Pre-change condition | Post-change counterpart | Disposition |
| --- | --- | --- |
| At the prior PR head, call `filter="data"` and retry unfiltered after a `TypeError`. | Capture `hasattr(tarfile, "data_filter")` once before any extraction. Call once with `filter="data"` when present and once without a filter when absent. | Replaces the fail-open retry with a preflight capability decision. The member-type, member-name, `linkname`, and target-confinement predicates are byte-unchanged; confined links remain accepted without the filter. |

Show `_safe_extract_tar` is unchanged.

## Mechanical gates

- Gate 1: not applicable. This change adds no non-dunder shared hook and converts no `NotImplementedError` hook to concrete behavior.
- Gate 2: not applicable. This change adds no public shared-layer symbol. Existing `safe_extract_tar` remains called by `ManagedRuntimeManager.ensure` in production.
- Gate 3: exactly the three Step 3 census rows above have executable coverage. No corpus row was added, dropped, or reinterpreted.
- Existing git, Memory, and model-hub fixture files are byte-unchanged.

## Evidence

- Unit/contract: 92 combined composite, shared-manager, and tmux tests passed.
- Call sequence: tmux asserts exactly `["data"]` with capability present and `[None]` with capability absent; the absent branch's confined hard-link fixture passes.
- Mutation: exact shared refusal-block removal produced `1 failed` (`DID NOT RAISE`); restoration produced `1 passed`.
- Released artifacts: the v3.0.13 manifest and all six archives were digest-verified; every platform shape installed through `ManagedRuntimeManager.ensure`, re-resolved its admitted CLI from disk, and exposed the expected esbuild entrypoints.
- Capability pairing: CPython 3.10.11/3.10.12 and 3.11.3/3.11.4 source tags confirm `data_filter` and the extraction `filter` parameter arrive together.
- Lint: Ruff passed on every changed Python file.
- Residual manual: no Incus regression run; this step changes archive installation internals and has no direct IM/UI workflow. Integration regression remains for the orchestrator's convergence pass.

## Size against merge base

- Production source: +36 / -7 lines, net +29.
- Tests, fixtures, and fixture documentation: +630 / -15 lines, net +615.
- Total: +666 / -22 lines, net +644.

## Known-by-design ledger

- Shared link-free binary archives keep the unfiltered fallback on Python 3.10.0-3.10.11 and 3.11.0-3.11.3; composite link archives are explicitly declined there. POSIX mode and final-tree ownership normalization remain deferred.
- Show retains its pre-existing link-member behavior. Tmux retains all four link/member safety predicates and its confined-link behavior; only the filter capability decision and single-call extraction branch changed.
- Filtered extraction may either accept or reject the order-dependent hard link across Python patch versions, but the external sibling remains content-, inode-, and link-count-identical in both outcomes.
- Show's parallel installer remains in place; this step supplies the shared composite representation but does not perform the later Show cutover.
