### PR TITLE
fix(ui): improve mobile file previews

### DIFF
--- a/ui/src/components/ui/dialog.test.tsx
+++ b/ui/src/components/ui/dialog.test.tsx
@@ -1,0 +1,25 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Dialog, DialogContent, DialogTitle } from './dialog';
+
+afterEach(cleanup);
+
+describe('DialogContent mobile sheet', () => {
+  it('provides the shared tall height and bottom-up motion', () => {
+    render(
+      <Dialog open>
+        <DialogContent aria-describedby={undefined} mobileSheetHeight="tall">
+          <DialogTitle>Preview</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.className).toContain('max-md:h-[90dvh]');
+    expect(dialog.className).toContain('max-md:data-[state=open]:slide-in-from-bottom');
+    expect(dialog.className).toContain('max-md:data-[state=closed]:slide-out-to-bottom');
+  });
+});

--- a/ui/src/components/ui/dialog.tsx
+++ b/ui/src/components/ui/dialog.tsx
@@ -24,10 +24,15 @@ export const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+type DialogContentProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+  /** Give content-heavy phone dialogs a resolved, near-full-screen sheet height. */
+  mobileSheetHeight?: 'content' | 'tall';
+};
+
 export const DialogContent = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  DialogContentProps
+>(({ className, children, mobileSheetHeight = 'content', ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -37,8 +42,10 @@ export const DialogContent = React.forwardRef<
         // slides up from the bottom edge, rounded top + drag handle, capped height
         // with internal scroll and a safe-area bottom inset. A caller's custom
         // max-w (e.g. max-w-sm) still applies on desktop; max-md:max-w-none forces
-        // the full-width sheet on phones.
-        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg max-h-[calc(100dvh-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl border border-border bg-card p-6 shadow-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95 max-md:left-0 max-md:right-0 max-md:top-auto max-md:bottom-0 max-md:w-full max-md:max-w-none max-md:max-h-[88dvh] max-md:translate-x-0 max-md:translate-y-0 max-md:rounded-2xl max-md:rounded-b-none max-md:p-5 max-md:pb-[calc(1.5rem+env(safe-area-inset-bottom))] max-md:data-[state=open]:zoom-in-100 max-md:data-[state=closed]:zoom-out-100 max-md:data-[state=open]:slide-in-from-bottom max-md:data-[state=closed]:slide-out-to-bottom',
+        // the full-width sheet on phones. Content-heavy callers can opt into a
+        // resolved 90dvh height without re-declaring the shared sheet behavior.
+        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg max-h-[calc(100dvh-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl border border-border bg-card p-6 shadow-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95 max-md:left-0 max-md:right-0 max-md:top-auto max-md:bottom-0 max-md:w-full max-md:max-w-none max-md:max-h-[90dvh] max-md:translate-x-0 max-md:translate-y-0 max-md:rounded-2xl max-md:rounded-b-none max-md:p-5 max-md:pb-[calc(1.5rem+env(safe-area-inset-bottom))] max-md:data-[state=open]:zoom-in-100 max-md:data-[state=closed]:zoom-out-100 max-md:data-[state=open]:slide-in-from-bottom max-md:data-[state=closed]:slide-out-to-bottom max-md:data-[state=open]:duration-300 max-md:data-[state=closed]:duration-200',
+        mobileSheetHeight === 'tall' && 'max-md:h-[90dvh]',
         className
       )}
       {...props}

--- a/ui/src/components/ui/file-preview.test.tsx
+++ b/ui/src/components/ui/file-preview.test.tsx
@@ -1,0 +1,33 @@
+/* @vitest-environment jsdom */
+
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  EDITOR_FONT_DEFAULT,
+  adjustEditorFontSize,
+  resetEditorFontSize,
+} from '@/lib/editorFontSize';
+import { FilePreview } from './file-preview';
+
+beforeEach(resetEditorFontSize);
+
+afterEach(() => {
+  cleanup();
+  resetEditorFontSize();
+});
+
+describe('FilePreview font size', () => {
+  it('tracks the Editor font-size preference for Markdown previews', () => {
+    const { container } = render(
+      <FilePreview source={{ name: 'notes.md', text: '# Preview' }} />,
+    );
+    const preview = container.querySelector<HTMLElement>('.vr-fileview-text');
+
+    expect(preview?.style.getPropertyValue('--vr-fileview-font-size')).toBe(`${EDITOR_FONT_DEFAULT}px`);
+
+    act(() => adjustEditorFontSize(3));
+
+    expect(preview?.style.getPropertyValue('--vr-fileview-font-size')).toBe(`${EDITOR_FONT_DEFAULT + 3}px`);
+  });
+});

--- a/ui/src/components/ui/file-preview.tsx
+++ b/ui/src/components/ui/file-preview.tsx
@@ -8,6 +8,11 @@ import { Markdown } from '@/components/ui/markdown';
 import { useTheme } from '@/context/ThemeContext';
 import { apiFetch } from '@/lib/apiFetch';
 import {
+  EDITOR_FONT_DEFAULT,
+  getEditorFontSize,
+  subscribeEditorFontSize,
+} from '@/lib/editorFontSize';
+import {
   CODE_HIGHLIGHT_MAX_BYTES,
   CSV_MAX_COLS,
   CSV_MAX_ROWS,
@@ -640,6 +645,11 @@ type TextKind = 'svg' | 'html' | 'markdown' | 'json' | 'csv' | 'code';
 const TextPreview: React.FC<{ source: PreviewSource; kind: TextKind; onText?: (text: string) => void; className?: string }> = ({ source, kind, onText, className }) => {
   const { t } = useTranslation();
   const onTextRef = useLatestRef(onText);
+  const fontSize = React.useSyncExternalStore(
+    subscribeEditorFontSize,
+    getEditorFontSize,
+    () => EDITOR_FONT_DEFAULT,
+  );
   const [state, setState] = React.useState<{ phase: 'loading' | 'ready' | 'error' | 'toolarge'; text: string }>(() =>
     source.text != null ? { phase: 'ready', text: source.text } : { phase: 'loading', text: '' },
   );
@@ -698,17 +708,33 @@ const TextPreview: React.FC<{ source: PreviewSource; kind: TextKind; onText?: (t
   if (state.phase === 'error') return <Centered className={className}>{t('preview.failed')}</Centered>;
 
   const text = state.text;
-  if (kind === 'markdown')
-    return (
-      <div className={clsx('h-full min-h-0 overflow-auto bg-surface', className)}>
+  let content: React.ReactNode;
+  if (kind === 'markdown') {
+    content = (
+      <div className="h-full min-h-0 overflow-auto bg-surface">
         <Markdown content={text} interactive={false} className="vr-fileview-md mx-auto max-w-3xl px-6 py-5" />
       </div>
     );
-  if (kind === 'svg') return <ImageBody src={`data:image/svg+xml;charset=utf-8,${encodeURIComponent(text)}`} name={source.name} className={className} />;
-  if (kind === 'html') return <HtmlView html={text} className={className} />;
-  if (kind === 'json') return <JsonBlock text={text} className={className} />;
-  if (kind === 'csv') return <CsvTable text={text} className={className} />;
-  return <CodeBlock code={text} lang={codeLanguage(source.name, source.ext)} className={className} />;
+  } else if (kind === 'svg') {
+    content = <ImageBody src={`data:image/svg+xml;charset=utf-8,${encodeURIComponent(text)}`} name={source.name} />;
+  } else if (kind === 'html') {
+    content = <HtmlView html={text} />;
+  } else if (kind === 'json') {
+    content = <JsonBlock text={text} />;
+  } else if (kind === 'csv') {
+    content = <CsvTable text={text} />;
+  } else {
+    content = <CodeBlock code={text} lang={codeLanguage(source.name, source.ext)} />;
+  }
+
+  return (
+    <div
+      className={clsx('vr-fileview-text h-full min-h-0', className)}
+      style={{ '--vr-fileview-font-size': `${fontSize}px` } as React.CSSProperties}
+    >
+      {content}
+    </div>
+  );
 };
 
 // Scroll container shared by the text renderers (their inner markup owns its own padding via the

--- a/ui/src/components/ui/file-viewer-modal.tsx
+++ b/ui/src/components/ui/file-viewer-modal.tsx
@@ -94,7 +94,11 @@ export default function FileViewerModal({ target, onClose }: { target: FilePrevi
           header leaves room for that close X. */}
       {/* Definite height (not just max-h): the FilePreview kernel scrolls internally via h-full, which
           needs a resolved parent height — a content-driven box would collapse it. */}
-      <DialogContent aria-describedby={undefined} className="flex h-[80vh] w-full max-w-3xl flex-col gap-0 overflow-hidden p-0 max-md:h-[82dvh]">
+      <DialogContent
+        aria-describedby={undefined}
+        mobileSheetHeight="tall"
+        className="flex h-[80vh] w-full max-w-3xl flex-col gap-0 overflow-hidden p-0"
+      >
         <div className="flex items-center gap-2 border-b border-border px-4 py-3 pr-12">
           <FileText className="size-4 shrink-0 text-muted" />
           <div className="min-w-0 flex-1">

--- a/ui/src/components/ui/preview-json.tsx
+++ b/ui/src/components/ui/preview-json.tsx
@@ -13,7 +13,10 @@ export default function PreviewJson({ value }: { value: object }) {
   return (
     <JsonView
       value={value}
-      style={resolvedTheme === 'light' ? githubLightTheme : githubDarkTheme}
+      style={{
+        ...(resolvedTheme === 'light' ? githubLightTheme : githubDarkTheme),
+        fontSize: 'var(--vr-fileview-font-size, 13px)',
+      }}
       collapsed={2}
       displayDataTypes={false}
       shortenTextAfterLength={0}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -877,3 +877,12 @@ pre,
 .vr-fileview-table th { background: var(--surface-2); font-weight: 600; }
 .vr-fileview-table tbody tr:nth-child(even) { background: var(--surface-3); }
 .vr-fileview-note { padding: 8px 14px; font-size: 11.5px; color: var(--muted); border-top: 1px solid var(--border); }
+
+/* Text previews share the Editor's persisted font-size preference. The custom
+   property is owned by FilePreview so every shell (Editor preview, Files,
+   chat) updates live without coupling its surrounding chrome to that setting. */
+.vr-fileview-text { font-size: var(--vr-fileview-font-size, 13px); }
+.vr-fileview-text :is(.vr-fileview-md, .vr-fileview-pre, .vr-fileview-code pre, .vr-fileview-json, .vr-fileview-table) {
+  font-size: inherit;
+}
+.vr-fileview-text .vr-fileview-md pre code { font-size: 0.92em; }


### PR DESCRIPTION
## What changed

- add a reusable tall mobile-sheet height to the shared Dialog content while keeping the shared bottom-up enter/exit motion
- use the tall sheet for chat file previews, increasing the mobile viewer from 82dvh to 90dvh
- make text-derived file previews subscribe to the persisted Editor font-size preference across Editor, Files, and chat preview shells
- keep Markdown, fenced code, source code, JSON, and CSV typography on the same live preference

## Evidence

- Unit: added Dialog mobile-sheet and live Markdown preview font-size coverage
- Contract: no API or persisted-data shape changes
- Scenario IDs: none; no matching scenario catalog entry exists for this UI-only behavior
- UI suite: 255 files / 3,226 tests passed
- UI lint baseline: passed
- Production UI build: passed
- Manual: isolated 390px-wide renders at 13px and 17px confirmed the 90dvh sheet layout and live typography scaling without overlap

## Risk and residual checks

- Existing content-sized dialogs remain content-sized; only callers opting into the tall variant receive a fixed mobile height
- The build retains existing third-party Rolldown annotation and chunk-size warnings
- Residual integration check: exercise a real chat attachment in the local Incus regression environment before release
