### PR TITLE
fix(ui): clarify long Agent activity durations

### DIFF
--- a/ui/src/components/workbench/AgentActivityGroup.test.tsx
+++ b/ui/src/components/workbench/AgentActivityGroup.test.tsx
@@ -4,16 +4,38 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    t: (key: string) => key === 'chat.agentActivity.dayShort' ? 'd' : key,
+  }),
 }));
 
 import { ActivityCard } from './AgentActivityGroup';
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
 });
 
 describe('ActivityCard display shortcut', () => {
+  it('shows hour and day units when a live run crosses those boundaries', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-26T02:00:00Z'));
+    const elapsedMs = (24 + 14) * 3_600_000 + 33 * 60_000 + 11_000;
+
+    render(
+      <ActivityCard
+        rows={[]}
+        startedAtMs={Date.now() - elapsedMs}
+        expanded
+        onToggleExpanded={vi.fn()}
+        showToolCalls
+        onToggleTools={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('1d 14:33:11')).toBeTruthy();
+  });
+
   it('renders a compact neutral close control beside the existing header controls', () => {
     const onDisableActivity = vi.fn();
     render(

--- a/ui/src/components/workbench/AgentActivityGroup.tsx
+++ b/ui/src/components/workbench/AgentActivityGroup.tsx
@@ -30,6 +30,7 @@ import { copyTextToClipboard } from '../../lib/utils';
 import {
   activityDurationParts,
   filterActivityRows,
+  formatActivityElapsedClock,
   genericChips,
   parseToolCall,
   parseToolName,
@@ -451,9 +452,7 @@ export const ActivityCard: React.FC<{
   }, [expanded]);
 
   const elapsedMs = Math.max(0, nowMs - (startedAtMs ?? mountedAt));
-  const mm = Math.floor(elapsedMs / 60000);
-  const ss = Math.floor((elapsedMs % 60000) / 1000);
-  const clock = `${String(mm).padStart(2, '0')}:${String(ss).padStart(2, '0')}`;
+  const clock = formatActivityElapsedClock(elapsedMs, t('chat.agentActivity.dayShort'));
 
   return (
     <div className="flex w-full justify-start">

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -3883,6 +3883,7 @@
       "retry": "Retry",
       "durationMin": "{{minutes}}m {{seconds}}s",
       "durationSec": "{{seconds}}s",
+      "dayShort": "d",
       "empty": "No activity recorded for this turn.",
       "tools": "Tools",
       "showTools": "Show tool calls",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -3883,6 +3883,7 @@
       "retry": "重试",
       "durationMin": "{{minutes}} 分 {{seconds}} 秒",
       "durationSec": "{{seconds}} 秒",
+      "dayShort": "d",
       "empty": "本轮没有执行过程记录。",
       "tools": "工具",
       "showTools": "显示工具调用",

--- a/ui/src/lib/agentActivity.test.ts
+++ b/ui/src/lib/agentActivity.test.ts
@@ -6,6 +6,7 @@ import {
   activityDurationParts,
   activityRowFromMessage,
   filterActivityRows,
+  formatActivityElapsedClock,
   genericChips,
   groupFromWire,
   initialLiveActivity,
@@ -230,6 +231,21 @@ describe('activityDurationParts', () => {
   it('returns null for null/negative', () => {
     expect(activityDurationParts(null)).toBeNull();
     expect(activityDurationParts(-5)).toBeNull();
+  });
+});
+
+describe('formatActivityElapsedClock', () => {
+  it('adds hours and days only when those units become meaningful', () => {
+    expect(formatActivityElapsedClock(0, 'd')).toBe('00:00');
+    expect(formatActivityElapsedClock(59 * 60_000 + 59_000, 'd')).toBe('59:59');
+    expect(formatActivityElapsedClock(60 * 60_000, 'd')).toBe('01:00:00');
+    expect(formatActivityElapsedClock(23 * 3_600_000 + 59 * 60_000 + 59_000, 'd')).toBe('23:59:59');
+    expect(formatActivityElapsedClock((24 + 14) * 3_600_000 + 33 * 60_000 + 11_000, 'd')).toBe('1d 14:33:11');
+  });
+
+  it('clamps invalid or negative elapsed values to zero', () => {
+    expect(formatActivityElapsedClock(-1, 'd')).toBe('00:00');
+    expect(formatActivityElapsedClock(Number.NaN, 'd')).toBe('00:00');
   });
 });
 

--- a/ui/src/lib/agentActivity.ts
+++ b/ui/src/lib/agentActivity.ts
@@ -239,6 +239,23 @@ export const activityDurationParts = (
   return { minutes: Math.floor(totalSeconds / 60), seconds: totalSeconds % 60 };
 };
 
+// Precise elapsed clock for the live activity card. Keep the compact MM:SS
+// shape below one hour, then expose hours and days instead of letting minutes
+// grow into an increasingly hard-to-read total.
+export const formatActivityElapsedClock = (ms: number, daySuffix: string): string => {
+  const totalSeconds = Number.isFinite(ms) ? Math.max(0, Math.floor(ms / 1000)) : 0;
+  const days = Math.floor(totalSeconds / 86_400);
+  const hours = Math.floor((totalSeconds % 86_400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const pad = (value: number) => String(value).padStart(2, '0');
+
+  const clock = hours > 0 || days > 0
+    ? `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`
+    : `${pad(minutes)}:${pad(seconds)}`;
+  return days > 0 ? `${days}${daySuffix} ${clock}` : clock;
+};
+
 // ===== Tool-call summary v2 (A/D): 3-tier degrade, frontend-only parse =====
 // ``ActivityRow.text`` for a tool call is the backend ``format_toolcall`` STRING —
 // ``🔧 `ToolName` `{compact json}` `` (base_formatter.py). Tool names and arg keys


### PR DESCRIPTION
## What changed

- Keep the live Agent activity timer as `MM:SS` below one hour.
- Show `HH:MM:SS` from one hour through 23:59:59.
- Show `Nd HH:MM:SS` after 24 hours, for example `1d 14:33:11`.
- Keep the compact day suffix in the localized resource surface.

## Validation

- Focused Vitest coverage: 42 tests passed, including hour/day boundaries and the rendered activity card.
- UI lint baseline passed across 731 TypeScript sources.
- Production UI build passed.

## Residual check

- A real long-running installed session remains a manual acceptance check; deterministic render coverage verifies the same displayed clock shape without waiting hours.

## Dependencies

- None. This follows the Agent activity display controls merged in #1697.

## Known by design

- `chat.agentActivity.dayShort` is `d` in both English and Chinese. The owner requested the exact compact clock form `1d 14:33:11` from the Chinese Workbench; this token is intentionally language-neutral, while long-form Chinese duration copy continues to use `天` elsewhere.
