### PR TITLE
refactor(memory): preserve upgrade package shape

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -1046,7 +1046,18 @@ class Controller:
             allow_disabled=True,
             retry_plugin_error=True,
         ) as lease:
-            return await lease.runtime.install_artifact()
+            result = await lease.runtime.install_artifact()
+            if result.get("ok") is True and lease.temporary:
+                condition = self._memory_runtime_condition()
+                async with condition:
+                    if (
+                        getattr(self, "memory_runtime", None) is lease.runtime
+                        and getattr(self, "_memory_runtime_temporary", False)
+                        and self.config.memory.enabled
+                    ):
+                        self._memory_runtime_temporary = False
+                        self._memory_runtime_temporary_config = None
+            return result
 
     async def reconcile_memory(self, memory_config: MemoryConfig) -> dict[str, Any]:
         """Hot-apply persisted Memory settings without destructive fallback."""

--- a/core/update_checker.py
+++ b/core/update_checker.py
@@ -1098,7 +1098,10 @@ class UpdateChecker:
                 logger.error(f"Upgrade failed: {result['message']}")
                 if result.get("output"):
                     logger.error(f"Output: {result['output']}")
-                self._remove_update_marker()
+                if result.get("code") == "restart_in_progress":
+                    logger.info("Retaining update marker owned by the active restart")
+                else:
+                    self._remove_update_marker()
                 return result
 
     def _write_update_marker(

--- a/core/update_checker.py
+++ b/core/update_checker.py
@@ -1065,7 +1065,18 @@ class UpdateChecker:
             # Run upgrade in thread to avoid blocking event loop
             from vibe.api import do_upgrade
 
-            result = await asyncio.to_thread(do_upgrade, True)
+            memory_enabled = bool(
+                getattr(
+                    getattr(getattr(self.controller, "config", None), "memory", None),
+                    "enabled",
+                    False,
+                )
+            )
+            result = await asyncio.to_thread(
+                do_upgrade,
+                True,
+                memory_enabled=memory_enabled,
+            )
 
             if result["ok"]:
                 logger.info(f"Upgrade successful: {result['message']}")

--- a/tests/scenarios/memory_independence/catalog.yaml
+++ b/tests/scenarios/memory_independence/catalog.yaml
@@ -129,3 +129,9 @@ scenarios:
     kind: guardrail
     layer: scenario
     test: tests/test_memory_disabled_isolation.py::test_memory_indep_017_core_workflows_run_without_avibe_memory
+  - id: MEMORY-INDEP-018
+    name: Upgrades preserve the optional Memory package and pinned rollback restores the prior package shape
+    status: covered
+    kind: correctness
+    layer: scenario
+    test: tests/test_upgrade_flow.py::test_memory_indep_018_upgrade_and_rollback_preserve_optional_package_shape

--- a/tests/test_i18n_backend_keys.py
+++ b/tests/test_i18n_backend_keys.py
@@ -78,6 +78,19 @@ def test_no_backend_translation_is_blank() -> None:
 
 @pytest.mark.parametrize(
     "key",
+    [
+        "lifecycle.cli.restartInProgressUpgrade",
+        "lifecycle.cli.restartInProgressRestart",
+        "lifecycle.cli.restartInProgressAction",
+    ],
+)
+def test_cli_lifecycle_contention_messages_are_localized(key: str) -> None:
+    for lang in get_supported_languages():
+        assert t(key, lang) != key
+
+
+@pytest.mark.parametrize(
+    "key",
     sorted(
         {
             *_MEMORY_CLI_RUNTIME_STATE_I18N_KEYS.values(),

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -1505,18 +1505,18 @@ def test_memory_runtime_dependency_job_stops_when_package_resolution_fails(monke
         lambda: calls.append(True)
         or {
             "ok": False,
-            "message": "memory_plugin_incompatible",
+            "message": "memory_runtime_install_failed",
             "output": "resolver failed",
-            "reason": "memory_plugin_incompatible",
+            "reason": "memory_runtime_install_failed",
             "download_error": None,
         },
     )
 
     assert api._prepare_memory_runtime_job() == {
         "ok": False,
-        "message": "memory_plugin_incompatible",
+        "message": "memory_runtime_install_failed",
         "output": "resolver failed",
-        "reason": "memory_plugin_incompatible",
+        "reason": "memory_runtime_install_failed",
         "download_error": None,
     }
     assert calls == [True]
@@ -1559,6 +1559,52 @@ def test_memory_package_install_uses_the_non_replacing_add_plan(monkeypatch):
         }
     ]
     assert executed == [plan]
+
+
+def test_memory_package_install_reports_nonzero_installer_as_install_failure(
+    monkeypatch,
+):
+    monkeypatch.setattr(api, "installed_metadata_describes_running_code", lambda: True)
+    monkeypatch.setattr(api, "package_mutation_lock", nullcontext)
+    monkeypatch.setattr(api, "build_memory_add_plan", lambda **kwargs: object())
+    monkeypatch.setattr(
+        api,
+        "execute_upgrade_plan",
+        lambda plan, **kwargs: subprocess.CompletedProcess(
+            [],
+            1,
+            stdout="",
+            stderr="index unavailable",
+        ),
+    )
+
+    assert api._install_memory_package_for_current_release() == {
+        "ok": False,
+        "message": "memory_runtime_install_failed",
+        "output": "index unavailable",
+        "reason": "memory_runtime_install_failed",
+        "download_error": None,
+    }
+
+
+def test_memory_package_install_reports_resolver_exception_as_install_failure(
+    monkeypatch,
+):
+    monkeypatch.setattr(api, "installed_metadata_describes_running_code", lambda: True)
+    monkeypatch.setattr(api, "package_mutation_lock", nullcontext)
+
+    def fail_plan(**kwargs):
+        raise RuntimeError("resolver unavailable")
+
+    monkeypatch.setattr(api, "build_memory_add_plan", fail_plan)
+
+    assert api._install_memory_package_for_current_release() == {
+        "ok": False,
+        "message": "memory_runtime_install_failed",
+        "output": "resolver unavailable",
+        "reason": "memory_runtime_install_failed",
+        "download_error": None,
+    }
 
 
 def test_memory_package_install_refuses_a_stale_pre_restart_process(monkeypatch):

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -15,7 +15,7 @@ import os
 import subprocess
 import tarfile
 import urllib.error
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -23,6 +23,11 @@ import pytest
 
 from core import latest_version_cache
 from vibe import api
+
+
+@pytest.fixture(autouse=True)
+def _no_restart_in_flight(monkeypatch):
+    monkeypatch.setattr(api, "restart_in_flight", lambda: False)
 
 
 class _FakeHTTPResponse:
@@ -1352,6 +1357,16 @@ def test_memory_runtime_dependency_job_restarts_after_repairing_unavailable_fact
     controller_calls: list[bool] = []
     installs: list[bool] = []
     restarts: list[dict] = []
+    mutation_lease_held = False
+
+    @contextmanager
+    def mutation_lock():
+        nonlocal mutation_lease_held
+        mutation_lease_held = True
+        try:
+            yield
+        finally:
+            mutation_lease_held = False
 
     def install_runtime() -> dict:
         controller_calls.append(True)
@@ -1370,13 +1385,20 @@ def test_memory_runtime_dependency_job_restarts_after_repairing_unavailable_fact
     monkeypatch.setattr(
         api,
         "_install_memory_package_for_current_release",
-        lambda: installs.append(True) or {"ok": True, "output": "installed"},
+        lambda: (
+            installs.append(mutation_lease_held)
+            or {"ok": True, "output": "installed"}
+        ),
     )
+    monkeypatch.setattr(api, "package_mutation_lock", mutation_lock)
     monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/bin/vibe")
     monkeypatch.setattr(
         api,
         "schedule_restart",
-        lambda **kwargs: restarts.append(kwargs) or {"ok": True, "job_id": "memory-repair"},
+        lambda **kwargs: (
+            restarts.append({**kwargs, "lease_held": mutation_lease_held})
+            or {"ok": True, "job_id": "memory-repair"}
+        ),
     )
 
     assert api._prepare_memory_runtime_job() == {
@@ -1394,8 +1416,45 @@ def test_memory_runtime_dependency_job_restarts_after_repairing_unavailable_fact
             "delay_seconds": 2.0,
             "vibe_path": "/bin/vibe",
             "trigger": "memory-package-repair",
+            "lease_held": True,
         }
     ]
+    assert mutation_lease_held is False
+
+
+def test_memory_runtime_dependency_job_refuses_an_in_flight_restart_before_repair(
+    monkeypatch,
+):
+    from vibe import internal_client
+
+    monkeypatch.setattr(
+        internal_client,
+        "memory_install_runtime_sync",
+        lambda: {
+            "status_code": 503,
+            "body": {"ok": False, "reason": "memory_plugin_unavailable"},
+        },
+    )
+    monkeypatch.setattr(api, "restart_in_flight", lambda: True)
+    monkeypatch.setattr(
+        api,
+        "_install_memory_package_for_current_release",
+        lambda: pytest.fail("an in-flight restart must prevent package repair"),
+    )
+    monkeypatch.setattr(
+        api,
+        "schedule_restart",
+        lambda **kwargs: pytest.fail("an in-flight restart must not schedule another"),
+    )
+
+    assert api._prepare_memory_runtime_job() == {
+        "ok": False,
+        "message": "restart_in_progress",
+        "output": None,
+        "reason": "restart_in_progress",
+        "download_error": None,
+        "restarting": False,
+    }
 
 
 def test_memory_runtime_dependency_job_restarts_after_repairing_incompatible_package(

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -1344,43 +1344,58 @@ def test_memory_runtime_dependency_job_preserves_controller_closed_error(monkeyp
     }
 
 
-def test_memory_runtime_dependency_job_installs_missing_package_then_retries_controller(
+def test_memory_runtime_dependency_job_restarts_after_repairing_unavailable_factory(
     monkeypatch,
 ):
     from vibe import internal_client
 
-    responses = iter(
-        [
-            {
-                "status_code": 503,
-                "body": {"ok": False, "reason": "memory_plugin_unavailable"},
-            },
-            {
-                "status_code": 200,
-                "body": {"ok": True, "reason": None, "download_error": None},
-            },
-        ]
-    )
+    controller_calls: list[bool] = []
     installs: list[bool] = []
+    restarts: list[dict] = []
+
+    def install_runtime() -> dict:
+        controller_calls.append(True)
+        return {
+            "status_code": 503,
+            # This token also covers an imported implementation whose factory
+            # is absent or raises, so this process cannot safely retry it.
+            "body": {"ok": False, "reason": "memory_plugin_unavailable"},
+        }
+
     monkeypatch.setattr(
         internal_client,
         "memory_install_runtime_sync",
-        lambda: next(responses),
+        install_runtime,
     )
     monkeypatch.setattr(
         api,
         "_install_memory_package_for_current_release",
         lambda: installs.append(True) or {"ok": True, "output": "installed"},
     )
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/bin/vibe")
+    monkeypatch.setattr(
+        api,
+        "schedule_restart",
+        lambda **kwargs: restarts.append(kwargs) or {"ok": True, "job_id": "memory-repair"},
+    )
 
     assert api._prepare_memory_runtime_job() == {
         "ok": True,
-        "message": "memory_runtime_ready",
-        "output": None,
+        "message": "memory_runtime_restart_scheduled",
+        "output": "installed",
         "reason": None,
         "download_error": None,
+        "restarting": True,
     }
+    assert controller_calls == [True]
     assert installs == [True]
+    assert restarts == [
+        {
+            "delay_seconds": 2.0,
+            "vibe_path": "/bin/vibe",
+            "trigger": "memory-package-repair",
+        }
+    ]
 
 
 def test_memory_runtime_dependency_job_restarts_after_repairing_incompatible_package(

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -1383,6 +1383,95 @@ def test_memory_runtime_dependency_job_installs_missing_package_then_retries_con
     assert installs == [True]
 
 
+def test_memory_runtime_dependency_job_restarts_after_repairing_incompatible_package(
+    monkeypatch,
+):
+    from vibe import internal_client
+
+    controller_calls: list[bool] = []
+    package_installs: list[bool] = []
+    restarts: list[dict] = []
+
+    def install_runtime() -> dict:
+        controller_calls.append(True)
+        return {
+            "status_code": 503,
+            "body": {"ok": False, "reason": "memory_plugin_incompatible"},
+        }
+
+    monkeypatch.setattr(internal_client, "memory_install_runtime_sync", install_runtime)
+    monkeypatch.setattr(
+        api,
+        "_install_memory_package_for_current_release",
+        lambda: package_installs.append(True) or {"ok": True, "output": "installed"},
+    )
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/bin/vibe")
+    monkeypatch.setattr(
+        api,
+        "schedule_restart",
+        lambda **kwargs: restarts.append(kwargs) or {"ok": True, "job_id": "memory-repair"},
+    )
+
+    assert api._prepare_memory_runtime_job() == {
+        "ok": True,
+        "message": "memory_runtime_restart_scheduled",
+        "output": "installed",
+        "reason": None,
+        "download_error": None,
+        "restarting": True,
+    }
+    assert controller_calls == [True]
+    assert package_installs == [True]
+    assert restarts == [
+        {
+            "delay_seconds": 2.0,
+            "vibe_path": "/bin/vibe",
+            "trigger": "memory-package-repair",
+        }
+    ]
+
+
+def test_memory_runtime_dependency_job_requires_restart_when_scheduling_fails(
+    monkeypatch,
+):
+    from vibe import internal_client
+
+    controller_calls: list[bool] = []
+
+    def install_runtime() -> dict:
+        controller_calls.append(True)
+        return {
+            "status_code": 503,
+            "body": {"ok": False, "reason": "memory_plugin_incompatible"},
+        }
+
+    monkeypatch.setattr(internal_client, "memory_install_runtime_sync", install_runtime)
+    monkeypatch.setattr(
+        api,
+        "_install_memory_package_for_current_release",
+        lambda: {"ok": True, "output": "installed"},
+    )
+
+    def fail_schedule(**kwargs):
+        raise RuntimeError("scheduler unavailable")
+
+    monkeypatch.setattr(
+        api,
+        "schedule_restart",
+        fail_schedule,
+    )
+
+    assert api._prepare_memory_runtime_job() == {
+        "ok": False,
+        "message": "memory_runtime_restart_required",
+        "output": "scheduler unavailable",
+        "reason": "memory_runtime_restart_required",
+        "download_error": None,
+        "restarting": False,
+    }
+    assert controller_calls == [True]
+
+
 def test_memory_runtime_dependency_job_stops_when_package_resolution_fails(monkeypatch):
     from vibe import internal_client
 

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -1343,6 +1343,80 @@ def test_memory_runtime_dependency_job_preserves_controller_closed_error(monkeyp
     }
 
 
+def test_memory_runtime_dependency_job_installs_missing_package_then_retries_controller(
+    monkeypatch,
+):
+    from vibe import internal_client
+
+    responses = iter(
+        [
+            {
+                "status_code": 503,
+                "body": {"ok": False, "reason": "memory_plugin_unavailable"},
+            },
+            {
+                "status_code": 200,
+                "body": {"ok": True, "reason": None, "download_error": None},
+            },
+        ]
+    )
+    installs: list[bool] = []
+    monkeypatch.setattr(
+        internal_client,
+        "memory_install_runtime_sync",
+        lambda: next(responses),
+    )
+    monkeypatch.setattr(
+        api,
+        "_install_memory_package_for_current_release",
+        lambda: installs.append(True) or {"ok": True, "output": "installed"},
+    )
+
+    assert api._prepare_memory_runtime_job() == {
+        "ok": True,
+        "message": "memory_runtime_ready",
+        "output": None,
+        "reason": None,
+        "download_error": None,
+    }
+    assert installs == [True]
+
+
+def test_memory_runtime_dependency_job_stops_when_package_resolution_fails(monkeypatch):
+    from vibe import internal_client
+
+    calls: list[bool] = []
+    monkeypatch.setattr(
+        internal_client,
+        "memory_install_runtime_sync",
+        lambda: {
+            "status_code": 503,
+            "body": {"ok": False, "reason": "memory_plugin_incompatible"},
+        },
+    )
+    monkeypatch.setattr(
+        api,
+        "_install_memory_package_for_current_release",
+        lambda: calls.append(True)
+        or {
+            "ok": False,
+            "message": "memory_plugin_incompatible",
+            "output": "resolver failed",
+            "reason": "memory_plugin_incompatible",
+            "download_error": None,
+        },
+    )
+
+    assert api._prepare_memory_runtime_job() == {
+        "ok": False,
+        "message": "memory_plugin_incompatible",
+        "output": "resolver failed",
+        "reason": "memory_plugin_incompatible",
+        "download_error": None,
+    }
+    assert calls == [True]
+
+
 def test_dependencies_status_node_unsupported_not_ready(monkeypatch):
     # Node present but below the runtime minimum (node_supported False) -> not ready.
     monkeypatch.setattr(

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -15,6 +15,7 @@ import os
 import subprocess
 import tarfile
 import urllib.error
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -1415,6 +1416,69 @@ def test_memory_runtime_dependency_job_stops_when_package_resolution_fails(monke
         "download_error": None,
     }
     assert calls == [True]
+
+
+def test_memory_package_install_uses_the_non_replacing_add_plan(monkeypatch):
+    from vibe import __version__
+
+    plan = object()
+    planned: list[dict] = []
+    executed: list[object] = []
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/bin/vibe")
+    monkeypatch.setattr(
+        api,
+        "installed_metadata_describes_running_code",
+        lambda: True,
+    )
+    monkeypatch.setattr(api, "installed_package_name", lambda: "avibe-os")
+    monkeypatch.setattr(api, "package_mutation_lock", nullcontext)
+    monkeypatch.setattr(
+        api,
+        "build_memory_add_plan",
+        lambda **kwargs: planned.append(kwargs) or plan,
+    )
+    monkeypatch.setattr(
+        api,
+        "execute_upgrade_plan",
+        lambda selected, **kwargs: executed.append(selected)
+        or subprocess.CompletedProcess([], 0, stdout="installed", stderr=""),
+    )
+
+    result = api._install_memory_package_for_current_release()
+
+    assert result["ok"] is True
+    assert planned == [
+        {
+            "vibe_path": "/bin/vibe",
+            "version": __version__,
+            "package_name": "avibe-os",
+        }
+    ]
+    assert executed == [plan]
+
+
+def test_memory_package_install_refuses_a_stale_pre_restart_process(monkeypatch):
+    monkeypatch.setattr(api, "package_mutation_lock", nullcontext)
+    monkeypatch.setattr(
+        api,
+        "installed_metadata_describes_running_code",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        api,
+        "build_memory_add_plan",
+        lambda **kwargs: pytest.fail("stale code must not pin or mutate the replaced install"),
+    )
+
+    result = api._install_memory_package_for_current_release()
+
+    assert result == {
+        "ok": False,
+        "message": "memory_runtime_install_failed",
+        "output": "Avibe changed on disk; restart before installing Memory.",
+        "reason": "memory_runtime_install_failed",
+        "download_error": None,
+    }
 
 
 def test_dependencies_status_node_unsupported_not_ready(monkeypatch):

--- a/tests/test_memory_disabled_isolation.py
+++ b/tests/test_memory_disabled_isolation.py
@@ -877,6 +877,40 @@ async def test_disabled_install_owns_runtime_until_successful_close() -> None:
 
 
 @pytest.mark.asyncio
+async def test_enabled_install_promotes_the_recovered_runtime_for_capture() -> None:
+    controller = Controller.__new__(Controller)
+    controller.config = types.SimpleNamespace(
+        memory=replace(_disabled_app_config().memory, enabled=True)
+    )
+    controller.memory_adapter = DisabledMemoryAdapter()
+    controller.memory_runtime = None
+    controller.memory_module = None
+    controller._memory_reconcile_task = None
+    controller._memory_disabled_cleanup_task = None
+    controller._memory_plugin_error = MemoryPluginUnavailableError("startup failed")
+
+    class _Runtime:
+        module = object()
+        closed = False
+        retired = False
+
+        async def install_artifact(self) -> dict[str, object]:
+            return {"ok": True}
+
+        async def close(self) -> None:
+            raise AssertionError("an enabled repaired runtime must stay attached")
+
+    runtime = _Runtime()
+    controller._create_memory_runtime = lambda config, **kwargs: runtime
+
+    assert await controller.install_memory_runtime() == {"ok": True}
+    assert controller.memory_runtime is runtime
+    assert controller.memory_module is runtime.module
+    assert isinstance(controller.memory_adapter, EnabledMemoryAdapter)
+    assert controller._memory_runtime_temporary is False
+
+
+@pytest.mark.asyncio
 async def test_cancelled_install_does_not_cancel_shared_disabled_cleanup() -> None:
     controller = Controller.__new__(Controller)
     controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)

--- a/tests/test_memory_distribution.py
+++ b/tests/test_memory_distribution.py
@@ -75,6 +75,17 @@ def _run(python: Path, *args: str, cwd: Path) -> None:
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def _venv(tmp_path: Path, name: str) -> Path:
+    environment = tmp_path / name
+    subprocess.run(
+        [sys.executable, "-m", "venv", str(environment)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return environment / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+
 def test_memory_extra_and_distribution_share_one_compatibility_window() -> None:
     host = _project(ROOT / "pyproject.toml")
     memory = _project(MEMORY_PROJECT / "pyproject.toml")
@@ -179,14 +190,7 @@ def test_wheel_installation_matrix(
 ) -> None:
     core_wheel = _wheel_path("AVIBE_CORE_WHEEL")
     memory_wheel = _wheel_path("AVIBE_MEMORY_WHEEL")
-    environment = tmp_path / installation
-    subprocess.run(
-        [sys.executable, "-m", "venv", str(environment)],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    python = environment / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    python = _venv(tmp_path, installation)
     wheels = [core_wheel]
     if installation == "core+memory":
         wheels.append(memory_wheel)
@@ -226,3 +230,142 @@ def test_wheel_installation_matrix(
             ),
             cwd=tmp_path,
         )
+
+
+def test_packaged_memory_states_missing_disabled_enabled_and_incompatible(
+    tmp_path: Path,
+) -> None:
+    core_wheel = _wheel_path("AVIBE_CORE_WHEEL")
+    memory_wheel = _wheel_path("AVIBE_MEMORY_WHEEL")
+
+    missing_python = _venv(tmp_path, "missing")
+    _run(
+        missing_python,
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        "--no-deps",
+        str(core_wheel),
+        cwd=tmp_path,
+    )
+    _run(
+        missing_python,
+        "-c",
+        (
+            "from types import SimpleNamespace; "
+            "from core.memory_loader import load_memory_runtime; "
+            "from vibe.memory_contract import MemoryPluginUnavailableError; "
+            "\ntry: load_memory_runtime(SimpleNamespace(enabled=True))\n"
+            "except MemoryPluginUnavailableError: pass\n"
+            "else: raise AssertionError('missing package did not fail closed')"
+        ),
+        cwd=tmp_path,
+    )
+
+    enabled_python = _venv(tmp_path, "enabled")
+    _run(
+        enabled_python,
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        "--no-deps",
+        str(core_wheel),
+        str(memory_wheel),
+        cwd=tmp_path,
+    )
+    _run(
+        enabled_python,
+        "-c",
+        (
+            "import sys; from importlib.metadata import distribution; "
+            "from types import SimpleNamespace; import core.memory_loader as loader; "
+            "runtime_file = next(path for path in distribution('avibe-memory').files "
+            "if str(path) == 'avibe_memory/runtime.py').locate(); "
+            "assert 'MEMORY_RUNTIME_PROTOCOL_VERSION = 1' in runtime_file.read_text(); "
+            "assert loader.load_memory_runtime(SimpleNamespace(enabled=False)) is None; "
+            "assert 'avibe_memory.runtime' not in sys.modules; "
+            "implementation = SimpleNamespace(MEMORY_RUNTIME_PROTOCOL_VERSION=1, "
+            "create_memory_runtime=lambda config, **kwargs: "
+            "SimpleNamespace(module=object(), close=lambda: None, available=True)); "
+            "loader.importlib.import_module = lambda name: implementation; "
+            "runtime = loader.load_memory_runtime(SimpleNamespace(enabled=True)); "
+            "assert runtime.available is True"
+        ),
+        cwd=tmp_path,
+    )
+
+    incompatible_root = tmp_path / "incompatible"
+    package = incompatible_root / "avibe_memory"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "runtime.py").write_text(
+        "MEMORY_RUNTIME_PROTOCOL_VERSION = 999\n"
+        "def create_memory_runtime(config, **kwargs): raise AssertionError('must not construct')\n",
+        encoding="utf-8",
+    )
+    _run(
+        missing_python,
+        "-c",
+        (
+            "from types import SimpleNamespace; "
+            "from core.memory_loader import load_memory_runtime; "
+            "from vibe.memory_contract import MemoryPluginIncompatibleError; "
+            "\ntry: load_memory_runtime(SimpleNamespace(enabled=True))\n"
+            "except MemoryPluginIncompatibleError: pass\n"
+            "else: raise AssertionError('incompatible package did not fail closed')"
+        ),
+        cwd=incompatible_root,
+    )
+
+
+def test_packaged_memory_upgrade_and_core_only_rollback_restore_shape(
+    tmp_path: Path,
+) -> None:
+    core_wheel = _wheel_path("AVIBE_CORE_WHEEL")
+    memory_wheel = _wheel_path("AVIBE_MEMORY_WHEEL")
+    python = _venv(tmp_path, "shape-round-trip")
+    install_core = [
+        str(python),
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        "--no-deps",
+        str(core_wheel),
+    ]
+    subprocess.run(install_core, check=True, capture_output=True, text=True)
+
+    _run(
+        python,
+        "-c",
+        "import importlib.util; assert importlib.util.find_spec('avibe_memory') is None",
+        cwd=tmp_path,
+    )
+    subprocess.run(
+        [*install_core[:-1], str(core_wheel), str(memory_wheel)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    _run(
+        python,
+        "-c",
+        "import importlib.util; assert importlib.util.find_spec('avibe_memory') is not None",
+        cwd=tmp_path,
+    )
+
+    subprocess.run(install_core, check=True, capture_output=True, text=True)
+    subprocess.run(
+        [str(python), "-m", "pip", "uninstall", "--yes", "avibe-memory"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    _run(
+        python,
+        "-c",
+        "import importlib.util; assert importlib.util.find_spec('avibe_memory') is None",
+        cwd=tmp_path,
+    )

--- a/tests/test_memory_distribution.py
+++ b/tests/test_memory_distribution.py
@@ -15,6 +15,8 @@ from packaging.version import Version
 import pytest
 import yaml
 
+from vibe.upgrade import MEMORY_PACKAGE_COMPATIBILITY
+
 try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
@@ -23,7 +25,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
 
 ROOT = Path(__file__).resolve().parents[1]
 MEMORY_PROJECT = ROOT / "packaging" / "avibe-memory"
-COMPATIBILITY = SpecifierSet(">=3.0.14.dev0,<3.1")
+COMPATIBILITY = SpecifierSet(MEMORY_PACKAGE_COMPATIBILITY)
 RELEASE_GATE = "Block Memory Wave 3a release until Waves 3b and 3c"
 
 

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -651,6 +651,7 @@ def test_first_split_upgrade_adds_memory_after_stop_and_before_start(monkeypatch
         lambda **kwargs: target,
     )
     monkeypatch.setattr(restart_supervisor, "configured_memory_enabled", lambda: True)
+    monkeypatch.setattr(restart_supervisor, "memory_package_installed", lambda: False)
     monkeypatch.setattr(
         restart_supervisor,
         "build_memory_add_plan",
@@ -687,6 +688,56 @@ def test_first_split_upgrade_adds_memory_after_stop_and_before_start(monkeypatch
     assert rc == 0
     assert calls == ["stop_runtime", "add-memory", "start_runtime"]
     status = runtime.read_json(runtime.get_restart_status_path())
+    assert status["memory_package_prepare"] == {"method": "pip", "ok": True}
+
+
+def test_explicit_pre_split_upgrade_adds_missing_memory_between_stop_and_start(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    calls: list[str] = []
+    target = _rollback_target(version="3.0.13")
+    plan = SimpleNamespace(method="pip")
+
+    monkeypatch.setattr(restart_supervisor, "get_build_identity", lambda: SimpleNamespace(kind="package"))
+    monkeypatch.setattr(restart_supervisor, "configured_memory_enabled", lambda: True)
+    monkeypatch.setattr(restart_supervisor, "memory_package_installed", lambda: False)
+    monkeypatch.setattr(restart_supervisor, "build_memory_add_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "execute_upgrade_plan",
+        lambda selected, **kwargs: calls.append("add-memory")
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(
+        restart_supervisor,
+        "_stop_runtime_for_restart",
+        lambda stop_ui=True: _fake_stop_runtime(calls),
+    )
+    monkeypatch.setattr(
+        restart_supervisor,
+        "_start_runtime_processes",
+        lambda start_ui=True: _fake_start_runtime(calls),
+    )
+    monkeypatch.setattr(restart_supervisor, "_wait_for_service_lock_release", lambda: True)
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 222)
+    monkeypatch.setattr(runtime, "service_pid_recorded", lambda pid: pid == 222)
+    monkeypatch.setattr(runtime, "service_instance_started", lambda pid: pid == 222)
+
+    rc = restart_supervisor._run_restart_job(
+        job_id="job-explicit-first-split",
+        delay_seconds=0,
+        vibe_path="/bin/vibe",
+        trigger="upgrade",
+        rollback_to=target,
+    )
+
+    assert rc == 0
+    assert calls == ["stop_runtime", "add-memory", "start_runtime"]
+    status = runtime.read_json(runtime.get_restart_status_path())
+    assert status["rollback_target_source"] == "explicit"
     assert status["memory_package_prepare"] == {"method": "pip", "ok": True}
 
 

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -877,6 +877,11 @@ def test_restart_job_schedules_pending_followup_after_success(monkeypatch, tmp_p
         "restart_in_flight",
         lambda: pytest.fail("the supervisor follow-up path must bypass ordinary refusal"),
     )
+    monkeypatch.setattr(
+        restart_supervisor,
+        "package_mutation_lock",
+        lambda: pytest.fail("the supervisor follow-up path must bypass human-entry acquire"),
+    )
 
     original_schedule_restart = restart_supervisor.schedule_restart
 

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -32,10 +32,15 @@ _REPLACED_INSTALL = runtime.ServiceLauncher(
 )
 
 
-def _rollback_target(version: str = "3.0.10") -> RollbackTarget:
+def _rollback_target(version: str = "3.0.10", *, memory_package: bool = False) -> RollbackTarget:
     """The install to go back to, as the upgrade captured it before installing."""
 
-    return RollbackTarget(version=version, package="vibe-remote", launcher=_REPLACED_INSTALL)
+    return RollbackTarget(
+        version=version,
+        package="vibe-remote",
+        launcher=_REPLACED_INSTALL,
+        memory_package=memory_package,
+    )
 
 
 def _fake_start_runtime(calls, service_pid: int = 222, ui_pid: int = 333):
@@ -1514,7 +1519,7 @@ def test_a_recoverable_restart_carries_its_rollback_target_into_the_job(monkeypa
 
     monkeypatch.setattr(restart_supervisor.subprocess, "Popen", fake_popen)
 
-    target = _rollback_target()
+    target = _rollback_target(memory_package=True)
     restart_supervisor.schedule_restart(
         delay_seconds=0,
         vibe_path="/bin/vibe",

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -8,6 +8,7 @@ import sqlite3
 import sys
 import textwrap
 import threading
+import time
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from types import SimpleNamespace
@@ -155,6 +156,56 @@ def test_schedule_restart_spawns_supervisor_and_records_status(monkeypatch, tmp_
     assert calls["kwargs"]["start_new_session"] is True
     assert calls["kwargs"]["env"] == {"PATH": "/bin"}
     assert runtime.read_json(runtime.get_restart_status_path())["job_id"] == result["job_id"]
+
+
+def test_restart_in_flight_uses_live_supervisor_identity_and_seed_grace(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    status_path = runtime.get_restart_status_path()
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 4242)
+    monkeypatch.setattr(
+        runtime,
+        "process_create_time",
+        lambda pid: 12.5 if pid == 4242 else None,
+    )
+
+    runtime.write_json(
+        status_path,
+        {
+            "state": "running",
+            "supervisor_pid": 4242,
+            "supervisor_started_at": 12.5,
+        },
+    )
+    assert restart_supervisor.restart_in_flight() is True
+
+    runtime.write_json(
+        status_path,
+        {
+            "state": "running",
+            "supervisor_pid": 4242,
+            "supervisor_started_at": 13.5,
+        },
+    )
+    assert restart_supervisor.restart_in_flight() is False
+
+    runtime.write_json(
+        status_path,
+        {"state": "scheduled", "supervisor_pid": None},
+    )
+    assert restart_supervisor.restart_in_flight() is True
+    stale = time.time() - restart_supervisor.RESTART_SEED_GRACE_SECONDS - 1
+    os.utime(status_path, (stale, stale))
+    assert restart_supervisor.restart_in_flight() is False
+
+    runtime.write_json(
+        status_path,
+        {"state": "succeeded", "supervisor_pid": 4242},
+    )
+    assert restart_supervisor.restart_in_flight() is False
 
 
 def test_legacy_upgrade_target_reads_the_running_release_and_launcher(monkeypatch, tmp_path):
@@ -776,6 +827,11 @@ def test_restart_job_prepares_show_runtime_after_service_start(monkeypatch, tmp_
     monkeypatch.setattr(restart_supervisor, "get_restart_environment", lambda vibe_path=None: None)
     monkeypatch.setattr(restart_supervisor, "_discover_legacy_upgrade_target", lambda **kwargs: None)
     monkeypatch.setattr(restart_supervisor, "get_build_identity", lambda: SimpleNamespace(kind="source"))
+    monkeypatch.setattr(
+        restart_supervisor,
+        "restart_in_flight",
+        lambda: pytest.fail("the supervisor prepare path must bypass ordinary refusal"),
+    )
 
     def fake_run(command, **kwargs):
         calls.append(("run", command))
@@ -816,6 +872,11 @@ def test_restart_job_schedules_pending_followup_after_success(monkeypatch, tmp_p
     monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 222)
     monkeypatch.setattr(runtime, "service_pid_recorded", lambda pid: pid == 222)
     monkeypatch.setattr(runtime, "service_instance_started", lambda pid: pid == 222)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "restart_in_flight",
+        lambda: pytest.fail("the supervisor follow-up path must bypass ordinary refusal"),
+    )
 
     original_schedule_restart = restart_supervisor.schedule_restart
 
@@ -1354,6 +1415,11 @@ def test_a_restart_that_leaves_nothing_running_puts_the_old_version_back(monkeyp
     """
 
     armed = _upgrade_restart_that_dies_after_migrating(monkeypatch, tmp_path, service_running=False)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "restart_in_flight",
+        lambda: pytest.fail("the supervisor rollback path must bypass ordinary refusal"),
+    )
 
     rc = restart_supervisor._run_restart_job(
         job_id="jobroll", delay_seconds=0, vibe_path="/bin/vibe", trigger="upgrade", rollback_to=_rollback_target()

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -832,8 +832,14 @@ def test_restart_job_prepares_show_runtime_after_service_start(monkeypatch, tmp_
         "restart_in_flight",
         lambda: pytest.fail("the supervisor prepare path must bypass ordinary refusal"),
     )
+    monkeypatch.setattr(
+        restart_supervisor,
+        "package_mutation_lock",
+        lambda: pytest.fail("the supervisor lifecycle must bypass human-entry acquire"),
+    )
 
     def fake_run(command, **kwargs):
+        assert runtime.read_json(runtime.get_restart_status_path())["state"] == "running"
         calls.append(("run", command))
         return SimpleNamespace(returncode=0)
 
@@ -886,7 +892,12 @@ def test_restart_job_schedules_pending_followup_after_success(monkeypatch, tmp_p
     original_schedule_restart = restart_supervisor.schedule_restart
 
     def _schedule_restart(**kwargs):
+        assert runtime.read_json(runtime.get_restart_status_path())["state"] == "running"
         scheduled.append(kwargs)
+        runtime.write_json(
+            runtime.get_restart_status_path(),
+            {"state": "scheduled", "job_id": "followup"},
+        )
         return {"job_id": "followup"}
 
     restart_supervisor.mark_pending_restart(
@@ -918,6 +929,66 @@ def test_restart_job_schedules_pending_followup_after_success(monkeypatch, tmp_p
         }
     ]
     assert runtime.read_json(restart_supervisor._pending_restart_path()) is None
+    assert runtime.read_json(runtime.get_restart_status_path()) == {
+        "state": "scheduled",
+        "job_id": "followup",
+    }
+
+
+def test_restart_job_records_terminal_success_when_pending_followup_schedule_fails(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    paths.get_runtime_pid_path().write_text("111", encoding="utf-8")
+    calls = []
+
+    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda stop_ui=True: _fake_stop_runtime(calls))
+    monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda start_ui=True: _fake_start_runtime(calls))
+    monkeypatch.setattr(restart_supervisor, "_wait_for_service_lock_release", lambda: True)
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 222)
+    monkeypatch.setattr(runtime, "service_pid_recorded", lambda pid: pid == 222)
+    monkeypatch.setattr(runtime, "service_instance_started", lambda pid: pid == 222)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "restart_in_flight",
+        lambda: pytest.fail("the supervisor follow-up path must bypass ordinary refusal"),
+    )
+    monkeypatch.setattr(
+        restart_supervisor,
+        "package_mutation_lock",
+        lambda: pytest.fail("the supervisor follow-up path must bypass human-entry acquire"),
+    )
+
+    restart_supervisor.mark_pending_restart(
+        trigger="web-ui-config-pending",
+        scope="service",
+        reason="restart_in_progress",
+        restart_job_id="jobpending",
+    )
+
+    def schedule_restart(**kwargs):
+        assert runtime.read_json(runtime.get_restart_status_path())["state"] == "running"
+        raise RuntimeError("spawn failed")
+
+    monkeypatch.setattr(restart_supervisor, "schedule_restart", schedule_restart)
+
+    rc = restart_supervisor._run_restart_job(
+        job_id="jobpending",
+        delay_seconds=0,
+        vibe_path="/bin/vibe",
+        trigger="web-ui",
+        scope="service",
+    )
+
+    assert rc == 0
+    status = runtime.read_json(runtime.get_restart_status_path())
+    assert status["state"] == "succeeded"
+    assert status["pending_restart"] == {
+        "scheduled": False,
+        "error": "spawn failed",
+    }
 
 
 def test_restart_job_aborts_when_stop_fails(monkeypatch, tmp_path):

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -32,7 +32,12 @@ _REPLACED_INSTALL = runtime.ServiceLauncher(
 )
 
 
-def _rollback_target(version: str = "3.0.10", *, memory_package: bool = False) -> RollbackTarget:
+def _rollback_target(
+    version: str = "3.0.10",
+    *,
+    memory_package: bool = False,
+    memory_version: str | None = None,
+) -> RollbackTarget:
     """The install to go back to, as the upgrade captured it before installing."""
 
     return RollbackTarget(
@@ -40,6 +45,7 @@ def _rollback_target(version: str = "3.0.10", *, memory_package: bool = False) -
         package="vibe-remote",
         launcher=_REPLACED_INSTALL,
         memory_package=memory_package,
+        memory_version=memory_version,
     )
 
 
@@ -185,6 +191,30 @@ def test_legacy_upgrade_target_reads_the_running_release_and_launcher(monkeypatc
         version="3.0.12",
         package="avibe-os",
         launcher=runtime.ServiceLauncher(python=str(python_path), main=str(service_main)),
+    )
+
+
+def test_legacy_rollback_shape_distinguishes_bundled_and_split_memory(monkeypatch):
+    monkeypatch.setattr(restart_supervisor, "memory_package_installed", lambda: False)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "installed_memory_package_version",
+        lambda: None,
+    )
+    monkeypatch.setattr(restart_supervisor, "configured_memory_enabled", lambda: True)
+
+    assert restart_supervisor._legacy_memory_package_shape("3.0.13") == (False, None)
+    assert restart_supervisor._legacy_memory_package_shape("3.0.14") == (True, None)
+
+    monkeypatch.setattr(restart_supervisor, "memory_package_installed", lambda: True)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "installed_memory_package_version",
+        lambda: "3.0.14",
+    )
+    assert restart_supervisor._legacy_memory_package_shape("3.0.14") == (
+        True,
+        "3.0.14",
     )
 
 
@@ -605,6 +635,59 @@ def test_restart_job_stops_and_starts_service(monkeypatch, tmp_path):
     assert "wait_service_lock_release_seconds" in status["stage_durations"]
     assert "start_runtime_seconds" in status["stage_durations"]
     assert "restart_total_seconds" in status["stage_durations"]
+
+
+def test_first_split_upgrade_adds_memory_after_stop_and_before_start(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    calls: list[str] = []
+    target = _rollback_target(version="3.0.13")
+    plan = SimpleNamespace(method="pip")
+
+    monkeypatch.setattr(restart_supervisor, "get_build_identity", lambda: SimpleNamespace(kind="package"))
+    monkeypatch.setattr(
+        restart_supervisor,
+        "_discover_legacy_upgrade_target",
+        lambda **kwargs: target,
+    )
+    monkeypatch.setattr(restart_supervisor, "configured_memory_enabled", lambda: True)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "build_memory_add_plan",
+        lambda **kwargs: plan,
+    )
+    monkeypatch.setattr(
+        restart_supervisor,
+        "execute_upgrade_plan",
+        lambda selected, **kwargs: calls.append("add-memory")
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(
+        restart_supervisor,
+        "_stop_runtime_for_restart",
+        lambda stop_ui=True: _fake_stop_runtime(calls),
+    )
+    monkeypatch.setattr(
+        restart_supervisor,
+        "_start_runtime_processes",
+        lambda start_ui=True: _fake_start_runtime(calls),
+    )
+    monkeypatch.setattr(restart_supervisor, "_wait_for_service_lock_release", lambda: True)
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 222)
+    monkeypatch.setattr(runtime, "service_pid_recorded", lambda pid: pid == 222)
+    monkeypatch.setattr(runtime, "service_instance_started", lambda pid: pid == 222)
+
+    rc = restart_supervisor._run_restart_job(
+        job_id="job-first-split",
+        delay_seconds=0,
+        vibe_path="/bin/vibe",
+        trigger="upgrade",
+    )
+
+    assert rc == 0
+    assert calls == ["stop_runtime", "add-memory", "start_runtime"]
+    status = runtime.read_json(runtime.get_restart_status_path())
+    assert status["memory_package_prepare"] == {"method": "pip", "ok": True}
 
 
 def test_restart_job_uses_lock_holder_when_pidfile_is_missing(monkeypatch, tmp_path):
@@ -1519,7 +1602,11 @@ def test_a_recoverable_restart_carries_its_rollback_target_into_the_job(monkeypa
 
     monkeypatch.setattr(restart_supervisor.subprocess, "Popen", fake_popen)
 
-    target = _rollback_target(memory_package=True)
+    target = _rollback_target(
+        version="3.0.14",
+        memory_package=True,
+        memory_version="3.0.14",
+    )
     restart_supervisor.schedule_restart(
         delay_seconds=0,
         vibe_path="/bin/vibe",
@@ -1545,3 +1632,18 @@ def test_a_recoverable_restart_carries_its_rollback_target_into_the_job(monkeypa
     # from here" is the exact wrong answer, and a silent one.
     with pytest.raises(SystemExit):
         restart_supervisor.main(["--job-id", "jobpartial", "--rollback-to", "3.0.10"])
+    with pytest.raises(SystemExit):
+        restart_supervisor.main(
+            [
+                "--job-id",
+                "jobpartialmemory",
+                "--rollback-to",
+                "3.0.14",
+                "--rollback-python",
+                "/bin/python",
+                "--rollback-main",
+                "/site-packages/vibe/service_main.py",
+                "--rollback-memory-version",
+                "3.0.14",
+            ]
+        )

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -156,6 +156,7 @@ def test_run_ui_server_skips_sentry_when_config_load_fails(monkeypatch):
     monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
 
     monkeypatch.setattr(ui_server.paths, "ensure_data_dirs", lambda: None)
+    monkeypatch.setattr("vibe.runtime.write_json", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         ui_server.V2Config,
         "load",
@@ -193,6 +194,7 @@ def test_run_ui_server_reconciles_remote_access_after_binding(monkeypatch):
     config = _config()
 
     monkeypatch.setattr(ui_server.paths, "ensure_data_dirs", lambda: None)
+    monkeypatch.setattr("vibe.runtime.write_json", lambda *args, **kwargs: None)
     # run_ui_server loads config via settings_service.load_config (PR #340), not
     # V2Config.load — patch the real seam, otherwise config is None and the
     # reconcile thread early-returns.
@@ -242,6 +244,7 @@ def test_run_ui_server_retries_when_prebind_reports_port_in_use(monkeypatch):
         return DummySocket()
 
     monkeypatch.setattr(ui_server.paths, "ensure_data_dirs", lambda: None)
+    monkeypatch.setattr("vibe.runtime.write_json", lambda *args, **kwargs: None)
     monkeypatch.setattr(ui_server.V2Config, "load", lambda *args, **kwargs: _config())
     monkeypatch.setattr(ui_server, "init_sentry", lambda *args, **kwargs: None)
     monkeypatch.setattr(ui_server, "_bind_ui_socket", bind_socket)

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -849,6 +849,7 @@ _FLAT_CODED_BODY_EXEMPTIONS = {
     # POST /api/control — StatusContext.control() uses a raw ``apiFetch`` and reads the
     # top-level ``body.code`` itself, exactly like ChatPage's messages POST.
     "control",
+    "_control_lock_timeout_response",
     # Public Show Page document + its annotation overlay: a SEPARATE document with its
     # own fetch and React tree, so no host ``ApiProvider`` ever parses these bodies
     # (round 5's "out of reach" row).

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -2497,7 +2497,7 @@ def test_config_restart_fallback_schedules_when_in_flight_finishes_after_marker(
         "supervisor_pid": 4242,
     }
     runtime.write_json(runtime.get_restart_status_path(), restart_status)
-    in_flight_results = iter([True, False])
+    in_flight_results = iter([True, False, False])
     scheduled: list[dict] = []
     mutation_lease_held = False
 
@@ -2640,7 +2640,7 @@ def test_config_restart_fallback_timeout_reacquires_when_restart_finishes(
         finally:
             mutation_lease_held = False
 
-    in_flight_results = iter([True, False])
+    in_flight_results = iter([True, False, False])
 
     def schedule_restart(**kwargs):
         assert mutation_lease_held is True
@@ -2667,6 +2667,62 @@ def test_config_restart_fallback_timeout_reacquires_when_restart_finishes(
     assert 0 <= lock_timeouts[1] <= 5
     assert runtime.read_json(restart_supervisor._pending_restart_path()) is None
     assert mutation_lease_held is False
+
+
+def test_config_restart_fallback_reacquire_binds_to_a_competing_restart(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from vibe import restart_supervisor
+    from vibe import runtime
+
+    runtime.get_restart_status_path().parent.mkdir(parents=True, exist_ok=True)
+    runtime.write_json(
+        runtime.get_restart_status_path(),
+        {"state": "running", "job_id": "job-finishing", "supervisor_pid": 4242},
+    )
+    lock_timeouts: list[float | None] = []
+
+    @contextmanager
+    def mutation_lock(*, timeout_seconds=None):
+        lock_timeouts.append(timeout_seconds)
+        if len(lock_timeouts) == 1:
+            raise MigrationLockTimeout("package mutation is still running")
+        yield
+
+    in_flight_calls = 0
+
+    def restart_in_flight():
+        nonlocal in_flight_calls
+        in_flight_calls += 1
+        if in_flight_calls == 1:
+            return True
+        if in_flight_calls == 2:
+            return False
+        runtime.write_json(
+            runtime.get_restart_status_path(),
+            {"state": "scheduled", "job_id": "job-competitor", "supervisor_pid": 5252},
+        )
+        return True
+
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", restart_in_flight)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "schedule_restart",
+        lambda **kwargs: pytest.fail("the competitor already owns the restart"),
+    )
+
+    result = ui_server._schedule_service_restart_for_config_fallback()
+
+    assert result["ok"] is True
+    assert result["code"] == "restart_pending_after_in_progress"
+    assert result["restart"]["job_id"] == "job-competitor"
+    assert lock_timeouts == [None, ui_server._RESTART_REACQUIRE_TIMEOUT_SECONDS]
+    pending = runtime.read_json(restart_supervisor._pending_restart_path())
+    assert pending["restart_job_id"] == "job-competitor"
+    assert pending["trigger"] == "web-ui-config-pending"
 
 
 def test_config_restart_fallback_timeout_cleans_marker_when_reacquire_is_busy(
@@ -3488,7 +3544,7 @@ def test_wechat_qr_restart_reacquires_when_the_live_restart_finishes(
         finally:
             mutation_lease_held = False
 
-    in_flight_results = iter([True, False])
+    in_flight_results = iter([True, False, False])
 
     def schedule_restart(**kwargs):
         assert mutation_lease_held is True

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -2502,7 +2502,7 @@ def test_config_restart_fallback_schedules_when_in_flight_finishes_after_marker(
     mutation_lease_held = False
 
     @contextmanager
-    def mutation_lock():
+    def mutation_lock(*, timeout_seconds=None):
         nonlocal mutation_lease_held
         mutation_lease_held = True
         try:
@@ -3303,8 +3303,11 @@ def test_json_payload_parsing_runs_off_the_asgi_loop(monkeypatch):
 def test_wechat_qr_poll_marks_bind_hint_and_schedules_managed_restart(monkeypatch):
     from vibe import runtime
 
+    event_loop_threads = []
+
     class _Auth:
         async def poll_status(self, session_key, verify_code=None):
+            event_loop_threads.append(threading.get_ident())
             assert session_key == "qr-session"
             return {
                 "status": "confirmed",
@@ -3314,7 +3317,7 @@ def test_wechat_qr_poll_marks_bind_hint_and_schedules_managed_restart(monkeypatc
             }
 
     bound_users = []
-    restart_calls = []
+    restart_threads = []
     persisted = []
 
     runtime.ensure_config()
@@ -3323,7 +3326,8 @@ def test_wechat_qr_poll_marks_bind_hint_and_schedules_managed_restart(monkeypatc
     monkeypatch.setattr(
         ui_server,
         "_schedule_wechat_qr_login_restart",
-        lambda: restart_calls.append(True) or {"job_id": "restart-1"},
+        lambda: restart_threads.append(threading.get_ident())
+        or {"ok": True, "restart": {"job_id": "restart-1"}},
     )
     monkeypatch.setattr(
         "vibe.api.auto_bind_wechat_user",
@@ -3339,7 +3343,9 @@ def test_wechat_qr_poll_marks_bind_hint_and_schedules_managed_restart(monkeypatc
     )
 
     assert response.status_code == 200
-    assert response.get_json()["status"] == "confirmed"
+    payload = response.get_json()
+    assert payload["status"] == "confirmed"
+    assert payload["restart_scheduled"] is True
     assert persisted == [
         {
             "status": "confirmed",
@@ -3349,7 +3355,8 @@ def test_wechat_qr_poll_marks_bind_hint_and_schedules_managed_restart(monkeypatc
         }
     ]
     assert bound_users == ["wx-user"]
-    assert restart_calls == [True]
+    assert len(restart_threads) == 1
+    assert restart_threads[0] != event_loop_threads[0]
 
 
 def test_wechat_qr_restart_holds_package_lease_through_scheduling(monkeypatch):
@@ -3376,7 +3383,8 @@ def test_wechat_qr_restart_holds_package_lease_through_scheduling(monkeypatch):
     monkeypatch.setattr(restart_supervisor, "schedule_restart", schedule_restart)
 
     assert ui_server._schedule_wechat_qr_login_restart() == {
-        "job_id": "wechat-restart",
+        "ok": True,
+        "restart": {"job_id": "wechat-restart"},
     }
     assert mutation_lease_held is False
 
@@ -3399,7 +3407,8 @@ def test_wechat_qr_restart_marks_pending_for_an_in_flight_restart(monkeypatch, t
         yield
 
     monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
-    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: True)
+    in_flight_results = iter([True, True])
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: next(in_flight_results))
     monkeypatch.setattr(
         restart_supervisor,
         "schedule_restart",
@@ -3437,7 +3446,8 @@ def test_wechat_qr_restart_marks_pending_after_lease_timeout_with_live_restart(
         yield
 
     monkeypatch.setattr(ui_server, "package_mutation_lock", blocked_mutation_lock)
-    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: True)
+    in_flight_results = iter([True, True])
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: next(in_flight_results))
     monkeypatch.setattr(
         restart_supervisor,
         "schedule_restart",
@@ -3450,6 +3460,54 @@ def test_wechat_qr_restart_marks_pending_after_lease_timeout_with_live_restart(
     assert result["restart"] == restart_status
     pending = runtime.read_json(restart_supervisor._pending_restart_path())
     assert pending["restart_job_id"] == "job-live"
+
+
+def test_wechat_qr_restart_reacquires_when_the_live_restart_finishes(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from vibe import restart_supervisor
+    from vibe import runtime
+
+    runtime.get_restart_status_path().parent.mkdir(parents=True, exist_ok=True)
+    runtime.write_json(
+        runtime.get_restart_status_path(),
+        {"state": "running", "job_id": "job-finishing", "supervisor_pid": 4242},
+    )
+    lock_timeouts: list[float | None] = []
+    mutation_lease_held = False
+
+    @contextmanager
+    def mutation_lock(*, timeout_seconds=None):
+        nonlocal mutation_lease_held
+        lock_timeouts.append(timeout_seconds)
+        mutation_lease_held = True
+        try:
+            yield
+        finally:
+            mutation_lease_held = False
+
+    in_flight_results = iter([True, False])
+
+    def schedule_restart(**kwargs):
+        assert mutation_lease_held is True
+        assert kwargs == {"delay_seconds": 2.0, "trigger": "wechat-qr-login"}
+        return {"job_id": "wechat-followup"}
+
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: next(in_flight_results))
+    monkeypatch.setattr(restart_supervisor, "schedule_restart", schedule_restart)
+
+    result = ui_server._schedule_wechat_qr_login_restart()
+
+    assert result == {
+        "ok": True,
+        "restart": {"job_id": "wechat-followup"},
+        "code": "restart_scheduled_after_in_flight_finished",
+    }
+    assert lock_timeouts == [None, ui_server._RESTART_REACQUIRE_TIMEOUT_SECONDS]
+    assert runtime.read_json(restart_supervisor._pending_restart_path()) is None
 
 
 def test_wechat_qr_restart_reports_busy_after_lease_timeout_without_restart(
@@ -3480,6 +3538,49 @@ def test_wechat_qr_restart_reports_busy_after_lease_timeout_without_restart(
         "code": "restart_not_scheduled_package_busy",
         "error": "a package operation is in progress; restart was not scheduled",
         "restart": {},
+    }
+
+
+def test_wechat_qr_poll_reports_saved_login_when_restart_is_package_busy(monkeypatch):
+    from vibe import runtime
+
+    class _Auth:
+        async def poll_status(self, session_key, verify_code=None):
+            return {
+                "status": "confirmed",
+                "bot_token": "wechat-token",
+                "user_id": "wx-user",
+            }
+
+    runtime.ensure_config()
+    monkeypatch.setattr(ui_server, "_get_wechat_auth", lambda: _Auth())
+    monkeypatch.setattr(ui_server, "_persist_wechat_qr_credentials", lambda result: None)
+    monkeypatch.setattr("vibe.api.auto_bind_wechat_user", lambda user_id: {"ok": True})
+    monkeypatch.setattr(
+        ui_server,
+        "_schedule_wechat_qr_login_restart",
+        lambda: {
+            "ok": False,
+            "code": "restart_not_scheduled_package_busy",
+            "error": "a package operation is in progress; restart was not scheduled",
+            "restart": {},
+        },
+    )
+
+    client = app.test_client()
+    response = client.post(
+        "/api/wechat/qr_login/poll",
+        json={"session_key": "qr-session"},
+        headers=csrf_headers(client),
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "status": "confirmed",
+        "bot_token": "wechat-token",
+        "user_id": "wx-user",
+        "restart_scheduled": False,
+        "restart_reason": "restart_not_scheduled_package_busy",
     }
 
 

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -3640,6 +3640,61 @@ def test_wechat_qr_poll_reports_saved_login_when_restart_is_package_busy(monkeyp
     }
 
 
+def test_wechat_qr_poll_reports_saved_login_when_restart_scheduling_raises(monkeypatch):
+    from vibe import runtime
+
+    class _Auth:
+        async def poll_status(self, session_key, verify_code=None):
+            return {
+                "status": "confirmed",
+                "bot_token": "wechat-token",
+                "user_id": "wx-user",
+            }
+
+    persisted: list[dict] = []
+    bound: list[str] = []
+    runtime.ensure_config()
+    monkeypatch.setattr(ui_server, "_get_wechat_auth", lambda: _Auth())
+    monkeypatch.setattr(
+        ui_server,
+        "_persist_wechat_qr_credentials",
+        lambda result: persisted.append(dict(result)),
+    )
+    monkeypatch.setattr(
+        "vibe.api.auto_bind_wechat_user",
+        lambda user_id: bound.append(user_id) or {"ok": True},
+    )
+    monkeypatch.setattr(
+        ui_server,
+        "_schedule_wechat_qr_login_restart",
+        lambda: (_ for _ in ()).throw(RuntimeError("supervisor unavailable")),
+    )
+
+    client = app.test_client()
+    response = client.post(
+        "/api/wechat/qr_login/poll",
+        json={"session_key": "qr-session"},
+        headers=csrf_headers(client),
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "status": "confirmed",
+        "bot_token": "wechat-token",
+        "user_id": "wx-user",
+        "restart_scheduled": False,
+        "restart_reason": "restart_not_scheduled",
+    }
+    assert persisted == [
+        {
+            "status": "confirmed",
+            "bot_token": "wechat-token",
+            "user_id": "wx-user",
+        }
+    ]
+    assert bound == ["wx-user"]
+
+
 def test_wechat_qr_poll_passes_verify_code(monkeypatch):
     class _Auth:
         async def poll_status(self, session_key, verify_code=None):

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -2,12 +2,14 @@ import asyncio
 import gzip
 import json
 import threading
+from contextlib import contextmanager
 from types import SimpleNamespace
 
 import pytest
 
 from fastapi import Request as FastAPIRequest
 from storage.importer import ensure_sqlite_state
+from storage.lock import MigrationLockTimeout
 from vibe.ui_compat import (
     TEST_REMOTE_ADDR_HEADER,
     CompatApp,
@@ -2400,9 +2402,25 @@ def test_config_restart_fallback_schedules_when_in_flight_finishes_after_marker(
     runtime.write_json(runtime.get_restart_status_path(), restart_status)
     in_flight_results = iter([True, False])
     scheduled: list[dict] = []
+    mutation_lease_held = False
 
+    @contextmanager
+    def mutation_lock():
+        nonlocal mutation_lease_held
+        mutation_lease_held = True
+        try:
+            yield
+        finally:
+            mutation_lease_held = False
+
+    def schedule_restart(**kwargs):
+        assert mutation_lease_held is True
+        scheduled.append(kwargs)
+        return {"job_id": "followup"}
+
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock, raising=False)
     monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: next(in_flight_results))
-    monkeypatch.setattr(restart_supervisor, "schedule_restart", lambda **kwargs: scheduled.append(kwargs) or {"job_id": "followup"})
+    monkeypatch.setattr(restart_supervisor, "schedule_restart", schedule_restart)
     monkeypatch.setattr(runtime, "read_status", lambda: {"service_pid": 11, "ui_pid": 22})
 
     result = ui_server._schedule_service_restart_for_config_fallback()
@@ -2412,6 +2430,48 @@ def test_config_restart_fallback_schedules_when_in_flight_finishes_after_marker(
     assert result["restart"] == {"job_id": "followup"}
     assert scheduled == [{"delay_seconds": 0.0, "trigger": "web-ui-config", "scope": "service"}]
     assert runtime.read_json(restart_supervisor._pending_restart_path()) is None
+    assert mutation_lease_held is False
+
+
+def test_config_restart_fallback_marks_pending_when_package_lease_is_held(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from vibe import restart_supervisor
+    from vibe import runtime
+
+    runtime.get_restart_status_path().parent.mkdir(parents=True, exist_ok=True)
+
+    @contextmanager
+    def blocked_mutation_lock():
+        raise MigrationLockTimeout("package mutation is still running")
+        yield
+
+    monkeypatch.setattr(
+        ui_server,
+        "package_mutation_lock",
+        blocked_mutation_lock,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        ui_server,
+        "_restart_in_flight",
+        lambda: pytest.fail("status must be checked after acquiring the lease"),
+    )
+    monkeypatch.setattr(
+        restart_supervisor,
+        "schedule_restart",
+        lambda **kwargs: pytest.fail("restart must not be scheduled"),
+    )
+
+    result = ui_server._schedule_service_restart_for_config_fallback()
+
+    assert result["ok"] is True
+    assert result["code"] == "restart_pending_after_in_progress"
+    pending = runtime.read_json(restart_supervisor._pending_restart_path())
+    assert pending["reason"] == "restart_in_progress"
+    assert pending["trigger"] == "web-ui-config-pending"
 
 
 def test_static_ui_assets_use_cache_headers(monkeypatch, tmp_path):

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -2371,6 +2371,20 @@ def test_config_restart_fallback_marks_pending_restart_when_restart_in_flight(mo
     assert pending["scope"] == "service"
 
 
+def test_ui_restart_in_flight_uses_the_shared_supervisor_predicate(monkeypatch):
+    from vibe import restart_supervisor
+
+    calls: list[bool] = []
+    monkeypatch.setattr(
+        restart_supervisor,
+        "restart_in_flight",
+        lambda: calls.append(True) or True,
+    )
+
+    assert ui_server._restart_in_flight() is True
+    assert calls == [True]
+
+
 def test_config_restart_fallback_schedules_when_in_flight_finishes_after_marker(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     from vibe import restart_supervisor

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -2244,6 +2244,51 @@ def test_config_post_restarts_running_service_when_backend_reconcile_is_unavaila
     assert restart_calls == [True]
 
 
+def test_config_post_reports_backend_restart_not_scheduled_while_package_busy(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from vibe import api
+    from vibe import internal_client
+    from vibe import runtime
+
+    payload = _full_config_payload()
+    payload["agents"]["opencode"]["enabled"] = False
+    api.save_config(payload)
+
+    async def _reconcile_agent_backends(_backends):
+        raise internal_client.InternalServerUnavailable("missing socket")
+
+    monkeypatch.setattr(internal_client, "reconcile_agent_backends", _reconcile_agent_backends)
+    monkeypatch.setattr(runtime, "service_process_running", lambda: True)
+    monkeypatch.setattr(
+        ui_server,
+        "_schedule_service_restart_for_config_fallback",
+        lambda: {
+            "ok": False,
+            "code": "restart_not_scheduled_package_busy",
+            "error": "a package operation is in progress; restart was not scheduled",
+            "restart": {},
+        },
+    )
+
+    client = app.test_client()
+    response = client.post(
+        "/api/config",
+        json={"agents": {"opencode": {"enabled": True}}},
+        headers=csrf_headers(client),
+    )
+
+    assert response.status_code == 200
+    runtime_result = response.get_json()["agent_backend_runtime"]
+    assert runtime_result["restart_scheduled"] is False
+    assert runtime_result["restart_code"] == "restart_not_scheduled_package_busy"
+    assert runtime_result["restart_error"] == (
+        "a package operation is in progress; restart was not scheduled"
+    )
+
+
 def test_config_post_non_platform_change_does_not_reconcile_platforms(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     from vibe import api
@@ -2340,6 +2385,58 @@ def test_config_post_schedules_service_restart_when_hot_reconcile_fails(monkeypa
     assert runtime["restart_scheduled"] is True
     assert runtime["body"]["error"] == "IM thread for discord did not stop within timeout"
     assert restart_calls == [True]
+
+
+def test_config_post_reports_platform_restart_not_scheduled_while_package_busy(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from vibe import api
+    from vibe import internal_client
+
+    payload = _full_config_payload()
+    payload["platforms"] = {"enabled": ["discord"], "primary": "discord"}
+    api.save_config(payload)
+
+    async def _reconcile_platforms():
+        raise internal_client.InternalServerUnavailable("missing socket")
+
+    monkeypatch.setattr(internal_client, "reconcile_platforms", _reconcile_platforms)
+    monkeypatch.setattr(
+        ui_server,
+        "_schedule_service_restart_for_config_fallback",
+        lambda: {
+            "ok": False,
+            "code": "restart_not_scheduled_package_busy",
+            "error": "a package operation is in progress; restart was not scheduled",
+            "restart": {},
+        },
+    )
+
+    client = app.test_client()
+    response = client.post(
+        "/api/config",
+        json={
+            "platforms": {
+                "enabled": ["discord", "slack"],
+                "primary": "discord",
+            },
+            "slack": {
+                "bot_token": "xoxb-hot-token",
+                "app_token": "xapp-hot-token",
+            },
+        },
+        headers=csrf_headers(client),
+    )
+
+    assert response.status_code == 200
+    runtime_result = response.get_json()["platform_runtime"]
+    assert runtime_result["restart_scheduled"] is False
+    assert runtime_result["restart_code"] == "restart_not_scheduled_package_busy"
+    assert runtime_result["restart_error"] == (
+        "a package operation is in progress; restart was not scheduled"
+    )
 
 
 def test_config_restart_fallback_marks_pending_restart_when_restart_in_flight(monkeypatch, tmp_path):
@@ -2467,10 +2564,11 @@ def test_config_restart_fallback_does_not_mark_pending_for_package_contention_al
 
     result = ui_server._schedule_service_restart_for_config_fallback()
 
-    assert result["ok"] is True
+    assert result["ok"] is False
     assert result == {
-        "ok": True,
+        "ok": False,
         "code": "restart_not_scheduled_package_busy",
+        "error": "a package operation is in progress; restart was not scheduled",
         "restart": {},
     }
     assert runtime.read_json(restart_supervisor._pending_restart_path()) is None
@@ -2512,6 +2610,109 @@ def test_config_restart_fallback_timeout_marks_pending_for_a_live_restart(
     assert result["restart"] == restart_status
     pending = runtime.read_json(restart_supervisor._pending_restart_path())
     assert pending["restart_job_id"] == "job-live"
+
+
+def test_config_restart_fallback_timeout_reacquires_when_restart_finishes(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from vibe import restart_supervisor
+    from vibe import runtime
+
+    runtime.get_restart_status_path().parent.mkdir(parents=True, exist_ok=True)
+    runtime.write_json(
+        runtime.get_restart_status_path(),
+        {"state": "running", "job_id": "job-finishing", "supervisor_pid": 4242},
+    )
+    lock_timeouts: list[float | None] = []
+    mutation_lease_held = False
+
+    @contextmanager
+    def mutation_lock(*, timeout_seconds=None):
+        nonlocal mutation_lease_held
+        lock_timeouts.append(timeout_seconds)
+        if len(lock_timeouts) == 1:
+            raise MigrationLockTimeout("package mutation is still running")
+        mutation_lease_held = True
+        try:
+            yield
+        finally:
+            mutation_lease_held = False
+
+    in_flight_results = iter([True, False])
+
+    def schedule_restart(**kwargs):
+        assert mutation_lease_held is True
+        assert kwargs == {
+            "delay_seconds": 0.0,
+            "trigger": "web-ui-config",
+            "scope": "service",
+        }
+        return {"job_id": "job-reacquired"}
+
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: next(in_flight_results))
+    monkeypatch.setattr(restart_supervisor, "schedule_restart", schedule_restart)
+
+    result = ui_server._schedule_service_restart_for_config_fallback()
+
+    assert result == {
+        "ok": True,
+        "restart": {"job_id": "job-reacquired"},
+        "code": "restart_scheduled_after_in_flight_finished",
+    }
+    assert lock_timeouts[0] is None
+    assert lock_timeouts[1] == ui_server._RESTART_REACQUIRE_TIMEOUT_SECONDS
+    assert 0 <= lock_timeouts[1] <= 5
+    assert runtime.read_json(restart_supervisor._pending_restart_path()) is None
+    assert mutation_lease_held is False
+
+
+def test_config_restart_fallback_timeout_cleans_marker_when_reacquire_is_busy(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from vibe import restart_supervisor
+    from vibe import runtime
+
+    restart_status = {
+        "state": "running",
+        "job_id": "job-finishing",
+        "supervisor_pid": 4242,
+    }
+    runtime.get_restart_status_path().parent.mkdir(parents=True, exist_ok=True)
+    runtime.write_json(runtime.get_restart_status_path(), restart_status)
+    lock_timeouts: list[float | None] = []
+
+    @contextmanager
+    def blocked_mutation_lock(*, timeout_seconds=None):
+        lock_timeouts.append(timeout_seconds)
+        raise MigrationLockTimeout("package mutation is still running")
+        yield
+
+    in_flight_results = iter([True, False])
+    monkeypatch.setattr(ui_server, "package_mutation_lock", blocked_mutation_lock)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: next(in_flight_results))
+    monkeypatch.setattr(
+        restart_supervisor,
+        "schedule_restart",
+        lambda **kwargs: pytest.fail("restart must not be scheduled without the lease"),
+    )
+
+    result = ui_server._schedule_service_restart_for_config_fallback()
+
+    assert result == {
+        "ok": False,
+        "code": "restart_not_scheduled_package_busy",
+        "error": "a package operation is in progress; restart was not scheduled",
+        "restart": restart_status,
+    }
+    assert lock_timeouts[0] is None
+    assert lock_timeouts[1] == ui_server._RESTART_REACQUIRE_TIMEOUT_SECONDS
+    assert 0 <= lock_timeouts[1] <= 5
+    assert runtime.read_json(restart_supervisor._pending_restart_path()) is None
 
 
 def test_static_ui_assets_use_cache_headers(monkeypatch, tmp_path):
@@ -3149,6 +3350,137 @@ def test_wechat_qr_poll_marks_bind_hint_and_schedules_managed_restart(monkeypatc
     ]
     assert bound_users == ["wx-user"]
     assert restart_calls == [True]
+
+
+def test_wechat_qr_restart_holds_package_lease_through_scheduling(monkeypatch):
+    from vibe import restart_supervisor
+
+    mutation_lease_held = False
+
+    @contextmanager
+    def mutation_lock():
+        nonlocal mutation_lease_held
+        mutation_lease_held = True
+        try:
+            yield
+        finally:
+            mutation_lease_held = False
+
+    def schedule_restart(**kwargs):
+        assert mutation_lease_held is True
+        assert kwargs == {"delay_seconds": 2.0, "trigger": "wechat-qr-login"}
+        return {"job_id": "wechat-restart"}
+
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: False)
+    monkeypatch.setattr(restart_supervisor, "schedule_restart", schedule_restart)
+
+    assert ui_server._schedule_wechat_qr_login_restart() == {
+        "job_id": "wechat-restart",
+    }
+    assert mutation_lease_held is False
+
+
+def test_wechat_qr_restart_marks_pending_for_an_in_flight_restart(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from vibe import restart_supervisor
+    from vibe import runtime
+
+    restart_status = {
+        "state": "running",
+        "job_id": "job-live",
+        "supervisor_pid": 4242,
+    }
+    runtime.get_restart_status_path().parent.mkdir(parents=True, exist_ok=True)
+    runtime.write_json(runtime.get_restart_status_path(), restart_status)
+
+    @contextmanager
+    def mutation_lock():
+        yield
+
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: True)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "schedule_restart",
+        lambda **kwargs: pytest.fail("a second restart must not be scheduled"),
+    )
+
+    result = ui_server._schedule_wechat_qr_login_restart()
+
+    assert result["code"] == "restart_pending_after_in_progress"
+    assert result["restart"] == restart_status
+    pending = runtime.read_json(restart_supervisor._pending_restart_path())
+    assert pending["restart_job_id"] == "job-live"
+    assert pending["trigger"] == "wechat-qr-login-pending"
+
+
+def test_wechat_qr_restart_marks_pending_after_lease_timeout_with_live_restart(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from vibe import restart_supervisor
+    from vibe import runtime
+
+    restart_status = {
+        "state": "running",
+        "job_id": "job-live",
+        "supervisor_pid": 4242,
+    }
+    runtime.get_restart_status_path().parent.mkdir(parents=True, exist_ok=True)
+    runtime.write_json(runtime.get_restart_status_path(), restart_status)
+
+    @contextmanager
+    def blocked_mutation_lock():
+        raise MigrationLockTimeout("package mutation is still running")
+        yield
+
+    monkeypatch.setattr(ui_server, "package_mutation_lock", blocked_mutation_lock)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: True)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "schedule_restart",
+        lambda **kwargs: pytest.fail("a second restart must not be scheduled"),
+    )
+
+    result = ui_server._schedule_wechat_qr_login_restart()
+
+    assert result["code"] == "restart_pending_after_in_progress"
+    assert result["restart"] == restart_status
+    pending = runtime.read_json(restart_supervisor._pending_restart_path())
+    assert pending["restart_job_id"] == "job-live"
+
+
+def test_wechat_qr_restart_reports_busy_after_lease_timeout_without_restart(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from vibe import restart_supervisor
+    from vibe import runtime
+
+    runtime.get_restart_status_path().parent.mkdir(parents=True, exist_ok=True)
+
+    @contextmanager
+    def blocked_mutation_lock():
+        raise MigrationLockTimeout("package mutation is still running")
+        yield
+
+    monkeypatch.setattr(ui_server, "package_mutation_lock", blocked_mutation_lock)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: False)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "schedule_restart",
+        lambda **kwargs: pytest.fail("restart must not be scheduled without the lease"),
+    )
+
+    assert ui_server._schedule_wechat_qr_login_restart() == {
+        "ok": False,
+        "code": "restart_not_scheduled_package_busy",
+        "error": "a package operation is in progress; restart was not scheduled",
+        "restart": {},
+    }
 
 
 def test_wechat_qr_poll_passes_verify_code(monkeypatch):

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -2470,6 +2470,56 @@ def test_config_restart_fallback_marks_pending_restart_when_restart_in_flight(mo
     assert pending["scope"] == "service"
 
 
+@pytest.mark.parametrize("terminal_state", ["succeeded", "failed", "cancelled"])
+def test_config_restart_fallback_does_not_publish_pending_after_terminal_status(
+    monkeypatch,
+    tmp_path,
+    terminal_state,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from vibe import restart_supervisor
+    from vibe import runtime
+
+    restart_status = {
+        "ok": terminal_state == "succeeded",
+        "state": terminal_state,
+        "job_id": "job-finished",
+        "supervisor_pid": 4242,
+    }
+    runtime.get_restart_status_path().parent.mkdir(parents=True, exist_ok=True)
+    runtime.write_json(runtime.get_restart_status_path(), restart_status)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "mark_pending_restart",
+        lambda **kwargs: pytest.fail("terminal restart status must not publish a pending marker"),
+    )
+
+    assert ui_server._mark_service_restart_pending(trigger="web-ui-config-pending") == {
+        "ok": True,
+        "pending_restart": None,
+        "restart": restart_status,
+        "code": "restart_no_longer_in_flight",
+    }
+    assert runtime.read_json(restart_supervisor._pending_restart_path()) is None
+
+
+def test_config_restart_fallback_preserves_died_job_pending_marker(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from vibe import restart_supervisor
+    from vibe import runtime
+
+    runtime.get_restart_status_path().parent.mkdir(parents=True, exist_ok=True)
+
+    result = ui_server._mark_service_restart_pending(trigger="web-ui-config-pending")
+
+    assert result["ok"] is True
+    assert result["code"] == "restart_pending_after_in_progress"
+    assert result["restart"] == {}
+    pending = runtime.read_json(restart_supervisor._pending_restart_path())
+    assert pending["restart_job_id"] is None
+    assert result["pending_restart"] == pending
+
+
 def test_ui_restart_in_flight_uses_the_shared_supervisor_predicate(monkeypatch):
     from vibe import restart_supervisor
 

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -2433,7 +2433,7 @@ def test_config_restart_fallback_schedules_when_in_flight_finishes_after_marker(
     assert mutation_lease_held is False
 
 
-def test_config_restart_fallback_marks_pending_when_package_lease_is_held(
+def test_config_restart_fallback_does_not_mark_pending_for_package_contention_alone(
     monkeypatch,
     tmp_path,
 ):
@@ -2457,7 +2457,7 @@ def test_config_restart_fallback_marks_pending_when_package_lease_is_held(
     monkeypatch.setattr(
         ui_server,
         "_restart_in_flight",
-        lambda: pytest.fail("status must be checked after acquiring the lease"),
+        lambda: False,
     )
     monkeypatch.setattr(
         restart_supervisor,
@@ -2468,10 +2468,50 @@ def test_config_restart_fallback_marks_pending_when_package_lease_is_held(
     result = ui_server._schedule_service_restart_for_config_fallback()
 
     assert result["ok"] is True
+    assert result == {
+        "ok": True,
+        "code": "restart_not_scheduled_package_busy",
+        "restart": {},
+    }
+    assert runtime.read_json(restart_supervisor._pending_restart_path()) is None
+
+
+def test_config_restart_fallback_timeout_marks_pending_for_a_live_restart(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from vibe import restart_supervisor
+    from vibe import runtime
+
+    runtime.get_restart_status_path().parent.mkdir(parents=True, exist_ok=True)
+    restart_status = {
+        "state": "running",
+        "job_id": "job-live",
+        "supervisor_pid": 4242,
+    }
+    runtime.write_json(runtime.get_restart_status_path(), restart_status)
+
+    @contextmanager
+    def blocked_mutation_lock():
+        raise MigrationLockTimeout("package mutation is still running")
+        yield
+
+    monkeypatch.setattr(ui_server, "package_mutation_lock", blocked_mutation_lock)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: True)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "schedule_restart",
+        lambda **kwargs: pytest.fail("restart must not be scheduled"),
+    )
+
+    result = ui_server._schedule_service_restart_for_config_fallback()
+
+    assert result["ok"] is True
     assert result["code"] == "restart_pending_after_in_progress"
+    assert result["restart"] == restart_status
     pending = runtime.read_json(restart_supervisor._pending_restart_path())
-    assert pending["reason"] == "restart_in_progress"
-    assert pending["trigger"] == "web-ui-config-pending"
+    assert pending["restart_job_id"] == "job-live"
 
 
 def test_static_ui_assets_use_cache_headers(monkeypatch, tmp_path):

--- a/tests/test_ui_server_logs.py
+++ b/tests/test_ui_server_logs.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import os
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 
 from config import paths
+from storage.lock import MigrationLockTimeout
+from vibe import ui_server
 from vibe.ui_server import app
 from vibe import runtime
 from tests.ui_server_test_helpers import csrf_headers
@@ -319,13 +322,29 @@ def test_control_restart_schedules_restart_job(monkeypatch, tmp_path):
     runtime.write_status("running", detail="running", service_pid=12345, ui_pid=67890)
     paths.get_runtime_pid_path().write_text("12345", encoding="utf-8")
     calls = []
+    mutation_lease_held = False
 
     import vibe.restart_supervisor as restart_supervisor
 
+    @contextmanager
+    def mutation_lock():
+        nonlocal mutation_lease_held
+        mutation_lease_held = True
+        try:
+            yield
+        finally:
+            mutation_lease_held = False
+
+    def schedule_restart(**kwargs):
+        assert mutation_lease_held is True
+        calls.append(kwargs)
+        return {"job_id": "job123", "state": "scheduled"}
+
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock, raising=False)
     monkeypatch.setattr(
         restart_supervisor,
         "schedule_restart",
-        lambda **kwargs: calls.append(kwargs) or {"job_id": "job123", "state": "scheduled"},
+        schedule_restart,
     )
 
     client = app.test_client()
@@ -344,6 +363,48 @@ def test_control_restart_schedules_restart_job(monkeypatch, tmp_path):
     calls.clear()
     client.post("/api/control", json={"action": "restart", "scope": "service"}, headers=csrf_headers(client))
     assert calls == [{"delay_seconds": 0.0, "trigger": "web-ui", "scope": "service"}]
+    assert mutation_lease_held is False
+
+
+def test_control_restart_fails_closed_when_package_lease_is_held(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    runtime.write_status("running", detail="running", service_pid=12345, ui_pid=67890)
+
+    import vibe.restart_supervisor as restart_supervisor
+
+    @contextmanager
+    def blocked_mutation_lock():
+        raise MigrationLockTimeout("package mutation is still running")
+        yield
+
+    monkeypatch.setattr(
+        ui_server,
+        "package_mutation_lock",
+        blocked_mutation_lock,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        ui_server,
+        "_restart_in_flight",
+        lambda: (_ for _ in ()).throw(AssertionError("status must be checked after acquiring the lease")),
+    )
+    monkeypatch.setattr(
+        restart_supervisor,
+        "schedule_restart",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("restart must not be scheduled")),
+    )
+
+    client = app.test_client()
+    response = client.post(
+        "/api/control",
+        json={"action": "restart"},
+        headers=csrf_headers(client),
+    )
+
+    assert response.status_code == 409
+    assert response.get_json()["code"] == "restart_in_progress"
+    assert response.get_json()["error"] == "a restart is already in progress"
 
 
 def test_control_restart_rejects_overlapping_restart(monkeypatch, tmp_path):

--- a/tests/test_ui_server_logs.py
+++ b/tests/test_ui_server_logs.py
@@ -382,7 +382,7 @@ def test_control_start_stop_refuse_an_in_flight_restart(monkeypatch, tmp_path, a
 
 
 @pytest.mark.parametrize("action", ["start", "stop"])
-def test_control_start_stop_fail_closed_when_package_lease_is_held(
+def test_control_start_stop_reports_package_busy_when_package_lease_is_held(
     monkeypatch,
     tmp_path,
     action,
@@ -396,11 +396,7 @@ def test_control_start_stop_fail_closed_when_package_lease_is_held(
         yield
 
     monkeypatch.setattr(ui_server, "package_mutation_lock", blocked_mutation_lock)
-    monkeypatch.setattr(
-        ui_server,
-        "_restart_in_flight",
-        lambda: pytest.fail("status must be checked after acquiring the lease"),
-    )
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: False)
     monkeypatch.setattr(
         runtime,
         "start_service",
@@ -416,11 +412,12 @@ def test_control_start_stop_fail_closed_when_package_lease_is_held(
     response = client.post(
         "/api/control",
         json={"action": action},
-        headers=csrf_headers(client),
+        headers={**csrf_headers(client), "Accept-Language": "zh-CN"},
     )
 
     assert response.status_code == 409
-    assert response.get_json()["code"] == "restart_in_progress"
+    assert response.get_json()["code"] == "restart_not_scheduled_package_busy"
+    assert response.get_json()["error"] == "已有软件包操作正在进行，修复未执行。"
 
 
 def test_control_restart_schedules_restart_job(monkeypatch, tmp_path):
@@ -473,7 +470,7 @@ def test_control_restart_schedules_restart_job(monkeypatch, tmp_path):
     assert mutation_lease_held is False
 
 
-def test_control_restart_fails_closed_when_package_lease_is_held(monkeypatch, tmp_path):
+def test_control_restart_reports_package_busy_when_package_lease_is_held(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     runtime.write_status("running", detail="running", service_pid=12345, ui_pid=67890)
@@ -491,11 +488,7 @@ def test_control_restart_fails_closed_when_package_lease_is_held(monkeypatch, tm
         blocked_mutation_lock,
         raising=False,
     )
-    monkeypatch.setattr(
-        ui_server,
-        "_restart_in_flight",
-        lambda: (_ for _ in ()).throw(AssertionError("status must be checked after acquiring the lease")),
-    )
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: False)
     monkeypatch.setattr(
         restart_supervisor,
         "schedule_restart",
@@ -506,6 +499,47 @@ def test_control_restart_fails_closed_when_package_lease_is_held(monkeypatch, tm
     response = client.post(
         "/api/control",
         json={"action": "restart"},
+        headers=csrf_headers(client),
+    )
+
+    assert response.status_code == 409
+    assert response.get_json()["code"] == "restart_not_scheduled_package_busy"
+    assert response.get_json()["error"] == (
+        "A package operation is already in progress; the repair was not performed."
+    )
+
+
+@pytest.mark.parametrize("action", ["start", "stop", "restart"])
+def test_control_lease_timeout_preserves_live_restart_diagnosis(
+    monkeypatch,
+    tmp_path,
+    action,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+
+    @contextmanager
+    def blocked_mutation_lock():
+        raise MigrationLockTimeout("restart supervisor owns the package lease")
+        yield
+
+    monkeypatch.setattr(ui_server, "package_mutation_lock", blocked_mutation_lock)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: True)
+    monkeypatch.setattr(
+        runtime,
+        "start_service",
+        lambda: pytest.fail("start must not run while restart is in flight"),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "stop_service",
+        lambda: pytest.fail("stop must not run while restart is in flight"),
+    )
+
+    client = app.test_client()
+    response = client.post(
+        "/api/control",
+        json={"action": action},
         headers=csrf_headers(client),
     )
 

--- a/tests/test_ui_server_logs.py
+++ b/tests/test_ui_server_logs.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import os
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from datetime import datetime
 from pathlib import Path
+
+import pytest
 
 from config import paths
 from storage.lock import MigrationLockTimeout
@@ -283,18 +285,35 @@ def test_control_start_reuses_running_service_without_stop(monkeypatch, tmp_path
     paths.ensure_data_dirs()
     runtime.write_status("running", detail="already running", service_pid=12345, ui_pid=67890)
     calls = []
+    mutation_lease_held = False
+
+    @contextmanager
+    def mutation_lock():
+        nonlocal mutation_lease_held
+        mutation_lease_held = True
+        try:
+            yield
+        finally:
+            mutation_lease_held = False
 
     monkeypatch.setattr(runtime, "ensure_config", lambda: calls.append("ensure_config"))
     monkeypatch.setattr(runtime, "stop_service", lambda: calls.append("stop_service"))
-    monkeypatch.setattr(runtime, "start_service", lambda: calls.append("start_service") or 12345)
+    monkeypatch.setattr(
+        runtime,
+        "start_service",
+        lambda: calls.append(("start_service", mutation_lease_held)) or 12345,
+    )
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: False)
 
     client = app.test_client()
     response = client.post("/api/control", json={"action": "start"}, headers=csrf_headers(client))
 
     assert response.status_code == 200
-    assert calls == ["ensure_config", "start_service"]
+    assert calls == ["ensure_config", ("start_service", True)]
     payload = response.get_json()
     assert payload["status"]["service_pid"] == 12345
+    assert mutation_lease_held is False
 
 
 def test_control_stop_uses_locked_service_stop(monkeypatch, tmp_path):
@@ -303,17 +322,105 @@ def test_control_stop_uses_locked_service_stop(monkeypatch, tmp_path):
     runtime.write_status("running", detail="running", service_pid=12345, ui_pid=67890)
     paths.get_runtime_pid_path().write_text("12345", encoding="utf-8")
     calls = []
+    mutation_lease_held = False
+
+    @contextmanager
+    def mutation_lock():
+        nonlocal mutation_lease_held
+        mutation_lease_held = True
+        try:
+            yield
+        finally:
+            mutation_lease_held = False
 
     monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 12345)
-    monkeypatch.setattr(runtime, "stop_service", lambda: calls.append("stop_service") or True)
+    monkeypatch.setattr(
+        runtime,
+        "stop_service",
+        lambda: calls.append(("stop_service", mutation_lease_held)) or True,
+    )
     monkeypatch.setattr(runtime, "stop_process", lambda pid_path: calls.append(("stop_process", pid_path)) or True)
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: False)
 
     client = app.test_client()
     response = client.post("/api/control", json={"action": "stop"}, headers=csrf_headers(client))
 
     assert response.status_code == 200
-    assert calls == ["stop_service"]
+    assert calls == [("stop_service", True)]
     assert response.get_json()["status"]["state"] == "stopped"
+    assert mutation_lease_held is False
+
+
+@pytest.mark.parametrize("action", ["start", "stop"])
+def test_control_start_stop_refuse_an_in_flight_restart(monkeypatch, tmp_path, action):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    monkeypatch.setattr(ui_server, "package_mutation_lock", nullcontext)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: True)
+    monkeypatch.setattr(
+        runtime,
+        "start_service",
+        lambda: pytest.fail("start must not run while restart is in flight"),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "stop_service",
+        lambda: pytest.fail("stop must not run while restart is in flight"),
+    )
+
+    client = app.test_client()
+    response = client.post(
+        "/api/control",
+        json={"action": action},
+        headers=csrf_headers(client),
+    )
+
+    assert response.status_code == 409
+    assert response.get_json()["code"] == "restart_in_progress"
+    assert response.get_json()["error"] == "a restart is already in progress"
+
+
+@pytest.mark.parametrize("action", ["start", "stop"])
+def test_control_start_stop_fail_closed_when_package_lease_is_held(
+    monkeypatch,
+    tmp_path,
+    action,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+
+    @contextmanager
+    def blocked_mutation_lock():
+        raise MigrationLockTimeout("package mutation is still running")
+        yield
+
+    monkeypatch.setattr(ui_server, "package_mutation_lock", blocked_mutation_lock)
+    monkeypatch.setattr(
+        ui_server,
+        "_restart_in_flight",
+        lambda: pytest.fail("status must be checked after acquiring the lease"),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "start_service",
+        lambda: pytest.fail("start must not run while package mutation is active"),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "stop_service",
+        lambda: pytest.fail("stop must not run while package mutation is active"),
+    )
+
+    client = app.test_client()
+    response = client.post(
+        "/api/control",
+        json={"action": action},
+        headers=csrf_headers(client),
+    )
+
+    assert response.status_code == 409
+    assert response.get_json()["code"] == "restart_in_progress"
 
 
 def test_control_restart_schedules_restart_job(monkeypatch, tmp_path):

--- a/tests/test_ui_server_logs.py
+++ b/tests/test_ui_server_logs.py
@@ -352,6 +352,89 @@ def test_control_stop_uses_locked_service_stop(monkeypatch, tmp_path):
     assert mutation_lease_held is False
 
 
+def test_control_start_uses_ui_pid_sampled_after_package_lease(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    current_status = {"state": "running", "service_pid": 111, "ui_pid": 100}
+    writes: list[tuple] = []
+
+    @contextmanager
+    def mutation_lock():
+        current_status["service_pid"] = 222
+        current_status["ui_pid"] = 200
+        yield
+
+    monkeypatch.setattr(runtime, "read_status", lambda: dict(current_status))
+    monkeypatch.setattr(runtime, "write_status", lambda *args: writes.append(args))
+    monkeypatch.setattr(runtime, "ensure_config", lambda: None)
+    monkeypatch.setattr(runtime, "start_service", lambda: 333)
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: False)
+
+    client = app.test_client()
+    response = client.post("/api/control", json={"action": "start"}, headers=csrf_headers(client))
+
+    assert response.status_code == 200
+    assert writes == [("running", "started", 333, 200)]
+
+
+def test_control_stop_uses_status_sampled_after_package_lease(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    current_status = {"state": "running", "service_pid": 111, "ui_pid": 100}
+    writes: list[tuple] = []
+
+    @contextmanager
+    def mutation_lock():
+        current_status["service_pid"] = 222
+        current_status["ui_pid"] = 200
+        yield
+
+    monkeypatch.setattr(runtime, "read_status", lambda: dict(current_status))
+    monkeypatch.setattr(runtime, "write_status", lambda *args: writes.append(args))
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: False)
+    monkeypatch.setattr(ui_server, "_stop_runtime_process_or_error", lambda *args: (True, None))
+    monkeypatch.setattr("vibe.cli._stop_opencode_server", lambda: None)
+
+    client = app.test_client()
+    response = client.post("/api/control", json={"action": "stop"}, headers=csrf_headers(client))
+
+    assert response.status_code == 200
+    assert writes == [
+        ("stopping", "stopping", 222, 200),
+        ("stopped", "stopped", None, 200),
+    ]
+
+
+def test_control_restart_uses_status_sampled_after_package_lease(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    current_status = {"state": "running", "service_pid": 111, "ui_pid": 100}
+    writes: list[tuple] = []
+
+    @contextmanager
+    def mutation_lock():
+        current_status["service_pid"] = 222
+        current_status["ui_pid"] = 200
+        yield
+
+    monkeypatch.setattr(runtime, "read_status", lambda: dict(current_status))
+    monkeypatch.setattr(runtime, "write_status", lambda *args: writes.append(args))
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: False)
+    monkeypatch.setattr(
+        "vibe.restart_supervisor.schedule_restart",
+        lambda **kwargs: {"job_id": "job123", "state": "scheduled"},
+    )
+
+    client = app.test_client()
+    response = client.post("/api/control", json={"action": "restart"}, headers=csrf_headers(client))
+
+    assert response.status_code == 200
+    assert writes == [("restarting", "restarting", 222, 200)]
+
+
 @pytest.mark.parametrize("action", ["start", "stop"])
 def test_control_start_stop_refuse_an_in_flight_restart(monkeypatch, tmp_path, action):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))

--- a/tests/test_ui_server_reload.py
+++ b/tests/test_ui_server_reload.py
@@ -231,8 +231,6 @@ def test_ui_reload_holds_package_lease_through_spawn_and_releases_before_shutdow
     assert response.status_code == 200
     assert response.get_json()["ok"] is True
     assert events == [
-        ("lock-enter", 0),
-        ("lock-exit", 0),
         ("lock-enter", None),
         "spawn",
         "write-status",
@@ -242,13 +240,14 @@ def test_ui_reload_holds_package_lease_through_spawn_and_releases_before_shutdow
     assert server.should_exit is True
 
 
-def test_ui_reload_retries_busy_worker_then_degrades_without_changing_response(
+def test_ui_reload_retries_busy_worker_then_leaves_current_server_running(
     monkeypatch,
     caplog,
 ):
     lock_calls: list[float | None] = []
     sleeps: list[float] = []
     spawned: list[bool] = []
+    status_writes: list[bool] = []
 
     @contextmanager
     def blocked_mutation_lock(*, timeout_seconds=None):
@@ -269,7 +268,7 @@ def test_ui_reload_retries_busy_worker_then_degrades_without_changing_response(
         "spawn_background",
         lambda *args, **kwargs: spawned.append(True) or 222,
     )
-    monkeypatch.setattr(runtime, "write_status", lambda *args: None)
+    monkeypatch.setattr(runtime, "write_status", lambda *args: status_writes.append(True))
     monkeypatch.setattr("vibe.ui_server.time.sleep", lambda delay: sleeps.append(delay))
 
     client = app.test_client()
@@ -283,8 +282,9 @@ def test_ui_reload_retries_busy_worker_then_degrades_without_changing_response(
 
     assert response.status_code == 200
     assert response.get_json() == {"ok": True, "host": "127.0.0.1", "port": 5123}
-    assert lock_calls == [0, None, None]
-    assert sleeps == [1.0, 0.2]
-    assert spawned == [True]
-    assert server.should_exit is True
+    assert lock_calls == [None, None]
+    assert sleeps == [1.0]
+    assert spawned == []
+    assert status_writes == []
+    assert server.should_exit is False
     assert "restart_not_scheduled_package_busy" in caplog.text

--- a/tests/test_ui_server_reload.py
+++ b/tests/test_ui_server_reload.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import threading
+from contextlib import contextmanager
 
 from config.v2_config import (
     AgentsConfig,
@@ -11,7 +12,8 @@ from config.v2_config import (
     UiConfig,
     V2Config,
 )
-from vibe import runtime
+from storage.lock import MigrationLockTimeout
+from vibe import runtime, ui_server
 from vibe.ui_server import app
 
 from tests.ui_server_test_helpers import csrf_headers
@@ -180,3 +182,109 @@ def test_ui_reload_routes_replacement_output_through_runtime_log_sinks(monkeypat
     assert captured["spawn"][2:4] == ("ui_stdout.log", "ui_stderr.log")
     assert captured["spawn"][5] == memory_ui_secret
     assert captured["status"][-1] == 222
+
+
+def test_ui_reload_holds_package_lease_through_spawn_and_releases_before_shutdown(
+    monkeypatch,
+):
+    events: list[object] = []
+
+    @contextmanager
+    def mutation_lock(*, timeout_seconds=None):
+        events.append(("lock-enter", timeout_seconds))
+        try:
+            yield
+        finally:
+            events.append(("lock-exit", timeout_seconds))
+
+    class _Server:
+        should_exit = False
+
+    server = _Server()
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(ui_server, "_server", server)
+    monkeypatch.setattr(threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(runtime, "read_status", lambda: {"state": "running", "service_pid": 111})
+    monkeypatch.setattr(
+        runtime,
+        "spawn_background",
+        lambda *args, **kwargs: events.append("spawn") or 222,
+    )
+    monkeypatch.setattr(
+        runtime,
+        "write_status",
+        lambda *args: events.append("write-status"),
+    )
+    monkeypatch.setattr(
+        "vibe.ui_server.time.sleep",
+        lambda delay: events.append(("sleep", delay, server.should_exit)),
+    )
+
+    client = app.test_client()
+    response = client.post(
+        "/api/ui/reload",
+        json={"host": "127.0.0.1", "port": 5123},
+        headers=csrf_headers(client, "http://127.0.0.1:5123"),
+        base_url="http://127.0.0.1:5123",
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["ok"] is True
+    assert events == [
+        ("lock-enter", 0),
+        ("lock-exit", 0),
+        ("lock-enter", None),
+        "spawn",
+        "write-status",
+        ("lock-exit", None),
+        ("sleep", 0.2, False),
+    ]
+    assert server.should_exit is True
+
+
+def test_ui_reload_retries_busy_worker_then_degrades_without_changing_response(
+    monkeypatch,
+    caplog,
+):
+    lock_calls: list[float | None] = []
+    sleeps: list[float] = []
+    spawned: list[bool] = []
+
+    @contextmanager
+    def blocked_mutation_lock(*, timeout_seconds=None):
+        lock_calls.append(timeout_seconds)
+        raise MigrationLockTimeout("package mutation is still running")
+        yield
+
+    class _Server:
+        should_exit = False
+
+    server = _Server()
+    monkeypatch.setattr(ui_server, "package_mutation_lock", blocked_mutation_lock)
+    monkeypatch.setattr(ui_server, "_server", server)
+    monkeypatch.setattr(threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(runtime, "read_status", lambda: {"state": "running", "service_pid": 111})
+    monkeypatch.setattr(
+        runtime,
+        "spawn_background",
+        lambda *args, **kwargs: spawned.append(True) or 222,
+    )
+    monkeypatch.setattr(runtime, "write_status", lambda *args: None)
+    monkeypatch.setattr("vibe.ui_server.time.sleep", lambda delay: sleeps.append(delay))
+
+    client = app.test_client()
+    with caplog.at_level("WARNING"):
+        response = client.post(
+            "/api/ui/reload",
+            json={"host": "127.0.0.1", "port": 5123},
+            headers=csrf_headers(client, "http://127.0.0.1:5123"),
+            base_url="http://127.0.0.1:5123",
+        )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "host": "127.0.0.1", "port": 5123}
+    assert lock_calls == [0, None, None]
+    assert sleeps == [1.0, 0.2]
+    assert spawned == [True]
+    assert server.should_exit is True
+    assert "restart_not_scheduled_package_busy" in caplog.text

--- a/tests/test_ui_server_reload.py
+++ b/tests/test_ui_server_reload.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import os
+import sys
 import threading
+import types
 from contextlib import contextmanager, nullcontext
 
 import pytest
@@ -52,6 +55,21 @@ class _NoopThread:
 class _ImmediateThread(_NoopThread):
     def start(self) -> None:
         self._target(*self._args, **self._kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_reload_runtime(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    runtime.paths.ensure_data_dirs()
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: False)
+
+
+def _write_replacement_facts(pid: int) -> None:
+    runtime.paths.get_runtime_ui_pid_path().write_text(str(pid), encoding="utf-8")
+    runtime.write_json(
+        runtime.paths.get_runtime_dir() / "ui_server_ready.json",
+        {"pid": pid, "bound_at": 1.0},
+    )
 
 
 def test_ui_reload_overrides_bind_host_when_tunnel_enabled(monkeypatch):
@@ -141,6 +159,7 @@ def test_ui_reload_uses_requested_host_when_tunnel_disabled(monkeypatch):
 
 def test_ui_reload_routes_replacement_output_through_runtime_log_sinks(monkeypatch):
     captured: dict = {}
+    status = {"state": "running", "service_pid": 111}
     memory_ui_secret = "test-memory-ui-secret"
     monkeypatch.setattr(
         "core.services.settings.load_config",
@@ -148,10 +167,9 @@ def test_ui_reload_routes_replacement_output_through_runtime_log_sinks(monkeypat
     )
     monkeypatch.setattr("vibe.memory_ui_access._process_secret", memory_ui_secret)
     monkeypatch.setattr(threading, "Thread", _ImmediateThread)
-    monkeypatch.setattr(runtime, "read_status", lambda: {"state": "running", "service_pid": 111})
+    monkeypatch.setattr(runtime, "read_status", lambda: status.copy())
     monkeypatch.setattr(runtime, "write_status", lambda *args: captured.setdefault("status", args))
     monkeypatch.setattr(runtime, "ui_pid_file_points_to_running_ui", lambda: True)
-    monkeypatch.setattr(runtime, "ui_server_healthy", lambda **kwargs: True)
 
     def fake_spawn(
         args,
@@ -169,6 +187,8 @@ def test_ui_reload_routes_replacement_output_through_runtime_log_sinks(monkeypat
             env,
             memory_ui_secret,
         )
+        status.update(state="starting", detail="fresh", service_pid=333)
+        _write_replacement_facts(222)
         return 222
 
     monkeypatch.setattr(runtime, "spawn_background", fake_spawn)
@@ -185,7 +205,7 @@ def test_ui_reload_routes_replacement_output_through_runtime_log_sinks(monkeypat
     assert captured["spawn"][1] == runtime.paths.get_runtime_ui_pid_path()
     assert captured["spawn"][2:4] == ("ui_stdout.log", "ui_stderr.log")
     assert captured["spawn"][5] == memory_ui_secret
-    assert captured["status"][-1] == 222
+    assert captured["status"] == ("starting", "fresh", 333, 222)
 
 
 def test_ui_reload_stops_old_server_and_waits_for_replacement_inside_package_lease(
@@ -223,11 +243,12 @@ def test_ui_reload_stops_old_server_and_waits_for_replacement_inside_package_lea
     monkeypatch.setattr(ui_server, "_server", server)
     monkeypatch.setattr(threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(runtime, "read_status", lambda: {"state": "running", "service_pid": 111})
-    monkeypatch.setattr(
-        runtime,
-        "spawn_background",
-        lambda *args, **kwargs: events.append(("spawn", mutation_lease_held)) or 222,
-    )
+    def spawn(*args, **kwargs):
+        events.append(("spawn", mutation_lease_held))
+        _write_replacement_facts(222)
+        return 222
+
+    monkeypatch.setattr(runtime, "spawn_background", spawn)
     monkeypatch.setattr(
         runtime,
         "write_status",
@@ -238,11 +259,6 @@ def test_ui_reload_stops_old_server_and_waits_for_replacement_inside_package_lea
         runtime,
         "ui_pid_file_points_to_running_ui",
         lambda: events.append(("identity", mutation_lease_held)) or next(identities),
-    )
-    monkeypatch.setattr(
-        runtime,
-        "ui_server_healthy",
-        lambda **kwargs: events.append(("health", mutation_lease_held, kwargs)) or True,
     )
     monkeypatch.setattr(
         "vibe.ui_server.time.sleep",
@@ -267,13 +283,12 @@ def test_ui_reload_stops_old_server_and_waits_for_replacement_inside_package_lea
         ("identity", True),
         ("sleep", 0.2, True),
         ("identity", True),
-        ("health", True, {"host": "127.0.0.1", "port": 5123}),
         ("lock-exit", None),
     ]
     assert server.should_exit is True
 
 
-def test_ui_reload_health_is_secondary_to_replacement_identity(monkeypatch):
+def test_ui_reload_waits_for_child_ready_marker_matching_replacement_pid(monkeypatch):
     readiness_events: list[str] = []
 
     class _Server:
@@ -283,20 +298,35 @@ def test_ui_reload_health_is_secondary_to_replacement_identity(monkeypatch):
     monkeypatch.setattr(ui_server, "_server", _Server())
     monkeypatch.setattr(threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(runtime, "read_status", lambda: {"state": "running", "service_pid": 111})
-    monkeypatch.setattr(runtime, "spawn_background", lambda *args, **kwargs: 222)
+    def spawn(*args, **kwargs):
+        runtime.paths.get_runtime_ui_pid_path().write_text("222", encoding="utf-8")
+        runtime.write_json(
+            runtime.paths.get_runtime_dir() / "ui_server_ready.json",
+            {"pid": 111, "bound_at": 1.0},
+        )
+        return 222
+
+    monkeypatch.setattr(runtime, "spawn_background", spawn)
     monkeypatch.setattr(runtime, "write_status", lambda *args: None)
-    identities = iter([False, True])
     monkeypatch.setattr(
         runtime,
         "ui_pid_file_points_to_running_ui",
-        lambda: readiness_events.append("identity") or next(identities),
+        lambda: readiness_events.append("identity") or True,
     )
     monkeypatch.setattr(
         runtime,
         "ui_server_healthy",
-        lambda **kwargs: readiness_events.append("health") or True,
+        lambda **kwargs: pytest.fail("same-port health must not satisfy readiness"),
     )
-    monkeypatch.setattr("vibe.ui_server.time.sleep", lambda delay: readiness_events.append("sleep"))
+
+    def sleep(_delay):
+        readiness_events.append("sleep")
+        runtime.write_json(
+            runtime.paths.get_runtime_dir() / "ui_server_ready.json",
+            {"pid": 222, "bound_at": 2.0},
+        )
+
+    monkeypatch.setattr("vibe.ui_server.time.sleep", sleep)
 
     client = app.test_client()
     response = client.post(
@@ -308,11 +338,17 @@ def test_ui_reload_health_is_secondary_to_replacement_identity(monkeypatch):
 
     assert response.status_code == 200
     assert response.get_json() == {"ok": True, "host": "127.0.0.1", "port": 5123}
-    assert readiness_events == ["identity", "sleep", "identity", "health"]
+    assert readiness_events == ["identity", "sleep", "identity"]
 
 
 def test_ui_reload_identity_timeout_writes_error_after_one_spawn(monkeypatch, caplog):
     events: list[object] = []
+    statuses = iter(
+        [
+            {"state": "running", "service_pid": 111, "ui_pid": 110},
+            {"state": "stopping", "service_pid": 333, "ui_pid": 221},
+        ]
+    )
 
     @contextmanager
     def mutation_lock(*, timeout_seconds=None):
@@ -332,15 +368,21 @@ def test_ui_reload_identity_timeout_writes_error_after_one_spawn(monkeypatch, ca
     monkeypatch.setattr(
         runtime,
         "read_status",
-        lambda: {"state": "running", "service_pid": 111, "ui_pid": 110},
+        lambda: next(statuses),
     )
-    monkeypatch.setattr(
-        runtime,
-        "spawn_background",
-        lambda *args, **kwargs: events.append("spawn") or 222,
-    )
+
+    def spawn(*args, **kwargs):
+        events.append("spawn")
+        runtime.paths.get_runtime_ui_pid_path().write_text("222", encoding="utf-8")
+        runtime.write_json(
+            runtime.paths.get_runtime_dir() / "ui_server_ready.json",
+            {"pid": 110, "bound_at": 1.0},
+        )
+        return 222
+
+    monkeypatch.setattr(runtime, "spawn_background", spawn)
     monkeypatch.setattr(runtime, "write_status", lambda *args: events.append(("status", args)))
-    monkeypatch.setattr(runtime, "ui_pid_file_points_to_running_ui", lambda: False)
+    monkeypatch.setattr(runtime, "ui_pid_file_points_to_running_ui", lambda: True)
     monkeypatch.setattr("vibe.ui_server.time.sleep", lambda delay: events.append(("sleep", delay)))
 
     client = app.test_client()
@@ -356,7 +398,7 @@ def test_ui_reload_identity_timeout_writes_error_after_one_spawn(monkeypatch, ca
     assert response.get_json() == {"ok": True, "host": "127.0.0.1", "port": 5123}
     assert server.should_exit is True
     assert events.count("spawn") == 1
-    assert events[-2:] == [("status", ("error", "ui_reload_timeout", 111, 222)), "lock-exit"]
+    assert events[-2:] == [("status", ("error", "ui_reload_timeout", 333, 222)), "lock-exit"]
     assert events.count(("sleep", 0.2)) == 50
     assert "ui_reload_timeout" in caplog.text
 
@@ -405,12 +447,15 @@ def test_ui_reload_retries_one_spawn_failure_inside_the_same_lease(monkeypatch, 
             raise RuntimeError("first popen failed")
         assert received_pid_path.read_text(encoding="utf-8") == "110"
         received_pid_path.write_text("222", encoding="utf-8")
+        runtime.write_json(
+            runtime.paths.get_runtime_dir() / "ui_server_ready.json",
+            {"pid": 222, "bound_at": 1.0},
+        )
         return 222
 
     monkeypatch.setattr(runtime, "spawn_background", flaky_spawn)
     monkeypatch.setattr(runtime, "write_status", lambda *args: events.append(("status", args)))
     monkeypatch.setattr(runtime, "ui_pid_file_points_to_running_ui", lambda: True)
-    monkeypatch.setattr(runtime, "ui_server_healthy", lambda **kwargs: True)
 
     client = app.test_client()
     response = client.post(
@@ -460,7 +505,7 @@ def test_ui_reload_two_spawn_failures_write_error_without_further_retry(
     monkeypatch.setattr(
         runtime,
         "read_status",
-        lambda: {"state": "running", "service_pid": 111, "ui_pid": 110},
+        lambda: {"state": "stopping", "service_pid": 333, "ui_pid": 444},
     )
     pid_path = runtime.paths.get_runtime_ui_pid_path()
     pid_path.write_text("110", encoding="utf-8")
@@ -479,11 +524,6 @@ def test_ui_reload_two_spawn_failures_write_error_without_further_retry(
         "ui_pid_file_points_to_running_ui",
         lambda: pytest.fail("identity must not be checked when both Popen attempts fail"),
     )
-    monkeypatch.setattr(
-        runtime,
-        "ui_server_healthy",
-        lambda **kwargs: pytest.fail("health must not be checked when both Popen attempts fail"),
-    )
 
     client = app.test_client()
     with caplog.at_level("ERROR"):
@@ -501,7 +541,7 @@ def test_ui_reload_two_spawn_failures_write_error_without_further_retry(
         "lock-enter",
         "spawn",
         "spawn",
-        ("status", ("error", "ui_reload_failed", 111, 110)),
+        ("status", ("error", "ui_reload_failed", 333, 444)),
         "lock-exit",
     ]
     assert pid_path.read_text(encoding="utf-8") == "110"
@@ -525,6 +565,11 @@ def test_ui_reload_spawn_retry_and_readiness_share_one_deadline(monkeypatch, tmp
         if spawn_attempts == 1:
             now[0] = 109.9
             raise RuntimeError("slow first failure")
+        runtime.paths.get_runtime_ui_pid_path().write_text("222", encoding="utf-8")
+        runtime.write_json(
+            runtime.paths.get_runtime_dir() / "ui_server_ready.json",
+            {"pid": 110, "bound_at": 1.0},
+        )
         return 222
 
     def sleep(delay: float):
@@ -534,19 +579,16 @@ def test_ui_reload_spawn_retry_and_readiness_share_one_deadline(monkeypatch, tmp
     monkeypatch.setattr(ui_server, "package_mutation_lock", nullcontext)
     monkeypatch.setattr(ui_server, "_server", _Server())
     monkeypatch.setattr(threading, "Thread", _ImmediateThread)
-    monkeypatch.setattr(
-        runtime,
-        "read_status",
-        lambda: {"state": "running", "service_pid": 111, "ui_pid": 110},
+    statuses_to_read = iter(
+        [
+            {"state": "running", "service_pid": 111, "ui_pid": 110},
+            {"state": "stopping", "service_pid": 333, "ui_pid": 221},
+        ]
     )
+    monkeypatch.setattr(runtime, "read_status", lambda: next(statuses_to_read))
     monkeypatch.setattr(runtime, "spawn_background", spawn)
     monkeypatch.setattr(runtime, "write_status", lambda *args: statuses.append(args))
-    monkeypatch.setattr(runtime, "ui_pid_file_points_to_running_ui", lambda: False)
-    monkeypatch.setattr(
-        runtime,
-        "ui_server_healthy",
-        lambda **kwargs: pytest.fail("health requires replacement identity"),
-    )
+    monkeypatch.setattr(runtime, "ui_pid_file_points_to_running_ui", lambda: True)
     monkeypatch.setattr("vibe.ui_server.time.monotonic", lambda: now[0])
     monkeypatch.setattr("vibe.ui_server.time.sleep", sleep)
 
@@ -561,7 +603,65 @@ def test_ui_reload_spawn_retry_and_readiness_share_one_deadline(monkeypatch, tmp
     assert response.status_code == 200
     assert spawn_attempts == 2
     assert sleeps == pytest.approx([0.1])
-    assert statuses[-1] == ("error", "ui_reload_timeout", 111, 222)
+    assert statuses[-1] == ("error", "ui_reload_timeout", 333, 222)
+
+
+def test_ui_reload_refuses_restart_in_flight_before_stopping_current_server(
+    monkeypatch,
+    caplog,
+):
+    events: list[str] = []
+
+    @contextmanager
+    def mutation_lock(*, timeout_seconds=None):
+        events.append("lock-enter")
+        try:
+            yield
+        finally:
+            events.append("lock-exit")
+
+    class _Server:
+        _should_exit = False
+
+        @property
+        def should_exit(self):
+            return self._should_exit
+
+        @should_exit.setter
+        def should_exit(self, value):
+            events.append("stop")
+            self._should_exit = value
+
+    server = _Server()
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: True)
+    monkeypatch.setattr(ui_server, "_server", server)
+    monkeypatch.setattr(threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(
+        runtime,
+        "spawn_background",
+        lambda *args, **kwargs: pytest.fail("restart overlap must not spawn"),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "write_status",
+        lambda *args: pytest.fail("restart overlap must not write status"),
+    )
+
+    client = app.test_client()
+    with caplog.at_level("WARNING"):
+        response = client.post(
+            "/api/ui/reload",
+            json={"host": "127.0.0.1", "port": 5123},
+            headers=csrf_headers(client, "http://127.0.0.1:5123"),
+            base_url="http://127.0.0.1:5123",
+        )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "host": "127.0.0.1", "port": 5123}
+    assert events == ["lock-enter", "lock-exit"]
+    assert server.should_exit is False
+    assert "restart_in_progress" in caplog.text
 
 
 def test_ui_reload_retries_busy_worker_then_leaves_current_server_running(
@@ -612,3 +712,50 @@ def test_ui_reload_retries_busy_worker_then_leaves_current_server_running(
     assert status_writes == []
     assert server.should_exit is False
     assert "restart_not_scheduled_package_busy" in caplog.text
+
+
+def test_run_ui_server_writes_child_ready_marker_after_bind_before_run(monkeypatch):
+    events: list[str] = []
+    actual_write_json = runtime.write_json
+
+    class _Socket:
+        pass
+
+    class _Server:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def run(self, sockets=None):
+            events.append("run")
+
+    fake_uvicorn = types.ModuleType("uvicorn")
+    fake_uvicorn.Config = lambda *args, **kwargs: (args, kwargs)
+    fake_uvicorn.Server = _Server
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+    monkeypatch.setattr(
+        "vibe.memory_ui_access.initialize_process_ui_read_secret",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "core.services.settings.load_config",
+        lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+    monkeypatch.setattr(threading, "Thread", _NoopThread)
+    monkeypatch.setattr(
+        ui_server,
+        "_bind_ui_socket",
+        lambda host, port: events.append("bind") or _Socket(),
+    )
+
+    def write_json(path, payload):
+        events.append("marker")
+        actual_write_json(path, payload)
+
+    monkeypatch.setattr(runtime, "write_json", write_json)
+
+    ui_server.run_ui_server("127.0.0.1", 5123)
+
+    marker = runtime.read_json(runtime.paths.get_runtime_dir() / "ui_server_ready.json")
+    assert events == ["bind", "marker", "run"]
+    assert marker["pid"] == os.getpid()
+    assert isinstance(marker["bound_at"], float)

--- a/tests/test_ui_server_reload.py
+++ b/tests/test_ui_server_reload.py
@@ -4,7 +4,7 @@ import os
 import sys
 import threading
 import types
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 
 import pytest
 
@@ -106,6 +106,125 @@ def test_ui_reload_overrides_bind_host_when_tunnel_enabled(monkeypatch):
     call = captured_calls[-1]
     assert call["requested_host"] == "100.97.103.112"
     assert call["config"].remote_access.vibe_cloud.enabled is True
+
+
+def test_ui_reload_admission_refuses_when_restart_is_already_in_flight(monkeypatch):
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: True)
+    monkeypatch.setattr(
+        threading,
+        "Thread",
+        lambda *args, **kwargs: pytest.fail("worker must not be constructed"),
+    )
+    monkeypatch.setattr(
+        ui_server,
+        "package_mutation_lock",
+        lambda **kwargs: pytest.fail("already-live restart should refuse before lock"),
+    )
+
+    client = app.test_client()
+    response = client.post(
+        "/api/ui/reload",
+        json={"host": "127.0.0.1", "port": 5123},
+        headers=csrf_headers(client, "http://127.0.0.1:5123"),
+        base_url="http://127.0.0.1:5123",
+    )
+
+    assert response.status_code == 409
+    assert response.get_json()["code"] == "restart_in_progress"
+
+
+def test_ui_reload_admission_reports_package_busy_without_constructing_worker(monkeypatch):
+    lock_calls: list[int] = []
+
+    @contextmanager
+    def blocked_lock(*, timeout_seconds=None):
+        lock_calls.append(timeout_seconds)
+        raise MigrationLockTimeout("package mutation is still running")
+        yield
+
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: False)
+    monkeypatch.setattr(ui_server, "package_mutation_lock", blocked_lock)
+    monkeypatch.setattr(
+        threading,
+        "Thread",
+        lambda *args, **kwargs: pytest.fail("busy admission must not construct worker"),
+    )
+
+    client = app.test_client()
+    response = client.post(
+        "/api/ui/reload",
+        json={"host": "127.0.0.1", "port": 5123},
+        headers=csrf_headers(client, "http://127.0.0.1:5123"),
+        base_url="http://127.0.0.1:5123",
+    )
+
+    assert response.status_code == 409
+    assert response.get_json() == {
+        "ok": False,
+        "code": "restart_not_scheduled_package_busy",
+        "error": "a package operation is in progress; restart was not scheduled",
+        "restart": {},
+    }
+    assert lock_calls == [0]
+
+
+def test_ui_reload_admission_timeout_distinguishes_restart_that_started(monkeypatch):
+    in_flight = iter([False, True])
+
+    @contextmanager
+    def blocked_lock(*, timeout_seconds=None):
+        raise MigrationLockTimeout("package mutation is still running")
+        yield
+
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: next(in_flight))
+    monkeypatch.setattr(ui_server, "package_mutation_lock", blocked_lock)
+    monkeypatch.setattr(
+        threading,
+        "Thread",
+        lambda *args, **kwargs: pytest.fail("timeout admission must not construct worker"),
+    )
+
+    client = app.test_client()
+    response = client.post(
+        "/api/ui/reload",
+        json={"host": "127.0.0.1", "port": 5123},
+        headers=csrf_headers(client, "http://127.0.0.1:5123"),
+        base_url="http://127.0.0.1:5123",
+    )
+
+    assert response.status_code == 409
+    assert response.get_json()["code"] == "restart_in_progress"
+
+
+def test_ui_reload_admission_releases_predicate_lease_before_spawning(monkeypatch):
+    lock_calls: list[int] = []
+    threads: list[object] = []
+
+    @contextmanager
+    def admission_lock(*, timeout_seconds=None):
+        lock_calls.append(timeout_seconds)
+        yield
+
+    class _Thread(_NoopThread):
+        def __init__(self, *args, **kwargs):
+            threads.append(self)
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(ui_server, "package_mutation_lock", admission_lock)
+    monkeypatch.setattr(threading, "Thread", _Thread)
+
+    client = app.test_client()
+    response = client.post(
+        "/api/ui/reload",
+        json={"host": "127.0.0.1", "port": 5123},
+        headers=csrf_headers(client, "http://127.0.0.1:5123"),
+        base_url="http://127.0.0.1:5123",
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "host": "127.0.0.1", "port": 5123}
+    assert lock_calls == [0]
+    assert len(threads) == 1
 
 
 def test_ui_reload_rejects_non_string_host(monkeypatch):
@@ -276,6 +395,8 @@ def test_ui_reload_stops_old_server_and_waits_for_replacement_inside_package_lea
     assert response.status_code == 200
     assert response.get_json()["ok"] is True
     assert events == [
+        ("lock-enter", 0),
+        ("lock-exit", 0),
         ("lock-enter", None),
         "stop-old",
         ("spawn", True),
@@ -294,7 +415,11 @@ def test_ui_reload_waits_for_child_ready_marker_matching_replacement_pid(monkeyp
     class _Server:
         should_exit = False
 
-    monkeypatch.setattr(ui_server, "package_mutation_lock", nullcontext)
+    @contextmanager
+    def mutation_lock(*, timeout_seconds=None):
+        yield
+
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
     monkeypatch.setattr(ui_server, "_server", _Server())
     monkeypatch.setattr(threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(runtime, "read_status", lambda: {"state": "running", "service_pid": 111})
@@ -470,6 +595,8 @@ def test_ui_reload_retries_one_spawn_failure_inside_the_same_lease(monkeypatch, 
     assert server.should_exit is True
     assert events == [
         "lock-enter",
+        "lock-exit",
+        "lock-enter",
         ("spawn", 1),
         ("spawn", 2),
         ("status", ("running", None, 111, 222)),
@@ -539,6 +666,8 @@ def test_ui_reload_two_spawn_failures_write_error_without_further_retry(
     assert server.should_exit is True
     assert events == [
         "lock-enter",
+        "lock-exit",
+        "lock-enter",
         "spawn",
         "spawn",
         ("status", ("error", "ui_reload_failed", 333, 444)),
@@ -576,7 +705,11 @@ def test_ui_reload_spawn_retry_and_readiness_share_one_deadline(monkeypatch, tmp
         sleeps.append(delay)
         now[0] += delay
 
-    monkeypatch.setattr(ui_server, "package_mutation_lock", nullcontext)
+    @contextmanager
+    def mutation_lock(*, timeout_seconds=None):
+        yield
+
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
     monkeypatch.setattr(ui_server, "_server", _Server())
     monkeypatch.setattr(threading, "Thread", _ImmediateThread)
     statuses_to_read = iter(
@@ -634,7 +767,8 @@ def test_ui_reload_refuses_restart_in_flight_before_stopping_current_server(
 
     server = _Server()
     monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
-    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: True)
+    in_flight = iter([False, False, True])
+    monkeypatch.setattr(ui_server, "_restart_in_flight", lambda: next(in_flight))
     monkeypatch.setattr(ui_server, "_server", server)
     monkeypatch.setattr(threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(
@@ -659,7 +793,12 @@ def test_ui_reload_refuses_restart_in_flight_before_stopping_current_server(
 
     assert response.status_code == 200
     assert response.get_json() == {"ok": True, "host": "127.0.0.1", "port": 5123}
-    assert events == ["lock-enter", "lock-exit"]
+    assert events == [
+        "lock-enter",
+        "lock-exit",
+        "lock-enter",
+        "lock-exit",
+    ]
     assert server.should_exit is False
     assert "restart_in_progress" in caplog.text
 
@@ -673,10 +812,15 @@ def test_ui_reload_retries_busy_worker_then_leaves_current_server_running(
     spawned: list[bool] = []
     status_writes: list[bool] = []
 
+    lock_attempts = 0
+
     @contextmanager
     def blocked_mutation_lock(*, timeout_seconds=None):
+        nonlocal lock_attempts
+        lock_attempts += 1
         lock_calls.append(timeout_seconds)
-        raise MigrationLockTimeout("package mutation is still running")
+        if lock_attempts > 1:
+            raise MigrationLockTimeout("package mutation is still running")
         yield
 
     class _Server:
@@ -706,7 +850,7 @@ def test_ui_reload_retries_busy_worker_then_leaves_current_server_running(
 
     assert response.status_code == 200
     assert response.get_json() == {"ok": True, "host": "127.0.0.1", "port": 5123}
-    assert lock_calls == [None, None]
+    assert lock_calls == [0, None, None]
     assert sleeps == [1.0]
     assert spawned == []
     assert status_writes == []

--- a/tests/test_ui_server_reload.py
+++ b/tests/test_ui_server_reload.py
@@ -151,6 +151,7 @@ def test_ui_reload_routes_replacement_output_through_runtime_log_sinks(monkeypat
     monkeypatch.setattr(runtime, "read_status", lambda: {"state": "running", "service_pid": 111})
     monkeypatch.setattr(runtime, "write_status", lambda *args: captured.setdefault("status", args))
     monkeypatch.setattr(runtime, "ui_pid_file_points_to_running_ui", lambda: True)
+    monkeypatch.setattr(runtime, "ui_server_healthy", lambda **kwargs: True)
 
     def fake_spawn(
         args,
@@ -239,6 +240,11 @@ def test_ui_reload_stops_old_server_and_waits_for_replacement_inside_package_lea
         lambda: events.append(("identity", mutation_lease_held)) or next(identities),
     )
     monkeypatch.setattr(
+        runtime,
+        "ui_server_healthy",
+        lambda **kwargs: events.append(("health", mutation_lease_held, kwargs)) or True,
+    )
+    monkeypatch.setattr(
         "vibe.ui_server.time.sleep",
         lambda delay: events.append(("sleep", delay, mutation_lease_held)),
     )
@@ -261,13 +267,14 @@ def test_ui_reload_stops_old_server_and_waits_for_replacement_inside_package_lea
         ("identity", True),
         ("sleep", 0.2, True),
         ("identity", True),
+        ("health", True, {"host": "127.0.0.1", "port": 5123}),
         ("lock-exit", None),
     ]
     assert server.should_exit is True
 
 
-def test_ui_reload_same_port_readiness_uses_replacement_identity_not_health(monkeypatch):
-    identity_checks: list[bool] = []
+def test_ui_reload_health_is_secondary_to_replacement_identity(monkeypatch):
+    readiness_events: list[str] = []
 
     class _Server:
         should_exit = False
@@ -278,16 +285,18 @@ def test_ui_reload_same_port_readiness_uses_replacement_identity_not_health(monk
     monkeypatch.setattr(runtime, "read_status", lambda: {"state": "running", "service_pid": 111})
     monkeypatch.setattr(runtime, "spawn_background", lambda *args, **kwargs: 222)
     monkeypatch.setattr(runtime, "write_status", lambda *args: None)
-    monkeypatch.setattr(
-        runtime,
-        "ui_server_healthy",
-        lambda *args, **kwargs: pytest.fail("same-port health can belong to the old UI"),
-    )
+    identities = iter([False, True])
     monkeypatch.setattr(
         runtime,
         "ui_pid_file_points_to_running_ui",
-        lambda: identity_checks.append(True) or True,
+        lambda: readiness_events.append("identity") or next(identities),
     )
+    monkeypatch.setattr(
+        runtime,
+        "ui_server_healthy",
+        lambda **kwargs: readiness_events.append("health") or True,
+    )
+    monkeypatch.setattr("vibe.ui_server.time.sleep", lambda delay: readiness_events.append("sleep"))
 
     client = app.test_client()
     response = client.post(
@@ -299,7 +308,7 @@ def test_ui_reload_same_port_readiness_uses_replacement_identity_not_health(monk
 
     assert response.status_code == 200
     assert response.get_json() == {"ok": True, "host": "127.0.0.1", "port": 5123}
-    assert identity_checks == [True]
+    assert readiness_events == ["identity", "sleep", "identity", "health"]
 
 
 def test_ui_reload_identity_timeout_writes_error_after_one_spawn(monkeypatch, caplog):
@@ -352,7 +361,85 @@ def test_ui_reload_identity_timeout_writes_error_after_one_spawn(monkeypatch, ca
     assert "ui_reload_timeout" in caplog.text
 
 
-def test_ui_reload_spawn_failure_writes_error_without_retry(monkeypatch, caplog):
+def test_ui_reload_retries_one_spawn_failure_inside_the_same_lease(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    runtime.paths.ensure_data_dirs()
+    events: list[object] = []
+    mutation_lease_held = False
+
+    @contextmanager
+    def mutation_lock(*, timeout_seconds=None):
+        nonlocal mutation_lease_held
+        mutation_lease_held = True
+        events.append("lock-enter")
+        try:
+            yield
+        finally:
+            events.append("lock-exit")
+            mutation_lease_held = False
+
+    class _Server:
+        should_exit = False
+
+    server = _Server()
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(ui_server, "_server", server)
+    monkeypatch.setattr(threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(
+        runtime,
+        "read_status",
+        lambda: {"state": "running", "service_pid": 111, "ui_pid": 110},
+    )
+    pid_path = runtime.paths.get_runtime_ui_pid_path()
+    pid_path.write_text("110", encoding="utf-8")
+    spawn_attempts = 0
+
+    def flaky_spawn(args, received_pid_path, *spawn_args, **spawn_kwargs):
+        nonlocal spawn_attempts
+        spawn_attempts += 1
+        assert mutation_lease_held is True
+        assert received_pid_path == pid_path
+        events.append(("spawn", spawn_attempts))
+        if spawn_attempts == 1:
+            received_pid_path.write_text("999", encoding="utf-8")
+            raise RuntimeError("first popen failed")
+        assert received_pid_path.read_text(encoding="utf-8") == "110"
+        received_pid_path.write_text("222", encoding="utf-8")
+        return 222
+
+    monkeypatch.setattr(runtime, "spawn_background", flaky_spawn)
+    monkeypatch.setattr(runtime, "write_status", lambda *args: events.append(("status", args)))
+    monkeypatch.setattr(runtime, "ui_pid_file_points_to_running_ui", lambda: True)
+    monkeypatch.setattr(runtime, "ui_server_healthy", lambda **kwargs: True)
+
+    client = app.test_client()
+    response = client.post(
+        "/api/ui/reload",
+        json={"host": "127.0.0.1", "port": 5123},
+        headers=csrf_headers(client, "http://127.0.0.1:5123"),
+        base_url="http://127.0.0.1:5123",
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "host": "127.0.0.1", "port": 5123}
+    assert server.should_exit is True
+    assert events == [
+        "lock-enter",
+        ("spawn", 1),
+        ("spawn", 2),
+        ("status", ("running", None, 111, 222)),
+        "lock-exit",
+    ]
+    assert pid_path.read_text(encoding="utf-8") == "222"
+
+
+def test_ui_reload_two_spawn_failures_write_error_without_further_retry(
+    monkeypatch,
+    tmp_path,
+    caplog,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    runtime.paths.ensure_data_dirs()
     events: list[object] = []
 
     @contextmanager
@@ -375,17 +462,27 @@ def test_ui_reload_spawn_failure_writes_error_without_retry(monkeypatch, caplog)
         "read_status",
         lambda: {"state": "running", "service_pid": 111, "ui_pid": 110},
     )
+    pid_path = runtime.paths.get_runtime_ui_pid_path()
+    pid_path.write_text("110", encoding="utf-8")
 
-    def fail_spawn(*args, **kwargs):
+    def fail_spawn(args, received_pid_path, *spawn_args, **spawn_kwargs):
+        attempt = len([event for event in events if event == "spawn"]) + 1
         events.append("spawn")
-        raise RuntimeError("popen failed")
+        assert received_pid_path.read_text(encoding="utf-8") == "110"
+        received_pid_path.write_text(str(900 + attempt), encoding="utf-8")
+        raise RuntimeError(f"popen failed {attempt}")
 
     monkeypatch.setattr(runtime, "spawn_background", fail_spawn)
     monkeypatch.setattr(runtime, "write_status", lambda *args: events.append(("status", args)))
     monkeypatch.setattr(
         runtime,
         "ui_pid_file_points_to_running_ui",
-        lambda: pytest.fail("identity must not be checked when Popen fails"),
+        lambda: pytest.fail("identity must not be checked when both Popen attempts fail"),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "ui_server_healthy",
+        lambda **kwargs: pytest.fail("health must not be checked when both Popen attempts fail"),
     )
 
     client = app.test_client()
@@ -403,10 +500,68 @@ def test_ui_reload_spawn_failure_writes_error_without_retry(monkeypatch, caplog)
     assert events == [
         "lock-enter",
         "spawn",
+        "spawn",
         ("status", ("error", "ui_reload_failed", 111, 110)),
         "lock-exit",
     ]
+    assert pid_path.read_text(encoding="utf-8") == "110"
     assert "ui_reload_failed" in caplog.text
+
+
+def test_ui_reload_spawn_retry_and_readiness_share_one_deadline(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    runtime.paths.ensure_data_dirs()
+    now = [100.0]
+    spawn_attempts = 0
+    sleeps: list[float] = []
+    statuses: list[tuple] = []
+
+    class _Server:
+        should_exit = False
+
+    def spawn(*args, **kwargs):
+        nonlocal spawn_attempts
+        spawn_attempts += 1
+        if spawn_attempts == 1:
+            now[0] = 109.9
+            raise RuntimeError("slow first failure")
+        return 222
+
+    def sleep(delay: float):
+        sleeps.append(delay)
+        now[0] += delay
+
+    monkeypatch.setattr(ui_server, "package_mutation_lock", nullcontext)
+    monkeypatch.setattr(ui_server, "_server", _Server())
+    monkeypatch.setattr(threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(
+        runtime,
+        "read_status",
+        lambda: {"state": "running", "service_pid": 111, "ui_pid": 110},
+    )
+    monkeypatch.setattr(runtime, "spawn_background", spawn)
+    monkeypatch.setattr(runtime, "write_status", lambda *args: statuses.append(args))
+    monkeypatch.setattr(runtime, "ui_pid_file_points_to_running_ui", lambda: False)
+    monkeypatch.setattr(
+        runtime,
+        "ui_server_healthy",
+        lambda **kwargs: pytest.fail("health requires replacement identity"),
+    )
+    monkeypatch.setattr("vibe.ui_server.time.monotonic", lambda: now[0])
+    monkeypatch.setattr("vibe.ui_server.time.sleep", sleep)
+
+    client = app.test_client()
+    response = client.post(
+        "/api/ui/reload",
+        json={"host": "127.0.0.1", "port": 5123},
+        headers=csrf_headers(client, "http://127.0.0.1:5123"),
+        base_url="http://127.0.0.1:5123",
+    )
+
+    assert response.status_code == 200
+    assert spawn_attempts == 2
+    assert sleeps == pytest.approx([0.1])
+    assert statuses[-1] == ("error", "ui_reload_timeout", 111, 222)
 
 
 def test_ui_reload_retries_busy_worker_then_leaves_current_server_running(

--- a/tests/test_ui_server_reload.py
+++ b/tests/test_ui_server_reload.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import threading
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
+
+import pytest
 
 from config.v2_config import (
     AgentsConfig,
@@ -148,6 +150,7 @@ def test_ui_reload_routes_replacement_output_through_runtime_log_sinks(monkeypat
     monkeypatch.setattr(threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(runtime, "read_status", lambda: {"state": "running", "service_pid": 111})
     monkeypatch.setattr(runtime, "write_status", lambda *args: captured.setdefault("status", args))
+    monkeypatch.setattr(runtime, "ui_pid_file_points_to_running_ui", lambda: True)
 
     def fake_spawn(
         args,
@@ -184,21 +187,35 @@ def test_ui_reload_routes_replacement_output_through_runtime_log_sinks(monkeypat
     assert captured["status"][-1] == 222
 
 
-def test_ui_reload_holds_package_lease_through_spawn_and_releases_before_shutdown(
+def test_ui_reload_stops_old_server_and_waits_for_replacement_inside_package_lease(
     monkeypatch,
 ):
     events: list[object] = []
+    mutation_lease_held = False
 
     @contextmanager
     def mutation_lock(*, timeout_seconds=None):
+        nonlocal mutation_lease_held
+        mutation_lease_held = True
         events.append(("lock-enter", timeout_seconds))
         try:
             yield
         finally:
             events.append(("lock-exit", timeout_seconds))
+            mutation_lease_held = False
 
     class _Server:
-        should_exit = False
+        _should_exit = False
+
+        @property
+        def should_exit(self):
+            return self._should_exit
+
+        @should_exit.setter
+        def should_exit(self, value):
+            assert mutation_lease_held is True
+            events.append("stop-old")
+            self._should_exit = value
 
     server = _Server()
     monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
@@ -208,16 +225,22 @@ def test_ui_reload_holds_package_lease_through_spawn_and_releases_before_shutdow
     monkeypatch.setattr(
         runtime,
         "spawn_background",
-        lambda *args, **kwargs: events.append("spawn") or 222,
+        lambda *args, **kwargs: events.append(("spawn", mutation_lease_held)) or 222,
     )
     monkeypatch.setattr(
         runtime,
         "write_status",
-        lambda *args: events.append("write-status"),
+        lambda *args: events.append(("write-status", mutation_lease_held)),
+    )
+    identities = iter([False, True])
+    monkeypatch.setattr(
+        runtime,
+        "ui_pid_file_points_to_running_ui",
+        lambda: events.append(("identity", mutation_lease_held)) or next(identities),
     )
     monkeypatch.setattr(
         "vibe.ui_server.time.sleep",
-        lambda delay: events.append(("sleep", delay, server.should_exit)),
+        lambda delay: events.append(("sleep", delay, mutation_lease_held)),
     )
 
     client = app.test_client()
@@ -232,12 +255,158 @@ def test_ui_reload_holds_package_lease_through_spawn_and_releases_before_shutdow
     assert response.get_json()["ok"] is True
     assert events == [
         ("lock-enter", None),
-        "spawn",
-        "write-status",
+        "stop-old",
+        ("spawn", True),
+        ("write-status", True),
+        ("identity", True),
+        ("sleep", 0.2, True),
+        ("identity", True),
         ("lock-exit", None),
-        ("sleep", 0.2, False),
     ]
     assert server.should_exit is True
+
+
+def test_ui_reload_same_port_readiness_uses_replacement_identity_not_health(monkeypatch):
+    identity_checks: list[bool] = []
+
+    class _Server:
+        should_exit = False
+
+    monkeypatch.setattr(ui_server, "package_mutation_lock", nullcontext)
+    monkeypatch.setattr(ui_server, "_server", _Server())
+    monkeypatch.setattr(threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(runtime, "read_status", lambda: {"state": "running", "service_pid": 111})
+    monkeypatch.setattr(runtime, "spawn_background", lambda *args, **kwargs: 222)
+    monkeypatch.setattr(runtime, "write_status", lambda *args: None)
+    monkeypatch.setattr(
+        runtime,
+        "ui_server_healthy",
+        lambda *args, **kwargs: pytest.fail("same-port health can belong to the old UI"),
+    )
+    monkeypatch.setattr(
+        runtime,
+        "ui_pid_file_points_to_running_ui",
+        lambda: identity_checks.append(True) or True,
+    )
+
+    client = app.test_client()
+    response = client.post(
+        "/api/ui/reload",
+        json={"host": "127.0.0.1", "port": 5123},
+        headers=csrf_headers(client, "http://127.0.0.1:5123"),
+        base_url="http://127.0.0.1:5123",
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "host": "127.0.0.1", "port": 5123}
+    assert identity_checks == [True]
+
+
+def test_ui_reload_identity_timeout_writes_error_after_one_spawn(monkeypatch, caplog):
+    events: list[object] = []
+
+    @contextmanager
+    def mutation_lock(*, timeout_seconds=None):
+        events.append("lock-enter")
+        try:
+            yield
+        finally:
+            events.append("lock-exit")
+
+    class _Server:
+        should_exit = False
+
+    server = _Server()
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(ui_server, "_server", server)
+    monkeypatch.setattr(threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(
+        runtime,
+        "read_status",
+        lambda: {"state": "running", "service_pid": 111, "ui_pid": 110},
+    )
+    monkeypatch.setattr(
+        runtime,
+        "spawn_background",
+        lambda *args, **kwargs: events.append("spawn") or 222,
+    )
+    monkeypatch.setattr(runtime, "write_status", lambda *args: events.append(("status", args)))
+    monkeypatch.setattr(runtime, "ui_pid_file_points_to_running_ui", lambda: False)
+    monkeypatch.setattr("vibe.ui_server.time.sleep", lambda delay: events.append(("sleep", delay)))
+
+    client = app.test_client()
+    with caplog.at_level("WARNING"):
+        response = client.post(
+            "/api/ui/reload",
+            json={"host": "127.0.0.1", "port": 5123},
+            headers=csrf_headers(client, "http://127.0.0.1:5123"),
+            base_url="http://127.0.0.1:5123",
+        )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "host": "127.0.0.1", "port": 5123}
+    assert server.should_exit is True
+    assert events.count("spawn") == 1
+    assert events[-2:] == [("status", ("error", "ui_reload_timeout", 111, 222)), "lock-exit"]
+    assert events.count(("sleep", 0.2)) == 50
+    assert "ui_reload_timeout" in caplog.text
+
+
+def test_ui_reload_spawn_failure_writes_error_without_retry(monkeypatch, caplog):
+    events: list[object] = []
+
+    @contextmanager
+    def mutation_lock(*, timeout_seconds=None):
+        events.append("lock-enter")
+        try:
+            yield
+        finally:
+            events.append("lock-exit")
+
+    class _Server:
+        should_exit = False
+
+    server = _Server()
+    monkeypatch.setattr(ui_server, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(ui_server, "_server", server)
+    monkeypatch.setattr(threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(
+        runtime,
+        "read_status",
+        lambda: {"state": "running", "service_pid": 111, "ui_pid": 110},
+    )
+
+    def fail_spawn(*args, **kwargs):
+        events.append("spawn")
+        raise RuntimeError("popen failed")
+
+    monkeypatch.setattr(runtime, "spawn_background", fail_spawn)
+    monkeypatch.setattr(runtime, "write_status", lambda *args: events.append(("status", args)))
+    monkeypatch.setattr(
+        runtime,
+        "ui_pid_file_points_to_running_ui",
+        lambda: pytest.fail("identity must not be checked when Popen fails"),
+    )
+
+    client = app.test_client()
+    with caplog.at_level("ERROR"):
+        response = client.post(
+            "/api/ui/reload",
+            json={"host": "127.0.0.1", "port": 5123},
+            headers=csrf_headers(client, "http://127.0.0.1:5123"),
+            base_url="http://127.0.0.1:5123",
+        )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "host": "127.0.0.1", "port": 5123}
+    assert server.should_exit is True
+    assert events == [
+        "lock-enter",
+        "spawn",
+        ("status", ("error", "ui_reload_failed", 111, 110)),
+        "lock-exit",
+    ]
+    assert "ui_reload_failed" in caplog.text
 
 
 def test_ui_reload_retries_busy_worker_then_leaves_current_server_running(

--- a/tests/test_update_checker_platforms.py
+++ b/tests/test_update_checker_platforms.py
@@ -493,7 +493,7 @@ def test_suppressed_post_update_notification_writes_verification_marker(monkeypa
 
     monkeypatch.setattr(
         "vibe.api.do_upgrade",
-        lambda restart: {"ok": True, "restarting": True, "message": "ok", "output": None},
+        lambda restart, **kwargs: {"ok": True, "restarting": True, "message": "ok", "output": None},
     )
 
     result = asyncio.run(checker._perform_update("1.0.1", suppress_post_update_notification=True))
@@ -503,6 +503,26 @@ def test_suppressed_post_update_notification_writes_verification_marker(monkeypa
     data = json.loads(marker.read_text(encoding="utf-8"))
     assert data["version"] == "1.0.1"
     assert data["suppress_success_notification"] is True
+
+
+def test_automatic_update_passes_live_memory_enablement_to_upgrade(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    SettingsStore.reset_instance()
+    controller = _StubController(SettingsStore.get_instance())
+    controller.config.memory = type("Memory", (), {"enabled": True})()
+    checker = UpdateChecker(controller, UpdateConfig())
+    calls = []
+
+    def do_upgrade(restart, **kwargs):
+        calls.append((restart, kwargs))
+        return {"ok": True, "restarting": False, "message": "ok", "output": None}
+
+    monkeypatch.setattr("vibe.api.do_upgrade", do_upgrade)
+
+    result = asyncio.run(checker._perform_update("1.0.1"))
+
+    assert result["ok"] is True
+    assert calls == [(True, {"memory_enabled": True})]
 
 
 def test_update_marker_records_platform_for_non_slack_callbacks(monkeypatch, tmp_path):

--- a/tests/test_update_checker_platforms.py
+++ b/tests/test_update_checker_platforms.py
@@ -525,6 +525,53 @@ def test_automatic_update_passes_live_memory_enablement_to_upgrade(monkeypatch, 
     assert calls == [(True, {"memory_enabled": True})]
 
 
+def test_restart_contention_preserves_existing_update_marker(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    SettingsStore.reset_instance()
+    checker = UpdateChecker(_StubController(SettingsStore.get_instance()), UpdateConfig())
+    checker._write_update_marker("1.0.1", channel_id="channel", message_id="message")
+    marker = tmp_path / "state" / "pending_update_notification.json"
+    before = marker.read_text(encoding="utf-8")
+    monkeypatch.setattr(
+        "vibe.api.do_upgrade",
+        lambda restart, **kwargs: {
+            "ok": False,
+            "restarting": False,
+            "message": "restart_in_progress",
+            "output": None,
+            "code": "restart_in_progress",
+        },
+    )
+
+    result = asyncio.run(checker._perform_update("1.0.2"))
+
+    assert result["code"] == "restart_in_progress"
+    assert marker.read_text(encoding="utf-8") == before
+
+
+def test_failed_update_still_removes_existing_update_marker(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    SettingsStore.reset_instance()
+    checker = UpdateChecker(_StubController(SettingsStore.get_instance()), UpdateConfig())
+    checker._write_update_marker("1.0.1")
+    marker = tmp_path / "state" / "pending_update_notification.json"
+    monkeypatch.setattr(
+        "vibe.api.do_upgrade",
+        lambda restart, **kwargs: {
+            "ok": False,
+            "restarting": False,
+            "message": "upgrade_failed",
+            "output": "resolver failed",
+            "code": "upgrade_failed",
+        },
+    )
+
+    result = asyncio.run(checker._perform_update("1.0.2"))
+
+    assert result["code"] == "upgrade_failed"
+    assert not marker.exists()
+
+
 def test_update_marker_records_platform_for_non_slack_callbacks(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -202,9 +202,11 @@ def test_memory_indep_018_upgrade_and_rollback_preserve_optional_package_shape(
             "--yes",
             "avibe-memory",
         ]
+        assert rollback_core_only.cleanup_after_command is True
     else:
         assert rollback_core_only.preflight_command is None
         assert rollback_core_only.cleanup_command is None
+        assert rollback_core_only.cleanup_after_command is False
 
 
 def test_enabled_upgrade_selects_memory_extra_when_package_is_missing(monkeypatch):
@@ -343,6 +345,105 @@ def test_core_only_pip_rollback_download_failure_preserves_the_current_install(
     assert "--no-deps" in calls[0]
     assert calls[0][-1] == "avibe-os==3.0.13"
     assert not any("avibe-memory" in argument for argument in calls[0])
+
+
+@pytest.mark.parametrize(
+    ("version", "expected_order"),
+    [
+        ("3.0.13", ["cleanup", "install"]),
+        ("not-a-version", ["cleanup", "install"]),
+        ("3.0.14.dev0", ["install", "cleanup"]),
+    ],
+)
+def test_core_only_pip_rollback_orders_cleanup_from_the_pinned_target(
+    monkeypatch,
+    version,
+    expected_order,
+):
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: True)
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        uv_path=None,
+        base_env={"PATH": "/usr/bin"},
+        version=version,
+        package_name="avibe-os",
+        memory_package=False,
+    )
+    actions: list[str] = []
+
+    def fake_run(command, **kwargs):
+        if "download" in command:
+            actions.append("preflight")
+        elif command == plan.cleanup_command:
+            actions.append("cleanup")
+        else:
+            assert command == plan.command
+            actions.append("install")
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    result = execute_upgrade_plan(plan, run=fake_run, capture_output=True, text=True)
+
+    assert result.returncode == 0
+    assert actions == ["preflight", *expected_order]
+
+
+def test_split_core_only_rollback_install_failure_skips_memory_cleanup(monkeypatch):
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: True)
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        uv_path=None,
+        base_env={"PATH": "/usr/bin"},
+        version="3.0.14",
+        package_name="avibe-os",
+        memory_package=False,
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if "download" in command:
+            return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+        if command == plan.cleanup_command:
+            raise AssertionError("Memory must remain installed when the host install fails")
+        return subprocess.CompletedProcess(
+            command,
+            42,
+            stdout="",
+            stderr="host dependencies unavailable",
+        )
+
+    result = execute_upgrade_plan(plan, run=fake_run, capture_output=True, text=True)
+
+    assert result.returncode == 42
+    assert len(calls) == 2
+    assert "download" in calls[0]
+    assert calls[1] == plan.command
+
+
+def test_split_core_only_rollback_reports_cleanup_failure_after_install():
+    plan = UpgradePlan(
+        command=["installer", "pinned-split-core"],
+        env=None,
+        method="test",
+        cleanup_command=["installer", "remove-memory"],
+        cleanup_after_command=True,
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        returncode = 17 if command == plan.cleanup_command else 0
+        return subprocess.CompletedProcess(
+            command,
+            returncode,
+            stdout="",
+            stderr="cleanup failed" if returncode else "",
+        )
+
+    result = execute_upgrade_plan(plan, run=fake_run, capture_output=True, text=True)
+
+    assert result.returncode == 17
+    assert calls == [plan.command, plan.cleanup_command]
 
 
 @pytest.mark.parametrize("preflight_returncode", [0, 42])
@@ -625,7 +726,7 @@ def test_pip_preflight_checks_only_target_artifacts_for_offline_local_wheel(
     assert [path.name for path in scratch.iterdir()] == [host.name]
 
 
-def test_core_only_rollback_removes_memory_before_the_pinned_install():
+def test_bundled_core_only_rollback_removes_memory_before_the_pinned_install():
     plan = UpgradePlan(
         command=["installer", "pinned-core"],
         env=None,

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -2095,6 +2095,50 @@ def test_cmd_upgrade_refuses_an_in_flight_restart_before_mutation(
     assert "restart is already in progress" in capsys.readouterr().out
 
 
+@pytest.mark.parametrize(
+    ("restart_live", "expected"),
+    [
+        (True, "已有重启正在进行，升级未执行。"),
+        (False, "已有软件包操作正在进行，修复未执行。"),
+    ],
+)
+def test_cmd_upgrade_localizes_package_lease_contention(
+    monkeypatch,
+    capsys,
+    restart_live,
+    expected,
+):
+    @contextmanager
+    def blocked_mutation_lock():
+        raise cli.MigrationLockTimeout("raw lock diagnostic")
+        yield
+
+    monkeypatch.setattr(
+        cli,
+        "get_latest_version",
+        lambda: {"error": None, "has_update": True, "latest": "3.0.15"},
+    )
+    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(cli, "package_mutation_lock", blocked_mutation_lock)
+    monkeypatch.setattr(cli, "restart_in_flight", lambda: restart_live)
+    monkeypatch.setattr(cli, "_configured_cli_language", lambda: "zh")
+    monkeypatch.setattr(
+        cli,
+        "build_upgrade_plan",
+        lambda **kwargs: pytest.fail("lease contention must prevent upgrade planning"),
+    )
+    monkeypatch.setattr(
+        cli,
+        "schedule_restart",
+        lambda **kwargs: pytest.fail("lease contention must prevent restart scheduling"),
+    )
+
+    assert cli.cmd_upgrade() == 2
+    output = capsys.readouterr().out
+    assert expected in output
+    assert "raw lock diagnostic" not in output
+
+
 def test_cmd_upgrade_running_runtime_honors_show_runtime_skip_for_restart(monkeypatch):
     plan = UpgradePlan(
         command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -16,6 +16,8 @@ from vibe.runtime import ServiceLauncher
 from vibe.upgrade import (
     UpgradePlan,
     build_upgrade_plan,
+    configured_memory_enabled,
+    execute_upgrade_plan,
     has_newer_version,
     get_current_vibe_bin_dir,
     get_latest_version_info,
@@ -52,6 +54,172 @@ def _tree_is_not_an_installed_distribution(monkeypatch):
     """
 
     monkeypatch.setattr("vibe.upgrade._distributions_providing_this_package", lambda: [])
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: False)
+    monkeypatch.setattr(api, "configured_memory_enabled", lambda: False)
+    monkeypatch.setattr(cli, "configured_memory_enabled", lambda: False)
+
+
+def test_upgrade_preserves_memory_shape_when_config_cannot_be_read(monkeypatch):
+    def fail_to_load():
+        raise OSError("config is unreadable")
+
+    monkeypatch.setattr("config.v2_config.V2Config.load", fail_to_load)
+
+    assert configured_memory_enabled() is True
+
+
+@pytest.mark.parametrize(
+    ("python_executable", "uv_path", "method"),
+    [
+        ("/tmp/.local/share/uv/tools/avibe-os/bin/python", "/usr/local/bin/uv", "uv"),
+        ("/usr/bin/python3", None, "pip"),
+    ],
+)
+def test_memory_indep_018_upgrade_and_rollback_preserve_optional_package_shape(
+    monkeypatch,
+    python_executable,
+    uv_path,
+    method,
+):
+    monkeypatch.setattr("vibe.upgrade.os.path.exists", lambda path: True)
+    monkeypatch.setattr("vibe.upgrade.os.access", lambda path, mode: True)
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: True)
+    monkeypatch.setattr("vibe.__version__", "3.0.14")
+    launcher = ServiceLauncher(
+        python="/uv/tools/avibe-os/bin/python",
+        main="/uv/tools/avibe-os/lib/python3.13/site-packages/vibe/service_main.py",
+    )
+    monkeypatch.setattr("vibe.runtime.current_service_launcher", lambda: launcher)
+    monkeypatch.setattr("vibe.upgrade.installed_package_name", lambda *args, **kwargs: "avibe-os")
+
+    forward = build_upgrade_plan(
+        python_executable=python_executable,
+        uv_path=uv_path,
+        base_env={"PATH": "/usr/bin"},
+    )
+
+    assert forward.method == method
+    assert "avibe-os[memory]" in forward.command
+    assert forward.preflight_command is not None
+    assert "--dry-run" in forward.preflight_command
+    assert forward.rollback_to == RollbackTarget(
+        version="3.0.14",
+        package="avibe-os",
+        launcher=launcher,
+        memory_package=True,
+    )
+
+    rollback_with_memory = build_upgrade_plan(
+        python_executable=python_executable,
+        uv_path=uv_path,
+        base_env={"PATH": "/usr/bin"},
+        version="3.0.14",
+        package_name="avibe-os",
+        memory_package=True,
+    )
+    assert "avibe-os[memory]==3.0.14" in rollback_with_memory.command
+    assert rollback_with_memory.preflight_command is not None
+    assert rollback_with_memory.cleanup_command is None
+
+    rollback_core_only = build_upgrade_plan(
+        python_executable=python_executable,
+        uv_path=uv_path,
+        base_env={"PATH": "/usr/bin"},
+        version="3.0.14",
+        package_name="avibe-os",
+        memory_package=False,
+    )
+    assert "avibe-os==3.0.14" in rollback_core_only.command
+    assert not any("[memory]" in argument for argument in rollback_core_only.command)
+    if method == "pip":
+        assert rollback_core_only.cleanup_command == [
+            python_executable,
+            "-m",
+            "pip",
+            "uninstall",
+            "--yes",
+            "avibe-memory",
+        ]
+    else:
+        assert rollback_core_only.cleanup_command is None
+
+
+def test_enabled_upgrade_selects_memory_extra_when_package_is_missing(monkeypatch):
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: False)
+
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        uv_path=None,
+        base_env={"PATH": "/usr/bin"},
+        memory_enabled=True,
+    )
+
+    assert plan.command[-1] == "avibe-os[memory]"
+    assert plan.preflight_command is not None
+
+
+def test_disabled_core_only_upgrade_keeps_the_core_only_shape(monkeypatch):
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: False)
+
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        uv_path=None,
+        base_env={"PATH": "/usr/bin"},
+        memory_enabled=False,
+    )
+
+    assert plan.command[-1] == "avibe-os"
+    assert plan.preflight_command is None
+
+
+def test_memory_preflight_failure_never_runs_the_replacing_install():
+    plan = UpgradePlan(
+        command=["installer", "replace"],
+        env=None,
+        method="test",
+        preflight_command=["installer", "preflight"],
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 42, stdout="", stderr="incompatible")
+
+    result = execute_upgrade_plan(plan, run=fake_run, capture_output=True, text=True)
+
+    assert result.returncode == 42
+    assert calls == [["installer", "preflight"]]
+
+
+def test_core_only_rollback_removes_memory_only_after_the_pinned_install_succeeds():
+    plan = UpgradePlan(
+        command=["installer", "pinned-core"],
+        env=None,
+        method="test",
+        cleanup_command=["installer", "remove-memory"],
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    result = execute_upgrade_plan(plan, run=fake_run, capture_output=True, text=True)
+
+    assert result.returncode == 0
+    assert calls == [["installer", "pinned-core"], ["installer", "remove-memory"]]
+
+
+def test_controller_startup_has_no_python_package_install_path():
+    source = (Path(__file__).resolve().parents[1] / "core" / "controller.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "build_upgrade_plan" not in source
+    assert "execute_upgrade_plan" not in source
+    assert "memory_package_installed" not in source
+    assert '"pip"' not in source
+    assert '"uv", "tool", "install"' not in source
 
 
 def test_build_upgrade_plan_uses_uv_and_preserves_tool_bin_dir(monkeypatch):

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -34,6 +34,7 @@ from vibe.upgrade import (
     get_safe_cwd,
     installed_metadata_describes_running_code,
     installed_package_name,
+    package_mutation_lock,
     pinned_package_spec,
     RollbackTarget,
     rollback_target,
@@ -447,6 +448,29 @@ def test_package_plan_holds_the_shared_mutation_lease_for_resolution_and_install
         (["installer", "install"], True),
     ]
     assert held is False
+
+
+def test_package_mutation_lock_forwards_a_bounded_retry_timeout(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    observed: list[float | None] = []
+
+    class FakeLock:
+        def __init__(self, lock_path, *, timeout_seconds):
+            assert lock_path.name == "package-mutation.lock"
+            observed.append(timeout_seconds)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return None
+
+    monkeypatch.setattr("storage.lock.MigrationFileLock", FakeLock)
+
+    with package_mutation_lock(timeout_seconds=1.0):
+        pass
+
+    assert observed == [1.0]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import ast
 import os
+import shutil
 import subprocess
 import sys
+import zipfile
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import Any
@@ -129,8 +131,10 @@ def test_memory_indep_018_upgrade_and_rollback_preserve_optional_package_shape(
             forward.preflight_command.index("--dest") + 1
         ] == PIP_DOWNLOAD_DEST_PLACEHOLDER
         assert "--dry-run" not in forward.preflight_command
+        assert "--no-deps" in forward.preflight_command
     else:
         assert "--dry-run" in forward.preflight_command
+        assert "--no-deps" not in forward.preflight_command
     assert forward.rollback_to == RollbackTarget(
         version="3.0.14",
         package="avibe-os",
@@ -159,8 +163,10 @@ def test_memory_indep_018_upgrade_and_rollback_preserve_optional_package_shape(
             "download",
         ]
         assert "--dry-run" not in rollback_with_memory.preflight_command
+        assert "--no-deps" in rollback_with_memory.preflight_command
     else:
         assert "--dry-run" in rollback_with_memory.preflight_command
+        assert "--no-deps" not in rollback_with_memory.preflight_command
     assert rollback_with_memory.cleanup_command is None
 
     rollback_core_only = build_upgrade_plan(
@@ -181,6 +187,7 @@ def test_memory_indep_018_upgrade_and_rollback_preserve_optional_package_shape(
             "download",
             "--dest",
             PIP_DOWNLOAD_DEST_PLACEHOLDER,
+            "--no-deps",
             "avibe-os==3.0.14",
         ]
         assert not any(
@@ -222,6 +229,7 @@ def test_enabled_upgrade_selects_memory_extra_when_package_is_missing(monkeypatc
         plan.preflight_command.index("--dest") + 1
     ] == PIP_DOWNLOAD_DEST_PLACEHOLDER
     assert "--dry-run" not in plan.preflight_command
+    assert "--no-deps" in plan.preflight_command
 
 
 def test_enabled_pip_upgrade_renders_url_extra_as_named_requirement(monkeypatch):
@@ -332,6 +340,7 @@ def test_core_only_pip_rollback_download_failure_preserves_the_current_install(
     assert result.returncode == 42
     assert len(calls) == 1
     assert calls[0][:4] == ["/usr/bin/python3", "-m", "pip", "download"]
+    assert "--no-deps" in calls[0]
     assert calls[0][-1] == "avibe-os==3.0.13"
     assert not any("avibe-memory" in argument for argument in calls[0])
 
@@ -374,6 +383,7 @@ def test_pip_download_preflight_removes_scratch_on_success_and_failure(
             "download",
             "--dest",
             PIP_DOWNLOAD_DEST_PLACEHOLDER,
+            "--no-deps",
             "avibe-os[memory]",
         ],
         cleanup_command=["installer", "cleanup"],
@@ -393,6 +403,7 @@ def test_pip_download_preflight_removes_scratch_on_success_and_failure(
                 "download",
                 "--dest",
                 str(scratch),
+                "--no-deps",
                 "avibe-os[memory]",
             ]
         ]
@@ -405,6 +416,7 @@ def test_pip_download_preflight_removes_scratch_on_success_and_failure(
                 "download",
                 "--dest",
                 str(scratch),
+                "--no-deps",
                 "avibe-os[memory]",
             ],
             ["installer", "cleanup"],
@@ -525,6 +537,92 @@ def test_memory_add_plan_force_reinstalls_only_the_compatible_memory_distributio
         assert "--dry-run" not in plan.preflight_command
         assert "--force-reinstall" not in plan.preflight_command
         assert "--no-deps" in plan.preflight_command
+
+
+def _write_minimal_wheel(
+    wheel_dir: Path,
+    *,
+    name: str,
+    version: str,
+    requires_dist: tuple[str, ...] = (),
+    provides_extra: str | None = None,
+) -> Path:
+    normalized = name.replace("-", "_")
+    wheel = wheel_dir / f"{normalized}-{version}-py3-none-any.whl"
+    dist_info = f"{normalized}-{version}.dist-info"
+    module = normalized
+    metadata = [
+        "Metadata-Version: 2.1",
+        f"Name: {name}",
+        f"Version: {version}",
+    ]
+    if provides_extra:
+        metadata.append(f"Provides-Extra: {provides_extra}")
+    metadata.extend(f"Requires-Dist: {requirement}" for requirement in requires_dist)
+    files = {
+        f"{module}/__init__.py": "",
+        f"{dist_info}/METADATA": "\n".join(metadata) + "\n",
+        f"{dist_info}/WHEEL": (
+            "Wheel-Version: 1.0\n"
+            "Generator: avibe-test\n"
+            "Root-Is-Purelib: true\n"
+            "Tag: py3-none-any\n"
+        ),
+    }
+    files[f"{dist_info}/RECORD"] = "".join(f"{path},,\n" for path in files)
+    with zipfile.ZipFile(wheel, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path, content in files.items():
+            archive.writestr(path, content)
+    return wheel
+
+
+def test_pip_preflight_checks_only_target_artifacts_for_offline_local_wheel(
+    monkeypatch,
+    tmp_path,
+):
+    wheels = tmp_path / "wheels"
+    wheels.mkdir()
+    host = _write_minimal_wheel(
+        wheels,
+        name="avibe-os",
+        version="9.9.9",
+        requires_dist=('avibe-offline-only-dependency==1.0; extra == "memory"',),
+        provides_extra="memory",
+    )
+    offline_env = {
+        **os.environ,
+        "PIP_NO_INDEX": "1",
+        "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+    }
+    monkeypatch.setenv("AVIBE_UPGRADE_PACKAGE_SPEC", str(host))
+    monkeypatch.setattr("vibe.upgrade.installed_metadata_describes_running_code", lambda: True)
+
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        uv_path=None,
+        base_env=offline_env,
+        memory_enabled=True,
+    )
+
+    assert plan.preflight_command is not None
+    assert "--no-deps" in plan.preflight_command
+    assert "--no-deps" not in plan.command
+    scratch = tmp_path / "download"
+    scratch.mkdir()
+    pip_executable = shutil.which("pip3") or shutil.which("pip")
+    if pip_executable is None:
+        pytest.skip("a pip executable is required for the offline wheel smoke check")
+    preflight = [pip_executable, *plan.preflight_command[3:]]
+    preflight[preflight.index(PIP_DOWNLOAD_DEST_PLACEHOLDER)] = str(scratch)
+    resolved = subprocess.run(
+        preflight,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=offline_env,
+    )
+    assert resolved.returncode == 0, resolved.stderr
+    assert [path.name for path in scratch.iterdir()] == [host.name]
 
 
 def test_core_only_rollback_removes_memory_before_the_pinned_install():
@@ -1491,6 +1589,45 @@ def test_do_upgrade_uses_upgrade_plan_env_and_restarts(monkeypatch):
     assert mutation_lease_held is False
 
 
+def test_do_upgrade_samples_runtime_after_start_wins_the_package_lease(monkeypatch):
+    plan = UpgradePlan(command=["installer", "upgrade"], env=None, method="test")
+    runtime_running = False
+    sampled: list[bool] = []
+    scheduled: list[dict[str, Any]] = []
+
+    @contextmanager
+    def mutation_lock():
+        nonlocal runtime_running
+        runtime_running = True
+        yield
+
+    def sample_runtime() -> bool:
+        sampled.append(runtime_running)
+        return runtime_running
+
+    monkeypatch.setattr(api, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(api, "_runtime_process_was_running", sample_runtime)
+    monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(api, "schedule_restart", lambda **kwargs: scheduled.append(kwargs))
+    monkeypatch.setattr(
+        api.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="done",
+            stderr="",
+        ),
+    )
+
+    result = api.do_upgrade(auto_restart=True)
+
+    assert sampled == [True]
+    assert result["restarting"] is True
+    assert len(scheduled) == 1
+
+
 def test_do_upgrade_refuses_an_in_flight_restart_before_planning_or_mutation(
     monkeypatch,
 ):
@@ -1781,6 +1918,53 @@ def test_cmd_upgrade_uses_upgrade_plan_env(monkeypatch):
         "rollback_to": LEGACY_INSTALL,
     }
     assert mutation_lease_held is False
+
+
+def test_cmd_upgrade_samples_runtime_after_stop_wins_the_package_lease(
+    monkeypatch,
+):
+    plan = UpgradePlan(command=["installer", "upgrade"], env=None, method="test")
+    runtime_running = True
+    sampled: list[bool] = []
+    commands: list[list[str]] = []
+
+    @contextmanager
+    def mutation_lock():
+        nonlocal runtime_running
+        runtime_running = False
+        yield
+
+    def sample_runtime() -> bool:
+        sampled.append(runtime_running)
+        return runtime_running
+
+    monkeypatch.setattr(cli, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(
+        cli,
+        "get_latest_version",
+        lambda: {"error": None, "has_update": True, "latest": "2.2.0"},
+    )
+    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(cli, "_runtime_process_was_running", sample_runtime)
+    monkeypatch.setattr(cli, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(
+        cli,
+        "schedule_restart",
+        lambda **kwargs: pytest.fail("a stopped runtime must not be restarted"),
+    )
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="done", stderr="")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    assert cli.cmd_upgrade() == 0
+    assert sampled == [False]
+    assert commands == [
+        plan.command,
+        ["/custom/bin/vibe", "runtime", "prepare", "--strict"],
+    ]
 
 
 def test_cmd_upgrade_refuses_an_in_flight_restart_before_mutation(

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -4,6 +4,7 @@ import ast
 import os
 import subprocess
 import sys
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +16,7 @@ from vibe import api, cli
 from vibe.runtime import ServiceLauncher
 from vibe.upgrade import (
     UpgradePlan,
+    build_memory_add_plan,
     build_upgrade_plan,
     configured_memory_enabled,
     execute_upgrade_plan,
@@ -55,6 +57,10 @@ def _tree_is_not_an_installed_distribution(monkeypatch):
 
     monkeypatch.setattr("vibe.upgrade._distributions_providing_this_package", lambda: [])
     monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: False)
+    monkeypatch.setattr("vibe.upgrade.installed_memory_package_version", lambda: None)
+    monkeypatch.setattr("vibe.upgrade.package_mutation_lock", nullcontext)
+    monkeypatch.setattr(api, "package_mutation_lock", nullcontext)
+    monkeypatch.setattr(cli, "package_mutation_lock", nullcontext)
     monkeypatch.setattr(api, "configured_memory_enabled", lambda: False)
     monkeypatch.setattr(cli, "configured_memory_enabled", lambda: False)
 
@@ -84,6 +90,10 @@ def test_memory_indep_018_upgrade_and_rollback_preserve_optional_package_shape(
     monkeypatch.setattr("vibe.upgrade.os.path.exists", lambda path: True)
     monkeypatch.setattr("vibe.upgrade.os.access", lambda path, mode: True)
     monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: True)
+    monkeypatch.setattr(
+        "vibe.upgrade.installed_memory_package_version",
+        lambda: "3.0.14",
+    )
     monkeypatch.setattr("vibe.__version__", "3.0.14")
     launcher = ServiceLauncher(
         python="/uv/tools/avibe-os/bin/python",
@@ -107,6 +117,7 @@ def test_memory_indep_018_upgrade_and_rollback_preserve_optional_package_shape(
         package="avibe-os",
         launcher=launcher,
         memory_package=True,
+        memory_version="3.0.14",
     )
 
     rollback_with_memory = build_upgrade_plan(
@@ -116,8 +127,10 @@ def test_memory_indep_018_upgrade_and_rollback_preserve_optional_package_shape(
         version="3.0.14",
         package_name="avibe-os",
         memory_package=True,
+        memory_version="3.0.14",
     )
     assert "avibe-os[memory]==3.0.14" in rollback_with_memory.command
+    assert "avibe-memory==3.0.14" in rollback_with_memory.command
     assert rollback_with_memory.preflight_command is not None
     assert rollback_with_memory.cleanup_command is None
 
@@ -189,6 +202,81 @@ def test_memory_preflight_failure_never_runs_the_replacing_install():
 
     assert result.returncode == 42
     assert calls == [["installer", "preflight"]]
+
+
+def test_package_plan_holds_the_shared_mutation_lease_for_resolution_and_install(
+    monkeypatch,
+):
+    held = False
+    calls: list[tuple[list[str], bool]] = []
+
+    @contextmanager
+    def mutation_lock():
+        nonlocal held
+        assert held is False
+        held = True
+        try:
+            yield
+        finally:
+            held = False
+
+    def fake_run(command, **kwargs):
+        calls.append((command, held))
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("vibe.upgrade.package_mutation_lock", mutation_lock)
+    plan = UpgradePlan(
+        command=["installer", "install"],
+        env=None,
+        method="test",
+        preflight_command=["installer", "preflight"],
+    )
+
+    result = execute_upgrade_plan(plan, run=fake_run, capture_output=True, text=True)
+
+    assert result.returncode == 0
+    assert calls == [
+        (["installer", "preflight"], True),
+        (["installer", "install"], True),
+    ]
+    assert held is False
+
+
+@pytest.mark.parametrize(
+    ("python_executable", "uv_path", "method"),
+    [
+        ("/tmp/.local/share/uv/tools/avibe-os/bin/python", "/usr/local/bin/uv", "uv"),
+        ("/usr/bin/python3", None, "pip"),
+    ],
+)
+def test_memory_add_plan_never_force_reinstalls_the_running_core(
+    monkeypatch,
+    python_executable,
+    uv_path,
+    method,
+):
+    monkeypatch.setattr("vibe.upgrade.os.path.exists", lambda path: True)
+    monkeypatch.setattr("vibe.upgrade.os.access", lambda path, mode: True)
+
+    plan = build_memory_add_plan(
+        version="3.0.14",
+        package_name="avibe-os",
+        python_executable=python_executable,
+        uv_path=uv_path,
+        base_env={"PATH": "/usr/bin"},
+    )
+
+    assert plan.method == method
+    assert "avibe-os[memory]==3.0.14" in plan.command
+    assert plan.preflight_command is not None
+    assert "--dry-run" in plan.preflight_command
+    assert "--force" not in plan.command
+    assert "--force-reinstall" not in plan.command
+    if method == "uv":
+        assert plan.command[:3] == ["/usr/local/bin/uv", "pip", "install"]
+        assert "tool" not in plan.command
+    else:
+        assert plan.command[:4] == [python_executable, "-m", "pip", "install"]
 
 
 def test_core_only_rollback_removes_memory_only_after_the_pinned_install_succeeds():

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from vibe import api, cli
 from vibe.runtime import ServiceLauncher
 from vibe.upgrade import (
+    MEMORY_PACKAGE_COMPATIBILITY,
     UpgradePlan,
     build_memory_add_plan,
     build_upgrade_plan,
@@ -249,7 +250,7 @@ def test_package_plan_holds_the_shared_mutation_lease_for_resolution_and_install
         ("/usr/bin/python3", None, "pip"),
     ],
 )
-def test_memory_add_plan_never_force_reinstalls_the_running_core(
+def test_memory_add_plan_force_reinstalls_only_the_compatible_memory_distribution(
     monkeypatch,
     python_executable,
     uv_path,
@@ -267,14 +268,19 @@ def test_memory_add_plan_never_force_reinstalls_the_running_core(
     )
 
     assert plan.method == method
-    assert "avibe-os[memory]==3.0.14" in plan.command
+    memory_requirement = f"avibe-memory{MEMORY_PACKAGE_COMPATIBILITY}"
+    assert memory_requirement in plan.command
     assert plan.preflight_command is not None
     assert "--dry-run" in plan.preflight_command
-    assert "--force" not in plan.command
-    assert "--force-reinstall" not in plan.command
+    assert "--force-reinstall" in plan.command
+    assert "--no-deps" in plan.command
+    assert memory_requirement in plan.preflight_command
+    assert not any(argument.startswith("avibe-os") for argument in plan.command)
+    assert plan.cleanup_command is None
     if method == "uv":
         assert plan.command[:3] == ["/usr/local/bin/uv", "pip", "install"]
         assert "tool" not in plan.command
+        assert plan.command[plan.command.index("--python") + 1] == python_executable
     else:
         assert plan.command[:4] == [python_executable, "-m", "pip", "install"]
 

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -258,6 +258,63 @@ def test_enabled_pip_upgrade_renders_url_extra_as_named_requirement(monkeypatch)
     assert f"{package_url}[memory]" not in plan.preflight_command
 
 
+@pytest.mark.parametrize(
+    "package_spec",
+    [
+        "git+https://git.example.test/avibe.git",
+        "git+https://git.example.test/avibe.git@abc123#subdirectory=python",
+    ],
+)
+def test_enabled_pip_upgrade_renders_bare_vcs_extra_as_named_requirement(
+    monkeypatch,
+    package_spec,
+):
+    monkeypatch.setenv("AVIBE_UPGRADE_PACKAGE_SPEC", package_spec)
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: False)
+    monkeypatch.setattr(
+        "vibe.upgrade.installed_metadata_describes_running_code",
+        lambda: True,
+    )
+
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        uv_path=None,
+        base_env={"PATH": "/usr/bin"},
+        memory_enabled=True,
+    )
+
+    named_requirement = f"avibe-os[memory] @ {package_spec}"
+    assert plan.command[-1] == named_requirement
+    assert plan.preflight_command is not None
+    assert plan.preflight_command[-1] == named_requirement
+    assert f"{package_spec}[memory]" not in plan.command
+    assert f"{package_spec}[memory]" not in plan.preflight_command
+
+
+def test_enabled_pip_upgrade_preserves_named_requirement_when_adding_extra(
+    monkeypatch,
+):
+    package_spec = "avibe-os[cloud]>=3.0"
+    monkeypatch.setenv("AVIBE_UPGRADE_PACKAGE_SPEC", package_spec)
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: False)
+    monkeypatch.setattr(
+        "vibe.upgrade.installed_metadata_describes_running_code",
+        lambda: True,
+    )
+
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        uv_path=None,
+        base_env={"PATH": "/usr/bin"},
+        memory_enabled=True,
+    )
+
+    named_requirement = "avibe-os[cloud,memory]>=3.0"
+    assert plan.command[-1] == named_requirement
+    assert plan.preflight_command is not None
+    assert plan.preflight_command[-1] == named_requirement
+
+
 def test_enabled_pip_upgrade_retains_local_path_extra_syntax(monkeypatch):
     package_path = "/tmp/avibe_os-3.0.14-py3-none-any.whl"
     monkeypatch.setenv("AVIBE_UPGRADE_PACKAGE_SPEC", package_path)

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -172,6 +172,52 @@ def test_enabled_upgrade_selects_memory_extra_when_package_is_missing(monkeypatc
     assert plan.preflight_command is not None
 
 
+def test_enabled_pip_upgrade_renders_url_extra_as_named_requirement(monkeypatch):
+    package_url = "https://downloads.example.test/avibe_os-3.0.14-py3-none-any.whl"
+    monkeypatch.setenv("AVIBE_UPGRADE_PACKAGE_SPEC", package_url)
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: False)
+    monkeypatch.setattr(
+        "vibe.upgrade.installed_metadata_describes_running_code",
+        lambda: True,
+    )
+
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        uv_path=None,
+        base_env={"PATH": "/usr/bin"},
+        memory_enabled=True,
+    )
+
+    named_requirement = f"avibe-os[memory] @ {package_url}"
+    assert plan.command[-1] == named_requirement
+    assert plan.preflight_command is not None
+    assert plan.preflight_command[-1] == named_requirement
+    assert f"{package_url}[memory]" not in plan.command
+    assert f"{package_url}[memory]" not in plan.preflight_command
+
+
+def test_enabled_pip_upgrade_retains_local_path_extra_syntax(monkeypatch):
+    package_path = "/tmp/avibe_os-3.0.14-py3-none-any.whl"
+    monkeypatch.setenv("AVIBE_UPGRADE_PACKAGE_SPEC", package_path)
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: False)
+    monkeypatch.setattr(
+        "vibe.upgrade.installed_metadata_describes_running_code",
+        lambda: True,
+    )
+
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        uv_path=None,
+        base_env={"PATH": "/usr/bin"},
+        memory_enabled=True,
+    )
+
+    local_requirement = f"{package_path}[memory]"
+    assert plan.command[-1] == local_requirement
+    assert plan.preflight_command is not None
+    assert plan.preflight_command[-1] == local_requirement
+
+
 def test_disabled_core_only_upgrade_keeps_the_core_only_shape(monkeypatch):
     monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: False)
 

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -18,6 +18,7 @@ from vibe.upgrade import (
     MEMORY_PACKAGE_COMPATIBILITY,
     PIP_DOWNLOAD_DEST_PLACEHOLDER,
     UpgradePlan,
+    _distributions_providing_this_package,
     build_memory_add_plan,
     build_upgrade_plan,
     configured_memory_enabled,
@@ -31,6 +32,7 @@ from vibe.upgrade import (
     get_restart_shell_command,
     get_running_vibe_path,
     get_safe_cwd,
+    installed_metadata_describes_running_code,
     installed_package_name,
     pinned_package_spec,
     RollbackTarget,
@@ -65,6 +67,8 @@ def _tree_is_not_an_installed_distribution(monkeypatch):
     monkeypatch.setattr(cli, "package_mutation_lock", nullcontext)
     monkeypatch.setattr(api, "configured_memory_enabled", lambda: False)
     monkeypatch.setattr(cli, "configured_memory_enabled", lambda: False)
+    monkeypatch.setattr(api, "restart_in_flight", lambda: False)
+    monkeypatch.setattr(cli, "restart_in_flight", lambda: False)
 
 
 def test_upgrade_preserves_memory_shape_when_config_cannot_be_read(monkeypatch):
@@ -169,6 +173,19 @@ def test_memory_indep_018_upgrade_and_rollback_preserve_optional_package_shape(
     assert "avibe-os==3.0.14" in rollback_core_only.command
     assert not any("[memory]" in argument for argument in rollback_core_only.command)
     if method == "pip":
+        assert rollback_core_only.preflight_command == [
+            python_executable,
+            "-m",
+            "pip",
+            "download",
+            "--dest",
+            PIP_DOWNLOAD_DEST_PLACEHOLDER,
+            "avibe-os==3.0.14",
+        ]
+        assert not any(
+            "avibe-memory" in argument
+            for argument in rollback_core_only.preflight_command
+        )
         assert rollback_core_only.cleanup_command == [
             python_executable,
             "-m",
@@ -178,6 +195,7 @@ def test_memory_indep_018_upgrade_and_rollback_preserve_optional_package_shape(
             "avibe-memory",
         ]
     else:
+        assert rollback_core_only.preflight_command is None
         assert rollback_core_only.cleanup_command is None
 
 
@@ -283,6 +301,38 @@ def test_memory_preflight_failure_never_runs_the_replacing_install():
 
     assert result.returncode == 42
     assert calls == [["installer", "preflight"]]
+
+
+def test_core_only_pip_rollback_download_failure_preserves_the_current_install(
+    monkeypatch,
+):
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: True)
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        uv_path=None,
+        base_env={"PATH": "/usr/bin"},
+        version="3.0.13",
+        package_name="avibe-os",
+        memory_package=False,
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            42,
+            stdout="",
+            stderr="host release unavailable",
+        )
+
+    result = execute_upgrade_plan(plan, run=fake_run, capture_output=True, text=True)
+
+    assert result.returncode == 42
+    assert len(calls) == 1
+    assert calls[0][:4] == ["/usr/bin/python3", "-m", "pip", "download"]
+    assert calls[0][-1] == "avibe-os==3.0.13"
+    assert not any("avibe-memory" in argument for argument in calls[0])
 
 
 @pytest.mark.parametrize("preflight_returncode", [0, 42])
@@ -761,6 +811,37 @@ def test_a_forward_upgrade_on_an_undamaged_install_is_left_to_the_installer(monk
 
     assert "--upgrade" in plan.command
     assert "--force-reinstall" not in plan.command
+
+
+def test_optional_memory_provider_does_not_describe_the_running_host(monkeypatch):
+    monkeypatch.setattr(
+        "vibe.upgrade._distributions_providing_this_package",
+        _distributions_providing_this_package,
+    )
+    monkeypatch.setattr(
+        "importlib.metadata.packages_distributions",
+        lambda: {"vibe": ["avibe-os", "avibe_memory"]},
+    )
+    recorded = {"avibe-os": "3.0.14", "avibe_memory": "3.0.13"}
+    monkeypatch.setattr("importlib.metadata.version", lambda name: recorded[name])
+    monkeypatch.setattr("vibe.__version__", "3.0.14")
+
+    assert _distributions_providing_this_package() == ["avibe-os"]
+    assert installed_metadata_describes_running_code() is True
+    assert installed_package_name() == "avibe-os"
+
+
+def test_mismatched_host_rename_pair_still_marks_metadata_stale(monkeypatch):
+    monkeypatch.setattr(
+        "vibe.upgrade._distributions_providing_this_package",
+        lambda: ["avibe-os", "vibe-remote"],
+    )
+    recorded = {"avibe-os": "3.0.14", "vibe-remote": "3.0.13"}
+    monkeypatch.setattr("importlib.metadata.version", lambda name: recorded[name])
+    monkeypatch.setattr("vibe.__version__", "3.0.14")
+
+    assert installed_metadata_describes_running_code() is False
+    assert installed_package_name() == "avibe-os"
 
 
 @pytest.mark.parametrize(
@@ -1330,11 +1411,26 @@ def test_do_upgrade_uses_upgrade_plan_env_and_restarts(monkeypatch):
         rollback_to=LEGACY_INSTALL,
     )
     calls: dict[str, Any] = {}
+    mutation_lease_held = False
 
+    @contextmanager
+    def mutation_lock():
+        nonlocal mutation_lease_held
+        mutation_lease_held = True
+        try:
+            yield
+        finally:
+            mutation_lease_held = False
+
+    monkeypatch.setattr(api, "package_mutation_lock", mutation_lock)
     monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
     monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
     monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
-    monkeypatch.setattr(api, "schedule_restart", lambda **kwargs: calls.setdefault("restart_kwargs", kwargs))
+    def schedule_restart(**kwargs):
+        assert mutation_lease_held is True
+        calls["restart_kwargs"] = kwargs
+
+    monkeypatch.setattr(api, "schedule_restart", schedule_restart)
 
     def fake_run(cmd, **kwargs):
         if cmd == plan.command:
@@ -1367,6 +1463,34 @@ def test_do_upgrade_uses_upgrade_plan_env_and_restarts(monkeypatch):
         # together, because a pin needs the first two and a machine that predates
         # the rename does not answer "avibe-os" for either.
         "rollback_to": LEGACY_INSTALL,
+    }
+    assert mutation_lease_held is False
+
+
+def test_do_upgrade_refuses_an_in_flight_restart_before_planning_or_mutation(
+    monkeypatch,
+):
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
+    monkeypatch.setattr(api, "restart_in_flight", lambda: True)
+    monkeypatch.setattr(
+        api,
+        "build_upgrade_plan",
+        lambda **kwargs: pytest.fail("an in-flight restart must prevent planning"),
+    )
+    monkeypatch.setattr(
+        api,
+        "schedule_restart",
+        lambda **kwargs: pytest.fail("an in-flight restart must not schedule another"),
+    )
+
+    assert api.do_upgrade(auto_restart=True) == {
+        "ok": False,
+        "message": "restart_in_progress",
+        "output": None,
+        "restarting": False,
+        "reason": "restart_in_progress",
+        "code": "restart_in_progress",
     }
 
 
@@ -1581,13 +1705,25 @@ def test_cmd_upgrade_uses_upgrade_plan_env(monkeypatch):
         rollback_to=LEGACY_INSTALL,
     )
     calls: dict[str, Any] = {}
+    mutation_lease_held = False
 
+    @contextmanager
+    def mutation_lock():
+        nonlocal mutation_lease_held
+        mutation_lease_held = True
+        try:
+            yield
+        finally:
+            mutation_lease_held = False
+
+    monkeypatch.setattr(cli, "package_mutation_lock", mutation_lock)
     monkeypatch.setattr(cli, "get_latest_version", lambda: {"error": None, "has_update": True, "latest": "2.2.0"})
     monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
     monkeypatch.setattr(cli, "build_upgrade_plan", lambda **kwargs: plan)
     monkeypatch.setattr(cli, "_runtime_process_was_running", lambda: True)
 
     def fake_schedule_restart(**kwargs):
+        assert mutation_lease_held is True
         calls["restart_kwargs"] = kwargs
         return {"job_id": "restart"}
 
@@ -1620,6 +1756,34 @@ def test_cmd_upgrade_uses_upgrade_plan_env(monkeypatch):
         # See the do_upgrade case: the restart is handed the install to fall back to.
         "rollback_to": LEGACY_INSTALL,
     }
+    assert mutation_lease_held is False
+
+
+def test_cmd_upgrade_refuses_an_in_flight_restart_before_mutation(
+    monkeypatch,
+    capsys,
+):
+    monkeypatch.setattr(
+        cli,
+        "get_latest_version",
+        lambda: {"error": None, "has_update": True, "latest": "3.0.15"},
+    )
+    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(cli, "_runtime_process_was_running", lambda: True)
+    monkeypatch.setattr(cli, "restart_in_flight", lambda: True)
+    monkeypatch.setattr(
+        cli,
+        "build_upgrade_plan",
+        lambda **kwargs: pytest.fail("an in-flight restart must prevent planning"),
+    )
+    monkeypatch.setattr(
+        cli,
+        "schedule_restart",
+        lambda **kwargs: pytest.fail("an in-flight restart must not schedule another"),
+    )
+
+    assert cli.cmd_upgrade() == 2
+    assert "restart is already in progress" in capsys.readouterr().out
 
 
 def test_cmd_upgrade_running_runtime_honors_show_runtime_skip_for_restart(monkeypatch):

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -16,6 +16,7 @@ from vibe import api, cli
 from vibe.runtime import ServiceLauncher
 from vibe.upgrade import (
     MEMORY_PACKAGE_COMPATIBILITY,
+    PIP_DOWNLOAD_DEST_PLACEHOLDER,
     UpgradePlan,
     build_memory_add_plan,
     build_upgrade_plan,
@@ -112,7 +113,19 @@ def test_memory_indep_018_upgrade_and_rollback_preserve_optional_package_shape(
     assert forward.method == method
     assert "avibe-os[memory]" in forward.command
     assert forward.preflight_command is not None
-    assert "--dry-run" in forward.preflight_command
+    if method == "pip":
+        assert forward.preflight_command[:4] == [
+            python_executable,
+            "-m",
+            "pip",
+            "download",
+        ]
+        assert forward.preflight_command[
+            forward.preflight_command.index("--dest") + 1
+        ] == PIP_DOWNLOAD_DEST_PLACEHOLDER
+        assert "--dry-run" not in forward.preflight_command
+    else:
+        assert "--dry-run" in forward.preflight_command
     assert forward.rollback_to == RollbackTarget(
         version="3.0.14",
         package="avibe-os",
@@ -133,6 +146,16 @@ def test_memory_indep_018_upgrade_and_rollback_preserve_optional_package_shape(
     assert "avibe-os[memory]==3.0.14" in rollback_with_memory.command
     assert "avibe-memory==3.0.14" in rollback_with_memory.command
     assert rollback_with_memory.preflight_command is not None
+    if method == "pip":
+        assert rollback_with_memory.preflight_command[:4] == [
+            python_executable,
+            "-m",
+            "pip",
+            "download",
+        ]
+        assert "--dry-run" not in rollback_with_memory.preflight_command
+    else:
+        assert "--dry-run" in rollback_with_memory.preflight_command
     assert rollback_with_memory.cleanup_command is None
 
     rollback_core_only = build_upgrade_plan(
@@ -170,6 +193,16 @@ def test_enabled_upgrade_selects_memory_extra_when_package_is_missing(monkeypatc
 
     assert plan.command[-1] == "avibe-os[memory]"
     assert plan.preflight_command is not None
+    assert plan.preflight_command[:4] == [
+        "/usr/bin/python3",
+        "-m",
+        "pip",
+        "download",
+    ]
+    assert plan.preflight_command[
+        plan.preflight_command.index("--dest") + 1
+    ] == PIP_DOWNLOAD_DEST_PLACEHOLDER
+    assert "--dry-run" not in plan.preflight_command
 
 
 def test_enabled_pip_upgrade_renders_url_extra_as_named_requirement(monkeypatch):
@@ -238,6 +271,7 @@ def test_memory_preflight_failure_never_runs_the_replacing_install():
         env=None,
         method="test",
         preflight_command=["installer", "preflight"],
+        cleanup_command=["installer", "cleanup"],
     )
     calls: list[list[str]] = []
 
@@ -249,6 +283,82 @@ def test_memory_preflight_failure_never_runs_the_replacing_install():
 
     assert result.returncode == 42
     assert calls == [["installer", "preflight"]]
+
+
+@pytest.mark.parametrize("preflight_returncode", [0, 42])
+def test_pip_download_preflight_removes_scratch_on_success_and_failure(
+    monkeypatch,
+    tmp_path,
+    preflight_returncode,
+):
+    scratch = tmp_path / "pip-download"
+    calls: list[list[str]] = []
+
+    def make_scratch(**kwargs):
+        scratch.mkdir()
+        return str(scratch)
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        if "download" in command:
+            assert command[command.index("--dest") + 1] == str(scratch)
+            assert scratch.is_dir()
+            return subprocess.CompletedProcess(
+                command,
+                preflight_returncode,
+                stdout="",
+                stderr="resolver failed" if preflight_returncode else "",
+            )
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr("vibe.upgrade.tempfile.mkdtemp", make_scratch)
+    plan = UpgradePlan(
+        command=["installer", "install"],
+        env=None,
+        method="pip",
+        preflight_command=[
+            "/usr/bin/python3",
+            "-m",
+            "pip",
+            "download",
+            "--dest",
+            PIP_DOWNLOAD_DEST_PLACEHOLDER,
+            "avibe-os[memory]",
+        ],
+        cleanup_command=["installer", "cleanup"],
+    )
+
+    result = execute_upgrade_plan(plan, run=fake_run, capture_output=True, text=True)
+
+    assert result.returncode == preflight_returncode
+    assert scratch.exists() is False
+    assert PIP_DOWNLOAD_DEST_PLACEHOLDER not in calls[0]
+    if preflight_returncode:
+        assert calls == [
+            [
+                "/usr/bin/python3",
+                "-m",
+                "pip",
+                "download",
+                "--dest",
+                str(scratch),
+                "avibe-os[memory]",
+            ]
+        ]
+    else:
+        assert calls == [
+            [
+                "/usr/bin/python3",
+                "-m",
+                "pip",
+                "download",
+                "--dest",
+                str(scratch),
+                "avibe-os[memory]",
+            ],
+            ["installer", "cleanup"],
+            ["installer", "install"],
+        ]
 
 
 def test_package_plan_holds_the_shared_mutation_lease_for_resolution_and_install(
@@ -317,7 +427,6 @@ def test_memory_add_plan_force_reinstalls_only_the_compatible_memory_distributio
     memory_requirement = f"avibe-memory{MEMORY_PACKAGE_COMPATIBILITY}"
     assert memory_requirement in plan.command
     assert plan.preflight_command is not None
-    assert "--dry-run" in plan.preflight_command
     assert "--force-reinstall" in plan.command
     assert "--no-deps" in plan.command
     assert memory_requirement in plan.preflight_command
@@ -327,8 +436,21 @@ def test_memory_add_plan_force_reinstalls_only_the_compatible_memory_distributio
         assert plan.command[:3] == ["/usr/local/bin/uv", "pip", "install"]
         assert "tool" not in plan.command
         assert plan.command[plan.command.index("--python") + 1] == python_executable
+        assert "--dry-run" in plan.preflight_command
     else:
         assert plan.command[:4] == [python_executable, "-m", "pip", "install"]
+        assert plan.preflight_command[:4] == [
+            python_executable,
+            "-m",
+            "pip",
+            "download",
+        ]
+        assert plan.preflight_command[
+            plan.preflight_command.index("--dest") + 1
+        ] == PIP_DOWNLOAD_DEST_PLACEHOLDER
+        assert "--dry-run" not in plan.preflight_command
+        assert "--force-reinstall" not in plan.preflight_command
+        assert "--no-deps" in plan.preflight_command
 
 
 def test_core_only_rollback_removes_memory_before_the_pinned_install():

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -279,7 +279,7 @@ def test_memory_add_plan_never_force_reinstalls_the_running_core(
         assert plan.command[:4] == [python_executable, "-m", "pip", "install"]
 
 
-def test_core_only_rollback_removes_memory_only_after_the_pinned_install_succeeds():
+def test_core_only_rollback_removes_memory_before_the_pinned_install():
     plan = UpgradePlan(
         command=["installer", "pinned-core"],
         env=None,
@@ -295,7 +295,52 @@ def test_core_only_rollback_removes_memory_only_after_the_pinned_install_succeed
     result = execute_upgrade_plan(plan, run=fake_run, capture_output=True, text=True)
 
     assert result.returncode == 0
-    assert calls == [["installer", "pinned-core"], ["installer", "remove-memory"]]
+    assert calls == [["installer", "remove-memory"], ["installer", "pinned-core"]]
+
+
+def test_core_only_rollback_cleanup_order_preserves_bundled_record_overlap(tmp_path):
+    implementation = tmp_path / "avibe_memory" / "runtime.py"
+    implementation.parent.mkdir()
+    implementation.write_text("split distribution\n", encoding="utf-8")
+    plan = UpgradePlan(
+        command=["installer", "pinned-bundled-core"],
+        env=None,
+        method="test",
+        cleanup_command=["installer", "remove-split-memory"],
+    )
+
+    def fake_run(command, **kwargs):
+        if command == plan.cleanup_command:
+            # pip uninstall follows avibe-memory's RECORD, including paths that
+            # the pre-split host also owns after it is restored.
+            implementation.unlink()
+        else:
+            implementation.write_text("bundled host\n", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    result = execute_upgrade_plan(plan, run=fake_run, capture_output=True, text=True)
+
+    assert result.returncode == 0
+    assert implementation.read_text(encoding="utf-8") == "bundled host\n"
+
+
+def test_core_only_rollback_cleanup_failure_never_mutates_the_host():
+    plan = UpgradePlan(
+        command=["installer", "pinned-core"],
+        env=None,
+        method="test",
+        cleanup_command=["installer", "remove-memory"],
+    )
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 17, stdout="", stderr="cleanup failed")
+
+    result = execute_upgrade_plan(plan, run=fake_run, capture_output=True, text=True)
+
+    assert result.returncode == 17
+    assert calls == [["installer", "remove-memory"]]
 
 
 def test_controller_startup_has_no_python_package_install_path():

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -1400,18 +1400,78 @@ def test_current_cli_install_family_resolves_cached_launcher_symlink(monkeypatch
 
 def test_repair_duplicate_service_processes_stops_only_extra_process(monkeypatch):
     stopped = []
+    mutation_lease_held = False
     paths.ensure_data_dirs()
+
+    @contextmanager
+    def mutation_lock():
+        nonlocal mutation_lease_held
+        mutation_lease_held = True
+        try:
+            yield
+        finally:
+            mutation_lease_held = False
+
+    def stop_pid(pid, timeout=5):
+        assert mutation_lease_held is True
+        stopped.append(pid)
+        return True
+
+    def refresh_status():
+        assert mutation_lease_held is True
+
+    monkeypatch.setattr(cli, "package_mutation_lock", mutation_lock)
     monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
     monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: 1234)
     monkeypatch.setattr(cli.runtime, "extra_service_process_pids", lambda owner_pid=None: [2222])
-    monkeypatch.setattr(cli.runtime, "stop_pid", lambda pid, timeout=5: stopped.append(pid) or True)
-    monkeypatch.setattr(cli, "_write_refreshed_runtime_status", lambda: None)
+    monkeypatch.setattr(cli.runtime, "stop_pid", stop_pid)
+    monkeypatch.setattr(cli, "_write_refreshed_runtime_status", refresh_status)
 
     result = cli._repair_duplicate_service_processes()
 
     assert result["status"] == "repaired"
     assert stopped == [2222]
     assert result["stopped_pids"] == [2222]
+    assert mutation_lease_held is False
+
+
+def test_repair_duplicate_service_processes_starts_under_the_same_package_lease(
+    monkeypatch,
+):
+    mutation_lease_held = False
+    stopped: list[int] = []
+    paths.ensure_data_dirs()
+
+    @contextmanager
+    def mutation_lock():
+        nonlocal mutation_lease_held
+        mutation_lease_held = True
+        try:
+            yield
+        finally:
+            mutation_lease_held = False
+
+    def stop_pid(pid, timeout=5):
+        assert mutation_lease_held is True
+        stopped.append(pid)
+        return True
+
+    def start_after_repair(*args, **kwargs):
+        assert mutation_lease_held is True
+        return {"target": args[0], "status": "repaired", "message": args[1]}
+
+    monkeypatch.setattr(cli, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
+    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: None)
+    monkeypatch.setattr(cli.runtime, "extra_service_process_pids", lambda owner_pid=None: [2222])
+    monkeypatch.setattr(cli.runtime, "stop_pid", stop_pid)
+    monkeypatch.setattr(cli, "_start_service_after_repair", start_after_repair)
+
+    result = cli._repair_duplicate_service_processes()
+
+    assert result["status"] == "repaired"
+    assert stopped == [2222]
+    assert mutation_lease_held is False
 
 
 def _stub_repair_service_restart(monkeypatch, *, live_ui_pid):
@@ -1515,7 +1575,32 @@ def test_repair_stale_install_runtime_stops_only_legacy_extra_process(monkeypatc
 def test_repair_stale_install_runtime_restarts_when_legacy_owner_is_stopped(monkeypatch):
     stopped = []
     statuses = []
+    mutation_lease_held = False
     paths.ensure_data_dirs()
+
+    @contextmanager
+    def mutation_lock():
+        nonlocal mutation_lease_held
+        mutation_lease_held = True
+        try:
+            yield
+        finally:
+            mutation_lease_held = False
+
+    def stop_pid(pid, timeout=5):
+        assert mutation_lease_held is True
+        stopped.append(pid)
+        return True
+
+    def start_service(**kwargs):
+        assert mutation_lease_held is True
+        return 3333
+
+    def write_status(*args):
+        assert mutation_lease_held is True
+        statuses.append(args)
+
+    monkeypatch.setattr(cli, "package_mutation_lock", mutation_lock)
     monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
     monkeypatch.setattr(cli, "_current_cli_install_family", lambda: cli.PACKAGE_NAME)
     monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: 1111)
@@ -1525,11 +1610,11 @@ def test_repair_stale_install_runtime_restarts_when_legacy_owner_is_stopped(monk
         "get_process_command",
         lambda pid: "/home/test/.local/share/uv/tools/vibe-remote/bin/python service_main.py",
     )
-    monkeypatch.setattr(cli.runtime, "stop_pid", lambda pid, timeout=5: stopped.append(pid) or True)
+    monkeypatch.setattr(cli.runtime, "stop_pid", stop_pid)
     monkeypatch.setattr(cli, "_live_ui_server_pid", lambda: None)
-    monkeypatch.setattr(cli.runtime, "start_service", lambda **kwargs: 3333)
+    monkeypatch.setattr(cli.runtime, "start_service", start_service)
     monkeypatch.setattr(cli.runtime, "read_status", lambda: {"ui_pid": 4444})
-    monkeypatch.setattr(cli.runtime, "write_status", lambda *args: statuses.append(args))
+    monkeypatch.setattr(cli.runtime, "write_status", write_status)
 
     result = cli._repair_stale_install_runtime()
 
@@ -1537,6 +1622,7 @@ def test_repair_stale_install_runtime_restarts_when_legacy_owner_is_stopped(monk
     assert stopped == [1111]
     assert result["service_pid"] == 3333
     assert statuses == [("running", "pid=3333", 3333, 4444)]
+    assert mutation_lease_held is False
 
 
 def test_repair_stale_install_runtime_restarts_after_lockless_legacy_stopped(monkeypatch):
@@ -1590,6 +1676,130 @@ def test_repair_stale_install_runtime_reports_failed_when_restart_fails(monkeypa
     assert stopped == [1111]
     assert result["stopped_pids"] == [1111]
     assert refreshed == [True]
+
+
+def _prepare_doctor_lifecycle_repair(monkeypatch, target, *, detected=True):
+    paths.ensure_data_dirs()
+    monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
+    if target == "duplicate-service-processes":
+        monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: 1111)
+        monkeypatch.setattr(
+            cli.runtime,
+            "extra_service_process_pids",
+            lambda owner_pid=None: [2222] if detected else [],
+        )
+        return cli._repair_duplicate_service_processes
+
+    monkeypatch.setattr(cli, "_current_cli_install_family", lambda: cli.PACKAGE_NAME)
+    monkeypatch.setattr(
+        cli.runtime,
+        "resolve_service_owner_pid",
+        lambda include_starting=False: 1111 if detected else None,
+    )
+    monkeypatch.setattr(cli.runtime, "extra_service_process_pids", lambda owner_pid=None: [])
+    monkeypatch.setattr(
+        cli.runtime,
+        "get_process_command",
+        lambda pid: "/home/test/.local/share/uv/tools/vibe-remote/bin/python service_main.py",
+    )
+    return cli._repair_stale_install_runtime
+
+
+@pytest.mark.parametrize(
+    "target",
+    ["duplicate-service-processes", "stale-install-runtime"],
+)
+def test_doctor_lifecycle_repairs_refuse_an_in_flight_restart(
+    monkeypatch,
+    target,
+):
+    repair = _prepare_doctor_lifecycle_repair(monkeypatch, target)
+    monkeypatch.setattr(cli, "restart_in_flight", lambda: True)
+    monkeypatch.setattr(
+        cli.runtime,
+        "stop_pid",
+        lambda *args, **kwargs: pytest.fail("an in-flight restart must prevent service stops"),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_start_service_after_repair",
+        lambda *args, **kwargs: pytest.fail("an in-flight restart must prevent service starts"),
+    )
+
+    result = repair()
+
+    assert result == {
+        "target": target,
+        "status": "failed",
+        "message": "A restart is already in progress; the operation was not performed.",
+        "reason": "restart_in_progress",
+    }
+
+
+@pytest.mark.parametrize(
+    "target",
+    ["duplicate-service-processes", "stale-install-runtime"],
+)
+def test_doctor_lifecycle_repairs_report_package_lease_timeout(
+    monkeypatch,
+    target,
+):
+    repair = _prepare_doctor_lifecycle_repair(monkeypatch, target)
+
+    @contextmanager
+    def blocked_mutation_lock():
+        raise MigrationLockTimeout("package mutation is still running")
+        yield
+
+    monkeypatch.setattr(cli, "_configured_cli_language", lambda: "zh")
+    monkeypatch.setattr(cli, "package_mutation_lock", blocked_mutation_lock)
+    monkeypatch.setattr(
+        cli,
+        "restart_in_flight",
+        lambda: pytest.fail("restart state must be checked only after lease acquisition"),
+    )
+    monkeypatch.setattr(
+        cli.runtime,
+        "stop_pid",
+        lambda *args, **kwargs: pytest.fail("lease timeout must prevent service stops"),
+    )
+
+    result = repair()
+
+    assert result == {
+        "target": target,
+        "status": "failed",
+        "message": "已有软件包操作正在进行，修复未执行。",
+        "reason": "restart_not_scheduled_package_busy",
+    }
+
+
+@pytest.mark.parametrize(
+    "target",
+    ["duplicate-service-processes", "stale-install-runtime"],
+)
+@pytest.mark.parametrize("dry_run", [False, True])
+def test_doctor_lifecycle_repair_skip_and_dry_run_paths_do_not_take_package_lease(
+    monkeypatch,
+    target,
+    dry_run,
+):
+    repair = _prepare_doctor_lifecycle_repair(
+        monkeypatch,
+        target,
+        detected=dry_run,
+    )
+
+    @contextmanager
+    def forbidden_mutation_lock():
+        raise AssertionError("skip and dry-run paths must remain lock-free")
+        yield
+
+    monkeypatch.setattr(cli, "package_mutation_lock", forbidden_mutation_lock)
+
+    result = repair(dry_run=dry_run)
+
+    assert result["status"] == ("planned" if dry_run else "skipped")
 
 
 def test_repair_home_migration_skips_empty_home_without_initializing(monkeypatch, tmp_path):

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import contextmanager, nullcontext
 import json
 import os
 import pytest
@@ -14,6 +15,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from config import paths
+from storage.lock import MigrationLockTimeout
 from vibe import runtime
 from vibe import cli
 from vibe import remote_access
@@ -603,6 +605,21 @@ def test_cmd_restart_schedules_delayed_restart(monkeypatch, capsys):
     scheduled = {}
     stop_called = []
     start_called = []
+    mutation_lease_held = False
+
+    @contextmanager
+    def mutation_lock():
+        nonlocal mutation_lease_held
+        mutation_lease_held = True
+        try:
+            yield
+        finally:
+            mutation_lease_held = False
+
+    def schedule_restart(**kwargs):
+        assert mutation_lease_held is True
+        scheduled.update(kwargs)
+        return {"job_id": "job123"}
 
     monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/usr/local/bin/vibe")
     monkeypatch.setattr(
@@ -611,9 +628,11 @@ def test_cmd_restart_schedules_delayed_restart(monkeypatch, capsys):
         lambda **kwargs: scheduled.update(kwargs) or {"job_id": "job123"},
         raising=False,
     )
-    monkeypatch.setattr(cli, "schedule_restart", lambda **kwargs: scheduled.update(kwargs) or {"job_id": "job123"})
+    monkeypatch.setattr(cli, "schedule_restart", schedule_restart)
     monkeypatch.setattr(cli, "cmd_stop", lambda: stop_called.append(True))
     monkeypatch.setattr(cli, "cmd_vibe", lambda: start_called.append(True))
+    monkeypatch.setattr(cli, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(cli, "restart_in_flight", lambda: False)
 
     assert cli._cmd_restart_with_delay(60) == 0
     assert scheduled == {
@@ -623,6 +642,7 @@ def test_cmd_restart_schedules_delayed_restart(monkeypatch, capsys):
     }
     assert stop_called == []
     assert start_called == []
+    assert mutation_lease_held is False
 
     output = capsys.readouterr().out
     assert "Restart scheduled in 1 minute." in output
@@ -635,6 +655,8 @@ def test_cmd_restart_schedules_delayed_restart_without_cached_vibe(monkeypatch):
 
     monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: None)
     monkeypatch.setattr(cli, "schedule_restart", lambda **kwargs: scheduled.update(kwargs) or {"job_id": "job456"})
+    monkeypatch.setattr(cli, "package_mutation_lock", nullcontext)
+    monkeypatch.setattr(cli, "restart_in_flight", lambda: False)
 
     assert cli._cmd_restart_with_delay(5) == 0
     assert scheduled == {
@@ -646,12 +668,75 @@ def test_cmd_restart_schedules_delayed_restart_without_cached_vibe(monkeypatch):
 
 def test_cmd_restart_schedules_supervisor_by_default(monkeypatch):
     calls = []
+    mutation_lease_held = False
+
+    @contextmanager
+    def mutation_lock():
+        nonlocal mutation_lease_held
+        mutation_lease_held = True
+        try:
+            yield
+        finally:
+            mutation_lease_held = False
+
+    def schedule_restart(**kwargs):
+        assert mutation_lease_held is True
+        calls.append(kwargs)
+        return {"job_id": "job789"}
 
     monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/usr/local/bin/vibe")
-    monkeypatch.setattr(cli, "schedule_restart", lambda **kwargs: calls.append(kwargs) or {"job_id": "job789"})
+    monkeypatch.setattr(cli, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(cli, "restart_in_flight", lambda: False)
+    monkeypatch.setattr(cli, "schedule_restart", schedule_restart)
 
     assert cli._cmd_restart_with_delay(0) == 0
     assert calls == [{"delay_seconds": 0.0, "vibe_path": "/usr/local/bin/vibe", "trigger": "cli"}]
+    assert mutation_lease_held is False
+
+
+@pytest.mark.parametrize("delay_seconds", [0.0, 60.0])
+def test_cmd_restart_refuses_an_in_flight_restart(
+    monkeypatch,
+    capsys,
+    delay_seconds,
+):
+    monkeypatch.setattr(cli, "package_mutation_lock", nullcontext)
+    monkeypatch.setattr(cli, "restart_in_flight", lambda: True)
+    monkeypatch.setattr(
+        cli,
+        "schedule_restart",
+        lambda **kwargs: pytest.fail("restart must not be scheduled"),
+    )
+
+    assert cli._cmd_restart_with_delay(delay_seconds) == 2
+    assert "restart is already in progress" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("delay_seconds", [0.0, 60.0])
+def test_cmd_restart_fails_closed_when_package_lease_is_held(
+    monkeypatch,
+    capsys,
+    delay_seconds,
+):
+    @contextmanager
+    def blocked_mutation_lock():
+        raise MigrationLockTimeout("package mutation is still running")
+        yield
+
+    monkeypatch.setattr(cli, "package_mutation_lock", blocked_mutation_lock)
+    monkeypatch.setattr(
+        cli,
+        "restart_in_flight",
+        lambda: pytest.fail("status must be checked after acquiring the lease"),
+    )
+    monkeypatch.setattr(
+        cli,
+        "schedule_restart",
+        lambda **kwargs: pytest.fail("restart must not be scheduled"),
+    )
+
+    assert cli._cmd_restart_with_delay(delay_seconds) == 2
+    assert "restart is already in progress" in capsys.readouterr().out
 
 
 def test_cmd_stop_ignores_absent_services(monkeypatch):

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -745,6 +745,26 @@ def test_cmd_restart_fails_closed_when_package_lease_is_held(
     assert "restart is already in progress" in capsys.readouterr().out
 
 
+@pytest.mark.parametrize(
+    ("operation", "expected"),
+    [
+        ("upgrade", "已有重启正在进行，升级未执行。"),
+        ("restart", "已有重启正在进行，未安排新的重启。"),
+        ("lifecycle", "已有重启正在进行，操作未执行。"),
+    ],
+)
+def test_restart_contention_messages_follow_configured_cli_language(
+    monkeypatch,
+    capsys,
+    operation,
+    expected,
+):
+    monkeypatch.setattr(cli, "_configured_cli_language", lambda: "zh")
+
+    assert cli._restart_in_progress_exit(operation=operation) == 2
+    assert expected in capsys.readouterr().out
+
+
 def test_cmd_stop_ignores_absent_services(monkeypatch):
     status = []
 

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -719,10 +719,19 @@ def test_cmd_restart_refuses_an_in_flight_restart(
 
 
 @pytest.mark.parametrize("delay_seconds", [0.0, 60.0])
+@pytest.mark.parametrize(
+    ("restart_live", "expected"),
+    [
+        (True, "restart is already in progress"),
+        (False, "package operation is already in progress"),
+    ],
+)
 def test_cmd_restart_fails_closed_when_package_lease_is_held(
     monkeypatch,
     capsys,
     delay_seconds,
+    restart_live,
+    expected,
 ):
     @contextmanager
     def blocked_mutation_lock():
@@ -730,11 +739,7 @@ def test_cmd_restart_fails_closed_when_package_lease_is_held(
         yield
 
     monkeypatch.setattr(cli, "package_mutation_lock", blocked_mutation_lock)
-    monkeypatch.setattr(
-        cli,
-        "restart_in_flight",
-        lambda: pytest.fail("status must be checked after acquiring the lease"),
-    )
+    monkeypatch.setattr(cli, "restart_in_flight", lambda: restart_live)
     monkeypatch.setattr(
         cli,
         "schedule_restart",
@@ -742,7 +747,7 @@ def test_cmd_restart_fails_closed_when_package_lease_is_held(
     )
 
     assert cli._cmd_restart_with_delay(delay_seconds) == 2
-    assert "restart is already in progress" in capsys.readouterr().out
+    assert expected in capsys.readouterr().out
 
 
 @pytest.mark.parametrize(
@@ -830,10 +835,19 @@ def test_cli_start_stop_refuse_an_in_flight_restart(monkeypatch, capsys, command
 
 
 @pytest.mark.parametrize("command_name", ["cmd_start", "cmd_stop"])
+@pytest.mark.parametrize(
+    ("restart_live", "expected"),
+    [
+        (True, "restart is already in progress"),
+        (False, "package operation is already in progress"),
+    ],
+)
 def test_cli_start_stop_fail_closed_when_package_lease_is_held(
     monkeypatch,
     capsys,
     command_name,
+    restart_live,
+    expected,
 ):
     @contextmanager
     def blocked_mutation_lock():
@@ -841,11 +855,7 @@ def test_cli_start_stop_fail_closed_when_package_lease_is_held(
         yield
 
     monkeypatch.setattr(cli, "package_mutation_lock", blocked_mutation_lock)
-    monkeypatch.setattr(
-        cli,
-        "restart_in_flight",
-        lambda: pytest.fail("status must be checked after acquiring the lease"),
-    )
+    monkeypatch.setattr(cli, "restart_in_flight", lambda: restart_live)
     monkeypatch.setattr(
         cli,
         f"_{command_name}_under_package_lease",
@@ -854,7 +864,7 @@ def test_cli_start_stop_fail_closed_when_package_lease_is_held(
     )
 
     assert getattr(cli, command_name)() == 2
-    assert "restart is already in progress" in capsys.readouterr().out
+    assert expected in capsys.readouterr().out
 
 
 def test_cmd_stop_fails_when_live_service_survives(monkeypatch, capsys):

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -21,6 +21,12 @@ from vibe import cli
 from vibe import remote_access
 
 
+@pytest.fixture(autouse=True)
+def _no_lifecycle_contention(monkeypatch):
+    monkeypatch.setattr(cli, "package_mutation_lock", nullcontext)
+    monkeypatch.setattr(cli, "restart_in_flight", lambda: False)
+
+
 def _make_fake_uv_tool(
     tmp_path: Path,
     *,
@@ -750,6 +756,85 @@ def test_cmd_stop_ignores_absent_services(monkeypatch):
 
     assert cli.cmd_stop() == 0
     assert status == [("stopped", None)]
+
+
+@pytest.mark.parametrize(
+    ("command_name", "implementation_name"),
+    [
+        ("cmd_start", "_cmd_start_under_package_lease"),
+        ("cmd_stop", "_cmd_stop_under_package_lease"),
+    ],
+)
+def test_cli_start_stop_hold_package_lease_through_the_action(
+    monkeypatch,
+    command_name,
+    implementation_name,
+):
+    mutation_lease_held = False
+    calls: list[bool] = []
+
+    @contextmanager
+    def mutation_lock():
+        nonlocal mutation_lease_held
+        mutation_lease_held = True
+        try:
+            yield
+        finally:
+            mutation_lease_held = False
+
+    monkeypatch.setattr(cli, "package_mutation_lock", mutation_lock)
+    monkeypatch.setattr(
+        cli,
+        implementation_name,
+        lambda: calls.append(mutation_lease_held) or 0,
+        raising=False,
+    )
+
+    assert getattr(cli, command_name)() == 0
+    assert calls == [True]
+    assert mutation_lease_held is False
+
+
+@pytest.mark.parametrize("command_name", ["cmd_start", "cmd_stop"])
+def test_cli_start_stop_refuse_an_in_flight_restart(monkeypatch, capsys, command_name):
+    monkeypatch.setattr(cli, "restart_in_flight", lambda: True)
+    monkeypatch.setattr(
+        cli,
+        f"_{command_name}_under_package_lease",
+        lambda: pytest.fail("lifecycle action must not run"),
+        raising=False,
+    )
+
+    assert getattr(cli, command_name)() == 2
+    assert "restart is already in progress" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("command_name", ["cmd_start", "cmd_stop"])
+def test_cli_start_stop_fail_closed_when_package_lease_is_held(
+    monkeypatch,
+    capsys,
+    command_name,
+):
+    @contextmanager
+    def blocked_mutation_lock():
+        raise MigrationLockTimeout("package mutation is still running")
+        yield
+
+    monkeypatch.setattr(cli, "package_mutation_lock", blocked_mutation_lock)
+    monkeypatch.setattr(
+        cli,
+        "restart_in_flight",
+        lambda: pytest.fail("status must be checked after acquiring the lease"),
+    )
+    monkeypatch.setattr(
+        cli,
+        f"_{command_name}_under_package_lease",
+        lambda: pytest.fail("lifecycle action must not run"),
+        raising=False,
+    )
+
+    assert getattr(cli, command_name)() == 2
+    assert "restart is already in progress" in capsys.readouterr().out
 
 
 def test_cmd_stop_fails_when_live_service_survives(monkeypatch, capsys):

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -1474,6 +1474,61 @@ def test_repair_duplicate_service_processes_starts_under_the_same_package_lease(
     assert mutation_lease_held is False
 
 
+def test_repair_duplicate_service_processes_resamples_promoted_owner(monkeypatch):
+    paths.ensure_data_dirs()
+    owners = iter([None, 2222])
+    owner_samples: list[int | None] = []
+
+    def resolve_owner(*, include_starting=False):
+        owner = next(owners)
+        owner_samples.append(owner)
+        return owner
+
+    def extra_pids(*, owner_pid=None):
+        return [2222] if owner_pid is None else []
+
+    monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
+    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", resolve_owner)
+    monkeypatch.setattr(cli.runtime, "extra_service_process_pids", extra_pids)
+    monkeypatch.setattr(
+        cli.runtime,
+        "stop_pid",
+        lambda *args, **kwargs: pytest.fail("the promoted owner must not be stopped"),
+    )
+
+    result = cli._repair_duplicate_service_processes()
+
+    assert result["status"] == "skipped"
+    assert owner_samples == [None, 2222]
+
+
+def test_repair_duplicate_service_processes_uses_still_extra_resample(monkeypatch):
+    paths.ensure_data_dirs()
+    owners = iter([None, 1111])
+    stopped: list[int] = []
+
+    monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
+    monkeypatch.setattr(
+        cli.runtime,
+        "resolve_service_owner_pid",
+        lambda include_starting=False: next(owners),
+    )
+    monkeypatch.setattr(cli.runtime, "extra_service_process_pids", lambda owner_pid=None: [2222])
+    monkeypatch.setattr(cli.runtime, "stop_pid", lambda pid, timeout=5: stopped.append(pid) or True)
+    monkeypatch.setattr(cli, "_write_refreshed_runtime_status", lambda: None)
+    monkeypatch.setattr(
+        cli,
+        "_start_service_after_repair",
+        lambda *args, **kwargs: pytest.fail("the resampled owner keeps the service running"),
+    )
+
+    result = cli._repair_duplicate_service_processes()
+
+    assert result["status"] == "repaired"
+    assert result["stopped_pids"] == [2222]
+    assert stopped == [2222]
+
+
 def _stub_repair_service_restart(monkeypatch, *, live_ui_pid):
     """Wire _start_service_after_repair onto fakes and record what each side got."""
 
@@ -1548,19 +1603,20 @@ def test_repair_still_reports_success_when_the_ui_restart_fails(monkeypatch):
 def test_repair_stale_install_runtime_stops_only_legacy_extra_process(monkeypatch):
     stopped = []
     refreshed = []
+    classified: list[int] = []
     paths.ensure_data_dirs()
     monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
     monkeypatch.setattr(cli, "_current_cli_install_family", lambda: cli.PACKAGE_NAME)
     monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: 1111)
     monkeypatch.setattr(cli.runtime, "extra_service_process_pids", lambda owner_pid=None: [2222])
-    monkeypatch.setattr(
-        cli.runtime,
-        "get_process_command",
-        lambda pid: {
+    def get_process_command(pid):
+        classified.append(pid)
+        return {
             1111: "/home/test/.local/share/uv/tools/avibe-os/bin/python service_main.py",
             2222: "/home/test/.local/share/uv/tools/vibe-remote/bin/python service_main.py",
-        }[pid],
-    )
+        }[pid]
+
+    monkeypatch.setattr(cli.runtime, "get_process_command", get_process_command)
     monkeypatch.setattr(cli.runtime, "stop_pid", lambda pid, timeout=5: stopped.append(pid) or True)
     monkeypatch.setattr(cli.runtime, "start_service", lambda: (_ for _ in ()).throw(AssertionError("must not restart current owner")))
     monkeypatch.setattr(cli, "_write_refreshed_runtime_status", lambda: refreshed.append(True))
@@ -1570,6 +1626,38 @@ def test_repair_stale_install_runtime_stops_only_legacy_extra_process(monkeypatc
     assert result["status"] == "repaired"
     assert stopped == [2222]
     assert refreshed == [True]
+    assert classified == [1111, 2222, 1111, 2222]
+
+
+def test_repair_stale_install_runtime_resamples_process_family(monkeypatch):
+    paths.ensure_data_dirs()
+    commands = iter(
+        [
+            "/home/test/.local/share/uv/tools/vibe-remote/bin/python service_main.py",
+            "/home/test/.local/share/uv/tools/avibe-os/bin/python service_main.py",
+        ]
+    )
+    classified: list[int] = []
+
+    def get_process_command(pid):
+        classified.append(pid)
+        return next(commands)
+
+    monkeypatch.setattr(cli.runtime, "service_instance_lock_attached_to_process", lambda: False)
+    monkeypatch.setattr(cli, "_current_cli_install_family", lambda: cli.PACKAGE_NAME)
+    monkeypatch.setattr(cli.runtime, "resolve_service_owner_pid", lambda include_starting=False: 1111)
+    monkeypatch.setattr(cli.runtime, "extra_service_process_pids", lambda owner_pid=None: [])
+    monkeypatch.setattr(cli.runtime, "get_process_command", get_process_command)
+    monkeypatch.setattr(
+        cli.runtime,
+        "stop_pid",
+        lambda *args, **kwargs: pytest.fail("a current-family process must not be stopped"),
+    )
+
+    result = cli._repair_stale_install_runtime()
+
+    assert result["status"] == "skipped"
+    assert classified == [1111, 1111]
 
 
 def test_repair_stale_install_runtime_restarts_when_legacy_owner_is_stopped(monkeypatch):
@@ -1778,28 +1866,50 @@ def test_doctor_lifecycle_repairs_report_package_lease_timeout(
     "target",
     ["duplicate-service-processes", "stale-install-runtime"],
 )
-@pytest.mark.parametrize("dry_run", [False, True])
-def test_doctor_lifecycle_repair_skip_and_dry_run_paths_do_not_take_package_lease(
+def test_doctor_lifecycle_repair_dry_run_does_not_take_package_lease(
     monkeypatch,
     target,
-    dry_run,
 ):
-    repair = _prepare_doctor_lifecycle_repair(
-        monkeypatch,
-        target,
-        detected=dry_run,
-    )
+    repair = _prepare_doctor_lifecycle_repair(monkeypatch, target)
 
     @contextmanager
     def forbidden_mutation_lock():
-        raise AssertionError("skip and dry-run paths must remain lock-free")
+        raise AssertionError("dry-run paths must remain lock-free")
         yield
 
     monkeypatch.setattr(cli, "package_mutation_lock", forbidden_mutation_lock)
 
-    result = repair(dry_run=dry_run)
+    result = repair(dry_run=True)
 
-    assert result["status"] == ("planned" if dry_run else "skipped")
+    assert result["status"] == "planned"
+
+
+@pytest.mark.parametrize(
+    "target",
+    ["duplicate-service-processes", "stale-install-runtime"],
+)
+def test_doctor_lifecycle_repair_empty_resample_happens_under_package_lease(
+    monkeypatch,
+    target,
+):
+    repair = _prepare_doctor_lifecycle_repair(monkeypatch, target, detected=False)
+    mutation_lease_held = False
+
+    @contextmanager
+    def mutation_lock():
+        nonlocal mutation_lease_held
+        mutation_lease_held = True
+        try:
+            yield
+        finally:
+            mutation_lease_held = False
+
+    monkeypatch.setattr(cli, "package_mutation_lock", mutation_lock)
+
+    result = repair()
+
+    assert result["status"] == "skipped"
+    assert mutation_lease_held is False
 
 
 def test_repair_home_migration_skips_empty_home_without_initializing(monkeypatch, tmp_path):

--- a/ui/src/components/settings/SettingsServicePage.test.tsx
+++ b/ui/src/components/settings/SettingsServicePage.test.tsx
@@ -1,0 +1,74 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SettingsServicePage } from './SettingsServicePage';
+
+const api = vi.hoisted(() => ({
+  getConfig: vi.fn(),
+}));
+const status = vi.hoisted(() => ({
+  control: vi.fn(),
+  value: { state: 'running', service_pid: 123 },
+}));
+const showToast = vi.hoisted(() => vi.fn());
+
+vi.mock('@/context/ApiContext', () => ({ useApi: () => api }));
+vi.mock('@/context/StatusContext', () => ({
+  useStatus: () => ({ status: status.value, control: status.control }),
+}));
+vi.mock('@/context/ToastContext', () => ({
+  useToast: () => ({ showToast }),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('./SettingsPageShell', () => ({
+  SettingsPageShell: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const renderPage = () => render(
+  <MemoryRouter>
+    <SettingsServicePage />
+  </MemoryRouter>,
+);
+
+beforeEach(() => {
+  api.getConfig.mockResolvedValue({
+    ui: { setup_host: '127.0.0.1', setup_port: 5123 },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('SettingsServicePage lifecycle contention', () => {
+  it.each([
+    ['restart_in_progress', 'settings.service.restartInProgress'],
+    ['restart_not_scheduled_package_busy', 'settings.service.packageMutationBusy'],
+  ])('shows a localized error toast for %s', async (code, message) => {
+    status.control.mockRejectedValue(Object.assign(new Error(code), { code }));
+    renderPage();
+
+    await userEvent.click(screen.getByRole('button', { name: 'common.restart' }));
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(message, 'error'));
+  });
+
+  it('keeps unexpected control failures on the existing logging path', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    status.control.mockRejectedValue(new Error('unexpected'));
+    renderPage();
+
+    await userEvent.click(screen.getByRole('button', { name: 'common.restart' }));
+
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+    expect(showToast).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/ui/src/components/settings/SettingsServicePage.tsx
+++ b/ui/src/components/settings/SettingsServicePage.tsx
@@ -77,11 +77,33 @@ export const SettingsServicePage: React.FC = () => {
         setConfigField(['ui', 'setup_host'], uiPayload.setup_host),
         setConfigField(['ui', 'setup_port'], uiPayload.setup_port),
       ]);
-      await apiFetch('/api/ui/reload', {
+      const reloadResponse = await apiFetch('/api/ui/reload', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ host: uiPayload.setup_host, port: uiPayload.setup_port }),
       });
+      let reloadBody: { ok?: boolean; code?: string; error?: unknown; message?: string } | null = null;
+      try {
+        reloadBody = await reloadResponse.json();
+      } catch {
+        reloadBody = null;
+      }
+      if (!reloadResponse.ok || reloadBody?.ok === false) {
+        if (reloadBody?.code === 'restart_in_progress') {
+          setUiMessage(t('settings.service.restartInProgress'));
+        } else if (reloadBody?.code === 'restart_not_scheduled_package_busy') {
+          setUiMessage(t('settings.service.packageMutationBusy'));
+        } else {
+          const reloadError =
+            typeof reloadBody?.error === 'string'
+              ? reloadBody.error
+              : typeof reloadBody?.message === 'string'
+                ? reloadBody.message
+                : null;
+          setUiMessage(reloadError || t('common.saveFailed'));
+        }
+        return;
+      }
       // If the UI server's bind host or port changed, the current page is on
       // the old origin and may become unreachable. Redirect (or surface the
       // new origin) so the user is not stranded.

--- a/ui/src/components/settings/SettingsServicePage.tsx
+++ b/ui/src/components/settings/SettingsServicePage.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 
 import { useStatus } from '@/context/StatusContext';
 import { useApi } from '@/context/ApiContext';
+import { useToast } from '@/context/ToastContext';
 import { apiFetch } from '@/lib/apiFetch';
 import { SettingsPageShell } from './SettingsPageShell';
 import { CompactField, SettingsPanel, SettingsRow } from './SettingsPrimitives';
@@ -19,6 +20,7 @@ import { applyAppTitle } from '@/lib/documentTitle';
 export const SettingsServicePage: React.FC = () => {
   const { t } = useTranslation();
   const { status, control } = useStatus();
+  const { showToast } = useToast();
   const api = useApi();
   const navigate = useNavigate();
   // Back-compat: Remote Access moved to its own page. Old deep links to the
@@ -46,6 +48,12 @@ export const SettingsServicePage: React.FC = () => {
     try {
       await control(action);
     } catch (e) {
+      const code = (e as { code?: unknown } | null)?.code;
+      if (code === 'restart_in_progress') {
+        showToast(t('settings.service.restartInProgress'), 'error');
+      } else if (code === 'restart_not_scheduled_package_busy') {
+        showToast(t('settings.service.packageMutationBusy'), 'error');
+      }
       console.error('Service control action failed', e);
     } finally {
       setLoading(false);

--- a/ui/src/components/settings/SettingsServicePage.uiReload.test.tsx
+++ b/ui/src/components/settings/SettingsServicePage.uiReload.test.tsx
@@ -1,0 +1,82 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SettingsServicePage } from './SettingsServicePage';
+
+const api = vi.hoisted(() => ({
+  getConfig: vi.fn(),
+  mutateConfig: vi.fn(),
+}));
+const status = vi.hoisted(() => ({
+  control: vi.fn(),
+  value: { state: 'running', service_pid: 123 },
+}));
+const apiFetch = vi.hoisted(() => vi.fn());
+
+vi.mock('@/context/ApiContext', () => ({ useApi: () => api }));
+vi.mock('@/context/StatusContext', () => ({
+  useStatus: () => ({ status: status.value, control: status.control }),
+}));
+vi.mock('@/context/ToastContext', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('@/lib/apiFetch', () => ({ apiFetch }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('./SettingsPageShell', () => ({
+  SettingsPageShell: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const renderPage = () => render(
+  <MemoryRouter>
+    <SettingsServicePage />
+  </MemoryRouter>,
+);
+
+beforeEach(() => {
+  api.getConfig.mockResolvedValue({
+    ui: { setup_host: '127.0.0.2', setup_port: 6000 },
+  });
+  api.mutateConfig.mockResolvedValue({});
+  apiFetch.mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe('SettingsServicePage UI reload admission', () => {
+  it.each([
+    ['restart_in_progress', 'settings.service.restartInProgress'],
+    ['restart_not_scheduled_package_busy', 'settings.service.packageMutationBusy'],
+  ])('surfaces %s without redirecting', async (code, message) => {
+    apiFetch.mockResolvedValue(
+      new Response(JSON.stringify({ ok: false, code, error: 'busy' }), { status: 409 }),
+    );
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+    renderPage();
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'common.saveAndRestart' })).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'common.saveAndRestart' }));
+
+    await waitFor(() => expect(screen.getByText(message)).toBeTruthy());
+    expect(setTimeoutSpy.mock.calls.some(([, delay]) => delay === 1500)).toBe(false);
+  });
+
+  it('keeps the success redirect after an admitted reload', async () => {
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+    renderPage();
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'common.saveAndRestart' })).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'common.saveAndRestart' }));
+    await waitFor(() => expect(screen.getByText(/settings\.consoleServerRedirecting/)).toBeTruthy());
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1500);
+  });
+});

--- a/ui/src/components/settings/memory/memoryCopyContract.test.ts
+++ b/ui/src/components/settings/memory/memoryCopyContract.test.ts
@@ -86,8 +86,21 @@ describe('Memory UI copy contracts', () => {
       'memory_delete_data_failed',
       'memory_plugin_unavailable',
       'memory_plugin_incompatible',
+      'memory_runtime_restart_required',
+      'restart_in_progress',
     ] as const) {
       expect(bundles[language].errors[key]).toBeTruthy();
     }
+  });
+
+  it('keeps dependency restart guidance explicit in both locales', () => {
+    expect(en.errors.memory_runtime_restart_required).toBe(
+      'Memory package installed. Restart Avibe to activate it.',
+    );
+    expect(en.errors.restart_in_progress).toBe(
+      'A restart is already in progress. Try again after it finishes.',
+    );
+    expect(zh.errors.memory_runtime_restart_required).toBe('Memory 包已安装，请重启 Avibe 以启用。');
+    expect(zh.errors.restart_in_progress).toBe('已有重启正在进行，请等待其完成后再试。');
   });
 });

--- a/ui/src/components/settings/shared/useBackendRuntime.test.ts
+++ b/ui/src/components/settings/shared/useBackendRuntime.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import en from '@/i18n/en.json';
+import zh from '@/i18n/zh.json';
+
+import { backendRuntimeApplyError } from './useBackendRuntime';
+
+describe('backendRuntimeApplyError', () => {
+  it('localizes package-mutation contention by stable restart code', () => {
+    expect(
+      backendRuntimeApplyError(
+        {
+          agent_backend_runtime: {
+            restart_code: 'restart_not_scheduled_package_busy',
+            restart_error: 'a package operation is in progress; restart was not scheduled',
+          },
+        },
+        'Save failed',
+        '已有软件包操作正在进行，未安排重启。',
+      ),
+    ).toBe('已有软件包操作正在进行，未安排重启。');
+  });
+
+  it('preserves backend error text for other restart codes', () => {
+    expect(
+      backendRuntimeApplyError(
+        {
+          agent_backend_runtime: {
+            restart_code: 'restart_spawn_failed',
+            restart_error: 'supervisor unavailable',
+          },
+        },
+        'Save failed',
+        'localized busy message',
+      ),
+    ).toBe('supervisor unavailable');
+  });
+
+  it('ships the package-mutation message in both UI locales', () => {
+    expect(en.settings.agentBackend.packageMutationBusy).toBe(
+      'A package operation is in progress; restart was not scheduled.',
+    );
+    expect(zh.settings.agentBackend.packageMutationBusy).toBe(
+      '已有软件包操作正在进行，未安排重启。',
+    );
+  });
+});

--- a/ui/src/components/settings/shared/useBackendRuntime.ts
+++ b/ui/src/components/settings/shared/useBackendRuntime.ts
@@ -67,11 +67,16 @@ type BackendRuntimeApplyResult = {
   hot_reconciled?: boolean;
   restart_scheduled?: boolean;
   apply_on_next_start?: boolean;
+  restart_code?: string;
   restart_error?: string;
   error?: string;
 };
 
-const assertBackendRuntimeApplied = (savedConfig: unknown, fallbackMessage: string) => {
+export const backendRuntimeApplyError = (
+  savedConfig: unknown,
+  fallbackMessage: string,
+  packageMutationBusyMessage: string,
+): string | null => {
   const runtime = (
     savedConfig as { agent_backend_runtime?: BackendRuntimeApplyResult } | null
   )?.agent_backend_runtime;
@@ -81,9 +86,25 @@ const assertBackendRuntimeApplied = (savedConfig: unknown, fallbackMessage: stri
     runtime.restart_scheduled === true ||
     runtime.apply_on_next_start === true
   ) {
-    return;
+    return null;
   }
-  throw new Error(runtime.restart_error || runtime.error || fallbackMessage);
+  if (runtime.restart_code === 'restart_not_scheduled_package_busy') {
+    return packageMutationBusyMessage;
+  }
+  return runtime.restart_error || runtime.error || fallbackMessage;
+};
+
+const assertBackendRuntimeApplied = (
+  savedConfig: unknown,
+  fallbackMessage: string,
+  packageMutationBusyMessage: string,
+) => {
+  const message = backendRuntimeApplyError(
+    savedConfig,
+    fallbackMessage,
+    packageMutationBusyMessage,
+  );
+  if (message) throw new Error(message);
 };
 
 /**
@@ -210,7 +231,11 @@ export function useBackendRuntime({
       // The config boundary owns both persistence and live runtime
       // reconciliation. A second route-level restart would refresh the backend
       // twice and could interrupt a transport that was just rebuilt.
-      assertBackendRuntimeApplied(saved, t('common.saveFailed'));
+      assertBackendRuntimeApplied(
+        saved,
+        t('common.saveFailed'),
+        t('settings.agentBackend.packageMutationBusy'),
+      );
       setSavedCliPath(cliPath);
       showToast(t('common.saved'), 'success');
     } catch (e) {
@@ -235,7 +260,11 @@ export function useBackendRuntime({
           setConfigField(['agents', backend, 'enabled'], next),
         ]);
         saved = true;
-        assertBackendRuntimeApplied(savedConfig, t('common.saveFailed'));
+        assertBackendRuntimeApplied(
+          savedConfig,
+          t('common.saveFailed'),
+          t('settings.agentBackend.packageMutationBusy'),
+        );
       } catch (e) {
         showToast(errorMessage(e) || t('common.saveFailed'), 'error');
         if (!saved) setEnabled(!next);

--- a/ui/src/components/steps/WeChatConfig.test.tsx
+++ b/ui/src/components/steps/WeChatConfig.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import en from '../../i18n/en.json';
+import zh from '../../i18n/zh.json';
+import { WeChatConfig } from './WeChatConfig';
+
+const mocks = vi.hoisted(() => ({
+  wechatStartLogin: vi.fn(),
+  wechatPollLogin: vi.fn(),
+}));
+
+vi.mock('../../context/ApiContext', () => ({
+  useApi: () => mocks,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('WeChatConfig restart activation notice', () => {
+  it('shows the localized restart notice after login is saved without a restart', async () => {
+    mocks.wechatStartLogin.mockResolvedValue({
+      qrcode_url: 'https://wechat.example.test/login',
+      session_key: 'qr-session',
+    });
+    mocks.wechatPollLogin.mockResolvedValue({
+      status: 'confirmed',
+      bot_token: 'wechat-token',
+      restart_scheduled: false,
+      restart_reason: 'restart_not_scheduled_package_busy',
+    });
+
+    render(
+      <WeChatConfig
+        data={{ wechat: {} }}
+        onNext={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText('wechatConfig.restartRequired')).toBeTruthy();
+    expect(en.wechatConfig.restartRequired).toBe('Login saved. A restart is needed to activate it.');
+    expect(zh.wechatConfig.restartRequired).toBe('登录已保存，需重启后生效。');
+  });
+});

--- a/ui/src/components/steps/WeChatConfig.tsx
+++ b/ui/src/components/steps/WeChatConfig.tsx
@@ -171,7 +171,11 @@ export const WeChatConfig: React.FC<WeChatConfigProps> = ({
           setNeedsVerifyCode(false);
           setVerifyCode('');
           setLoginState('connected');
-          setMessage(result.message || t('wechatConfig.connected'));
+          setMessage(
+            result.restart_scheduled === false
+              ? t('wechatConfig.restartRequired')
+              : result.message || t('wechatConfig.connected')
+          );
           setBotToken(result.bot_token || '');
           setBaseUrl(result.base_url || '');
           activeSessionKeyRef.current = null;
@@ -233,7 +237,11 @@ export const WeChatConfig: React.FC<WeChatConfigProps> = ({
         setNeedsVerifyCode(false);
         setVerifyCode('');
         setLoginState('connected');
-        setMessage(result.message || t('wechatConfig.connected'));
+        setMessage(
+          result.restart_scheduled === false
+            ? t('wechatConfig.restartRequired')
+            : result.message || t('wechatConfig.connected')
+        );
         setBotToken(result.bot_token || '');
         setBaseUrl(result.base_url || '');
         activeSessionKeyRef.current = null;

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1778,6 +1778,8 @@
     "memory_runtime_missing": "The memory-runtime dependency isn't installed yet.",
     "memory_runtime_unsupported": "The memory-runtime dependency isn't supported on this platform.",
     "memory_runtime_install_failed": "The memory-runtime dependency failed to install.",
+    "memory_runtime_restart_required": "Memory package installed. Restart Avibe to activate it.",
+    "restart_in_progress": "A restart is already in progress. Try again after it finishes.",
     "memory_runtime_install_requires_disabled_memory": "Turn Memory off in Settings \u2192 Memory before repairing a running Memory runtime.",
     "memory_reconcile_failed": "Avibe couldn't apply the Memory settings. Check the runtime logs for the failing step.",
     "memory_sidecar_unavailable": "The Memory sidecar isn't reachable right now.",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -322,6 +322,9 @@
     "platformsSubtitle": "Configure which messaging platforms are connected and how each one is enabled.",
     "backendsTitle": "Backends",
     "backendsSubtitle": "Manage agent backends, default routing, and local CLI availability.",
+    "agentBackend": {
+      "packageMutationBusy": "A package operation is in progress; restart was not scheduled."
+    },
     "dependenciesTitle": "Dependencies",
     "dependenciesSubtitle": "Local runtimes that Avibe installs and keeps up to date automatically.",
     "dependencies": {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2560,6 +2560,7 @@
     "submitVerifyCode": "Continue",
     "scanHint": "Open WeChat on your phone and scan this QR code to log in.",
     "connected": "WeChat connected successfully!",
+    "restartRequired": "Login saved. A restart is needed to activate it.",
     "connectedTitle": "Connected",
     "connectionEstablished": "WeChat connection established",
     "nextStepTitle": "Next Step",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -306,6 +306,10 @@
     "logFileLabel": "Log file",
     "serviceRuntimeTitle": "Runtime control",
     "serviceRuntimeSubtitle": "Start, stop, and restart the local Avibe service while checking the live process state.",
+    "service": {
+      "restartInProgress": "A restart is already in progress. Try again after it finishes.",
+      "packageMutationBusy": "A package operation is in progress. Try again after it finishes."
+    },
     "statusNow": "Current state",
     "consoleServerTitle": "Console server",
     "consoleServerHint": "Saving these values restarts only the Web UI server.",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -306,6 +306,10 @@
     "logFileLabel": "日志文件",
     "serviceRuntimeTitle": "运行控制",
     "serviceRuntimeSubtitle": "查看本地 Avibe 进程状态，并执行启动、停止和重启。",
+    "service": {
+      "restartInProgress": "已有重启正在进行，请等待其完成后再试。",
+      "packageMutationBusy": "已有软件包操作正在进行，请等待其完成后再试。"
+    },
     "statusNow": "当前状态",
     "consoleServerTitle": "控制台服务",
     "consoleServerHint": "保存这些值只会重启 Web UI 服务，不会重启主服务。",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2560,6 +2560,7 @@
     "submitVerifyCode": "继续",
     "scanHint": "打开手机微信，扫描此二维码登录。",
     "connected": "微信连接成功！",
+    "restartRequired": "登录已保存，需重启后生效。",
     "connectedTitle": "已连接",
     "connectionEstablished": "微信连接已建立",
     "nextStepTitle": "下一步",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -322,6 +322,9 @@
     "platformsSubtitle": "配置启用哪些消息平台，以及每个平台的接入状态。",
     "backendsTitle": "后端",
     "backendsSubtitle": "管理 agent 后端、默认路由和本地 CLI 可用性。",
+    "agentBackend": {
+      "packageMutationBusy": "已有软件包操作正在进行，未安排重启。"
+    },
     "dependenciesTitle": "依赖",
     "dependenciesSubtitle": "Avibe 自动安装并保持最新的本地运行时。",
     "dependencies": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1778,6 +1778,8 @@
     "memory_runtime_missing": "memory-runtime 依赖尚未安装。",
     "memory_runtime_unsupported": "memory-runtime 依赖在此平台上不受支持。",
     "memory_runtime_install_failed": "memory-runtime 依赖安装失败。",
+    "memory_runtime_restart_required": "Memory 包已安装，请重启 Avibe 以启用。",
+    "restart_in_progress": "已有重启正在进行，请等待其完成后再试。",
     "memory_runtime_install_requires_disabled_memory": "记忆运行时正在使用中。请先在「设置 → 记忆」中关闭记忆，再修复。",
     "memory_reconcile_failed": "Avibe 无法应用记忆设置。请查看运行时日志了解失败步骤。",
     "memory_sidecar_unavailable": "记忆 sidecar 当前不可访问。",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -60,10 +60,14 @@ from vibe.opencode_config import (
 )
 from vibe.build_identity import get_build_identity
 from vibe.upgrade import (
+    PACKAGE_NAME,
     build_upgrade_plan,
+    configured_memory_enabled,
+    execute_upgrade_plan,
     get_latest_version_info,
     get_running_vibe_path,
     get_safe_cwd,
+    installed_package_name,
     should_skip_show_runtime_prepare,
 )
 from vibe.restart_supervisor import schedule_restart
@@ -6116,7 +6120,11 @@ def get_local_version_info() -> dict:
     return {"current": __version__, "build": get_build_identity().as_dict()}
 
 
-def do_upgrade(auto_restart: bool = True) -> dict:
+def do_upgrade(
+    auto_restart: bool = True,
+    *,
+    memory_enabled: bool | None = None,
+) -> dict:
     """Perform upgrade to latest version.
 
     Args:
@@ -6126,7 +6134,14 @@ def do_upgrade(auto_restart: bool = True) -> dict:
         {"ok": bool, "message": str, "output": str | None, "restarting": bool}
     """
     current_vibe_path = get_running_vibe_path()
-    plan = build_upgrade_plan(vibe_path=current_vibe_path)
+    plan = build_upgrade_plan(
+        vibe_path=current_vibe_path,
+        memory_enabled=(
+            configured_memory_enabled()
+            if memory_enabled is None
+            else memory_enabled
+        ),
+    )
     runtime_was_running = _runtime_process_was_running()
 
     # Use a stable directory as cwd to avoid "Current directory does not exist"
@@ -6135,12 +6150,12 @@ def do_upgrade(auto_restart: bool = True) -> dict:
     safe_cwd = get_safe_cwd()
 
     try:
-        result = subprocess.run(
-            plan.command,
+        result = execute_upgrade_plan(
+            plan,
+            run=subprocess.run,
             capture_output=True,
             text=True,
             timeout=120,
-            env=plan.env,
             cwd=safe_cwd,
         )
         if result.returncode == 0:
@@ -8562,6 +8577,52 @@ def _memory_runtime_dependency_status(memory_runtime: dict) -> str:
     return "error"
 
 
+def _install_memory_package_for_current_release() -> dict:
+    """Explicitly add the Memory extra to the current packaged install."""
+
+    from vibe import __version__
+
+    try:
+        plan = build_upgrade_plan(
+            vibe_path=get_running_vibe_path(),
+            version=__version__,
+            package_name=installed_package_name() or PACKAGE_NAME,
+            memory_package=True,
+        )
+        result = execute_upgrade_plan(
+            plan,
+            run=subprocess.run,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            cwd=get_safe_cwd(),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "ok": False,
+            "message": "memory_plugin_unavailable",
+            "output": str(exc),
+            "reason": "memory_plugin_unavailable",
+            "download_error": None,
+        }
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()[-4000:] or None
+        return {
+            "ok": False,
+            "message": "memory_plugin_incompatible",
+            "output": detail,
+            "reason": "memory_plugin_incompatible",
+            "download_error": None,
+        }
+    return {
+        "ok": True,
+        "message": "memory_plugin_installed",
+        "output": (result.stdout or "").strip()[-4000:] or None,
+        "reason": None,
+        "download_error": None,
+    }
+
+
 def _prepare_show_runtime_job() -> dict:
     try:
         from core.show_runtime import get_show_runtime_manager
@@ -8593,20 +8654,32 @@ def _prepare_show_runtime_job() -> dict:
 
 
 def _prepare_memory_runtime_job() -> dict:
-    """Install EverOS through the controller-owned activation lifecycle."""
+    """Install the optional package when needed, then activate EverOS."""
 
-    try:
-        from vibe import internal_client
+    from vibe import internal_client
 
-        response = internal_client.memory_install_runtime_sync()
-    except Exception:  # noqa: BLE001
-        return {
-            "ok": False,
-            "message": "memory_runtime_install_failed",
-            "output": None,
-            "reason": "memory_runtime_install_failed",
-            "download_error": None,
-        }
+    def install_runtime() -> dict:
+        try:
+            return internal_client.memory_install_runtime_sync()
+        except Exception:  # noqa: BLE001
+            return {
+                "status_code": 503,
+                "body": {
+                    "ok": False,
+                    "reason": "memory_runtime_install_failed",
+                    "download_error": None,
+                },
+            }
+
+    response = install_runtime()
+    first_payload = response.get("body") if isinstance(response.get("body"), dict) else {}
+    first_reason = first_payload.get("reason")
+    if first_reason in {"memory_plugin_unavailable", "memory_plugin_incompatible"}:
+        package_result = _install_memory_package_for_current_release()
+        if not package_result.get("ok"):
+            return package_result
+        response = install_runtime()
+
     payload = response.get("body") if isinstance(response.get("body"), dict) else {}
     if response.get("status_code") != 200:
         payload = {

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -73,7 +73,7 @@ from vibe.upgrade import (
     package_mutation_lock,
     should_skip_show_runtime_prepare,
 )
-from vibe.restart_supervisor import schedule_restart
+from vibe.restart_supervisor import restart_in_flight, schedule_restart
 from vibe import backend_model_catalog
 from vibe.i18n import t as backend_t
 from modules.agents.catalog import (
@@ -6143,9 +6143,21 @@ def do_upgrade(
     # errors.  The vibe service process cwd may be inside the uv tool venv
     # directory, which uv deletes and recreates during upgrade.
     safe_cwd = get_safe_cwd()
+    restarting = False
+    restart_failed = False
+    runtime_output = None
 
     try:
         with package_mutation_lock():
+            if restart_in_flight():
+                return {
+                    "ok": False,
+                    "message": "restart_in_progress",
+                    "output": None,
+                    "restarting": False,
+                    "reason": "restart_in_progress",
+                    "code": "restart_in_progress",
+                }
             plan = build_upgrade_plan(
                 vibe_path=current_vibe_path,
                 memory_enabled=(
@@ -6162,11 +6174,7 @@ def do_upgrade(
                 timeout=120,
                 cwd=safe_cwd,
             )
-        if result.returncode == 0:
-            restarting = False
-            restart_failed = False
-            runtime_output = None
-            if auto_restart and runtime_was_running:
+            if result.returncode == 0 and auto_restart and runtime_was_running:
                 try:
                     schedule_restart(
                         delay_seconds=2.0,
@@ -6178,8 +6186,12 @@ def do_upgrade(
                     restarting = True
                 except Exception as exc:
                     restart_failed = True
-                    runtime_output = f"Restart scheduling failed; run `vibe restart` to use the new version.\n{exc}"
-            else:
+                    runtime_output = (
+                        "Restart scheduling failed; run `vibe restart` to use the new version.\n"
+                        f"{exc}"
+                    )
+        if result.returncode == 0:
+            if not (auto_restart and runtime_was_running):
                 runtime_output = _prepare_show_runtime_after_upgrade(current_vibe_path, safe_cwd)
             if restarting:
                 message = "Upgrade successful. Restarting..."
@@ -8687,24 +8699,34 @@ def _prepare_memory_runtime_job() -> dict:
     first_payload = response.get("body") if isinstance(response.get("body"), dict) else {}
     first_reason = first_payload.get("reason")
     if first_reason in {"memory_plugin_unavailable", "memory_plugin_incompatible"}:
-        package_result = _install_memory_package_for_current_release()
-        if not package_result.get("ok"):
-            return package_result
-        try:
-            schedule_restart(
-                delay_seconds=2.0,
-                vibe_path=get_running_vibe_path(),
-                trigger="memory-package-repair",
-            )
-        except Exception as exc:  # noqa: BLE001
-            return {
-                "ok": False,
-                "message": "memory_runtime_restart_required",
-                "output": str(exc),
-                "reason": "memory_runtime_restart_required",
-                "download_error": None,
-                "restarting": False,
-            }
+        with package_mutation_lock():
+            if restart_in_flight():
+                return {
+                    "ok": False,
+                    "message": "restart_in_progress",
+                    "output": None,
+                    "reason": "restart_in_progress",
+                    "download_error": None,
+                    "restarting": False,
+                }
+            package_result = _install_memory_package_for_current_release()
+            if not package_result.get("ok"):
+                return package_result
+            try:
+                schedule_restart(
+                    delay_seconds=2.0,
+                    vibe_path=get_running_vibe_path(),
+                    trigger="memory-package-repair",
+                )
+            except Exception as exc:  # noqa: BLE001
+                return {
+                    "ok": False,
+                    "message": "memory_runtime_restart_required",
+                    "output": str(exc),
+                    "reason": "memory_runtime_restart_required",
+                    "download_error": None,
+                    "restarting": False,
+                }
         return {
             "ok": True,
             "message": "memory_runtime_restart_scheduled",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -8690,31 +8690,29 @@ def _prepare_memory_runtime_job() -> dict:
         package_result = _install_memory_package_for_current_release()
         if not package_result.get("ok"):
             return package_result
-        if first_reason == "memory_plugin_incompatible":
-            try:
-                schedule_restart(
-                    delay_seconds=2.0,
-                    vibe_path=get_running_vibe_path(),
-                    trigger="memory-package-repair",
-                )
-            except Exception as exc:  # noqa: BLE001
-                return {
-                    "ok": False,
-                    "message": "memory_runtime_restart_required",
-                    "output": str(exc),
-                    "reason": "memory_runtime_restart_required",
-                    "download_error": None,
-                    "restarting": False,
-                }
+        try:
+            schedule_restart(
+                delay_seconds=2.0,
+                vibe_path=get_running_vibe_path(),
+                trigger="memory-package-repair",
+            )
+        except Exception as exc:  # noqa: BLE001
             return {
-                "ok": True,
-                "message": "memory_runtime_restart_scheduled",
-                "output": package_result.get("output"),
-                "reason": None,
+                "ok": False,
+                "message": "memory_runtime_restart_required",
+                "output": str(exc),
+                "reason": "memory_runtime_restart_required",
                 "download_error": None,
-                "restarting": True,
+                "restarting": False,
             }
-        response = install_runtime()
+        return {
+            "ok": True,
+            "message": "memory_runtime_restart_scheduled",
+            "output": package_result.get("output"),
+            "reason": None,
+            "download_error": None,
+            "restarting": True,
+        }
 
     payload = response.get("body") if isinstance(response.get("body"), dict) else {}
     if response.get("status_code") != 200:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -6137,7 +6137,6 @@ def do_upgrade(
         {"ok": bool, "message": str, "output": str | None, "restarting": bool}
     """
     current_vibe_path = get_running_vibe_path()
-    runtime_was_running = _runtime_process_was_running()
 
     # Use a stable directory as cwd to avoid "Current directory does not exist"
     # errors.  The vibe service process cwd may be inside the uv tool venv
@@ -6158,6 +6157,7 @@ def do_upgrade(
                     "reason": "restart_in_progress",
                     "code": "restart_in_progress",
                 }
+            runtime_was_running = _runtime_process_was_running()
             plan = build_upgrade_plan(
                 vibe_path=current_vibe_path,
                 memory_enabled=(

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -8612,18 +8612,18 @@ def _install_memory_package_for_current_release() -> dict:
     except Exception as exc:  # noqa: BLE001
         return {
             "ok": False,
-            "message": "memory_plugin_unavailable",
+            "message": "memory_runtime_install_failed",
             "output": str(exc),
-            "reason": "memory_plugin_unavailable",
+            "reason": "memory_runtime_install_failed",
             "download_error": None,
         }
     if result.returncode != 0:
         detail = (result.stderr or result.stdout or "").strip()[-4000:] or None
         return {
             "ok": False,
-            "message": "memory_plugin_incompatible",
+            "message": "memory_runtime_install_failed",
             "output": detail,
-            "reason": "memory_plugin_incompatible",
+            "reason": "memory_runtime_install_failed",
             "download_error": None,
         }
     return {

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -8690,6 +8690,30 @@ def _prepare_memory_runtime_job() -> dict:
         package_result = _install_memory_package_for_current_release()
         if not package_result.get("ok"):
             return package_result
+        if first_reason == "memory_plugin_incompatible":
+            try:
+                schedule_restart(
+                    delay_seconds=2.0,
+                    vibe_path=get_running_vibe_path(),
+                    trigger="memory-package-repair",
+                )
+            except Exception as exc:  # noqa: BLE001
+                return {
+                    "ok": False,
+                    "message": "memory_runtime_restart_required",
+                    "output": str(exc),
+                    "reason": "memory_runtime_restart_required",
+                    "download_error": None,
+                    "restarting": False,
+                }
+            return {
+                "ok": True,
+                "message": "memory_runtime_restart_scheduled",
+                "output": package_result.get("output"),
+                "reason": None,
+                "download_error": None,
+                "restarting": True,
+            }
         response = install_runtime()
 
     payload = response.get("body") if isinstance(response.get("body"), dict) else {}

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -61,13 +61,16 @@ from vibe.opencode_config import (
 from vibe.build_identity import get_build_identity
 from vibe.upgrade import (
     PACKAGE_NAME,
+    build_memory_add_plan,
     build_upgrade_plan,
     configured_memory_enabled,
     execute_upgrade_plan,
     get_latest_version_info,
     get_running_vibe_path,
     get_safe_cwd,
+    installed_metadata_describes_running_code,
     installed_package_name,
+    package_mutation_lock,
     should_skip_show_runtime_prepare,
 )
 from vibe.restart_supervisor import schedule_restart
@@ -6134,14 +6137,6 @@ def do_upgrade(
         {"ok": bool, "message": str, "output": str | None, "restarting": bool}
     """
     current_vibe_path = get_running_vibe_path()
-    plan = build_upgrade_plan(
-        vibe_path=current_vibe_path,
-        memory_enabled=(
-            configured_memory_enabled()
-            if memory_enabled is None
-            else memory_enabled
-        ),
-    )
     runtime_was_running = _runtime_process_was_running()
 
     # Use a stable directory as cwd to avoid "Current directory does not exist"
@@ -6150,14 +6145,23 @@ def do_upgrade(
     safe_cwd = get_safe_cwd()
 
     try:
-        result = execute_upgrade_plan(
-            plan,
-            run=subprocess.run,
-            capture_output=True,
-            text=True,
-            timeout=120,
-            cwd=safe_cwd,
-        )
+        with package_mutation_lock():
+            plan = build_upgrade_plan(
+                vibe_path=current_vibe_path,
+                memory_enabled=(
+                    configured_memory_enabled()
+                    if memory_enabled is None
+                    else memory_enabled
+                ),
+            )
+            result = execute_upgrade_plan(
+                plan,
+                run=subprocess.run,
+                capture_output=True,
+                text=True,
+                timeout=120,
+                cwd=safe_cwd,
+            )
         if result.returncode == 0:
             restarting = False
             restart_failed = False
@@ -8583,20 +8587,28 @@ def _install_memory_package_for_current_release() -> dict:
     from vibe import __version__
 
     try:
-        plan = build_upgrade_plan(
-            vibe_path=get_running_vibe_path(),
-            version=__version__,
-            package_name=installed_package_name() or PACKAGE_NAME,
-            memory_package=True,
-        )
-        result = execute_upgrade_plan(
-            plan,
-            run=subprocess.run,
-            capture_output=True,
-            text=True,
-            timeout=600,
-            cwd=get_safe_cwd(),
-        )
+        with package_mutation_lock():
+            if not installed_metadata_describes_running_code():
+                return {
+                    "ok": False,
+                    "message": "memory_runtime_install_failed",
+                    "output": "Avibe changed on disk; restart before installing Memory.",
+                    "reason": "memory_runtime_install_failed",
+                    "download_error": None,
+                }
+            plan = build_memory_add_plan(
+                vibe_path=get_running_vibe_path(),
+                version=__version__,
+                package_name=installed_package_name() or PACKAGE_NAME,
+            )
+            result = execute_upgrade_plan(
+                plan,
+                run=subprocess.run,
+                capture_output=True,
+                text=True,
+                timeout=600,
+                cwd=get_safe_cwd(),
+            )
     except Exception as exc:  # noqa: BLE001
         return {
             "ok": False,

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -14528,6 +14528,10 @@ def cmd_upgrade():
         else:
             print(f"\033[31mUpgrade failed:\033[0m\n{result.stderr}")
             return 1
+    except MigrationLockTimeout:
+        if restart_in_flight():
+            return _restart_in_progress_exit(operation="upgrade")
+        return _package_mutation_busy_exit()
     except Exception as e:
         print(f"\033[31mUpgrade failed: {e}\033[0m")
         return 1

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -12631,10 +12631,10 @@ def cmd_start():
     try:
         with package_mutation_lock():
             if restart_in_flight():
-                return _restart_in_progress_exit()
+                return _restart_in_progress_exit(operation="lifecycle")
             return _cmd_start_under_package_lease()
     except MigrationLockTimeout:
-        return _restart_in_progress_exit()
+        return _restart_in_progress_exit(operation="lifecycle")
 
 
 def _cmd_start_under_package_lease():
@@ -12811,10 +12811,10 @@ def cmd_stop():
     try:
         with package_mutation_lock():
             if restart_in_flight():
-                return _restart_in_progress_exit()
+                return _restart_in_progress_exit(operation="lifecycle")
             return _cmd_stop_under_package_lease()
     except MigrationLockTimeout:
-        return _restart_in_progress_exit()
+        return _restart_in_progress_exit(operation="lifecycle")
 
 
 def _cmd_stop_under_package_lease():
@@ -14420,7 +14420,6 @@ def cmd_upgrade():
     print("\nUpgrading...")
 
     current_vibe_path = cache_running_vibe_path()
-    runtime_was_running = _runtime_process_was_running()
 
     # Use a stable directory as cwd to avoid issues when running from a
     # directory that uv may delete during upgrade (e.g. inside the uv tool venv).
@@ -14431,8 +14430,8 @@ def cmd_upgrade():
     try:
         with package_mutation_lock():
             if restart_in_flight():
-                print("\033[33mA restart is already in progress; upgrade was not started.\033[0m")
-                return 2
+                return _restart_in_progress_exit(operation="upgrade")
+            runtime_was_running = _runtime_process_was_running()
             plan = build_upgrade_plan(
                 vibe_path=current_vibe_path,
                 memory_enabled=configured_memory_enabled(),
@@ -14899,8 +14898,17 @@ def _format_restart_delay(delay_seconds: float) -> str:
     return f"{delay_seconds:g} seconds"
 
 
-def _restart_in_progress_exit() -> int:
-    print("\033[33mA restart is already in progress; restart was not scheduled.\033[0m")
+_RESTART_IN_PROGRESS_CLI_KEYS = {
+    "upgrade": "lifecycle.cli.restartInProgressUpgrade",
+    "restart": "lifecycle.cli.restartInProgressRestart",
+    "lifecycle": "lifecycle.cli.restartInProgressAction",
+}
+
+
+def _restart_in_progress_exit(*, operation: str = "restart") -> int:
+    language = normalize_language(_configured_cli_language())
+    message = i18n_t(_RESTART_IN_PROGRESS_CLI_KEYS[operation], language)
+    print(f"\033[33m{message}\033[0m")
     return 2
 
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -12054,6 +12054,20 @@ def _doctor_repair_result(target: str, status: str, message: str, **details) -> 
     return payload
 
 
+def _doctor_lifecycle_repair_blocked(target: str, reason: str) -> dict:
+    key = (
+        "lifecycle.cli.restartInProgressAction"
+        if reason == "restart_in_progress"
+        else "lifecycle.cli.packageMutationInProgressAction"
+    )
+    return _doctor_repair_result(
+        target,
+        "failed",
+        i18n_t(key, _configured_cli_language()),
+        reason=reason,
+    )
+
+
 class _ShowRuntimeStartabilityState(str, Enum):
     STARTABLE = "startable"
     NOT_STARTABLE = "not_startable"
@@ -12248,30 +12262,44 @@ def _repair_duplicate_service_processes(*, dry_run: bool = False) -> dict:
 
     stopped: list[int] = []
     failed: list[int] = []
-    for pid in extra_pids:
-        if runtime.stop_pid(pid, timeout=5):
-            stopped.append(pid)
-        else:
-            failed.append(pid)
+    try:
+        with package_mutation_lock():
+            if restart_in_flight():
+                return _doctor_lifecycle_repair_blocked(target, "restart_in_progress")
+            for pid in extra_pids:
+                if runtime.stop_pid(pid, timeout=5):
+                    stopped.append(pid)
+                else:
+                    failed.append(pid)
 
-    if not owner_pid and stopped and not failed:
-        return _start_service_after_repair(
-            target,
-            "Stopped lockless service process(es) and started a clean service.",
-            "Stopped lockless service process(es), but failed to start a clean service",
-            stopped_pids=stopped,
-        )
+            if not owner_pid and stopped and not failed:
+                return _start_service_after_repair(
+                    target,
+                    "Stopped lockless service process(es) and started a clean service.",
+                    "Stopped lockless service process(es), but failed to start a clean service",
+                    stopped_pids=stopped,
+                )
 
-    _write_refreshed_runtime_status()
-    if failed:
-        return _doctor_repair_result(
+            _write_refreshed_runtime_status()
+            if failed:
+                return _doctor_repair_result(
+                    target,
+                    "failed",
+                    "Some extra service processes could not be stopped.",
+                    stopped_pids=stopped,
+                    failed_pids=failed,
+                )
+            return _doctor_repair_result(
+                target,
+                "repaired",
+                "Stopped extra Avibe service process(es).",
+                stopped_pids=stopped,
+            )
+    except MigrationLockTimeout:
+        return _doctor_lifecycle_repair_blocked(
             target,
-            "failed",
-            "Some extra service processes could not be stopped.",
-            stopped_pids=stopped,
-            failed_pids=failed,
+            "restart_not_scheduled_package_busy",
         )
-    return _doctor_repair_result(target, "repaired", "Stopped extra Avibe service process(es).", stopped_pids=stopped)
 
 
 def _repair_stale_install_runtime(*, dry_run: bool = False) -> dict:
@@ -12305,37 +12333,46 @@ def _repair_stale_install_runtime(*, dry_run: bool = False) -> dict:
 
     stopped: list[int] = []
     failed: list[int] = []
-    for pid in stale_pids:
-        if runtime.stop_pid(pid, timeout=5):
-            stopped.append(pid)
-        else:
-            failed.append(pid)
+    try:
+        with package_mutation_lock():
+            if restart_in_flight():
+                return _doctor_lifecycle_repair_blocked(target, "restart_in_progress")
+            for pid in stale_pids:
+                if runtime.stop_pid(pid, timeout=5):
+                    stopped.append(pid)
+                else:
+                    failed.append(pid)
 
-    if failed:
-        _write_refreshed_runtime_status()
-        return _doctor_repair_result(
+            if failed:
+                _write_refreshed_runtime_status()
+                return _doctor_repair_result(
+                    target,
+                    "failed",
+                    "Some legacy vibe-remote service processes could not be stopped.",
+                    stopped_pids=stopped,
+                    failed_pids=failed,
+                )
+
+            if current_pids or (owner_pid is not None and owner_pid not in stale_pids):
+                _write_refreshed_runtime_status()
+                return _doctor_repair_result(
+                    target,
+                    "repaired",
+                    "Stopped legacy vibe-remote service process(es).",
+                    stopped_pids=stopped,
+                )
+
+            return _start_service_after_repair(
+                target,
+                "Stopped legacy vibe-remote service process and started the current Avibe service.",
+                "Stopped legacy vibe-remote service process, but failed to start the current Avibe service",
+                stopped_pids=stopped,
+            )
+    except MigrationLockTimeout:
+        return _doctor_lifecycle_repair_blocked(
             target,
-            "failed",
-            "Some legacy vibe-remote service processes could not be stopped.",
-            stopped_pids=stopped,
-            failed_pids=failed,
+            "restart_not_scheduled_package_busy",
         )
-
-    if current_pids or (owner_pid is not None and owner_pid not in stale_pids):
-        _write_refreshed_runtime_status()
-        return _doctor_repair_result(
-            target,
-            "repaired",
-            "Stopped legacy vibe-remote service process(es).",
-            stopped_pids=stopped,
-        )
-
-    return _start_service_after_repair(
-        target,
-        "Stopped legacy vibe-remote service process and started the current Avibe service.",
-        "Stopped legacy vibe-remote service process, but failed to start the current Avibe service",
-        stopped_pids=stopped,
-    )
 
 
 def _repair_managed_dependency(target: str, installer, *, dry_run: bool = False) -> dict:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -12628,6 +12628,16 @@ def _live_ui_server_pid() -> int | None:
 
 
 def cmd_start():
+    try:
+        with package_mutation_lock():
+            if restart_in_flight():
+                return _restart_in_progress_exit()
+            return _cmd_start_under_package_lease()
+    except MigrationLockTimeout:
+        return _restart_in_progress_exit()
+
+
+def _cmd_start_under_package_lease():
     _guard_cli_default_state_migration()
     paths.ensure_data_dirs()
     config = _ensure_config()
@@ -12798,6 +12808,16 @@ def _runtime_process_was_running() -> bool:
 
 
 def cmd_stop():
+    try:
+        with package_mutation_lock():
+            if restart_in_flight():
+                return _restart_in_progress_exit()
+            return _cmd_stop_under_package_lease()
+    except MigrationLockTimeout:
+        return _restart_in_progress_exit()
+
+
+def _cmd_stop_under_package_lease():
     service_was_running = _pid_file_points_to_live_process(paths.get_runtime_pid_path())
     ui_was_running = _pid_file_points_to_live_process(paths.get_runtime_ui_pid_path())
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -12250,9 +12250,9 @@ def _repair_duplicate_service_processes(*, dry_run: bool = False) -> dict:
 
     owner_pid = runtime.resolve_service_owner_pid(include_starting=False)
     extra_pids = runtime.extra_service_process_pids(owner_pid=owner_pid)
-    if not extra_pids:
-        return _doctor_repair_result(target, "skipped", "No extra Avibe service process was detected.")
     if dry_run:
+        if not extra_pids:
+            return _doctor_repair_result(target, "skipped", "No extra Avibe service process was detected.")
         return _doctor_repair_result(
             target,
             "planned",
@@ -12266,6 +12266,10 @@ def _repair_duplicate_service_processes(*, dry_run: bool = False) -> dict:
         with package_mutation_lock():
             if restart_in_flight():
                 return _doctor_lifecycle_repair_blocked(target, "restart_in_progress")
+            owner_pid = runtime.resolve_service_owner_pid(include_starting=False)
+            extra_pids = runtime.extra_service_process_pids(owner_pid=owner_pid)
+            if not extra_pids:
+                return _doctor_repair_result(target, "skipped", "No extra Avibe service process was detected.")
             for pid in extra_pids:
                 if runtime.stop_pid(pid, timeout=5):
                     stopped.append(pid)
@@ -12302,14 +12306,9 @@ def _repair_duplicate_service_processes(*, dry_run: bool = False) -> dict:
         )
 
 
-def _repair_stale_install_runtime(*, dry_run: bool = False) -> dict:
-    target = "stale-install-runtime"
-    if runtime.service_instance_lock_attached_to_process():
-        return _doctor_repair_result(target, "failed", "Run this repair from the CLI, not from inside the service process.")
-    if not _runtime_home_exists_for_repair():
-        return _doctor_repair_result(target, "skipped", "No runtime home exists yet; no service process state needs repair.")
-
-    current_family = _current_cli_install_family()
+def _stale_install_runtime_processes(
+    current_family: str | None,
+) -> tuple[int | None, list[int], list[int]]:
     owner_pid = runtime.resolve_service_owner_pid(include_starting=False)
     service_pids = [pid for pid in [owner_pid] if pid]
     service_pids.extend(runtime.extra_service_process_pids(owner_pid=owner_pid))
@@ -12321,9 +12320,21 @@ def _repair_stale_install_runtime(*, dry_run: bool = False) -> dict:
             stale_pids.append(pid)
         elif family == PACKAGE_NAME:
             current_pids.append(pid)
-    if not stale_pids:
-        return _doctor_repair_result(target, "skipped", "No legacy vibe-remote service process was detected.")
+    return owner_pid, stale_pids, current_pids
+
+
+def _repair_stale_install_runtime(*, dry_run: bool = False) -> dict:
+    target = "stale-install-runtime"
+    if runtime.service_instance_lock_attached_to_process():
+        return _doctor_repair_result(target, "failed", "Run this repair from the CLI, not from inside the service process.")
+    if not _runtime_home_exists_for_repair():
+        return _doctor_repair_result(target, "skipped", "No runtime home exists yet; no service process state needs repair.")
+
+    current_family = _current_cli_install_family()
+    owner_pid, stale_pids, current_pids = _stale_install_runtime_processes(current_family)
     if dry_run:
+        if not stale_pids:
+            return _doctor_repair_result(target, "skipped", "No legacy vibe-remote service process was detected.")
         return _doctor_repair_result(
             target,
             "planned",
@@ -12337,6 +12348,9 @@ def _repair_stale_install_runtime(*, dry_run: bool = False) -> dict:
         with package_mutation_lock():
             if restart_in_flight():
                 return _doctor_lifecycle_repair_blocked(target, "restart_in_progress")
+            owner_pid, stale_pids, current_pids = _stale_install_runtime_processes(current_family)
+            if not stale_pids:
+                return _doctor_repair_result(target, "skipped", "No legacy vibe-remote service process was detected.")
             for pid in stale_pids:
                 if runtime.stop_pid(pid, timeout=5):
                     stopped.append(pid)

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -62,7 +62,7 @@ from core.watches import (
 )
 from vibe import __version__, api, runtime
 from vibe.i18n import normalize_language, t as i18n_t
-from vibe.restart_supervisor import schedule_restart
+from vibe.restart_supervisor import restart_in_flight, schedule_restart
 from vibe.screenshot import ScreenshotError, capture_screenshot
 from vibe.upgrade import (
     CURRENT_VIBE_EXECUTABLE_ENV,
@@ -14404,9 +14404,14 @@ def cmd_upgrade():
     # Use a stable directory as cwd to avoid issues when running from a
     # directory that uv may delete during upgrade (e.g. inside the uv tool venv).
     safe_cwd = get_safe_cwd()
+    restart = None
+    restart_error = None
 
     try:
         with package_mutation_lock():
+            if restart_in_flight():
+                print("\033[33mA restart is already in progress; upgrade was not started.\033[0m")
+                return 2
             plan = build_upgrade_plan(
                 vibe_path=current_vibe_path,
                 memory_enabled=configured_memory_enabled(),
@@ -14419,9 +14424,7 @@ def cmd_upgrade():
                 text=True,
                 cwd=safe_cwd,
             )
-        if result.returncode == 0:
-            print("\033[32mUpgrade successful!\033[0m")
-            if runtime_was_running:
+            if result.returncode == 0 and runtime_was_running:
                 try:
                     restart = schedule_restart(
                         delay_seconds=0.0,
@@ -14431,14 +14434,18 @@ def cmd_upgrade():
                         rollback_to=plan.rollback_to,
                     )
                 except Exception as exc:
+                    restart_error = exc
+        if result.returncode == 0:
+            print("\033[32mUpgrade successful!\033[0m")
+            if runtime_was_running:
+                if restart_error is not None:
                     print("\033[33mUpgrade installed, but restart scheduling failed.\033[0m")
-                    print(f"Restart error: {exc}")
+                    print(f"Restart error: {restart_error}")
                     print("Run `vibe restart` to use the new version.")
                     return 2
-                else:
-                    print("Restart scheduled to use the new version.")
-                    print(f"Job ID: {restart['job_id']}")
-                    print("Run `vibe status` to inspect the restart result.")
+                print("Restart scheduled to use the new version.")
+                print(f"Job ID: {restart['job_id']}")
+                print("Run `vibe status` to inspect the restart result.")
             else:
                 _prepare_show_runtime_after_install(current_vibe_path)
                 print("Avibe was not running; the new version will be used next time you start it.")

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -12685,7 +12685,9 @@ def cmd_start():
                 return _restart_in_progress_exit(operation="lifecycle")
             return _cmd_start_under_package_lease()
     except MigrationLockTimeout:
-        return _restart_in_progress_exit(operation="lifecycle")
+        if restart_in_flight():
+            return _restart_in_progress_exit(operation="lifecycle")
+        return _package_mutation_busy_exit()
 
 
 def _cmd_start_under_package_lease():
@@ -12865,7 +12867,9 @@ def cmd_stop():
                 return _restart_in_progress_exit(operation="lifecycle")
             return _cmd_stop_under_package_lease()
     except MigrationLockTimeout:
-        return _restart_in_progress_exit(operation="lifecycle")
+        if restart_in_flight():
+            return _restart_in_progress_exit(operation="lifecycle")
+        return _package_mutation_busy_exit()
 
 
 def _cmd_stop_under_package_lease():
@@ -14963,6 +14967,13 @@ def _restart_in_progress_exit(*, operation: str = "restart") -> int:
     return 2
 
 
+def _package_mutation_busy_exit() -> int:
+    language = normalize_language(_configured_cli_language())
+    message = i18n_t("lifecycle.cli.packageMutationInProgressAction", language)
+    print(f"\033[33m{message}\033[0m")
+    return 2
+
+
 def _schedule_delayed_restart(delay_seconds: float) -> int:
     try:
         with package_mutation_lock():
@@ -14974,7 +14985,9 @@ def _schedule_delayed_restart(delay_seconds: float) -> int:
                 trigger="cli",
             )
     except MigrationLockTimeout:
-        return _restart_in_progress_exit()
+        if restart_in_flight():
+            return _restart_in_progress_exit()
+        return _package_mutation_busy_exit()
     print(f"Restart scheduled in {_format_restart_delay(delay_seconds)}.")
     print(f"Job ID: {result['job_id']}")
     print("This command exits immediately; the restart supervisor will run in the background.")
@@ -14995,7 +15008,9 @@ def _cmd_restart_with_delay(delay_seconds: float) -> int:
                 trigger="cli",
             )
     except MigrationLockTimeout:
-        return _restart_in_progress_exit()
+        if restart_in_flight():
+            return _restart_in_progress_exit()
+        return _package_mutation_busy_exit()
     print("Restart scheduled.")
     print(f"Job ID: {result['job_id']}")
     print("Run `vibe status` to inspect the restart result.")

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -96,6 +96,7 @@ from storage.pagination import (
     page_sequence,
     pagination_payload,
 )
+from storage.lock import MigrationLockTimeout
 from storage.read_only_query import ReadOnlyQueryError, run_read_only_query
 from storage.settings_service import make_scope_id
 
@@ -14878,9 +14879,23 @@ def _format_restart_delay(delay_seconds: float) -> str:
     return f"{delay_seconds:g} seconds"
 
 
+def _restart_in_progress_exit() -> int:
+    print("\033[33mA restart is already in progress; restart was not scheduled.\033[0m")
+    return 2
+
+
 def _schedule_delayed_restart(delay_seconds: float) -> int:
-    current_vibe_path = cache_running_vibe_path()
-    result = schedule_restart(delay_seconds=delay_seconds, vibe_path=current_vibe_path, trigger="cli")
+    try:
+        with package_mutation_lock():
+            if restart_in_flight():
+                return _restart_in_progress_exit()
+            result = schedule_restart(
+                delay_seconds=delay_seconds,
+                vibe_path=cache_running_vibe_path(),
+                trigger="cli",
+            )
+    except MigrationLockTimeout:
+        return _restart_in_progress_exit()
     print(f"Restart scheduled in {_format_restart_delay(delay_seconds)}.")
     print(f"Job ID: {result['job_id']}")
     print("This command exits immediately; the restart supervisor will run in the background.")
@@ -14891,7 +14906,17 @@ def _cmd_restart_with_delay(delay_seconds: float) -> int:
     if delay_seconds > 0:
         return _schedule_delayed_restart(delay_seconds)
 
-    result = schedule_restart(delay_seconds=0.0, vibe_path=cache_running_vibe_path(), trigger="cli")
+    try:
+        with package_mutation_lock():
+            if restart_in_flight():
+                return _restart_in_progress_exit()
+            result = schedule_restart(
+                delay_seconds=0.0,
+                vibe_path=cache_running_vibe_path(),
+                trigger="cli",
+            )
+    except MigrationLockTimeout:
+        return _restart_in_progress_exit()
     print("Restart scheduled.")
     print(f"Job ID: {result['job_id']}")
     print("Run `vibe status` to inspect the restart result.")

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -70,6 +70,8 @@ from vibe.upgrade import (
     PACKAGE_NAME,
     build_upgrade_plan,
     cache_running_vibe_path,
+    configured_memory_enabled,
+    execute_upgrade_plan,
     get_latest_version_info,
     get_safe_cwd,
     should_skip_show_runtime_prepare,
@@ -14396,7 +14398,10 @@ def cmd_upgrade():
     print("\nUpgrading...")
 
     current_vibe_path = cache_running_vibe_path()
-    plan = build_upgrade_plan(vibe_path=current_vibe_path)
+    plan = build_upgrade_plan(
+        vibe_path=current_vibe_path,
+        memory_enabled=configured_memory_enabled(),
+    )
     print(f"Using {plan.method}: {' '.join(plan.command)}")
     runtime_was_running = _runtime_process_was_running()
 
@@ -14405,7 +14410,13 @@ def cmd_upgrade():
     safe_cwd = get_safe_cwd()
 
     try:
-        result = subprocess.run(plan.command, capture_output=True, text=True, env=plan.env, cwd=safe_cwd)
+        result = execute_upgrade_plan(
+            plan,
+            run=subprocess.run,
+            capture_output=True,
+            text=True,
+            cwd=safe_cwd,
+        )
         if result.returncode == 0:
             print("\033[32mUpgrade successful!\033[0m")
             if runtime_was_running:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -74,6 +74,7 @@ from vibe.upgrade import (
     execute_upgrade_plan,
     get_latest_version_info,
     get_safe_cwd,
+    package_mutation_lock,
     should_skip_show_runtime_prepare,
 )
 from storage.db import create_sqlite_engine
@@ -14398,11 +14399,6 @@ def cmd_upgrade():
     print("\nUpgrading...")
 
     current_vibe_path = cache_running_vibe_path()
-    plan = build_upgrade_plan(
-        vibe_path=current_vibe_path,
-        memory_enabled=configured_memory_enabled(),
-    )
-    print(f"Using {plan.method}: {' '.join(plan.command)}")
     runtime_was_running = _runtime_process_was_running()
 
     # Use a stable directory as cwd to avoid issues when running from a
@@ -14410,13 +14406,19 @@ def cmd_upgrade():
     safe_cwd = get_safe_cwd()
 
     try:
-        result = execute_upgrade_plan(
-            plan,
-            run=subprocess.run,
-            capture_output=True,
-            text=True,
-            cwd=safe_cwd,
-        )
+        with package_mutation_lock():
+            plan = build_upgrade_plan(
+                vibe_path=current_vibe_path,
+                memory_enabled=configured_memory_enabled(),
+            )
+            print(f"Using {plan.method}: {' '.join(plan.command)}")
+            result = execute_upgrade_plan(
+                plan,
+                run=subprocess.run,
+                capture_output=True,
+                text=True,
+                cwd=safe_cwd,
+            )
         if result.returncode == 0:
             print("\033[32mUpgrade successful!\033[0m")
             if runtime_was_running:

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -746,6 +746,13 @@
   "permission": {
     "adminOnly": "🔒 Only admins can change bot settings. Contact an admin if you need access."
   },
+  "lifecycle": {
+    "cli": {
+      "restartInProgressUpgrade": "A restart is already in progress; upgrade was not started.",
+      "restartInProgressRestart": "A restart is already in progress; restart was not scheduled.",
+      "restartInProgressAction": "A restart is already in progress; the operation was not performed."
+    }
+  },
   "memory": {
     "cli": {
       "help": {

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -750,7 +750,8 @@
     "cli": {
       "restartInProgressUpgrade": "A restart is already in progress; upgrade was not started.",
       "restartInProgressRestart": "A restart is already in progress; restart was not scheduled.",
-      "restartInProgressAction": "A restart is already in progress; the operation was not performed."
+      "restartInProgressAction": "A restart is already in progress; the operation was not performed.",
+      "packageMutationInProgressAction": "A package operation is already in progress; the repair was not performed."
     }
   },
   "memory": {

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -750,7 +750,8 @@
     "cli": {
       "restartInProgressUpgrade": "已有重启正在进行，升级未执行。",
       "restartInProgressRestart": "已有重启正在进行，未安排新的重启。",
-      "restartInProgressAction": "已有重启正在进行，操作未执行。"
+      "restartInProgressAction": "已有重启正在进行，操作未执行。",
+      "packageMutationInProgressAction": "已有软件包操作正在进行，修复未执行。"
     }
   },
   "memory": {

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -746,6 +746,13 @@
   "permission": {
     "adminOnly": "🔒 仅管理员可以修改 Bot 设置。如需权限请联系管理员。"
   },
+  "lifecycle": {
+    "cli": {
+      "restartInProgressUpgrade": "已有重启正在进行，升级未执行。",
+      "restartInProgressRestart": "已有重启正在进行，未安排新的重启。",
+      "restartInProgressAction": "已有重启正在进行，操作未执行。"
+    }
+  },
   "memory": {
     "cli": {
       "help": {

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -15,6 +15,8 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import NamedTuple
 
+from packaging.version import InvalidVersion, Version
+
 from config import paths
 
 # Imported here, at the top, rather than where the rollback path uses it. This
@@ -31,13 +33,18 @@ from vibe.upgrade import (
     PACKAGE_NAME,
     RollbackTarget,
     _names_a_published_release,
+    build_memory_add_plan,
     build_upgrade_plan,
+    configured_memory_enabled,
     execute_upgrade_plan,
     get_restart_command,
     get_restart_environment,
     get_restart_invocation_command,
     get_safe_cwd,
+    installed_memory_package_version,
     installed_package_name,
+    memory_package_installed,
+    package_mutation_lock,
 )
 
 
@@ -54,6 +61,7 @@ _ROLLBACK_INSTALL_TIMEOUT_SECONDS = 600.0
 # next to an already-warm CLI -- is not the right bound here. This one is only
 # ever paid in full when the UI is genuinely not coming.
 _ROLLBACK_UI_READY_TIMEOUT_SECONDS = 60.0
+_MEMORY_SPLIT_MIN_VERSION = Version("3.0.14.dev0")
 
 
 class StartedRuntime(NamedTuple):
@@ -279,7 +287,30 @@ def _discover_legacy_upgrade_target(*, trigger: str, vibe_path: str | None) -> R
         if metadata is None:
             return None
         version, package = metadata
-    return RollbackTarget(version=version, package=package, launcher=launcher)
+    memory_package, memory_version = _legacy_memory_package_shape(version)
+    return RollbackTarget(
+        version=version,
+        package=package,
+        launcher=launcher,
+        memory_package=memory_package,
+        memory_version=memory_version,
+    )
+
+
+def _legacy_memory_package_shape(version: str) -> tuple[bool, str | None]:
+    """Infer the prior shape when an older release could not serialize it."""
+
+    try:
+        if Version(version) < _MEMORY_SPLIT_MIN_VERSION:
+            return False, None
+    except InvalidVersion:
+        pass
+    installed = memory_package_installed()
+    enabled = configured_memory_enabled()
+    return (
+        installed or enabled,
+        installed_memory_package_version() if installed else None,
+    )
 
 
 def _now_iso() -> str:
@@ -656,31 +687,32 @@ def _roll_back_failed_upgrade(
         write(f"cannot roll back to {version}: the failed generation did not stop")
         return rollback
 
+    plan = None
     try:
-        plan = build_upgrade_plan(
-            vibe_path=vibe_path,
-            version=version,
-            package_name=rollback_to.package,
-            memory_package=rollback_to.memory_package,
-        )
+        with package_mutation_lock():
+            plan = build_upgrade_plan(
+                vibe_path=vibe_path,
+                version=version,
+                package_name=rollback_to.package,
+                memory_package=rollback_to.memory_package,
+                memory_version=rollback_to.memory_version,
+            )
+            rollback["install"] = {"method": plan.method, "ok": None}
+            record(rollback)
+            result = execute_upgrade_plan(
+                plan,
+                run=subprocess.run,
+                capture_output=True,
+                text=True,
+                cwd=get_safe_cwd(),
+                timeout=_ROLLBACK_INSTALL_TIMEOUT_SECONDS,
+            )
     except Exception as exc:
-        rollback.update(state="failed", error=f"cannot build a pinned install for {version}: {exc}")
-        record(rollback)
-        return rollback
-
-    rollback["install"] = {"method": plan.method, "ok": None}
-    record(rollback)
-    try:
-        result = execute_upgrade_plan(
-            plan,
-            run=subprocess.run,
-            capture_output=True,
-            text=True,
-            cwd=get_safe_cwd(),
-            timeout=_ROLLBACK_INSTALL_TIMEOUT_SECONDS,
-        )
-    except Exception as exc:
-        rollback["install"] = {"method": plan.method, "ok": False, "error": str(exc)}
+        rollback["install"] = {
+            "method": plan.method if plan is not None else "unknown",
+            "ok": False,
+            "error": str(exc),
+        }
         rollback.update(state="failed", error=f"installing {version} failed: {exc}")
         record(rollback)
         return rollback
@@ -876,13 +908,14 @@ def _run_restart_job(
             "scope": scope,
             # Recorded whether or not a rollback ends up happening, so a failed
             # restart with no `rollback` record is readable: armed and killed
-            # before it could recover, versus never recoverable at all. All three
-            # fields of the target, because a record that named the version and
-            # the distribution but not the install would be silent about the one
-            # of the three that has actually been wrong in production.
+            # before it could recover, versus never recoverable at all. Every
+            # dimension is recorded because a target that named the version and
+            # distribution but not the install would be silent about one of the
+            # dimensions that have actually been wrong in production.
             "rollback_to": rollback_to.version if rollback_to else None,
             "rollback_package": rollback_to.package if rollback_to else None,
             "rollback_memory_package": rollback_to.memory_package if rollback_to else None,
+            "rollback_memory_version": rollback_to.memory_version if rollback_to else None,
             "rollback_launcher": rollback_to.launcher._asdict() if rollback_to else None,
             "rollback_target_source": rollback_target_source,
             "rollback_discovery_error": rollback_discovery_error,
@@ -941,6 +974,59 @@ def _run_restart_job(
             mark_duration("wait_service_lock_release_seconds", wait_lock_release_started_at)
             return fail("service lock did not release after stopping runtime", 2, started_at=restart_started_at)
         mark_duration("wait_service_lock_release_seconds", wait_lock_release_started_at)
+
+        if (
+            rollback_target_source == "running_service"
+            and configured_memory_enabled()
+        ):
+            try:
+                from vibe import __version__
+
+                with package_mutation_lock():
+                    memory_plan = build_memory_add_plan(
+                        version=__version__,
+                        vibe_path=vibe_path,
+                        package_name=installed_package_name(),
+                    )
+                    memory_result = execute_upgrade_plan(
+                        memory_plan,
+                        run=subprocess.run,
+                        capture_output=True,
+                        text=True,
+                        cwd=safe_cwd,
+                        timeout=_ROLLBACK_INSTALL_TIMEOUT_SECONDS,
+                    )
+            except Exception as exc:
+                payload["memory_package_prepare"] = {
+                    "method": None,
+                    "ok": False,
+                    "error": str(exc),
+                }
+                _write_status(payload)
+                return fail(
+                    f"preparing Memory for the upgraded release failed: {exc}",
+                    2,
+                    started_at=restart_started_at,
+                )
+            if memory_result.returncode != 0:
+                detail = (memory_result.stderr or memory_result.stdout or "").strip()[-2000:]
+                payload["memory_package_prepare"] = {
+                    "method": memory_plan.method,
+                    "ok": False,
+                    "error": detail or f"exit code {memory_result.returncode}",
+                }
+                _write_status(payload)
+                return fail(
+                    "preparing Memory for the upgraded release failed",
+                    2,
+                    started_at=restart_started_at,
+                )
+            payload["memory_package_prepare"] = {
+                "method": memory_plan.method,
+                "ok": True,
+            }
+            _write_status(payload)
+            write(f"prepared Memory package using {memory_plan.method}")
 
         if rollback_to:
             # Read here and nowhere else: the service is stopped, its lock is
@@ -1115,6 +1201,8 @@ def schedule_restart(
             command.extend(["--rollback-package", rollback_to.package])
         if rollback_to.memory_package:
             command.append("--rollback-memory-package")
+        if rollback_to.memory_version:
+            command.extend(["--rollback-memory-version", rollback_to.memory_version])
     env = get_restart_environment(vibe_path=vibe_path)
     log_path = _restart_log_path(job_id)
     log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1187,6 +1275,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--rollback-to")
     parser.add_argument("--rollback-package")
     parser.add_argument("--rollback-memory-package", action="store_true")
+    parser.add_argument("--rollback-memory-version")
     parser.add_argument("--rollback-python")
     parser.add_argument("--rollback-main")
     args = parser.parse_args(argv)
@@ -1199,11 +1288,14 @@ def main(argv: list[str] | None = None) -> int:
     if args.rollback_to:
         if not args.rollback_python or not args.rollback_main:
             parser.error("--rollback-to requires --rollback-python and --rollback-main")
+        if args.rollback_memory_version and not args.rollback_memory_package:
+            parser.error("--rollback-memory-version requires --rollback-memory-package")
         rollback_to = RollbackTarget(
             version=args.rollback_to,
             package=args.rollback_package,
             launcher=runtime.ServiceLauncher(python=args.rollback_python, main=args.rollback_main),
             memory_package=args.rollback_memory_package,
+            memory_version=args.rollback_memory_version,
         )
     return _run_restart_job(
         job_id=args.job_id,

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -32,6 +32,7 @@ from vibe.upgrade import (
     RollbackTarget,
     _names_a_published_release,
     build_upgrade_plan,
+    execute_upgrade_plan,
     get_restart_command,
     get_restart_environment,
     get_restart_invocation_command,
@@ -656,7 +657,12 @@ def _roll_back_failed_upgrade(
         return rollback
 
     try:
-        plan = build_upgrade_plan(vibe_path=vibe_path, version=version, package_name=rollback_to.package)
+        plan = build_upgrade_plan(
+            vibe_path=vibe_path,
+            version=version,
+            package_name=rollback_to.package,
+            memory_package=rollback_to.memory_package,
+        )
     except Exception as exc:
         rollback.update(state="failed", error=f"cannot build a pinned install for {version}: {exc}")
         record(rollback)
@@ -665,11 +671,11 @@ def _roll_back_failed_upgrade(
     rollback["install"] = {"method": plan.method, "ok": None}
     record(rollback)
     try:
-        result = subprocess.run(
-            plan.command,
+        result = execute_upgrade_plan(
+            plan,
+            run=subprocess.run,
             capture_output=True,
             text=True,
-            env=plan.env,
             cwd=get_safe_cwd(),
             timeout=_ROLLBACK_INSTALL_TIMEOUT_SECONDS,
         )
@@ -876,6 +882,7 @@ def _run_restart_job(
             # of the three that has actually been wrong in production.
             "rollback_to": rollback_to.version if rollback_to else None,
             "rollback_package": rollback_to.package if rollback_to else None,
+            "rollback_memory_package": rollback_to.memory_package if rollback_to else None,
             "rollback_launcher": rollback_to.launcher._asdict() if rollback_to else None,
             "rollback_target_source": rollback_target_source,
             "rollback_discovery_error": rollback_discovery_error,
@@ -1106,6 +1113,8 @@ def schedule_restart(
         )
         if rollback_to.package:
             command.extend(["--rollback-package", rollback_to.package])
+        if rollback_to.memory_package:
+            command.append("--rollback-memory-package")
     env = get_restart_environment(vibe_path=vibe_path)
     log_path = _restart_log_path(job_id)
     log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1177,6 +1186,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--prepare-show-runtime", action="store_true")
     parser.add_argument("--rollback-to")
     parser.add_argument("--rollback-package")
+    parser.add_argument("--rollback-memory-package", action="store_true")
     parser.add_argument("--rollback-python")
     parser.add_argument("--rollback-main")
     args = parser.parse_args(argv)
@@ -1193,6 +1203,7 @@ def main(argv: list[str] | None = None) -> int:
             version=args.rollback_to,
             package=args.rollback_package,
             launcher=runtime.ServiceLauncher(python=args.rollback_python, main=args.rollback_main),
+            memory_package=args.rollback_memory_package,
         )
     return _run_restart_job(
         job_id=args.job_id,

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -976,8 +976,9 @@ def _run_restart_job(
         mark_duration("wait_service_lock_release_seconds", wait_lock_release_started_at)
 
         if (
-            rollback_target_source == "running_service"
+            trigger == "upgrade"
             and configured_memory_enabled()
+            and not memory_package_installed()
         ):
             try:
                 from vibe import __version__

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -32,6 +32,7 @@ from vibe.upgrade import (
     LEGACY_PACKAGE_NAME,
     PACKAGE_NAME,
     RollbackTarget,
+    _MEMORY_SPLIT_MIN_VERSION,
     _names_a_published_release,
     build_memory_add_plan,
     build_upgrade_plan,
@@ -62,9 +63,6 @@ _ROLLBACK_INSTALL_TIMEOUT_SECONDS = 600.0
 # next to an already-warm CLI -- is not the right bound here. This one is only
 # ever paid in full when the UI is genuinely not coming.
 _ROLLBACK_UI_READY_TIMEOUT_SECONDS = 60.0
-_MEMORY_SPLIT_MIN_VERSION = Version("3.0.14.dev0")
-
-
 class StartedRuntime(NamedTuple):
     """What a start actually launched, and where its UI can be checked.
 

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -1104,9 +1104,7 @@ def _run_restart_job(
         runtime.write_status("running", f"pid={new_pid}", new_pid, _live_ui_pid(recorded_ui_pid))
 
         mark_duration("restart_total_seconds", restart_started_at)
-        payload.update(ok=True, state="succeeded", new_pid=new_pid, error=None)
-        _write_status(payload)
-        write(f"restart job succeeded new_pid={new_pid}")
+        payload.update(new_pid=new_pid, error=None)
 
         if prepare_show_runtime:
             env = get_restart_environment(vibe_path=vibe_path)
@@ -1155,9 +1153,15 @@ def _run_restart_job(
                 )
             except Exception as exc:
                 payload["pending_restart"] = {"scheduled": False, "error": str(exc)}
+                payload.update(ok=True, state="succeeded")
                 _write_status(payload)
                 write(f"failed to schedule pending follow-up restart: {exc}")
+                write(f"restart job succeeded new_pid={new_pid}")
+            return 0
 
+        payload.update(ok=True, state="succeeded")
+        _write_status(payload)
+        write(f"restart job succeeded new_pid={new_pid}")
         return 0
 
 

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -51,6 +51,7 @@ from vibe.upgrade import (
 logger = logging.getLogger(__name__)
 _RESTART_LOG_RETENTION = 10
 _SERVICE_LOCK_RELEASE_TIMEOUT_SECONDS = 30.0
+RESTART_SEED_GRACE_SECONDS = 60.0
 # Long enough for a package index to be slow, short enough that a hung download
 # does not leave the machine sitting with no service forever. A rollback that
 # times out is recorded as failed, which is a diagnosable state; a rollback that
@@ -325,6 +326,30 @@ def _restart_log_path(job_id: str) -> Path:
 
 def _pending_restart_path() -> Path:
     return paths.get_runtime_dir() / "pending_restart.json"
+
+
+def restart_in_flight() -> bool:
+    """Whether restart status identifies a live or freshly seeded job."""
+
+    status_path = runtime.get_restart_status_path()
+    status = runtime.read_json(status_path) or {}
+    if status.get("state") not in ("scheduled", "running"):
+        return False
+    supervisor_pid = status.get("supervisor_pid")
+    if isinstance(supervisor_pid, int):
+        if not runtime.pid_alive(supervisor_pid):
+            return False
+        started_at = status.get("supervisor_started_at")
+        if started_at is not None:
+            current = runtime.process_create_time(supervisor_pid)
+            if current is not None and current != started_at:
+                return False
+        return True
+    try:
+        age = time.time() - status_path.stat().st_mtime
+    except OSError:
+        return False
+    return age < RESTART_SEED_GRACE_SECONDS
 
 
 def mark_pending_restart(

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6584,6 +6584,8 @@ def _schedule_guarded_restart(
             with package_mutation_lock(
                 timeout_seconds=_RESTART_REACQUIRE_TIMEOUT_SECONDS,
             ):
+                if _restart_in_flight():
+                    return _mark_service_restart_pending(trigger=pending_trigger)
                 restart = schedule()
         except MigrationLockTimeout:
             _remove_pending_restart_marker()

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6574,7 +6574,13 @@ def _schedule_service_restart_for_config_fallback() -> dict[str, Any]:
                     return pending_result
                 restart = _schedule_restart()
     except MigrationLockTimeout:
-        return _mark_pending()
+        if _restart_in_flight():
+            return _mark_pending()
+        return {
+            "ok": True,
+            "code": "restart_not_scheduled_package_busy",
+            "restart": runtime.read_json(runtime.get_restart_status_path()) or {},
+        }
     return {"ok": True, "restart": restart}
 
 
@@ -6633,18 +6639,70 @@ def control():
     action = payload.get("action")
     status = runtime.read_status()
     status["last_action"] = action
-    if action == "start":
-        runtime.ensure_config()
-        service_pid = runtime.start_service()
-        runtime.write_status("running", "started", service_pid, status.get("ui_pid"))
-    elif action == "stop":
-        runtime.write_status("stopping", "stopping", status.get("service_pid"), status.get("ui_pid"))
-        stopped, error = _stop_runtime_process_or_error(paths.get_runtime_pid_path(), "Vibe service")
-        if not stopped:
-            runtime.write_status("error", error, status.get("service_pid"), status.get("ui_pid"))
-            return jsonify({"ok": False, "action": action, "error": error, "status": runtime.read_status()}), 500
-        _stop_opencode_server()
-        runtime.write_status("stopped", "stopped", None, status.get("ui_pid"))
+    if action in {"start", "stop"}:
+        try:
+            with package_mutation_lock():
+                if _restart_in_flight():
+                    return (
+                        jsonify(
+                            {
+                                "ok": False,
+                                "action": action,
+                                "error": "a restart is already in progress",
+                                "code": "restart_in_progress",
+                                "status": runtime.read_status(),
+                            }
+                        ),
+                        409,
+                    )
+                if action == "start":
+                    runtime.ensure_config()
+                    service_pid = runtime.start_service()
+                    runtime.write_status("running", "started", service_pid, status.get("ui_pid"))
+                else:
+                    runtime.write_status(
+                        "stopping",
+                        "stopping",
+                        status.get("service_pid"),
+                        status.get("ui_pid"),
+                    )
+                    stopped, error = _stop_runtime_process_or_error(
+                        paths.get_runtime_pid_path(),
+                        "Vibe service",
+                    )
+                    if not stopped:
+                        runtime.write_status(
+                            "error",
+                            error,
+                            status.get("service_pid"),
+                            status.get("ui_pid"),
+                        )
+                        return (
+                            jsonify(
+                                {
+                                    "ok": False,
+                                    "action": action,
+                                    "error": error,
+                                    "status": runtime.read_status(),
+                                }
+                            ),
+                            500,
+                        )
+                    _stop_opencode_server()
+                    runtime.write_status("stopped", "stopped", None, status.get("ui_pid"))
+        except MigrationLockTimeout:
+            return (
+                jsonify(
+                    {
+                        "ok": False,
+                        "action": action,
+                        "error": "a restart is already in progress",
+                        "code": "restart_in_progress",
+                        "status": runtime.read_status(),
+                    }
+                ),
+                409,
+            )
     elif action == "restart":
         # Scope defaults to "all" (full restart) so the manual Dashboard /
         # Settings → Service restart buttons keep restarting BOTH processes

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6569,6 +6569,43 @@ def _remove_pending_restart_marker() -> None:
         logger.debug("Failed to remove stale pending restart marker", exc_info=True)
 
 
+def _schedule_guarded_restart(
+    *,
+    pending_trigger: str,
+    schedule: Callable[[], dict[str, Any]],
+) -> dict[str, Any]:
+    def _mark_pending_or_schedule_after_finish() -> dict[str, Any]:
+        pending_result = _mark_service_restart_pending(trigger=pending_trigger)
+        if _restart_in_flight():
+            return pending_result
+
+        _remove_pending_restart_marker()
+        try:
+            with package_mutation_lock(
+                timeout_seconds=_RESTART_REACQUIRE_TIMEOUT_SECONDS,
+            ):
+                restart = schedule()
+        except MigrationLockTimeout:
+            _remove_pending_restart_marker()
+            return _restart_not_scheduled_package_busy()
+        return {
+            "ok": True,
+            "restart": restart,
+            "code": "restart_scheduled_after_in_flight_finished",
+        }
+
+    try:
+        with package_mutation_lock():
+            if _restart_in_flight():
+                return _mark_pending_or_schedule_after_finish()
+            restart = schedule()
+    except MigrationLockTimeout:
+        if _restart_in_flight():
+            return _mark_pending_or_schedule_after_finish()
+        return _restart_not_scheduled_package_busy()
+    return {"ok": True, "restart": restart}
+
+
 def _schedule_service_restart_for_config_fallback() -> dict[str, Any]:
     from vibe import runtime
     from vibe.restart_supervisor import schedule_restart
@@ -6578,46 +6615,10 @@ def _schedule_service_restart_for_config_fallback() -> dict[str, Any]:
         runtime.write_status("restarting", "restarting", status.get("service_pid"), status.get("ui_pid"))
         return schedule_restart(delay_seconds=0.0, trigger="web-ui-config", scope="service")
 
-    try:
-        with package_mutation_lock():
-            with _RESTART_CONTROL_LOCK:
-                if _restart_in_flight():
-                    pending_result = _mark_service_restart_pending(
-                        trigger="web-ui-config-pending",
-                    )
-                    if not _restart_in_flight():
-                        _remove_pending_restart_marker()
-                        restart = _schedule_restart()
-                        return {
-                            "ok": True,
-                            "restart": restart,
-                            "code": "restart_scheduled_after_in_flight_finished",
-                        }
-                    return pending_result
-                restart = _schedule_restart()
-    except MigrationLockTimeout:
-        if _restart_in_flight():
-            pending_result = _mark_service_restart_pending(
-                trigger="web-ui-config-pending",
-            )
-            if _restart_in_flight():
-                return pending_result
-            _remove_pending_restart_marker()
-            try:
-                with package_mutation_lock(
-                    timeout_seconds=_RESTART_REACQUIRE_TIMEOUT_SECONDS,
-                ):
-                    restart = _schedule_restart()
-            except MigrationLockTimeout:
-                _remove_pending_restart_marker()
-                return _restart_not_scheduled_package_busy()
-            return {
-                "ok": True,
-                "restart": restart,
-                "code": "restart_scheduled_after_in_flight_finished",
-            }
-        return _restart_not_scheduled_package_busy()
-    return {"ok": True, "restart": restart}
+    return _schedule_guarded_restart(
+        pending_trigger="web-ui-config-pending",
+        schedule=_schedule_restart,
+    )
 
 
 def _save_config_and_runtime_decisions(payload: dict) -> tuple[V2Config, bool, bool, list[str]]:
@@ -7691,19 +7692,13 @@ def _schedule_wechat_qr_login_restart() -> dict:
     """Schedule a managed restart after QR-login credentials are persisted."""
     from vibe.restart_supervisor import schedule_restart
 
-    try:
-        with package_mutation_lock():
-            if _restart_in_flight():
-                return _mark_service_restart_pending(
-                    trigger="wechat-qr-login-pending",
-                )
-            return schedule_restart(delay_seconds=2.0, trigger="wechat-qr-login")
-    except MigrationLockTimeout:
-        if _restart_in_flight():
-            return _mark_service_restart_pending(
-                trigger="wechat-qr-login-pending",
-            )
-        return _restart_not_scheduled_package_busy()
+    return _schedule_guarded_restart(
+        pending_trigger="wechat-qr-login-pending",
+        schedule=lambda: schedule_restart(
+            delay_seconds=2.0,
+            trigger="wechat-qr-login",
+        ),
+    )
 
 
 def _persist_wechat_qr_credentials(result: dict) -> None:
@@ -7803,8 +7798,20 @@ async def wechat_qr_login_poll():
             logger.warning("Failed to auto-bind WeChat user: %s", e)
 
         try:
-            restart = _schedule_wechat_qr_login_restart()
-            logger.info("Scheduled service restart after WeChat QR login: %s", restart.get("job_id"))
+            restart = await asyncio.to_thread(_schedule_wechat_qr_login_restart)
+            result["restart_scheduled"] = bool(restart.get("ok"))
+            if result["restart_scheduled"]:
+                restart_status = restart.get("restart") or {}
+                logger.info(
+                    "Scheduled service restart after WeChat QR login: %s",
+                    restart_status.get("job_id"),
+                )
+            else:
+                result["restart_reason"] = "restart_not_scheduled_package_busy"
+                logger.warning(
+                    "WeChat QR credentials were saved but restart was not scheduled: %s",
+                    restart.get("error") or restart.get("code"),
+                )
         except Exception as exc:
             logger.warning("Failed to schedule service restart after WeChat QR login: %s", exc)
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6541,6 +6541,32 @@ def _restart_not_scheduled_package_busy() -> dict[str, Any]:
     }
 
 
+def _control_lock_timeout_response(*, action: str):
+    from vibe import runtime
+
+    if _restart_in_flight():
+        code = "restart_in_progress"
+        error = "a restart is already in progress"
+    else:
+        code = "restart_not_scheduled_package_busy"
+        error = t(
+            "lifecycle.cli.packageMutationInProgressAction",
+            _request_ui_language(),
+        )
+    return (
+        jsonify(
+            {
+                "ok": False,
+                "action": action,
+                "error": error,
+                "code": code,
+                "status": runtime.read_status(),
+            }
+        ),
+        409,
+    )
+
+
 def _mark_service_restart_pending(*, trigger: str) -> dict[str, Any]:
     from vibe import runtime
     from vibe.restart_supervisor import mark_pending_restart
@@ -6737,18 +6763,7 @@ def control():
                     _stop_opencode_server()
                     runtime.write_status("stopped", "stopped", None, status.get("ui_pid"))
         except MigrationLockTimeout:
-            return (
-                jsonify(
-                    {
-                        "ok": False,
-                        "action": action,
-                        "error": "a restart is already in progress",
-                        "code": "restart_in_progress",
-                        "status": runtime.read_status(),
-                    }
-                ),
-                409,
-            )
+            return _control_lock_timeout_response(action=action)
     elif action == "restart":
         # Scope defaults to "all" (full restart) so the manual Dashboard /
         # Settings → Service restart buttons keep restarting BOTH processes
@@ -6787,18 +6802,7 @@ def control():
                         scope=scope,
                     )
         except MigrationLockTimeout:
-            return (
-                jsonify(
-                    {
-                        "ok": False,
-                        "action": action,
-                        "error": "a restart is already in progress",
-                        "code": "restart_in_progress",
-                        "status": runtime.read_status(),
-                    }
-                ),
-                409,
-            )
+            return _control_lock_timeout_response(action=action)
         return jsonify({"ok": True, "action": action, "restart": result, "status": runtime.read_status()})
     return jsonify({"ok": True, "action": action, "status": runtime.read_status()})
 
@@ -7436,24 +7440,45 @@ def ui_reload():
         from config import paths as config_paths
         from vibe.memory_ui_access import process_ui_read_secret
 
-        command = f"from vibe.ui_server import run_ui_server; run_ui_server('{bind_host}', {port})"
-        memory_ui_secret = process_ui_read_secret()
-        spawn_kwargs = (
-            {"memory_ui_secret": memory_ui_secret} if memory_ui_secret is not None else {}
-        )
-        pid = runtime.spawn_background(
-            [sys.executable, "-c", command],
-            config_paths.get_runtime_ui_pid_path(),
-            "ui_stdout.log",
-            "ui_stderr.log",
-            **spawn_kwargs,
-        )
-        runtime.write_status(
-            status.get("state", "running"),
-            status.get("detail"),
-            status.get("service_pid"),
-            pid,
-        )
+        def _spawn_replacement() -> None:
+            command = f"from vibe.ui_server import run_ui_server; run_ui_server('{bind_host}', {port})"
+            memory_ui_secret = process_ui_read_secret()
+            spawn_kwargs = (
+                {"memory_ui_secret": memory_ui_secret}
+                if memory_ui_secret is not None
+                else {}
+            )
+            pid = runtime.spawn_background(
+                [sys.executable, "-c", command],
+                config_paths.get_runtime_ui_pid_path(),
+                "ui_stdout.log",
+                "ui_stderr.log",
+                **spawn_kwargs,
+            )
+            runtime.write_status(
+                status.get("state", "running"),
+                status.get("detail"),
+                status.get("service_pid"),
+                pid,
+            )
+
+        spawned = False
+        for attempt in range(2):
+            try:
+                with package_mutation_lock():
+                    _spawn_replacement()
+                spawned = True
+                break
+            except MigrationLockTimeout:
+                if attempt == 0:
+                    time.sleep(1.0)
+        if not spawned:
+            logger.warning(
+                "UI reload proceeding without package mutation lease after retry: %s",
+                "restart_not_scheduled_package_busy",
+            )
+            _spawn_replacement()
+
         time.sleep(0.2)
         # Shutdown the old server to release the port
         if _server:
@@ -7463,6 +7488,14 @@ def ui_reload():
                 shutdown = getattr(_server, "shutdown", None)
                 if callable(shutdown):
                     shutdown()
+
+    # This try-lock is advisory only: the response stays optimistic and the
+    # worker owns the acquire/release pair required by the thread-owned lease.
+    try:
+        with package_mutation_lock(timeout_seconds=0):
+            pass
+    except MigrationLockTimeout:
+        pass
 
     # Schedule restart after response is sent
     threading.Thread(target=_restart).start()

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7474,10 +7474,10 @@ def ui_reload():
                     time.sleep(1.0)
         if not spawned:
             logger.warning(
-                "UI reload proceeding without package mutation lease after retry: %s",
+                "UI reload not scheduled after package mutation lease retry: %s",
                 "restart_not_scheduled_package_busy",
             )
-            _spawn_replacement()
+            return
 
         time.sleep(0.2)
         # Shutdown the old server to release the port
@@ -7488,14 +7488,6 @@ def ui_reload():
                 shutdown = getattr(_server, "shutdown", None)
                 if callable(shutdown):
                     shutdown()
-
-    # This try-lock is advisory only: the response stays optimistic and the
-    # worker owns the acquire/release pair required by the thread-owned lease.
-    try:
-        with package_mutation_lock(timeout_seconds=0):
-            pass
-    except MigrationLockTimeout:
-        pass
 
     # Schedule restart after response is sent
     threading.Thread(target=_restart).start()

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6546,6 +6546,13 @@ def _mark_service_restart_pending(*, trigger: str) -> dict[str, Any]:
     from vibe.restart_supervisor import mark_pending_restart
 
     restart_status = runtime.read_json(runtime.get_restart_status_path()) or {}
+    if restart_status.get("state") in {"succeeded", "failed", "cancelled"}:
+        return {
+            "ok": True,
+            "pending_restart": None,
+            "restart": restart_status,
+            "code": "restart_no_longer_in_flight",
+        }
     pending = mark_pending_restart(
         trigger=trigger,
         scope="service",

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6730,24 +6730,32 @@ def control():
                 if action == "start":
                     runtime.ensure_config()
                     service_pid = runtime.start_service()
-                    runtime.write_status("running", "started", service_pid, status.get("ui_pid"))
+                    current_status = runtime.read_status()
+                    runtime.write_status(
+                        "running",
+                        "started",
+                        service_pid,
+                        current_status.get("ui_pid"),
+                    )
                 else:
+                    current_status = runtime.read_status()
                     runtime.write_status(
                         "stopping",
                         "stopping",
-                        status.get("service_pid"),
-                        status.get("ui_pid"),
+                        current_status.get("service_pid"),
+                        current_status.get("ui_pid"),
                     )
                     stopped, error = _stop_runtime_process_or_error(
                         paths.get_runtime_pid_path(),
                         "Vibe service",
                     )
                     if not stopped:
+                        current_status = runtime.read_status()
                         runtime.write_status(
                             "error",
                             error,
-                            status.get("service_pid"),
-                            status.get("ui_pid"),
+                            current_status.get("service_pid"),
+                            current_status.get("ui_pid"),
                         )
                         return (
                             jsonify(
@@ -6761,7 +6769,13 @@ def control():
                             500,
                         )
                     _stop_opencode_server()
-                    runtime.write_status("stopped", "stopped", None, status.get("ui_pid"))
+                    current_status = runtime.read_status()
+                    runtime.write_status(
+                        "stopped",
+                        "stopped",
+                        None,
+                        current_status.get("ui_pid"),
+                    )
         except MigrationLockTimeout:
             return _control_lock_timeout_response(action=action)
     elif action == "restart":
@@ -6790,11 +6804,12 @@ def control():
                             ),
                             409,
                         )
+                    current_status = runtime.read_status()
                     runtime.write_status(
                         "restarting",
                         "restarting",
-                        status.get("service_pid"),
-                        status.get("ui_pid"),
+                        current_status.get("service_pid"),
+                        current_status.get("ui_pid"),
                     )
                     result = schedule_restart(
                         delay_seconds=0.0,
@@ -7458,37 +7473,69 @@ def ui_reload():
                 if memory_ui_secret is not None
                 else {}
             )
-            pid = runtime.spawn_background(
-                [sys.executable, "-c", command],
-                config_paths.get_runtime_ui_pid_path(),
-                "ui_stdout.log",
-                "ui_stderr.log",
-                **spawn_kwargs,
-            )
-            runtime.write_status(
-                status.get("state", "running"),
-                status.get("detail"),
-                status.get("service_pid"),
-                pid,
-            )
+            pid_path = config_paths.get_runtime_ui_pid_path()
+            try:
+                previous_pid_contents = pid_path.read_bytes()
+            except FileNotFoundError:
+                previous_pid_contents = None
+            try:
+                pid = runtime.spawn_background(
+                    [sys.executable, "-c", command],
+                    pid_path,
+                    "ui_stdout.log",
+                    "ui_stderr.log",
+                    **spawn_kwargs,
+                )
+                runtime.write_status(
+                    status.get("state", "running"),
+                    status.get("detail"),
+                    status.get("service_pid"),
+                    pid,
+                )
+            except Exception:
+                try:
+                    current_pid_contents = pid_path.read_bytes()
+                except FileNotFoundError:
+                    current_pid_contents = None
+                if current_pid_contents != previous_pid_contents:
+                    if previous_pid_contents is None:
+                        pid_path.unlink(missing_ok=True)
+                    else:
+                        pid_path.write_bytes(previous_pid_contents)
+                raise
             return pid
 
-        def _replacement_identity_ready() -> bool:
+        def _replacement_identity_ready(deadline: float) -> bool:
             for attempt in range(51):
-                if runtime.ui_pid_file_points_to_running_ui():
-                    return True
-                if attempt < 50:
-                    time.sleep(0.2)
+                if time.monotonic() > deadline:
+                    break
+                if runtime.ui_pid_file_points_to_running_ui() and runtime.ui_server_healthy(
+                    host=bind_host,
+                    port=port,
+                ):
+                    return time.monotonic() <= deadline
+                remaining = deadline - time.monotonic()
+                if attempt == 50 or remaining <= 0:
+                    break
+                time.sleep(min(0.2, remaining))
             return False
 
         spawned = False
         for attempt in range(2):
             try:
                 with package_mutation_lock():
+                    deadline = time.monotonic() + 10.0
                     _stop_current_server()
-                    try:
-                        replacement_pid = _spawn_replacement()
-                    except Exception:
+                    replacement_pid = None
+                    spawn_error = None
+                    for _spawn_attempt in range(2):
+                        try:
+                            replacement_pid = _spawn_replacement()
+                            spawn_error = None
+                            break
+                        except Exception as exc:
+                            spawn_error = exc
+                    if replacement_pid is None:
                         runtime.write_status(
                             "error",
                             "ui_reload_failed",
@@ -7498,9 +7545,10 @@ def ui_reload():
                         logger.exception(
                             "UI reload replacement failed to spawn: %s",
                             "ui_reload_failed",
+                            exc_info=spawn_error,
                         )
                         return
-                    if not _replacement_identity_ready():
+                    if not _replacement_identity_ready(deadline):
                         runtime.write_status(
                             "error",
                             "ui_reload_timeout",

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6517,42 +6517,14 @@ def local_version():
 # could both pass the check before either seeds restart_status.json, scheduling
 # two supervisors that race on the same pid files + lock.
 _RESTART_CONTROL_LOCK = threading.Lock()
-# How long a just-seeded, pid-less "scheduled" status is treated as in flight
-# (its supervisor is still starting up). Past this, a pid-less status is stale
-# (the supervisor died before recording its pid) and must NOT block restarts.
-_RESTART_SEED_GRACE_SECONDS = 60.0
 
 
 def _restart_in_flight() -> bool:
-    """True only when a restart is genuinely still running, so a stale status
-    can never permanently block Web restarts."""
-    from vibe import runtime
+    """Delegate restart ownership checks to the shared supervisor predicate."""
 
-    status = runtime.read_json(runtime.get_restart_status_path()) or {}
-    if status.get("state") not in ("scheduled", "running"):
-        return False
-    sup_pid = status.get("supervisor_pid")
-    if isinstance(sup_pid, int):
-        if not runtime.pid_alive(sup_pid):
-            return False
-        # Guard against PID reuse: a dead supervisor's pid can be reclaimed by an
-        # unrelated process (notably across a reboot), which would otherwise keep
-        # blocking restarts until that process exits. The job records its
-        # ``supervisor_started_at`` (process create time), so only treat the pid
-        # as the live supervisor when the create time still matches.
-        started_at = status.get("supervisor_started_at")
-        if started_at is not None:
-            current = runtime.process_create_time(sup_pid)
-            if current is not None and current != started_at:
-                return False
-        return True
-    # No supervisor pid recorded yet: in flight only while the seed is fresh
-    # (the child is still starting). An older pid-less status is stale.
-    try:
-        age = time.time() - runtime.get_restart_status_path().stat().st_mtime
-    except OSError:
-        return False
-    return age < _RESTART_SEED_GRACE_SECONDS
+    from vibe.restart_supervisor import restart_in_flight
+
+    return restart_in_flight()
 
 
 def _schedule_service_restart_for_config_fallback() -> dict[str, Any]:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7435,8 +7435,6 @@ def ui_reload():
     except (TypeError, ValueError):
         return jsonify({"error": "invalid_port"}), 400
 
-    status = runtime.read_status()
-
     try:
         from core.services import settings as settings_service
 
@@ -7486,10 +7484,11 @@ def ui_reload():
                     "ui_stderr.log",
                     **spawn_kwargs,
                 )
+                fresh = runtime.read_status()
                 runtime.write_status(
-                    status.get("state", "running"),
-                    status.get("detail"),
-                    status.get("service_pid"),
+                    fresh.get("state", "running"),
+                    fresh.get("detail"),
+                    fresh.get("service_pid"),
                     pid,
                 )
             except Exception:
@@ -7505,13 +7504,22 @@ def ui_reload():
                 raise
             return pid
 
-        def _replacement_identity_ready(deadline: float) -> bool:
+        def _replacement_identity_ready(replacement_pid: int, deadline: float) -> bool:
+            pid_path = config_paths.get_runtime_ui_pid_path()
+            ready_path = config_paths.get_runtime_dir() / "ui_server_ready.json"
             for attempt in range(51):
                 if time.monotonic() > deadline:
                     break
-                if runtime.ui_pid_file_points_to_running_ui() and runtime.ui_server_healthy(
-                    host=bind_host,
-                    port=port,
+                try:
+                    recorded_pid = int(pid_path.read_text(encoding="utf-8").strip())
+                except (OSError, ValueError):
+                    recorded_pid = None
+                ready = runtime.read_json(ready_path) or {}
+                marker_pid = ready.get("pid") if isinstance(ready, dict) else None
+                if (
+                    runtime.ui_pid_file_points_to_running_ui()
+                    and recorded_pid == replacement_pid
+                    and marker_pid == replacement_pid
                 ):
                     return time.monotonic() <= deadline
                 remaining = deadline - time.monotonic()
@@ -7524,6 +7532,12 @@ def ui_reload():
         for attempt in range(2):
             try:
                 with package_mutation_lock():
+                    if _restart_in_flight():
+                        logger.warning(
+                            "UI reload not scheduled while restart is active: %s",
+                            "restart_in_progress",
+                        )
+                        return
                     deadline = time.monotonic() + 10.0
                     _stop_current_server()
                     replacement_pid = None
@@ -7536,11 +7550,12 @@ def ui_reload():
                         except Exception as exc:
                             spawn_error = exc
                     if replacement_pid is None:
+                        fresh = runtime.read_status()
                         runtime.write_status(
                             "error",
                             "ui_reload_failed",
-                            status.get("service_pid"),
-                            status.get("ui_pid"),
+                            fresh.get("service_pid"),
+                            fresh.get("ui_pid"),
                         )
                         logger.exception(
                             "UI reload replacement failed to spawn: %s",
@@ -7548,11 +7563,12 @@ def ui_reload():
                             exc_info=spawn_error,
                         )
                         return
-                    if not _replacement_identity_ready(deadline):
+                    if not _replacement_identity_ready(replacement_pid, deadline):
+                        fresh = runtime.read_status()
                         runtime.write_status(
                             "error",
                             "ui_reload_timeout",
-                            status.get("service_pid"),
+                            fresh.get("service_pid"),
                             replacement_pid,
                         )
                         logger.warning(
@@ -16480,6 +16496,12 @@ def run_ui_server(host: str, port: int) -> None:
                 workers=1,
             )
             bound_socket = _bind_ui_socket(host, port)
+            from vibe import runtime
+
+            runtime.write_json(
+                paths.get_runtime_dir() / "ui_server_ready.json",
+                {"pid": os.getpid(), "bound_at": time.time()},
+            )
             _server = uvicorn.Server(uvicorn_config)
             # Reconcile remote_access in the background so cloudflared download/
             # connector start does not block /health and the rest of the UI

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7815,6 +7815,8 @@ async def wechat_qr_login_poll():
                     restart.get("error") or restart.get("code"),
                 )
         except Exception as exc:
+            result["restart_scheduled"] = False
+            result["restart_reason"] = "restart_not_scheduled"
             logger.warning("Failed to schedule service restart after WeChat QR login: %s", exc)
 
     return jsonify(result)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7440,7 +7440,17 @@ def ui_reload():
         from config import paths as config_paths
         from vibe.memory_ui_access import process_ui_read_secret
 
-        def _spawn_replacement() -> None:
+        def _stop_current_server() -> None:
+            if not _server:
+                return
+            if hasattr(_server, "should_exit"):
+                _server.should_exit = True
+                return
+            shutdown = getattr(_server, "shutdown", None)
+            if callable(shutdown):
+                shutdown()
+
+        def _spawn_replacement() -> int:
             command = f"from vibe.ui_server import run_ui_server; run_ui_server('{bind_host}', {port})"
             memory_ui_secret = process_ui_read_secret()
             spawn_kwargs = (
@@ -7461,12 +7471,47 @@ def ui_reload():
                 status.get("service_pid"),
                 pid,
             )
+            return pid
+
+        def _replacement_identity_ready() -> bool:
+            for attempt in range(51):
+                if runtime.ui_pid_file_points_to_running_ui():
+                    return True
+                if attempt < 50:
+                    time.sleep(0.2)
+            return False
 
         spawned = False
         for attempt in range(2):
             try:
                 with package_mutation_lock():
-                    _spawn_replacement()
+                    _stop_current_server()
+                    try:
+                        replacement_pid = _spawn_replacement()
+                    except Exception:
+                        runtime.write_status(
+                            "error",
+                            "ui_reload_failed",
+                            status.get("service_pid"),
+                            status.get("ui_pid"),
+                        )
+                        logger.exception(
+                            "UI reload replacement failed to spawn: %s",
+                            "ui_reload_failed",
+                        )
+                        return
+                    if not _replacement_identity_ready():
+                        runtime.write_status(
+                            "error",
+                            "ui_reload_timeout",
+                            status.get("service_pid"),
+                            replacement_pid,
+                        )
+                        logger.warning(
+                            "UI reload replacement identity timed out: %s",
+                            "ui_reload_timeout",
+                        )
+                        return
                 spawned = True
                 break
             except MigrationLockTimeout:
@@ -7478,16 +7523,6 @@ def ui_reload():
                 "restart_not_scheduled_package_busy",
             )
             return
-
-        time.sleep(0.2)
-        # Shutdown the old server to release the port
-        if _server:
-            if hasattr(_server, "should_exit"):
-                _server.should_exit = True
-            else:
-                shutdown = getattr(_server, "shutdown", None)
-                if callable(shutdown):
-                    shutdown()
 
     # Schedule restart after response is sent
     threading.Thread(target=_restart).start()

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7435,6 +7435,25 @@ def ui_reload():
     except (TypeError, ValueError):
         return jsonify({"error": "invalid_port"}), 400
 
+    def _restart_in_progress_response():
+        return _coded_error_response(
+            "restart_in_progress",
+            "a restart is already in progress",
+            409,
+            restart=runtime.read_json(runtime.get_restart_status_path()) or {},
+        )
+
+    if _restart_in_flight():
+        return _restart_in_progress_response()
+    try:
+        with package_mutation_lock(timeout_seconds=0):
+            if _restart_in_flight():
+                return _restart_in_progress_response()
+    except MigrationLockTimeout:
+        if _restart_in_flight():
+            return _restart_in_progress_response()
+        return jsonify(_restart_not_scheduled_package_busy()), 409
+
     try:
         from core.services import settings as settings_service
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -79,7 +79,9 @@ from vibe.model_service import MODEL_SERVICE_REFRESH_PATH
 from vibe.runtime import get_ui_dist_path, get_working_dir
 from vibe.sentry_integration import init_sentry
 from storage.delivery_states import ADMITTED_DELIVERY_STATES
+from storage.lock import MigrationLockTimeout
 from vibe.ui_memory_routes import register_memory_routes
+from vibe.upgrade import package_mutation_lock
 
 if TYPE_CHECKING:
     from core.show_runtime import ShowRuntimeUnavailableError
@@ -6536,35 +6538,43 @@ def _schedule_service_restart_for_config_fallback() -> dict[str, Any]:
         runtime.write_status("restarting", "restarting", status.get("service_pid"), status.get("ui_pid"))
         return schedule_restart(delay_seconds=0.0, trigger="web-ui-config", scope="service")
 
-    with _RESTART_CONTROL_LOCK:
-        if _restart_in_flight():
-            restart_status = runtime.read_json(runtime.get_restart_status_path()) or {}
-            pending = mark_pending_restart(
-                trigger="web-ui-config-pending",
-                scope="service",
-                reason="restart_in_progress",
-                restart_job_id=restart_status.get("job_id"),
-            )
-            if not _restart_in_flight():
-                try:
-                    from vibe.restart_supervisor import _pending_restart_path
+    def _mark_pending() -> dict[str, Any]:
+        restart_status = runtime.read_json(runtime.get_restart_status_path()) or {}
+        pending = mark_pending_restart(
+            trigger="web-ui-config-pending",
+            scope="service",
+            reason="restart_in_progress",
+            restart_job_id=restart_status.get("job_id"),
+        )
+        return {
+            "ok": True,
+            "pending_restart": pending,
+            "restart": restart_status,
+            "code": "restart_pending_after_in_progress",
+        }
 
-                    _pending_restart_path().unlink(missing_ok=True)
-                except OSError:
-                    logger.debug("Failed to remove stale pending restart marker", exc_info=True)
+    try:
+        with package_mutation_lock():
+            with _RESTART_CONTROL_LOCK:
+                if _restart_in_flight():
+                    pending_result = _mark_pending()
+                    if not _restart_in_flight():
+                        try:
+                            from vibe.restart_supervisor import _pending_restart_path
+
+                            _pending_restart_path().unlink(missing_ok=True)
+                        except OSError:
+                            logger.debug("Failed to remove stale pending restart marker", exc_info=True)
+                        restart = _schedule_restart()
+                        return {
+                            "ok": True,
+                            "restart": restart,
+                            "code": "restart_scheduled_after_in_flight_finished",
+                        }
+                    return pending_result
                 restart = _schedule_restart()
-                return {
-                    "ok": True,
-                    "restart": restart,
-                    "code": "restart_scheduled_after_in_flight_finished",
-                }
-            return {
-                "ok": True,
-                "pending_restart": pending,
-                "restart": restart_status,
-                "code": "restart_pending_after_in_progress",
-            }
-        restart = _schedule_restart()
+    except MigrationLockTimeout:
+        return _mark_pending()
     return {"ok": True, "restart": restart}
 
 
@@ -6641,27 +6651,50 @@ def control():
         # (a UI host/port change needs the UI server itself to come back up).
         # Only the platform-config flow opts into "service" (keep the Web UI up).
         scope = payload.get("scope") if payload.get("scope") in ("all", "service") else "all"
-        # Reject overlapping restarts: a service-only restart leaves the Web UI
-        # up, so a user (or another tab) could fire a second restart while the
-        # first supervisor is still bouncing the service — two jobs would race
-        # on the same pid files + lock. The check + schedule are held under one
-        # process lock so two concurrent requests can't both slip through.
-        with _RESTART_CONTROL_LOCK:
-            if _restart_in_flight():
-                return (
-                    jsonify(
-                        {
-                            "ok": False,
-                            "action": action,
-                            "error": "a restart is already in progress",
-                            "code": "restart_in_progress",
-                            "status": runtime.read_status(),
-                        }
-                    ),
-                    409,
-                )
-            runtime.write_status("restarting", "restarting", status.get("service_pid"), status.get("ui_pid"))
-            result = schedule_restart(delay_seconds=0.0, trigger="web-ui", scope=scope)
+
+        # The package lease prevents a supervisor from stopping this process
+        # while another process is replacing the environment. The process lock
+        # remains nested inside it to serialize concurrent Web requests.
+        try:
+            with package_mutation_lock():
+                with _RESTART_CONTROL_LOCK:
+                    if _restart_in_flight():
+                        return (
+                            jsonify(
+                                {
+                                    "ok": False,
+                                    "action": action,
+                                    "error": "a restart is already in progress",
+                                    "code": "restart_in_progress",
+                                    "status": runtime.read_status(),
+                                }
+                            ),
+                            409,
+                        )
+                    runtime.write_status(
+                        "restarting",
+                        "restarting",
+                        status.get("service_pid"),
+                        status.get("ui_pid"),
+                    )
+                    result = schedule_restart(
+                        delay_seconds=0.0,
+                        trigger="web-ui",
+                        scope=scope,
+                    )
+        except MigrationLockTimeout:
+            return (
+                jsonify(
+                    {
+                        "ok": False,
+                        "action": action,
+                        "error": "a restart is already in progress",
+                        "code": "restart_in_progress",
+                        "status": runtime.read_status(),
+                    }
+                ),
+                409,
+            )
         return jsonify({"ok": True, "action": action, "restart": result, "status": runtime.read_status()})
     return jsonify({"ok": True, "action": action, "status": runtime.read_status()})
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6519,6 +6519,7 @@ def local_version():
 # could both pass the check before either seeds restart_status.json, scheduling
 # two supervisors that race on the same pid files + lock.
 _RESTART_CONTROL_LOCK = threading.Lock()
+_RESTART_REACQUIRE_TIMEOUT_SECONDS = 1.0
 
 
 def _restart_in_flight() -> bool:
@@ -6529,42 +6530,63 @@ def _restart_in_flight() -> bool:
     return restart_in_flight()
 
 
+def _restart_not_scheduled_package_busy() -> dict[str, Any]:
+    from vibe import runtime
+
+    return {
+        "ok": False,
+        "code": "restart_not_scheduled_package_busy",
+        "error": "a package operation is in progress; restart was not scheduled",
+        "restart": runtime.read_json(runtime.get_restart_status_path()) or {},
+    }
+
+
+def _mark_service_restart_pending(*, trigger: str) -> dict[str, Any]:
+    from vibe import runtime
+    from vibe.restart_supervisor import mark_pending_restart
+
+    restart_status = runtime.read_json(runtime.get_restart_status_path()) or {}
+    pending = mark_pending_restart(
+        trigger=trigger,
+        scope="service",
+        reason="restart_in_progress",
+        restart_job_id=restart_status.get("job_id"),
+    )
+    return {
+        "ok": True,
+        "pending_restart": pending,
+        "restart": restart_status,
+        "code": "restart_pending_after_in_progress",
+    }
+
+
+def _remove_pending_restart_marker() -> None:
+    try:
+        from vibe.restart_supervisor import _pending_restart_path
+
+        _pending_restart_path().unlink(missing_ok=True)
+    except OSError:
+        logger.debug("Failed to remove stale pending restart marker", exc_info=True)
+
+
 def _schedule_service_restart_for_config_fallback() -> dict[str, Any]:
     from vibe import runtime
-    from vibe.restart_supervisor import mark_pending_restart, schedule_restart
+    from vibe.restart_supervisor import schedule_restart
 
     def _schedule_restart() -> dict[str, Any]:
         status = runtime.read_status()
         runtime.write_status("restarting", "restarting", status.get("service_pid"), status.get("ui_pid"))
         return schedule_restart(delay_seconds=0.0, trigger="web-ui-config", scope="service")
 
-    def _mark_pending() -> dict[str, Any]:
-        restart_status = runtime.read_json(runtime.get_restart_status_path()) or {}
-        pending = mark_pending_restart(
-            trigger="web-ui-config-pending",
-            scope="service",
-            reason="restart_in_progress",
-            restart_job_id=restart_status.get("job_id"),
-        )
-        return {
-            "ok": True,
-            "pending_restart": pending,
-            "restart": restart_status,
-            "code": "restart_pending_after_in_progress",
-        }
-
     try:
         with package_mutation_lock():
             with _RESTART_CONTROL_LOCK:
                 if _restart_in_flight():
-                    pending_result = _mark_pending()
+                    pending_result = _mark_service_restart_pending(
+                        trigger="web-ui-config-pending",
+                    )
                     if not _restart_in_flight():
-                        try:
-                            from vibe.restart_supervisor import _pending_restart_path
-
-                            _pending_restart_path().unlink(missing_ok=True)
-                        except OSError:
-                            logger.debug("Failed to remove stale pending restart marker", exc_info=True)
+                        _remove_pending_restart_marker()
                         restart = _schedule_restart()
                         return {
                             "ok": True,
@@ -6575,12 +6597,26 @@ def _schedule_service_restart_for_config_fallback() -> dict[str, Any]:
                 restart = _schedule_restart()
     except MigrationLockTimeout:
         if _restart_in_flight():
-            return _mark_pending()
-        return {
-            "ok": True,
-            "code": "restart_not_scheduled_package_busy",
-            "restart": runtime.read_json(runtime.get_restart_status_path()) or {},
-        }
+            pending_result = _mark_service_restart_pending(
+                trigger="web-ui-config-pending",
+            )
+            if _restart_in_flight():
+                return pending_result
+            _remove_pending_restart_marker()
+            try:
+                with package_mutation_lock(
+                    timeout_seconds=_RESTART_REACQUIRE_TIMEOUT_SECONDS,
+                ):
+                    restart = _schedule_restart()
+            except MigrationLockTimeout:
+                _remove_pending_restart_marker()
+                return _restart_not_scheduled_package_busy()
+            return {
+                "ok": True,
+                "restart": restart,
+                "code": "restart_scheduled_after_in_flight_finished",
+            }
+        return _restart_not_scheduled_package_busy()
     return {"ok": True, "restart": restart}
 
 
@@ -7655,7 +7691,19 @@ def _schedule_wechat_qr_login_restart() -> dict:
     """Schedule a managed restart after QR-login credentials are persisted."""
     from vibe.restart_supervisor import schedule_restart
 
-    return schedule_restart(delay_seconds=2.0, trigger="wechat-qr-login")
+    try:
+        with package_mutation_lock():
+            if _restart_in_flight():
+                return _mark_service_restart_pending(
+                    trigger="wechat-qr-login-pending",
+                )
+            return schedule_restart(delay_seconds=2.0, trigger="wechat-qr-login")
+    except MigrationLockTimeout:
+        if _restart_in_flight():
+            return _mark_service_restart_pending(
+                trigger="wechat-qr-login-pending",
+            )
+        return _restart_not_scheduled_package_busy()
 
 
 def _persist_wechat_qr_credentials(result: dict) -> None:

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -1061,8 +1061,10 @@ def build_upgrade_plan(
         ]
     preflight_command = None
     if include_memory or cleanup_command is not None:
-        # Unlike install, download never treats installed metadata as satisfied;
-        # legacy pip therefore needs neither (nor supports) an upgrade flag here.
+        # Preflight checks that the target artifacts resolve before mutating the
+        # environment. The live install still resolves already-satisfied runtime
+        # dependencies; asking ``pip download`` for them would make an otherwise
+        # offline-safe upgrade depend on fetching every transitive wheel again.
         preflight_command = [
             executable,
             "-m",
@@ -1070,6 +1072,7 @@ def build_upgrade_plan(
             "download",
             "--dest",
             PIP_DOWNLOAD_DEST_PLACEHOLDER,
+            "--no-deps",
         ]
         preflight_command.append(package_spec)
         if pinned_memory_spec:

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -892,13 +892,16 @@ def rollback_target() -> RollbackTarget | None:
 def _with_memory_extra(package_spec: str) -> str:
     """Select the host's Memory extra without rewriting non-name specs by hand."""
 
+    if package_spec.startswith(
+        ("git+", "hg+", "svn+", "bz+", "http://", "https://")
+    ):
+        return f"{PACKAGE_NAME}[{MEMORY_EXTRA_NAME}] @ {package_spec}"
+
     try:
         from packaging.requirements import InvalidRequirement, Requirement
 
         requirement = Requirement(package_spec)
     except InvalidRequirement:
-        if package_spec.startswith(("http://", "https://")):
-            return f"{PACKAGE_NAME}[{MEMORY_EXTRA_NAME}] @ {package_spec}"
         # pip and uv accept extras on local wheel paths in this form. Those paths
         # are deliberately not parsed as named PEP 508 requirements.
         return f"{package_spec}[{MEMORY_EXTRA_NAME}]"

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import NamedTuple, cast
 
+from packaging.version import InvalidVersion, Version
+
 from vibe import runtime as runtime_mod
 
 
@@ -29,6 +31,7 @@ MEMORY_PACKAGE_COMPATIBILITY = ">=3.0.14.dev0,<3.1"
 MEMORY_PACKAGE_REQUIREMENT = (
     f"{MEMORY_PACKAGE_NAME}{MEMORY_PACKAGE_COMPATIBILITY}"
 )
+_MEMORY_SPLIT_MIN_VERSION = Version("3.0.14.dev0")
 PIP_DOWNLOAD_DEST_PLACEHOLDER = "{avibe-pip-download-destination}"
 PACKAGE_MUTATION_LOCK_TIMEOUT_SECONDS = 30.0
 DEFAULT_UPDATE_METADATA_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
@@ -96,6 +99,7 @@ class UpgradePlan:
     rollback_to: RollbackTarget | None = None
     preflight_command: list[str] | None = None
     cleanup_command: list[str] | None = None
+    cleanup_after_command: bool = False
 
 
 def execute_upgrade_plan(
@@ -104,17 +108,17 @@ def execute_upgrade_plan(
     run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
     **run_kwargs: object,
 ) -> subprocess.CompletedProcess[str]:
-    """Resolve, remove an overlapping optional package, then install.
+    """Resolve, then install and clean up in the plan's recorded order.
 
     The optional preflight resolves required distributions without writing the
     environment. It protects both Memory-preserving plans and destructive pip
     rollbacks, so an unavailable optional package or pinned host returns before
     the current install is changed. A core-only pip rollback needs cleanup
     because pip installs are additive: pinning only ``avibe-os`` does not remove
-    an optional distribution left by the failed generation. That cleanup runs
-    before the pinned host reinstall because the split distribution and a
-    pre-split host own the same implementation paths; uninstalling it afterward
-    would delete files the restored host just wrote.
+    an optional distribution left by the failed generation. A bundled target
+    cleans up first because both distributions own the same implementation
+    paths. A split target installs first so dependency failure cannot strip
+    Memory from the still-running generation.
     """
 
     with package_mutation_lock():
@@ -137,12 +141,21 @@ def execute_upgrade_plan(
             if preflight.returncode != 0:
                 return preflight
 
-        if plan.cleanup_command is not None:
+        if plan.cleanup_command is not None and not plan.cleanup_after_command:
             cleaned = run(plan.cleanup_command, env=plan.env, **run_kwargs)
             if cleaned.returncode != 0:
                 return cleaned
 
-        return run(plan.command, env=plan.env, **run_kwargs)
+        installed = run(plan.command, env=plan.env, **run_kwargs)
+        if installed.returncode != 0:
+            return installed
+
+        if plan.cleanup_command is not None and plan.cleanup_after_command:
+            cleaned = run(plan.cleanup_command, env=plan.env, **run_kwargs)
+            if cleaned.returncode != 0:
+                return cleaned
+
+        return installed
 
 
 @contextmanager
@@ -1050,6 +1063,7 @@ def build_upgrade_plan(
     if pinned_memory_spec:
         command.append(pinned_memory_spec)
     cleanup_command = None
+    cleanup_after_command = False
     if version and not include_memory and memory_package_installed():
         cleanup_command = [
             executable,
@@ -1059,6 +1073,10 @@ def build_upgrade_plan(
             "--yes",
             MEMORY_PACKAGE_NAME,
         ]
+        try:
+            cleanup_after_command = Version(version) >= _MEMORY_SPLIT_MIN_VERSION
+        except InvalidVersion:
+            pass
     preflight_command = None
     if include_memory or cleanup_command is not None:
         # Preflight checks that the target artifacts resolve before mutating the
@@ -1084,6 +1102,7 @@ def build_upgrade_plan(
         rollback_to=rollback_to,
         preflight_command=preflight_command,
         cleanup_command=cleanup_command,
+        cleanup_after_command=cleanup_after_command,
     )
 
 

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -99,15 +99,17 @@ def execute_upgrade_plan(
     run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
     **run_kwargs: object,
 ) -> subprocess.CompletedProcess[str]:
-    """Resolve, install, and normalize one package shape in that order.
+    """Resolve, remove an overlapping optional package, then install.
 
     The optional preflight exists for plans that require the Memory extra. Its
     installer performs dependency resolution without writing the environment,
     so an unavailable or incompatible ``avibe-memory`` release returns before
     the command that replaces the running Avibe install. A core-only pip
-    rollback needs the final cleanup because pip installs are additive: pinning
-    only ``avibe-os`` does not remove an optional distribution left by the
-    failed generation.
+    rollback needs cleanup because pip installs are additive: pinning only
+    ``avibe-os`` does not remove an optional distribution left by the failed
+    generation. That cleanup runs before the pinned host reinstall because the
+    split distribution and a pre-split host own the same implementation paths;
+    uninstalling it afterward would delete files the restored host just wrote.
     """
 
     with package_mutation_lock():
@@ -116,12 +118,12 @@ def execute_upgrade_plan(
             if preflight.returncode != 0:
                 return preflight
 
-        installed = run(plan.command, env=plan.env, **run_kwargs)
-        if installed.returncode != 0 or plan.cleanup_command is None:
-            return installed
+        if plan.cleanup_command is not None:
+            cleaned = run(plan.cleanup_command, env=plan.env, **run_kwargs)
+            if cleaned.returncode != 0:
+                return cleaned
 
-        cleaned = run(plan.cleanup_command, env=plan.env, **run_kwargs)
-        return installed if cleaned.returncode == 0 else cleaned
+        return run(plan.command, env=plan.env, **run_kwargs)
 
 
 @contextmanager

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -106,15 +106,15 @@ def execute_upgrade_plan(
 ) -> subprocess.CompletedProcess[str]:
     """Resolve, remove an overlapping optional package, then install.
 
-    The optional preflight exists for plans that require the Memory extra. Its
-    installer performs dependency resolution without writing the environment,
-    so an unavailable or incompatible ``avibe-memory`` release returns before
-    the command that replaces the running Avibe install. A core-only pip
-    rollback needs cleanup because pip installs are additive: pinning only
-    ``avibe-os`` does not remove an optional distribution left by the failed
-    generation. That cleanup runs before the pinned host reinstall because the
-    split distribution and a pre-split host own the same implementation paths;
-    uninstalling it afterward would delete files the restored host just wrote.
+    The optional preflight resolves required distributions without writing the
+    environment. It protects both Memory-preserving plans and destructive pip
+    rollbacks, so an unavailable optional package or pinned host returns before
+    the current install is changed. A core-only pip rollback needs cleanup
+    because pip installs are additive: pinning only ``avibe-os`` does not remove
+    an optional distribution left by the failed generation. That cleanup runs
+    before the pinned host reinstall because the split distribution and a
+    pre-split host own the same implementation paths; uninstalling it afterward
+    would delete files the restored host just wrote.
     """
 
     with package_mutation_lock():
@@ -651,14 +651,22 @@ def configured_memory_enabled() -> bool:
 
 
 def _distributions_providing_this_package() -> list[str]:
-    """Every installed distribution that provides the package this module is in."""
+    """Host distributions that provide the package this module is in."""
 
     try:
         from importlib.metadata import packages_distributions
+        from packaging.utils import canonicalize_name
     except ImportError:  # pragma: no cover - importlib.metadata ships with 3.10+
         return []
     try:
-        return sorted(set(packages_distributions().get(__name__.split(".")[0], [])))
+        memory_name = canonicalize_name(MEMORY_PACKAGE_NAME)
+        return sorted(
+            {
+                name
+                for name in packages_distributions().get(__name__.split(".")[0], [])
+                if canonicalize_name(name) != memory_name
+            }
+        )
     except Exception:  # pragma: no cover - a broken environment answers nothing
         logger.debug("Failed to read installed distribution metadata", exc_info=True)
         return []
@@ -1038,8 +1046,18 @@ def build_upgrade_plan(
     command.append(package_spec)
     if pinned_memory_spec:
         command.append(pinned_memory_spec)
+    cleanup_command = None
+    if version and not include_memory and memory_package_installed():
+        cleanup_command = [
+            executable,
+            "-m",
+            "pip",
+            "uninstall",
+            "--yes",
+            MEMORY_PACKAGE_NAME,
+        ]
     preflight_command = None
-    if include_memory:
+    if include_memory or cleanup_command is not None:
         # Unlike install, download never treats installed metadata as satisfied;
         # legacy pip therefore needs neither (nor supports) an upgrade flag here.
         preflight_command = [
@@ -1053,16 +1071,6 @@ def build_upgrade_plan(
         preflight_command.append(package_spec)
         if pinned_memory_spec:
             preflight_command.append(pinned_memory_spec)
-    cleanup_command = None
-    if version and not include_memory and memory_package_installed():
-        cleanup_command = [
-            executable,
-            "-m",
-            "pip",
-            "uninstall",
-            "--yes",
-            MEMORY_PACKAGE_NAME,
-        ]
     return UpgradePlan(
         command=command,
         env=dict(base_env or os.environ),

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -29,6 +29,7 @@ MEMORY_PACKAGE_COMPATIBILITY = ">=3.0.14.dev0,<3.1"
 MEMORY_PACKAGE_REQUIREMENT = (
     f"{MEMORY_PACKAGE_NAME}{MEMORY_PACKAGE_COMPATIBILITY}"
 )
+PIP_DOWNLOAD_DEST_PLACEHOLDER = "{avibe-pip-download-destination}"
 PACKAGE_MUTATION_LOCK_TIMEOUT_SECONDS = 30.0
 DEFAULT_UPDATE_METADATA_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
 CURRENT_VIBE_EXECUTABLE_ENV = "VIBE_CURRENT_EXECUTABLE"
@@ -118,7 +119,21 @@ def execute_upgrade_plan(
 
     with package_mutation_lock():
         if plan.preflight_command is not None:
-            preflight = run(plan.preflight_command, env=plan.env, **run_kwargs)
+            preflight_command = plan.preflight_command
+            scratch_dir: str | None = None
+            try:
+                if PIP_DOWNLOAD_DEST_PLACEHOLDER in preflight_command:
+                    scratch_dir = tempfile.mkdtemp(prefix="avibe-pip-download-")
+                    preflight_command = [
+                        scratch_dir
+                        if argument == PIP_DOWNLOAD_DEST_PLACEHOLDER
+                        else argument
+                        for argument in preflight_command
+                    ]
+                preflight = run(preflight_command, env=plan.env, **run_kwargs)
+            finally:
+                if scratch_dir is not None:
+                    shutil.rmtree(scratch_dir, ignore_errors=True)
             if preflight.returncode != 0:
                 return preflight
 
@@ -1025,15 +1040,16 @@ def build_upgrade_plan(
         command.append(pinned_memory_spec)
     preflight_command = None
     if include_memory:
+        # Unlike install, download never treats installed metadata as satisfied;
+        # legacy pip therefore needs neither (nor supports) an upgrade flag here.
         preflight_command = [
             executable,
             "-m",
             "pip",
-            "install",
-            "--dry-run",
+            "download",
+            "--dest",
+            PIP_DOWNLOAD_DEST_PLACEHOLDER,
         ]
-        if not version:
-            preflight_command.append("--upgrade")
         preflight_command.append(package_spec)
         if pinned_memory_spec:
             preflight_command.append(pinned_memory_spec)
@@ -1116,10 +1132,9 @@ def build_memory_add_plan(
         executable,
         "-m",
         "pip",
-        "install",
-        "--dry-run",
-        "--upgrade",
-        "--force-reinstall",
+        "download",
+        "--dest",
+        PIP_DOWNLOAD_DEST_PLACEHOLDER,
         "--no-deps",
         MEMORY_PACKAGE_REQUIREMENT,
     ]

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -146,7 +146,10 @@ def execute_upgrade_plan(
 
 
 @contextmanager
-def package_mutation_lock():
+def package_mutation_lock(
+    *,
+    timeout_seconds: float | None = PACKAGE_MUTATION_LOCK_TIMEOUT_SECONDS,
+):
     """Serialize every resolver/install transaction across Avibe processes."""
 
     from config import paths
@@ -156,7 +159,7 @@ def package_mutation_lock():
     lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     with MigrationFileLock(
         lock_path,
-        timeout_seconds=PACKAGE_MUTATION_LOCK_TIMEOUT_SECONDS,
+        timeout_seconds=timeout_seconds,
     ):
         yield
 

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 import urllib.request
 from collections.abc import Callable, Mapping
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import NamedTuple, cast
@@ -24,6 +25,7 @@ PACKAGE_NAME = "avibe-os"
 LEGACY_PACKAGE_NAME = "vibe-remote"
 MEMORY_PACKAGE_NAME = "avibe-memory"
 MEMORY_EXTRA_NAME = "memory"
+PACKAGE_MUTATION_LOCK_TIMEOUT_SECONDS = 30.0
 DEFAULT_UPDATE_METADATA_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
 CURRENT_VIBE_EXECUTABLE_ENV = "VIBE_CURRENT_EXECUTABLE"
 SHOW_RUNTIME_SKIP_ENV = "VIBE_INSTALL_SKIP_SHOW_RUNTIME"
@@ -108,17 +110,34 @@ def execute_upgrade_plan(
     failed generation.
     """
 
-    if plan.preflight_command is not None:
-        preflight = run(plan.preflight_command, env=plan.env, **run_kwargs)
-        if preflight.returncode != 0:
-            return preflight
+    with package_mutation_lock():
+        if plan.preflight_command is not None:
+            preflight = run(plan.preflight_command, env=plan.env, **run_kwargs)
+            if preflight.returncode != 0:
+                return preflight
 
-    installed = run(plan.command, env=plan.env, **run_kwargs)
-    if installed.returncode != 0 or plan.cleanup_command is None:
-        return installed
+        installed = run(plan.command, env=plan.env, **run_kwargs)
+        if installed.returncode != 0 or plan.cleanup_command is None:
+            return installed
 
-    cleaned = run(plan.cleanup_command, env=plan.env, **run_kwargs)
-    return installed if cleaned.returncode == 0 else cleaned
+        cleaned = run(plan.cleanup_command, env=plan.env, **run_kwargs)
+        return installed if cleaned.returncode == 0 else cleaned
+
+
+@contextmanager
+def package_mutation_lock():
+    """Serialize every resolver/install transaction across Avibe processes."""
+
+    from config import paths
+    from storage.lock import MigrationFileLock
+
+    lock_path = paths.get_runtime_dir() / "package-mutation.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    with MigrationFileLock(
+        lock_path,
+        timeout_seconds=PACKAGE_MUTATION_LOCK_TIMEOUT_SECONDS,
+    ):
+        yield
 
 
 def resolve_command_path(command: str | None, search_path: str | None = None) -> str | None:
@@ -573,6 +592,25 @@ def memory_package_installed() -> bool:
     return True
 
 
+def installed_memory_package_version() -> str | None:
+    """Return the exact optional distribution version, when it is readable."""
+
+    try:
+        from importlib.metadata import PackageNotFoundError, distribution
+
+        version = distribution(MEMORY_PACKAGE_NAME).version
+    except PackageNotFoundError:
+        return None
+    except Exception:
+        logger.warning(
+            "Could not determine the installed %s version",
+            MEMORY_PACKAGE_NAME,
+            exc_info=True,
+        )
+        return None
+    return str(version).strip() or None
+
+
 def configured_memory_enabled() -> bool:
     """Read the persisted Memory switch for an explicit upgrade action."""
 
@@ -735,6 +773,7 @@ class RollbackTarget(NamedTuple):
     package: str | None
     launcher: runtime_mod.ServiceLauncher
     memory_package: bool = False
+    memory_version: str | None = None
 
 
 def _names_a_published_release(version: str) -> bool:
@@ -793,11 +832,15 @@ def rollback_target() -> RollbackTarget | None:
 
     if not _names_a_published_release(__version__):
         return None
+    memory_package = memory_package_installed()
     return RollbackTarget(
         version=__version__,
         package=installed_package_name(),
         launcher=runtime_mod.current_service_launcher(),
-        memory_package=memory_package_installed(),
+        memory_package=memory_package,
+        memory_version=(
+            installed_memory_package_version() if memory_package else None
+        ),
     )
 
 
@@ -872,6 +915,7 @@ def build_upgrade_plan(
     package_name: str | None = None,
     memory_enabled: bool = False,
     memory_package: bool | None = None,
+    memory_version: str | None = None,
 ) -> UpgradePlan:
     """How to install avibe: the newest release, or `version` exactly.
 
@@ -909,6 +953,11 @@ def build_upgrade_plan(
     )
     if not version and include_memory:
         package_spec = _with_memory_extra(package_spec)
+    pinned_memory_spec = (
+        f"{MEMORY_PACKAGE_NAME}=={memory_version}"
+        if include_memory and memory_version
+        else None
+    )
 
     if is_uv_tool_install(executable) and uv_binary:
         env = dict(base_env or os.environ)
@@ -916,6 +965,8 @@ def build_upgrade_plan(
         if vibe_bin_dir:
             env["UV_TOOL_BIN_DIR"] = vibe_bin_dir
         command = [uv_binary, "tool", "install", package_spec]
+        if pinned_memory_spec:
+            command.extend(["--with", pinned_memory_spec])
         if not version:
             command.append("--upgrade")
         if version or package_spec != PACKAGE_NAME or is_legacy_uv_tool_install(executable):
@@ -933,6 +984,8 @@ def build_upgrade_plan(
             if not version:
                 preflight_command.append("--upgrade")
             preflight_command.append(package_spec)
+            if pinned_memory_spec:
+                preflight_command.append(pinned_memory_spec)
         return UpgradePlan(
             command=command,
             env=env,
@@ -960,6 +1013,8 @@ def build_upgrade_plan(
     if version or not installed_metadata_describes_running_code():
         command.append("--force-reinstall")
     command.append(package_spec)
+    if pinned_memory_spec:
+        command.append(pinned_memory_spec)
     preflight_command = None
     if include_memory:
         preflight_command = [
@@ -972,6 +1027,8 @@ def build_upgrade_plan(
         if not version:
             preflight_command.append("--upgrade")
         preflight_command.append(package_spec)
+        if pinned_memory_spec:
+            preflight_command.append(pinned_memory_spec)
     cleanup_command = None
     if version and not include_memory and memory_package_installed():
         cleanup_command = [
@@ -989,6 +1046,78 @@ def build_upgrade_plan(
         rollback_to=rollback_to,
         preflight_command=preflight_command,
         cleanup_command=cleanup_command,
+    )
+
+
+def build_memory_add_plan(
+    *,
+    version: str,
+    vibe_path: str | None = None,
+    package_name: str | None = None,
+    python_executable: str | None = None,
+    uv_path: str | None = None,
+    base_env: dict[str, str] | None = None,
+) -> UpgradePlan:
+    """Add the current host's Memory extra without replacing the host itself."""
+
+    executable = python_executable or sys.executable
+    package_spec = pinned_package_spec(
+        version,
+        python_executable=executable,
+        package_name=package_name,
+        memory_package=True,
+    )
+    uv_binary = find_uv_binary(uv_path=uv_path, base_env=base_env)
+    env = dict(base_env or os.environ)
+    if is_uv_tool_install(executable) and uv_binary:
+        command = [
+            uv_binary,
+            "pip",
+            "install",
+            "--upgrade",
+            "--python",
+            executable,
+            package_spec,
+        ]
+        preflight = [
+            uv_binary,
+            "pip",
+            "install",
+            "--dry-run",
+            "--upgrade",
+            "--python",
+            executable,
+            package_spec,
+        ]
+        return UpgradePlan(
+            command=command,
+            env=env,
+            method="uv",
+            preflight_command=preflight,
+        )
+
+    command = [
+        executable,
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        package_spec,
+    ]
+    preflight = [
+        executable,
+        "-m",
+        "pip",
+        "install",
+        "--dry-run",
+        "--upgrade",
+        package_spec,
+    ]
+    return UpgradePlan(
+        command=command,
+        env=env,
+        method="pip",
+        preflight_command=preflight,
     )
 
 

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -6,10 +6,11 @@ import os
 import re
 import shlex
 import shutil
+import subprocess
 import sys
 import tempfile
 import urllib.request
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import NamedTuple, cast
@@ -21,6 +22,8 @@ logger = logging.getLogger(__name__)
 
 PACKAGE_NAME = "avibe-os"
 LEGACY_PACKAGE_NAME = "vibe-remote"
+MEMORY_PACKAGE_NAME = "avibe-memory"
+MEMORY_EXTRA_NAME = "memory"
 DEFAULT_UPDATE_METADATA_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
 CURRENT_VIBE_EXECUTABLE_ENV = "VIBE_CURRENT_EXECUTABLE"
 SHOW_RUNTIME_SKIP_ENV = "VIBE_INSTALL_SKIP_SHOW_RUNTIME"
@@ -84,6 +87,38 @@ class UpgradePlan:
     env: dict[str, str] | None
     method: str
     rollback_to: RollbackTarget | None = None
+    preflight_command: list[str] | None = None
+    cleanup_command: list[str] | None = None
+
+
+def execute_upgrade_plan(
+    plan: UpgradePlan,
+    *,
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    **run_kwargs: object,
+) -> subprocess.CompletedProcess[str]:
+    """Resolve, install, and normalize one package shape in that order.
+
+    The optional preflight exists for plans that require the Memory extra. Its
+    installer performs dependency resolution without writing the environment,
+    so an unavailable or incompatible ``avibe-memory`` release returns before
+    the command that replaces the running Avibe install. A core-only pip
+    rollback needs the final cleanup because pip installs are additive: pinning
+    only ``avibe-os`` does not remove an optional distribution left by the
+    failed generation.
+    """
+
+    if plan.preflight_command is not None:
+        preflight = run(plan.preflight_command, env=plan.env, **run_kwargs)
+        if preflight.returncode != 0:
+            return preflight
+
+    installed = run(plan.command, env=plan.env, **run_kwargs)
+    if installed.returncode != 0 or plan.cleanup_command is None:
+        return installed
+
+    cleaned = run(plan.cleanup_command, env=plan.env, **run_kwargs)
+    return installed if cleaned.returncode == 0 else cleaned
 
 
 def resolve_command_path(command: str | None, search_path: str | None = None) -> str | None:
@@ -512,6 +547,50 @@ def installed_package_name(python_executable: str | None = None) -> str | None:
     return match.group("name") if match else None
 
 
+def memory_package_installed() -> bool:
+    """Whether the optional Memory distribution is part of this install.
+
+    Distribution metadata, rather than an implementation import, is the package
+    shape shipped by the installer. An unreadable metadata environment is
+    treated as present: preserving an optional package unnecessarily may stop an
+    upgrade at resolution, while guessing it absent can silently remove enabled
+    Memory and erase the only evidence a rollback needed.
+    """
+
+    try:
+        from importlib.metadata import PackageNotFoundError, distribution
+
+        distribution(MEMORY_PACKAGE_NAME)
+    except PackageNotFoundError:
+        return False
+    except Exception:
+        logger.warning(
+            "Could not determine whether %s is installed; preserving the Memory package shape",
+            MEMORY_PACKAGE_NAME,
+            exc_info=True,
+        )
+        return True
+    return True
+
+
+def configured_memory_enabled() -> bool:
+    """Read the persisted Memory switch for an explicit upgrade action."""
+
+    try:
+        from config.v2_config import V2Config
+
+        return bool(V2Config.load().memory.enabled)
+    except FileNotFoundError:
+        return False
+    except Exception:
+        logger.warning(
+            "Could not read Memory enablement while planning the upgrade; "
+            "preserving the optional package shape",
+            exc_info=True,
+        )
+        return True
+
+
 def _distributions_providing_this_package() -> list[str]:
     """Every installed distribution that provides the package this module is in."""
 
@@ -655,6 +734,7 @@ class RollbackTarget(NamedTuple):
     version: str
     package: str | None
     launcher: runtime_mod.ServiceLauncher
+    memory_package: bool = False
 
 
 def _names_a_published_release(version: str) -> bool:
@@ -717,11 +797,39 @@ def rollback_target() -> RollbackTarget | None:
         version=__version__,
         package=installed_package_name(),
         launcher=runtime_mod.current_service_launcher(),
+        memory_package=memory_package_installed(),
     )
 
 
+def _with_memory_extra(package_spec: str) -> str:
+    """Select the host's Memory extra without rewriting non-name specs by hand."""
+
+    try:
+        from packaging.requirements import InvalidRequirement, Requirement
+
+        requirement = Requirement(package_spec)
+    except InvalidRequirement:
+        # pip and uv accept extras on local wheel paths in this form. Those paths
+        # are deliberately not parsed as named PEP 508 requirements.
+        return f"{package_spec}[{MEMORY_EXTRA_NAME}]"
+
+    extras = sorted({*requirement.extras, MEMORY_EXTRA_NAME})
+    rendered = f"{requirement.name}[{','.join(extras)}]"
+    if requirement.url:
+        rendered += f" @ {requirement.url}"
+    else:
+        rendered += str(requirement.specifier)
+    if requirement.marker:
+        rendered += f"; {requirement.marker}"
+    return rendered
+
+
 def pinned_package_spec(
-    version: str, *, python_executable: str | None = None, package_name: str | None = None
+    version: str,
+    *,
+    python_executable: str | None = None,
+    package_name: str | None = None,
+    memory_package: bool = False,
 ) -> str:
     """The distribution this install came from, pinned to exactly one version.
 
@@ -750,7 +858,8 @@ def pinned_package_spec(
     spec = package_name or installed_package_name(python_executable) or get_upgrade_package_spec()
     if _BARE_PACKAGE_NAME_RE.fullmatch(spec) is None:
         raise ValueError("The configured upgrade package spec cannot carry a version pin")
-    return f"{spec}=={version}"
+    pinned = f"{spec}=={version}"
+    return _with_memory_extra(pinned) if memory_package else pinned
 
 
 def build_upgrade_plan(
@@ -761,6 +870,8 @@ def build_upgrade_plan(
     base_env: dict[str, str] | None = None,
     version: str | None = None,
     package_name: str | None = None,
+    memory_enabled: bool = False,
+    memory_package: bool | None = None,
 ) -> UpgradePlan:
     """How to install avibe: the newest release, or `version` exactly.
 
@@ -780,12 +891,24 @@ def build_upgrade_plan(
     # its own: the process building one is the release that failed, so measuring
     # there would carry the failure forward as its own recovery target.
     rollback_to = None if version else rollback_target()
+    include_memory = (
+        bool(memory_package)
+        if version
+        else bool(memory_enabled or memory_package_installed())
+    )
     uv_binary = find_uv_binary(uv_path=uv_path, base_env=base_env)
     package_spec = (
-        pinned_package_spec(version, python_executable=executable, package_name=package_name)
+        pinned_package_spec(
+            version,
+            python_executable=executable,
+            package_name=package_name,
+            memory_package=include_memory,
+        )
         if version
         else get_upgrade_package_spec()
     )
+    if not version and include_memory:
+        package_spec = _with_memory_extra(package_spec)
 
     if is_uv_tool_install(executable) and uv_binary:
         env = dict(base_env or os.environ)
@@ -797,11 +920,25 @@ def build_upgrade_plan(
             command.append("--upgrade")
         if version or package_spec != PACKAGE_NAME or is_legacy_uv_tool_install(executable):
             command.append("--force")
+        preflight_command = None
+        if include_memory:
+            preflight_command = [
+                uv_binary,
+                "pip",
+                "install",
+                "--dry-run",
+                "--python",
+                executable,
+            ]
+            if not version:
+                preflight_command.append("--upgrade")
+            preflight_command.append(package_spec)
         return UpgradePlan(
             command=command,
             env=env,
             method="uv",
             rollback_to=rollback_to,
+            preflight_command=preflight_command,
         )
 
     command = [executable, "-m", "pip", "install"]
@@ -823,11 +960,35 @@ def build_upgrade_plan(
     if version or not installed_metadata_describes_running_code():
         command.append("--force-reinstall")
     command.append(package_spec)
+    preflight_command = None
+    if include_memory:
+        preflight_command = [
+            executable,
+            "-m",
+            "pip",
+            "install",
+            "--dry-run",
+        ]
+        if not version:
+            preflight_command.append("--upgrade")
+        preflight_command.append(package_spec)
+    cleanup_command = None
+    if version and not include_memory and memory_package_installed():
+        cleanup_command = [
+            executable,
+            "-m",
+            "pip",
+            "uninstall",
+            "--yes",
+            MEMORY_PACKAGE_NAME,
+        ]
     return UpgradePlan(
         command=command,
         env=dict(base_env or os.environ),
         method="pip",
         rollback_to=rollback_to,
+        preflight_command=preflight_command,
+        cleanup_command=cleanup_command,
     )
 
 

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -25,6 +25,10 @@ PACKAGE_NAME = "avibe-os"
 LEGACY_PACKAGE_NAME = "vibe-remote"
 MEMORY_PACKAGE_NAME = "avibe-memory"
 MEMORY_EXTRA_NAME = "memory"
+MEMORY_PACKAGE_COMPATIBILITY = ">=3.0.14.dev0,<3.1"
+MEMORY_PACKAGE_REQUIREMENT = (
+    f"{MEMORY_PACKAGE_NAME}{MEMORY_PACKAGE_COMPATIBILITY}"
+)
 PACKAGE_MUTATION_LOCK_TIMEOUT_SECONDS = 30.0
 DEFAULT_UPDATE_METADATA_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
 CURRENT_VIBE_EXECUTABLE_ENV = "VIBE_CURRENT_EXECUTABLE"
@@ -1060,15 +1064,9 @@ def build_memory_add_plan(
     uv_path: str | None = None,
     base_env: dict[str, str] | None = None,
 ) -> UpgradePlan:
-    """Add the current host's Memory extra without replacing the host itself."""
+    """Replace the compatible Memory distribution without replacing its host."""
 
     executable = python_executable or sys.executable
-    package_spec = pinned_package_spec(
-        version,
-        python_executable=executable,
-        package_name=package_name,
-        memory_package=True,
-    )
     uv_binary = find_uv_binary(uv_path=uv_path, base_env=base_env)
     env = dict(base_env or os.environ)
     if is_uv_tool_install(executable) and uv_binary:
@@ -1077,9 +1075,11 @@ def build_memory_add_plan(
             "pip",
             "install",
             "--upgrade",
+            "--force-reinstall",
+            "--no-deps",
             "--python",
             executable,
-            package_spec,
+            MEMORY_PACKAGE_REQUIREMENT,
         ]
         preflight = [
             uv_binary,
@@ -1087,9 +1087,11 @@ def build_memory_add_plan(
             "install",
             "--dry-run",
             "--upgrade",
+            "--force-reinstall",
+            "--no-deps",
             "--python",
             executable,
-            package_spec,
+            MEMORY_PACKAGE_REQUIREMENT,
         ]
         return UpgradePlan(
             command=command,
@@ -1104,7 +1106,9 @@ def build_memory_add_plan(
         "pip",
         "install",
         "--upgrade",
-        package_spec,
+        "--force-reinstall",
+        "--no-deps",
+        MEMORY_PACKAGE_REQUIREMENT,
     ]
     preflight = [
         executable,
@@ -1113,7 +1117,9 @@ def build_memory_add_plan(
         "install",
         "--dry-run",
         "--upgrade",
-        package_spec,
+        "--force-reinstall",
+        "--no-deps",
+        MEMORY_PACKAGE_REQUIREMENT,
     ]
     return UpgradePlan(
         command=command,

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -858,6 +858,8 @@ def _with_memory_extra(package_spec: str) -> str:
 
         requirement = Requirement(package_spec)
     except InvalidRequirement:
+        if package_spec.startswith(("http://", "https://")):
+            return f"{PACKAGE_NAME}[{MEMORY_EXTRA_NAME}] @ {package_spec}"
         # pip and uv accept extras on local wheel paths in this form. Those paths
         # are deliberately not parsed as named PEP 508 requirements.
         return f"{package_spec}[{MEMORY_EXTRA_NAME}]"


### PR DESCRIPTION
## Summary

- preserve the optional `avibe-memory` package when Memory is enabled or the distribution is already installed
- resolve the host plus Memory extra before replacing the current install, and restore the recorded core-only or core-plus-Memory shape on pinned rollback
- preflight destructive pip rollbacks, uninstall split Memory before restoring a bundled pre-split host, and keep overlapping RECORD paths intact
- let the existing explicit Settings dependency action install the current Memory distribution; successful package repairs always restart before plugin reuse
- serialize ordinary upgrades, repairs, human lifecycle/restart actions, and WeChat QR restart scheduling through the package lease, while keeping supervisor recovery paths available
- keep controller startup package-free

## Scenario

- `MEMORY-INDEP-018`: enabled upgrade keeps Memory installed and pinned rollback restores the prior package shape

## Known-by-design

| ID | Residual path | Owner | Disposition |
| --- | --- | --- | --- |
| `MEMORY-INDEP-018-KBD-1` | A pre-split `vibe upgrade` run while the service is stopped is planned entirely by the old release. It installs plain `avibe-os`, schedules no restart supervisor, and can leave enabled Memory unavailable at the next startup; core stays healthy and the explicit Settings repair remains the recovery path. | Wave 3c | The first `avibe-os` release that no longer bundles `avibe_memory` must still pull `avibe-memory` for that one transition release, or retain the bundled module for one more release. |
| `MEMORY-INDEP-018-KBD-2` | When Memory is disabled and `avibe-memory` is absent, the first explicit dependency action installs the distribution and schedules a restart. Disabled startup intentionally does not install EverOS, so the artifact arrives on the next explicit dependency action or when Memory is enabled. The enabled path remains one click because its restart wake installs EverOS. | Wave 3b | Accepted: no pending flag, disabled-startup wake, or in-process plugin retry; a second explicit dependency action is allowed. |
| `MEMORY-INDEP-018-KBD-3` | Supported Memory-preserving upgrade package specs are HTTP(S) URLs, parsed PEP 508 named requirements, and local filesystem paths. A `file://` package spec is not supported; use the equivalent filesystem path. | Wave 3b | Accepted: keep the package-spec grammar bounded; no scheme expansion. |
| `MEMORY-INDEP-018-KBD-5` | During the one-era pre-split bundled rollback, an available pinned host can still have historical dependencies that are unsatisfiable. Cleanup must precede installation to protect overlapping RECORD paths, so that failed install can leave the current failed generation without split Memory. | Wave 3b | Accepted: keep target-artifact-only `pip download --no-deps` preflight; recover through the explicit Settings dependency repair. Split-era targets install before cleanup. |
| `MEMORY-INDEP-018-KBD-6` | During the one-era uv-to-pip transition, a legacy planner explicit rollback argv does not carry Memory package shape. If uv removes `avibe-memory` from a core-plus-disabled-Memory install before the new supervisor starts, the prior optional package is no longer observable and rollback can restore core-only; core remains healthy. | Wave 3c | Accepted for Wave 3b: recover with the explicit Settings dependency repair; revisit with Memory pin and release-transition ownership in Wave 3c. |
| `MEMORY-INDEP-018-KBD-7` | After UI reload stops the old UI, two replacement spawn failures leave the UI unavailable; package shape and runtime status remain controlled. | Wave 3b | Accepted: keep stop-before-spawn and the bounded single respawn; recover with an operator `vibe restart`, without restoring the old server or switching to spawn-first. |
| `MEMORY-INDEP-018-KBD-8` | UI reload readiness is the socket-bound identity of the replacement PID: the parent-owned UI PID file and child-written `ui_server_ready.json` must match. ASGI lifespan handlers continue after that point, as they do on a cold `vibe` start. | Wave 3b | Accepted: freeze readiness at the bound child identity; do not add a startup-complete event, relocate the marker, or introduce another protocol. |

| `MEMORY-INDEP-018-KBD-9` | A UI reload can be admitted and return optimistically before its worker completes; a later package-lease retry, replacement spawn, or readiness failure can abort the handoff and leave the existing UI requiring operator recovery. | Wave 3b | Accepted: request admission only establishes a non-conflicting handoff; bounded worker failure follows the existing KBD-7 recovery semantics. |

## Evidence

- Unit: upgrade planning/execution, legacy-pip direct-artifact download preflight and scratch cleanup, offline local-wheel resolution, URL-extra rendering, cleanup-before-reinstall ordering and RECORD overlap, lease-fresh runtime restart decisions, rollback supervisor argument round-trip, automatic updater wiring, Settings missing/incompatible/installer-failure coverage, package-lease coverage through restart/lifecycle/QR actions, bounded fallback reacquire, QR ASGI offload/busy response, localized contention copy, and supervisor status ownership through preparation/follow-up handoff
- Contract: preflight resolution blocks replacement without re-downloading transitive dependencies; core-only pip rollback resolves the pinned host before removing the optional distribution; optional Memory metadata does not claim host ownership; host rename-pair skew remains stale; upgrades, repairs, Web/CLI lifecycle actions, QR restart, and config fallback cannot overlap package mutation; timeout fallback creates pending state only for a verified live restart and otherwise reports unscheduled contention; supervisor recovery bypasses the human-entry gate
- Scenario: memory-independence catalog validation and `MEMORY-INDEP-018`
- Packaged smoke: freshly built core and Memory wheels cover missing, disabled, enabled, incompatible, upgrade, and rollback states
- Residual manual checks: none; no local service restart or persisted-state mutation was needed

## Validation

- `pytest -q tests/test_upgrade_flow.py tests/test_restart_supervisor.py tests/test_update_checker_platforms.py tests/scenarios/memory_independence/test_memory_independence_catalog.py tests/test_memory_disabled_isolation.py::test_enabled_install_promotes_the_recovered_runtime_for_capture -x` (164 passed)
- `pytest -q tests/test_local_deps.py -k 'memory_runtime_dependency_job or memory_package_install' -x` (11 passed, 109 deselected)
- `pytest -q tests/test_ui_server_fastapi.py -x` (125 passed)
- `pytest -q tests/test_ui_server_logs.py -x` (20 passed)
- `pytest -q tests/test_vibe_cli.py -x` (194 passed)
- `pytest -q tests/test_upgrade_flow.py tests/test_i18n_backend_keys.py tests/test_i18n_key_parity.py` (180 passed)
- `pytest -q tests/test_local_deps.py tests/test_restart_supervisor.py tests/test_memory_distribution.py tests/test_memory_runtime_release.py tests/test_upgrade_flow.py` (264 passed, 5 packaged-wheel skips)
- `npm test -- --run src/components/steps/WeChatConfig.test.tsx` (1 passed)
- `npm test -- src/components/settings/memory/memoryCopyContract.test.ts` (15 passed)
- `npm run build`
- `npm run lint`
- `AVIBE_CORE_WHEEL=... AVIBE_MEMORY_WHEEL=... pytest -q tests/test_memory_distribution.py` (8 passed)
- `ruff check` on all changed Python files
- `git diff --check`