### PR TITLE
fix(model-hub): fill settings workspace

### DIFF
--- a/ui/src/components/settings/SettingsLayout.test.tsx
+++ b/ui/src/components/settings/SettingsLayout.test.tsx
@@ -116,15 +116,19 @@ describe('SettingsLayout', () => {
     expect(shell?.className).not.toContain('min-h-full');
   });
 
-  it('lets Model Hub fill the route pane without changing other settings page widths', () => {
-    const { unmount } = renderLayout('/settings/models');
+  it.each(['/settings/models', '/settings/models/'])(
+    'lets Model Hub fill the route pane at %s',
+    (path) => {
+      renderLayout(path);
 
-    const modelHubFrame = screen.getByText('models-body').parentElement;
-    expect(modelHubFrame?.className).toContain('min-h-full');
-    expect(modelHubFrame?.className).not.toContain('mx-auto');
-    expect(modelHubFrame?.className).not.toContain('max-w-[1180px]');
+      const modelHubFrame = screen.getByText('models-body').parentElement;
+      expect(modelHubFrame?.className).toContain('min-h-full');
+      expect(modelHubFrame?.className).not.toContain('mx-auto');
+      expect(modelHubFrame?.className).not.toContain('max-w-[1180px]');
+    },
+  );
 
-    unmount();
+  it('keeps standard settings pages constrained', () => {
     renderLayout('/settings/replies');
 
     const standardFrame = screen.getByText('replies-body').parentElement;

--- a/ui/src/components/settings/SettingsLayout.test.tsx
+++ b/ui/src/components/settings/SettingsLayout.test.tsx
@@ -68,6 +68,7 @@ const renderLayout = (path: string) => render(
   <MemoryRouter initialEntries={[path]}>
     <Routes>
       <Route path="/settings" element={<SettingsLayoutHarness />}>
+        <Route path="models" element={<div>models-body</div>} />
         <Route path="replies" element={<div>replies-body</div>} />
         <Route path="service" element={<div>service-body</div>} />
         <Route path="platforms" element={<div>platforms-body</div>} />
@@ -113,6 +114,23 @@ describe('SettingsLayout', () => {
     expect(shell?.className).toContain('min-h-0');
     expect(shell?.className).toContain('md:h-auto');
     expect(shell?.className).not.toContain('min-h-full');
+  });
+
+  it('lets Model Hub fill the route pane without changing other settings page widths', () => {
+    const { unmount } = renderLayout('/settings/models');
+
+    const modelHubFrame = screen.getByText('models-body').parentElement;
+    expect(modelHubFrame?.className).toContain('min-h-full');
+    expect(modelHubFrame?.className).not.toContain('mx-auto');
+    expect(modelHubFrame?.className).not.toContain('max-w-[1180px]');
+
+    unmount();
+    renderLayout('/settings/replies');
+
+    const standardFrame = screen.getByText('replies-body').parentElement;
+    expect(standardFrame?.className).toContain('mx-auto');
+    expect(standardFrame?.className).toContain('max-w-[1180px]');
+    expect(standardFrame?.className).not.toContain('min-h-full');
   });
 
   it('renders the three-group rail and feature-gated owner sections', async () => {

--- a/ui/src/components/settings/SettingsLayout.tsx
+++ b/ui/src/components/settings/SettingsLayout.tsx
@@ -184,6 +184,7 @@ export const SettingsLayout: React.FC = () => {
   const [memoryVisible, setMemoryVisible] = useState(false);
   const [channelSettingsVisible, setChannelSettingsVisible] = useState(false);
   const atRoot = location.pathname === '/settings' || location.pathname === '/settings/';
+  const isModelHub = location.pathname === '/settings/models';
 
   useEffect(() => {
     if (!capabilities.can_manage_instance) return;
@@ -331,7 +332,12 @@ export const SettingsLayout: React.FC = () => {
         </nav>
 
         <section className={clsx('min-w-0 flex-1 overflow-y-auto', atRoot && 'hidden md:block')}>
-          <div className="mx-auto w-full max-w-[1180px] px-4 pb-[calc(1.25rem+env(safe-area-inset-bottom))] pt-5 md:px-6 md:pb-7 md:pt-7 lg:px-8">
+          <div
+            className={clsx(
+              'w-full px-4 pb-[calc(1.25rem+env(safe-area-inset-bottom))] pt-5 md:px-6 md:pb-7 md:pt-7 lg:px-8',
+              isModelHub ? 'min-h-full' : 'mx-auto max-w-[1180px]',
+            )}
+          >
             {!atRoot && (
               <NavLink
                 to="/settings"

--- a/ui/src/components/settings/SettingsLayout.tsx
+++ b/ui/src/components/settings/SettingsLayout.tsx
@@ -184,7 +184,7 @@ export const SettingsLayout: React.FC = () => {
   const [memoryVisible, setMemoryVisible] = useState(false);
   const [channelSettingsVisible, setChannelSettingsVisible] = useState(false);
   const atRoot = location.pathname === '/settings' || location.pathname === '/settings/';
-  const isModelHub = location.pathname === '/settings/models';
+  const isModelHub = pathMatches(location.pathname, '/settings/models');
 
   useEffect(() => {
     if (!capabilities.can_manage_instance) return;


### PR DESCRIPTION
## Summary

- let Model Hub use the full Settings route width instead of the shared 1180px reading-width cap
- make the Model Hub route frame fill the remaining Settings height
- preserve the existing centered width contract for every other Settings page

## Evidence

- Design frame `IM4c2` keeps the Models main area at `fill_container`; the existing implementation added a second centered max-width boundary around it.
- At 1664x1329, the Models route frame now matches its 1228x1273 pane instead of measuring 1180x1035.
- At 390x844 and 320x568, the route pane still owns vertical scrolling and neither the pane nor the document overflows horizontally.

## Validation

- `npm test -- --run src/components/settings/SettingsLayout.test.tsx src/components/settings/models/SettingsModelsPage.render.test.tsx` (51 tests)
- `npm run lint -- --quiet`
- `npm run build`
- local Incus regression browser QA at 1664x1329, 390x844, and 320x568
