### PR TITLE
fix(memory): close crash recovery gaps

### DIFF
--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -350,6 +350,7 @@ class MemoryRuntime:
         # enter an EverOSPort only inside the owned child probe/sidecar.
         self._provider = EverOSPort(self._socket_path)
         self._runtime_error: str | None = None
+        self._released_ownership_blocked = False
         self._needs_repair_reason: str | None = (
             "memory_legacy_recovery_required"
             if config.legacy_needs_repair
@@ -722,12 +723,24 @@ class MemoryRuntime:
         """Best-effort compatibility cleanup for ordinary non-destructive flows."""
 
         async with self._reconcile_lock:
+            was_blocked = self._released_ownership_blocked
             try:
                 required_no_follow_flag()
             except ConfinedFilesystemError as exc:
                 logger.warning("Recorded EverOS recovery is unavailable: %s", exc)
+                self._released_ownership_blocked = True
+                self._runtime_error = "memory_sidecar_unavailable"
                 return False
-            return await self._supervisor.reconcile_orphans()
+            reconciled = await self._supervisor.reconcile_orphans()
+            if not reconciled and self._supervisor.status.retains_configuration:
+                # The current supervisor-owned child is not released ownership.
+                reconciled = True
+            self._released_ownership_blocked = not reconciled
+            if not reconciled:
+                self._runtime_error = "memory_sidecar_unavailable"
+            elif was_blocked and self._runtime_error == "memory_sidecar_unavailable":
+                self._runtime_error = None
+            return reconciled
 
     async def reconcile(self, config: MemoryConfig) -> dict[str, Any]:
         """Apply persisted config without restarting the Avibe service."""
@@ -743,7 +756,12 @@ class MemoryRuntime:
         # sidecar is exactly the boot that may face one from the run before it.
         # Takes and releases the reconcile lock itself; the lock this method
         # acquires later is a separate, sequential acquisition.
-        await self._reconcile_released_ownership()
+        if not await self._reconcile_released_ownership():
+            return {
+                "ok": False,
+                "state": "needs_repair" if self.needs_repair else "degraded",
+                "error": "memory_sidecar_unavailable",
+            }
         if not self.available:
             # A transient store failure must not close Memory forever: every
             # reconciliation is another chance to open it.
@@ -1096,9 +1114,13 @@ class MemoryRuntime:
         payload = _runtime_health_payload(runtime)
         payload["state"] = self.runtime_state()
         payload["reason"] = (
-            self._needs_repair_reason
-            if self.needs_repair
-            else self._runtime_error
+            self._runtime_error
+            if self._released_ownership_blocked
+            else (
+                self._needs_repair_reason
+                if self.needs_repair
+                else self._runtime_error
+            )
         )
         payload["attachment_capture"] = {
             "status": _attachment_capture_status(
@@ -1115,6 +1137,8 @@ class MemoryRuntime:
     ]:
         if self.needs_repair:
             return "needs_repair"
+        if self._released_ownership_blocked:
+            return "degraded"
         if not self._config.enabled:
             return "disabled"
         if self._artifact_installing or self._reconcile_lock.locked():
@@ -1964,7 +1988,12 @@ class MemoryRuntime:
 
             # Even disabled or repair-fenced startup must stop a sidecar recorded
             # by the previous Avibe process before returning.
-            await self._reconcile_released_ownership()
+            if not await self._reconcile_released_ownership():
+                return {
+                    "ok": False,
+                    "state": "needs_repair" if self.needs_repair else "degraded",
+                    "error": "memory_sidecar_unavailable",
+                }
             if (
                 self._wake_config.enabled
                 and not self.available

--- a/core/memory/supervisor.py
+++ b/core/memory/supervisor.py
@@ -358,27 +358,26 @@ class EverOSSupervisor:
         child: EverOSProcessPort,
         epoch: int,
     ) -> None:
-        should_restart = False
         async with self._lock:
             if self._closing or epoch != self._epoch or child is not self._child:
                 return
+            # A retained helper or process tree still needs the same bounded Wake
+            # path. Wake retries stop proof before it can create a replacement.
+            # Slow recovery does not earn a fresh budget. Only a replacement
+            # that stayed admitted for the full window starts a new episode.
+            stable_since = self._restart_stable_since
+            if (
+                stable_since is not None
+                and time.monotonic() - stable_since
+                >= self._restart_window_seconds
+            ):
+                self._restart_attempts = 0
+            self._restart_stable_since = None
             if not child.retains_active_config:
-                # Slow recovery does not earn a fresh budget. Only a replacement
-                # that stayed admitted for the full window starts a new episode.
-                stable_since = self._restart_stable_since
-                if (
-                    stable_since is not None
-                    and time.monotonic() - stable_since
-                    >= self._restart_window_seconds
-                ):
-                    self._restart_attempts = 0
-                self._restart_stable_since = None
                 self._child = None
-                should_restart = True
         await self._notify(self._on_unavailable, "unexpected-exit")
-        if should_restart:
-            async with self._lock:
-                self._schedule_restart_locked(epoch)
+        async with self._lock:
+            self._schedule_restart_locked(epoch)
 
     def _schedule_restart_locked(self, epoch: int) -> None:
         if self._closing or self._closed or epoch != self._epoch:

--- a/tests/scenarios/INDEX.yaml
+++ b/tests/scenarios/INDEX.yaml
@@ -90,6 +90,8 @@ capabilities:
       - tests/test_ui_memory_routes.py
     unit_or_contract_tests:
       - tests/test_memory_wake.py
+      - tests/test_memory_supervisor.py
+      - tests/test_memory_confined_filesystem.py
       - tests/test_controller_memory_data_reset.py
       - tests/test_memory_store.py
       - tests/test_internal_client.py

--- a/tests/scenarios/memory_repair/catalog.yaml
+++ b/tests/scenarios/memory_repair/catalog.yaml
@@ -5,6 +5,7 @@ capability:
   canonical_tests:
     - tests/test_ui_memory_routes.py
     - tests/test_memory_wake.py
+    - tests/test_memory_supervisor.py
     - tests/test_controller_memory_data_reset.py
     - tests/test_internal_server.py
     - tests/test_internal_client.py
@@ -70,6 +71,42 @@ scenarios:
     then: Wake repairs the artifact, replaces the child, and preserves the existing root
     expected_outputs:
       - A replacement running child and intact Memory data
+  - id: MEMORY-WAKE-202
+    name: Retained execution re-enters bounded Wake without overlapping owners
+    status: covered
+    kind: recovery
+    layer: contract
+    test: tests/test_memory_supervisor.py::test_retained_child_reenters_bounded_wake_before_replacement
+    related_tests:
+      - tests/test_memory_supervisor.py::test_retained_child_exhausts_recovery_without_dual_ownership
+    actor: Memory runtime supervisor
+    trigger: The direct EverOS child exits while its process tree may remain
+    conditions:
+      - The supervisor still retains authority for the prior execution
+    given: An unexpected exit cannot initially prove that the owned process tree stopped
+    when: Volatile bounded recovery re-enters Wake
+    then: Wake retries stop proof before replacement and exhausts its budget without overlap when proof remains unavailable
+    expected_outputs:
+      - One running replacement after proven stop, or one retained degraded owner after bounded failure
+  - id: MEMORY-WAKE-203
+    name: Released ownership failure remains visible across startup gates
+    status: covered
+    kind: safety
+    layer: contract
+    test: tests/test_memory_wake.py::test_orphan_recovery_degrades_without_no_follow_but_reset_fails_closed
+    related_tests:
+      - tests/test_memory_wake.py::test_reconcile_reports_released_ownership_failure
+      - tests/test_memory_wake.py::test_repair_fenced_wake_reports_released_ownership_failure
+      - tests/test_memory_confined_filesystem.py::test_memory_persistence_fails_closed_without_no_follow_before_touching_path
+    actor: Memory runtime
+    trigger: Startup cannot safely reconcile released EverOS ownership
+    conditions:
+      - Memory may be disabled or already fenced for Repair
+    given: Released ownership cannot be verified or reaped safely
+    when: Wake or config reconciliation reaches an early lifecycle return
+    then: The operation reports the ownership failure instead of a successful disabled or ordinary repair-only result
+    expected_outputs:
+      - Degraded or needs_repair state with memory_sidecar_unavailable
   - id: MEMORY-REPAIR-201
     name: Repair requires exact accepted-loss confirmation and genuine eligibility
     status: covered

--- a/tests/scenarios/memory_repair/observations.yaml
+++ b/tests/scenarios/memory_repair/observations.yaml
@@ -6,7 +6,9 @@ observations:
       - MEMORY-WAKE-001
       - MEMORY-WAKE-002
       - MEMORY-WAKE-201
-    observation: Startup, explicit Wake, and unexpected child recovery share one volatile non-destructive path; failures never route into Repair.
+      - MEMORY-WAKE-202
+      - MEMORY-WAKE-203
+    observation: Startup, explicit Wake, and unexpected child recovery share one volatile non-destructive path; retained ownership is stopped before replacement, reconciliation failures stay visible, and failures never route into Repair.
   - id: MEMORY-REPAIR-OBS-002
     scenarios:
       - MEMORY-REPAIR-201

--- a/tests/test_memory_confined_filesystem.py
+++ b/tests/test_memory_confined_filesystem.py
@@ -111,14 +111,11 @@ for enabled in (False, True):
     )
     assert runtime.available is False
     result = asyncio.run(runtime.reconcile(MemoryConfig(enabled=enabled)))
-    if enabled:
-        assert result == {
-            "ok": False,
-            "state": "degraded",
-            "error": "memory_sidecar_unavailable",
-        }
-    else:
-        assert result == {"ok": True, "state": "disabled"}
+    assert result == {
+        "ok": False,
+        "state": "degraded",
+        "error": "memory_sidecar_unavailable",
+    }
     asyncio.run(runtime.close())
     assert not runtime_home.exists()
 assert not home.exists()

--- a/tests/test_memory_supervisor.py
+++ b/tests/test_memory_supervisor.py
@@ -333,9 +333,11 @@ async def test_recovery_authority_reaches_an_artifact_activation_task(
     await supervisor.close()
 
 
-async def test_unreaped_child_degrades_without_launching_a_replacement(
+async def test_retained_child_reenters_bounded_wake_before_replacement(
     tmp_path: Path,
 ) -> None:
+    """MEMORY-WAKE-202: retained execution is stopped before replacement."""
+
     unavailable = 0
 
     def observe_unavailable() -> None:
@@ -351,7 +353,16 @@ async def test_unreaped_child_degrades_without_launching_a_replacement(
                 if asyncio.iscoroutine(result):
                     await result
 
-    factory = FakeEverOSProcessFactory(template=RetainedProcess)
+    first = True
+
+    def process() -> FakeEverOSProcess:
+        nonlocal first
+        if first:
+            first = False
+            return RetainedProcess()
+        return FakeEverOSProcess()
+
+    factory = FakeEverOSProcessFactory(template=process)
     supervisor = _supervisor(
         tmp_path,
         factory,
@@ -359,13 +370,62 @@ async def test_unreaped_child_degrades_without_launching_a_replacement(
     )
     assert await supervisor.wake(Path(sys.executable), _settings()) is True
 
-    await factory.supervised[0].unexpected_exit()
-    await _settle()
+    retained = factory.supervised[0]
+    await retained.unexpected_exit()
+    for _ in range(20):
+        await _settle()
+        if (
+            len(factory.supervised) == 2
+            and factory.supervised[1].running
+            and supervisor._restart_task is None
+        ):
+            break
 
     assert unavailable == 1
+    assert retained.stops == 1
+    assert retained.retains_active_config is False
+    assert len(factory.supervised) == 2
+    assert factory.supervised[1].running is True
+    assert supervisor.status.state == "running"
+    assert supervisor.status.retains_configuration is True
+    await supervisor.close()
+
+
+async def test_retained_child_exhausts_recovery_without_dual_ownership(
+    tmp_path: Path,
+) -> None:
+    """MEMORY-WAKE-202: failed stop proof exhausts one bounded recovery budget."""
+
+    class RetainedProcess(FakeEverOSProcess):
+        async def unexpected_exit(self) -> None:
+            self._running = False
+            self._process_tree_retained = True
+            if self.on_unexpected_exit is not None:
+                result = self.on_unexpected_exit()
+                if asyncio.iscoroutine(result):
+                    await result
+
+    retained = RetainedProcess(stop_failure=RuntimeError("tree retained"))
+    factory = FakeEverOSProcessFactory(template=lambda: retained)
+    supervisor = _supervisor(
+        tmp_path,
+        factory,
+        restart_delays=(0.0, 0.0),
+    )
+    assert await supervisor.wake(Path(sys.executable), _settings()) is True
+
+    await retained.unexpected_exit()
+    for _ in range(40):
+        await _settle()
+        if supervisor._restart_task is None and retained.stops == 2:
+            break
+
+    assert retained.stops == 2
+    assert retained.retains_active_config is True
     assert len(factory.supervised) == 1
     assert supervisor.status.state == "degraded"
-    assert supervisor.status.retains_configuration is True
+
+    retained.stop_failure = None
     await supervisor.close()
 
 

--- a/tests/test_memory_wake.py
+++ b/tests/test_memory_wake.py
@@ -367,6 +367,8 @@ async def test_orphan_recovery_degrades_without_no_follow_but_reset_fails_closed
     monkeypatch: pytest.MonkeyPatch,
     memory_runtime_factory,
 ) -> None:
+    """MEMORY-WAKE-203: unreconciled ownership is never reported as disabled."""
+
     runtime = memory_runtime_factory(
         MemoryConfig(enabled=False),
         effective_home=tmp_path,
@@ -384,11 +386,85 @@ async def test_orphan_recovery_degrades_without_no_follow_but_reset_fails_closed
 
     assert await runtime.wake() == {
         "ok": False,
-        "state": "disabled",
-        "error": "memory_disabled",
+        "state": "degraded",
+        "error": "memory_sidecar_unavailable",
     }
+    assert runtime.runtime_state() == "degraded"
+    assert (await runtime.status_payload())["reason"] == "memory_sidecar_unavailable"
     with pytest.raises(ConfinedFilesystemError, match="no-follow unavailable"):
         await runtime.prepare_data_reset()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_reports_released_ownership_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    memory_runtime_factory,
+) -> None:
+    """MEMORY-WAKE-203: config reconciliation cannot hide orphan failure."""
+
+    runtime = memory_runtime_factory(
+        MemoryConfig(enabled=False),
+        effective_home=tmp_path,
+    )
+
+    outcomes = iter((False, True))
+
+    async def released_reconciliation(*, fail_closed: bool = False) -> bool:
+        assert fail_closed is False
+        return next(outcomes)
+
+    monkeypatch.setattr(
+        runtime._supervisor,
+        "reconcile_orphans",
+        released_reconciliation,
+    )
+
+    assert await runtime.reconcile(MemoryConfig(enabled=False)) == {
+        "ok": False,
+        "state": "degraded",
+        "error": "memory_sidecar_unavailable",
+    }
+    assert runtime.runtime_state() == "degraded"
+
+    assert await runtime.reconcile(MemoryConfig(enabled=False)) == {
+        "ok": True,
+        "state": "disabled",
+    }
+    assert runtime.runtime_state() == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_repair_fenced_wake_reports_released_ownership_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    memory_runtime_factory,
+) -> None:
+    """MEMORY-WAKE-203: repair eligibility does not conceal orphan failure."""
+
+    runtime = memory_runtime_factory(
+        _config(legacy_needs_repair=True),
+        effective_home=tmp_path,
+    )
+
+    async def failed_reconciliation(*, fail_closed: bool = False) -> bool:
+        assert fail_closed is False
+        return False
+
+    monkeypatch.setattr(
+        runtime._supervisor,
+        "reconcile_orphans",
+        failed_reconciliation,
+    )
+
+    assert await runtime.wake() == {
+        "ok": False,
+        "state": "needs_repair",
+        "error": "memory_sidecar_unavailable",
+    }
+    status = await runtime.status_payload()
+    assert status["state"] == "needs_repair"
+    assert status["reason"] == "memory_sidecar_unavailable"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- route retained EverOS process trees back through the existing bounded Wake budget
- require proven stop before any replacement child can start, while remaining degraded without dual ownership when proof never succeeds
- surface released ownership reconciliation failures during disabled and repair-fenced startup instead of reporting an ordinary disabled or repair-only result
- keep the new safety projection process-local; no observer log, replay state, pending stage, or durable recovery workflow is added

## Scenarios

- `MEMORY-WAKE-202`: retained execution re-enters bounded Wake without overlapping owners
- `MEMORY-WAKE-203`: released ownership failure remains visible across startup gates

## Evidence

- Unit/contract: focused Supervisor, Wake, Runtime, Process, Store, Processing Record, controller reset, internal API/client, and UI route tests updated or rerun
- Scenario: Memory Repair catalog, observations, and project index updated for `MEMORY-WAKE-202` and `MEMORY-WAKE-203`
- Broad focused suite: `991 passed, 6 skipped`
- Static: Ruff, compileall, YAML parsing, and `git diff --check` passed

## Residual Checks

- The optional packaged EverOS runtime contract remained skipped because that runtime is not installed in this worktree.
- Incus and live service verification were not run for this focused recovery fix.
- Three unchanged legacy Office modality tests fail on this machine and reproduce on the exact `origin/dev` baseline; they were excluded from the green broad focused run.
