### PR TITLE
fix(model-hub): restore mobile scrolling

### DIFF
--- a/ui/src/components/settings/SettingsLayout.test.tsx
+++ b/ui/src/components/settings/SettingsLayout.test.tsx
@@ -102,6 +102,19 @@ afterEach(() => {
 });
 
 describe('SettingsLayout', () => {
+  it('keeps the mobile shell constrained so the route pane owns vertical scrolling', () => {
+    renderLayout('/settings/replies');
+
+    const routePane = screen.getByText('replies-body').closest('section');
+    const shell = routePane?.parentElement?.parentElement;
+
+    expect(routePane?.className).toContain('overflow-y-auto');
+    expect(shell?.className).toContain('h-full');
+    expect(shell?.className).toContain('min-h-0');
+    expect(shell?.className).toContain('md:h-auto');
+    expect(shell?.className).not.toContain('min-h-full');
+  });
+
   it('renders the three-group rail and feature-gated owner sections', async () => {
     renderLayout('/settings/replies');
 

--- a/ui/src/components/settings/SettingsLayout.tsx
+++ b/ui/src/components/settings/SettingsLayout.tsx
@@ -272,7 +272,7 @@ export const SettingsLayout: React.FC = () => {
   }, [atRoot, capabilities.can_manage_instance, isDesktop, navigate]);
 
   return (
-    <div className="flex min-h-full flex-col bg-background md:min-h-screen">
+    <div className="flex h-full min-h-0 flex-col bg-background md:h-auto md:min-h-screen">
       <header className="flex h-[calc(3.5rem+env(safe-area-inset-top))] shrink-0 items-center justify-between border-b border-border bg-surface px-4 pt-[env(safe-area-inset-top)] md:h-14 md:pt-0">
         <div className="flex min-w-0 items-center gap-2 text-[13px] font-semibold text-foreground">
           <Settings className="size-4 text-mint-ink" />

--- a/ui/src/components/settings/models/GatewayModule.test.tsx
+++ b/ui/src/components/settings/models/GatewayModule.test.tsx
@@ -25,6 +25,33 @@ const agent: AgentSupply = {
 afterEach(cleanup);
 
 describe('GatewayModule region failure treatment', () => {
+  it('fills a narrow overview column without preserving an intrinsic panel width', () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <GatewayModule
+          supply={readyRegion([])}
+          runtime={null}
+          runtimeSnapshot={null}
+          onRetry={vi.fn()}
+          sources={[]}
+          chains={{}}
+          pendingBackends={new Set()}
+          switchFailures={new Set()}
+          connectingBackend={null}
+          onConnectHub={vi.fn()}
+          onSwitchDirect={vi.fn()}
+          onOpenOrder={vi.fn()}
+          onOpenRoute={vi.fn()}
+          onProbeSettled={vi.fn()}
+        />
+      </I18nextProvider>,
+    );
+
+    const panel = screen.getByRole('heading', { name: /Gateway|网关/i }).closest('section');
+    expect(panel?.className).toContain('w-full');
+    expect(panel?.className).toContain('min-w-0');
+  });
+
   it('keeps the last good Agent rows visible with an F2 retry after a later read fails', async () => {
     const onRetry = vi.fn();
     render(

--- a/ui/src/components/settings/models/GatewayModule.tsx
+++ b/ui/src/components/settings/models/GatewayModule.tsx
@@ -26,7 +26,7 @@ export const GatewayModule: React.FC<GatewayModuleProps> = ({ runtime, runtimeSn
   });
   const listening = runtimeSnapshot?.status.listening;
   return (
-    <section className="relative z-20 flex max-h-full min-h-[420px] flex-col self-start overflow-hidden rounded-[14px] border border-border bg-surface">
+    <section className="relative z-20 flex max-h-full min-h-[420px] w-full min-w-0 flex-col self-start overflow-hidden rounded-[14px] border border-border bg-surface">
       <header className="flex h-14 shrink-0 items-center justify-between border-b border-border px-3.5">
         <h2 className="text-[16px] font-bold leading-[23px] text-foreground">{t('settings.models.gateway.heading')}</h2>
         {listening && <span className="model-hub-pill model-hub-fill-0a border border-border text-muted">{listening.host}:{listening.port}</span>}

--- a/ui/src/components/settings/models/SourcesCard.test.tsx
+++ b/ui/src/components/settings/models/SourcesCard.test.tsx
@@ -25,6 +25,18 @@ const retained: Source = {
 afterEach(cleanup);
 
 describe('SourcesCard footer', () => {
+  it('fills a narrow overview column without preserving an intrinsic panel width', () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <SourcesCard read={readyRegion([])} onRetry={vi.fn()} onOpenSource={vi.fn()} onAddApiKey={vi.fn()} onAddSubscription={vi.fn()} />
+      </I18nextProvider>,
+    );
+
+    const panel = screen.getByRole('heading', { name: /Sources|来源/i }).closest('section');
+    expect(panel?.className).toContain('w-full');
+    expect(panel?.className).toContain('min-w-0');
+  });
+
   it('exposes the upstream info note to keyboard activation and Escape dismissal', async () => {
     const user = userEvent.setup();
     render(

--- a/ui/src/components/settings/models/SourcesCard.tsx
+++ b/ui/src/components/settings/models/SourcesCard.tsx
@@ -34,7 +34,7 @@ export const SourcesCard: React.FC<{
   // leave ~100px of void above it. `max-h-full` still hands overflow to the
   // scroll region when there are more.
   return (
-    <section className="relative z-20 flex max-h-full flex-col self-start overflow-hidden rounded-[14px] border border-border bg-surface">
+    <section className="relative z-20 flex max-h-full w-full min-w-0 flex-col self-start overflow-hidden rounded-[14px] border border-border bg-surface">
       <div className="flex h-14 shrink-0 items-center justify-between border-b border-border px-3.5">
         <span className="flex items-center gap-[7px]">
           <h2 className="text-[16px] font-bold leading-[23px] text-foreground">{t('settings.models.upstream.heading')}</h2>


### PR DESCRIPTION
## Summary

- capability: Model Hub remains usable inside the mobile settings shell.
- user-visible change: the Model Hub route scrolls vertically on narrow screens, while the Sources and Gateway panels fit the available column instead of clipping past the viewport.
- motivation: the settings shell locked document scrolling, but its route layout grew with content instead of constraining the inner scroll pane; narrow panels also retained their intrinsic width.

## Scenario Coverage

- scenario IDs: none; this is responsive containment for the existing Model Hub shell.
- unit / contract coverage: SettingsLayout owns a constrained mobile shell, and both overview panels explicitly fill and shrink within narrow columns.
- scenario coverage: 59 focused SettingsLayout and Model Hub component/page tests pass.
- residual manual checks: the merged Model Hub design contract explicitly leaves responsive containment to implementation, so no new `design.pen` frame is required.

## Validation

- commands run: focused Vitest suites, UI lint baseline, production UI build, ESLint on changed files, and `git diff --check`.
- result: all pass. Local Incus browser QA passed at 320x568, 390x844, and 1470x797. At 320px, the route pane scrolls from top to its exact bottom, document width remains 320px, no element crosses the viewport, and both overview panels resolve to the 288px content width. Usage and Logs remain reachable at 390px; desktop retains document-flow scrolling with no horizontal overflow.

## Risks / Follow-ups

- risk: low; the change only adjusts responsive size constraints and keeps desktop behavior behind existing `md:` overrides.
- follow-up: none.
