### PR TITLE
fix(memory): make disabled status projection truthful

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -415,6 +415,7 @@ class Controller:
         self._trace_retention_future: Optional[Any] = None
         self._memory_reconcile_task: Optional[asyncio.Task] = None
         self._memory_disabled_cleanup_task: Optional[asyncio.Task] = None
+        self._memory_disabled_cleanup_unproved = False
         self._memory_replacement_gate = asyncio.Lock()
         self._memory_runtime_lease_condition = asyncio.Condition(
             self._memory_replacement_gate
@@ -1049,19 +1050,21 @@ class Controller:
         self,
         *,
         retained_runtime: bool = False,
+        cleanup_unproved: bool = False,
     ) -> dict[str, Any]:
         config = self.config.memory
+        runtime_busy = retained_runtime or cleanup_unproved
         needs_repair = bool(config.legacy_needs_repair)
-        state = "degraded" if retained_runtime else (
+        state = "degraded" if runtime_busy else (
             "needs_repair" if needs_repair else "disabled"
         )
-        reason = "memory_runtime_busy" if retained_runtime else (
+        reason = "memory_runtime_busy" if runtime_busy else (
             "memory_legacy_recovery_required" if needs_repair else None
         )
         return {
             "status": "ok",
             "source": self._disabled_memory_source_payload(
-                reason="memory_runtime_busy" if retained_runtime else "memory_disabled"
+                reason="memory_runtime_busy" if runtime_busy else "memory_disabled"
             ),
             "health": None,
             "state": state,
@@ -1074,6 +1077,18 @@ class Controller:
                 )
             },
         }
+
+    def _disabled_memory_status_payload_locked(self) -> dict[str, Any]:
+        """Project Controller-owned disabled state while its condition is held."""
+
+        cleanup_task = getattr(self, "_memory_disabled_cleanup_task", None)
+        return self._disabled_memory_status_payload(
+            retained_runtime=getattr(self, "memory_runtime", None) is not None,
+            cleanup_unproved=(
+                getattr(self, "_memory_disabled_cleanup_unproved", False)
+                or (cleanup_task is not None and not cleanup_task.done())
+            ),
+        )
 
     def _disabled_memory_processing_record_payload(self) -> dict[str, Any]:
         def unavailable() -> dict[str, Any]:
@@ -1111,11 +1126,15 @@ class Controller:
         condition = self._memory_runtime_condition()
         async with condition:
             if not self.config.memory.enabled:
-                return self._disabled_memory_status_payload(
-                    retained_runtime=getattr(self, "memory_runtime", None) is not None
-                )
-        async with self._borrow_memory_runtime() as lease:
-            return await lease.runtime.status_payload()
+                return self._disabled_memory_status_payload_locked()
+        try:
+            async with self._borrow_memory_runtime() as lease:
+                return await lease.runtime.status_payload()
+        except MemoryStoreUnavailableError:
+            async with condition:
+                if not self.config.memory.enabled:
+                    return self._disabled_memory_status_payload_locked()
+            raise
 
     async def wake_memory(self) -> dict[str, Any]:
         """Wake enabled Memory, or return the host-owned disabled outcome."""
@@ -2361,51 +2380,66 @@ class Controller:
         except OSError:
             return False
 
-    def _schedule_disabled_memory_cleanup(self) -> None:
+    async def _schedule_disabled_memory_cleanup(self) -> None:
         """Reap older owned Memory children only when a record exists."""
 
-        if not isinstance(
-            getattr(self, "memory_adapter", None),
-            DisabledMemoryAdapter,
-        ):
-            return
-        task = getattr(self, "_memory_disabled_cleanup_task", None)
-        if task is not None and not task.done():
-            return
-        memory_dir = paths.get_vibe_remote_dir() / "memory"
-        if not self._disabled_memory_ownership_exists(memory_dir):
-            return
-        self._memory_disabled_cleanup_task = asyncio.create_task(
-            self._cleanup_disabled_memory_process(memory_dir),
-            name="memory-disabled-everos-cleanup",
-        )
+        condition = self._memory_runtime_condition()
+        async with condition:
+            if not isinstance(
+                getattr(self, "memory_adapter", None),
+                DisabledMemoryAdapter,
+            ):
+                return
+            task = getattr(self, "_memory_disabled_cleanup_task", None)
+            if task is not None and not task.done():
+                return
+            memory_dir = paths.get_vibe_remote_dir() / "memory"
+            if not self._disabled_memory_ownership_exists(memory_dir):
+                return
+            self._memory_disabled_cleanup_unproved = True
+            self._memory_disabled_cleanup_task = asyncio.create_task(
+                self._cleanup_disabled_memory_process(memory_dir),
+                name="memory-disabled-everos-cleanup",
+            )
 
     async def _cleanup_disabled_memory_process(self, memory_dir: Path) -> None:
         """Lazily load the proven-ownership reaper after service readiness."""
 
-        async with self._memory_replacement_lock():
+        condition = self._memory_runtime_condition()
+        async with condition:
             if not isinstance(
                 getattr(self, "memory_adapter", None),
                 DisabledMemoryAdapter,
             ) or getattr(self, "memory_runtime", None) is not None:
                 return
             if not self._disabled_memory_ownership_exists(memory_dir):
+                self._memory_disabled_cleanup_unproved = False
                 return
+            self._memory_disabled_cleanup_unproved = True
 
-            try:
-                from core.memory.process import ReleasedEverOSOrphanReconciler
+        try:
+            from core.memory.process import ReleasedEverOSOrphanReconciler
 
-                reconciler = ReleasedEverOSOrphanReconciler(
-                    provider_root=memory_dir / "everos-root",
-                    effective_home=paths.get_vibe_remote_dir(),
-                )
-                await reconciler.reconcile_orphans()
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                logger.warning(
-                    "Disabled Memory could not clean up an older owned EverOS process",
-                    exc_info=True,
+            reconciler = ReleasedEverOSOrphanReconciler(
+                provider_root=memory_dir / "everos-root",
+                effective_home=paths.get_vibe_remote_dir(),
+            )
+            await reconciler.reconcile_orphans()
+        except asyncio.CancelledError:
+            async with condition:
+                self._memory_disabled_cleanup_unproved = True
+            raise
+        except Exception:
+            async with condition:
+                self._memory_disabled_cleanup_unproved = True
+            logger.warning(
+                "Disabled Memory could not clean up an older owned EverOS process",
+                exc_info=True,
+            )
+        else:
+            async with condition:
+                self._memory_disabled_cleanup_unproved = (
+                    self._disabled_memory_ownership_exists(memory_dir)
                 )
 
     def _run_im_runtime(self) -> None:
@@ -2511,7 +2545,7 @@ class Controller:
         # embedded and test paths that run a controller are unaffected.
         self._publish_readiness_unless_im_runtime_failed()
         try:
-            self._schedule_disabled_memory_cleanup()
+            await self._schedule_disabled_memory_cleanup()
         except Exception as e:
             logger.error(f"Failed to schedule disabled Memory cleanup: {e}", exc_info=True)
 

--- a/core/controller.py
+++ b/core/controller.py
@@ -908,6 +908,12 @@ class Controller:
                 while getattr(self, "_memory_runtime_leases_blocked", False):
                     await condition.wait()
                 runtime = getattr(self, "memory_runtime", None)
+                if (
+                    memory_config is None
+                    and not self.config.memory.enabled
+                    and not allow_disabled
+                ):
+                    raise MemoryStoreUnavailableError("Memory is disabled")
                 if runtime is not None and getattr(runtime, "retired", False):
                     raise MemoryRuntimeCloseUnprovedError(
                         "Memory runtime remains fenced after an unproved close"
@@ -920,12 +926,6 @@ class Controller:
                 ):
                     break
                 await condition.wait()
-            if (
-                memory_config is None
-                and not self.config.memory.enabled
-                and not allow_disabled
-            ):
-                raise MemoryStoreUnavailableError("Memory is disabled")
             temporary = runtime is None
             if temporary:
                 runtime = self._create_memory_runtime(selected_config)
@@ -1002,6 +1002,7 @@ class Controller:
                     self.memory_adapter = DisabledMemoryAdapter()
                     self.memory_module = None
                     self.config.memory = memory_config
+                    self._recheck_disabled_memory_cleanup_locked()
                     return {"ok": True, "state": "disabled"}
                 runtime = self._create_memory_runtime(memory_config)
                 self._attach_memory_runtime_locked(runtime, capture_enabled=True)
@@ -1012,6 +1013,7 @@ class Controller:
                 if not memory_config.enabled:
                     self.memory_adapter = DisabledMemoryAdapter()
                     await self._close_memory_runtime_locked(runtime, retire=False)
+                    self._recheck_disabled_memory_cleanup_locked()
                 else:
                     self.memory_adapter = None
             return result
@@ -2379,6 +2381,18 @@ class Controller:
             )
         except OSError:
             return False
+
+    def _recheck_disabled_memory_cleanup_locked(self) -> None:
+        """Clear a stale cleanup fence only after released ownership is absent."""
+
+        if not self._memory_replacement_lock().locked():
+            raise RuntimeError("Memory cleanup recheck requires the replacement lock")
+        if not getattr(self, "_memory_disabled_cleanup_unproved", False):
+            return
+        memory_dir = paths.get_vibe_remote_dir() / "memory"
+        self._memory_disabled_cleanup_unproved = (
+            self._disabled_memory_ownership_exists(memory_dir)
+        )
 
     async def _schedule_disabled_memory_cleanup(self) -> None:
         """Reap older owned Memory children only when a record exists."""

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -363,6 +363,7 @@ def _build_controller_double(handler=None):
     controller.memory_module = None
     controller._memory_reconcile_task = None
     controller._memory_disabled_cleanup_task = None
+    controller._memory_disabled_cleanup_unproved = False
     controller._memory_replacement_gate = None
     controller._memory_runtime_lease_condition = None
     controller._memory_runtime_lease_count = 0
@@ -382,6 +383,7 @@ def _build_controller_double(handler=None):
         "_borrow_memory_runtime",
         "_disabled_memory_source_payload",
         "_disabled_memory_status_payload",
+        "_disabled_memory_status_payload_locked",
         "_disabled_memory_processing_record_payload",
         "_disabled_memory_maintenance_payload",
         "_memory_scope_for_runtime",
@@ -465,6 +467,27 @@ def test_disabled_memory_status_route_uses_host_projection_without_runtime() -> 
     assert response.json()["state"] == "disabled"
     assert response.json()["source"]["reason"] == "memory_disabled"
     controller._create_memory_runtime.assert_not_called()
+
+
+def test_memory_status_unknown_failure_uses_stable_envelope() -> None:
+    controller = _build_controller_double()
+    controller.memory_status_payload = AsyncMock(
+        side_effect=RuntimeError("injected lifecycle failure")
+    )
+    app = internal_server.create_app(controller)
+
+    async def _exercise() -> httpx.Response:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://test",
+        ) as client:
+            return await client.get("/internal/memory/status")
+
+    response = asyncio.run(_exercise())
+
+    assert response.status_code == 503
+    assert response.json() == {"error": "memory_store_unavailable"}
 
 
 def test_memory_projects_unknown_lifecycle_failure_uses_stable_envelope() -> None:

--- a/tests/test_memory_disabled_isolation.py
+++ b/tests/test_memory_disabled_isolation.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import time
 import types
+from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from pathlib import Path
 
@@ -59,6 +60,37 @@ def _memory_state_entries(home: Path) -> list[Path]:
     ]
 
 
+async def _start_disabled_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+    reconcile_orphans: Callable[[], Awaitable[None]],
+) -> tuple[Controller, asyncio.Task[None], Path]:
+    memory_dir = paths.get_vibe_remote_dir() / "memory"
+    record_path = memory_dir / ".rt" / "everos.sidecar.json"
+    record_path.parent.mkdir(parents=True)
+    record_path.write_text("{}", encoding="utf-8")
+
+    class _Reconciler:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        async def reconcile_orphans(self) -> None:
+            await reconcile_orphans()
+
+    process_module = types.ModuleType("core.memory.process")
+    process_module.ReleasedEverOSOrphanReconciler = _Reconciler
+    monkeypatch.setitem(sys.modules, "core.memory.process", process_module)
+
+    controller = Controller.__new__(Controller)
+    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
+    controller.memory_adapter = DisabledMemoryAdapter()
+    controller.memory_runtime = None
+    controller._memory_disabled_cleanup_task = None
+    await controller._schedule_disabled_memory_cleanup()
+    cleanup_task = controller._memory_disabled_cleanup_task
+    assert cleanup_task is not None
+    return controller, cleanup_task, record_path
+
+
 def test_memory_indep_013_disabled_fresh_startup_has_no_runtime_side_effects(
     tmp_path: Path,
 ) -> None:
@@ -100,7 +132,7 @@ assert not [
     if any("memory" in part.casefold() or "everos" in part.casefold()
            for part in path.relative_to(home).parts)
 ]
-controller._schedule_disabled_memory_cleanup()
+asyncio.run(controller._schedule_disabled_memory_cleanup())
 assert controller._memory_disabled_cleanup_task is None
 assert "core.memory.process" not in sys.modules
 
@@ -268,7 +300,7 @@ async def test_disabled_cleanup_reaps_only_preexisting_everos_ownership(
     controller.memory_runtime = None
     controller._memory_disabled_cleanup_task = None
 
-    controller._schedule_disabled_memory_cleanup()
+    await controller._schedule_disabled_memory_cleanup()
 
     assert controller._memory_disabled_cleanup_task is not None
     await controller._memory_disabled_cleanup_task
@@ -278,6 +310,84 @@ async def test_disabled_cleanup_reaps_only_preexisting_everos_ownership(
             paths.get_vibe_remote_dir(),
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_disabled_cleanup_pending_projects_degraded_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cleanup_started = asyncio.Event()
+    cleanup_release = asyncio.Event()
+
+    async def reconcile_orphans() -> None:
+        cleanup_started.set()
+        await cleanup_release.wait()
+        record_path.unlink()
+
+    controller, cleanup_task, record_path = await _start_disabled_cleanup(
+        monkeypatch,
+        reconcile_orphans,
+    )
+    await cleanup_started.wait()
+
+    try:
+        status = await asyncio.wait_for(
+            controller.memory_status_payload(),
+            timeout=0.1,
+        )
+        assert status["state"] == "degraded"
+        assert status["reason"] == "memory_runtime_busy"
+        assert status["source"]["reason"] == "memory_runtime_busy"
+    finally:
+        cleanup_release.set()
+        await cleanup_task
+
+
+@pytest.mark.asyncio
+async def test_disabled_cleanup_failure_remains_degraded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def reconcile_orphans() -> None:
+        raise RuntimeError("cleanup failed")
+
+    controller, cleanup_task, _record_path = await _start_disabled_cleanup(
+        monkeypatch,
+        reconcile_orphans,
+    )
+    await cleanup_task
+
+    status = await controller.memory_status_payload()
+
+    assert status["state"] == "degraded"
+    assert status["reason"] == "memory_runtime_busy"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("remove_ownership", "expected_state"),
+    [(False, "degraded"), (True, "disabled")],
+)
+async def test_disabled_cleanup_success_rechecks_released_ownership(
+    monkeypatch: pytest.MonkeyPatch,
+    remove_ownership: bool,
+    expected_state: str,
+) -> None:
+    async def reconcile_orphans() -> None:
+        if remove_ownership:
+            record_path.unlink()
+
+    controller, cleanup_task, record_path = await _start_disabled_cleanup(
+        monkeypatch,
+        reconcile_orphans,
+    )
+    await cleanup_task
+
+    status = await controller.memory_status_payload()
+
+    assert status["state"] == expected_state
+    assert status["reason"] == (
+        "memory_runtime_busy" if expected_state == "degraded" else None
+    )
 
 
 @pytest.mark.asyncio
@@ -663,6 +773,28 @@ async def test_disabled_status_preserves_legacy_repair_fence_without_runtime() -
 
 
 @pytest.mark.asyncio
+async def test_disabled_cleanup_fence_precedes_legacy_repair_projection() -> None:
+    controller = Controller.__new__(Controller)
+    controller.config = types.SimpleNamespace(
+        memory=replace(
+            _disabled_app_config().memory,
+            legacy_needs_repair=True,
+        )
+    )
+    controller.memory_adapter = DisabledMemoryAdapter()
+    controller.memory_runtime = None
+    controller.memory_module = None
+    controller._memory_disabled_cleanup_task = None
+    controller._memory_disabled_cleanup_unproved = True
+
+    status = await controller.memory_status_payload()
+
+    assert status["state"] == "degraded"
+    assert status["reason"] == "memory_runtime_busy"
+    assert status["source"]["reason"] == "memory_runtime_busy"
+
+
+@pytest.mark.asyncio
 async def test_disabled_dashboard_reads_do_not_construct_runtime() -> None:
     controller = Controller.__new__(Controller)
     controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
@@ -799,6 +931,44 @@ async def test_enabled_status_does_not_wait_for_startup_wake() -> None:
     finally:
         wake_release.set()
         await controller._memory_reconcile_task
+
+
+@pytest.mark.asyncio
+async def test_enabled_status_reprojects_when_disabled_before_borrow() -> None:
+    enabled = replace(_disabled_app_config().memory, enabled=True)
+    disabled = replace(enabled, enabled=False)
+    controller = Controller.__new__(Controller)
+    controller.config = types.SimpleNamespace(memory=enabled)
+    controller.memory_adapter = None
+    controller.memory_runtime = None
+    controller.memory_module = None
+    controller._memory_reconcile_task = None
+    controller._memory_disabled_cleanup_task = None
+    borrow_started = asyncio.Event()
+    borrow_release = asyncio.Event()
+
+    async def await_cleanup() -> None:
+        borrow_started.set()
+        await borrow_release.wait()
+
+    controller._await_disabled_memory_cleanup = await_cleanup
+    controller._create_memory_runtime = lambda _config: pytest.fail(
+        "status must re-project disabled state before constructing Memory"
+    )
+    status_task = asyncio.create_task(controller.memory_status_payload())
+    await borrow_started.wait()
+
+    condition = controller._memory_runtime_condition()
+    async with condition:
+        controller.config.memory = disabled
+    borrow_release.set()
+
+    status = await status_task
+
+    assert status["status"] == "ok"
+    assert status["state"] == "disabled"
+    assert status["reason"] is None
+    assert status["source"]["reason"] == "memory_disabled"
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_disabled_isolation.py
+++ b/tests/test_memory_disabled_isolation.py
@@ -425,6 +425,7 @@ async def test_memory_reconcile_lazily_enters_and_leaves_enabled_runtime(
     controller.memory_adapter = DisabledMemoryAdapter()
     controller.memory_runtime = None
     controller.memory_module = None
+    controller._memory_disabled_cleanup_unproved = True
 
     enabled = replace(controller.config.memory, enabled=True)
     assert await controller.reconcile_memory(enabled) == {
@@ -447,6 +448,7 @@ async def test_memory_reconcile_lazily_enters_and_leaves_enabled_runtime(
     assert controller.memory_module is None
     assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
     assert controller.config.memory.enabled is False
+    assert controller._memory_disabled_cleanup_unproved is False
 
 
 @pytest.mark.asyncio
@@ -969,6 +971,67 @@ async def test_enabled_status_reprojects_when_disabled_before_borrow() -> None:
     assert status["state"] == "disabled"
     assert status["reason"] is None
     assert status["source"]["reason"] == "memory_disabled"
+
+
+@pytest.mark.asyncio
+async def test_enabled_status_reprojects_after_failed_disable_close() -> None:
+    enabled = replace(_disabled_app_config().memory, enabled=True)
+    disabled = replace(enabled, enabled=False)
+    controller = Controller.__new__(Controller)
+    controller.config = types.SimpleNamespace(memory=enabled)
+    controller.memory_adapter = None
+    controller._memory_disabled_cleanup_task = None
+    status_waiting = asyncio.Event()
+    status_release = asyncio.Event()
+
+    class _Runtime:
+        def __init__(self) -> None:
+            self.module = object()
+            self.closed = False
+            self.retired = False
+
+        async def status_payload(self) -> dict[str, object]:
+            pytest.fail("status must re-project before reading a retired runtime")
+
+        async def reconcile(self, config) -> dict[str, object]:
+            return {"ok": True, "state": "disabled"}
+
+        async def close(self) -> None:
+            raise RuntimeError("close failed")
+
+        def retire(self) -> None:
+            self.retired = True
+
+    runtime = _Runtime()
+    controller.memory_runtime = runtime
+    controller.memory_module = runtime.module
+
+    async def hold_status_before_borrow() -> None:
+        status_waiting.set()
+        await status_release.wait()
+
+    controller._await_disabled_memory_cleanup = hold_status_before_borrow
+    status_task = asyncio.create_task(controller.memory_status_payload())
+    await status_waiting.wait()
+
+    async def cleanup_ready() -> None:
+        return None
+
+    controller._await_disabled_memory_cleanup = cleanup_ready
+    try:
+        with pytest.raises(RuntimeError, match="close failed"):
+            await controller.reconcile_memory(disabled)
+    finally:
+        status_release.set()
+
+    status = await status_task
+
+    assert runtime.retired is True
+    assert controller.memory_runtime is runtime
+    assert status["status"] == "ok"
+    assert status["state"] == "degraded"
+    assert status["reason"] == "memory_runtime_busy"
+    assert status["source"]["reason"] == "memory_runtime_busy"
 
 
 @pytest.mark.asyncio

--- a/ui/src/components/settings/memory/MemoryStatusPanel.i18n.test.tsx
+++ b/ui/src/components/settings/memory/MemoryStatusPanel.i18n.test.tsx
@@ -47,6 +47,24 @@ afterEach(cleanup);
 
 describe('MemoryStatusPanel localized recovery contract', () => {
   it.each([
+    [
+      'en',
+      'Memory is still handling work and could not stop safely.',
+      'Reason: Memory is still handling work and could not stop safely.',
+    ],
+    [
+      'zh',
+      '记忆仍在处理工作，无法安全停止。',
+      '原因：记忆仍在处理工作，无法安全停止。',
+    ],
+  ] as const)('localizes runtime-busy status and source reasons in %s', (language, reason, sourceReason) => {
+    renderStatus(language, 'degraded', 'memory_runtime_busy');
+    expect(screen.getByText(reason)).toBeTruthy();
+    expect(screen.getByText(sourceReason)).toBeTruthy();
+    expect(screen.queryByText(/memory_runtime_busy/)).toBeNull();
+  });
+
+  it.each([
     ['en', 'Needs repair', 'The confined local Memory data root is unusable or incompatible and needs Repair.'],
     ['zh', '需要修复', '受限的本地记忆数据根不可用或不兼容，需要修复。'],
   ] as const)('localizes needs_repair and its confined-root reason in %s', (language, state, reason) => {

--- a/ui/src/components/settings/memory/memoryStatusPresentation.ts
+++ b/ui/src/components/settings/memory/memoryStatusPresentation.ts
@@ -43,6 +43,7 @@ const HEALTH_STATUS_LABEL_KEYS = {
 
 const MEMORY_SOURCE_ERROR_REASONS = new Set([
   'memory_disabled',
+  'memory_runtime_busy',
   'memory_runtime_missing',
   'memory_runtime_unsupported',
   'memory_runtime_install_failed',


### PR DESCRIPTION
## Capability

Implements the Wave 0.1 Disabled = inert + truthful status projection contract from #1694. Disabled cleanup that is pending, failed, or still owns a released record now reports HTTP 200 with `status=ok`, `state=degraded`, and `memory_runtime_busy`. A status read that loses an enabled-to-disabled race re-projects host-owned disabled state instead of surfacing a transient store failure.

Admission for preflight, install, delete, repair, processing, maintenance, CLI, Settings actions, config, and persisted data shapes is unchanged.

## Scenarios

- `MEMORY-INDEP-013`: fresh disabled startup remains free of Memory runtime/process/filesystem side effects.
- Consuming regressions cover pending cleanup, cleanup failure, successful cleanup plus ownership recheck, later lifecycle proof, enabled-to-disabled status races including failed close, unknown lifecycle failure 503, and retained-runtime/cleanup/legacy-repair precedence.

## Evidence

- Unit: `tests/test_memory_disabled_isolation.py` covers Controller cleanup state, later lifecycle proof, and status race projection.
- Contract: `tests/test_internal_server.py` preserves the exact `{"error":"memory_store_unavailable"}` 503 envelope for unknown status failures.
- UI presentation: `MemoryStatusPanel.i18n.test.tsx` proves `memory_runtime_busy` is localized in both English and Chinese source/status surfaces; the production UI build passes.
- Scenario: the existing Memory independence catalog and `MEMORY-INDEP-013` remain green.
- Local: 200 disabled-isolation/internal-route/readiness tests and 175 runtime/release/process/admission/reset/catalog tests passed; changed-Python Ruff passed.
- Residual manual checks: none. This is a hermetic host-status projection and localization mapping change with no CLI, config, data-format, service restart, or production-state workflow to exercise manually.

## Dependencies

- Depends on the Controller-owned Memory lifecycle introduced by merged PR #1693 (`2aa9945fb68f20c9723236c67fb26c7660784a5e`).
- Fixes #1694.

## Known-by-design

- The cleanup-unproved latch is Controller-lifetime only. If the reaper deletes released ownership, then fails, and the process crashes before status can retain that fact, restart cannot recover it from the now-absent record. Wave 0.1 intentionally adds no persisted field, retry, timer, lifecycle manager, new process, RPC, or plugin infrastructure.
- Enabled and unknown Memory status failures continue to use the existing exact 503 error envelope.