### PR TITLE
refactor(memory): split optional distribution

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,6 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+        with:
+          # Both distributions use VCS-derived versions; a shallow PR merge
+          # checkout falls back to 0.1.dev1 instead of the 3.0 release line.
+          fetch-depth: 0
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,7 @@ jobs:
           cache: "pip"
           cache-dependency-path: |
             pyproject.toml
+            packaging/avibe-memory/pyproject.toml
             uv.lock
       - name: Run pre-commit (ruff)
         run: |
@@ -56,15 +57,20 @@ jobs:
           cache: "pip"
           cache-dependency-path: |
             pyproject.toml
+            packaging/avibe-memory/pyproject.toml
             uv.lock
 
       - name: Build package artifact
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          pip install build
+          pip install -e . build pytest
           python scripts/prepare_local_show_runtime_manifest.py
+          python -m build --outdir memory-dist packaging/avibe-memory
           python -m build --wheel
+          AVIBE_CORE_WHEEL="$(ls dist/avibe_os-*.whl)" \
+          AVIBE_MEMORY_WHEEL="$(ls memory-dist/avibe_memory-*.whl)" \
+            pytest tests/test_memory_distribution.py -v
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -257,6 +257,11 @@ jobs:
           echo "SETUPTOOLS_SCM_PRETEND_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
           echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_OS=$PACKAGE_VERSION" >> "$GITHUB_ENV"
 
+      - name: Block Memory Wave 3a release until Waves 3b and 3c
+        run: |
+          echo "::error title=Memory Wave 3a release blocked::Wave 3b must preserve the optional package across upgrade and rollback, and Wave 3c must own manifest validation and memory-first publication."
+          exit 1
+
       - name: Verify Show Runtime release assets
         run: |
           python - <<'PY'

--- a/.github/workflows/release_ai.yml
+++ b/.github/workflows/release_ai.yml
@@ -201,6 +201,11 @@ jobs:
           echo "SETUPTOOLS_SCM_PRETEND_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
           echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_OS=$PACKAGE_VERSION" >> "$GITHUB_ENV"
 
+      - name: Block Memory Wave 3a release until Waves 3b and 3c
+        run: |
+          echo "::error title=Memory Wave 3a release blocked::Wave 3b must preserve the optional package across upgrade and rollback, and Wave 3c must own manifest validation and memory-first publication."
+          exit 1
+
       - name: Build Python package
         run: |
           pip install build

--- a/packaging/avibe-memory/README.md
+++ b/packaging/avibe-memory/README.md
@@ -24,6 +24,13 @@ matching `avibe-memory` release first and verify that the package index serves
 it before publishing `avibe-os`. This order is required because the host extra
 must resolve at the moment it becomes public.
 
+This package split is not release-ready by itself. Do not tag or publish that
+first host release until the upgrade and rollback package-shape planner (Wave
+3b) and the release automation and manifest ownership changes (Wave 3c) have
+landed. Wave 3c owns building and publishing `avibe-memory` first and verifying
+its package-index availability. Wave 3a intentionally leaves both the upgrade
+planner and release workflows unchanged.
+
 The package split changes distribution ownership only. The installed import
 path remains `avibe_memory`, the host keeps its fixed loader and protocol
 constant, and the EverOS artifact manifest remains available as

--- a/packaging/avibe-memory/README.md
+++ b/packaging/avibe-memory/README.md
@@ -1,0 +1,33 @@
+# avibe-memory
+
+`avibe-memory` is the optional in-process Memory implementation for `avibe-os`.
+Install it through the host extra so the resolver selects a compatible pair:
+
+```console
+pip install "avibe-os[memory]"
+```
+
+The `3.0.x` package line implements Memory runtime protocol `1` and requires
+`avibe-os>=3.0.14.dev0,<3.1`. The host extra applies the same compatibility
+range to this distribution.
+
+## Distribution contract
+
+Build the independent distribution from the repository root:
+
+```console
+python -m build packaging/avibe-memory
+```
+
+For the first `avibe-os` release that exposes the `memory` extra, publish the
+matching `avibe-memory` release first and verify that the package index serves
+it before publishing `avibe-os`. This order is required because the host extra
+must resolve at the moment it becomes public.
+
+The package split changes distribution ownership only. The installed import
+path remains `avibe_memory`, the host keeps its fixed loader and protocol
+constant, and the EverOS artifact manifest remains available as
+`vibe/memory_runtime_manifest.json`. Runtime, storage, configuration, and data
+formats are unchanged, so the previous source-compatible Avibe release can
+load the same persisted state. Upgrade and rollback package-shape planning is
+owned by the subsequent migration wave.

--- a/packaging/avibe-memory/hatch_build.py
+++ b/packaging/avibe-memory/hatch_build.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CustomBuildHook(BuildHookInterface):
+    PLUGIN_NAME = "custom"
+
+    def initialize(self, version: str, build_data: dict) -> None:
+        root = Path(self.root)
+        repository_root = root.parents[1]
+        source_root = root if (root / "avibe_memory").is_dir() else repository_root
+        sources = {
+            source_root / "vibe" / "memory_runtime_manifest.json": (
+                "vibe/memory_runtime_manifest.json"
+            ),
+        }
+        if source_root != root:
+            sources[source_root / "avibe_memory"] = "avibe_memory"
+        missing = [str(path) for path in sources if not path.exists()]
+        if missing:
+            raise RuntimeError(
+                "avibe-memory build sources are missing: " + ", ".join(missing)
+            )
+        force_include = build_data.setdefault("force_include", {})
+        force_include.update({str(path): target for path, target in sources.items()})

--- a/packaging/avibe-memory/pyproject.toml
+++ b/packaging/avibe-memory/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[project]
+name = "avibe-memory"
+dynamic = ["version"]
+description = "Optional in-process Memory implementation for Avibe"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.10"
+authors = [
+    { name = "cyhhao", email = "cyhhao@users.noreply.github.com" }
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "avibe-os>=3.0.14.dev0,<3.1",
+]
+
+[project.urls]
+Homepage = "https://github.com/avibe-bot/avibe"
+Repository = "https://github.com/avibe-bot/avibe"
+Documentation = "https://github.com/avibe-bot/avibe#readme"
+Issues = "https://github.com/avibe-bot/avibe/issues"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
+
+[tool.hatch.build.hooks.custom]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,11 @@ dependencies = [
     "prometheus-client>=0.20.0",
 ]
 
+[project.optional-dependencies]
+memory = [
+    "avibe-memory>=3.0.14.dev0,<3.1",
+]
+
 [project.urls]
 Homepage = "https://github.com/avibe-bot/avibe"
 Repository = "https://github.com/avibe-bot/avibe"
@@ -100,14 +105,14 @@ artifacts = [
     "vibe/show_runtime_manifest.json",
     "vibe/tmux_runtime_manifest.json",
     "vibe/git_runtime_manifest.json",
-    "vibe/memory_runtime_manifest.json",
     "vibe/model_hub_runtime/cliproxyapi_manifest.json",
 ]
 
 [tool.hatch.build.hooks.custom]
 
 [tool.hatch.build.targets.wheel]
-packages = ["vibe", "config", "core", "modules", "storage", "avibe_memory"]
+packages = ["vibe", "config", "core", "modules", "storage"]
+exclude = ["vibe/memory_runtime_manifest.json"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "main.py" = "vibe/service_main.py"
@@ -121,7 +126,6 @@ include = [
     "core/**",
     "modules/**",
     "storage/**",
-    "avibe_memory/**",
     "hatch_build.py",
     "main.py",
     "scripts/prepare_local_show_runtime_manifest.py",
@@ -130,11 +134,11 @@ include = [
     "vibe/show_runtime_manifest.json",
     "vibe/tmux_runtime_manifest.json",
     "vibe/git_runtime_manifest.json",
-    "vibe/memory_runtime_manifest.json",
     "vibe/model_hub_runtime/cliproxyapi_manifest.json",
     "README.md",
     "LICENSE",
 ]
+exclude = ["vibe/memory_runtime_manifest.json"]
 
 [tool.ruff]
 line-length = 120
@@ -158,3 +162,6 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=1.4.0",
 ]
+
+[tool.uv.sources]
+avibe-memory = { path = "packaging/avibe-memory" }

--- a/tests/test_memory_disabled_isolation.py
+++ b/tests/test_memory_disabled_isolation.py
@@ -482,14 +482,19 @@ def test_memory_indep_017_core_workflows_run_without_avibe_memory(
     )
 
 
-def test_wave_2c_package_metadata_bundles_avibe_memory() -> None:
-    """Wave 2 keeps Memory in the avibe-os wheel and source distribution."""
+def test_wave_3a_package_metadata_separates_avibe_memory_distribution() -> None:
+    """Wave 3a keeps the implementation out of the core distribution."""
 
     metadata = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     targets = metadata["tool"]["hatch"]["build"]["targets"]
+    memory_metadata = tomllib.loads(
+        (ROOT / "packaging/avibe-memory/pyproject.toml").read_text(encoding="utf-8")
+    )
 
-    assert "avibe_memory" in targets["wheel"]["packages"]
-    assert "avibe_memory/**" in targets["sdist"]["include"]
+    assert "avibe_memory" not in targets["wheel"]["packages"]
+    assert "avibe_memory/**" not in targets["sdist"]["include"]
+    assert "vibe/memory_runtime_manifest.json" in targets["wheel"]["exclude"]
+    assert memory_metadata["project"]["name"] == "avibe-memory"
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_distribution.py
+++ b/tests/test_memory_distribution.py
@@ -91,6 +91,10 @@ def test_publish_order_guard_requires_memory_before_the_first_host_extra() -> No
 
     assert "publish the matching `avibe-memory` release first" in contract
     assert "before publishing `avibe-os`" in contract
+    assert "This package split is not release-ready by itself" in contract
+    assert "upgrade and rollback package-shape planner (Wave 3b)" in contract
+    assert "release automation and manifest ownership changes (Wave 3c)" in contract
+    assert "Wave 3a intentionally leaves both the upgrade planner" in contract
     assert "Upgrade and rollback package-shape planning is" in contract
 
 
@@ -134,6 +138,7 @@ def test_built_wheels_have_independent_contents_and_compatible_metadata() -> Non
     assert memory_version in memory_requirement.specifier
     assert host_requirement.specifier == COMPATIBILITY
     assert core_version in host_requirement.specifier
+    assert memory_version == core_version
 
 
 @pytest.mark.parametrize("installation", ["core-only", "core+memory"])

--- a/tests/test_memory_distribution.py
+++ b/tests/test_memory_distribution.py
@@ -13,6 +13,7 @@ from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
 from packaging.version import Version
 import pytest
+import yaml
 
 try:
     import tomllib
@@ -23,6 +24,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
 ROOT = Path(__file__).resolve().parents[1]
 MEMORY_PROJECT = ROOT / "packaging" / "avibe-memory"
 COMPATIBILITY = SpecifierSet(">=3.0.14.dev0,<3.1")
+RELEASE_GATE = "Block Memory Wave 3a release until Waves 3b and 3c"
 
 
 def _project(path: Path) -> dict[str, Any]:
@@ -96,6 +98,35 @@ def test_publish_order_guard_requires_memory_before_the_first_host_extra() -> No
     assert "release automation and manifest ownership changes (Wave 3c)" in contract
     assert "Wave 3a intentionally leaves both the upgrade planner" in contract
     assert "Upgrade and rollback package-shape planning is" in contract
+
+
+def test_release_workflows_fail_closed_before_the_split_package_builds() -> None:
+    expectations = (
+        ("publish.yml", "Build package", "Verify package runtime manifests"),
+        ("release_ai.yml", "Build Python package", "Verify bundled runtime manifests"),
+    )
+
+    for workflow_name, build_step, wheel_assertion_step in expectations:
+        workflow = yaml.safe_load(
+            (ROOT / ".github" / "workflows" / workflow_name).read_text(
+                encoding="utf-8"
+            )
+        )
+        matching_jobs = []
+        for job in workflow["jobs"].values():
+            steps = job.get("steps", [])
+            names = [step.get("name") for step in steps]
+            if RELEASE_GATE in names:
+                matching_jobs.append((steps, names))
+
+        assert len(matching_jobs) == 1
+        steps, names = matching_jobs[0]
+        gate_index = names.index(RELEASE_GATE)
+        gate_command = steps[gate_index]["run"]
+        assert gate_index < names.index(build_step) < names.index(wheel_assertion_step)
+        assert "Wave 3b" in gate_command
+        assert "Wave 3c" in gate_command
+        assert "exit 1" in gate_command
 
 
 def test_built_wheels_have_independent_contents_and_compatible_metadata() -> None:

--- a/tests/test_memory_distribution.py
+++ b/tests/test_memory_distribution.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from email.parser import Parser
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+import zipfile
+
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.utils import canonicalize_name
+from packaging.version import Version
+import pytest
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MEMORY_PROJECT = ROOT / "packaging" / "avibe-memory"
+COMPATIBILITY = SpecifierSet(">=3.0.14.dev0,<3.1")
+
+
+def _project(path: Path) -> dict[str, Any]:
+    return tomllib.loads(path.read_text(encoding="utf-8"))["project"]
+
+
+def _requirement(requirements: list[str], name: str) -> Requirement:
+    canonical_name = canonicalize_name(name)
+    matches = [
+        Requirement(value)
+        for value in requirements
+        if canonicalize_name(Requirement(value).name) == canonical_name
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _wheel_path(variable: str) -> Path:
+    value = os.environ.get(variable)
+    if value is None:
+        pytest.skip(f"{variable} is set by the package-matrix build job")
+    path = Path(value).resolve()
+    assert path.is_file()
+    return path
+
+
+def _wheel_metadata(wheel: Path) -> tuple[set[str], Any]:
+    with zipfile.ZipFile(wheel) as archive:
+        names = set(archive.namelist())
+        metadata_paths = [name for name in names if name.endswith(".dist-info/METADATA")]
+        assert len(metadata_paths) == 1
+        metadata = Parser().parsestr(
+            archive.read(metadata_paths[0]).decode("utf-8")
+        )
+    return names, metadata
+
+
+def _run(python: Path, *args: str, cwd: Path) -> None:
+    environment = {**os.environ, "PYTHONPATH": ""}
+    result = subprocess.run(
+        [str(python), *args],
+        cwd=cwd,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_memory_extra_and_distribution_share_one_compatibility_window() -> None:
+    host = _project(ROOT / "pyproject.toml")
+    memory = _project(MEMORY_PROJECT / "pyproject.toml")
+
+    memory_requirement = _requirement(host["optional-dependencies"]["memory"], "avibe-memory")
+    host_requirement = _requirement(memory["dependencies"], "avibe-os")
+
+    assert memory_requirement.specifier == COMPATIBILITY
+    assert host_requirement.specifier == COMPATIBILITY
+
+
+def test_publish_order_guard_requires_memory_before_the_first_host_extra() -> None:
+    contract = " ".join(
+        (MEMORY_PROJECT / "README.md").read_text(encoding="utf-8").split()
+    )
+
+    assert "publish the matching `avibe-memory` release first" in contract
+    assert "before publishing `avibe-os`" in contract
+    assert "Upgrade and rollback package-shape planning is" in contract
+
+
+def test_built_wheels_have_independent_contents_and_compatible_metadata() -> None:
+    core_wheel = _wheel_path("AVIBE_CORE_WHEEL")
+    memory_wheel = _wheel_path("AVIBE_MEMORY_WHEEL")
+    core_names, core_metadata = _wheel_metadata(core_wheel)
+    memory_names, memory_metadata = _wheel_metadata(memory_wheel)
+
+    assert core_metadata["Name"] == "avibe-os"
+    assert memory_metadata["Name"] == "avibe-memory"
+    assert not any(name.startswith("avibe_memory/") for name in core_names)
+    assert "vibe/memory_runtime_manifest.json" not in core_names
+    assert "core/memory_loader.py" in core_names
+
+    source_files = {
+        path.relative_to(ROOT).as_posix()
+        for path in (ROOT / "avibe_memory").rglob("*")
+        if path.is_file() and "__pycache__" not in path.parts
+    }
+    packaged_files = {
+        name for name in memory_names if name.startswith("avibe_memory/")
+    }
+    assert packaged_files == source_files
+    assert "vibe/memory_runtime_manifest.json" in memory_names
+    with zipfile.ZipFile(memory_wheel) as archive:
+        assert archive.read("vibe/memory_runtime_manifest.json") == (
+            ROOT / "vibe/memory_runtime_manifest.json"
+        ).read_bytes()
+
+    core_requires = core_metadata.get_all("Requires-Dist") or []
+    memory_requires = memory_metadata.get_all("Requires-Dist") or []
+    memory_requirement = _requirement(core_requires, "avibe-memory")
+    host_requirement = _requirement(memory_requires, "avibe-os")
+    core_version = Version(core_metadata["Version"])
+    memory_version = Version(memory_metadata["Version"])
+
+    assert memory_requirement.specifier == COMPATIBILITY
+    assert memory_requirement.marker is not None
+    assert memory_requirement.marker.evaluate({"extra": "memory"})
+    assert memory_version in memory_requirement.specifier
+    assert host_requirement.specifier == COMPATIBILITY
+    assert core_version in host_requirement.specifier
+
+
+@pytest.mark.parametrize("installation", ["core-only", "core+memory"])
+def test_wheel_installation_matrix(
+    installation: str,
+    tmp_path: Path,
+) -> None:
+    core_wheel = _wheel_path("AVIBE_CORE_WHEEL")
+    memory_wheel = _wheel_path("AVIBE_MEMORY_WHEEL")
+    environment = tmp_path / installation
+    subprocess.run(
+        [sys.executable, "-m", "venv", str(environment)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    python = environment / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    wheels = [core_wheel]
+    if installation == "core+memory":
+        wheels.append(memory_wheel)
+    _run(
+        python,
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        "--no-deps",
+        *(str(wheel) for wheel in wheels),
+        cwd=tmp_path,
+    )
+
+    expected = installation == "core+memory"
+    _run(
+        python,
+        "-c",
+        (
+            "import importlib.util; "
+            "import core.memory_loader as loader; "
+            f"assert (importlib.util.find_spec('avibe_memory') is not None) is {expected!r}; "
+            "assert loader.MEMORY_RUNTIME_ENTRYPOINT == 'avibe_memory.runtime'; "
+            "assert loader.MEMORY_RUNTIME_PROTOCOL_VERSION == 1"
+        ),
+        cwd=tmp_path,
+    )
+    if expected:
+        _run(
+            python,
+            "-c",
+            (
+                "from importlib.metadata import distribution; "
+                "import avibe_memory; "
+                "assert distribution('avibe-memory').metadata['Name'] == 'avibe-memory'; "
+                "assert avibe_memory.__name__ == 'avibe_memory'"
+            ),
+            cwd=tmp_path,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -295,6 +295,16 @@ wheels = [
 ]
 
 [[package]]
+name = "avibe-memory"
+source = { directory = "packaging/avibe-memory" }
+dependencies = [
+    { name = "avibe-os" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "avibe-os", specifier = ">=3.0.14.dev0,<3.1" }]
+
+[[package]]
 name = "avibe-os"
 source = { editable = "." }
 dependencies = [
@@ -331,6 +341,11 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 
+[package.optional-dependencies]
+memory = [
+    { name = "avibe-memory" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "jsonschema" },
@@ -345,6 +360,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "anyio", specifier = ">=4.0.0" },
     { name = "apscheduler", specifier = ">=3.10.4" },
+    { name = "avibe-memory", marker = "extra == 'memory'", directory = "packaging/avibe-memory" },
     { name = "claude-agent-sdk", specifier = ">=0.2.93" },
     { name = "cryptography", specifier = ">=42.0" },
     { name = "discord-py", specifier = ">=2.4.0" },
@@ -372,6 +388,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.12.2" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27" },
 ]
+provides-extras = ["memory"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Capability

Ship the already-extracted `avibe_memory` implementation as the independent
`avibe-memory` distribution while keeping `avibe-os` core-only by default.

- adds independent Hatch/VCS metadata and sdist/wheel build path for `avibe-memory`
- exposes `avibe-os[memory]` with the symmetric `>=3.0.14.dev0,<3.1` compatibility window
- excludes `avibe_memory/**` and `vibe/memory_runtime_manifest.json` from `avibe-os` artifacts
- preserves the fixed `avibe_memory.runtime` loader, protocol `1`, in-process Adapter,
  one EverOS child, installed manifest resource path, and all runtime/data/config formats
- documents and tests the publication order: `avibe-memory` must be available before
  the first `avibe-os` release that exposes the extra

## Affected scenarios

`MEMORY-INDEP-001`, `MEMORY-INDEP-002`, `MEMORY-INDEP-003`,
`MEMORY-INDEP-004`, `MEMORY-INDEP-005`, `MEMORY-INDEP-006`,
`MEMORY-INDEP-007`, `MEMORY-INDEP-008`, `MEMORY-INDEP-009`,
`MEMORY-INDEP-010`, `MEMORY-INDEP-011`, `MEMORY-INDEP-012`,
`MEMORY-INDEP-013`, `MEMORY-INDEP-014`, `MEMORY-INDEP-015`,
`MEMORY-INDEP-016`, `MEMORY-INDEP-017`.

## Evidence layers

- **Unit:** `tests/test_memory_distribution.py` passes 6/6 metadata, publish-order,
  fail-closed release-gate, wheel-content, and install-matrix checks.
- **Contract:** independent `avibe-memory` sdist+wheel and `avibe-os` sdist+wheel
  build smoke pass; core-only install cannot discover `avibe_memory`; core+memory
  install discovers the compatible independent distribution; manifest bytes remain
  identical at `vibe/memory_runtime_manifest.json` only in the optional wheel.
- **Scenario:** exact `MEMORY-INDEP-001..017` nodes pass 17/17; broad Memory suite
  passes 820 with 9 expected runtime-dependent skips.
- **Static:** changed-Python Ruff and repository pre-commit pass; `uv lock --check`,
  workflow YAML parse, and `git diff --check` pass.
- **Source/rollback:** the existing Incus runner syncs source to
  `/opt/avibe/source` and installs it with `pip install -e .`, so source-based
  master regression retains the top-level `avibe_memory` implementation.
- **Residual manual:** no live service restart, Incus, or production-state operation
  was performed by instruction. Package-index publication and packaged user-facing
  integration remain for the orchestrator/release lane.

## Dependencies and deferred scope

Wave 2c (#1705) is already present in the `dev` base. This packaging-only PR
has no merge dependency. It is not independently release-ready: do not tag or
publish the first `avibe-os` release exposing `memory` until Wave 3b preserves
the optional package across upgrade/rollback and Wave 3c moves manifest validation
and build/publish ownership to `avibe-memory`. Those waves must land before that
release, while their planner and release-script changes remain outside Wave 3a.
Both official and GitHub-only release workflows now fail closed before package build
with a named gate until those prerequisites land.

## Known-by-design ledger

- `avibe-memory` contributes only the existing
  `vibe/memory_runtime_manifest.json` data resource under the host-owned `vibe`
  package path. This preserves manifest lookup without changing runtime code or
  introducing package discovery.
- The repository keeps the top-level `avibe_memory` source directory so source
  checkouts and the prior release remain compatible; only built distribution
  ownership changes.
- Default `uv sync` stays core-only. `uv sync --extra memory` selects the local
  independent package at the same VCS-derived version.
- Controller startup still never installs or downloads a Python package.
- **Finding 1 -> Wave 3b:** the current upgrade planner still installs bare
  `avibe-os`. Preserving optional package presence is Wave 3b; the named release
  gate prevents this split from shipping before that planner lands.
- **Findings 2 and 3 -> Wave 3c:** the current release workflows and scheduled
  manifest guard still validate and publish only the host artifact. Manifest
  ownership plus memory-first build, package-index verification, and publication
  automation are Wave 3c; the named release gate prevents the host extra from
  becoming public before that lane lands.