### PR TITLE
fix(upgrade): install Avibe environments atomically

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,11 +324,13 @@ npm install -g @openai/codex
 
 ```bash
 vibe stop
+avibe_home="${AVIBE_HOME:-$HOME/.avibe}"
+avibe_home="${avibe_home/#\~/$HOME}"
 uv tool uninstall avibe-os
 uv tool uninstall vibe-remote   # legacy installs
 vibe_bin="$(command -v vibe)" && rm -f "$vibe_bin" "$(dirname "$vibe_bin")/.vibe.avibe-generation"
-rm -rf "${AVIBE_HOME:-$HOME/.avibe}/runtime/install-generations"
-rm -rf ~/.avibe ~/.vibe_remote
+rm -rf "$avibe_home/runtime/install-generations"
+rm -rf "$avibe_home" ~/.vibe_remote
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ npm install -g @openai/codex
 vibe stop
 uv tool uninstall avibe-os
 uv tool uninstall vibe-remote   # legacy installs
-rm -f ~/.local/bin/vibe
+vibe_bin="$(command -v vibe)" && rm -f "$vibe_bin" "$(dirname "$vibe_bin")/.vibe.avibe-generation"
 rm -rf "${AVIBE_HOME:-$HOME/.avibe}/runtime/install-generations"
 rm -rf ~/.avibe ~/.vibe_remote
 ```

--- a/README.md
+++ b/README.md
@@ -326,6 +326,8 @@ npm install -g @openai/codex
 vibe stop
 uv tool uninstall avibe-os
 uv tool uninstall vibe-remote   # legacy installs
+rm -f ~/.local/bin/vibe
+rm -rf "${AVIBE_HOME:-$HOME/.avibe}/runtime/install-generations"
 rm -rf ~/.avibe ~/.vibe_remote
 ```
 

--- a/core/install_integrity.py
+++ b/core/install_integrity.py
@@ -157,9 +157,9 @@ def verify_site_packages(
             # include ``../../../bin/<entrypoint>`` for generated scripts.  The
             # enclosing tool root is the trust boundary, not site-packages
             # itself; anything that escapes that root is still rejected.
-            if root.name == "site-packages" and root.parent.name.startswith("python"):
+            if root.name in {"site-packages", "dist-packages"} and root.parent.name.startswith("python"):
                 allowed_root = root.parent.parent.parent.resolve()
-            elif root.name == "site-packages" and root.parent.name == "Lib":
+            elif root.name in {"site-packages", "dist-packages"} and root.parent.name == "Lib":
                 allowed_root = root.parent.parent.resolve()
             else:
                 allowed_root = root

--- a/core/install_integrity.py
+++ b/core/install_integrity.py
@@ -13,6 +13,7 @@ import base64
 import csv
 import hashlib
 import importlib.metadata as importlib_metadata
+import json
 import os
 import subprocess
 import tempfile
@@ -28,6 +29,7 @@ from packaging.utils import canonicalize_name
 
 
 RUNTIME_DISTRIBUTIONS = ("avibe-os", "vibe-remote")
+RUNTIME_PROBE_PREFIX = "avibe-runtime-distributions:"
 
 
 @dataclass(frozen=True)
@@ -48,6 +50,15 @@ class IntegrityResult:
         if len(self.failures) > 5:
             suffix += f", and {len(self.failures) - 5} more"
         return suffix
+
+
+@dataclass(frozen=True)
+class DependencyGraph:
+    """Installed distributions reachable from Avibe's wheel metadata."""
+
+    distributions: tuple[str, ...] = ()
+    records: tuple[str, ...] = ()
+    failures: tuple[str, ...] = ()
 
 
 def isolated_probe_environment() -> dict[str, str]:
@@ -125,16 +136,20 @@ def record_paths(site_packages: Path, distribution_names: Iterable[str] | None =
 
     wanted = None
     if distribution_names is not None:
-        wanted = {name.replace("-", "_").lower() for name in distribution_names}
+        wanted = {canonicalize_name(name) for name in distribution_names}
     paths: list[Path] = []
     for record in sorted(site_packages.glob("*.dist-info/RECORD")):
-        if wanted is not None:
-            stem = record.parent.name.removesuffix(".dist-info")
-            package = stem.rsplit("-", 1)[0].replace("-", "_").lower()
-            if package not in wanted:
-                continue
+        if wanted is not None and record_distribution_name(record) not in wanted:
+            continue
         paths.append(record)
     return paths
+
+
+def record_distribution_name(record: Path) -> str:
+    """Return the canonical distribution name owning one wheel RECORD."""
+
+    stem = record.parent.name.removesuffix(".dist-info")
+    return canonicalize_name(stem.rsplit("-", 1)[0])
 
 
 def verify_site_packages(
@@ -152,11 +167,32 @@ def verify_site_packages(
 
     root = Path(site_packages).expanduser().resolve()
     records = record_paths(root, distribution_names)
+    return verify_record_files(root, records)
+
+
+def verify_record_files(site_packages: Path | str, records: Iterable[Path]) -> IntegrityResult:
+    """Verify exact wheel RECORD files selected by the candidate interpreter."""
+
+    root = Path(site_packages).expanduser().resolve()
+    failures: list[str] = []
+    safe_records: list[Path] = []
+    for record in records:
+        try:
+            record = Path(record).expanduser().resolve()
+            record.relative_to(root)
+        except (OSError, RuntimeError, ValueError):
+            failures.append(f"unsafe RECORD path {record}")
+            continue
+        if record.name != "RECORD" or not record.parent.name.endswith(".dist-info"):
+            failures.append(f"unsafe RECORD path {record}")
+            continue
+        safe_records.append(record)
+    records = tuple(safe_records)
     if not records:
-        return IntegrityResult(False, failures=(f"no RECORD file under {root}",))
+        failures.append(f"no RECORD file under {root}")
+        return IntegrityResult(False, failures=tuple(failures))
 
     checked = 0
-    failures: list[str] = []
     for record_path in records:
         try:
             rows = list(csv.reader(record_path.read_text(encoding="utf-8").splitlines()))
@@ -234,9 +270,9 @@ def runtime_import_modules() -> tuple[str, ...]:
     )
 
 
-def dependency_graph_failures(
+def inspect_dependency_graph(
     distribution_names: Iterable[str] = RUNTIME_DISTRIBUTIONS,
-) -> tuple[str, ...]:
+) -> DependencyGraph:
     """Validate the installed dependency closure rooted at Avibe's wheel metadata."""
 
     candidates = tuple(distribution_names)
@@ -250,7 +286,7 @@ def dependency_graph_failures(
         except importlib_metadata.PackageNotFoundError:
             continue
     if root is None:
-        return (f"missing runtime distribution: {' or '.join(candidates)}",)
+        return DependencyGraph(failures=(f"missing runtime distribution: {' or '.join(candidates)}",))
 
     root_name = canonicalize_name(root.metadata.get("Name") or root_candidate)
     distributions = {root_name: root}
@@ -305,19 +341,39 @@ def dependency_graph_failures(
             if dependency_name not in processed_extras or previous_extras != frozenset(dependency_extras):
                 pending.append(dependency_name)
 
-    return tuple(sorted(failures))
+    records: list[str] = []
+    for distribution_name, distribution in distributions.items():
+        record = next(
+            (
+                file
+                for file in (distribution.files or ())
+                if file.name == "RECORD" and file.parent.name.endswith(".dist-info")
+            ),
+            None,
+        )
+        if record is None:
+            failures.add(f"no RECORD for dependency {distribution_name}")
+            continue
+        records.append(str(distribution.locate_file(record)))
+
+    return DependencyGraph(
+        distributions=tuple(sorted(distributions)),
+        records=tuple(sorted(dict.fromkeys(records))),
+        failures=tuple(sorted(failures)),
+    )
 
 
-def probe_runtime_environment(required_imports: Iterable[str] | None = None) -> None:
+def probe_runtime_environment(required_imports: Iterable[str] | None = None) -> tuple[str, ...]:
     """Raise when declared dependencies or registered platform imports are broken."""
 
-    failures = dependency_graph_failures()
-    if failures:
-        raise RuntimeError("; ".join(failures))
+    graph = inspect_dependency_graph()
+    if graph.failures:
+        raise RuntimeError("; ".join(graph.failures))
     modules = runtime_import_modules() if required_imports is None else tuple(required_imports)
     for module in modules:
         if module:
             import_module(module)
+    return graph.records
 
 
 def verify_python_environment(
@@ -333,27 +389,51 @@ def verify_python_environment(
     if not site_packages:
         return IntegrityResult(False, failures=(f"no site-packages for {executable}",))
 
-    failures: list[str] = []
-    checked = 0
-    for site_package in site_packages:
-        result = verify_site_packages(site_package)
-        checked += result.checked_files
-        failures.extend(result.failures)
-    if failures:
-        return IntegrityResult(False, checked_files=checked, failures=tuple(failures))
-
     probe_call = (
         "probe_runtime_environment()"
         if required_imports is None
         else f"probe_runtime_environment({tuple(module for module in required_imports if module)!r})"
     )
-    code = f"from core.install_integrity import probe_runtime_environment; {probe_call}"
+    code = (
+        "import json; "
+        "from core.install_integrity import probe_runtime_environment; "
+        f"print({RUNTIME_PROBE_PREFIX!r} + json.dumps({probe_call}))"
+    )
     try:
         process = run_isolated_probe([executable, "-c", code], timeout=timeout)
     except (OSError, subprocess.SubprocessError) as exc:
-        return IntegrityResult(False, checked_files=checked, failures=(f"runtime probe failed: {exc}",))
+        return IntegrityResult(False, failures=(f"runtime probe failed: {exc}",))
     if process.returncode != 0:
         detail = (process.stderr or process.stdout or "runtime probe failed").strip().splitlines()[-1]
-        return IntegrityResult(False, checked_files=checked, failures=(f"runtime probe failed: {detail}",))
+        return IntegrityResult(False, failures=(f"runtime probe failed: {detail}",))
+
+    dependency_line = next(
+        (line for line in process.stdout.splitlines() if line.startswith(RUNTIME_PROBE_PREFIX)),
+        None,
+    )
+    try:
+        record_names = tuple(json.loads(dependency_line.removeprefix(RUNTIME_PROBE_PREFIX)))
+    except (AttributeError, TypeError, ValueError, json.JSONDecodeError):
+        return IntegrityResult(False, failures=("runtime probe did not report its dependency records",))
+
+    failures: list[str] = []
+    checked = 0
+    records_by_site: dict[Path, list[Path]] = {site_package: [] for site_package in site_packages}
+    for record_name in record_names:
+        try:
+            record = Path(record_name).expanduser().resolve()
+            site_package = next(root for root in site_packages if record.is_relative_to(root))
+        except (OSError, RuntimeError, StopIteration):
+            failures.append(f"dependency RECORD outside candidate site-packages: {record_name}")
+            continue
+        records_by_site[site_package].append(record)
+    for site_package, records in records_by_site.items():
+        if not records:
+            continue
+        result = verify_record_files(site_package, records)
+        checked += result.checked_files
+        failures.extend(result.failures)
+    if failures:
+        return IntegrityResult(False, checked_files=checked, failures=tuple(failures))
 
     return IntegrityResult(True, checked_files=checked)

--- a/core/install_integrity.py
+++ b/core/install_integrity.py
@@ -40,6 +40,15 @@ class IntegrityResult:
         return suffix
 
 
+def isolated_probe_environment() -> dict[str, str]:
+    """Keep the candidate interpreter from importing the caller's checkout."""
+
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    environment.pop("PYTHONHOME", None)
+    return environment
+
+
 def site_packages_for_python(python_executable: str | os.PathLike[str]) -> list[Path]:
     """Return site-packages directories belonging to a Python executable."""
 
@@ -66,6 +75,7 @@ def site_packages_for_python(python_executable: str | os.PathLike[str]) -> list[
             timeout=10,
             check=False,
             cwd=tempfile.gettempdir(),
+            env=isolated_probe_environment(),
         )
     except (OSError, subprocess.SubprocessError):
         result = None
@@ -235,6 +245,7 @@ def verify_python_environment(
                 # Do not let a source checkout on the caller's cwd satisfy the
                 # probe in place of the candidate environment being checked.
                 cwd=tempfile.gettempdir(),
+                env=isolated_probe_environment(),
             )
         except (OSError, subprocess.SubprocessError) as exc:
             return IntegrityResult(False, checked_files=checked, failures=(f"import probe failed: {exc}",))

--- a/core/install_integrity.py
+++ b/core/install_integrity.py
@@ -56,7 +56,6 @@ def site_packages_for_python(python_executable: str | os.PathLike[str]) -> list[
     # a shared Python binary, while their import path and sysconfig point at
     # the tool environment selected through that symlink.
     executable = Path(python_executable).expanduser()
-    root = executable.parent.parent
     discovered: list[Path] = []
     probe = (
         "import site, sysconfig; "
@@ -82,22 +81,15 @@ def site_packages_for_python(python_executable: str | os.PathLike[str]) -> list[
     if result is not None and result.returncode == 0:
         discovered.extend(Path(line).expanduser() for line in result.stdout.splitlines() if line.strip())
 
-    heuristic = [
-        *sorted((root / "lib").glob("python*/site-packages")),
-        *sorted((root / "lib").glob("python*/dist-packages")),
-        root / "Lib" / "site-packages",
-    ]
     def has_record(path: Path) -> bool:
         return path.is_dir() and any(path.glob("*.dist-info/RECORD"))
 
-    # Prefer the environment-local layout. If it is absent (for example a
-    # system Python with a pip user install), retain interpreter-reported
-    # locations that actually contain wheel metadata. Some Windows Python
-    # builds report their environment root as ``purelib``; accepting that path
-    # would make an unrelated top-level directory fail with "no RECORD".
-    local = [path for path in heuristic if path.is_dir()]
-    reported = [path for path in discovered if has_record(path)]
-    discovered = [*local, *reported] if local else reported
+    # The probed interpreter owns its import-path boundary. Filesystem globs
+    # cannot infer that boundary when a prefix contains multiple Python
+    # versions, so accept only interpreter-reported locations with wheel
+    # metadata. A probe that cannot run is an invalid candidate, not a reason
+    # to verify a sibling interpreter's packages.
+    discovered = [path for path in discovered if has_record(path)]
     candidates: list[Path] = []
     seen: set[Path] = set()
     for path in discovered:

--- a/core/install_integrity.py
+++ b/core/install_integrity.py
@@ -12,12 +12,22 @@ from __future__ import annotations
 import base64
 import csv
 import hashlib
+import importlib.metadata as importlib_metadata
 import os
 import subprocess
 import tempfile
+from collections import deque
 from dataclasses import dataclass
+from importlib import import_module
 from pathlib import Path, PurePosixPath
 from typing import Iterable, Sequence
+
+from packaging.markers import default_environment
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+
+
+RUNTIME_DISTRIBUTIONS = ("avibe-os", "vibe-remote")
 
 
 @dataclass(frozen=True)
@@ -209,13 +219,114 @@ def verify_site_packages(
     return IntegrityResult(not failures, checked_files=checked, failures=tuple(failures))
 
 
+def runtime_import_modules() -> tuple[str, ...]:
+    """Return import boundaries for every registered user-facing platform."""
+
+    from config.platform_registry import platform_descriptors
+
+    return tuple(
+        dict.fromkeys(
+            (
+                "vibe",
+                *(descriptor.client_module for descriptor in platform_descriptors()),
+            )
+        )
+    )
+
+
+def dependency_graph_failures(
+    distribution_names: Iterable[str] = RUNTIME_DISTRIBUTIONS,
+) -> tuple[str, ...]:
+    """Validate the installed dependency closure rooted at Avibe's wheel metadata."""
+
+    candidates = tuple(distribution_names)
+    root = None
+    root_candidate = ""
+    for name in candidates:
+        try:
+            root = importlib_metadata.distribution(name)
+            root_candidate = name
+            break
+        except importlib_metadata.PackageNotFoundError:
+            continue
+    if root is None:
+        return (f"missing runtime distribution: {' or '.join(candidates)}",)
+
+    root_name = canonicalize_name(root.metadata.get("Name") or root_candidate)
+    distributions = {root_name: root}
+    requested_extras: dict[str, set[str]] = {root_name: set()}
+    processed_extras: dict[str, frozenset[str]] = {}
+    pending = deque([root_name])
+    failures: set[str] = set()
+    marker_environment = default_environment()
+
+    while pending:
+        distribution_name = pending.popleft()
+        extras = requested_extras[distribution_name]
+        extras_snapshot = frozenset(extras)
+        if processed_extras.get(distribution_name) == extras_snapshot:
+            continue
+        processed_extras[distribution_name] = extras_snapshot
+        distribution = distributions[distribution_name]
+
+        for raw_requirement in distribution.requires or ():
+            try:
+                requirement = Requirement(raw_requirement)
+            except InvalidRequirement:
+                failures.add(f"invalid dependency metadata: {raw_requirement}")
+                continue
+            marker_extras = extras or {""}
+            if requirement.marker is not None and not any(
+                requirement.marker.evaluate({**marker_environment, "extra": extra})
+                for extra in marker_extras
+            ):
+                continue
+
+            dependency_name = canonicalize_name(requirement.name)
+            try:
+                dependency = importlib_metadata.distribution(requirement.name)
+            except importlib_metadata.PackageNotFoundError:
+                failures.add(f"missing dependency: {requirement.name}")
+                continue
+            if requirement.specifier and not requirement.specifier.contains(
+                dependency.version,
+                prereleases=True,
+            ):
+                failures.add(
+                    f"incompatible dependency: {requirement.name} {dependency.version} "
+                    f"does not satisfy {requirement.specifier}"
+                )
+                continue
+
+            distributions[dependency_name] = dependency
+            dependency_extras = requested_extras.setdefault(dependency_name, set())
+            previous_extras = frozenset(dependency_extras)
+            dependency_extras.update(requirement.extras)
+            if dependency_name not in processed_extras or previous_extras != frozenset(dependency_extras):
+                pending.append(dependency_name)
+
+    return tuple(sorted(failures))
+
+
+def probe_runtime_environment(required_imports: Iterable[str] | None = None) -> None:
+    """Raise when declared dependencies or registered platform imports are broken."""
+
+    failures = dependency_graph_failures()
+    if failures:
+        raise RuntimeError("; ".join(failures))
+    modules = runtime_import_modules() if required_imports is None else tuple(required_imports)
+    for module in modules:
+        if module:
+            import_module(module)
+
+
 def verify_python_environment(
     python_executable: str | os.PathLike[str],
     *,
-    required_imports: Iterable[str] = ("vibe", "lark_oapi", "modules.im.multi"),
+    required_imports: Iterable[str] | None = None,
     timeout: float = 30.0,
 ) -> IntegrityResult:
-    """Verify package records and import the modules required at startup."""
+    """Verify package records, dependency closure, and platform imports."""
 
     executable = str(Path(python_executable).expanduser())
     site_packages = site_packages_for_python(executable)
@@ -231,15 +342,18 @@ def verify_python_environment(
     if failures:
         return IntegrityResult(False, checked_files=checked, failures=tuple(failures))
 
-    modules = tuple(module for module in required_imports if module)
-    if modules:
-        code = "; ".join(f"import {module}" for module in modules)
-        try:
-            process = run_isolated_probe([executable, "-c", code], timeout=timeout)
-        except (OSError, subprocess.SubprocessError) as exc:
-            return IntegrityResult(False, checked_files=checked, failures=(f"import probe failed: {exc}",))
-        if process.returncode != 0:
-            detail = (process.stderr or process.stdout or "import probe failed").strip().splitlines()[-1]
-            return IntegrityResult(False, checked_files=checked, failures=(f"required import failed: {detail}",))
+    probe_call = (
+        "probe_runtime_environment()"
+        if required_imports is None
+        else f"probe_runtime_environment({tuple(module for module in required_imports if module)!r})"
+    )
+    code = f"from core.install_integrity import probe_runtime_environment; {probe_call}"
+    try:
+        process = run_isolated_probe([executable, "-c", code], timeout=timeout)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return IntegrityResult(False, checked_files=checked, failures=(f"runtime probe failed: {exc}",))
+    if process.returncode != 0:
+        detail = (process.stderr or process.stdout or "runtime probe failed").strip().splitlines()[-1]
+        return IntegrityResult(False, checked_files=checked, failures=(f"runtime probe failed: {detail}",))
 
     return IntegrityResult(True, checked_files=checked)

--- a/core/install_integrity.py
+++ b/core/install_integrity.py
@@ -17,7 +17,7 @@ import subprocess
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Iterable
+from typing import Iterable, Sequence
 
 
 @dataclass(frozen=True)
@@ -49,6 +49,21 @@ def isolated_probe_environment() -> dict[str, str]:
     return environment
 
 
+def run_isolated_probe(command: Sequence[str], *, timeout: float) -> subprocess.CompletedProcess[str]:
+    """Run a candidate probe from a private empty working directory."""
+
+    with tempfile.TemporaryDirectory(prefix="avibe-integrity-") as working_directory:
+        return subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            cwd=working_directory,
+            env=isolated_probe_environment(),
+        )
+
+
 def site_packages_for_python(python_executable: str | os.PathLike[str]) -> list[Path]:
     """Return site-packages directories belonging to a Python executable."""
 
@@ -67,15 +82,7 @@ def site_packages_for_python(python_executable: str | os.PathLike[str]) -> list[
         "print('\\n'.join(dict.fromkeys(path for path in paths if path)))"
     )
     try:
-        result = subprocess.run(
-            [str(executable), "-c", probe],
-            capture_output=True,
-            text=True,
-            timeout=10,
-            check=False,
-            cwd=tempfile.gettempdir(),
-            env=isolated_probe_environment(),
-        )
+        result = run_isolated_probe([str(executable), "-c", probe], timeout=10)
     except (OSError, subprocess.SubprocessError):
         result = None
     if result is not None and result.returncode == 0:
@@ -228,17 +235,7 @@ def verify_python_environment(
     if modules:
         code = "; ".join(f"import {module}" for module in modules)
         try:
-            process = subprocess.run(
-                [executable, "-c", code],
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                check=False,
-                # Do not let a source checkout on the caller's cwd satisfy the
-                # probe in place of the candidate environment being checked.
-                cwd=tempfile.gettempdir(),
-                env=isolated_probe_environment(),
-            )
+            process = run_isolated_probe([executable, "-c", code], timeout=timeout)
         except (OSError, subprocess.SubprocessError) as exc:
             return IntegrityResult(False, checked_files=checked, failures=(f"import probe failed: {exc}",))
         if process.returncode != 0:

--- a/core/install_integrity.py
+++ b/core/install_integrity.py
@@ -55,7 +55,7 @@ def site_packages_for_python(python_executable: str | os.PathLike[str]) -> list[
         "paths = [config.get('purelib'), config.get('platlib')]; "
         "paths += list(getattr(site, 'getsitepackages', lambda: [])()); "
         "user = getattr(site, 'getusersitepackages', lambda: '')(); "
-        "paths += [user] if user else []; "
+        "paths += [user] if user and getattr(site, 'ENABLE_USER_SITE', True) else []; "
         "print('\\n'.join(dict.fromkeys(path for path in paths if path)))"
     )
     try:

--- a/core/install_integrity.py
+++ b/core/install_integrity.py
@@ -77,10 +77,17 @@ def site_packages_for_python(python_executable: str | os.PathLike[str]) -> list[
         *sorted((root / "lib").glob("python*/dist-packages")),
         root / "Lib" / "site-packages",
     ]
+    def has_record(path: Path) -> bool:
+        return path.is_dir() and any(path.glob("*.dist-info/RECORD"))
+
     # Prefer the environment-local layout. If it is absent (for example a
-    # system Python with a pip user install), retain the interpreter-reported
-    # locations, including a user site directory.
-    discovered = [*heuristic, *discovered] if any(path.is_dir() for path in heuristic) else discovered
+    # system Python with a pip user install), retain interpreter-reported
+    # locations that actually contain wheel metadata. Some Windows Python
+    # builds report their environment root as ``purelib``; accepting that path
+    # would make an unrelated top-level directory fail with "no RECORD".
+    local = [path for path in heuristic if path.is_dir()]
+    reported = [path for path in discovered if has_record(path)]
+    discovered = [*local, *reported] if local else reported
     candidates: list[Path] = []
     seen: set[Path] = set()
     for path in discovered:

--- a/core/install_integrity.py
+++ b/core/install_integrity.py
@@ -1,0 +1,196 @@
+"""Integrity checks shared by local installers and the runtime doctor.
+
+Python installers record the files they put on disk in ``RECORD``.  A package
+version is not proof that those files are still complete: an interrupted copy
+can leave valid metadata beside a partial package tree.  These helpers make
+the file contents the source of truth without importing the package being
+checked.
+"""
+
+from __future__ import annotations
+
+import base64
+import csv
+import hashlib
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class IntegrityResult:
+    """Measured result of a package-tree verification."""
+
+    ok: bool
+    checked_files: int = 0
+    failures: tuple[str, ...] = ()
+
+    @property
+    def detail(self) -> str:
+        if self.ok:
+            return f"verified {self.checked_files} package files"
+        if not self.failures:
+            return "package integrity verification failed"
+        suffix = ", ".join(self.failures[:5])
+        if len(self.failures) > 5:
+            suffix += f", and {len(self.failures) - 5} more"
+        return suffix
+
+
+def site_packages_for_python(python_executable: str | os.PathLike[str]) -> list[Path]:
+    """Return site-packages directories belonging to a Python executable."""
+
+    executable = Path(python_executable).expanduser()
+    root = executable.parent.parent
+    candidates = sorted((root / "lib").glob("python*/site-packages"))
+    windows = root / "Lib" / "site-packages"
+    if windows.is_dir():
+        candidates.append(windows)
+    return [path for path in candidates if path.is_dir()]
+
+
+def record_paths(site_packages: Path, distribution_names: Iterable[str] | None = None) -> list[Path]:
+    """Find RECORD files, optionally limited to normalized distribution names."""
+
+    wanted = None
+    if distribution_names is not None:
+        wanted = {name.replace("-", "_").lower() for name in distribution_names}
+    paths: list[Path] = []
+    for record in sorted(site_packages.glob("*.dist-info/RECORD")):
+        if wanted is not None:
+            stem = record.parent.name.removesuffix(".dist-info")
+            package = stem.rsplit("-", 1)[0].replace("-", "_").lower()
+            if package not in wanted:
+                continue
+        paths.append(record)
+    return paths
+
+
+def verify_site_packages(
+    site_packages: Path | str,
+    *,
+    distribution_names: Iterable[str] | None = None,
+) -> IntegrityResult:
+    """Verify every hashed file named by installed distribution RECORD files.
+
+    The RECORD file itself is allowed to have an empty hash, as specified by
+    the wheel format.  Paths that escape ``site_packages`` are rejected rather
+    than resolved, so a malformed record cannot turn this check into a read of
+    an unrelated file.
+    """
+
+    root = Path(site_packages).expanduser().resolve()
+    records = record_paths(root, distribution_names)
+    if not records:
+        return IntegrityResult(False, failures=(f"no RECORD file under {root}",))
+
+    checked = 0
+    failures: list[str] = []
+    for record_path in records:
+        try:
+            rows = list(csv.reader(record_path.read_text(encoding="utf-8").splitlines()))
+        except (OSError, UnicodeError, csv.Error) as exc:
+            failures.append(f"{record_path.name}: {exc}")
+            continue
+        for row in rows:
+            if len(row) < 3 or not row[0]:
+                failures.append(f"{record_path.name}: malformed RECORD row")
+                continue
+            relative = PurePosixPath(row[0])
+            if relative.is_absolute():
+                failures.append(f"{record_path.name}: unsafe path {row[0]}")
+                continue
+            path = (root / Path(*relative.parts)).resolve()
+            # Wheel RECORD paths are relative to site-packages and legitimately
+            # include ``../../../bin/<entrypoint>`` for generated scripts.  The
+            # enclosing tool root is the trust boundary, not site-packages
+            # itself; anything that escapes that root is still rejected.
+            if root.name == "site-packages" and root.parent.name.startswith("python"):
+                allowed_root = root.parent.parent.parent.resolve()
+            elif root.name == "site-packages" and root.parent.name == "Lib":
+                allowed_root = root.parent.parent.resolve()
+            else:
+                allowed_root = root
+            try:
+                path.relative_to(allowed_root)
+            except ValueError:
+                failures.append(f"{record_path.name}: escaped path {row[0]}")
+                continue
+            if not path.is_file():
+                failures.append(f"missing {row[0]}")
+                continue
+            digest = row[1]
+            expected_size = row[2]
+            if digest:
+                try:
+                    algorithm, encoded = digest.split("=", 1)
+                    if algorithm not in {"sha256", "sha384", "sha512"}:
+                        failures.append(f"{row[0]}: unsupported hash {algorithm}")
+                        continue
+                    expected = base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
+                    actual = hashlib.new(algorithm, path.read_bytes()).digest()
+                except (OSError, ValueError, UnicodeError):
+                    failures.append(f"{row[0]}: invalid hash")
+                    continue
+                if actual != expected:
+                    failures.append(f"hash mismatch {row[0]}")
+                    continue
+            if expected_size:
+                try:
+                    if path.stat().st_size != int(expected_size):
+                        failures.append(f"size mismatch {row[0]}")
+                        continue
+                except (OSError, ValueError):
+                    failures.append(f"invalid size {row[0]}")
+                    continue
+            checked += 1
+
+    return IntegrityResult(not failures, checked_files=checked, failures=tuple(failures))
+
+
+def verify_python_environment(
+    python_executable: str | os.PathLike[str],
+    *,
+    required_imports: Iterable[str] = ("vibe", "lark_oapi", "modules.im.multi"),
+    timeout: float = 30.0,
+) -> IntegrityResult:
+    """Verify package records and import the modules required at startup."""
+
+    executable = str(Path(python_executable).expanduser())
+    site_packages = site_packages_for_python(executable)
+    if not site_packages:
+        return IntegrityResult(False, failures=(f"no site-packages for {executable}",))
+
+    failures: list[str] = []
+    checked = 0
+    for site_package in site_packages:
+        result = verify_site_packages(site_package)
+        checked += result.checked_files
+        failures.extend(result.failures)
+    if failures:
+        return IntegrityResult(False, checked_files=checked, failures=tuple(failures))
+
+    modules = tuple(module for module in required_imports if module)
+    if modules:
+        code = "; ".join(f"import {module}" for module in modules)
+        try:
+            process = subprocess.run(
+                [executable, "-c", code],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+                # Do not let a source checkout on the caller's cwd satisfy the
+                # probe in place of the candidate environment being checked.
+                cwd=tempfile.gettempdir(),
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return IntegrityResult(False, checked_files=checked, failures=(f"import probe failed: {exc}",))
+        if process.returncode != 0:
+            detail = (process.stderr or process.stdout or "import probe failed").strip().splitlines()[-1]
+            return IntegrityResult(False, checked_files=checked, failures=(f"required import failed: {detail}",))
+
+    return IntegrityResult(True, checked_files=checked)

--- a/core/install_integrity.py
+++ b/core/install_integrity.py
@@ -43,13 +43,55 @@ class IntegrityResult:
 def site_packages_for_python(python_executable: str | os.PathLike[str]) -> list[Path]:
     """Return site-packages directories belonging to a Python executable."""
 
+    # Keep the logical path intact. uv tool interpreters are often symlinks to
+    # a shared Python binary, while their import path and sysconfig point at
+    # the tool environment selected through that symlink.
     executable = Path(python_executable).expanduser()
     root = executable.parent.parent
-    candidates = sorted((root / "lib").glob("python*/site-packages"))
-    windows = root / "Lib" / "site-packages"
-    if windows.is_dir():
-        candidates.append(windows)
-    return [path for path in candidates if path.is_dir()]
+    discovered: list[Path] = []
+    probe = (
+        "import site, sysconfig; "
+        "config = sysconfig.get_paths(); "
+        "paths = [config.get('purelib'), config.get('platlib')]; "
+        "paths += list(getattr(site, 'getsitepackages', lambda: [])()); "
+        "user = getattr(site, 'getusersitepackages', lambda: '')(); "
+        "paths += [user] if user else []; "
+        "print('\\n'.join(dict.fromkeys(path for path in paths if path)))"
+    )
+    try:
+        result = subprocess.run(
+            [str(executable), "-c", probe],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+            cwd=tempfile.gettempdir(),
+        )
+    except (OSError, subprocess.SubprocessError):
+        result = None
+    if result is not None and result.returncode == 0:
+        discovered.extend(Path(line).expanduser() for line in result.stdout.splitlines() if line.strip())
+
+    heuristic = [
+        *sorted((root / "lib").glob("python*/site-packages")),
+        *sorted((root / "lib").glob("python*/dist-packages")),
+        root / "Lib" / "site-packages",
+    ]
+    # Prefer the environment-local layout. If it is absent (for example a
+    # system Python with a pip user install), retain the interpreter-reported
+    # locations, including a user site directory.
+    discovered = [*heuristic, *discovered] if any(path.is_dir() for path in heuristic) else discovered
+    candidates: list[Path] = []
+    seen: set[Path] = set()
+    for path in discovered:
+        try:
+            resolved = path.resolve()
+        except OSError:
+            continue
+        if resolved.is_dir() and resolved not in seen:
+            seen.add(resolved)
+            candidates.append(resolved)
+    return candidates
 
 
 def record_paths(site_packages: Path, distribution_names: Iterable[str] | None = None) -> list[Path]:

--- a/docs/INSTALL_FOR_AI.md
+++ b/docs/INSTALL_FOR_AI.md
@@ -167,7 +167,7 @@ Only run this if the user asks to remove Avibe:
 ```bash
 vibe stop
 uv tool uninstall vibe-remote
-rm -f ~/.local/bin/vibe
+vibe_bin="$(command -v vibe)" && rm -f "$vibe_bin" "$(dirname "$vibe_bin")/.vibe.avibe-generation"
 rm -rf "${AVIBE_HOME:-$HOME/.avibe}/runtime/install-generations"
 rm -rf ~/.vibe_remote
 ```

--- a/docs/INSTALL_FOR_AI.md
+++ b/docs/INSTALL_FOR_AI.md
@@ -167,5 +167,7 @@ Only run this if the user asks to remove Avibe:
 ```bash
 vibe stop
 uv tool uninstall vibe-remote
+rm -f ~/.local/bin/vibe
+rm -rf "${AVIBE_HOME:-$HOME/.avibe}/runtime/install-generations"
 rm -rf ~/.vibe_remote
 ```

--- a/docs/INSTALL_FOR_AI.md
+++ b/docs/INSTALL_FOR_AI.md
@@ -166,8 +166,10 @@ Only run this if the user asks to remove Avibe:
 
 ```bash
 vibe stop
+avibe_home="${AVIBE_HOME:-$HOME/.avibe}"
+avibe_home="${avibe_home/#\~/$HOME}"
 uv tool uninstall vibe-remote
 vibe_bin="$(command -v vibe)" && rm -f "$vibe_bin" "$(dirname "$vibe_bin")/.vibe.avibe-generation"
-rm -rf "${AVIBE_HOME:-$HOME/.avibe}/runtime/install-generations"
-rm -rf ~/.vibe_remote
+rm -rf "$avibe_home/runtime/install-generations"
+rm -rf "$avibe_home" ~/.vibe_remote
 ```

--- a/docs/INSTALL_FOR_AI_ZH.md
+++ b/docs/INSTALL_FOR_AI_ZH.md
@@ -167,7 +167,7 @@ vibe doctor
 ```bash
 vibe stop
 uv tool uninstall vibe-remote
-rm -f ~/.local/bin/vibe
+vibe_bin="$(command -v vibe)" && rm -f "$vibe_bin" "$(dirname "$vibe_bin")/.vibe.avibe-generation"
 rm -rf "${AVIBE_HOME:-$HOME/.avibe}/runtime/install-generations"
 rm -rf ~/.vibe_remote
 ```

--- a/docs/INSTALL_FOR_AI_ZH.md
+++ b/docs/INSTALL_FOR_AI_ZH.md
@@ -166,8 +166,10 @@ vibe doctor
 
 ```bash
 vibe stop
+avibe_home="${AVIBE_HOME:-$HOME/.avibe}"
+avibe_home="${avibe_home/#\~/$HOME}"
 uv tool uninstall vibe-remote
 vibe_bin="$(command -v vibe)" && rm -f "$vibe_bin" "$(dirname "$vibe_bin")/.vibe.avibe-generation"
-rm -rf "${AVIBE_HOME:-$HOME/.avibe}/runtime/install-generations"
-rm -rf ~/.vibe_remote
+rm -rf "$avibe_home/runtime/install-generations"
+rm -rf "$avibe_home" ~/.vibe_remote
 ```

--- a/docs/INSTALL_FOR_AI_ZH.md
+++ b/docs/INSTALL_FOR_AI_ZH.md
@@ -167,5 +167,7 @@ vibe doctor
 ```bash
 vibe stop
 uv tool uninstall vibe-remote
+rm -f ~/.local/bin/vibe
+rm -rf "${AVIBE_HOME:-$HOME/.avibe}/runtime/install-generations"
 rm -rf ~/.vibe_remote
 ```

--- a/install.ps1
+++ b/install.ps1
@@ -251,7 +251,57 @@ function Invoke-NativeCommand {
 function Invoke-UvToolInstallAttempt {
     param([string[]]$Arguments)
 
-    return Invoke-NativeCommand -FilePath "uv" -Arguments (@("tool", "install") + $Arguments)
+    $defaultHome = Join-Path $env:USERPROFILE ".avibe"
+    $legacyHome = Join-Path $env:USERPROFILE ".vibe_remote"
+    $runtimeHome = if ($env:AVIBE_HOME) {
+        $env:AVIBE_HOME
+    } elseif (Test-Path $defaultHome) {
+        $defaultHome
+    } elseif (Test-Path $legacyHome) {
+        $legacyHome
+    } else {
+        $defaultHome
+    }
+    $generationRoot = Join-Path (Join-Path $runtimeHome "runtime\install-generations") ([Guid]::NewGuid().ToString("N"))
+    $generationTools = Join-Path $generationRoot "tools"
+    $generationBin = Join-Path $generationRoot "bin"
+    $stableBin = Join-Path $env:USERPROFILE ".local\bin"
+    New-Item -ItemType Directory -Force -Path $generationTools, $generationBin, $stableBin | Out-Null
+
+    $previousToolDir = $env:UV_TOOL_DIR
+    $previousToolBinDir = $env:UV_TOOL_BIN_DIR
+    try {
+        $env:UV_TOOL_DIR = $generationTools
+        $env:UV_TOOL_BIN_DIR = $generationBin
+        $result = Invoke-NativeCommand -FilePath "uv" -Arguments (@("tool", "install") + $Arguments)
+        if (-not $result.Success) {
+            return $result
+        }
+
+        $candidate = Join-Path $generationBin "vibe.exe"
+        if (-not (Test-Path $candidate)) {
+            return @{
+                Success = $false
+                ExitCode = 1
+                Output = "uv completed but the candidate vibe launcher was not created"
+            }
+        }
+
+        $replacement = Join-Path $stableBin ("vibe.exe.avibe-" + [Guid]::NewGuid().ToString("N") + ".new")
+        try {
+            New-Item -ItemType SymbolicLink -Path $replacement -Target $candidate -ErrorAction Stop | Out-Null
+        } catch {
+            # Developer mode is not required for a normal Windows install. A
+            # hard link preserves the candidate bytes while still allowing an
+            # atomic Move-Item activation on the same volume.
+            New-Item -ItemType HardLink -Path $replacement -Target $candidate -ErrorAction Stop | Out-Null
+        }
+        Move-Item -Force -Path $replacement -Destination (Join-Path $stableBin "vibe.exe")
+        return $result
+    } finally {
+        if ($null -eq $previousToolDir) { Remove-Item Env:UV_TOOL_DIR -ErrorAction SilentlyContinue } else { $env:UV_TOOL_DIR = $previousToolDir }
+        if ($null -eq $previousToolBinDir) { Remove-Item Env:UV_TOOL_BIN_DIR -ErrorAction SilentlyContinue } else { $env:UV_TOOL_BIN_DIR = $previousToolBinDir }
+    }
 }
 
 function Install-Vibe {

--- a/install.ps1
+++ b/install.ps1
@@ -54,13 +54,25 @@ function Test-Command {
     return $?
 }
 
+function Resolve-InstallPath {
+    param([string]$Path)
+
+    $expanded = $Path
+    if ($expanded -eq "~") {
+        $expanded = $env:USERPROFILE
+    } elseif ($expanded.StartsWith("~\") -or $expanded.StartsWith("~/")) {
+        $expanded = Join-Path $env:USERPROFILE $expanded.Substring(2)
+    }
+    if (-not [System.IO.Path]::IsPathRooted($expanded)) {
+        $expanded = Join-Path (Get-Location) $expanded
+    }
+    return [System.IO.Path]::GetFullPath($expanded)
+}
+
 function Get-StableBinDirectory {
     $configured = $env:UV_TOOL_BIN_DIR
     $directory = if ($configured) { $configured } else { Join-Path $env:USERPROFILE ".local\bin" }
-    if (-not [System.IO.Path]::IsPathRooted($directory)) {
-        $directory = Join-Path (Get-Location) $directory
-    }
-    return [System.IO.Path]::GetFullPath($directory)
+    return Resolve-InstallPath $directory
 }
 
 function Get-GenerationPath {
@@ -248,14 +260,11 @@ function Invoke-NativeCommand {
     $stderrPath = [System.IO.Path]::GetTempFileName()
 
     try {
-        $process = Start-Process -FilePath $FilePath `
-            -ArgumentList $Arguments `
-            -RedirectStandardOutput $stdoutPath `
-            -RedirectStandardError $stderrPath `
-            -NoNewWindow `
-            -Wait `
-            -PassThru `
-            -ErrorAction Stop
+        # PowerShell's call operator preserves the argument vector. In
+        # contrast, Start-Process joins ArgumentList with spaces and loses the
+        # boundaries around paths containing whitespace.
+        & $FilePath @Arguments 1> $stdoutPath 2> $stderrPath
+        $exitCode = $LASTEXITCODE
 
         $stdout = if (Test-Path $stdoutPath) { [System.IO.File]::ReadAllText($stdoutPath) } else { "" }
         $stderr = if (Test-Path $stderrPath) { [System.IO.File]::ReadAllText($stderrPath) } else { "" }
@@ -269,8 +278,8 @@ function Invoke-NativeCommand {
         }
 
         return @{
-            Success = ($process.ExitCode -eq 0)
-            ExitCode = $process.ExitCode
+            Success = ($exitCode -eq 0)
+            ExitCode = $exitCode
             Output = ($capturedOutput -join [System.Environment]::NewLine).Trim()
         }
     } catch {
@@ -304,6 +313,55 @@ function Invoke-NativeCommand {
     }
 }
 
+function Activate-LegacyInstallCandidate {
+    param(
+        [string]$Candidate,
+        [string]$StableLauncher,
+        [string]$StableBin,
+        [string]$GenerationRoot
+    )
+
+    $probe = Invoke-NativeCommand -FilePath $Candidate -Arguments @("--help")
+    if (-not $probe.Success) {
+        return @{
+            Success = $false
+            ExitCode = $probe.ExitCode
+            Output = if ($probe.Output) { $probe.Output } else { "candidate vibe launcher failed its startup probe" }
+        }
+    }
+
+    $replacement = Join-Path $StableBin ("vibe.exe.avibe-" + [Guid]::NewGuid().ToString("N") + ".new")
+    try {
+        try {
+            New-Item -ItemType SymbolicLink -Path $replacement -Target $Candidate -ErrorAction Stop | Out-Null
+        } catch {
+            try {
+                New-Item -ItemType HardLink -Path $replacement -Target $Candidate -ErrorAction Stop | Out-Null
+            } catch {
+                Copy-Item -LiteralPath $Candidate -Destination $replacement -Force -ErrorAction Stop
+            }
+        }
+        Move-Item -Force -Path $replacement -Destination $StableLauncher
+    } catch {
+        Remove-Item -LiteralPath $replacement -Force -ErrorAction SilentlyContinue
+        return @{ Success = $false; ExitCode = 1; Output = (($_ | Out-String).Trim()) }
+    }
+
+    $markerReplacement = $null
+    try {
+        $marker = Join-Path $StableBin ".vibe.exe.avibe-generation"
+        $markerReplacement = Join-Path $StableBin (".vibe.exe.avibe-generation-" + [Guid]::NewGuid().ToString("N") + ".new")
+        Set-Content -LiteralPath $markerReplacement -Value $GenerationRoot -Encoding UTF8
+        Move-Item -Force -Path $markerReplacement -Destination $marker
+    } catch {
+        if ($markerReplacement) {
+            Remove-Item -LiteralPath $markerReplacement -Force -ErrorAction SilentlyContinue
+        }
+        Write-Warning "Could not record the legacy install generation; retained all installed generations."
+    }
+    return @{ Success = $true; ExitCode = 0; Output = "" }
+}
+
 function Invoke-UvToolInstallAttempt {
     param([string[]]$Arguments)
 
@@ -318,10 +376,7 @@ function Invoke-UvToolInstallAttempt {
     } else {
         $defaultHome
     }
-    if (-not [System.IO.Path]::IsPathRooted($runtimeHome)) {
-        $runtimeHome = Join-Path (Get-Location) $runtimeHome
-    }
-    $runtimeHome = [System.IO.Path]::GetFullPath($runtimeHome)
+    $runtimeHome = Resolve-InstallPath $runtimeHome
     $generationRoot = Join-Path (Join-Path $runtimeHome "runtime\install-generations") ([Guid]::NewGuid().ToString("N"))
     $generationTools = Join-Path $generationRoot "tools"
     $generationBin = Join-Path $generationRoot "bin"
@@ -357,15 +412,27 @@ function Invoke-UvToolInstallAttempt {
         Remove-Item Env:PYTHONHOME -ErrorAction SilentlyContinue
         Push-Location $runtimeHome
         try {
-            $activationArguments = @(
-                "__activate-install",
-                "--launcher", $stableLauncher,
-                "--candidate", $candidate
-            )
-            if ($previousGeneration) {
-                $activationArguments += @("--source-generation", $previousGeneration)
+            $protocol = Invoke-NativeCommand -FilePath $candidate -Arguments @("__activate-install", "--protocol-version")
+            if ($protocol.Success -and $protocol.Output.Trim() -eq "1") {
+                $activationArguments = @(
+                    "__activate-install",
+                    "--launcher", $stableLauncher,
+                    "--candidate", $candidate
+                )
+                if ($previousGeneration) {
+                    $activationArguments += @("--source-generation", $previousGeneration)
+                }
+                $activation = Invoke-NativeCommand -FilePath $candidate -Arguments $activationArguments
+            } else {
+                # Older released wheels predate the shared activation
+                # protocol. Switch atomically but retain every generation; a
+                # later protocol-aware install owns lifecycle cleanup.
+                $activation = Activate-LegacyInstallCandidate `
+                    -Candidate $candidate `
+                    -StableLauncher $stableLauncher `
+                    -StableBin $stableBin `
+                    -GenerationRoot $generationRoot
             }
-            $activation = Invoke-NativeCommand -FilePath $candidate -Arguments $activationArguments
         } finally {
             Pop-Location
             if ($null -eq $previousPythonPath) { Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue } else { $env:PYTHONPATH = $previousPythonPath }

--- a/install.ps1
+++ b/install.ps1
@@ -121,6 +121,10 @@ function Remove-StaleInstallGenerations {
     if (-not (Test-Path -LiteralPath $root -PathType Container)) {
         return
     }
+    $liveGeneration = Get-LauncherGeneration -Launcher (Join-Path (Get-StableBinDirectory) "vibe.exe") -StableBin (Get-StableBinDirectory) -GenerationRoot $root
+    if ($liveGeneration) {
+        $ActivePath = Join-Path $liveGeneration "bin\vibe.exe"
+    }
     $keep = @{}
     foreach ($path in @($ActivePath, $PreviousPath)) {
         if ($path) {
@@ -388,11 +392,17 @@ function Invoke-UvToolInstallAttempt {
             return $integrity
         }
 
+        $previousPythonPath = $env:PYTHONPATH
+        $previousPythonHome = $env:PYTHONHOME
+        Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue
+        Remove-Item Env:PYTHONHOME -ErrorAction SilentlyContinue
         Push-Location $runtimeHome
         try {
             $launcherProbe = Invoke-NativeCommand -FilePath $candidate -Arguments @("--help")
         } finally {
             Pop-Location
+            if ($null -eq $previousPythonPath) { Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue } else { $env:PYTHONPATH = $previousPythonPath }
+            if ($null -eq $previousPythonHome) { Remove-Item Env:PYTHONHOME -ErrorAction SilentlyContinue } else { $env:PYTHONHOME = $previousPythonHome }
         }
         if (-not $launcherProbe.Success) {
             Remove-Item -LiteralPath $generationRoot -Recurse -Force -ErrorAction SilentlyContinue

--- a/install.ps1
+++ b/install.ps1
@@ -78,7 +78,7 @@ function Get-StableBinDirectory {
 function Get-LauncherState {
     param(
         [string]$Launcher,
-        [string]$StableBin
+        [string]$RuntimeHome
     )
 
     $state = @{
@@ -86,20 +86,39 @@ function Get-LauncherState {
         SourcePath = $null
         ActivationOwner = $null
     }
-    $marker = Join-Path $StableBin ".vibe.exe.avibe-generation"
-    if (Test-Path -LiteralPath $marker) {
-        $marked = Get-Content -LiteralPath $marker -Raw -ErrorAction SilentlyContinue
-        if ($marked) {
-            $marked = $marked.Trim()
-        }
-        if ($marked) {
-            $state.SourcePath = $marked
-            $owner = Join-Path $marked "bin\vibe.exe"
-            if (Test-Path -LiteralPath $owner) {
-                $state.ActivationOwner = $owner
+    if (-not $state.Exists) {
+        return $state
+    }
+
+    $previousPythonPath = $env:PYTHONPATH
+    $previousPythonHome = $env:PYTHONHOME
+    $previousAvibeHome = $env:AVIBE_HOME
+    Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue
+    Remove-Item Env:PYTHONHOME -ErrorAction SilentlyContinue
+    $env:AVIBE_HOME = $RuntimeHome
+    Push-Location $RuntimeHome
+    try {
+        $protocol = Invoke-NativeCommand -FilePath $Launcher -Arguments @("__activate-install", "--protocol-version")
+        if ($protocol.Success -and [int]$protocol.Output.Trim() -ge 2) {
+            $snapshot = Invoke-NativeCommand `
+                -FilePath $Launcher `
+                -Arguments @("__activate-install", "--snapshot", "--launcher", $Launcher)
+            if ($snapshot.Success -and $snapshot.Output.Trim()) {
+                $state.SourcePath = $snapshot.Output.Trim()
+                $owner = Join-Path $state.SourcePath "bin\vibe.exe"
+                if (Test-Path -LiteralPath $owner) {
+                    $state.ActivationOwner = $owner
+                }
+                return $state
             }
-            return $state
         }
+    } catch {
+        # Released pre-protocol launchers fall through to legacy link discovery.
+    } finally {
+        Pop-Location
+        if ($null -eq $previousPythonPath) { Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue } else { $env:PYTHONPATH = $previousPythonPath }
+        if ($null -eq $previousPythonHome) { Remove-Item Env:PYTHONHOME -ErrorAction SilentlyContinue } else { $env:PYTHONHOME = $previousPythonHome }
+        if ($null -eq $previousAvibeHome) { Remove-Item Env:AVIBE_HOME -ErrorAction SilentlyContinue } else { $env:AVIBE_HOME = $previousAvibeHome }
     }
     try {
         $item = Get-Item -LiteralPath $Launcher -ErrorAction Stop
@@ -382,7 +401,7 @@ function Invoke-UvToolInstallAttempt {
     $stableLauncher = Join-Path $stableBin "vibe.exe"
     # The candidate's shared Python activation owner resolves this snapshot to
     # a generation. PowerShell must not duplicate junction/symlink identity.
-    $launcherState = Get-LauncherState -Launcher $stableLauncher -StableBin $stableBin
+    $launcherState = Get-LauncherState -Launcher $stableLauncher -RuntimeHome $runtimeHome
     $previousSourcePath = $launcherState.SourcePath
     New-Item -ItemType Directory -Force -Path $generationTools, $generationBin, $stableBin | Out-Null
 
@@ -416,13 +435,13 @@ function Invoke-UvToolInstallAttempt {
         Push-Location $runtimeHome
         try {
             $protocol = Invoke-NativeCommand -FilePath $candidate -Arguments @("__activate-install", "--protocol-version")
-            $activationOwner = if ($protocol.Success -and $protocol.Output.Trim() -eq "1") {
+            $activationOwner = if ($protocol.Success -and [int]$protocol.Output.Trim() -ge 1) {
                 $candidate
             } elseif ($launcherState.ActivationOwner) {
                 $ownerProtocol = Invoke-NativeCommand `
                     -FilePath $launcherState.ActivationOwner `
                     -Arguments @("__activate-install", "--protocol-version")
-                if ($ownerProtocol.Success -and $ownerProtocol.Output.Trim() -eq "1") {
+                if ($ownerProtocol.Success -and [int]$ownerProtocol.Output.Trim() -ge 1) {
                     $launcherState.ActivationOwner
                 } else {
                     $null
@@ -623,8 +642,9 @@ function Write-NextSteps {
     Write-Host "  pip uninstall avibe-os vibe-remote"
     Write-Host ("  Remove-Item -Force `"$(Join-Path $stableBin 'vibe.exe')`"")
     Write-Host ("  Remove-Item -Force `"$(Join-Path $stableBin '.vibe.exe.avibe-generation')`"")
-    Write-Host '  Remove-Item -Recurse -Force (Join-Path $(if ($env:AVIBE_HOME) { $env:AVIBE_HOME } else { "$env:USERPROFILE\.avibe" }) "runtime\install-generations")'
-    Write-Host "  Remove-Item -Recurse ~\.avibe, ~\.vibe_remote  # remove config and data"
+    Write-Host '  $avibeHome = if ($env:AVIBE_HOME) { $env:AVIBE_HOME -replace ''^~(?=[\\/]|$)'', $env:USERPROFILE } else { "$env:USERPROFILE\.avibe" }'
+    Write-Host '  Remove-Item -Recurse -Force (Join-Path $avibeHome "runtime\install-generations")'
+    Write-Host '  Remove-Item -Recurse $avibeHome, ~\.vibe_remote  # remove config and data'
     Write-Host ""
     Write-Host "Documentation:" -ForegroundColor Blue
     Write-Host "  https://github.com/$REPO#readme"

--- a/install.ps1
+++ b/install.ps1
@@ -287,6 +287,11 @@ function Invoke-UvToolInstallAttempt {
             }
         }
 
+        $integrity = Test-UvCandidate -Candidate $candidate -GenerationTools $generationTools -WorkingDirectory $runtimeHome
+        if (-not $integrity.Success) {
+            return $integrity
+        }
+
         $replacement = Join-Path $stableBin ("vibe.exe.avibe-" + [Guid]::NewGuid().ToString("N") + ".new")
         try {
             New-Item -ItemType SymbolicLink -Path $replacement -Target $candidate -ErrorAction Stop | Out-Null
@@ -301,6 +306,60 @@ function Invoke-UvToolInstallAttempt {
     } finally {
         if ($null -eq $previousToolDir) { Remove-Item Env:UV_TOOL_DIR -ErrorAction SilentlyContinue } else { $env:UV_TOOL_DIR = $previousToolDir }
         if ($null -eq $previousToolBinDir) { Remove-Item Env:UV_TOOL_BIN_DIR -ErrorAction SilentlyContinue } else { $env:UV_TOOL_BIN_DIR = $previousToolBinDir }
+    }
+}
+
+function Test-UvCandidate {
+    param(
+        [string]$Candidate,
+        [string]$GenerationTools,
+        [string]$WorkingDirectory
+    )
+
+    try {
+        $candidateTarget = (Resolve-Path -LiteralPath $Candidate -ErrorAction Stop).Path
+        $candidateBin = Split-Path -Parent $candidateTarget
+        $pythonCandidates = @(
+            (Join-Path $candidateBin "python.exe"),
+            (Join-Path $candidateBin "python3.exe"),
+            (Join-Path $GenerationTools "python.exe"),
+            (Join-Path $GenerationTools "python3.exe")
+        )
+        $candidatePython = $pythonCandidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+        if (-not $candidatePython) {
+            $candidatePython = Get-ChildItem -LiteralPath $GenerationTools -Recurse -File -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -in @("python.exe", "python3.exe") } |
+                Select-Object -First 1 -ExpandProperty FullName
+        }
+        if (-not $candidatePython) {
+            return @{
+                Success = $false
+                ExitCode = 1
+                Output = "could not find the candidate Python interpreter"
+            }
+        }
+
+        $probeCode = 'from core.install_integrity import verify_python_environment; result = verify_python_environment(__import__("sys").executable); print(result.detail); raise SystemExit(0 if result.ok else 1)'
+        Push-Location $WorkingDirectory
+        try {
+            $probe = Invoke-NativeCommand -FilePath $candidatePython -Arguments @("-c", $probeCode)
+        } finally {
+            Pop-Location
+        }
+        if (-not $probe.Success) {
+            return @{
+                Success = $false
+                ExitCode = $probe.ExitCode
+                Output = if ($probe.Output) { $probe.Output } else { "candidate Avibe environment failed integrity checks" }
+            }
+        }
+        return $probe
+    } catch {
+        return @{
+            Success = $false
+            ExitCode = 1
+            Output = (($_ | Out-String).Trim())
+        }
     }
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -345,6 +345,9 @@ function Invoke-UvToolInstallAttempt {
             Set-Content -LiteralPath $markerReplacement -Value $generationRoot -Encoding UTF8
             Move-Item -Force -Path $markerReplacement -Destination $marker
         } catch {
+            if ($markerReplacement) {
+                Remove-Item -LiteralPath $markerReplacement -Force -ErrorAction SilentlyContinue
+            }
             Write-Warning "Activated the launcher, but could not record its generation for offline rollback."
         }
         return $result

--- a/install.ps1
+++ b/install.ps1
@@ -99,12 +99,12 @@ function Get-LauncherState {
     Push-Location $RuntimeHome
     try {
         $protocol = Invoke-NativeCommand -FilePath $Launcher -Arguments @("__activate-install", "--protocol-version")
-        if ($protocol.Success -and [int]$protocol.Output.Trim() -ge 2) {
+        if ((Get-InstallProtocolVersion $protocol) -ge 2) {
             $snapshot = Invoke-NativeCommand `
                 -FilePath $Launcher `
                 -Arguments @("__activate-install", "--snapshot", "--launcher", $Launcher)
-            if ($snapshot.Success -and $snapshot.Output.Trim()) {
-                $state.SourcePath = $snapshot.Output.Trim()
+            if ($snapshot.Success -and $snapshot.Stdout.Trim()) {
+                $state.SourcePath = $snapshot.Stdout.Trim()
                 $owner = Join-Path $state.SourcePath "bin\vibe.exe"
                 if (Test-Path -LiteralPath $owner) {
                     $state.ActivationOwner = $owner
@@ -295,28 +295,35 @@ function Invoke-NativeCommand {
         return @{
             Success = ($exitCode -eq 0)
             ExitCode = $exitCode
+            Stdout = $stdout.Trim()
+            Stderr = $stderr.Trim()
             Output = ($capturedOutput -join [System.Environment]::NewLine).Trim()
         }
     } catch {
         $capturedOutput = @()
+        $stdout = ""
+        $stderr = ""
 
-        foreach ($path in @($stdoutPath, $stderrPath)) {
-            if (Test-Path $path) {
-                $streamOutput = [System.IO.File]::ReadAllText($path).Trim()
-                if ($streamOutput) {
-                    $capturedOutput += $streamOutput
-                }
-            }
+        if (Test-Path $stdoutPath) {
+            $stdout = [System.IO.File]::ReadAllText($stdoutPath).Trim()
+            if ($stdout) { $capturedOutput += $stdout }
+        }
+        if (Test-Path $stderrPath) {
+            $stderr = [System.IO.File]::ReadAllText($stderrPath).Trim()
+            if ($stderr) { $capturedOutput += $stderr }
         }
 
         $errorText = ($_ | Out-String).Trim()
         if ($errorText) {
             $capturedOutput += $errorText
         }
+        $capturedStderr = (($stderr, $errorText) | Where-Object { $_ }) -join [System.Environment]::NewLine
 
         return @{
             Success = $false
             ExitCode = 1
+            Stdout = $stdout
+            Stderr = $capturedStderr
             Output = ($capturedOutput -join [System.Environment]::NewLine).Trim()
         }
     } finally {
@@ -326,6 +333,19 @@ function Invoke-NativeCommand {
             }
         }
     }
+}
+
+function Get-InstallProtocolVersion {
+    param([object]$Result)
+
+    if (-not $Result.Success) {
+        return 0
+    }
+    [int]$version = 0
+    if (-not [int]::TryParse($Result.Stdout.Trim(), [ref]$version)) {
+        return 0
+    }
+    return $version
 }
 
 function Activate-LegacyInstallCandidate {
@@ -435,13 +455,13 @@ function Invoke-UvToolInstallAttempt {
         Push-Location $runtimeHome
         try {
             $protocol = Invoke-NativeCommand -FilePath $candidate -Arguments @("__activate-install", "--protocol-version")
-            $activationOwner = if ($protocol.Success -and [int]$protocol.Output.Trim() -ge 1) {
+            $activationOwner = if ((Get-InstallProtocolVersion $protocol) -ge 1) {
                 $candidate
             } elseif ($launcherState.ActivationOwner) {
                 $ownerProtocol = Invoke-NativeCommand `
                     -FilePath $launcherState.ActivationOwner `
                     -Arguments @("__activate-install", "--protocol-version")
-                if ($ownerProtocol.Success -and [int]$ownerProtocol.Output.Trim() -ge 1) {
+                if ((Get-InstallProtocolVersion $ownerProtocol) -ge 1) {
                     $launcherState.ActivationOwner
                 } else {
                     $null

--- a/install.ps1
+++ b/install.ps1
@@ -75,48 +75,29 @@ function Get-StableBinDirectory {
     return Resolve-InstallPath $directory
 }
 
-function Get-GenerationPath {
-    param(
-        [string]$Path,
-        [string]$GenerationRoot
-    )
-
-    try {
-        $root = ([System.IO.Path]::GetFullPath($GenerationRoot)).TrimEnd([System.IO.Path]::DirectorySeparatorChar)
-        $candidate = [System.IO.Path]::GetFullPath($Path)
-    } catch {
-        return $null
-    }
-    $prefix = $root + [System.IO.Path]::DirectorySeparatorChar
-    if (-not $candidate.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
-        return $null
-    }
-    $relative = $candidate.Substring($prefix.Length)
-    $name = $relative.Split([System.IO.Path]::DirectorySeparatorChar)[0]
-    if (-not $name) {
-        return $null
-    }
-    return Join-Path $root $name
-}
-
-function Get-LauncherGeneration {
+function Get-LauncherSourcePath {
     param(
         [string]$Launcher,
-        [string]$StableBin,
-        [string]$GenerationRoot
+        [string]$StableBin
     )
 
     $marker = Join-Path $StableBin ".vibe.exe.avibe-generation"
     if (Test-Path -LiteralPath $marker) {
         $marked = (Get-Content -LiteralPath $marker -Raw -ErrorAction SilentlyContinue).Trim()
-        $generation = Get-GenerationPath -Path $marked -GenerationRoot $GenerationRoot
-        if ($generation) {
-            return $generation
+        if ($marked) {
+            return $marked
         }
     }
     try {
-        $resolved = (Resolve-Path -LiteralPath $Launcher -ErrorAction Stop).Path
-        return Get-GenerationPath -Path $resolved -GenerationRoot $GenerationRoot
+        $item = Get-Item -LiteralPath $Launcher -ErrorAction Stop
+        $target = @($item.Target)[0]
+        if (-not $target) {
+            return $null
+        }
+        if (-not [System.IO.Path]::IsPathRooted($target)) {
+            $target = Join-Path $item.DirectoryName $target
+        }
+        return Resolve-InstallPath $target
     } catch {
         return $null
     }
@@ -382,7 +363,9 @@ function Invoke-UvToolInstallAttempt {
     $generationBin = Join-Path $generationRoot "bin"
     $stableBin = Get-StableBinDirectory
     $stableLauncher = Join-Path $stableBin "vibe.exe"
-    $previousGeneration = Get-LauncherGeneration -Launcher $stableLauncher -StableBin $stableBin -GenerationRoot (Join-Path $runtimeHome "runtime\install-generations")
+    # The candidate's shared Python activation owner resolves this snapshot to
+    # a generation. PowerShell must not duplicate junction/symlink identity.
+    $previousSourcePath = Get-LauncherSourcePath -Launcher $stableLauncher -StableBin $stableBin
     New-Item -ItemType Directory -Force -Path $generationTools, $generationBin, $stableBin | Out-Null
 
     $previousToolDir = $env:UV_TOOL_DIR
@@ -419,8 +402,8 @@ function Invoke-UvToolInstallAttempt {
                     "--launcher", $stableLauncher,
                     "--candidate", $candidate
                 )
-                if ($previousGeneration) {
-                    $activationArguments += @("--source-generation", $previousGeneration)
+                if ($previousSourcePath) {
+                    $activationArguments += @("--source-generation", $previousSourcePath)
                 }
                 $activation = Invoke-NativeCommand -FilePath $candidate -Arguments $activationArguments
             } else {

--- a/install.ps1
+++ b/install.ps1
@@ -54,6 +54,15 @@ function Test-Command {
     return $?
 }
 
+function Get-StableBinDirectory {
+    $configured = $env:UV_TOOL_BIN_DIR
+    $directory = if ($configured) { $configured } else { Join-Path $env:USERPROFILE ".local\bin" }
+    if (-not [System.IO.Path]::IsPathRooted($directory)) {
+        $directory = Join-Path (Get-Location) $directory
+    }
+    return [System.IO.Path]::GetFullPath($directory)
+}
+
 function Invoke-WebScriptWithRetry {
     param([string]$Url)
 
@@ -269,7 +278,7 @@ function Invoke-UvToolInstallAttempt {
     $generationRoot = Join-Path (Join-Path $runtimeHome "runtime\install-generations") ([Guid]::NewGuid().ToString("N"))
     $generationTools = Join-Path $generationRoot "tools"
     $generationBin = Join-Path $generationRoot "bin"
-    $stableBin = Join-Path $env:USERPROFILE ".local\bin"
+    $stableBin = Get-StableBinDirectory
     New-Item -ItemType Directory -Force -Path $generationTools, $generationBin, $stableBin | Out-Null
 
     $previousToolDir = $env:UV_TOOL_DIR
@@ -321,7 +330,13 @@ function Invoke-UvToolInstallAttempt {
             # Developer mode is not required for a normal Windows install. A
             # hard link preserves the candidate bytes while still allowing an
             # atomic Move-Item activation on the same volume.
-            New-Item -ItemType HardLink -Path $replacement -Target $candidate -ErrorAction Stop | Out-Null
+            try {
+                New-Item -ItemType HardLink -Path $replacement -Target $candidate -ErrorAction Stop | Out-Null
+            } catch {
+                # Hard links cannot cross volumes. Copying to a temporary file
+                # in the stable bin keeps the final Move-Item atomic there.
+                Copy-Item -LiteralPath $candidate -Destination $replacement -Force -ErrorAction Stop
+            }
         }
         Move-Item -Force -Path $replacement -Destination (Join-Path $stableBin "vibe.exe")
         return $result
@@ -464,7 +479,8 @@ function Test-Installation {
     
     # Refresh PATH
     $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
-    $env:Path += ";$env:USERPROFILE\.local\bin"
+    $stableBin = Get-StableBinDirectory
+    $env:Path += ";$stableBin"
     
     if (Test-Command "vibe") {
         Write-Success "vibe command is available"
@@ -475,7 +491,7 @@ function Test-Installation {
     
     # Check common install locations
     $vibeLocations = @(
-        "$env:USERPROFILE\.local\bin\vibe.exe"
+        (Join-Path $stableBin "vibe.exe")
     )
     
     foreach ($loc in $vibeLocations) {
@@ -518,6 +534,7 @@ function Prepare-ShowRuntime {
 }
 
 function Write-NextSteps {
+    $stableBin = Get-StableBinDirectory
     Write-Host ""
     Write-Host "Installation complete!" -ForegroundColor Green
     Write-Host ""
@@ -536,7 +553,7 @@ function Write-NextSteps {
     Write-Host "  uv tool uninstall avibe-os"
     Write-Host "  uv tool uninstall vibe-remote"
     Write-Host "  pip uninstall avibe-os vibe-remote"
-    Write-Host '  Remove-Item -Force "$env:USERPROFILE\.local\bin\vibe.exe"'
+    Write-Host ("  Remove-Item -Force `"$(Join-Path $stableBin 'vibe.exe')`"")
     Write-Host '  Remove-Item -Recurse -Force (Join-Path $(if ($env:AVIBE_HOME) { $env:AVIBE_HOME } else { "$env:USERPROFILE\.avibe" }) "runtime\install-generations")'
     Write-Host "  Remove-Item -Recurse ~\.avibe, ~\.vibe_remote  # remove config and data"
     Write-Host ""

--- a/install.ps1
+++ b/install.ps1
@@ -563,35 +563,19 @@ function Install-Vibe {
 
 function Test-Installation {
     Write-Info "Verifying installation..."
-    
-    # Refresh PATH
-    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+
     $stableBin = Get-StableBinDirectory
-    $env:Path += ";$stableBin"
-    
-    if (Test-Command "vibe") {
+    $stableLauncher = Join-Path $stableBin "vibe.exe"
+    $persistedPath = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+    $env:Path = "$stableBin;$persistedPath"
+
+    if (Test-Path -LiteralPath $stableLauncher) {
         Write-Success "vibe command is available"
         Write-Host ""
-        & vibe --help
+        & $stableLauncher --help
         return $true
     }
-    
-    # Check common install locations
-    $vibeLocations = @(
-        (Join-Path $stableBin "vibe.exe")
-    )
-    
-    foreach ($loc in $vibeLocations) {
-        if (Test-Path $loc) {
-            Write-Warning "vibe installed at $loc but not in PATH"
-            Write-Host ""
-            Write-Host "Add this directory to your PATH:" -ForegroundColor Yellow
-            Write-Host "  $(Split-Path $loc)"
-            Write-Host ""
-            return $true
-        }
-    }
-    
+
     Write-Error "Installation verification failed. vibe command not found."
 }
 
@@ -601,13 +585,14 @@ function Prepare-ShowRuntime {
         return
     }
 
-    if (-not (Test-Command "vibe")) {
+    $stableLauncher = Join-Path (Get-StableBinDirectory) "vibe.exe"
+    if (-not (Test-Path -LiteralPath $stableLauncher)) {
         Write-Warning "Show Runtime was not prepared because the vibe command is not available yet"
         return
     }
 
     Write-Info "Preparing Show Runtime for this platform..."
-    $result = Invoke-NativeCommand -FilePath "vibe" -Arguments @("runtime", "prepare", "--strict")
+    $result = Invoke-NativeCommand -FilePath $stableLauncher -Arguments @("runtime", "prepare", "--strict")
     if ($result.Success) {
         Write-Success "Show Runtime is ready"
         return

--- a/install.ps1
+++ b/install.ps1
@@ -339,6 +339,14 @@ function Invoke-UvToolInstallAttempt {
             }
         }
         Move-Item -Force -Path $replacement -Destination (Join-Path $stableBin "vibe.exe")
+        try {
+            $marker = Join-Path $stableBin ".vibe.exe.avibe-generation"
+            $markerReplacement = Join-Path $stableBin (".vibe.exe.avibe-generation-" + [Guid]::NewGuid().ToString("N") + ".new")
+            Set-Content -LiteralPath $markerReplacement -Value $generationRoot -Encoding UTF8
+            Move-Item -Force -Path $markerReplacement -Destination $marker
+        } catch {
+            Write-Warning "Activated the launcher, but could not record its generation for offline rollback."
+        }
         return $result
     } finally {
         if ($null -eq $previousToolDir) { Remove-Item Env:UV_TOOL_DIR -ErrorAction SilentlyContinue } else { $env:UV_TOOL_DIR = $previousToolDir }
@@ -554,6 +562,7 @@ function Write-NextSteps {
     Write-Host "  uv tool uninstall vibe-remote"
     Write-Host "  pip uninstall avibe-os vibe-remote"
     Write-Host ("  Remove-Item -Force `"$(Join-Path $stableBin 'vibe.exe')`"")
+    Write-Host ("  Remove-Item -Force `"$(Join-Path $stableBin '.vibe.exe.avibe-generation')`"")
     Write-Host '  Remove-Item -Recurse -Force (Join-Path $(if ($env:AVIBE_HOME) { $env:AVIBE_HOME } else { "$env:USERPROFILE\.avibe" }) "runtime\install-generations")'
     Write-Host "  Remove-Item -Recurse ~\.avibe, ~\.vibe_remote  # remove config and data"
     Write-Host ""

--- a/install.ps1
+++ b/install.ps1
@@ -536,6 +536,8 @@ function Write-NextSteps {
     Write-Host "  uv tool uninstall avibe-os"
     Write-Host "  uv tool uninstall vibe-remote"
     Write-Host "  pip uninstall avibe-os vibe-remote"
+    Write-Host '  Remove-Item -Force "$env:USERPROFILE\.local\bin\vibe.exe"'
+    Write-Host '  Remove-Item -Recurse -Force (Join-Path $(if ($env:AVIBE_HOME) { $env:AVIBE_HOME } else { "$env:USERPROFILE\.avibe" }) "runtime\install-generations")'
     Write-Host "  Remove-Item -Recurse ~\.avibe, ~\.vibe_remote  # remove config and data"
     Write-Host ""
     Write-Host "Documentation:" -ForegroundColor Blue

--- a/install.ps1
+++ b/install.ps1
@@ -339,12 +339,20 @@ function Test-UvCandidate {
             }
         }
 
-        $probeCode = 'from core.install_integrity import verify_python_environment; result = verify_python_environment(__import__("sys").executable); print(result.detail); raise SystemExit(0 if result.ok else 1)'
+        $probePath = Join-Path ([System.IO.Path]::GetTempPath()) ("avibe-integrity-" + [Guid]::NewGuid().ToString("N") + ".py")
+        $probeCode = @'
+from core.install_integrity import verify_python_environment
+result = verify_python_environment(__import__("sys").executable)
+print(result.detail)
+raise SystemExit(0 if result.ok else 1)
+'@
+        Set-Content -LiteralPath $probePath -Value $probeCode -Encoding utf8
         Push-Location $WorkingDirectory
         try {
-            $probe = Invoke-NativeCommand -FilePath $candidatePython -Arguments @("-c", $probeCode)
+            $probe = Invoke-NativeCommand -FilePath $candidatePython -Arguments @($probePath)
         } finally {
             Pop-Location
+            Remove-Item -LiteralPath $probePath -Force -ErrorAction SilentlyContinue
         }
         if (-not $probe.Success) {
             return @{

--- a/install.ps1
+++ b/install.ps1
@@ -63,6 +63,84 @@ function Get-StableBinDirectory {
     return [System.IO.Path]::GetFullPath($directory)
 }
 
+function Get-GenerationPath {
+    param(
+        [string]$Path,
+        [string]$GenerationRoot
+    )
+
+    try {
+        $root = ([System.IO.Path]::GetFullPath($GenerationRoot)).TrimEnd([System.IO.Path]::DirectorySeparatorChar)
+        $candidate = [System.IO.Path]::GetFullPath($Path)
+    } catch {
+        return $null
+    }
+    $prefix = $root + [System.IO.Path]::DirectorySeparatorChar
+    if (-not $candidate.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $null
+    }
+    $relative = $candidate.Substring($prefix.Length)
+    $name = $relative.Split([System.IO.Path]::DirectorySeparatorChar)[0]
+    if (-not $name) {
+        return $null
+    }
+    return Join-Path $root $name
+}
+
+function Get-LauncherGeneration {
+    param(
+        [string]$Launcher,
+        [string]$StableBin,
+        [string]$GenerationRoot
+    )
+
+    $marker = Join-Path $StableBin ".vibe.exe.avibe-generation"
+    if (Test-Path -LiteralPath $marker) {
+        $marked = (Get-Content -LiteralPath $marker -Raw -ErrorAction SilentlyContinue).Trim()
+        $generation = Get-GenerationPath -Path $marked -GenerationRoot $GenerationRoot
+        if ($generation) {
+            return $generation
+        }
+    }
+    try {
+        $resolved = (Resolve-Path -LiteralPath $Launcher -ErrorAction Stop).Path
+        return Get-GenerationPath -Path $resolved -GenerationRoot $GenerationRoot
+    } catch {
+        return $null
+    }
+}
+
+function Remove-StaleInstallGenerations {
+    param(
+        [string]$RuntimeHome,
+        [string]$ActivePath,
+        [string]$PreviousPath
+    )
+
+    $root = Join-Path (Join-Path $RuntimeHome "runtime\install-generations") ""
+    if (-not (Test-Path -LiteralPath $root -PathType Container)) {
+        return
+    }
+    $keep = @{}
+    foreach ($path in @($ActivePath, $PreviousPath)) {
+        if ($path) {
+            $generation = Get-GenerationPath -Path $path -GenerationRoot $root
+            if ($generation) {
+                $keep[$generation.ToUpperInvariant()] = $true
+            }
+        }
+    }
+    try {
+        Get-ChildItem -LiteralPath $root -Directory -ErrorAction Stop | ForEach-Object {
+            if (-not $keep.ContainsKey($_.FullName.ToUpperInvariant())) {
+                Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    } catch {
+        Write-Warning "Could not enumerate old Avibe install generations for cleanup."
+    }
+}
+
 function Invoke-WebScriptWithRetry {
     param([string]$Url)
 
@@ -279,6 +357,8 @@ function Invoke-UvToolInstallAttempt {
     $generationTools = Join-Path $generationRoot "tools"
     $generationBin = Join-Path $generationRoot "bin"
     $stableBin = Get-StableBinDirectory
+    $stableLauncher = Join-Path $stableBin "vibe.exe"
+    $previousGeneration = Get-LauncherGeneration -Launcher $stableLauncher -StableBin $stableBin -GenerationRoot (Join-Path $runtimeHome "runtime\install-generations")
     New-Item -ItemType Directory -Force -Path $generationTools, $generationBin, $stableBin | Out-Null
 
     $previousToolDir = $env:UV_TOOL_DIR
@@ -350,6 +430,7 @@ function Invoke-UvToolInstallAttempt {
             }
             Write-Warning "Activated the launcher, but could not record its generation for offline rollback."
         }
+        Remove-StaleInstallGenerations -RuntimeHome $runtimeHome -ActivePath $candidate -PreviousPath $previousGeneration
         return $result
     } finally {
         if ($null -eq $previousToolDir) { Remove-Item Env:UV_TOOL_DIR -ErrorAction SilentlyContinue } else { $env:UV_TOOL_DIR = $previousToolDir }

--- a/install.ps1
+++ b/install.ps1
@@ -262,6 +262,10 @@ function Invoke-UvToolInstallAttempt {
     } else {
         $defaultHome
     }
+    if (-not [System.IO.Path]::IsPathRooted($runtimeHome)) {
+        $runtimeHome = Join-Path (Get-Location) $runtimeHome
+    }
+    $runtimeHome = [System.IO.Path]::GetFullPath($runtimeHome)
     $generationRoot = Join-Path (Join-Path $runtimeHome "runtime\install-generations") ([Guid]::NewGuid().ToString("N"))
     $generationTools = Join-Path $generationRoot "tools"
     $generationBin = Join-Path $generationRoot "bin"
@@ -275,11 +279,13 @@ function Invoke-UvToolInstallAttempt {
         $env:UV_TOOL_BIN_DIR = $generationBin
         $result = Invoke-NativeCommand -FilePath "uv" -Arguments (@("tool", "install") + $Arguments)
         if (-not $result.Success) {
+            Remove-Item -LiteralPath $generationRoot -Recurse -Force -ErrorAction SilentlyContinue
             return $result
         }
 
         $candidate = Join-Path $generationBin "vibe.exe"
         if (-not (Test-Path $candidate)) {
+            Remove-Item -LiteralPath $generationRoot -Recurse -Force -ErrorAction SilentlyContinue
             return @{
                 Success = $false
                 ExitCode = 1
@@ -289,7 +295,23 @@ function Invoke-UvToolInstallAttempt {
 
         $integrity = Test-UvCandidate -Candidate $candidate -GenerationTools $generationTools -WorkingDirectory $runtimeHome
         if (-not $integrity.Success) {
+            Remove-Item -LiteralPath $generationRoot -Recurse -Force -ErrorAction SilentlyContinue
             return $integrity
+        }
+
+        Push-Location $runtimeHome
+        try {
+            $launcherProbe = Invoke-NativeCommand -FilePath $candidate -Arguments @("--help")
+        } finally {
+            Pop-Location
+        }
+        if (-not $launcherProbe.Success) {
+            Remove-Item -LiteralPath $generationRoot -Recurse -Force -ErrorAction SilentlyContinue
+            return @{
+                Success = $false
+                ExitCode = $launcherProbe.ExitCode
+                Output = if ($launcherProbe.Output) { $launcherProbe.Output } else { "candidate vibe launcher failed its startup probe" }
+            }
         }
 
         $replacement = Join-Path $stableBin ("vibe.exe.avibe-" + [Guid]::NewGuid().ToString("N") + ".new")

--- a/install.ps1
+++ b/install.ps1
@@ -110,41 +110,6 @@ function Get-LauncherGeneration {
     }
 }
 
-function Remove-StaleInstallGenerations {
-    param(
-        [string]$RuntimeHome,
-        [string]$ActivePath,
-        [string]$PreviousPath
-    )
-
-    $root = Join-Path (Join-Path $RuntimeHome "runtime\install-generations") ""
-    if (-not (Test-Path -LiteralPath $root -PathType Container)) {
-        return
-    }
-    $liveGeneration = Get-LauncherGeneration -Launcher (Join-Path (Get-StableBinDirectory) "vibe.exe") -StableBin (Get-StableBinDirectory) -GenerationRoot $root
-    if ($liveGeneration) {
-        $ActivePath = Join-Path $liveGeneration "bin\vibe.exe"
-    }
-    $keep = @{}
-    foreach ($path in @($ActivePath, $PreviousPath)) {
-        if ($path) {
-            $generation = Get-GenerationPath -Path $path -GenerationRoot $root
-            if ($generation) {
-                $keep[$generation.ToUpperInvariant()] = $true
-            }
-        }
-    }
-    try {
-        Get-ChildItem -LiteralPath $root -Directory -ErrorAction Stop | ForEach-Object {
-            if (-not $keep.ContainsKey($_.FullName.ToUpperInvariant())) {
-                Remove-Item -LiteralPath $_.FullName -Recurse -Force -ErrorAction SilentlyContinue
-            }
-        }
-    } catch {
-        Write-Warning "Could not enumerate old Avibe install generations for cleanup."
-    }
-}
-
 function Invoke-WebScriptWithRetry {
     param([string]$Url)
 
@@ -386,127 +351,38 @@ function Invoke-UvToolInstallAttempt {
             }
         }
 
-        $integrity = Test-UvCandidate -Candidate $candidate -GenerationTools $generationTools -WorkingDirectory $runtimeHome
-        if (-not $integrity.Success) {
-            Remove-Item -LiteralPath $generationRoot -Recurse -Force -ErrorAction SilentlyContinue
-            return $integrity
-        }
-
         $previousPythonPath = $env:PYTHONPATH
         $previousPythonHome = $env:PYTHONHOME
         Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue
         Remove-Item Env:PYTHONHOME -ErrorAction SilentlyContinue
         Push-Location $runtimeHome
         try {
-            $launcherProbe = Invoke-NativeCommand -FilePath $candidate -Arguments @("--help")
+            $activationArguments = @(
+                "__activate-install",
+                "--launcher", $stableLauncher,
+                "--candidate", $candidate
+            )
+            if ($previousGeneration) {
+                $activationArguments += @("--source-generation", $previousGeneration)
+            }
+            $activation = Invoke-NativeCommand -FilePath $candidate -Arguments $activationArguments
         } finally {
             Pop-Location
             if ($null -eq $previousPythonPath) { Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue } else { $env:PYTHONPATH = $previousPythonPath }
             if ($null -eq $previousPythonHome) { Remove-Item Env:PYTHONHOME -ErrorAction SilentlyContinue } else { $env:PYTHONHOME = $previousPythonHome }
         }
-        if (-not $launcherProbe.Success) {
+        if (-not $activation.Success) {
             Remove-Item -LiteralPath $generationRoot -Recurse -Force -ErrorAction SilentlyContinue
             return @{
                 Success = $false
-                ExitCode = $launcherProbe.ExitCode
-                Output = if ($launcherProbe.Output) { $launcherProbe.Output } else { "candidate vibe launcher failed its startup probe" }
+                ExitCode = $activation.ExitCode
+                Output = if ($activation.Output) { $activation.Output } else { "candidate Avibe environment could not be activated" }
             }
         }
-
-        $replacement = Join-Path $stableBin ("vibe.exe.avibe-" + [Guid]::NewGuid().ToString("N") + ".new")
-        try {
-            New-Item -ItemType SymbolicLink -Path $replacement -Target $candidate -ErrorAction Stop | Out-Null
-        } catch {
-            # Developer mode is not required for a normal Windows install. A
-            # hard link preserves the candidate bytes while still allowing an
-            # atomic Move-Item activation on the same volume.
-            try {
-                New-Item -ItemType HardLink -Path $replacement -Target $candidate -ErrorAction Stop | Out-Null
-            } catch {
-                # Hard links cannot cross volumes. Copying to a temporary file
-                # in the stable bin keeps the final Move-Item atomic there.
-                Copy-Item -LiteralPath $candidate -Destination $replacement -Force -ErrorAction Stop
-            }
-        }
-        Move-Item -Force -Path $replacement -Destination (Join-Path $stableBin "vibe.exe")
-        try {
-            $marker = Join-Path $stableBin ".vibe.exe.avibe-generation"
-            $markerReplacement = Join-Path $stableBin (".vibe.exe.avibe-generation-" + [Guid]::NewGuid().ToString("N") + ".new")
-            Set-Content -LiteralPath $markerReplacement -Value $generationRoot -Encoding UTF8
-            Move-Item -Force -Path $markerReplacement -Destination $marker
-        } catch {
-            if ($markerReplacement) {
-                Remove-Item -LiteralPath $markerReplacement -Force -ErrorAction SilentlyContinue
-            }
-            Write-Warning "Activated the launcher, but could not record its generation for offline rollback."
-        }
-        Remove-StaleInstallGenerations -RuntimeHome $runtimeHome -ActivePath $candidate -PreviousPath $previousGeneration
         return $result
     } finally {
         if ($null -eq $previousToolDir) { Remove-Item Env:UV_TOOL_DIR -ErrorAction SilentlyContinue } else { $env:UV_TOOL_DIR = $previousToolDir }
         if ($null -eq $previousToolBinDir) { Remove-Item Env:UV_TOOL_BIN_DIR -ErrorAction SilentlyContinue } else { $env:UV_TOOL_BIN_DIR = $previousToolBinDir }
-    }
-}
-
-function Test-UvCandidate {
-    param(
-        [string]$Candidate,
-        [string]$GenerationTools,
-        [string]$WorkingDirectory
-    )
-
-    try {
-        $candidateTarget = (Resolve-Path -LiteralPath $Candidate -ErrorAction Stop).Path
-        $candidateBin = Split-Path -Parent $candidateTarget
-        $pythonCandidates = @(
-            (Join-Path $candidateBin "python.exe"),
-            (Join-Path $candidateBin "python3.exe"),
-            (Join-Path $GenerationTools "python.exe"),
-            (Join-Path $GenerationTools "python3.exe")
-        )
-        $candidatePython = $pythonCandidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
-        if (-not $candidatePython) {
-            $candidatePython = Get-ChildItem -LiteralPath $GenerationTools -Recurse -File -ErrorAction SilentlyContinue |
-                Where-Object { $_.Name -in @("python.exe", "python3.exe") } |
-                Select-Object -First 1 -ExpandProperty FullName
-        }
-        if (-not $candidatePython) {
-            return @{
-                Success = $false
-                ExitCode = 1
-                Output = "could not find the candidate Python interpreter"
-            }
-        }
-
-        $probePath = Join-Path ([System.IO.Path]::GetTempPath()) ("avibe-integrity-" + [Guid]::NewGuid().ToString("N") + ".py")
-        $probeCode = @'
-from core.install_integrity import verify_python_environment
-result = verify_python_environment(__import__("sys").executable)
-print(result.detail)
-raise SystemExit(0 if result.ok else 1)
-'@
-        Set-Content -LiteralPath $probePath -Value $probeCode -Encoding utf8
-        Push-Location $WorkingDirectory
-        try {
-            $probe = Invoke-NativeCommand -FilePath $candidatePython -Arguments @($probePath)
-        } finally {
-            Pop-Location
-            Remove-Item -LiteralPath $probePath -Force -ErrorAction SilentlyContinue
-        }
-        if (-not $probe.Success) {
-            return @{
-                Success = $false
-                ExitCode = $probe.ExitCode
-                Output = if ($probe.Output) { $probe.Output } else { "candidate Avibe environment failed integrity checks" }
-            }
-        }
-        return $probe
-    } catch {
-        return @{
-            Success = $false
-            ExitCode = 1
-            Output = (($_ | Out-String).Trim())
-        }
     }
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -75,32 +75,47 @@ function Get-StableBinDirectory {
     return Resolve-InstallPath $directory
 }
 
-function Get-LauncherSourcePath {
+function Get-LauncherState {
     param(
         [string]$Launcher,
         [string]$StableBin
     )
 
+    $state = @{
+        Exists = Test-Path -LiteralPath $Launcher
+        SourcePath = $null
+        ActivationOwner = $null
+    }
     $marker = Join-Path $StableBin ".vibe.exe.avibe-generation"
     if (Test-Path -LiteralPath $marker) {
-        $marked = (Get-Content -LiteralPath $marker -Raw -ErrorAction SilentlyContinue).Trim()
+        $marked = Get-Content -LiteralPath $marker -Raw -ErrorAction SilentlyContinue
         if ($marked) {
-            return $marked
+            $marked = $marked.Trim()
+        }
+        if ($marked) {
+            $state.SourcePath = $marked
+            $owner = Join-Path $marked "bin\vibe.exe"
+            if (Test-Path -LiteralPath $owner) {
+                $state.ActivationOwner = $owner
+            }
+            return $state
         }
     }
     try {
         $item = Get-Item -LiteralPath $Launcher -ErrorAction Stop
         $target = @($item.Target)[0]
         if (-not $target) {
-            return $null
+            return $state
         }
         if (-not [System.IO.Path]::IsPathRooted($target)) {
             $target = Join-Path $item.DirectoryName $target
         }
-        return Resolve-InstallPath $target
+        $state.SourcePath = Resolve-InstallPath $target
+        $state.ActivationOwner = $state.SourcePath
     } catch {
-        return $null
+        return $state
     }
+    return $state
 }
 
 function Invoke-WebScriptWithRetry {
@@ -322,7 +337,9 @@ function Activate-LegacyInstallCandidate {
                 Copy-Item -LiteralPath $Candidate -Destination $replacement -Force -ErrorAction Stop
             }
         }
-        Move-Item -Force -Path $replacement -Destination $StableLauncher
+        # This fallback is fresh-install only. File.Move atomically refuses to
+        # overwrite a launcher that appeared while the candidate was staging.
+        [System.IO.File]::Move($replacement, $StableLauncher)
     } catch {
         Remove-Item -LiteralPath $replacement -Force -ErrorAction SilentlyContinue
         return @{ Success = $false; ExitCode = 1; Output = (($_ | Out-String).Trim()) }
@@ -365,7 +382,8 @@ function Invoke-UvToolInstallAttempt {
     $stableLauncher = Join-Path $stableBin "vibe.exe"
     # The candidate's shared Python activation owner resolves this snapshot to
     # a generation. PowerShell must not duplicate junction/symlink identity.
-    $previousSourcePath = Get-LauncherSourcePath -Launcher $stableLauncher -StableBin $stableBin
+    $launcherState = Get-LauncherState -Launcher $stableLauncher -StableBin $stableBin
+    $previousSourcePath = $launcherState.SourcePath
     New-Item -ItemType Directory -Force -Path $generationTools, $generationBin, $stableBin | Out-Null
 
     $previousToolDir = $env:UV_TOOL_DIR
@@ -391,12 +409,28 @@ function Invoke-UvToolInstallAttempt {
 
         $previousPythonPath = $env:PYTHONPATH
         $previousPythonHome = $env:PYTHONHOME
+        $previousAvibeHome = $env:AVIBE_HOME
         Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue
         Remove-Item Env:PYTHONHOME -ErrorAction SilentlyContinue
+        $env:AVIBE_HOME = $runtimeHome
         Push-Location $runtimeHome
         try {
             $protocol = Invoke-NativeCommand -FilePath $candidate -Arguments @("__activate-install", "--protocol-version")
-            if ($protocol.Success -and $protocol.Output.Trim() -eq "1") {
+            $activationOwner = if ($protocol.Success -and $protocol.Output.Trim() -eq "1") {
+                $candidate
+            } elseif ($launcherState.ActivationOwner) {
+                $ownerProtocol = Invoke-NativeCommand `
+                    -FilePath $launcherState.ActivationOwner `
+                    -Arguments @("__activate-install", "--protocol-version")
+                if ($ownerProtocol.Success -and $ownerProtocol.Output.Trim() -eq "1") {
+                    $launcherState.ActivationOwner
+                } else {
+                    $null
+                }
+            } else {
+                $null
+            }
+            if ($activationOwner) {
                 $activationArguments = @(
                     "__activate-install",
                     "--launcher", $stableLauncher,
@@ -405,11 +439,16 @@ function Invoke-UvToolInstallAttempt {
                 if ($previousSourcePath) {
                     $activationArguments += @("--source-generation", $previousSourcePath)
                 }
-                $activation = Invoke-NativeCommand -FilePath $candidate -Arguments $activationArguments
+                $activation = Invoke-NativeCommand -FilePath $activationOwner -Arguments $activationArguments
+            } elseif ($launcherState.Exists) {
+                $activation = @{
+                    Success = $false
+                    ExitCode = 1
+                    Output = "legacy candidate cannot safely replace an existing Avibe installation"
+                }
             } else {
-                # Older released wheels predate the shared activation
-                # protocol. Switch atomically but retain every generation; a
-                # later protocol-aware install owns lifecycle cleanup.
+                # A legacy wheel may bootstrap a fresh machine. Existing
+                # installs must route through a protocol-aware current owner.
                 $activation = Activate-LegacyInstallCandidate `
                     -Candidate $candidate `
                     -StableLauncher $stableLauncher `
@@ -420,6 +459,7 @@ function Invoke-UvToolInstallAttempt {
             Pop-Location
             if ($null -eq $previousPythonPath) { Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue } else { $env:PYTHONPATH = $previousPythonPath }
             if ($null -eq $previousPythonHome) { Remove-Item Env:PYTHONHOME -ErrorAction SilentlyContinue } else { $env:PYTHONHOME = $previousPythonHome }
+            if ($null -eq $previousAvibeHome) { Remove-Item Env:AVIBE_HOME -ErrorAction SilentlyContinue } else { $env:AVIBE_HOME = $previousAvibeHome }
         }
         if (-not $activation.Success) {
             Remove-Item -LiteralPath $generationRoot -Recurse -Force -ErrorAction SilentlyContinue

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,17 @@ PACKAGE_NAME="avibe-os"
 NODE_MINIMUM_REQUIREMENT="20.19+ or 22.12+"
 VIBE_BIN_PATH=""
 VIBE_TOOL_BIN_DIR=""
+VIBE_CANDIDATE_BIN_PATH=""
 ORIGINAL_PATH="$PATH"
+if [ -n "${AVIBE_HOME:-}" ]; then
+    AVIBE_RUNTIME_HOME="$AVIBE_HOME"
+elif [ -e "$HOME/.avibe" ] || [ -L "$HOME/.avibe" ]; then
+    AVIBE_RUNTIME_HOME="$HOME/.avibe"
+elif [ -e "$HOME/.vibe_remote" ] || [ -L "$HOME/.vibe_remote" ]; then
+    AVIBE_RUNTIME_HOME="$HOME/.vibe_remote"
+else
+    AVIBE_RUNTIME_HOME="$HOME/.avibe"
+fi
 REMOTE_ACCESS_PAIRING_KEY=""
 REMOTE_ACCESS_PAIRED=""
 
@@ -403,11 +413,29 @@ install_node_optional() {
 }
 
 uv_tool_install() {
-    if [ -n "$VIBE_TOOL_BIN_DIR" ]; then
-        UV_TOOL_BIN_DIR="$VIBE_TOOL_BIN_DIR" uv tool install "$@"
-    else
-        uv tool install "$@"
+    # uv writes a tool environment in place.  Give every attempt its own
+    # durable generation and activate its launcher only after uv exits
+    # successfully, so an interrupted copy cannot damage the active install.
+    local generation_root="$AVIBE_RUNTIME_HOME/runtime/install-generations/$(date +%s)-$$-${RANDOM}"
+    local generation_tools="$generation_root/tools"
+    local generation_bin="$generation_root/bin"
+    local stable_bin_dir="${VIBE_TOOL_BIN_DIR:-$HOME/.local/bin}"
+    mkdir -p "$generation_tools" "$generation_bin" "$stable_bin_dir"
+
+    if UV_TOOL_DIR="$generation_tools" UV_TOOL_BIN_DIR="$generation_bin" uv tool install "$@"; then
+        VIBE_CANDIDATE_BIN_PATH="$generation_bin/vibe"
+        if [ ! -x "$VIBE_CANDIDATE_BIN_PATH" ]; then
+            warn "uv completed but the candidate vibe launcher was not created"
+            return 1
+        fi
+        local replacement="$stable_bin_dir/.vibe.avibe-${RANDOM}.new"
+        ln -s "$VIBE_CANDIDATE_BIN_PATH" "$replacement"
+        mv -f "$replacement" "$stable_bin_dir/vibe"
+        VIBE_TOOL_BIN_DIR="$stable_bin_dir"
+        VIBE_BIN_PATH="$stable_bin_dir/vibe"
+        return 0
     fi
+    return 1
 }
 
 install_package_candidate() {

--- a/install.sh
+++ b/install.sh
@@ -441,47 +441,61 @@ uv_tool_install() {
         # snapshot against the generation root. Keep path identity out of the
         # bootstrap script so aliases cannot produce a second interpretation.
         local source_snapshot="$previous_target"
-        local activation_protocol=""
-        activation_protocol="$(
-            cd "$AVIBE_RUNTIME_HOME" || exit 1
-            env -u PYTHONPATH -u PYTHONHOME "$VIBE_CANDIDATE_BIN_PATH" \
-                __activate-install --protocol-version 2>/dev/null || true
-        )"
-        if [ "$activation_protocol" = "1" ]; then
-            local activation_args=(
-                __activate-install
-                --launcher "$stable_bin_dir/vibe"
-                --candidate "$VIBE_CANDIDATE_BIN_PATH"
-            )
-            if [ -n "$source_snapshot" ]; then
-                activation_args+=(--source-generation "$source_snapshot")
+        local activation_args=(
+            __activate-install
+            --launcher "$stable_bin_dir/vibe"
+            --candidate "$VIBE_CANDIDATE_BIN_PATH"
+        )
+        if [ -n "$source_snapshot" ]; then
+            activation_args+=(--source-generation "$source_snapshot")
+        fi
+        local activation_owner=""
+        local owner=""
+        local owner_protocol=""
+        for owner in "$VIBE_CANDIDATE_BIN_PATH" "$source_snapshot"; do
+            if [ -z "$owner" ] || [ ! -x "$owner" ]; then
+                continue
             fi
+            owner_protocol="$(
+                cd "$AVIBE_RUNTIME_HOME" || exit 1
+                env -u PYTHONPATH -u PYTHONHOME AVIBE_HOME="$AVIBE_RUNTIME_HOME" "$owner" \
+                    __activate-install --protocol-version 2>/dev/null || true
+            )"
+            if [ "$owner_protocol" = "1" ]; then
+                activation_owner="$owner"
+                break
+            fi
+        done
+        if [ -n "$activation_owner" ]; then
             if ! (
                 cd "$AVIBE_RUNTIME_HOME" || exit 1
-                env -u PYTHONPATH -u PYTHONHOME "$VIBE_CANDIDATE_BIN_PATH" "${activation_args[@]}"
+                env -u PYTHONPATH -u PYTHONHOME AVIBE_HOME="$AVIBE_RUNTIME_HOME" "$activation_owner" \
+                    "${activation_args[@]}"
             ); then
                 warn "candidate Avibe environment could not be activated"
                 rm -rf -- "$generation_root"
                 return 1
             fi
         else
-            # Older released wheels predate the shared activation protocol.
-            # Probe them, switch the launcher atomically, and deliberately skip
-            # cleanup; the retention grace keeps concurrent new-style upgrades
-            # safe, and a later protocol-aware install owns pruning.
+            # A legacy wheel can bootstrap a fresh machine, but replacing an
+            # existing launcher requires a current wheel to own the shared
+            # lock and source-snapshot checks above.
             if ! (
                 cd "$AVIBE_RUNTIME_HOME" || exit 1
-                env -u PYTHONPATH -u PYTHONHOME "$VIBE_CANDIDATE_BIN_PATH" --help >/dev/null 2>&1
+                env -u PYTHONPATH -u PYTHONHOME AVIBE_HOME="$AVIBE_RUNTIME_HOME" \
+                    "$VIBE_CANDIDATE_BIN_PATH" --help >/dev/null 2>&1
             ); then
                 warn "candidate vibe launcher failed its startup probe"
                 rm -rf -- "$generation_root"
                 return 1
             fi
-            local replacement="$stable_bin_dir/.vibe.avibe-${RANDOM}.new"
-            if ! ln -s "$VIBE_CANDIDATE_BIN_PATH" "$replacement" || \
-                ! mv -f "$replacement" "$stable_bin_dir/vibe"; then
+            if [ -e "$stable_bin_dir/vibe" ] || [ -L "$stable_bin_dir/vibe" ]; then
+                warn "legacy candidate cannot safely replace an existing Avibe installation"
+                rm -rf -- "$generation_root"
+                return 1
+            fi
+            if ! ln -s "$VIBE_CANDIDATE_BIN_PATH" "$stable_bin_dir/vibe"; then
                 warn "legacy candidate Avibe launcher could not be activated"
-                rm -f -- "$replacement"
                 rm -rf -- "$generation_root"
                 return 1
             fi

--- a/install.sh
+++ b/install.sh
@@ -439,21 +439,50 @@ uv_tool_install() {
         fi
         local source_generation=""
         source_generation="$(generation_path_for "$previous_target" || true)"
-        local activation_args=(
-            __activate-install
-            --launcher "$stable_bin_dir/vibe"
-            --candidate "$VIBE_CANDIDATE_BIN_PATH"
-        )
-        if [ -n "$source_generation" ]; then
-            activation_args+=(--source-generation "$source_generation")
-        fi
-        if ! (
+        local activation_protocol=""
+        activation_protocol="$(
             cd "$AVIBE_RUNTIME_HOME" || exit 1
-            env -u PYTHONPATH -u PYTHONHOME "$VIBE_CANDIDATE_BIN_PATH" "${activation_args[@]}"
-        ); then
-            warn "candidate Avibe environment could not be activated"
-            rm -rf -- "$generation_root"
-            return 1
+            env -u PYTHONPATH -u PYTHONHOME "$VIBE_CANDIDATE_BIN_PATH" \
+                __activate-install --protocol-version 2>/dev/null || true
+        )"
+        if [ "$activation_protocol" = "1" ]; then
+            local activation_args=(
+                __activate-install
+                --launcher "$stable_bin_dir/vibe"
+                --candidate "$VIBE_CANDIDATE_BIN_PATH"
+            )
+            if [ -n "$source_generation" ]; then
+                activation_args+=(--source-generation "$source_generation")
+            fi
+            if ! (
+                cd "$AVIBE_RUNTIME_HOME" || exit 1
+                env -u PYTHONPATH -u PYTHONHOME "$VIBE_CANDIDATE_BIN_PATH" "${activation_args[@]}"
+            ); then
+                warn "candidate Avibe environment could not be activated"
+                rm -rf -- "$generation_root"
+                return 1
+            fi
+        else
+            # Older released wheels predate the shared activation protocol.
+            # Probe them, switch the launcher atomically, and deliberately skip
+            # cleanup; the retention grace keeps concurrent new-style upgrades
+            # safe, and a later protocol-aware install owns pruning.
+            if ! (
+                cd "$AVIBE_RUNTIME_HOME" || exit 1
+                env -u PYTHONPATH -u PYTHONHOME "$VIBE_CANDIDATE_BIN_PATH" --help >/dev/null 2>&1
+            ); then
+                warn "candidate vibe launcher failed its startup probe"
+                rm -rf -- "$generation_root"
+                return 1
+            fi
+            local replacement="$stable_bin_dir/.vibe.avibe-${RANDOM}.new"
+            if ! ln -s "$VIBE_CANDIDATE_BIN_PATH" "$replacement" || \
+                ! mv -f "$replacement" "$stable_bin_dir/vibe"; then
+                warn "legacy candidate Avibe launcher could not be activated"
+                rm -f -- "$replacement"
+                rm -rf -- "$generation_root"
+                return 1
+            fi
         fi
         VIBE_TOOL_BIN_DIR="$stable_bin_dir"
         VIBE_BIN_PATH="$stable_bin_dir/vibe"

--- a/install.sh
+++ b/install.sh
@@ -437,8 +437,10 @@ uv_tool_install() {
             rm -rf -- "$generation_root"
             return 1
         fi
-        local source_generation=""
-        source_generation="$(generation_path_for "$previous_target" || true)"
+        # The candidate's shared Python activation owner canonicalizes this
+        # snapshot against the generation root. Keep path identity out of the
+        # bootstrap script so aliases cannot produce a second interpretation.
+        local source_snapshot="$previous_target"
         local activation_protocol=""
         activation_protocol="$(
             cd "$AVIBE_RUNTIME_HOME" || exit 1
@@ -451,8 +453,8 @@ uv_tool_install() {
                 --launcher "$stable_bin_dir/vibe"
                 --candidate "$VIBE_CANDIDATE_BIN_PATH"
             )
-            if [ -n "$source_generation" ]; then
-                activation_args+=(--source-generation "$source_generation")
+            if [ -n "$source_snapshot" ]; then
+                activation_args+=(--source-generation "$source_snapshot")
             fi
             if ! (
                 cd "$AVIBE_RUNTIME_HOME" || exit 1
@@ -490,20 +492,6 @@ uv_tool_install() {
     fi
     rm -rf -- "$generation_root"
     return 1
-}
-
-generation_path_for() {
-    local path="$1"
-    local root="$AVIBE_RUNTIME_HOME/runtime/install-generations"
-    local relative generation
-
-    case "$path" in
-        "$root"/*)
-            relative="${path#"$root"/}"
-            generation="${relative%%/*}"
-            [ -n "$generation" ] && printf '%s/%s\n' "$root" "$generation"
-            ;;
-    esac
 }
 
 install_package_candidate() {

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,11 @@ VIBE_TOOL_BIN_DIR=""
 VIBE_CANDIDATE_BIN_PATH=""
 ORIGINAL_PATH="$PATH"
 if [ -n "${AVIBE_HOME:-}" ]; then
-    AVIBE_RUNTIME_HOME="$AVIBE_HOME"
+    AVIBE_RUNTIME_HOME="${AVIBE_HOME/#\~/$HOME}"
+    case "$AVIBE_RUNTIME_HOME" in
+        /*) ;;
+        *) AVIBE_RUNTIME_HOME="$PWD/$AVIBE_RUNTIME_HOME" ;;
+    esac
 elif [ -e "$HOME/.avibe" ] || [ -L "$HOME/.avibe" ]; then
     AVIBE_RUNTIME_HOME="$HOME/.avibe"
 elif [ -e "$HOME/.vibe_remote" ] || [ -L "$HOME/.vibe_remote" ]; then
@@ -426,10 +430,12 @@ uv_tool_install() {
         VIBE_CANDIDATE_BIN_PATH="$generation_bin/vibe"
         if [ ! -x "$VIBE_CANDIDATE_BIN_PATH" ]; then
             warn "uv completed but the candidate vibe launcher was not created"
+            rm -rf -- "$generation_root"
             return 1
         fi
         if ! verify_uv_candidate "$VIBE_CANDIDATE_BIN_PATH"; then
             warn "uv completed but the candidate Avibe environment failed integrity checks"
+            rm -rf -- "$generation_root"
             return 1
         fi
         local replacement="$stable_bin_dir/.vibe.avibe-${RANDOM}.new"
@@ -439,6 +445,7 @@ uv_tool_install() {
         VIBE_BIN_PATH="$stable_bin_dir/vibe"
         return 0
     fi
+    rm -rf -- "$generation_root"
     return 1
 }
 
@@ -469,6 +476,13 @@ verify_uv_candidate() {
         [ -n "$detail" ] && warn "$detail"
         return 1
     }
+    if ! (
+        cd "$AVIBE_RUNTIME_HOME" || exit 1
+        "$candidate" --help >/dev/null 2>&1
+    ); then
+        warn "candidate vibe launcher failed its startup probe"
+        return 1
+    fi
     return 0
 }
 

--- a/install.sh
+++ b/install.sh
@@ -481,11 +481,20 @@ prune_install_generations() {
     local active_path="$1"
     local previous_path="$2"
     local root="$AVIBE_RUNTIME_HOME/runtime/install-generations"
-    local active_generation previous_generation generation
+    local stable_bin_dir="${VIBE_TOOL_BIN_DIR:-$HOME/.local/bin}"
+    local live_target live_generation active_generation previous_generation generation
 
     [ -d "$root" ] || return 0
     active_generation="$(generation_path_for "$active_path" || true)"
     previous_generation="$(generation_path_for "$previous_path" || true)"
+    # The installer and runtime upgrades are separate processes. Re-read the
+    # launcher immediately before pruning so an activation that happened after
+    # this install was staged is retained.
+    live_target="$(resolve_binary_path "$stable_bin_dir/vibe" || true)"
+    live_generation="$(generation_path_for "$live_target" || true)"
+    if [ -n "$live_generation" ]; then
+        active_generation="$live_generation"
+    fi
     for generation in "$root"/*; do
         [ -d "$generation" ] || continue
         if [ -n "$active_generation" ] && [ "$generation" = "$active_generation" ]; then
@@ -520,14 +529,14 @@ verify_uv_candidate() {
     local detail
     detail="$(
         cd "$AVIBE_RUNTIME_HOME" || exit 1
-        "$candidate_python" -c 'from core.install_integrity import verify_python_environment; result = verify_python_environment(__import__("sys").executable); print(result.detail); raise SystemExit(0 if result.ok else 1)'
+        env -u PYTHONPATH -u PYTHONHOME "$candidate_python" -c 'from core.install_integrity import verify_python_environment; result = verify_python_environment(__import__("sys").executable); print(result.detail); raise SystemExit(0 if result.ok else 1)'
     )" || {
         [ -n "$detail" ] && warn "$detail"
         return 1
     }
     if ! (
         cd "$AVIBE_RUNTIME_HOME" || exit 1
-        "$candidate" --help >/dev/null 2>&1
+        env -u PYTHONPATH -u PYTHONHOME "$candidate" --help >/dev/null 2>&1
     ); then
         warn "candidate vibe launcher failed its startup probe"
         return 1

--- a/install.sh
+++ b/install.sh
@@ -424,7 +424,11 @@ uv_tool_install() {
     local generation_tools="$generation_root/tools"
     local generation_bin="$generation_root/bin"
     local stable_bin_dir="${VIBE_TOOL_BIN_DIR:-$HOME/.local/bin}"
+    local previous_target=""
     mkdir -p "$generation_tools" "$generation_bin" "$stable_bin_dir"
+    if [ -e "$stable_bin_dir/vibe" ] || [ -L "$stable_bin_dir/vibe" ]; then
+        previous_target="$(resolve_binary_path "$stable_bin_dir/vibe" || true)"
+    fi
 
     if UV_TOOL_DIR="$generation_tools" UV_TOOL_BIN_DIR="$generation_bin" uv tool install "$@"; then
         VIBE_CANDIDATE_BIN_PATH="$generation_bin/vibe"
@@ -452,10 +456,46 @@ uv_tool_install() {
         fi
         VIBE_TOOL_BIN_DIR="$stable_bin_dir"
         VIBE_BIN_PATH="$stable_bin_dir/vibe"
+        prune_install_generations "$VIBE_CANDIDATE_BIN_PATH" "$previous_target"
         return 0
     fi
     rm -rf -- "$generation_root"
     return 1
+}
+
+generation_path_for() {
+    local path="$1"
+    local root="$AVIBE_RUNTIME_HOME/runtime/install-generations"
+    local relative generation
+
+    case "$path" in
+        "$root"/*)
+            relative="${path#"$root"/}"
+            generation="${relative%%/*}"
+            [ -n "$generation" ] && printf '%s/%s\n' "$root" "$generation"
+            ;;
+    esac
+}
+
+prune_install_generations() {
+    local active_path="$1"
+    local previous_path="$2"
+    local root="$AVIBE_RUNTIME_HOME/runtime/install-generations"
+    local active_generation previous_generation generation
+
+    [ -d "$root" ] || return 0
+    active_generation="$(generation_path_for "$active_path" || true)"
+    previous_generation="$(generation_path_for "$previous_path" || true)"
+    for generation in "$root"/*; do
+        [ -d "$generation" ] || continue
+        if [ -n "$active_generation" ] && [ "$generation" = "$active_generation" ]; then
+            continue
+        fi
+        if [ -n "$previous_generation" ] && [ "$generation" = "$previous_generation" ]; then
+            continue
+        fi
+        rm -rf -- "$generation" || warn "could not prune old Avibe install generation $generation"
+    done
 }
 
 verify_uv_candidate() {

--- a/install.sh
+++ b/install.sh
@@ -439,8 +439,17 @@ uv_tool_install() {
             return 1
         fi
         local replacement="$stable_bin_dir/.vibe.avibe-${RANDOM}.new"
-        ln -s "$VIBE_CANDIDATE_BIN_PATH" "$replacement"
-        mv -f "$replacement" "$stable_bin_dir/vibe"
+        if ! ln -s "$VIBE_CANDIDATE_BIN_PATH" "$replacement"; then
+            warn "candidate Avibe launcher could not be staged for activation"
+            rm -rf -- "$generation_root"
+            return 1
+        fi
+        if ! mv -f "$replacement" "$stable_bin_dir/vibe"; then
+            warn "candidate Avibe launcher could not be activated"
+            rm -f -- "$replacement"
+            rm -rf -- "$generation_root"
+            return 1
+        fi
         VIBE_TOOL_BIN_DIR="$stable_bin_dir"
         VIBE_BIN_PATH="$stable_bin_dir/vibe"
         return 0

--- a/install.sh
+++ b/install.sh
@@ -425,9 +425,25 @@ uv_tool_install() {
     local generation_bin="$generation_root/bin"
     local stable_bin_dir="${VIBE_TOOL_BIN_DIR:-$HOME/.local/bin}"
     local previous_target=""
+    local source_snapshot=""
     mkdir -p "$generation_tools" "$generation_bin" "$stable_bin_dir"
     if [ -e "$stable_bin_dir/vibe" ] || [ -L "$stable_bin_dir/vibe" ]; then
         previous_target="$(resolve_binary_path "$stable_bin_dir/vibe" || true)"
+        local current_protocol=""
+        current_protocol="$(
+            cd "$AVIBE_RUNTIME_HOME" || exit 1
+            env -u PYTHONPATH -u PYTHONHOME AVIBE_HOME="$AVIBE_RUNTIME_HOME" "$stable_bin_dir/vibe" \
+                __activate-install --protocol-version 2>/dev/null || true
+        )"
+        if [ "${current_protocol:-0}" -ge 2 ] 2>/dev/null; then
+            source_snapshot="$(
+                cd "$AVIBE_RUNTIME_HOME" || exit 1
+                env -u PYTHONPATH -u PYTHONHOME AVIBE_HOME="$AVIBE_RUNTIME_HOME" "$stable_bin_dir/vibe" \
+                    __activate-install --snapshot --launcher "$stable_bin_dir/vibe" 2>/dev/null || true
+            )"
+        else
+            source_snapshot="$previous_target"
+        fi
     fi
 
     if UV_TOOL_DIR="$generation_tools" UV_TOOL_BIN_DIR="$generation_bin" uv tool install "$@"; then
@@ -440,7 +456,6 @@ uv_tool_install() {
         # The candidate's shared Python activation owner canonicalizes this
         # snapshot against the generation root. Keep path identity out of the
         # bootstrap script so aliases cannot produce a second interpretation.
-        local source_snapshot="$previous_target"
         local activation_args=(
             __activate-install
             --launcher "$stable_bin_dir/vibe"
@@ -452,7 +467,7 @@ uv_tool_install() {
         local activation_owner=""
         local owner=""
         local owner_protocol=""
-        for owner in "$VIBE_CANDIDATE_BIN_PATH" "$source_snapshot"; do
+        for owner in "$VIBE_CANDIDATE_BIN_PATH" "$previous_target"; do
             if [ -z "$owner" ] || [ ! -x "$owner" ]; then
                 continue
             fi
@@ -461,7 +476,7 @@ uv_tool_install() {
                 env -u PYTHONPATH -u PYTHONHOME AVIBE_HOME="$AVIBE_RUNTIME_HOME" "$owner" \
                     __activate-install --protocol-version 2>/dev/null || true
             )"
-            if [ "$owner_protocol" = "1" ]; then
+            if [ "${owner_protocol:-0}" -ge 1 ] 2>/dev/null; then
                 activation_owner="$owner"
                 break
             fi
@@ -713,6 +728,17 @@ pair_remote_access() {
     success "Avibe service started"
 }
 
+print_uninstall_commands() {
+    echo "  avibe_home=\"\${AVIBE_HOME:-\$HOME/.avibe}\""
+    echo '  avibe_home="${avibe_home/#\~/$HOME}"'
+    echo "  uv tool uninstall avibe-os       # current uv install"
+    echo "  uv tool uninstall vibe-remote    # legacy uv install"
+    echo "  pip uninstall avibe-os vibe-remote"
+    echo "  rm -f \"$VIBE_TOOL_BIN_DIR/vibe\" \"$VIBE_TOOL_BIN_DIR/.vibe.avibe-generation\""
+    echo '  rm -rf "$avibe_home/runtime/install-generations"'
+    echo '  rm -rf "$avibe_home" ~/.vibe_remote   # remove config and data'
+}
+
 # Print next steps
 print_next_steps() {
     local vibe_dir
@@ -742,12 +768,7 @@ print_next_steps() {
         echo "  vibe doctor   - Run diagnostics"
         echo ""
         echo -e "${BLUE}Uninstall:${NC}"
-        echo "  uv tool uninstall avibe-os       # current uv install"
-        echo "  uv tool uninstall vibe-remote    # legacy uv install"
-        echo "  pip uninstall avibe-os vibe-remote"
-        echo "  rm -f \"$VIBE_TOOL_BIN_DIR/vibe\" \"$VIBE_TOOL_BIN_DIR/.vibe.avibe-generation\""
-        echo "  rm -rf \"\${AVIBE_HOME:-\$HOME/.avibe}/runtime/install-generations\""
-        echo "  rm -rf ~/.avibe ~/.vibe_remote   # remove config and data"
+        print_uninstall_commands
         if ! is_vibe_immediately_available; then
             echo ""
             echo -e "${BLUE}If 'vibe' is not found in a new shell:${NC}"
@@ -781,12 +802,7 @@ print_next_steps() {
     echo "  vibe doctor   - Run diagnostics"
     echo ""
     echo -e "${BLUE}Uninstall:${NC}"
-    echo "  uv tool uninstall avibe-os       # current uv install"
-    echo "  uv tool uninstall vibe-remote    # legacy uv install"
-    echo "  pip uninstall avibe-os vibe-remote"
-    echo "  rm -f \"$VIBE_TOOL_BIN_DIR/vibe\" \"$VIBE_TOOL_BIN_DIR/.vibe.avibe-generation\""
-    echo "  rm -rf \"\${AVIBE_HOME:-\$HOME/.avibe}/runtime/install-generations\""
-    echo "  rm -rf ~/.avibe ~/.vibe_remote   # remove config and data"
+    print_uninstall_commands
     echo ""
     echo -e "${BLUE}If 'vibe' is still not found:${NC}"
     echo "  ${VIBE_BIN_PATH:-$HOME/.local/bin/vibe}"

--- a/install.sh
+++ b/install.sh
@@ -437,26 +437,26 @@ uv_tool_install() {
             rm -rf -- "$generation_root"
             return 1
         fi
-        if ! verify_uv_candidate "$VIBE_CANDIDATE_BIN_PATH"; then
-            warn "uv completed but the candidate Avibe environment failed integrity checks"
-            rm -rf -- "$generation_root"
-            return 1
+        local source_generation=""
+        source_generation="$(generation_path_for "$previous_target" || true)"
+        local activation_args=(
+            __activate-install
+            --launcher "$stable_bin_dir/vibe"
+            --candidate "$VIBE_CANDIDATE_BIN_PATH"
+        )
+        if [ -n "$source_generation" ]; then
+            activation_args+=(--source-generation "$source_generation")
         fi
-        local replacement="$stable_bin_dir/.vibe.avibe-${RANDOM}.new"
-        if ! ln -s "$VIBE_CANDIDATE_BIN_PATH" "$replacement"; then
-            warn "candidate Avibe launcher could not be staged for activation"
-            rm -rf -- "$generation_root"
-            return 1
-        fi
-        if ! mv -f "$replacement" "$stable_bin_dir/vibe"; then
-            warn "candidate Avibe launcher could not be activated"
-            rm -f -- "$replacement"
+        if ! (
+            cd "$AVIBE_RUNTIME_HOME" || exit 1
+            env -u PYTHONPATH -u PYTHONHOME "$VIBE_CANDIDATE_BIN_PATH" "${activation_args[@]}"
+        ); then
+            warn "candidate Avibe environment could not be activated"
             rm -rf -- "$generation_root"
             return 1
         fi
         VIBE_TOOL_BIN_DIR="$stable_bin_dir"
         VIBE_BIN_PATH="$stable_bin_dir/vibe"
-        prune_install_generations "$VIBE_CANDIDATE_BIN_PATH" "$previous_target"
         return 0
     fi
     rm -rf -- "$generation_root"
@@ -475,73 +475,6 @@ generation_path_for() {
             [ -n "$generation" ] && printf '%s/%s\n' "$root" "$generation"
             ;;
     esac
-}
-
-prune_install_generations() {
-    local active_path="$1"
-    local previous_path="$2"
-    local root="$AVIBE_RUNTIME_HOME/runtime/install-generations"
-    local stable_bin_dir="${VIBE_TOOL_BIN_DIR:-$HOME/.local/bin}"
-    local live_target live_generation active_generation previous_generation generation
-
-    [ -d "$root" ] || return 0
-    active_generation="$(generation_path_for "$active_path" || true)"
-    previous_generation="$(generation_path_for "$previous_path" || true)"
-    # The installer and runtime upgrades are separate processes. Re-read the
-    # launcher immediately before pruning so an activation that happened after
-    # this install was staged is retained.
-    live_target="$(resolve_binary_path "$stable_bin_dir/vibe" || true)"
-    live_generation="$(generation_path_for "$live_target" || true)"
-    if [ -n "$live_generation" ]; then
-        active_generation="$live_generation"
-    fi
-    for generation in "$root"/*; do
-        [ -d "$generation" ] || continue
-        if [ -n "$active_generation" ] && [ "$generation" = "$active_generation" ]; then
-            continue
-        fi
-        if [ -n "$previous_generation" ] && [ "$generation" = "$previous_generation" ]; then
-            continue
-        fi
-        rm -rf -- "$generation" || warn "could not prune old Avibe install generation $generation"
-    done
-}
-
-verify_uv_candidate() {
-    local candidate="$1"
-    local candidate_target candidate_bin candidate_python
-    candidate_target="$(resolve_binary_path "$candidate" || true)"
-    if [ -z "$candidate_target" ] || [ ! -e "$candidate_target" ]; then
-        return 1
-    fi
-    candidate_bin="$(dirname "$candidate_target")"
-    for candidate_python in "$candidate_bin/python3" "$candidate_bin/python"; do
-        if [ -x "$candidate_python" ]; then
-            break
-        fi
-        candidate_python=""
-    done
-    if [ -z "$candidate_python" ]; then
-        warn "could not find the candidate Python interpreter"
-        return 1
-    fi
-
-    local detail
-    detail="$(
-        cd "$AVIBE_RUNTIME_HOME" || exit 1
-        env -u PYTHONPATH -u PYTHONHOME "$candidate_python" -c 'from core.install_integrity import verify_python_environment; result = verify_python_environment(__import__("sys").executable); print(result.detail); raise SystemExit(0 if result.ok else 1)'
-    )" || {
-        [ -n "$detail" ] && warn "$detail"
-        return 1
-    }
-    if ! (
-        cd "$AVIBE_RUNTIME_HOME" || exit 1
-        env -u PYTHONPATH -u PYTHONHOME "$candidate" --help >/dev/null 2>&1
-    ); then
-        warn "candidate vibe launcher failed its startup probe"
-        return 1
-    fi
-    return 0
 }
 
 install_package_candidate() {
@@ -781,7 +714,7 @@ print_next_steps() {
         echo "  uv tool uninstall avibe-os       # current uv install"
         echo "  uv tool uninstall vibe-remote    # legacy uv install"
         echo "  pip uninstall avibe-os vibe-remote"
-        echo "  rm -f ~/.local/bin/vibe"
+        echo "  rm -f \"$VIBE_TOOL_BIN_DIR/vibe\" \"$VIBE_TOOL_BIN_DIR/.vibe.avibe-generation\""
         echo "  rm -rf \"\${AVIBE_HOME:-\$HOME/.avibe}/runtime/install-generations\""
         echo "  rm -rf ~/.avibe ~/.vibe_remote   # remove config and data"
         if ! is_vibe_immediately_available; then
@@ -820,7 +753,7 @@ print_next_steps() {
     echo "  uv tool uninstall avibe-os       # current uv install"
     echo "  uv tool uninstall vibe-remote    # legacy uv install"
     echo "  pip uninstall avibe-os vibe-remote"
-    echo "  rm -f ~/.local/bin/vibe"
+    echo "  rm -f \"$VIBE_TOOL_BIN_DIR/vibe\" \"$VIBE_TOOL_BIN_DIR/.vibe.avibe-generation\""
     echo "  rm -rf \"\${AVIBE_HOME:-\$HOME/.avibe}/runtime/install-generations\""
     echo "  rm -rf ~/.avibe ~/.vibe_remote   # remove config and data"
     echo ""

--- a/install.sh
+++ b/install.sh
@@ -723,6 +723,8 @@ print_next_steps() {
         echo "  uv tool uninstall avibe-os       # current uv install"
         echo "  uv tool uninstall vibe-remote    # legacy uv install"
         echo "  pip uninstall avibe-os vibe-remote"
+        echo "  rm -f ~/.local/bin/vibe"
+        echo "  rm -rf \"\${AVIBE_HOME:-\$HOME/.avibe}/runtime/install-generations\""
         echo "  rm -rf ~/.avibe ~/.vibe_remote   # remove config and data"
         if ! is_vibe_immediately_available; then
             echo ""
@@ -760,6 +762,8 @@ print_next_steps() {
     echo "  uv tool uninstall avibe-os       # current uv install"
     echo "  uv tool uninstall vibe-remote    # legacy uv install"
     echo "  pip uninstall avibe-os vibe-remote"
+    echo "  rm -f ~/.local/bin/vibe"
+    echo "  rm -rf \"\${AVIBE_HOME:-\$HOME/.avibe}/runtime/install-generations\""
     echo "  rm -rf ~/.avibe ~/.vibe_remote   # remove config and data"
     echo ""
     echo -e "${BLUE}If 'vibe' is still not found:${NC}"

--- a/install.sh
+++ b/install.sh
@@ -428,6 +428,10 @@ uv_tool_install() {
             warn "uv completed but the candidate vibe launcher was not created"
             return 1
         fi
+        if ! verify_uv_candidate "$VIBE_CANDIDATE_BIN_PATH"; then
+            warn "uv completed but the candidate Avibe environment failed integrity checks"
+            return 1
+        fi
         local replacement="$stable_bin_dir/.vibe.avibe-${RANDOM}.new"
         ln -s "$VIBE_CANDIDATE_BIN_PATH" "$replacement"
         mv -f "$replacement" "$stable_bin_dir/vibe"
@@ -436,6 +440,36 @@ uv_tool_install() {
         return 0
     fi
     return 1
+}
+
+verify_uv_candidate() {
+    local candidate="$1"
+    local candidate_target candidate_bin candidate_python
+    candidate_target="$(resolve_binary_path "$candidate" || true)"
+    if [ -z "$candidate_target" ] || [ ! -e "$candidate_target" ]; then
+        return 1
+    fi
+    candidate_bin="$(dirname "$candidate_target")"
+    for candidate_python in "$candidate_bin/python3" "$candidate_bin/python"; do
+        if [ -x "$candidate_python" ]; then
+            break
+        fi
+        candidate_python=""
+    done
+    if [ -z "$candidate_python" ]; then
+        warn "could not find the candidate Python interpreter"
+        return 1
+    fi
+
+    local detail
+    detail="$(
+        cd "$AVIBE_RUNTIME_HOME" || exit 1
+        "$candidate_python" -c 'from core.install_integrity import verify_python_environment; result = verify_python_environment(__import__("sys").executable); print(result.detail); raise SystemExit(0 if result.ok else 1)'
+    )" || {
+        [ -n "$detail" ] && warn "$detail"
+        return 1
+    }
+    return 0
 }
 
 install_package_candidate() {

--- a/tests/test_install_integrity.py
+++ b/tests/test_install_integrity.py
@@ -67,6 +67,31 @@ def test_verify_python_environment_import_probe_does_not_use_caller_cwd(monkeypa
     assert calls[0]["cwd"] != str(tmp_path)
 
 
+def test_candidate_probe_does_not_inherit_pythonpath(monkeypatch, tmp_path):
+    site_packages = tmp_path / "lib" / "python3.12" / "site-packages"
+    _write_record(site_packages, "demo_pkg/__init__.py", b"value = 1\n")
+    executable = tmp_path / "bin" / "python3"
+    executable.parent.mkdir()
+    executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable.chmod(0o755)
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            return subprocess.CompletedProcess(args[0], 0, stdout=f"{site_packages}\n", stderr="")
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setenv("PYTHONPATH", str(tmp_path))
+    monkeypatch.setattr(install_integrity.subprocess, "run", fake_run)
+
+    result = install_integrity.verify_python_environment(executable, required_imports=("demo_pkg",))
+
+    assert result.ok is True
+    assert "PYTHONPATH" not in calls[0]["env"]
+    assert "PYTHONPATH" not in calls[1]["env"]
+
+
 def test_site_discovery_ignores_reported_prefix_without_record(monkeypatch, tmp_path):
     site_packages = tmp_path / "Lib" / "site-packages"
     _write_record(site_packages, "demo_pkg/__init__.py", b"value = 1\n")

--- a/tests/test_install_integrity.py
+++ b/tests/test_install_integrity.py
@@ -1,6 +1,8 @@
 import base64
 import hashlib
+import stat
 import subprocess
+from pathlib import Path
 
 from core import install_integrity
 from core.install_integrity import verify_site_packages
@@ -45,7 +47,7 @@ def test_verify_site_packages_rejects_a_changed_file(tmp_path):
     assert "hash mismatch demo_pkg/__init__.py" in result.failures
 
 
-def test_verify_python_environment_import_probe_does_not_use_caller_cwd(monkeypatch, tmp_path):
+def test_verify_python_environment_probes_use_private_empty_directories(monkeypatch, tmp_path):
     site_packages = tmp_path / "lib" / "python3.12" / "site-packages"
     _write_record(site_packages, "demo_pkg/__init__.py", b"value = 1\n")
     executable = tmp_path / "bin" / "python3"
@@ -55,7 +57,15 @@ def test_verify_python_environment_import_probe_does_not_use_caller_cwd(monkeypa
     calls = []
 
     def fake_run(*args, **kwargs):
-        calls.append(kwargs)
+        cwd = Path(kwargs["cwd"])
+        calls.append(
+            {
+                **kwargs,
+                "cwd_parent": cwd.parent,
+                "cwd_mode": stat.S_IMODE(cwd.stat().st_mode),
+                "cwd_entries": tuple(cwd.iterdir()),
+            }
+        )
         stdout = f"{site_packages}\n" if len(calls) == 1 else ""
         return subprocess.CompletedProcess(args[0], 0, stdout=stdout, stderr="")
 
@@ -64,8 +74,11 @@ def test_verify_python_environment_import_probe_does_not_use_caller_cwd(monkeypa
     result = install_integrity.verify_python_environment(executable, required_imports=("demo_pkg",))
 
     assert result.ok is True
-    assert calls[0]["cwd"] == install_integrity.tempfile.gettempdir()
-    assert calls[0]["cwd"] != str(tmp_path)
+    assert len(calls) == 2
+    assert all(call["cwd_parent"] == Path(install_integrity.tempfile.gettempdir()) for call in calls)
+    assert all(call["cwd_mode"] & 0o077 == 0 for call in calls)
+    assert all(call["cwd_entries"] == () for call in calls)
+    assert calls[0]["cwd"] != calls[1]["cwd"]
 
 
 def test_candidate_probe_does_not_inherit_pythonpath(monkeypatch, tmp_path):

--- a/tests/test_install_integrity.py
+++ b/tests/test_install_integrity.py
@@ -3,7 +3,9 @@ import hashlib
 import stat
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
+from config.platform_registry import platform_descriptors
 from core import install_integrity
 from core.install_integrity import verify_site_packages
 
@@ -175,3 +177,34 @@ def test_verify_site_packages_accepts_dist_packages_entry_point(tmp_path):
 
     assert result.ok is True
     assert result.checked_files == 1
+
+
+def test_runtime_imports_cover_every_registered_platform_client():
+    expected = {descriptor.client_module for descriptor in platform_descriptors()}
+
+    assert expected <= set(install_integrity.runtime_import_modules())
+
+
+def test_dependency_graph_rejects_a_wholly_missing_declared_distribution(monkeypatch):
+    distributions = {
+        "avibe-os": SimpleNamespace(
+            metadata={"Name": "avibe-os"},
+            version="1.0",
+            requires=("slack-sdk>=3.26", "discord.py>=2.4"),
+        ),
+        "slack-sdk": SimpleNamespace(
+            metadata={"Name": "slack-sdk"},
+            version="3.30",
+            requires=(),
+        ),
+    }
+
+    def distribution(name):
+        try:
+            return distributions[name]
+        except KeyError as exc:
+            raise install_integrity.importlib_metadata.PackageNotFoundError(name) from exc
+
+    monkeypatch.setattr(install_integrity.importlib_metadata, "distribution", distribution)
+
+    assert install_integrity.dependency_graph_failures() == ("missing dependency: discord.py",)

--- a/tests/test_install_integrity.py
+++ b/tests/test_install_integrity.py
@@ -1,0 +1,67 @@
+import base64
+import hashlib
+import subprocess
+
+from core import install_integrity
+from core.install_integrity import verify_site_packages
+
+
+def _write_record(root, relative: str, content: bytes) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    digest = base64.urlsafe_b64encode(hashlib.sha256(content).digest()).decode().rstrip("=")
+    record = root / "demo_pkg-1.0.dist-info" / "RECORD"
+    record.parent.mkdir(parents=True, exist_ok=True)
+    record.write_text(f"{relative},sha256={digest},{len(content)}\n", encoding="utf-8")
+
+
+def test_verify_site_packages_accepts_complete_record(tmp_path):
+    _write_record(tmp_path, "demo_pkg/__init__.py", b"value = 1\n")
+
+    result = verify_site_packages(tmp_path)
+
+    assert result.ok is True
+    assert result.checked_files == 1
+
+
+def test_verify_site_packages_rejects_a_missing_file_with_valid_metadata(tmp_path):
+    _write_record(tmp_path, "demo_pkg/__init__.py", b"value = 1\n")
+    (tmp_path / "demo_pkg" / "__init__.py").unlink()
+
+    result = verify_site_packages(tmp_path)
+
+    assert result.ok is False
+    assert "missing demo_pkg/__init__.py" in result.failures
+
+
+def test_verify_site_packages_rejects_a_changed_file(tmp_path):
+    _write_record(tmp_path, "demo_pkg/__init__.py", b"value = 1\n")
+    (tmp_path / "demo_pkg" / "__init__.py").write_bytes(b"value = 2\n")
+
+    result = verify_site_packages(tmp_path)
+
+    assert result.ok is False
+    assert "hash mismatch demo_pkg/__init__.py" in result.failures
+
+
+def test_verify_python_environment_import_probe_does_not_use_caller_cwd(monkeypatch, tmp_path):
+    site_packages = tmp_path / "lib" / "python3.12" / "site-packages"
+    _write_record(site_packages, "demo_pkg/__init__.py", b"value = 1\n")
+    executable = tmp_path / "bin" / "python3"
+    executable.parent.mkdir()
+    executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable.chmod(0o755)
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append(kwargs)
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(install_integrity.subprocess, "run", fake_run)
+
+    result = install_integrity.verify_python_environment(executable, required_imports=("demo_pkg",))
+
+    assert result.ok is True
+    assert calls[0]["cwd"] == install_integrity.tempfile.gettempdir()
+    assert calls[0]["cwd"] != str(tmp_path)

--- a/tests/test_install_integrity.py
+++ b/tests/test_install_integrity.py
@@ -1,5 +1,6 @@
 import base64
 import hashlib
+import json
 import stat
 import subprocess
 from pathlib import Path
@@ -10,14 +11,18 @@ from core import install_integrity
 from core.install_integrity import verify_site_packages
 
 
-def _write_record(root, relative: str, content: bytes) -> None:
+def _write_record(root, relative: str, content: bytes, *, distribution: str = "demo_pkg") -> None:
     path = root / relative
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(content)
     digest = base64.urlsafe_b64encode(hashlib.sha256(content).digest()).decode().rstrip("=")
-    record = root / "demo_pkg-1.0.dist-info" / "RECORD"
+    record = root / f"{distribution}-1.0.dist-info" / "RECORD"
     record.parent.mkdir(parents=True, exist_ok=True)
     record.write_text(f"{relative},sha256={digest},{len(content)}\n", encoding="utf-8")
+
+
+def _runtime_probe_output(*records: Path) -> str:
+    return f"{install_integrity.RUNTIME_PROBE_PREFIX}{json.dumps([str(record) for record in records])}\n"
 
 
 def test_verify_site_packages_accepts_complete_record(tmp_path):
@@ -68,7 +73,11 @@ def test_verify_python_environment_probes_use_private_empty_directories(monkeypa
                 "cwd_entries": tuple(cwd.iterdir()),
             }
         )
-        stdout = f"{site_packages}\n" if len(calls) == 1 else ""
+        stdout = (
+            f"{site_packages}\n"
+            if len(calls) == 1
+            else _runtime_probe_output(site_packages / "demo_pkg-1.0.dist-info" / "RECORD")
+        )
         return subprocess.CompletedProcess(args[0], 0, stdout=stdout, stderr="")
 
     monkeypatch.setattr(install_integrity.subprocess, "run", fake_run)
@@ -96,7 +105,12 @@ def test_candidate_probe_does_not_inherit_pythonpath(monkeypatch, tmp_path):
         calls.append(kwargs)
         if len(calls) == 1:
             return subprocess.CompletedProcess(args[0], 0, stdout=f"{site_packages}\n", stderr="")
-        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(
+            args[0],
+            0,
+            stdout=_runtime_probe_output(site_packages / "demo_pkg-1.0.dist-info" / "RECORD"),
+            stderr="",
+        )
 
     monkeypatch.setenv("PYTHONPATH", str(tmp_path))
     monkeypatch.setattr(install_integrity.subprocess, "run", fake_run)
@@ -191,11 +205,15 @@ def test_dependency_graph_rejects_a_wholly_missing_declared_distribution(monkeyp
             metadata={"Name": "avibe-os"},
             version="1.0",
             requires=("slack-sdk>=3.26", "discord.py>=2.4"),
+            files=(Path("avibe_os-1.0.dist-info/RECORD"),),
+            locate_file=lambda path: Path("/site-packages") / path,
         ),
         "slack-sdk": SimpleNamespace(
             metadata={"Name": "slack-sdk"},
             version="3.30",
             requires=(),
+            files=(Path("slack_sdk-3.30.dist-info/RECORD"),),
+            locate_file=lambda path: Path("/site-packages") / path,
         ),
     }
 
@@ -207,4 +225,41 @@ def test_dependency_graph_rejects_a_wholly_missing_declared_distribution(monkeyp
 
     monkeypatch.setattr(install_integrity.importlib_metadata, "distribution", distribution)
 
-    assert install_integrity.dependency_graph_failures() == ("missing dependency: discord.py",)
+    graph = install_integrity.inspect_dependency_graph()
+
+    assert graph.distributions == ("avibe-os", "slack-sdk")
+    assert graph.records == (
+        "/site-packages/avibe_os-1.0.dist-info/RECORD",
+        "/site-packages/slack_sdk-3.30.dist-info/RECORD",
+    )
+    assert graph.failures == ("missing dependency: discord.py",)
+
+
+def test_verify_python_environment_ignores_unrelated_distributions(monkeypatch, tmp_path):
+    site_packages = tmp_path / "lib" / "python3.12" / "site-packages"
+    _write_record(site_packages, "demo_pkg/__init__.py", b"value = 1\n")
+    unrelated = site_packages / "unrelated-1.0.dist-info" / "RECORD"
+    unrelated.parent.mkdir(parents=True)
+    unrelated.write_text("unrelated/missing.py,,\n", encoding="utf-8")
+    executable = tmp_path / "bin" / "python3"
+    executable.parent.mkdir()
+    executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable.chmod(0o755)
+    calls = 0
+
+    def fake_run(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        stdout = (
+            f"{site_packages}\n"
+            if calls == 1
+            else _runtime_probe_output(site_packages / "demo_pkg-1.0.dist-info" / "RECORD")
+        )
+        return subprocess.CompletedProcess(args[0], 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(install_integrity.subprocess, "run", fake_run)
+
+    result = install_integrity.verify_python_environment(executable, required_imports=("demo_pkg",))
+
+    assert result.ok is True
+    assert result.checked_files == 1

--- a/tests/test_install_integrity.py
+++ b/tests/test_install_integrity.py
@@ -87,6 +87,23 @@ def test_site_discovery_ignores_reported_prefix_without_record(monkeypatch, tmp_
     assert install_integrity.site_packages_for_python(executable) == [site_packages.resolve()]
 
 
+def test_site_discovery_probe_respects_disabled_user_site(monkeypatch, tmp_path):
+    executable = tmp_path / "bin" / "python3"
+    executable.parent.mkdir()
+    executable.write_text("", encoding="utf-8")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append(args[0][2])
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(install_integrity.subprocess, "run", fake_run)
+
+    install_integrity.site_packages_for_python(executable)
+
+    assert "ENABLE_USER_SITE" in calls[0]
+
+
 def test_verify_site_packages_accepts_dist_packages_entry_point(tmp_path):
     site_packages = tmp_path / "lib" / "python3.12" / "dist-packages"
     entrypoint = tmp_path / "bin" / "vibe"

--- a/tests/test_install_integrity.py
+++ b/tests/test_install_integrity.py
@@ -56,7 +56,8 @@ def test_verify_python_environment_import_probe_does_not_use_caller_cwd(monkeypa
 
     def fake_run(*args, **kwargs):
         calls.append(kwargs)
-        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+        stdout = f"{site_packages}\n" if len(calls) == 1 else ""
+        return subprocess.CompletedProcess(args[0], 0, stdout=stdout, stderr="")
 
     monkeypatch.setattr(install_integrity.subprocess, "run", fake_run)
 
@@ -127,6 +128,24 @@ def test_site_discovery_probe_respects_disabled_user_site(monkeypatch, tmp_path)
     install_integrity.site_packages_for_python(executable)
 
     assert "ENABLE_USER_SITE" in calls[0]
+
+
+def test_site_discovery_ignores_other_python_versions_in_the_same_prefix(monkeypatch, tmp_path):
+    selected = tmp_path / "lib" / "python3.12" / "site-packages"
+    sibling = tmp_path / "lib" / "python3.11" / "site-packages"
+    _write_record(selected, "demo_pkg/__init__.py", b"value = 1\n")
+    _write_record(sibling, "demo_pkg/__init__.py", b"value = 1\n")
+    executable = tmp_path / "bin" / "python3"
+    executable.parent.mkdir()
+    executable.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(
+        install_integrity.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, stdout=f"{selected}\n", stderr=""),
+    )
+
+    assert install_integrity.site_packages_for_python(executable) == [selected.resolve()]
 
 
 def test_verify_site_packages_accepts_dist_packages_entry_point(tmp_path):

--- a/tests/test_install_integrity.py
+++ b/tests/test_install_integrity.py
@@ -85,3 +85,19 @@ def test_site_discovery_ignores_reported_prefix_without_record(monkeypatch, tmp_
     monkeypatch.setattr(install_integrity.subprocess, "run", fake_run)
 
     assert install_integrity.site_packages_for_python(executable) == [site_packages.resolve()]
+
+
+def test_verify_site_packages_accepts_dist_packages_entry_point(tmp_path):
+    site_packages = tmp_path / "lib" / "python3.12" / "dist-packages"
+    entrypoint = tmp_path / "bin" / "vibe"
+    entrypoint.parent.mkdir(parents=True)
+    entrypoint.write_bytes(b"#!/bin/sh\n")
+    digest = base64.urlsafe_b64encode(hashlib.sha256(entrypoint.read_bytes()).digest()).decode().rstrip("=")
+    record = site_packages / "demo_pkg-1.0.dist-info" / "RECORD"
+    record.parent.mkdir(parents=True)
+    record.write_text(f"../../../bin/vibe,sha256={digest},{entrypoint.stat().st_size}\n", encoding="utf-8")
+
+    result = verify_site_packages(site_packages)
+
+    assert result.ok is True
+    assert result.checked_files == 1

--- a/tests/test_install_integrity.py
+++ b/tests/test_install_integrity.py
@@ -65,3 +65,23 @@ def test_verify_python_environment_import_probe_does_not_use_caller_cwd(monkeypa
     assert result.ok is True
     assert calls[0]["cwd"] == install_integrity.tempfile.gettempdir()
     assert calls[0]["cwd"] != str(tmp_path)
+
+
+def test_site_discovery_ignores_reported_prefix_without_record(monkeypatch, tmp_path):
+    site_packages = tmp_path / "Lib" / "site-packages"
+    _write_record(site_packages, "demo_pkg/__init__.py", b"value = 1\n")
+    executable = tmp_path / "Scripts" / "python.exe"
+    executable.parent.mkdir()
+    executable.write_text("", encoding="utf-8")
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args[0],
+            0,
+            stdout=f"{tmp_path}\n{site_packages}\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(install_integrity.subprocess, "run", fake_run)
+
+    assert install_integrity.site_packages_for_python(executable) == [site_packages.resolve()]

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -51,9 +51,14 @@ def _write_fake_uv(path: Path, uv_log: Path) -> None:
         cat > "$bin_dir/vibe" <<'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
+        if [ "${{VIBE_TEST_REQUIRE_CANONICAL_HOME:-}}" = "1" ] && \
+            [ "${{AVIBE_HOME:-}}" != "${{VIBE_TEST_EXPECTED_AVIBE_HOME:-}}" ]; then
+            echo "AVIBE_HOME was not canonicalized" >&2
+            exit 21
+        fi
         if [ "${{1:-}}" = "__activate-install" ]; then
             if [ "${{2:-}}" = "--protocol-version" ]; then
-                if [ "${{VIBE_TEST_LEGACY_ACTIVATION:-}}" = "1" ]; then
+                if [ -f "$(dirname "$0")/.legacy-activation" ]; then
                     exit 2
                 fi
                 echo "1"
@@ -64,6 +69,9 @@ def _write_fake_uv(path: Path, uv_log: Path) -> None:
                 exit 19
             fi
             shift
+            if [ -n "${{VIBE_TEST_ACTIVATION_OWNER_LOG:-}}" ]; then
+                printf '%s' "$0" > "$VIBE_TEST_ACTIVATION_OWNER_LOG"
+            fi
             launcher=""
             candidate=""
             source_generation=""
@@ -119,6 +127,9 @@ def _write_fake_uv(path: Path, uv_log: Path) -> None:
         fi
         EOF
         chmod +x "$bin_dir/vibe"
+        if [ "${{VIBE_TEST_LEGACY_ACTIVATION:-}}" = "1" ]; then
+            touch "$bin_dir/.legacy-activation"
+        fi
         cat > "$bin_dir/python3" <<'EOF'
         #!/usr/bin/env bash
         if [ "${1:-}" = "-c" ]; then
@@ -270,6 +281,8 @@ def test_install_script_canonicalizes_relative_avibe_home(tmp_path):
     env["HOME"] = str(home_dir)
     env["AVIBE_HOME"] = "relative-avibe"
     env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
+    env["VIBE_TEST_REQUIRE_CANONICAL_HOME"] = "1"
+    env["VIBE_TEST_EXPECTED_AVIBE_HOME"] = str(tmp_path / "relative-avibe")
 
     install_result = _install(env, cwd=tmp_path)
 
@@ -354,6 +367,31 @@ def test_install_script_activates_a_wheel_without_the_shared_protocol(tmp_path):
     assert install_result.returncode == 0, install_result.stdout + install_result.stderr
     assert version_result.returncode == 0, version_result.stdout + version_result.stderr
     assert "avibe-os 9.9.9" in version_result.stdout
+
+
+def test_install_script_uses_the_current_owner_for_a_legacy_candidate(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    path_dir = tmp_path / "path-bin"
+    path_dir.mkdir()
+    uv_log = tmp_path / "uv-tool-bin-dir.txt"
+    owner_log = tmp_path / "activation-owner.txt"
+    _write_fake_uv(path_dir / "uv", uv_log)
+
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
+
+    first = _install(env)
+    first_owner = (path_dir / "vibe").resolve()
+    env["VIBE_TEST_LEGACY_ACTIVATION"] = "1"
+    env["VIBE_TEST_ACTIVATION_OWNER_LOG"] = str(owner_log)
+    second = _install(env)
+
+    assert first.returncode == 0, first.stdout + first.stderr
+    assert second.returncode == 0, second.stdout + second.stderr
+    assert Path(owner_log.read_text(encoding="utf-8")).samefile(first_owner)
+    assert (path_dir / "vibe").resolve() != first_owner
 
 
 def test_install_script_keeps_active_launcher_when_uv_install_fails(tmp_path):
@@ -616,7 +654,7 @@ def test_windows_installer_honors_configured_tool_bin_and_cross_volume_copy_fall
 
     assert "function Get-StableBinDirectory" in powershell
     assert "function Resolve-InstallPath" in powershell
-    assert "function Get-LauncherSourcePath" in powershell
+    assert "function Get-LauncherState" in powershell
     assert "function Get-GenerationPath" not in powershell
     assert '$expanded.StartsWith("~\\")' in powershell
     assert "$configured = $env:UV_TOOL_BIN_DIR" in powershell
@@ -625,20 +663,23 @@ def test_windows_installer_honors_configured_tool_bin_and_cross_volume_copy_fall
     assert '$activationArguments += @("--source-generation", $previousSourcePath)' in powershell
     assert "function Remove-StaleInstallGenerations" not in powershell
     assert "function Activate-LegacyInstallCandidate" in powershell
+    assert "[System.IO.File]::Move($replacement, $StableLauncher)" in powershell
     assert "Start-Process -FilePath" not in powershell
     assert "& $FilePath @Arguments" in powershell
 
 
 def test_install_script_candidate_probes_ignore_python_path_overrides():
     script = INSTALL_SCRIPT.read_text(encoding="utf-8")
-    assert 'env -u PYTHONPATH -u PYTHONHOME "$VIBE_CANDIDATE_BIN_PATH" "${activation_args[@]}"' in script
+    assert 'env -u PYTHONPATH -u PYTHONHOME AVIBE_HOME="$AVIBE_RUNTIME_HOME"' in script
     assert "__activate-install --protocol-version" in script
     assert 'activation_args+=(--source-generation "$source_snapshot")' in script
     assert "generation_path_for" not in script
+    assert 'AVIBE_HOME="$AVIBE_RUNTIME_HOME" "$activation_owner"' in script
     assert "verify_uv_candidate" not in script
     powershell = INSTALL_POWERSHELL.read_text(encoding="utf-8")
     assert "$previousPythonPath = $env:PYTHONPATH" in powershell
     assert "Remove-Item Env:PYTHONHOME" in powershell
+    assert "$env:AVIBE_HOME = $runtimeHome" in powershell
     assert "Test-UvCandidate" not in powershell
 
 

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -687,6 +687,9 @@ def test_windows_installer_honors_configured_tool_bin_and_cross_volume_copy_fall
     assert "[System.IO.File]::Move($replacement, $StableLauncher)" in powershell
     assert "Start-Process -FilePath" not in powershell
     assert "& $FilePath @Arguments" in powershell
+    assert '$env:Path = "$stableBin;$persistedPath"' in powershell
+    assert "& $stableLauncher --help" in powershell
+    assert 'Invoke-NativeCommand -FilePath $stableLauncher -Arguments @("runtime", "prepare", "--strict")' in powershell
 
 
 def test_install_script_candidate_probes_ignore_python_path_overrides():

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -88,6 +88,9 @@ def _write_fake_uv(path: Path, uv_log: Path) -> None:
         fi
         EOF
         chmod +x "$bin_dir/vibe"
+        if [ "${{VIBE_TEST_UV_FAIL:-}}" = "1" ]; then
+            exit 17
+        fi
         """,
     )
 
@@ -179,6 +182,13 @@ def _vibe_version(env: dict[str, str], *, cwd: Path = REPO_ROOT) -> subprocess.C
     return _run("vibe version", cwd=cwd, env=env)
 
 
+def _assert_staged_uv_bin(uv_log: Path, home_dir: Path) -> None:
+    staged = Path(uv_log.read_text(encoding="utf-8"))
+    assert staged.is_absolute()
+    assert staged.name == "bin"
+    assert staged.parent.parent == home_dir / ".avibe" / "runtime" / "install-generations"
+
+
 def test_install_script_keeps_vibe_available_on_current_path(tmp_path):
     home_dir = tmp_path / "home"
     home_dir.mkdir()
@@ -202,6 +212,27 @@ def test_install_script_keeps_vibe_available_on_current_path(tmp_path):
     assert version_result.returncode == 0, version_result.stdout + version_result.stderr
     assert "avibe-os 9.9.9" in version_result.stdout
     assert uv_log.read_text(encoding="utf-8")
+
+
+def test_install_script_keeps_active_launcher_when_uv_install_fails(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    path_dir = tmp_path / "path-bin"
+    path_dir.mkdir()
+    uv_log = tmp_path / "uv-tool-bin-dir.txt"
+    active = path_dir / "vibe"
+    _write_executable(active, "#!/usr/bin/env bash\necho stable\n")
+    _write_fake_uv(path_dir / "uv", uv_log)
+
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
+    env["VIBE_TEST_UV_FAIL"] = "1"
+
+    install_result = _install(env)
+
+    assert install_result.returncode != 0
+    assert active.read_text(encoding="utf-8") == "#!/usr/bin/env bash\necho stable\n"
 
 
 def test_install_script_pairs_and_starts_with_verified_vibe_path(tmp_path):
@@ -489,7 +520,7 @@ def test_install_script_prefers_original_path_order(tmp_path):
     install_result = _install(env, cwd=tmp_path)
 
     assert install_result.returncode == 0, install_result.stdout + install_result.stderr
-    assert uv_log.read_text(encoding="utf-8") == str(first_dir)
+    _assert_staged_uv_bin(uv_log, home_dir)
 
 
 def test_install_script_skips_relative_path_entries_for_tool_bin(tmp_path):
@@ -534,7 +565,7 @@ def test_install_script_skips_virtualenv_bin_dirs(tmp_path):
     install_result = _install(env, cwd=tmp_path)
 
     assert install_result.returncode == 0, install_result.stdout + install_result.stderr
-    assert uv_log.read_text(encoding="utf-8") == str(stable_bin)
+    _assert_staged_uv_bin(uv_log, home_dir)
     assert not (venv_bin / "vibe").exists()
 
 
@@ -560,7 +591,7 @@ def test_install_script_skips_pyenv_and_mise_bin_dirs(tmp_path):
     install_result = _install(env, cwd=tmp_path)
 
     assert install_result.returncode == 0, install_result.stdout + install_result.stderr
-    assert uv_log.read_text(encoding="utf-8") == str(stable_bin)
+    _assert_staged_uv_bin(uv_log, home_dir)
     assert not (pyenv_bin / "vibe").exists()
     assert not (mise_bin / "vibe").exists()
 
@@ -585,7 +616,7 @@ def test_install_script_skips_pyenv_shims_dir(tmp_path):
     install_result = _install(env, cwd=tmp_path)
 
     assert install_result.returncode == 0, install_result.stdout + install_result.stderr
-    assert uv_log.read_text(encoding="utf-8") == str(stable_bin)
+    _assert_staged_uv_bin(uv_log, home_dir)
     assert not (shims_dir / "vibe").exists()
 
 
@@ -607,7 +638,7 @@ def test_install_script_prefers_bin_over_sbin(tmp_path):
     install_result = _install(env, cwd=tmp_path)
 
     assert install_result.returncode == 0, install_result.stdout + install_result.stderr
-    assert uv_log.read_text(encoding="utf-8") == str(bin_dir)
+    _assert_staged_uv_bin(uv_log, home_dir)
     assert not (sbin_dir / "vibe").exists()
 
 
@@ -676,7 +707,7 @@ def test_install_script_reinstalls_when_existing_uv_is_x86_on_apple_silicon(tmp_
 
     assert install_result.returncode == 0, install_result.stdout + install_result.stderr
     assert "Found x86_64 uv on Apple Silicon" in install_result.stdout
-    assert uv_log.read_text(encoding="utf-8") == str(path_dir)
+    _assert_staged_uv_bin(uv_log, home_dir)
 
 
 def test_install_script_omits_retry_all_errors_for_older_curl(tmp_path):
@@ -751,7 +782,7 @@ def test_install_script_accepts_universal_uv_with_arm64e_slice_on_apple_silicon(
     assert install_result.returncode == 0, install_result.stdout + install_result.stderr
     assert "Found x86_64 uv on Apple Silicon" not in install_result.stdout
     assert "uv is already installed" in install_result.stdout
-    assert uv_log.read_text(encoding="utf-8") == str(path_dir)
+    _assert_staged_uv_bin(uv_log, home_dir)
 
 
 def test_install_script_checks_uv_symlink_target_architecture_on_apple_silicon(tmp_path):
@@ -800,7 +831,7 @@ def test_install_script_checks_uv_symlink_target_architecture_on_apple_silicon(t
 
     assert install_result.returncode == 0, install_result.stdout + install_result.stderr
     assert "Found x86_64 uv on Apple Silicon" in install_result.stdout
-    assert uv_log.read_text(encoding="utf-8") == str(path_dir)
+    _assert_staged_uv_bin(uv_log, home_dir)
 
 
 def test_install_script_ignores_arch_tokens_in_uv_path_prefix(tmp_path):
@@ -848,4 +879,4 @@ def test_install_script_ignores_arch_tokens_in_uv_path_prefix(tmp_path):
 
     assert install_result.returncode == 0, install_result.stdout + install_result.stderr
     assert "Found x86_64 uv on Apple Silicon" in install_result.stdout
-    assert uv_log.read_text(encoding="utf-8") == str(path_dir)
+    _assert_staged_uv_bin(uv_log, home_dir)

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -687,6 +687,12 @@ def test_windows_installer_honors_configured_tool_bin_and_cross_volume_copy_fall
     assert "[System.IO.File]::Move($replacement, $StableLauncher)" in powershell
     assert "Start-Process -FilePath" not in powershell
     assert "& $FilePath @Arguments" in powershell
+    assert "Stdout = $stdout.Trim()" in powershell
+    assert "Stderr = $stderr.Trim()" in powershell
+    assert "function Get-InstallProtocolVersion" in powershell
+    assert "[int]::TryParse($Result.Stdout.Trim(), [ref]$version)" in powershell
+    assert "[int]$protocol.Output.Trim()" not in powershell
+    assert "$snapshot.Stdout.Trim()" in powershell
     assert '$env:Path = "$stableBin;$persistedPath"' in powershell
     assert "& $stableLauncher --help" in powershell
     assert 'Invoke-NativeCommand -FilePath $stableLauncher -Arguments @("runtime", "prepare", "--strict")' in powershell

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -66,13 +66,19 @@ def _write_fake_uv(path: Path, uv_log: Path) -> None:
             shift
             launcher=""
             candidate=""
+            source_generation=""
             while [ "$#" -gt 0 ]; do
                 case "$1" in
                     --launcher) launcher="$2"; shift 2 ;;
                     --candidate) candidate="$2"; shift 2 ;;
+                    --source-generation) source_generation="$2"; shift 2 ;;
                     *) shift ;;
                 esac
             done
+            if [ "${{VIBE_TEST_REQUIRE_SOURCE_GENERATION:-}}" = "1" ] && [ -z "$source_generation" ]; then
+                echo "source generation missing" >&2
+                exit 20
+            fi
             replacement="${{launcher}}.new"
             ln -s "$candidate" "$replacement"
             mv -f "$replacement" "$launcher"
@@ -274,6 +280,35 @@ def test_install_script_canonicalizes_relative_avibe_home(tmp_path):
     assert target.is_absolute()
     assert target.is_file()
     assert target.is_relative_to(tmp_path / "relative-avibe" / "runtime" / "install-generations")
+
+
+def test_repeated_install_preserves_source_through_a_home_symlink(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    physical_runtime_home = tmp_path / "physical-avibe"
+    physical_runtime_home.mkdir()
+    logical_runtime_home = tmp_path / "logical-avibe"
+    logical_runtime_home.symlink_to(physical_runtime_home, target_is_directory=True)
+    path_dir = tmp_path / "path-bin"
+    path_dir.mkdir()
+    uv_log = tmp_path / "uv-tool-bin-dir.txt"
+    _write_fake_uv(path_dir / "uv", uv_log)
+
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["AVIBE_HOME"] = str(logical_runtime_home)
+    env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
+
+    first = _install(env)
+    launcher = path_dir / "vibe"
+    physical_target = launcher.resolve()
+    launcher.unlink()
+    launcher.symlink_to(physical_target)
+    env["VIBE_TEST_REQUIRE_SOURCE_GENERATION"] = "1"
+    second = _install(env)
+
+    assert first.returncode == 0, first.stdout + first.stderr
+    assert second.returncode == 0, second.stdout + second.stderr
 
 
 def test_repeated_installer_runs_prune_old_generations(tmp_path):
@@ -581,11 +616,13 @@ def test_windows_installer_honors_configured_tool_bin_and_cross_volume_copy_fall
 
     assert "function Get-StableBinDirectory" in powershell
     assert "function Resolve-InstallPath" in powershell
+    assert "function Get-LauncherSourcePath" in powershell
+    assert "function Get-GenerationPath" not in powershell
     assert '$expanded.StartsWith("~\\")' in powershell
     assert "$configured = $env:UV_TOOL_BIN_DIR" in powershell
     assert '"__activate-install"' in powershell
     assert '"--protocol-version"' in powershell
-    assert '$activationArguments += @("--source-generation", $previousGeneration)' in powershell
+    assert '$activationArguments += @("--source-generation", $previousSourcePath)' in powershell
     assert "function Remove-StaleInstallGenerations" not in powershell
     assert "function Activate-LegacyInstallCandidate" in powershell
     assert "Start-Process -FilePath" not in powershell
@@ -596,7 +633,8 @@ def test_install_script_candidate_probes_ignore_python_path_overrides():
     script = INSTALL_SCRIPT.read_text(encoding="utf-8")
     assert 'env -u PYTHONPATH -u PYTHONHOME "$VIBE_CANDIDATE_BIN_PATH" "${activation_args[@]}"' in script
     assert "__activate-install --protocol-version" in script
-    assert 'activation_args+=(--source-generation "$source_generation")' in script
+    assert 'activation_args+=(--source-generation "$source_snapshot")' in script
+    assert "generation_path_for" not in script
     assert "verify_uv_candidate" not in script
     powershell = INSTALL_POWERSHELL.read_text(encoding="utf-8")
     assert "$previousPythonPath = $env:PYTHONPATH" in powershell

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -61,7 +61,26 @@ def _write_fake_uv(path: Path, uv_log: Path) -> None:
                 if [ -f "$(dirname "$0")/.legacy-activation" ]; then
                     exit 2
                 fi
-                echo "1"
+                echo "2"
+                exit 0
+            fi
+            if [ "${{2:-}}" = "--snapshot" ]; then
+                launcher=""
+                shift 2
+                while [ "$#" -gt 0 ]; do
+                    case "$1" in
+                        --launcher) launcher="$2"; shift 2 ;;
+                        *) shift ;;
+                    esac
+                done
+                target="$(readlink "$launcher" 2>/dev/null || true)"
+                if [ -n "$target" ]; then
+                    case "$target" in
+                        /*) ;;
+                        *) target="$(dirname "$launcher")/$target" ;;
+                    esac
+                    dirname "$(dirname "$target")"
+                fi
                 exit 0
             fi
             if [ "${{VIBE_TEST_CANDIDATE_PROBE_FAIL:-}}" = "1" ]; then
@@ -655,11 +674,13 @@ def test_windows_installer_honors_configured_tool_bin_and_cross_volume_copy_fall
     assert "function Get-StableBinDirectory" in powershell
     assert "function Resolve-InstallPath" in powershell
     assert "function Get-LauncherState" in powershell
+    assert "Get-Content -LiteralPath $marker" not in powershell
     assert "function Get-GenerationPath" not in powershell
     assert '$expanded.StartsWith("~\\")' in powershell
     assert "$configured = $env:UV_TOOL_BIN_DIR" in powershell
     assert '"__activate-install"' in powershell
     assert '"--protocol-version"' in powershell
+    assert '"--snapshot", "--launcher", $Launcher' in powershell
     assert '$activationArguments += @("--source-generation", $previousSourcePath)' in powershell
     assert "function Remove-StaleInstallGenerations" not in powershell
     assert "function Activate-LegacyInstallCandidate" in powershell
@@ -672,6 +693,7 @@ def test_install_script_candidate_probes_ignore_python_path_overrides():
     script = INSTALL_SCRIPT.read_text(encoding="utf-8")
     assert 'env -u PYTHONPATH -u PYTHONHOME AVIBE_HOME="$AVIBE_RUNTIME_HOME"' in script
     assert "__activate-install --protocol-version" in script
+    assert '__activate-install --snapshot --launcher "$stable_bin_dir/vibe"' in script
     assert 'activation_args+=(--source-generation "$source_snapshot")' in script
     assert "generation_path_for" not in script
     assert 'AVIBE_HOME="$AVIBE_RUNTIME_HOME" "$activation_owner"' in script
@@ -687,6 +709,30 @@ def test_uninstall_instructions_use_the_selected_stable_bin():
     script = INSTALL_SCRIPT.read_text(encoding="utf-8")
     assert r'rm -f \"$VIBE_TOOL_BIN_DIR/vibe\"' in script
     assert "rm -f ~/.local/bin/vibe" not in script
+
+
+def test_uninstall_instructions_expand_user_relative_avibe_home():
+    script = INSTALL_SCRIPT.read_text(encoding="utf-8")
+    assert 'avibe_home=\\"\\${AVIBE_HOME:-\\$HOME/.avibe}\\"' in script
+    assert 'avibe_home="${avibe_home/#\\~/$HOME}"' in script
+    assert 'rm -rf "$avibe_home/runtime/install-generations"' in script
+    assert 'rm -rf "$avibe_home" ~/.vibe_remote' in script
+
+    documents = (
+        (REPO_ROOT / "README.md").read_text(encoding="utf-8"),
+        (REPO_ROOT / "docs" / "INSTALL_FOR_AI.md").read_text(encoding="utf-8"),
+        (REPO_ROOT / "docs" / "INSTALL_FOR_AI_ZH.md").read_text(encoding="utf-8"),
+    )
+
+    for document in documents:
+        assert 'avibe_home="${AVIBE_HOME:-$HOME/.avibe}"' in document
+        assert 'avibe_home="${avibe_home/#\\~/$HOME}"' in document
+        assert 'rm -rf "$avibe_home/runtime/install-generations"' in document
+        assert 'rm -rf "$avibe_home" ~/.vibe_remote' in document
+
+    powershell = INSTALL_POWERSHELL.read_text(encoding="utf-8")
+    assert "-replace ''^~(?=[\\\\/]|$)'', $env:USERPROFILE" in powershell
+    assert "Remove-Item -Recurse $avibeHome, ~\\.vibe_remote" in powershell
 
 
 def test_install_script_continues_when_show_runtime_prepare_fails(tmp_path):

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -88,6 +88,19 @@ def _write_fake_uv(path: Path, uv_log: Path) -> None:
         fi
         EOF
         chmod +x "$bin_dir/vibe"
+        cat > "$bin_dir/python3" <<'EOF'
+        #!/usr/bin/env bash
+        if [ "${1:-}" = "-c" ]; then
+            if [ "${{VIBE_TEST_CANDIDATE_PROBE_FAIL:-}}" = "1" ]; then
+                echo "candidate import failed" >&2
+                exit 19
+            fi
+            echo "verified 1 package files"
+            exit 0
+        fi
+        exit 1
+        EOF
+        chmod +x "$bin_dir/python3"
         if [ "${{VIBE_TEST_UV_FAIL:-}}" = "1" ]; then
             exit 17
         fi
@@ -228,6 +241,27 @@ def test_install_script_keeps_active_launcher_when_uv_install_fails(tmp_path):
     env["HOME"] = str(home_dir)
     env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
     env["VIBE_TEST_UV_FAIL"] = "1"
+
+    install_result = _install(env)
+
+    assert install_result.returncode != 0
+    assert active.read_text(encoding="utf-8") == "#!/usr/bin/env bash\necho stable\n"
+
+
+def test_install_script_keeps_active_launcher_when_candidate_probe_fails(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    path_dir = tmp_path / "path-bin"
+    path_dir.mkdir()
+    uv_log = tmp_path / "uv-tool-bin-dir.txt"
+    active = path_dir / "vibe"
+    _write_executable(active, "#!/usr/bin/env bash\necho stable\n")
+    _write_fake_uv(path_dir / "uv", uv_log)
+
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
+    env["VIBE_TEST_CANDIDATE_PROBE_FAIL"] = "1"
 
     install_result = _install(env)
 

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -52,6 +52,13 @@ def _write_fake_uv(path: Path, uv_log: Path) -> None:
         #!/usr/bin/env bash
         set -euo pipefail
         if [ "${{1:-}}" = "__activate-install" ]; then
+            if [ "${{2:-}}" = "--protocol-version" ]; then
+                if [ "${{VIBE_TEST_LEGACY_ACTIVATION:-}}" = "1" ]; then
+                    exit 2
+                fi
+                echo "1"
+                exit 0
+            fi
             if [ "${{VIBE_TEST_CANDIDATE_PROBE_FAIL:-}}" = "1" ]; then
                 echo "candidate import failed" >&2
                 exit 19
@@ -291,6 +298,27 @@ def test_repeated_installer_runs_prune_old_generations(tmp_path):
     assert len(first_generations) == 1
     assert len(generations) == 2
     assert all(path.is_dir() for path in generations)
+
+
+def test_install_script_activates_a_wheel_without_the_shared_protocol(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    path_dir = tmp_path / "path-bin"
+    path_dir.mkdir()
+    uv_log = tmp_path / "uv-tool-bin-dir.txt"
+    _write_fake_uv(path_dir / "uv", uv_log)
+
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
+    env["VIBE_TEST_LEGACY_ACTIVATION"] = "1"
+
+    install_result = _install(env)
+    version_result = _vibe_version(env)
+
+    assert install_result.returncode == 0, install_result.stdout + install_result.stderr
+    assert version_result.returncode == 0, version_result.stdout + version_result.stderr
+    assert "avibe-os 9.9.9" in version_result.stdout
 
 
 def test_install_script_keeps_active_launcher_when_uv_install_fails(tmp_path):
@@ -552,16 +580,22 @@ def test_windows_installer_honors_configured_tool_bin_and_cross_volume_copy_fall
     powershell = INSTALL_POWERSHELL.read_text(encoding="utf-8")
 
     assert "function Get-StableBinDirectory" in powershell
+    assert "function Resolve-InstallPath" in powershell
+    assert '$expanded.StartsWith("~\\")' in powershell
     assert "$configured = $env:UV_TOOL_BIN_DIR" in powershell
     assert '"__activate-install"' in powershell
+    assert '"--protocol-version"' in powershell
     assert '$activationArguments += @("--source-generation", $previousGeneration)' in powershell
     assert "function Remove-StaleInstallGenerations" not in powershell
-    assert "New-Item -ItemType HardLink" not in powershell
+    assert "function Activate-LegacyInstallCandidate" in powershell
+    assert "Start-Process -FilePath" not in powershell
+    assert "& $FilePath @Arguments" in powershell
 
 
 def test_install_script_candidate_probes_ignore_python_path_overrides():
     script = INSTALL_SCRIPT.read_text(encoding="utf-8")
     assert 'env -u PYTHONPATH -u PYTHONHOME "$VIBE_CANDIDATE_BIN_PATH" "${activation_args[@]}"' in script
+    assert "__activate-install --protocol-version" in script
     assert 'activation_args+=(--source-generation "$source_generation")' in script
     assert "verify_uv_candidate" not in script
     powershell = INSTALL_POWERSHELL.read_text(encoding="utf-8")

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -506,6 +506,14 @@ def test_install_script_probes_the_same_libreoffice_path_as_memory(tmp_path):
     assert "Install LibreOffice from https://www.libreoffice.org/" not in powershell
 
 
+def test_windows_installer_honors_configured_tool_bin_and_cross_volume_copy_fallback():
+    powershell = INSTALL_POWERSHELL.read_text(encoding="utf-8")
+
+    assert "function Get-StableBinDirectory" in powershell
+    assert "$configured = $env:UV_TOOL_BIN_DIR" in powershell
+    assert "Copy-Item -LiteralPath $candidate -Destination $replacement" in powershell
+
+
 def test_install_script_continues_when_show_runtime_prepare_fails(tmp_path):
     home_dir = tmp_path / "home"
     home_dir.mkdir()

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -540,6 +540,15 @@ def test_windows_installer_honors_configured_tool_bin_and_cross_volume_copy_fall
     assert "Remove-StaleInstallGenerations -RuntimeHome $runtimeHome" in powershell
 
 
+def test_install_script_candidate_probes_ignore_python_path_overrides():
+    script = INSTALL_SCRIPT.read_text(encoding="utf-8")
+    assert 'env -u PYTHONPATH -u PYTHONHOME "$candidate_python"' in script
+    assert 'env -u PYTHONPATH -u PYTHONHOME "$candidate" --help' in script
+    powershell = INSTALL_POWERSHELL.read_text(encoding="utf-8")
+    assert "$previousPythonPath = $env:PYTHONPATH" in powershell
+    assert "Remove-Item Env:PYTHONHOME" in powershell
+
+
 def test_install_script_continues_when_show_runtime_prepare_fails(tmp_path):
     home_dir = tmp_path / "home"
     home_dir.mkdir()

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -51,7 +51,25 @@ def _write_fake_uv(path: Path, uv_log: Path) -> None:
         cat > "$bin_dir/vibe" <<'EOF'
         #!/usr/bin/env bash
         set -euo pipefail
-        if [ "${{1:-}}" = "--help" ]; then
+        if [ "${{1:-}}" = "__activate-install" ]; then
+            if [ "${{VIBE_TEST_CANDIDATE_PROBE_FAIL:-}}" = "1" ]; then
+                echo "candidate import failed" >&2
+                exit 19
+            fi
+            shift
+            launcher=""
+            candidate=""
+            while [ "$#" -gt 0 ]; do
+                case "$1" in
+                    --launcher) launcher="$2"; shift 2 ;;
+                    --candidate) candidate="$2"; shift 2 ;;
+                    *) shift ;;
+                esac
+            done
+            replacement="${{launcher}}.new"
+            ln -s "$candidate" "$replacement"
+            mv -f "$replacement" "$launcher"
+        elif [ "${{1:-}}" = "--help" ]; then
             echo "usage: vibe"
         elif [ "${{1:-}}" = "version" ]; then
             echo "avibe-os 9.9.9"
@@ -535,18 +553,27 @@ def test_windows_installer_honors_configured_tool_bin_and_cross_volume_copy_fall
 
     assert "function Get-StableBinDirectory" in powershell
     assert "$configured = $env:UV_TOOL_BIN_DIR" in powershell
-    assert "Copy-Item -LiteralPath $candidate -Destination $replacement" in powershell
-    assert "function Remove-StaleInstallGenerations" in powershell
-    assert "Remove-StaleInstallGenerations -RuntimeHome $runtimeHome" in powershell
+    assert '"__activate-install"' in powershell
+    assert '$activationArguments += @("--source-generation", $previousGeneration)' in powershell
+    assert "function Remove-StaleInstallGenerations" not in powershell
+    assert "New-Item -ItemType HardLink" not in powershell
 
 
 def test_install_script_candidate_probes_ignore_python_path_overrides():
     script = INSTALL_SCRIPT.read_text(encoding="utf-8")
-    assert 'env -u PYTHONPATH -u PYTHONHOME "$candidate_python"' in script
-    assert 'env -u PYTHONPATH -u PYTHONHOME "$candidate" --help' in script
+    assert 'env -u PYTHONPATH -u PYTHONHOME "$VIBE_CANDIDATE_BIN_PATH" "${activation_args[@]}"' in script
+    assert 'activation_args+=(--source-generation "$source_generation")' in script
+    assert "verify_uv_candidate" not in script
     powershell = INSTALL_POWERSHELL.read_text(encoding="utf-8")
     assert "$previousPythonPath = $env:PYTHONPATH" in powershell
     assert "Remove-Item Env:PYTHONHOME" in powershell
+    assert "Test-UvCandidate" not in powershell
+
+
+def test_uninstall_instructions_use_the_selected_stable_bin():
+    script = INSTALL_SCRIPT.read_text(encoding="utf-8")
+    assert r'rm -f \"$VIBE_TOOL_BIN_DIR/vibe\"' in script
+    assert "rm -f ~/.local/bin/vibe" not in script
 
 
 def test_install_script_continues_when_show_runtime_prepare_fails(tmp_path):

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -227,6 +227,30 @@ def test_install_script_keeps_vibe_available_on_current_path(tmp_path):
     assert uv_log.read_text(encoding="utf-8")
 
 
+def test_install_script_canonicalizes_relative_avibe_home(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    path_dir = tmp_path / "path-bin"
+    path_dir.mkdir()
+    uv_log = tmp_path / "uv-tool-bin-dir.txt"
+    _write_fake_uv(path_dir / "uv", uv_log)
+
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["AVIBE_HOME"] = "relative-avibe"
+    env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
+
+    install_result = _install(env, cwd=tmp_path)
+
+    assert install_result.returncode == 0, install_result.stdout + install_result.stderr
+    launcher = path_dir / "vibe"
+    assert launcher.is_symlink()
+    target = Path(os.readlink(launcher))
+    assert target.is_absolute()
+    assert target.is_file()
+    assert target.is_relative_to(tmp_path / "relative-avibe" / "runtime" / "install-generations")
+
+
 def test_install_script_keeps_active_launcher_when_uv_install_fails(tmp_path):
     home_dir = tmp_path / "home"
     home_dir.mkdir()

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -251,6 +251,30 @@ def test_install_script_canonicalizes_relative_avibe_home(tmp_path):
     assert target.is_relative_to(tmp_path / "relative-avibe" / "runtime" / "install-generations")
 
 
+def test_repeated_installer_runs_prune_old_generations(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    path_dir = tmp_path / "path-bin"
+    path_dir.mkdir()
+    uv_log = tmp_path / "uv-tool-bin-dir.txt"
+    _write_fake_uv(path_dir / "uv", uv_log)
+
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
+
+    first = _install(env)
+    first_generations = sorted((home_dir / ".avibe" / "runtime" / "install-generations").iterdir())
+    second = _install(env)
+    generations = sorted((home_dir / ".avibe" / "runtime" / "install-generations").iterdir())
+
+    assert first.returncode == 0, first.stdout + first.stderr
+    assert second.returncode == 0, second.stdout + second.stderr
+    assert len(first_generations) == 1
+    assert len(generations) == 2
+    assert all(path.is_dir() for path in generations)
+
+
 def test_install_script_keeps_active_launcher_when_uv_install_fails(tmp_path):
     home_dir = tmp_path / "home"
     home_dir.mkdir()
@@ -512,6 +536,8 @@ def test_windows_installer_honors_configured_tool_bin_and_cross_volume_copy_fall
     assert "function Get-StableBinDirectory" in powershell
     assert "$configured = $env:UV_TOOL_BIN_DIR" in powershell
     assert "Copy-Item -LiteralPath $candidate -Destination $replacement" in powershell
+    assert "function Remove-StaleInstallGenerations" in powershell
+    assert "Remove-StaleInstallGenerations -RuntimeHome $runtimeHome" in powershell
 
 
 def test_install_script_continues_when_show_runtime_prepare_fails(tmp_path):

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -146,6 +146,41 @@ def test_schedule_restart_spawns_supervisor_and_records_status(monkeypatch, tmp_
     assert runtime.read_json(runtime.get_restart_status_path())["job_id"] == result["job_id"]
 
 
+def test_schedule_restart_can_use_candidate_python_without_launcher_lock(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    calls = {}
+
+    monkeypatch.setattr(restart_supervisor, "get_restart_environment", lambda vibe_path=None: {"PATH": "/bin"})
+    monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
+    monkeypatch.setattr(restart_supervisor, "_prune_restart_logs", lambda: None)
+
+    def fake_popen(command, **kwargs):
+        calls["command"] = command
+        calls["kwargs"] = kwargs
+
+        class Proc:
+            pid = 45679
+
+        return Proc()
+
+    monkeypatch.setattr(restart_supervisor.subprocess, "Popen", fake_popen)
+
+    result = restart_supervisor.schedule_restart(
+        vibe_path=str(tmp_path / "stable" / "vibe.exe"),
+        python_executable=str(tmp_path / "generation" / "python.exe"),
+        trigger="upgrade",
+    )
+
+    assert result["state"] == "scheduled"
+    assert calls["command"][:4] == [
+        str(tmp_path / "generation" / "python.exe"),
+        "-c",
+        "from vibe.cli import main; main()",
+        "__restart-supervisor",
+    ]
+
+
 def test_legacy_upgrade_target_reads_the_running_release_and_launcher(monkeypatch, tmp_path):
     """A pre-rollback release can still hand the new supervisor its target."""
 

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -116,13 +116,23 @@ def test_schedule_restart_spawns_supervisor_and_records_status(monkeypatch, tmp_
     paths.ensure_data_dirs()
     paths.get_runtime_pid_path().write_text("12345", encoding="utf-8")
     calls = {}
+    events: list[str] = []
+
+    class Lock:
+        def __enter__(self):
+            events.append("lock-enter")
+
+        def __exit__(self, *_args):
+            events.append("lock-exit")
 
     monkeypatch.setattr(restart_supervisor, "get_restart_invocation_command", lambda vibe_path=None: ["/bin/vibe", "restart"])
     monkeypatch.setattr(restart_supervisor, "get_restart_environment", lambda vibe_path=None: {"PATH": "/bin"})
     monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
     monkeypatch.setattr(restart_supervisor, "_prune_restart_logs", lambda: None)
+    monkeypatch.setattr(restart_supervisor, "atomic_upgrade_lock", Lock)
 
     def fake_popen(command, **kwargs):
+        events.append("spawn")
         calls["command"] = command
         calls["kwargs"] = kwargs
 
@@ -144,6 +154,7 @@ def test_schedule_restart_spawns_supervisor_and_records_status(monkeypatch, tmp_
     assert calls["kwargs"]["start_new_session"] is True
     assert calls["kwargs"]["env"] == {"PATH": "/bin"}
     assert runtime.read_json(runtime.get_restart_status_path())["job_id"] == result["job_id"]
+    assert events == ["lock-enter", "spawn", "lock-exit"]
 
 
 def test_schedule_restart_can_use_candidate_python_without_launcher_lock(monkeypatch, tmp_path):

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -181,6 +181,36 @@ def test_schedule_restart_can_use_candidate_python_without_launcher_lock(monkeyp
     ]
 
 
+def test_candidate_supervisor_drops_source_pythonpath(monkeypatch, tmp_path):
+    monkeypatch.setenv("PYTHONPATH", "/source/checkout")
+    monkeypatch.setenv("PYTHONHOME", "/source/python")
+    monkeypatch.setattr(restart_supervisor, "get_restart_environment", lambda vibe_path=None: None)
+    monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
+    monkeypatch.setattr(restart_supervisor, "_prune_restart_logs", lambda: None)
+    calls = {}
+
+    def fake_popen(command, **kwargs):
+        calls["kwargs"] = kwargs
+
+        class Proc:
+            pid = 45680
+
+        return Proc()
+
+    monkeypatch.setattr(restart_supervisor.subprocess, "Popen", fake_popen)
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+
+    restart_supervisor.schedule_restart(
+        vibe_path=str(tmp_path / "stable" / "vibe.exe"),
+        python_executable=str(tmp_path / "generation" / "python.exe"),
+        trigger="upgrade",
+    )
+
+    assert "PYTHONPATH" not in calls["kwargs"]["env"]
+    assert "PYTHONHOME" not in calls["kwargs"]["env"]
+
+
 def test_legacy_upgrade_target_reads_the_running_release_and_launcher(monkeypatch, tmp_path):
     """A pre-rollback release can still hand the new supervisor its target."""
 

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -61,7 +61,7 @@ def _tree_is_not_an_installed_distribution(monkeypatch):
     monkeypatch.setattr("vibe.upgrade._distributions_providing_this_package", lambda: [])
 
 
-def test_build_upgrade_plan_uses_uv_and_preserves_tool_bin_dir(monkeypatch):
+def test_build_upgrade_plan_stages_custom_legacy_uv_launcher(monkeypatch):
     monkeypatch.setattr("vibe.upgrade.os.path.exists", lambda path: True)
     monkeypatch.setattr("vibe.upgrade.os.access", lambda path, mode: True)
 
@@ -75,10 +75,12 @@ def test_build_upgrade_plan_uses_uv_and_preserves_tool_bin_dir(monkeypatch):
     assert plan.method == "uv"
     assert plan.command == ["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"]
     assert plan.env is not None
-    assert "UV_TOOL_DIR" not in plan.env
+    assert "UV_TOOL_DIR" in plan.env
+    assert "UV_TOOL_BIN_DIR" in plan.env
     assert plan.env["PATH"] == "/usr/bin"
-    assert plan.preflight_error is not None
-    assert plan.activation is None
+    assert plan.preflight_error is None
+    assert plan.activation is not None
+    assert plan.activation.launcher == Path("/custom/bin/vibe")
 
 
 def test_build_upgrade_plan_forces_legacy_uv_tool_install(monkeypatch):
@@ -799,16 +801,26 @@ def test_is_uv_tool_install_uses_logical_atomic_generation_path(monkeypatch, tmp
     assert upgrade.is_uv_tool_install(str(executable))
 
 
-def test_custom_configured_bin_is_a_stable_launcher(monkeypatch, tmp_path):
+def test_custom_legacy_bin_is_a_stable_launcher_without_uv_environment(monkeypatch, tmp_path):
     from vibe import upgrade
 
     launcher = tmp_path / "custom-tools" / "vibe.exe"
     launcher.parent.mkdir(parents=True)
     launcher.write_text("launcher\n", encoding="utf-8")
     launcher.chmod(0o755)
-    monkeypatch.setenv("UV_TOOL_BIN_DIR", str(launcher.parent))
+    monkeypatch.delenv("UV_TOOL_BIN_DIR", raising=False)
 
     assert upgrade._is_stable_launcher_path(launcher)
+
+
+def test_uv_environment_entry_point_is_not_a_stable_launcher(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    root = tmp_path / "home" / "runtime" / "install-generations"
+    launcher = root / "generation" / "tools" / "avibe-os" / "bin" / "vibe.exe"
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
+
+    assert not upgrade._is_stable_launcher_path(launcher)
 
 
 def test_restart_is_pending_until_the_seed_marker_is_terminal(monkeypatch, tmp_path):

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -217,6 +217,82 @@ def test_prune_atomic_uv_install_generations_keeps_active_and_rollback(monkeypat
     assert not stale.parent.parent.exists()
 
 
+def test_activation_retains_the_generation_serving_a_live_process(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    root = tmp_path / "generations"
+    launcher = tmp_path / "bin" / "vibe"
+    previous = root / "previous" / "bin" / "vibe"
+    running_python = root / "running" / "tools" / "avibe-os" / "bin" / "python"
+    candidate = root / "candidate" / "bin" / "vibe"
+    stale = root / "stale" / "bin" / "vibe"
+    for path in (previous, running_python, candidate, stale):
+        path.parent.mkdir(parents=True)
+        path.write_text(path.parent.parent.name, encoding="utf-8")
+        path.chmod(0o755)
+    launcher.parent.mkdir(parents=True)
+    launcher.symlink_to(previous)
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
+    monkeypatch.setattr(upgrade, "running_install_paths", lambda: (running_python,))
+    monkeypatch.setattr(upgrade, "verify_upgrade_candidate", lambda _activation: upgrade.IntegrityResult(True, 1))
+
+    upgrade.activate_upgrade_candidate(upgrade.AtomicActivation(launcher, candidate, root / "previous"))
+
+    assert launcher.resolve() == candidate.resolve()
+    assert previous.exists()
+    assert running_python.exists()
+    assert not stale.parent.parent.exists()
+
+
+def test_installer_activation_uses_the_shared_locked_boundary(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    events: list[str] = []
+
+    class Lock:
+        def __enter__(self):
+            events.append("lock-enter")
+
+        def __exit__(self, *_args):
+            events.append("lock-exit")
+
+    activation = upgrade.AtomicActivation(tmp_path / "vibe", tmp_path / "candidate")
+    monkeypatch.setattr(upgrade, "atomic_upgrade_lock", Lock)
+    monkeypatch.setattr(upgrade, "activation_block_reason", lambda _activation: None)
+    monkeypatch.setattr(upgrade, "activate_upgrade_candidate", lambda _activation: events.append("activate"))
+
+    upgrade.activate_installer_candidate(activation)
+
+    assert events == ["lock-enter", "activate", "lock-exit"]
+
+
+def test_installer_rejects_a_snapshot_superseded_by_runtime_activation(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    root = tmp_path / "generations"
+    launcher = tmp_path / "bin" / "vibe"
+    old = root / "old" / "bin" / "vibe"
+    runtime_candidate = root / "runtime" / "bin" / "vibe"
+    installer_candidate = root / "installer" / "bin" / "vibe"
+    for path in (old, runtime_candidate, installer_candidate):
+        path.parent.mkdir(parents=True)
+        path.write_text(path.parent.parent.name, encoding="utf-8")
+        path.chmod(0o755)
+    launcher.parent.mkdir(parents=True)
+    launcher.symlink_to(old)
+    installer_activation = upgrade.AtomicActivation(launcher, installer_candidate, root / "old")
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
+    monkeypatch.setattr(upgrade, "running_install_paths", lambda: ())
+    monkeypatch.setattr(upgrade, "restart_is_pending", lambda: False)
+    monkeypatch.setattr(upgrade, "verify_upgrade_candidate", lambda _activation: upgrade.IntegrityResult(True, 1))
+
+    upgrade.activate_upgrade_candidate(upgrade.AtomicActivation(launcher, runtime_candidate, root / "old"))
+
+    with pytest.raises(RuntimeError, match="changed while the installer was staging"):
+        upgrade.activate_installer_candidate(installer_activation)
+    assert launcher.resolve() == runtime_candidate.resolve()
+
+
 def test_verify_upgrade_candidate_follows_uv_launcher_to_tool_environment(monkeypatch, tmp_path):
     from vibe import upgrade
 
@@ -382,7 +458,7 @@ def test_deferred_activation_dispatch_activates_then_schedules_restart(monkeypat
     calls: list[str] = []
     monkeypatch.setattr(cli.runtime, "pid_alive", lambda _pid: False)
     monkeypatch.setattr(cli, "atomic_upgrade_lock", lambda: nullcontext())
-    monkeypatch.setattr(cli, "atomic_activation_source_is_current", lambda _activation: True)
+    monkeypatch.setattr(cli, "activation_block_reason", lambda _activation: None)
     monkeypatch.setattr(cli, "activate_upgrade_candidate", lambda _activation: calls.append("activate"))
     monkeypatch.setattr(cli, "schedule_restart", lambda **_kwargs: calls.append("restart"))
 
@@ -400,6 +476,67 @@ def test_deferred_activation_dispatch_activates_then_schedules_restart(monkeypat
 
     assert result == 0
     assert calls == ["activate", "restart"]
+
+
+def test_deferred_activation_seeds_restart_before_releasing_install_lock(monkeypatch, tmp_path):
+    from vibe import cli
+
+    events: list[str] = []
+
+    class Lock:
+        def __enter__(self):
+            events.append("lock-enter")
+
+        def __exit__(self, *_args):
+            events.append("lock-exit")
+
+    monkeypatch.setattr(cli.runtime, "pid_alive", lambda _pid: False)
+    monkeypatch.setattr(cli, "atomic_upgrade_lock", Lock)
+    monkeypatch.setattr(cli, "activation_block_reason", lambda _activation: None)
+    monkeypatch.setattr(cli, "activate_upgrade_candidate", lambda _activation: events.append("activate"))
+    monkeypatch.setattr(cli, "schedule_restart", lambda **_kwargs: events.append("restart"))
+
+    result = cli._dispatch_deferred_upgrade_activation(
+        [
+            "--parent-pid",
+            "123",
+            "--launcher",
+            str(tmp_path / "vibe.exe"),
+            "--candidate",
+            str(tmp_path / "candidate.exe"),
+            "--restart",
+        ]
+    )
+
+    assert result == 0
+    assert events == ["lock-enter", "activate", "restart", "lock-exit"]
+
+
+def test_deferred_offline_activation_prepares_show_runtime(monkeypatch, tmp_path):
+    from vibe import cli
+
+    calls: list[str] = []
+    launcher = tmp_path / "vibe.exe"
+    monkeypatch.setattr(cli.runtime, "pid_alive", lambda _pid: False)
+    monkeypatch.setattr(cli, "atomic_upgrade_lock", lambda: nullcontext())
+    monkeypatch.setattr(cli, "activation_block_reason", lambda _activation: None)
+    monkeypatch.setattr(cli, "activate_upgrade_candidate", lambda _activation: calls.append("activate"))
+    monkeypatch.setattr(cli, "_prepare_show_runtime_after_install", lambda path: calls.append(f"prepare:{path}"))
+
+    result = cli._dispatch_deferred_upgrade_activation(
+        [
+            "--parent-pid",
+            "123",
+            "--launcher",
+            str(launcher),
+            "--candidate",
+            str(tmp_path / "candidate.exe"),
+            "--prepare-show-runtime",
+        ]
+    )
+
+    assert result == 0
+    assert calls == ["activate", f"prepare:{launcher}"]
 
 
 def test_deferred_upgrade_activation_uses_candidate_python(monkeypatch, tmp_path):
@@ -454,7 +591,7 @@ def test_deferred_activation_rejects_missing_source_when_launcher_changed(monkey
     calls: list[str] = []
     monkeypatch.setattr(cli.runtime, "pid_alive", lambda _pid: False)
     monkeypatch.setattr(cli, "atomic_upgrade_lock", lambda: nullcontext())
-    monkeypatch.setattr(cli, "atomic_activation_source_is_current", lambda _activation: False)
+    monkeypatch.setattr(cli, "activation_block_reason", lambda _activation: "superseded")
     monkeypatch.setattr(cli, "discard_atomic_uv_install_generation", lambda _path: calls.append("discard"))
     monkeypatch.setattr(cli, "activate_upgrade_candidate", lambda _activation: calls.append("activate"))
 
@@ -563,6 +700,17 @@ def test_restart_is_pending_until_the_seed_marker_is_terminal(monkeypatch, tmp_p
     assert restart_is_pending()
 
     runtime.write_json(status, {"state": "succeeded", "supervisor_pid": None})
+    assert not restart_is_pending()
+
+
+def test_legacy_restart_record_expires_even_when_its_pid_was_reused(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    status = runtime.get_restart_status_path()
+    status.parent.mkdir(parents=True)
+    runtime.write_json(status, {"state": "scheduled", "supervisor_pid": 456})
+    os.utime(status, (0, 0))
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 456)
+
     assert not restart_is_pending()
 
 

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from vibe import api, cli
 from vibe.runtime import ServiceLauncher
 from vibe.upgrade import (
+    AtomicActivation,
     UpgradePlan,
     build_upgrade_plan,
     has_newer_version,
@@ -68,8 +69,10 @@ def test_build_upgrade_plan_uses_uv_and_preserves_tool_bin_dir(monkeypatch):
     assert plan.method == "uv"
     assert plan.command == ["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"]
     assert plan.env is not None
-    assert plan.env["UV_TOOL_BIN_DIR"] == "/custom/bin"
+    assert "/runtime/install-generations/" in plan.env["UV_TOOL_DIR"]
+    assert plan.env["UV_TOOL_BIN_DIR"] != "/custom/bin"
     assert plan.env["PATH"] == "/usr/bin"
+    assert plan.activation is None
 
 
 def test_build_upgrade_plan_forces_legacy_uv_tool_install(monkeypatch):
@@ -98,6 +101,107 @@ def test_build_upgrade_plan_uses_pip_for_non_uv_install():
     assert plan.method == "pip"
     assert plan.command == ["/usr/bin/python3", "-m", "pip", "install", "--upgrade", "avibe-os"]
     assert plan.env == {"PATH": "/usr/bin"}
+
+
+def test_build_upgrade_plan_stages_uv_install_for_a_stable_launcher(monkeypatch, tmp_path):
+    launcher = tmp_path / "bin" / "vibe"
+    target = tmp_path / "old" / "vibe"
+    target.parent.mkdir(parents=True)
+    target.write_text("#!/bin/sh\n", encoding="utf-8")
+    launcher.parent.mkdir(parents=True)
+    launcher.symlink_to(target)
+    monkeypatch.setattr("vibe.upgrade.config_paths.get_vibe_remote_dir", lambda: tmp_path / "home")
+    monkeypatch.setattr("vibe.upgrade.os.path.exists", lambda path: True)
+    monkeypatch.setattr("vibe.upgrade.os.access", lambda path, mode: True)
+
+    plan = build_upgrade_plan(
+        python_executable="/tmp/.local/share/uv/tools/avibe-os/bin/python",
+        uv_path="/usr/local/bin/uv",
+        vibe_path=str(launcher),
+        base_env={"PATH": "/usr/bin"},
+    )
+
+    assert plan.activation is not None
+    assert plan.activation.launcher == launcher
+    assert plan.env is not None
+    assert plan.env["UV_TOOL_DIR"].startswith(str(tmp_path / "home" / "runtime" / "install-generations"))
+    assert plan.env["UV_TOOL_BIN_DIR"].startswith(str(tmp_path / "home" / "runtime" / "install-generations"))
+
+
+def test_activate_upgrade_candidate_replaces_launcher_only_after_verification(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    launcher = tmp_path / "bin" / "vibe"
+    old = tmp_path / "old" / "vibe"
+    candidate = tmp_path / "generation" / "bin" / "vibe"
+    old.parent.mkdir(parents=True)
+    candidate.parent.mkdir(parents=True)
+    old.write_text("old\n", encoding="utf-8")
+    candidate.write_text("new\n", encoding="utf-8")
+    candidate.chmod(0o755)
+    launcher.parent.mkdir(parents=True)
+    launcher.symlink_to(old)
+    activation = upgrade.AtomicActivation(launcher=launcher, candidate_launcher=candidate)
+    monkeypatch.setattr(upgrade, "verify_upgrade_candidate", lambda _activation: upgrade.IntegrityResult(True, 1))
+
+    upgrade.activate_upgrade_candidate(activation)
+
+    assert launcher.is_symlink()
+    assert launcher.resolve() == candidate.resolve()
+    assert old.read_text(encoding="utf-8") == "old\n"
+
+
+def test_verify_upgrade_candidate_follows_uv_launcher_to_tool_environment(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    launcher = tmp_path / "bin" / "vibe"
+    tool_bin = tmp_path / "tools" / "avibe-os" / "bin"
+    tool_bin.mkdir(parents=True)
+    launcher.parent.mkdir(parents=True)
+    launcher.symlink_to(tool_bin / "vibe")
+    (tool_bin / "vibe").write_text("#!/bin/sh\n", encoding="utf-8")
+    (tool_bin / "python3").write_text("#!/bin/sh\n", encoding="utf-8")
+    (tool_bin / "vibe").chmod(0o755)
+    (tool_bin / "python3").chmod(0o755)
+    activation = upgrade.AtomicActivation(launcher=launcher, candidate_launcher=launcher)
+    monkeypatch.setattr(upgrade, "verify_python_environment", lambda python: upgrade.IntegrityResult(True, 2))
+
+    result = upgrade.verify_upgrade_candidate(activation)
+
+    assert result.ok is True
+    assert result.checked_files == 2
+
+
+def test_do_upgrade_keeps_active_launcher_when_staged_install_fails(monkeypatch, tmp_path):
+    launcher = tmp_path / "bin" / "vibe"
+    old = tmp_path / "old" / "vibe"
+    candidate = tmp_path / "generation" / "bin" / "vibe"
+    old.parent.mkdir(parents=True)
+    candidate.parent.mkdir(parents=True)
+    old.write_text("old\n", encoding="utf-8")
+    candidate.write_text("partial\n", encoding="utf-8")
+    candidate.chmod(0o755)
+    launcher.parent.mkdir(parents=True)
+    launcher.symlink_to(old)
+    plan = UpgradePlan(
+        command=["uv", "tool", "install", "avibe-os", "--upgrade"],
+        env={},
+        method="uv",
+        activation=AtomicActivation(launcher, candidate),
+    )
+    monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: str(launcher))
+    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: False)
+    monkeypatch.setattr(
+        api.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(plan.command, 1, stdout="", stderr="interrupted"),
+    )
+
+    result = api.do_upgrade(auto_restart=False)
+
+    assert result["ok"] is False
+    assert launcher.resolve() == old.resolve()
 
 
 def test_build_upgrade_plan_uses_env_package_spec(monkeypatch):
@@ -877,7 +981,7 @@ def test_do_upgrade_uses_upgrade_plan_env_and_restarts(monkeypatch):
     assert calls["run_cmd"] == plan.command
     assert calls["run_kwargs"]["capture_output"] is True
     assert calls["run_kwargs"]["text"] is True
-    assert calls["run_kwargs"]["timeout"] == 120
+    assert calls["run_kwargs"]["timeout"] == 1800
     assert calls["run_kwargs"]["env"] == plan.env
     safe_cwd = calls["run_kwargs"].get("cwd")
     assert safe_cwd and os.path.isabs(safe_cwd), f"subprocess.run cwd must be an absolute path, got {safe_cwd!r}"

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -226,10 +226,15 @@ def test_activation_retains_the_generation_serving_a_live_process(monkeypatch, t
     running_python = root / "running" / "tools" / "avibe-os" / "bin" / "python"
     candidate = root / "candidate" / "bin" / "vibe"
     stale = root / "stale" / "bin" / "vibe"
-    for path in (previous, running_python, candidate, stale):
+    for path in (previous, candidate, stale):
         path.parent.mkdir(parents=True)
         path.write_text(path.parent.parent.name, encoding="utf-8")
         path.chmod(0o755)
+    shared_python = tmp_path / "shared-python" / "python"
+    shared_python.parent.mkdir()
+    shared_python.write_text("python", encoding="utf-8")
+    running_python.parent.mkdir(parents=True)
+    running_python.symlink_to(shared_python)
     launcher.parent.mkdir(parents=True)
     launcher.symlink_to(previous)
     monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
@@ -242,6 +247,30 @@ def test_activation_retains_the_generation_serving_a_live_process(monkeypatch, t
     assert previous.exists()
     assert running_python.exists()
     assert not stale.parent.parent.exists()
+
+
+def test_activation_compares_source_generation_by_filesystem_identity(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    physical_home = tmp_path / "physical-home"
+    logical_home = tmp_path / "logical-home"
+    logical_home.symlink_to(physical_home, target_is_directory=True)
+    root = physical_home / "runtime" / "install-generations"
+    source = root / "source" / "bin" / "vibe"
+    launcher = tmp_path / "bin" / "vibe"
+    source.parent.mkdir(parents=True)
+    launcher.parent.mkdir()
+    source.write_text("source", encoding="utf-8")
+    launcher.symlink_to(source)
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
+
+    activation = upgrade.AtomicActivation(
+        launcher,
+        root / "candidate" / "bin" / "vibe",
+        logical_home / "runtime" / "install-generations" / "source",
+    )
+
+    assert upgrade.atomic_activation_source_is_current(activation)
 
 
 def test_installer_activation_uses_the_shared_locked_boundary(monkeypatch, tmp_path):
@@ -264,6 +293,13 @@ def test_installer_activation_uses_the_shared_locked_boundary(monkeypatch, tmp_p
     upgrade.activate_installer_candidate(activation)
 
     assert events == ["lock-enter", "activate", "lock-exit"]
+
+
+def test_installer_activation_reports_its_protocol_version(capsys):
+    from vibe import cli
+
+    assert cli._dispatch_installer_activation(["--protocol-version"]) == 0
+    assert capsys.readouterr().out == "1\n"
 
 
 def test_installer_rejects_a_snapshot_superseded_by_runtime_activation(monkeypatch, tmp_path):

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -317,6 +317,25 @@ def test_launcher_generation_recognizes_windows_hardlink(monkeypatch, tmp_path):
     assert upgrade._launcher_generation(launcher, root) == generation
 
 
+def test_cli_launcher_path_uses_hardlinked_generation(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    root = tmp_path / "home" / "runtime" / "install-generations"
+    generation = root / "old"
+    source = generation / "bin" / "vibe.exe"
+    launcher = tmp_path / ".local" / "bin" / "vibe.exe"
+    source.parent.mkdir(parents=True)
+    launcher.parent.mkdir(parents=True)
+    source.write_text("old\n", encoding="utf-8")
+    source.chmod(0o755)
+    os.link(source, launcher)
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
+
+    saved = ServiceLauncher(python=str(launcher), main="service_main.py")
+
+    assert upgrade.get_cli_launcher_path(saved) == source
+
+
 def test_activate_upgrade_candidate_falls_back_to_hardlink(monkeypatch, tmp_path):
     from vibe import upgrade
 

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -361,6 +361,19 @@ def test_launcher_is_current_process_only_matches_windows_launcher(monkeypatch, 
     assert not upgrade.launcher_is_current_process(tmp_path / "bin" / "other.exe")
 
 
+def test_launcher_is_current_process_ignores_inherited_launcher_hint(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    launcher = tmp_path / "bin" / "vibe.exe"
+    launcher.parent.mkdir()
+    launcher.write_text("launcher\n", encoding="utf-8")
+    monkeypatch.setattr(upgrade.os, "name", "nt")
+    monkeypatch.setattr(upgrade.sys, "argv", [str(tmp_path / "service_main.py")])
+    monkeypatch.setenv("VIBE_CURRENT_EXECUTABLE", str(launcher))
+
+    assert not upgrade.launcher_is_current_process(launcher)
+
+
 def test_deferred_activation_dispatch_activates_then_schedules_restart(monkeypatch, tmp_path):
     from vibe import cli
 
@@ -433,6 +446,24 @@ def test_deferred_upgrade_activation_uses_candidate_python(monkeypatch, tmp_path
     assert "--restart" in calls["command"]
     assert "--prepare-show-runtime" in calls["command"]
     assert calls["kwargs"]["env"] == {"PATH": "clean"}
+
+
+def test_deferred_activation_rejects_missing_source_when_launcher_changed(monkeypatch, tmp_path):
+    from vibe import cli
+
+    calls: list[str] = []
+    monkeypatch.setattr(cli.runtime, "pid_alive", lambda _pid: False)
+    monkeypatch.setattr(cli, "atomic_upgrade_lock", lambda: nullcontext())
+    monkeypatch.setattr(cli, "atomic_activation_source_is_current", lambda _activation: False)
+    monkeypatch.setattr(cli, "discard_atomic_uv_install_generation", lambda _path: calls.append("discard"))
+    monkeypatch.setattr(cli, "activate_upgrade_candidate", lambda _activation: calls.append("activate"))
+
+    result = cli._dispatch_deferred_upgrade_activation(
+        ["--parent-pid", "123", "--launcher", str(tmp_path / "vibe.exe"), "--candidate", str(tmp_path / "candidate")]
+    )
+
+    assert result == 1
+    assert calls == ["discard"]
 
 
 def test_cli_launcher_path_uses_hardlinked_generation(monkeypatch, tmp_path):

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import ast
+from contextlib import nullcontext
 import os
+import stat
 import subprocess
 import sys
+from types import SimpleNamespace
 from pathlib import Path
 from typing import Any
 
@@ -24,6 +27,7 @@ from vibe.upgrade import (
     get_restart_environment,
     get_restart_invocation_command,
     get_restart_shell_command,
+    defer_upgrade_activation,
     prune_atomic_uv_install_generations,
     get_running_vibe_path,
     get_safe_cwd,
@@ -316,6 +320,119 @@ def test_launcher_generation_recognizes_windows_hardlink(monkeypatch, tmp_path):
     monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
 
     assert upgrade._launcher_generation(launcher, root) == generation
+
+
+def test_launcher_generation_does_not_match_hardlink_inode_on_another_device(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    root = tmp_path / "home" / "runtime" / "install-generations"
+    generation = root / "old"
+    source = generation / "bin" / "vibe.exe"
+    launcher = tmp_path / ".local" / "bin" / "vibe.exe"
+    source.parent.mkdir(parents=True)
+    launcher.parent.mkdir(parents=True)
+    source.write_text("old\n", encoding="utf-8")
+    launcher.write_text("old\n", encoding="utf-8")
+    original_stat = Path.stat
+
+    def fake_stat(path, *args, **kwargs):
+        if path == launcher:
+            return SimpleNamespace(st_dev=1, st_ino=7, st_mode=stat.S_IFREG)
+        if path == source:
+            return SimpleNamespace(st_dev=2, st_ino=7, st_mode=stat.S_IFREG)
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
+
+    assert upgrade._generation_for_hardlink(launcher, root) is None
+
+
+def test_launcher_is_current_process_only_matches_windows_launcher(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    launcher = tmp_path / "bin" / "vibe.exe"
+    launcher.parent.mkdir()
+    launcher.write_text("launcher\n", encoding="utf-8")
+    monkeypatch.setattr(upgrade.os, "name", "nt")
+    monkeypatch.setattr(upgrade.sys, "argv", [str(launcher)])
+
+    assert upgrade.launcher_is_current_process(launcher)
+    assert not upgrade.launcher_is_current_process(tmp_path / "bin" / "other.exe")
+
+
+def test_deferred_activation_dispatch_activates_then_schedules_restart(monkeypatch, tmp_path):
+    from vibe import cli
+
+    launcher = tmp_path / "bin" / "vibe.exe"
+    candidate = tmp_path / "generation" / "bin" / "vibe.exe"
+    calls: list[str] = []
+    monkeypatch.setattr(cli.runtime, "pid_alive", lambda _pid: False)
+    monkeypatch.setattr(cli, "atomic_upgrade_lock", lambda: nullcontext())
+    monkeypatch.setattr(cli, "atomic_activation_source_is_current", lambda _activation: True)
+    monkeypatch.setattr(cli, "activate_upgrade_candidate", lambda _activation: calls.append("activate"))
+    monkeypatch.setattr(cli, "schedule_restart", lambda **_kwargs: calls.append("restart"))
+
+    result = cli._dispatch_deferred_upgrade_activation(
+        [
+            "--parent-pid",
+            "123",
+            "--launcher",
+            str(launcher),
+            "--candidate",
+            str(candidate),
+            "--restart",
+        ]
+    )
+
+    assert result == 0
+    assert calls == ["activate", "restart"]
+
+
+def test_deferred_upgrade_activation_uses_candidate_python(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    launcher = tmp_path / ".local" / "bin" / "vibe.exe"
+    candidate = tmp_path / "generation" / "bin" / "vibe.exe"
+    candidate_python = tmp_path / "generation" / "tools" / "avibe-os" / "Scripts" / "python.exe"
+    candidate.parent.mkdir(parents=True)
+    candidate_python.parent.mkdir(parents=True)
+    candidate.write_text("candidate\n", encoding="utf-8")
+    candidate_python.write_text("python\n", encoding="utf-8")
+    activation = AtomicActivation(launcher, candidate, tmp_path / "generation")
+    rollback = RollbackTarget("3.0.10", "vibe-remote", ServiceLauncher("old-python", "old-main"))
+    calls = {}
+
+    monkeypatch.setattr(upgrade, "_candidate_python", lambda _candidate: candidate_python)
+    monkeypatch.setattr(upgrade.runtime_mod, "process_create_time", lambda _pid: 123.0)
+    monkeypatch.setattr(upgrade, "get_safe_cwd", lambda: str(tmp_path))
+    monkeypatch.setattr(upgrade, "isolated_probe_environment", lambda: {"PATH": "clean"})
+    monkeypatch.setattr(upgrade.config_paths, "get_logs_dir", lambda: tmp_path / "logs")
+
+    class Process:
+        pid = 456
+
+    def fake_popen(command, **kwargs):
+        calls["command"] = command
+        calls["kwargs"] = kwargs
+        return Process()
+
+    monkeypatch.setattr(upgrade.subprocess, "Popen", fake_popen)
+
+    process = defer_upgrade_activation(
+        activation,
+        parent_pid=123,
+        rollback_to=rollback,
+        restart_required=True,
+        prepare_show_runtime=True,
+    )
+
+    assert process.pid == 456
+    assert calls["command"][:4] == [str(candidate_python), "-c", "from vibe.cli import main; main()", "__activate-upgrade"]
+    assert "--parent-pid" in calls["command"]
+    assert "--restart" in calls["command"]
+    assert "--prepare-show-runtime" in calls["command"]
+    assert calls["kwargs"]["env"] == {"PATH": "clean"}
 
 
 def test_cli_launcher_path_uses_hardlinked_generation(monkeypatch, tmp_path):

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -11,7 +11,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from vibe import api, cli
+from vibe import api, cli, runtime
 from vibe.runtime import ServiceLauncher
 from vibe.upgrade import (
     AtomicActivation,
@@ -31,6 +31,7 @@ from vibe.upgrade import (
     pinned_package_spec,
     RollbackTarget,
     rollback_target,
+    restart_is_pending,
 )
 
 
@@ -360,13 +361,15 @@ def test_activate_upgrade_candidate_falls_back_to_copy_when_links_fail(monkeypat
     from vibe import upgrade
 
     launcher = tmp_path / ".local" / "bin" / "vibe"
-    candidate = tmp_path / "generation" / "bin" / "vibe"
+    root = tmp_path / "home" / "runtime" / "install-generations"
+    candidate = root / "generation" / "bin" / "vibe"
     launcher.parent.mkdir(parents=True)
     candidate.parent.mkdir(parents=True)
     launcher.write_text("old\n", encoding="utf-8")
     candidate.write_text("new\n", encoding="utf-8")
     candidate.chmod(0o755)
     activation = upgrade.AtomicActivation(launcher=launcher, candidate_launcher=candidate)
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
     monkeypatch.setattr(upgrade, "verify_upgrade_candidate", lambda _activation: upgrade.IntegrityResult(True, 1))
     monkeypatch.setattr(Path, "symlink_to", lambda self, _target: (_ for _ in ()).throw(OSError("symlink denied")))
     monkeypatch.setattr(upgrade.os, "link", lambda _target, _replacement: (_ for _ in ()).throw(OSError("cross-device link")))
@@ -375,6 +378,7 @@ def test_activate_upgrade_candidate_falls_back_to_copy_when_links_fail(monkeypat
 
     assert not launcher.is_symlink()
     assert launcher.read_text(encoding="utf-8") == "new\n"
+    assert upgrade._launcher_generation(launcher, root) == root / "generation"
 
 
 def test_is_uv_tool_install_uses_logical_atomic_generation_path(monkeypatch, tmp_path):
@@ -388,6 +392,49 @@ def test_is_uv_tool_install_uses_logical_atomic_generation_path(monkeypatch, tmp
     monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
 
     assert upgrade.is_uv_tool_install(str(executable))
+
+
+def test_custom_configured_bin_is_a_stable_launcher(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    launcher = tmp_path / "custom-tools" / "vibe.exe"
+    launcher.parent.mkdir(parents=True)
+    launcher.write_text("launcher\n", encoding="utf-8")
+    launcher.chmod(0o755)
+    monkeypatch.setenv("UV_TOOL_BIN_DIR", str(launcher.parent))
+
+    assert upgrade._is_stable_launcher_path(launcher)
+
+
+def test_restart_is_pending_until_the_seed_marker_is_terminal(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    status = runtime.get_restart_status_path()
+    status.parent.mkdir(parents=True)
+    runtime.write_json(status, {"state": "scheduled", "supervisor_pid": None})
+
+    assert restart_is_pending()
+
+    runtime.write_json(status, {"state": "succeeded", "supervisor_pid": None})
+    assert not restart_is_pending()
+
+
+def test_doctor_resolves_hardlinked_atomic_generation(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    root = tmp_path / "home" / "runtime" / "install-generations"
+    generation = root / "old"
+    launcher_source = generation / "bin" / "vibe.exe"
+    launcher = tmp_path / ".local" / "bin" / "vibe.exe"
+    site_packages = generation / "tools" / "avibe-os" / "lib" / "python3.12" / "site-packages"
+    launcher_source.parent.mkdir(parents=True)
+    site_packages.mkdir(parents=True)
+    launcher.parent.mkdir(parents=True)
+    launcher_source.write_text("launcher\n", encoding="utf-8")
+    os.link(launcher_source, launcher)
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
+    monkeypatch.setattr(cli, "atomic_uv_install_root", lambda: root)
+
+    assert site_packages in cli._uv_tool_site_packages_for_vibe(launcher)
 
 
 def test_do_upgrade_keeps_active_launcher_when_staged_install_fails(monkeypatch, tmp_path):

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -70,9 +70,9 @@ def test_build_upgrade_plan_uses_uv_and_preserves_tool_bin_dir(monkeypatch):
     assert plan.method == "uv"
     assert plan.command == ["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"]
     assert plan.env is not None
-    assert "/runtime/install-generations/" in plan.env["UV_TOOL_DIR"]
-    assert plan.env["UV_TOOL_BIN_DIR"] != "/custom/bin"
+    assert "UV_TOOL_DIR" not in plan.env
     assert plan.env["PATH"] == "/usr/bin"
+    assert plan.preflight_error is not None
     assert plan.activation is None
 
 
@@ -127,6 +127,21 @@ def test_build_upgrade_plan_stages_uv_install_for_a_stable_launcher(monkeypatch,
     assert plan.env is not None
     assert plan.env["UV_TOOL_DIR"].startswith(str(tmp_path / "home" / "runtime" / "install-generations"))
     assert plan.env["UV_TOOL_BIN_DIR"].startswith(str(tmp_path / "home" / "runtime" / "install-generations"))
+
+
+def test_build_upgrade_plan_refuses_uv_install_without_activation_point(monkeypatch):
+    monkeypatch.setattr("vibe.upgrade.os.path.exists", lambda path: True)
+    monkeypatch.setattr("vibe.upgrade.os.access", lambda path, mode: True)
+
+    plan = build_upgrade_plan(
+        python_executable="/tmp/.local/share/uv/tools/avibe-os/bin/python",
+        uv_path="/usr/local/bin/uv",
+        vibe_path="/tmp/.local/share/uv/tools/avibe-os/bin/vibe",
+        base_env={"PATH": "/usr/bin"},
+    )
+
+    assert plan.activation is None
+    assert plan.preflight_error is not None
 
 
 def test_activate_upgrade_candidate_replaces_launcher_only_after_verification(monkeypatch, tmp_path):
@@ -216,6 +231,54 @@ def test_verify_upgrade_candidate_follows_uv_launcher_to_tool_environment(monkey
 
     assert result.ok is True
     assert result.checked_files == 2
+
+
+def test_verify_upgrade_candidate_searches_staged_tools_for_windows_python(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    root = tmp_path / "generations"
+    candidate = root / "generation" / "bin" / "vibe.exe"
+    python = root / "generation" / "tools" / "avibe-os" / "Scripts" / "python.exe"
+    candidate.parent.mkdir(parents=True)
+    python.parent.mkdir(parents=True)
+    candidate.write_text("candidate\n", encoding="utf-8")
+    python.write_text("python\n", encoding="utf-8")
+    candidate.chmod(0o755)
+    python.chmod(0o755)
+    monkeypatch.setattr(upgrade.os, "name", "nt")
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
+    observed = {}
+
+    def verify(path):
+        observed["path"] = path
+        return upgrade.IntegrityResult(True, 3)
+
+    monkeypatch.setattr(upgrade, "verify_python_environment", verify)
+
+    result = upgrade.verify_upgrade_candidate(upgrade.AtomicActivation(candidate, candidate))
+
+    assert result.ok is True
+    assert observed["path"] == python
+
+
+def test_activate_upgrade_candidate_falls_back_to_hardlink(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    launcher = tmp_path / ".local" / "bin" / "vibe"
+    candidate = tmp_path / "generation" / "bin" / "vibe"
+    launcher.parent.mkdir(parents=True)
+    candidate.parent.mkdir(parents=True)
+    launcher.write_text("old\n", encoding="utf-8")
+    candidate.write_text("new\n", encoding="utf-8")
+    candidate.chmod(0o755)
+    activation = upgrade.AtomicActivation(launcher=launcher, candidate_launcher=candidate)
+    monkeypatch.setattr(upgrade, "verify_upgrade_candidate", lambda _activation: upgrade.IntegrityResult(True, 1))
+    monkeypatch.setattr(Path, "symlink_to", lambda self, _target: (_ for _ in ()).throw(OSError("symlink denied")))
+
+    upgrade.activate_upgrade_candidate(activation)
+
+    assert not launcher.is_symlink()
+    assert launcher.read_text(encoding="utf-8") == "new\n"
 
 
 def test_do_upgrade_keeps_active_launcher_when_staged_install_fails(monkeypatch, tmp_path):

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -24,6 +24,7 @@ from vibe.upgrade import (
     get_restart_environment,
     get_restart_invocation_command,
     get_restart_shell_command,
+    prune_atomic_uv_install_generations,
     get_running_vibe_path,
     get_safe_cwd,
     installed_package_name,
@@ -149,6 +150,51 @@ def test_activate_upgrade_candidate_replaces_launcher_only_after_verification(mo
     assert launcher.is_symlink()
     assert launcher.resolve() == candidate.resolve()
     assert old.read_text(encoding="utf-8") == "old\n"
+
+
+def test_activate_upgrade_candidate_replaces_windows_hardlink_launcher(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    launcher = tmp_path / ".local" / "bin" / "vibe.exe"
+    old_generation = tmp_path / "home" / "runtime" / "install-generations" / "old"
+    candidate = tmp_path / "home" / "runtime" / "install-generations" / "new" / "bin" / "vibe.exe"
+    launcher.parent.mkdir(parents=True)
+    old_launcher = old_generation / "bin" / "vibe.exe"
+    old_launcher.parent.mkdir(parents=True)
+    candidate.parent.mkdir(parents=True)
+    old_launcher.write_text("old\n", encoding="utf-8")
+    os.link(old_launcher, launcher)
+    os.utime(old_generation, (0, 0))
+    candidate.write_text("new\n", encoding="utf-8")
+    candidate.chmod(0o755)
+    activation = upgrade.AtomicActivation(launcher=launcher, candidate_launcher=candidate)
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: tmp_path / "home" / "runtime" / "install-generations")
+    monkeypatch.setattr(upgrade, "verify_upgrade_candidate", lambda _activation: upgrade.IntegrityResult(True, 1))
+
+    upgrade.activate_upgrade_candidate(activation)
+
+    assert launcher.is_symlink()
+    assert launcher.resolve() == candidate.resolve()
+
+
+def test_prune_atomic_uv_install_generations_keeps_active_and_rollback(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    root = tmp_path / "generations"
+    active = root / "active" / "bin" / "vibe"
+    rollback = root / "rollback" / "bin" / "vibe"
+    stale = root / "stale" / "bin" / "vibe"
+    for path in (active, rollback, stale):
+        path.parent.mkdir(parents=True)
+        path.write_text(path.parent.parent.name, encoding="utf-8")
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
+
+    removed = prune_atomic_uv_install_generations(keep=(active, rollback), min_age_seconds=0)
+
+    assert removed == [stale.parent.parent]
+    assert active.exists()
+    assert rollback.exists()
+    assert not stale.parent.parent.exists()
 
 
 def test_verify_upgrade_candidate_follows_uv_launcher_to_tool_environment(monkeypatch, tmp_path):

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -267,7 +267,7 @@ def test_activation_compares_source_generation_by_filesystem_identity(monkeypatc
     activation = upgrade.AtomicActivation(
         launcher,
         root / "candidate" / "bin" / "vibe",
-        logical_home / "runtime" / "install-generations" / "source",
+        logical_home / "runtime" / "install-generations" / "source" / "bin" / "vibe",
     )
 
     assert upgrade.atomic_activation_source_is_current(activation)

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -321,7 +321,25 @@ def test_installer_activation_reports_its_protocol_version(capsys):
     from vibe import cli
 
     assert cli._dispatch_installer_activation(["--protocol-version"]) == 0
-    assert capsys.readouterr().out == "1\n"
+    assert capsys.readouterr().out == "2\n"
+
+
+def test_installer_activation_snapshot_comes_from_shared_launcher_identity(monkeypatch, tmp_path, capsys):
+    from vibe import cli, upgrade
+
+    root = tmp_path / "generations"
+    generation = root / "active"
+    target = generation / "bin" / "vibe"
+    launcher = tmp_path / "bin" / "vibe"
+    target.parent.mkdir(parents=True)
+    launcher.parent.mkdir(parents=True)
+    target.write_text("active\n", encoding="utf-8")
+    launcher.symlink_to(target)
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
+    monkeypatch.setattr(cli, "atomic_uv_install_root", lambda: root)
+
+    assert cli._dispatch_installer_activation(["--snapshot", "--launcher", str(launcher)]) == 0
+    assert capsys.readouterr().out == f"{generation.resolve()}\n"
 
 
 def test_installer_rejects_a_snapshot_superseded_by_runtime_activation(monkeypatch, tmp_path):
@@ -480,6 +498,50 @@ def test_launcher_generation_does_not_match_hardlink_inode_on_another_device(mon
     monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
 
     assert upgrade._generation_for_hardlink(launcher, root) is None
+
+
+def test_hardlink_generation_lookup_degrades_when_root_cannot_be_enumerated(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    root = tmp_path / "home" / "runtime" / "install-generations"
+    launcher = tmp_path / ".local" / "bin" / "vibe.exe"
+    root.mkdir(parents=True)
+    launcher.parent.mkdir(parents=True)
+    launcher.write_text("launcher\n", encoding="utf-8")
+    original_iterdir = Path.iterdir
+
+    def denied(path):
+        if path == root.resolve():
+            raise PermissionError("denied")
+        return original_iterdir(path)
+
+    monkeypatch.setattr(Path, "iterdir", denied)
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
+
+    assert upgrade._generation_for_hardlink(launcher, root) is None
+
+
+def test_copy_marker_must_match_the_live_launcher(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    root = tmp_path / "home" / "runtime" / "install-generations"
+    old = root / "old"
+    current = root / "current"
+    launcher = tmp_path / ".local" / "bin" / "vibe.exe"
+    marker = launcher.parent / ".vibe.exe.avibe-generation"
+    for generation, content in ((old, "old\n"), (current, "current\n")):
+        candidate = generation / "bin" / "vibe.exe"
+        candidate.parent.mkdir(parents=True)
+        candidate.write_text(content, encoding="utf-8")
+    launcher.parent.mkdir(parents=True)
+    launcher.write_text("current\n", encoding="utf-8")
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
+
+    marker.write_text(str(old), encoding="utf-8")
+    assert upgrade._launcher_generation(launcher, root) is None
+
+    marker.write_text(str(current), encoding="utf-8")
+    assert upgrade._launcher_generation(launcher, root) == current.resolve()
 
 
 def test_launcher_is_current_process_only_matches_windows_launcher(monkeypatch, tmp_path):

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -28,7 +28,6 @@ from vibe.upgrade import (
     get_restart_invocation_command,
     get_restart_shell_command,
     defer_upgrade_activation,
-    prune_atomic_uv_install_generations,
     get_running_vibe_path,
     get_safe_cwd,
     installed_package_name,
@@ -199,56 +198,28 @@ def test_activate_upgrade_candidate_replaces_windows_hardlink_launcher(monkeypat
     assert launcher.resolve() == candidate.resolve()
 
 
-def test_prune_atomic_uv_install_generations_keeps_active_and_rollback(monkeypatch, tmp_path):
-    from vibe import upgrade
-
-    root = tmp_path / "generations"
-    active = root / "active" / "bin" / "vibe"
-    rollback = root / "rollback" / "bin" / "vibe"
-    stale = root / "stale" / "bin" / "vibe"
-    for path in (active, rollback, stale):
-        path.parent.mkdir(parents=True)
-        path.write_text(path.parent.parent.name, encoding="utf-8")
-    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
-
-    removed = prune_atomic_uv_install_generations(keep=(active, rollback), min_age_seconds=0)
-
-    assert removed == [stale.parent.parent]
-    assert active.exists()
-    assert rollback.exists()
-    assert not stale.parent.parent.exists()
-
-
-def test_activation_retains_the_generation_serving_a_live_process(monkeypatch, tmp_path):
+def test_activation_leaves_every_other_generation_untouched(monkeypatch, tmp_path):
     from vibe import upgrade
 
     root = tmp_path / "generations"
     launcher = tmp_path / "bin" / "vibe"
     previous = root / "previous" / "bin" / "vibe"
-    running_python = root / "running" / "tools" / "avibe-os" / "bin" / "python"
     candidate = root / "candidate" / "bin" / "vibe"
-    stale = root / "stale" / "bin" / "vibe"
-    for path in (previous, candidate, stale):
+    unrelated = root / "unrelated" / "bin" / "vibe"
+    for path in (previous, candidate, unrelated):
         path.parent.mkdir(parents=True)
         path.write_text(path.parent.parent.name, encoding="utf-8")
         path.chmod(0o755)
-    shared_python = tmp_path / "shared-python" / "python"
-    shared_python.parent.mkdir()
-    shared_python.write_text("python", encoding="utf-8")
-    running_python.parent.mkdir(parents=True)
-    running_python.symlink_to(shared_python)
     launcher.parent.mkdir(parents=True)
     launcher.symlink_to(previous)
     monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
-    monkeypatch.setattr(upgrade, "running_install_paths", lambda: (running_python,))
     monkeypatch.setattr(upgrade, "verify_upgrade_candidate", lambda _activation: upgrade.IntegrityResult(True, 1))
 
     upgrade.activate_upgrade_candidate(upgrade.AtomicActivation(launcher, candidate, root / "previous"))
 
     assert launcher.resolve() == candidate.resolve()
     assert previous.exists()
-    assert running_python.exists()
-    assert not stale.parent.parent.exists()
+    assert unrelated.exists()
 
 
 def test_activation_compares_source_generation_by_filesystem_identity(monkeypatch, tmp_path):
@@ -360,7 +331,6 @@ def test_installer_rejects_a_snapshot_superseded_by_runtime_activation(monkeypat
     launcher.symlink_to(old)
     installer_activation = upgrade.AtomicActivation(launcher, installer_candidate, root / "old")
     monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
-    monkeypatch.setattr(upgrade, "running_install_paths", lambda: ())
     monkeypatch.setattr(upgrade, "restart_is_pending", lambda: False)
     monkeypatch.setattr(upgrade, "verify_upgrade_candidate", lambda _activation: upgrade.IntegrityResult(True, 1))
 

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -273,6 +273,28 @@ def test_activation_compares_source_generation_by_filesystem_identity(monkeypatc
     assert upgrade.atomic_activation_source_is_current(activation)
 
 
+def test_activation_compares_a_conventional_launcher_snapshot(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    root = tmp_path / "runtime" / "install-generations"
+    old = tmp_path / "legacy" / "old-vibe"
+    new = tmp_path / "legacy" / "new-vibe"
+    launcher = tmp_path / "bin" / "vibe"
+    for path in (old, new):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(path.name, encoding="utf-8")
+        path.chmod(0o755)
+    launcher.parent.mkdir()
+    launcher.symlink_to(old)
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
+    activation = upgrade.AtomicActivation(launcher, root / "candidate" / "bin" / "vibe", old)
+
+    assert upgrade.atomic_activation_source_is_current(activation)
+    launcher.unlink()
+    launcher.symlink_to(new)
+    assert not upgrade.atomic_activation_source_is_current(activation)
+
+
 def test_installer_activation_uses_the_shared_locked_boundary(monkeypatch, tmp_path):
     from vibe import upgrade
 
@@ -746,6 +768,15 @@ def test_legacy_restart_record_expires_even_when_its_pid_was_reused(monkeypatch,
     runtime.write_json(status, {"state": "scheduled", "supervisor_pid": 456})
     os.utime(status, (0, 0))
     monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 456)
+
+    assert not restart_is_pending()
+
+
+def test_restart_state_with_a_non_object_shape_is_not_pending(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    status = runtime.get_restart_status_path()
+    status.parent.mkdir(parents=True)
+    status.write_text("[]", encoding="utf-8")
 
     assert not restart_is_pending()
 

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -241,7 +241,7 @@ def test_verify_upgrade_candidate_searches_staged_tools_for_windows_python(monke
     python = root / "generation" / "tools" / "avibe-os" / "Scripts" / "python.exe"
     candidate.parent.mkdir(parents=True)
     python.parent.mkdir(parents=True)
-    candidate.write_text("candidate\n", encoding="utf-8")
+    candidate.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     python.write_text("python\n", encoding="utf-8")
     candidate.chmod(0o755)
     python.chmod(0o755)
@@ -259,6 +259,62 @@ def test_verify_upgrade_candidate_searches_staged_tools_for_windows_python(monke
 
     assert result.ok is True
     assert observed["path"] == python
+
+
+def test_verify_upgrade_candidate_rejects_launcher_that_fails_startup_probe(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    candidate = tmp_path / "bin" / "vibe"
+    candidate.parent.mkdir(parents=True)
+    candidate.write_text("#!/bin/sh\nexit 9\n", encoding="utf-8")
+    candidate.chmod(0o755)
+    python = candidate.parent / "python3"
+    python.write_text("#!/bin/sh\n", encoding="utf-8")
+    python.chmod(0o755)
+    monkeypatch.setattr(upgrade, "verify_python_environment", lambda _python: upgrade.IntegrityResult(True, 3))
+
+    result = upgrade.verify_upgrade_candidate(upgrade.AtomicActivation(candidate, candidate))
+
+    assert result.ok is False
+    assert "launcher probe failed" in result.failures[0]
+
+
+def test_atomic_activation_source_must_still_be_active_under_lock(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    root = tmp_path / "home" / "runtime" / "install-generations"
+    old = root / "old" / "bin" / "vibe"
+    new = root / "new" / "bin" / "vibe"
+    launcher = tmp_path / ".local" / "bin" / "vibe"
+    for path in (old, new):
+        path.parent.mkdir(parents=True)
+        path.write_text(path.parent.parent.name, encoding="utf-8")
+        path.chmod(0o755)
+    launcher.parent.mkdir(parents=True)
+    launcher.symlink_to(old)
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
+    activation = upgrade.AtomicActivation(launcher, root / "candidate" / "bin" / "vibe", root / "old")
+
+    assert upgrade.atomic_activation_source_is_current(activation)
+    launcher.unlink()
+    launcher.symlink_to(new)
+    assert not upgrade.atomic_activation_source_is_current(activation)
+
+
+def test_launcher_generation_recognizes_windows_hardlink(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    root = tmp_path / "home" / "runtime" / "install-generations"
+    generation = root / "old"
+    source = generation / "bin" / "vibe.exe"
+    launcher = tmp_path / ".local" / "bin" / "vibe.exe"
+    source.parent.mkdir(parents=True)
+    launcher.parent.mkdir(parents=True)
+    source.write_text("old\n", encoding="utf-8")
+    os.link(source, launcher)
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
+
+    assert upgrade._launcher_generation(launcher, root) == generation
 
 
 def test_activate_upgrade_candidate_falls_back_to_hardlink(monkeypatch, tmp_path):
@@ -279,6 +335,40 @@ def test_activate_upgrade_candidate_falls_back_to_hardlink(monkeypatch, tmp_path
 
     assert not launcher.is_symlink()
     assert launcher.read_text(encoding="utf-8") == "new\n"
+
+
+def test_activate_upgrade_candidate_falls_back_to_copy_when_links_fail(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    launcher = tmp_path / ".local" / "bin" / "vibe"
+    candidate = tmp_path / "generation" / "bin" / "vibe"
+    launcher.parent.mkdir(parents=True)
+    candidate.parent.mkdir(parents=True)
+    launcher.write_text("old\n", encoding="utf-8")
+    candidate.write_text("new\n", encoding="utf-8")
+    candidate.chmod(0o755)
+    activation = upgrade.AtomicActivation(launcher=launcher, candidate_launcher=candidate)
+    monkeypatch.setattr(upgrade, "verify_upgrade_candidate", lambda _activation: upgrade.IntegrityResult(True, 1))
+    monkeypatch.setattr(Path, "symlink_to", lambda self, _target: (_ for _ in ()).throw(OSError("symlink denied")))
+    monkeypatch.setattr(upgrade.os, "link", lambda _target, _replacement: (_ for _ in ()).throw(OSError("cross-device link")))
+
+    upgrade.activate_upgrade_candidate(activation)
+
+    assert not launcher.is_symlink()
+    assert launcher.read_text(encoding="utf-8") == "new\n"
+
+
+def test_is_uv_tool_install_uses_logical_atomic_generation_path(monkeypatch, tmp_path):
+    from vibe import upgrade
+
+    root = tmp_path / "home" / "runtime" / "install-generations"
+    executable = root / "generation" / "tools" / "avibe-os" / "bin" / "python3"
+    executable.parent.mkdir(parents=True)
+    executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable.chmod(0o755)
+    monkeypatch.setattr(upgrade, "atomic_uv_install_root", lambda: root)
+
+    assert upgrade.is_uv_tool_install(str(executable))
 
 
 def test_do_upgrade_keeps_active_launcher_when_staged_install_fails(monkeypatch, tmp_path):

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -62,17 +62,22 @@ from vibe.opencode_config import (
 )
 from vibe.build_identity import get_build_identity
 from vibe.upgrade import (
+    AtomicActivation,
+    _candidate_python,
     activate_upgrade_candidate,
     atomic_activation_source_is_current,
     atomic_upgrade_lock,
     build_upgrade_plan,
+    defer_upgrade_activation,
     discard_atomic_uv_install_generation,
     get_latest_version_info,
     get_running_vibe_path,
     get_safe_cwd,
+    launcher_is_current_process,
     restart_is_pending,
     should_skip_show_runtime_prepare,
     UPGRADE_INSTALL_TIMEOUT_SECONDS,
+    verify_upgrade_candidate,
 )
 from vibe.restart_supervisor import schedule_restart
 from vibe import backend_model_catalog
@@ -6145,6 +6150,8 @@ def do_upgrade(auto_restart: bool = True) -> dict:
     restarting = False
     restart_failed = False
     runtime_output = None
+    deferred_activation = False
+    restart_python = None
 
     try:
         with atomic_upgrade_lock():
@@ -6177,7 +6184,25 @@ def do_upgrade(auto_restart: bool = True) -> dict:
             )
             if result.returncode == 0 and plan.activation is not None:
                 try:
-                    activate_upgrade_candidate(plan.activation)
+                    if os.name == "nt" and launcher_is_current_process(plan.activation.launcher):
+                        candidate_result = verify_upgrade_candidate(plan.activation)
+                        if not candidate_result.ok:
+                            raise RuntimeError(candidate_result.detail)
+                        defer_upgrade_activation(
+                            plan.activation,
+                            parent_pid=os.getpid(),
+                            rollback_to=plan.rollback_to,
+                            restart_required=auto_restart and runtime_was_running,
+                            prepare_show_runtime=(
+                                auto_restart
+                                and runtime_was_running
+                                and not should_skip_show_runtime_prepare()
+                            ),
+                        )
+                        deferred_activation = True
+                    else:
+                        restart_python = _candidate_python(plan.activation.candidate_launcher)
+                        activate_upgrade_candidate(plan.activation)
                 except Exception as exc:  # noqa: BLE001
                     discard_atomic_uv_install_generation(plan.activation.candidate_launcher)
                     return {
@@ -6197,7 +6222,7 @@ def do_upgrade(auto_restart: bool = True) -> dict:
                         "output": integrity.detail,
                         "restarting": False,
                     }
-            if result.returncode == 0 and auto_restart and runtime_was_running:
+            if result.returncode == 0 and auto_restart and runtime_was_running and not deferred_activation:
                 try:
                     schedule_restart(
                         delay_seconds=2.0,
@@ -6205,12 +6230,20 @@ def do_upgrade(auto_restart: bool = True) -> dict:
                         trigger="upgrade",
                         prepare_show_runtime=not should_skip_show_runtime_prepare(),
                         rollback_to=plan.rollback_to,
+                        **({"python_executable": str(restart_python)} if restart_python else {}),
                     )
                     restarting = True
                 except Exception as exc:
                     restart_failed = True
                     runtime_output = f"Restart scheduling failed; run `vibe restart` to use the new version.\n{exc}"
         if result.returncode == 0:
+            if deferred_activation:
+                return {
+                    "ok": True,
+                    "message": "Upgrade successful. Activation will complete after this process exits.",
+                    "output": _append_upgrade_output(result.stdout, None),
+                    "restarting": auto_restart and runtime_was_running,
+                }
             if not restarting and not restart_failed:
                 runtime_output = _prepare_show_runtime_after_upgrade(current_vibe_path, safe_cwd)
             if restarting:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -64,6 +64,7 @@ from vibe.build_identity import get_build_identity
 from vibe.upgrade import (
     activate_upgrade_candidate,
     build_upgrade_plan,
+    discard_atomic_uv_install_generation,
     get_latest_version_info,
     get_running_vibe_path,
     get_safe_cwd,
@@ -6151,6 +6152,7 @@ def do_upgrade(auto_restart: bool = True) -> dict:
                 try:
                     activate_upgrade_candidate(plan.activation)
                 except Exception as exc:  # noqa: BLE001
+                    discard_atomic_uv_install_generation(plan.activation.candidate_launcher)
                     return {
                         "ok": False,
                         "message": "Upgrade candidate failed integrity verification",
@@ -6198,6 +6200,8 @@ def do_upgrade(auto_restart: bool = True) -> dict:
                 "restarting": restarting,
             }
         else:
+            if plan.activation is not None:
+                discard_atomic_uv_install_generation(plan.activation.candidate_launcher)
             return {
                 "ok": False,
                 "message": "Upgrade failed",
@@ -6205,6 +6209,8 @@ def do_upgrade(auto_restart: bool = True) -> dict:
                 "restarting": False,
             }
     except subprocess.TimeoutExpired:
+        if plan.activation is not None:
+            discard_atomic_uv_install_generation(plan.activation.candidate_launcher)
         return {
             "ok": False,
             "message": "Upgrade timed out",
@@ -6212,6 +6218,8 @@ def do_upgrade(auto_restart: bool = True) -> dict:
             "restarting": False,
         }
     except Exception as e:
+        if plan.activation is not None:
+            discard_atomic_uv_install_generation(plan.activation.candidate_launcher)
         return {"ok": False, "message": str(e), "output": None, "restarting": False}
 
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -63,6 +63,7 @@ from vibe.opencode_config import (
 from vibe.build_identity import get_build_identity
 from vibe.upgrade import (
     activate_upgrade_candidate,
+    atomic_upgrade_lock,
     build_upgrade_plan,
     discard_atomic_uv_install_generation,
     get_latest_version_info,
@@ -6126,6 +6127,13 @@ def do_upgrade(auto_restart: bool = True) -> dict:
     """
     current_vibe_path = get_running_vibe_path()
     plan = build_upgrade_plan(vibe_path=current_vibe_path)
+    if plan.preflight_error:
+        return {
+            "ok": False,
+            "message": "Upgrade cannot be activated safely",
+            "output": plan.preflight_error,
+            "restarting": False,
+        }
     runtime_was_running = _runtime_process_was_running()
 
     # Use a stable directory as cwd to avoid "Current directory does not exist"
@@ -6134,21 +6142,21 @@ def do_upgrade(auto_restart: bool = True) -> dict:
     safe_cwd = get_safe_cwd()
 
     try:
-        result = subprocess.run(
-            plan.command,
-            capture_output=True,
-            text=True,
-            # A wheel install copies the complete candidate environment before
-            # it can be activated.  The old 120s bound interrupted that copy
-            # in-place and left metadata claiming a package tree that no longer
-            # existed.  The candidate is isolated now; this is only a bound for
-            # a genuinely hung resolver/download.
-            timeout=UPGRADE_INSTALL_TIMEOUT_SECONDS,
-            env=plan.env,
-            cwd=safe_cwd,
-        )
-        if result.returncode == 0:
-            if plan.activation is not None:
+        with atomic_upgrade_lock():
+            result = subprocess.run(
+                plan.command,
+                capture_output=True,
+                text=True,
+                # A wheel install copies the complete candidate environment before
+                # it can be activated.  The old 120s bound interrupted that copy
+                # in-place and left metadata claiming a package tree that no longer
+                # existed.  The candidate is isolated now; this is only a bound for
+                # a genuinely hung resolver/download.
+                timeout=UPGRADE_INSTALL_TIMEOUT_SECONDS,
+                env=plan.env,
+                cwd=safe_cwd,
+            )
+            if result.returncode == 0 and plan.activation is not None:
                 try:
                     activate_upgrade_candidate(plan.activation)
                 except Exception as exc:  # noqa: BLE001
@@ -6159,7 +6167,10 @@ def do_upgrade(auto_restart: bool = True) -> dict:
                         "output": str(exc),
                         "restarting": False,
                     }
-            elif plan.method == "pip":
+            elif result.returncode != 0 and plan.activation is not None:
+                discard_atomic_uv_install_generation(plan.activation.candidate_launcher)
+        if result.returncode == 0:
+            if plan.activation is None and plan.method == "pip":
                 integrity = verify_python_environment(sys.executable)
                 if not integrity.ok:
                     return {
@@ -6200,8 +6211,6 @@ def do_upgrade(auto_restart: bool = True) -> dict:
                 "restarting": restarting,
             }
         else:
-            if plan.activation is not None:
-                discard_atomic_uv_install_generation(plan.activation.candidate_launcher)
             return {
                 "ok": False,
                 "message": "Upgrade failed",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -12,6 +12,7 @@ import socket
 import ssl
 import stat
 import subprocess
+import sys
 import threading
 import time
 import urllib.parse
@@ -52,6 +53,7 @@ from config.v2_settings import (
 from config.v2_sessions import SessionsStore
 from config.platform_registry import get_platform_descriptor
 from core import latest_version_cache
+from core.install_integrity import verify_python_environment
 from core.memory.operation_lock import MemoryOperationBusy, MemoryOperationLease
 from vibe.opencode_config import (
     get_opencode_config_paths,
@@ -60,11 +62,13 @@ from vibe.opencode_config import (
 )
 from vibe.build_identity import get_build_identity
 from vibe.upgrade import (
+    activate_upgrade_candidate,
     build_upgrade_plan,
     get_latest_version_info,
     get_running_vibe_path,
     get_safe_cwd,
     should_skip_show_runtime_prepare,
+    UPGRADE_INSTALL_TIMEOUT_SECONDS,
 )
 from vibe.restart_supervisor import schedule_restart
 from vibe import backend_model_catalog
@@ -6133,11 +6137,35 @@ def do_upgrade(auto_restart: bool = True) -> dict:
             plan.command,
             capture_output=True,
             text=True,
-            timeout=120,
+            # A wheel install copies the complete candidate environment before
+            # it can be activated.  The old 120s bound interrupted that copy
+            # in-place and left metadata claiming a package tree that no longer
+            # existed.  The candidate is isolated now; this is only a bound for
+            # a genuinely hung resolver/download.
+            timeout=UPGRADE_INSTALL_TIMEOUT_SECONDS,
             env=plan.env,
             cwd=safe_cwd,
         )
         if result.returncode == 0:
+            if plan.activation is not None:
+                try:
+                    activate_upgrade_candidate(plan.activation)
+                except Exception as exc:  # noqa: BLE001
+                    return {
+                        "ok": False,
+                        "message": "Upgrade candidate failed integrity verification",
+                        "output": str(exc),
+                        "restarting": False,
+                    }
+            elif plan.method == "pip":
+                integrity = verify_python_environment(sys.executable)
+                if not integrity.ok:
+                    return {
+                        "ok": False,
+                        "message": "Upgrade installed an incomplete Python environment",
+                        "output": integrity.detail,
+                        "restarting": False,
+                    }
             restarting = False
             restart_failed = False
             runtime_output = None

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -70,6 +70,7 @@ from vibe.upgrade import (
     get_latest_version_info,
     get_running_vibe_path,
     get_safe_cwd,
+    restart_is_pending,
     should_skip_show_runtime_prepare,
     UPGRADE_INSTALL_TIMEOUT_SECONDS,
 )
@@ -6141,9 +6142,19 @@ def do_upgrade(auto_restart: bool = True) -> dict:
     # errors.  The vibe service process cwd may be inside the uv tool venv
     # directory, which uv deletes and recreates during upgrade.
     safe_cwd = get_safe_cwd()
+    restarting = False
+    restart_failed = False
+    runtime_output = None
 
     try:
         with atomic_upgrade_lock():
+            if restart_is_pending():
+                return {
+                    "ok": False,
+                    "message": "Upgrade already has a restart in progress",
+                    "output": "Wait for the pending restart to finish before starting another upgrade.",
+                    "restarting": False,
+                }
             if plan.activation is not None and not atomic_activation_source_is_current(plan.activation):
                 return {
                     "ok": False,
@@ -6177,8 +6188,7 @@ def do_upgrade(auto_restart: bool = True) -> dict:
                     }
             elif result.returncode != 0 and plan.activation is not None:
                 discard_atomic_uv_install_generation(plan.activation.candidate_launcher)
-        if result.returncode == 0:
-            if plan.activation is None and plan.method == "pip":
+            if result.returncode == 0 and plan.activation is None and plan.method == "pip":
                 integrity = verify_python_environment(sys.executable)
                 if not integrity.ok:
                     return {
@@ -6187,10 +6197,7 @@ def do_upgrade(auto_restart: bool = True) -> dict:
                         "output": integrity.detail,
                         "restarting": False,
                     }
-            restarting = False
-            restart_failed = False
-            runtime_output = None
-            if auto_restart and runtime_was_running:
+            if result.returncode == 0 and auto_restart and runtime_was_running:
                 try:
                     schedule_restart(
                         delay_seconds=2.0,
@@ -6203,7 +6210,8 @@ def do_upgrade(auto_restart: bool = True) -> dict:
                 except Exception as exc:
                     restart_failed = True
                     runtime_output = f"Restart scheduling failed; run `vibe restart` to use the new version.\n{exc}"
-            else:
+        if result.returncode == 0:
+            if not restarting and not restart_failed:
                 runtime_output = _prepare_show_runtime_after_upgrade(current_vibe_path, safe_cwd)
             if restarting:
                 message = "Upgrade successful. Restarting..."

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -63,6 +63,7 @@ from vibe.opencode_config import (
 from vibe.build_identity import get_build_identity
 from vibe.upgrade import (
     activate_upgrade_candidate,
+    atomic_activation_source_is_current,
     atomic_upgrade_lock,
     build_upgrade_plan,
     discard_atomic_uv_install_generation,
@@ -6143,6 +6144,13 @@ def do_upgrade(auto_restart: bool = True) -> dict:
 
     try:
         with atomic_upgrade_lock():
+            if plan.activation is not None and not atomic_activation_source_is_current(plan.activation):
+                return {
+                    "ok": False,
+                    "message": "Upgrade was superseded by another activation",
+                    "output": "The active Avibe generation changed while waiting for the upgrade lock; retry the upgrade.",
+                    "restarting": False,
+                }
             result = subprocess.run(
                 plan.command,
                 capture_output=True,

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -64,8 +64,8 @@ from vibe.build_identity import get_build_identity
 from vibe.upgrade import (
     AtomicActivation,
     _candidate_python,
+    activation_block_reason,
     activate_upgrade_candidate,
-    atomic_activation_source_is_current,
     atomic_upgrade_lock,
     build_upgrade_plan,
     defer_upgrade_activation,
@@ -6162,7 +6162,7 @@ def do_upgrade(auto_restart: bool = True) -> dict:
                     "output": "Wait for the pending restart to finish before starting another upgrade.",
                     "restarting": False,
                 }
-            if plan.activation is not None and not atomic_activation_source_is_current(plan.activation):
+            if plan.activation is not None and activation_block_reason(plan.activation) == "superseded":
                 return {
                     "ok": False,
                     "message": "Upgrade was superseded by another activation",
@@ -6193,11 +6193,7 @@ def do_upgrade(auto_restart: bool = True) -> dict:
                             parent_pid=os.getpid(),
                             rollback_to=plan.rollback_to,
                             restart_required=auto_restart and runtime_was_running,
-                            prepare_show_runtime=(
-                                auto_restart
-                                and runtime_was_running
-                                and not should_skip_show_runtime_prepare()
-                            ),
+                            prepare_show_runtime=not should_skip_show_runtime_prepare(),
                         )
                         deferred_activation = True
                     else:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -70,6 +70,7 @@ from vibe.upgrade import (
     LEGACY_PACKAGE_NAME,
     PACKAGE_NAME,
     activate_upgrade_candidate,
+    atomic_activation_source_is_current,
     atomic_uv_install_root,
     atomic_upgrade_lock,
     build_upgrade_plan,
@@ -14439,6 +14440,9 @@ def cmd_upgrade():
 
     try:
         with atomic_upgrade_lock():
+            if plan.activation is not None and not atomic_activation_source_is_current(plan.activation):
+                print("\033[31mUpgrade was superseded by another activation; retry the upgrade.\033[0m")
+                return 1
             result = subprocess.run(
                 plan.command,
                 capture_output=True,

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -71,6 +71,7 @@ from vibe.upgrade import (
     PACKAGE_NAME,
     activate_upgrade_candidate,
     atomic_uv_install_root,
+    atomic_upgrade_lock,
     build_upgrade_plan,
     cache_running_vibe_path,
     get_latest_version_info,
@@ -14426,6 +14427,9 @@ def cmd_upgrade():
 
     current_vibe_path = cache_running_vibe_path()
     plan = build_upgrade_plan(vibe_path=current_vibe_path)
+    if plan.preflight_error:
+        print(f"\033[31mUpgrade cannot be activated safely: {plan.preflight_error}\033[0m")
+        return 1
     print(f"Using {plan.method}: {' '.join(plan.command)}")
     runtime_was_running = _runtime_process_was_running()
 
@@ -14434,23 +14438,26 @@ def cmd_upgrade():
     safe_cwd = get_safe_cwd()
 
     try:
-        result = subprocess.run(
-            plan.command,
-            capture_output=True,
-            text=True,
-            env=plan.env,
-            cwd=safe_cwd,
-            timeout=UPGRADE_INSTALL_TIMEOUT_SECONDS,
-        )
-        if result.returncode == 0:
-            if plan.activation is not None:
+        with atomic_upgrade_lock():
+            result = subprocess.run(
+                plan.command,
+                capture_output=True,
+                text=True,
+                env=plan.env,
+                cwd=safe_cwd,
+                timeout=UPGRADE_INSTALL_TIMEOUT_SECONDS,
+            )
+            if result.returncode == 0 and plan.activation is not None:
                 try:
                     activate_upgrade_candidate(plan.activation)
                 except Exception as exc:  # noqa: BLE001
                     discard_atomic_uv_install_generation(plan.activation.candidate_launcher)
                     print(f"\033[31mUpgrade candidate failed integrity verification: {exc}\033[0m")
                     return 1
-            elif plan.method == "pip":
+            elif result.returncode != 0 and plan.activation is not None:
+                discard_atomic_uv_install_generation(plan.activation.candidate_launcher)
+        if result.returncode == 0:
+            if plan.activation is None and plan.method == "pip":
                 integrity = verify_python_environment(sys.executable)
                 if not integrity.ok:
                     print(f"\033[31mUpgrade installed an incomplete Python environment: {integrity.detail}\033[0m")
@@ -14479,8 +14486,6 @@ def cmd_upgrade():
                 print("Avibe was not running; the new version will be used next time you start it.")
             return 0
         else:
-            if plan.activation is not None:
-                discard_atomic_uv_install_generation(plan.activation.candidate_launcher)
             print(f"\033[31mUpgrade failed:\033[0m\n{result.stderr}")
             return 1
     except Exception as e:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -16819,6 +16819,9 @@ def _dispatch_deferred_upgrade_activation(argv: list[str]) -> int:
 def _dispatch_installer_activation(argv: list[str]) -> int:
     """Activate a staged one-command install through the shared Python owner."""
 
+    if argv == ["--protocol-version"]:
+        print("1")
+        return 0
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--launcher", required=True)
     parser.add_argument("--candidate", required=True)

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -75,6 +75,7 @@ from vibe.upgrade import (
     cache_running_vibe_path,
     get_latest_version_info,
     get_safe_cwd,
+    discard_atomic_uv_install_generation,
     should_skip_show_runtime_prepare,
     UPGRADE_INSTALL_TIMEOUT_SECONDS,
 )
@@ -14446,6 +14447,7 @@ def cmd_upgrade():
                 try:
                     activate_upgrade_candidate(plan.activation)
                 except Exception as exc:  # noqa: BLE001
+                    discard_atomic_uv_install_generation(plan.activation.candidate_launcher)
                     print(f"\033[31mUpgrade candidate failed integrity verification: {exc}\033[0m")
                     return 1
             elif plan.method == "pip":
@@ -14477,9 +14479,13 @@ def cmd_upgrade():
                 print("Avibe was not running; the new version will be used next time you start it.")
             return 0
         else:
+            if plan.activation is not None:
+                discard_atomic_uv_install_generation(plan.activation.candidate_launcher)
             print(f"\033[31mUpgrade failed:\033[0m\n{result.stderr}")
             return 1
     except Exception as e:
+        if plan.activation is not None:
+            discard_atomic_uv_install_generation(plan.activation.candidate_launcher)
         print(f"\033[31mUpgrade failed: {e}\033[0m")
         return 1
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -16820,13 +16820,21 @@ def _dispatch_installer_activation(argv: list[str]) -> int:
     """Activate a staged one-command install through the shared Python owner."""
 
     if argv == ["--protocol-version"]:
-        print("1")
+        print("2")
         return 0
     parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--snapshot", action="store_true")
     parser.add_argument("--launcher", required=True)
-    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--candidate")
     parser.add_argument("--source-generation")
     args = parser.parse_args(argv)
+    if args.snapshot:
+        generation = _launcher_generation(Path(args.launcher), atomic_uv_install_root())
+        if generation is not None:
+            print(generation)
+        return 0
+    if not args.candidate:
+        parser.error("--candidate is required unless --snapshot is used")
     activation = AtomicActivation(
         launcher=Path(args.launcher),
         candidate_launcher=Path(args.candidate),

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -51,6 +51,7 @@ from core.scheduled_tasks import (
 )
 from core.caller_context import caller_context_from_env, caller_resource_user_context
 from core.command_runner import command_line_preview
+from core.install_integrity import verify_python_environment, verify_site_packages
 from core.vibe_agents import AgentArchivedEditError, AgentArchiveError, AgentNameValidationError, AgentReferenceRewriteError, VibeAgent, VibeAgentStore, iter_global_agent_files, parse_agent_file, validate_agent_backend
 from core.watches import (
     DEFAULT_RETRY_EXIT_CODE,
@@ -68,11 +69,14 @@ from vibe.upgrade import (
     CURRENT_VIBE_EXECUTABLE_ENV,
     LEGACY_PACKAGE_NAME,
     PACKAGE_NAME,
+    activate_upgrade_candidate,
+    atomic_uv_install_root,
     build_upgrade_plan,
     cache_running_vibe_path,
     get_latest_version_info,
     get_safe_cwd,
     should_skip_show_runtime_prepare,
+    UPGRADE_INSTALL_TIMEOUT_SECONDS,
 )
 from storage.db import create_sqlite_engine
 from storage.background import (
@@ -11829,6 +11833,19 @@ def _uv_tool_site_packages_for_vibe(vibe_path: Path) -> list[Path]:
             seen_roots.add(key)
             tool_roots.append(resolved)
 
+    # Atomic upgrades keep each validated uv environment in a durable
+    # generation directory and switch only the stable PATH launcher.  Resolve
+    # that generation directly so doctor inspects the active candidate just as
+    # it inspects a conventional ``~/.local/share/uv/tools/<package>`` root.
+    try:
+        generation_root = atomic_uv_install_root().expanduser().resolve()
+        generation = vibe_path.expanduser().resolve().relative_to(generation_root).parts[0]
+    except (OSError, ValueError, IndexError):
+        generation = None
+    if generation:
+        for package_name in UV_TOOL_PACKAGE_NAMES:
+            add_tool_root(generation_root / generation / "tools" / package_name)
+
     parts = vibe_path.parts
     try:
         tools_index = parts.index("tools")
@@ -11993,6 +12010,28 @@ def _local_cli_installation_items() -> list[dict]:
             )
         else:
             _add_doctor_item(items, "pass", f"uv tool installation is not editable: {site_packages}")
+
+        # A successful package-manager exit only proves that its metadata was
+        # written.  RECORD is the wheel-level evidence that every installed
+        # file is still present and unchanged; this is what catches an
+        # interrupted dependency copy such as a half-written lark-oapi tree.
+        if any(site_packages.glob("*.dist-info")):
+            integrity = verify_site_packages(site_packages)
+            if integrity.ok:
+                _add_doctor_item(
+                    items,
+                    "pass",
+                    f"Python package files are intact: {integrity.detail}",
+                    code="installation.package_integrity",
+                )
+            else:
+                _add_doctor_item(
+                    items,
+                    "fail",
+                    f"Python package integrity check failed: {integrity.detail}",
+                    "Run `vibe upgrade` to install a new verified environment, or rerun the Avibe installer if the current CLI cannot start.",
+                    code="installation.package_integrity",
+                )
 
         alembic_dir = site_packages / "storage" / "alembic"
         versions_dir = alembic_dir / "versions"
@@ -14394,8 +14433,26 @@ def cmd_upgrade():
     safe_cwd = get_safe_cwd()
 
     try:
-        result = subprocess.run(plan.command, capture_output=True, text=True, env=plan.env, cwd=safe_cwd)
+        result = subprocess.run(
+            plan.command,
+            capture_output=True,
+            text=True,
+            env=plan.env,
+            cwd=safe_cwd,
+            timeout=UPGRADE_INSTALL_TIMEOUT_SECONDS,
+        )
         if result.returncode == 0:
+            if plan.activation is not None:
+                try:
+                    activate_upgrade_candidate(plan.activation)
+                except Exception as exc:  # noqa: BLE001
+                    print(f"\033[31mUpgrade candidate failed integrity verification: {exc}\033[0m")
+                    return 1
+            elif plan.method == "pip":
+                integrity = verify_python_environment(sys.executable)
+                if not integrity.ok:
+                    print(f"\033[31mUpgrade installed an incomplete Python environment: {integrity.detail}\033[0m")
+                    return 1
             print("\033[32mUpgrade successful!\033[0m")
             if runtime_was_running:
                 try:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -77,6 +77,8 @@ from vibe.upgrade import (
     cache_running_vibe_path,
     get_latest_version_info,
     get_safe_cwd,
+    _launcher_generation,
+    restart_is_pending,
     discard_atomic_uv_install_generation,
     should_skip_show_runtime_prepare,
     UPGRADE_INSTALL_TIMEOUT_SECONDS,
@@ -11840,14 +11842,11 @@ def _uv_tool_site_packages_for_vibe(vibe_path: Path) -> list[Path]:
     # generation directory and switch only the stable PATH launcher.  Resolve
     # that generation directly so doctor inspects the active candidate just as
     # it inspects a conventional ``~/.local/share/uv/tools/<package>`` root.
-    try:
-        generation_root = atomic_uv_install_root().expanduser().resolve()
-        generation = vibe_path.expanduser().resolve().relative_to(generation_root).parts[0]
-    except (OSError, ValueError, IndexError):
-        generation = None
+    generation_root = atomic_uv_install_root().expanduser().resolve()
+    generation = _launcher_generation(vibe_path, generation_root)
     if generation:
         for package_name in UV_TOOL_PACKAGE_NAMES:
-            add_tool_root(generation_root / generation / "tools" / package_name)
+            add_tool_root(generation / "tools" / package_name)
 
     parts = vibe_path.parts
     try:
@@ -14437,9 +14436,14 @@ def cmd_upgrade():
     # Use a stable directory as cwd to avoid issues when running from a
     # directory that uv may delete during upgrade (e.g. inside the uv tool venv).
     safe_cwd = get_safe_cwd()
+    restart = None
+    restart_error = None
 
     try:
         with atomic_upgrade_lock():
+            if restart_is_pending():
+                print("\033[31mUpgrade already has a restart in progress; wait for it to finish.\033[0m")
+                return 1
             if plan.activation is not None and not atomic_activation_source_is_current(plan.activation):
                 print("\033[31mUpgrade was superseded by another activation; retry the upgrade.\033[0m")
                 return 1
@@ -14460,14 +14464,12 @@ def cmd_upgrade():
                     return 1
             elif result.returncode != 0 and plan.activation is not None:
                 discard_atomic_uv_install_generation(plan.activation.candidate_launcher)
-        if result.returncode == 0:
-            if plan.activation is None and plan.method == "pip":
+            if result.returncode == 0 and plan.activation is None and plan.method == "pip":
                 integrity = verify_python_environment(sys.executable)
                 if not integrity.ok:
                     print(f"\033[31mUpgrade installed an incomplete Python environment: {integrity.detail}\033[0m")
                     return 1
-            print("\033[32mUpgrade successful!\033[0m")
-            if runtime_was_running:
+            if result.returncode == 0 and runtime_was_running:
                 try:
                     restart = schedule_restart(
                         delay_seconds=0.0,
@@ -14477,14 +14479,18 @@ def cmd_upgrade():
                         rollback_to=plan.rollback_to,
                     )
                 except Exception as exc:
-                    print("\033[33mUpgrade installed, but restart scheduling failed.\033[0m")
-                    print(f"Restart error: {exc}")
-                    print("Run `vibe restart` to use the new version.")
-                    return 2
-                else:
-                    print("Restart scheduled to use the new version.")
-                    print(f"Job ID: {restart['job_id']}")
-                    print("Run `vibe status` to inspect the restart result.")
+                    restart_error = exc
+        if result.returncode == 0:
+            print("\033[32mUpgrade successful!\033[0m")
+            if restart_error is not None:
+                print("\033[33mUpgrade installed, but restart scheduling failed.\033[0m")
+                print(f"Restart error: {restart_error}")
+                print("Run `vibe restart` to use the new version.")
+                return 2
+            if restart is not None:
+                print("Restart scheduled to use the new version.")
+                print(f"Job ID: {restart['job_id']}")
+                print("Run `vibe status` to inspect the restart result.")
             else:
                 _prepare_show_runtime_after_install(current_vibe_path)
                 print("Avibe was not running; the new version will be used next time you start it.")

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -72,8 +72,9 @@ from vibe.upgrade import (
     AtomicActivation,
     DEFERRED_ACTIVATION_TIMEOUT_SECONDS,
     RollbackTarget,
+    activate_installer_candidate,
     activate_upgrade_candidate,
-    atomic_activation_source_is_current,
+    activation_block_reason,
     atomic_uv_install_root,
     atomic_upgrade_lock,
     build_upgrade_plan,
@@ -85,6 +86,7 @@ from vibe.upgrade import (
     _candidate_python,
     launcher_is_current_process,
     restart_is_pending,
+    restart_record_is_pending,
     discard_atomic_uv_install_generation,
     should_skip_show_runtime_prepare,
     UPGRADE_INSTALL_TIMEOUT_SECONDS,
@@ -1231,17 +1233,7 @@ def _service_install_family_items(*, detect_extra_processes: bool = True) -> lis
 def _restart_status_is_stale(payload: dict, path: Path) -> bool:
     state = payload.get("state")
     if state in {"scheduled", "running"}:
-        supervisor_pid = payload.get("supervisor_pid")
-        if isinstance(supervisor_pid, int) and runtime.pid_alive(supervisor_pid):
-            started_at = payload.get("supervisor_started_at")
-            if started_at is not None:
-                current_started_at = runtime.process_create_time(supervisor_pid)
-                return current_started_at is not None and current_started_at != started_at
-        try:
-            age = time.time() - path.stat().st_mtime
-        except OSError:
-            return False
-        return age > DOCTOR_RESTART_SEED_GRACE_SECONDS
+        return not restart_record_is_pending(payload, path, grace_seconds=DOCTOR_RESTART_SEED_GRACE_SECONDS)
 
     if state in {"succeeded", "failed", "error", "cancelled"}:
         try:
@@ -14453,7 +14445,7 @@ def cmd_upgrade():
             if restart_is_pending():
                 print("\033[31mUpgrade already has a restart in progress; wait for it to finish.\033[0m")
                 return 1
-            if plan.activation is not None and not atomic_activation_source_is_current(plan.activation):
+            if plan.activation is not None and activation_block_reason(plan.activation) == "superseded":
                 print("\033[31mUpgrade was superseded by another activation; retry the upgrade.\033[0m")
                 return 1
             result = subprocess.run(
@@ -14475,7 +14467,7 @@ def cmd_upgrade():
                             parent_pid=os.getpid(),
                             rollback_to=plan.rollback_to,
                             restart_required=runtime_was_running,
-                            prepare_show_runtime=runtime_was_running and not should_skip_show_runtime_prepare(),
+                            prepare_show_runtime=not should_skip_show_runtime_prepare(),
                         )
                         deferred_activation = True
                     else:
@@ -16776,21 +16768,7 @@ def _dispatch_deferred_upgrade_activation(argv: list[str]) -> int:
         candidate_launcher=Path(args.candidate),
         source_generation=source_generation,
     )
-    try:
-        with atomic_upgrade_lock():
-            if not atomic_activation_source_is_current(activation):
-                discard_atomic_uv_install_generation(activation.candidate_launcher)
-                print("deferred upgrade activation was superseded by another activation", file=sys.stderr)
-                return 1
-            activate_upgrade_candidate(activation)
-    except Exception as exc:
-        discard_atomic_uv_install_generation(activation.candidate_launcher)
-        print(f"deferred upgrade activation failed: {exc}", file=sys.stderr)
-        return 1
-
-    if not args.restart:
-        return 0
-    if args.rollback_to and (not args.rollback_python or not args.rollback_main):
+    if args.restart and args.rollback_to and (not args.rollback_python or not args.rollback_main):
         print("deferred upgrade restart is missing its rollback launcher", file=sys.stderr)
         return 1
     rollback_to = (
@@ -16802,17 +16780,60 @@ def _dispatch_deferred_upgrade_activation(argv: list[str]) -> int:
         if args.rollback_to
         else None
     )
+    activated = False
     try:
-        schedule_restart(
-            delay_seconds=0.0,
-            vibe_path=args.launcher,
-            trigger="upgrade",
-            prepare_show_runtime=args.prepare_show_runtime,
-            rollback_to=rollback_to,
-            python_executable=sys.executable,
-        )
+        with atomic_upgrade_lock():
+            reason = activation_block_reason(activation)
+            if reason == "restart_pending":
+                discard_atomic_uv_install_generation(activation.candidate_launcher)
+                print("deferred upgrade activation found another restart in progress", file=sys.stderr)
+                return 1
+            if reason == "superseded":
+                discard_atomic_uv_install_generation(activation.candidate_launcher)
+                print("deferred upgrade activation was superseded by another activation", file=sys.stderr)
+                return 1
+            activate_upgrade_candidate(activation)
+            activated = True
+            if args.restart:
+                schedule_restart(
+                    delay_seconds=0.0,
+                    vibe_path=args.launcher,
+                    trigger="upgrade",
+                    prepare_show_runtime=args.prepare_show_runtime,
+                    rollback_to=rollback_to,
+                    python_executable=sys.executable,
+                )
     except Exception as exc:
-        print(f"deferred upgrade restart scheduling failed: {exc}", file=sys.stderr)
+        if not activated:
+            discard_atomic_uv_install_generation(activation.candidate_launcher)
+            print(f"deferred upgrade activation failed: {exc}", file=sys.stderr)
+        else:
+            print(f"deferred upgrade restart scheduling failed: {exc}", file=sys.stderr)
+        return 1
+
+    if not args.restart and args.prepare_show_runtime:
+        _prepare_show_runtime_after_install(args.launcher)
+    return 0
+
+
+def _dispatch_installer_activation(argv: list[str]) -> int:
+    """Activate a staged one-command install through the shared Python owner."""
+
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--launcher", required=True)
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--source-generation")
+    args = parser.parse_args(argv)
+    activation = AtomicActivation(
+        launcher=Path(args.launcher),
+        candidate_launcher=Path(args.candidate),
+        source_generation=Path(args.source_generation) if args.source_generation else None,
+    )
+    try:
+        activate_installer_candidate(activation)
+    except Exception as exc:
+        discard_atomic_uv_install_generation(activation.candidate_launcher)
+        print(f"installer activation failed: {exc}", file=sys.stderr)
         return 1
     return 0
 
@@ -16824,6 +16845,8 @@ def main():
         sys.exit(_dispatch_restart_supervisor(argv[1:]))
     if argv and argv[0] == "__activate-upgrade":
         sys.exit(_dispatch_deferred_upgrade_activation(argv[1:]))
+    if argv and argv[0] == "__activate-install":
+        sys.exit(_dispatch_installer_activation(argv[1:]))
     parser = build_parser()
     args = parser.parse_args()
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -12038,7 +12038,7 @@ def _local_cli_installation_items() -> list[dict]:
                     items,
                     "fail",
                     f"Python package integrity check failed: {integrity.detail}",
-                    "Run `vibe upgrade` to install a new verified environment, or rerun the Avibe installer if the current CLI cannot start.",
+                    "Rerun the Avibe installer to replace the active environment with a verified wheel.",
                     code="installation.package_integrity",
                 )
 
@@ -16778,7 +16778,7 @@ def _dispatch_deferred_upgrade_activation(argv: list[str]) -> int:
     )
     try:
         with atomic_upgrade_lock():
-            if source_generation is not None and not atomic_activation_source_is_current(activation):
+            if not atomic_activation_source_is_current(activation):
                 discard_atomic_uv_install_generation(activation.candidate_launcher)
                 print("deferred upgrade activation was superseded by another activation", file=sys.stderr)
                 return 1

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -69,19 +69,26 @@ from vibe.upgrade import (
     CURRENT_VIBE_EXECUTABLE_ENV,
     LEGACY_PACKAGE_NAME,
     PACKAGE_NAME,
+    AtomicActivation,
+    DEFERRED_ACTIVATION_TIMEOUT_SECONDS,
+    RollbackTarget,
     activate_upgrade_candidate,
     atomic_activation_source_is_current,
     atomic_uv_install_root,
     atomic_upgrade_lock,
     build_upgrade_plan,
     cache_running_vibe_path,
+    defer_upgrade_activation,
     get_latest_version_info,
     get_safe_cwd,
     _launcher_generation,
+    _candidate_python,
+    launcher_is_current_process,
     restart_is_pending,
     discard_atomic_uv_install_generation,
     should_skip_show_runtime_prepare,
     UPGRADE_INSTALL_TIMEOUT_SECONDS,
+    verify_upgrade_candidate,
 )
 from storage.db import create_sqlite_engine
 from storage.background import (
@@ -14438,6 +14445,8 @@ def cmd_upgrade():
     safe_cwd = get_safe_cwd()
     restart = None
     restart_error = None
+    deferred_activation = False
+    restart_python = None
 
     try:
         with atomic_upgrade_lock():
@@ -14457,7 +14466,21 @@ def cmd_upgrade():
             )
             if result.returncode == 0 and plan.activation is not None:
                 try:
-                    activate_upgrade_candidate(plan.activation)
+                    if os.name == "nt" and launcher_is_current_process(plan.activation.launcher):
+                        candidate_result = verify_upgrade_candidate(plan.activation)
+                        if not candidate_result.ok:
+                            raise RuntimeError(candidate_result.detail)
+                        defer_upgrade_activation(
+                            plan.activation,
+                            parent_pid=os.getpid(),
+                            rollback_to=plan.rollback_to,
+                            restart_required=runtime_was_running,
+                            prepare_show_runtime=runtime_was_running and not should_skip_show_runtime_prepare(),
+                        )
+                        deferred_activation = True
+                    else:
+                        restart_python = _candidate_python(plan.activation.candidate_launcher)
+                        activate_upgrade_candidate(plan.activation)
                 except Exception as exc:  # noqa: BLE001
                     discard_atomic_uv_install_generation(plan.activation.candidate_launcher)
                     print(f"\033[31mUpgrade candidate failed integrity verification: {exc}\033[0m")
@@ -14469,7 +14492,7 @@ def cmd_upgrade():
                 if not integrity.ok:
                     print(f"\033[31mUpgrade installed an incomplete Python environment: {integrity.detail}\033[0m")
                     return 1
-            if result.returncode == 0 and runtime_was_running:
+            if result.returncode == 0 and runtime_was_running and not deferred_activation:
                 try:
                     restart = schedule_restart(
                         delay_seconds=0.0,
@@ -14477,11 +14500,17 @@ def cmd_upgrade():
                         trigger="upgrade",
                         prepare_show_runtime=not should_skip_show_runtime_prepare(),
                         rollback_to=plan.rollback_to,
+                        **({"python_executable": str(restart_python)} if restart_python else {}),
                     )
                 except Exception as exc:
                     restart_error = exc
         if result.returncode == 0:
             print("\033[32mUpgrade successful!\033[0m")
+            if deferred_activation:
+                print("Upgrade validated; launcher activation will complete after this command exits.")
+                if runtime_was_running:
+                    print("Restart will be scheduled by the activation helper.")
+                return 0
             if restart_error is not None:
                 print("\033[33mUpgrade installed, but restart scheduling failed.\033[0m")
                 print(f"Restart error: {restart_error}")
@@ -16713,11 +16742,88 @@ def _dispatch_restart_supervisor(argv: list[str]) -> int:
     return restart_supervisor_main(argv)
 
 
+def _dispatch_deferred_upgrade_activation(argv: list[str]) -> int:
+    """Activate a Windows CLI upgrade after the parent launcher exits."""
+
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--parent-pid", type=int, required=True)
+    parser.add_argument("--parent-started-at", type=float)
+    parser.add_argument("--launcher", required=True)
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--source-generation")
+    parser.add_argument("--restart", action="store_true")
+    parser.add_argument("--prepare-show-runtime", action="store_true")
+    parser.add_argument("--rollback-to")
+    parser.add_argument("--rollback-package")
+    parser.add_argument("--rollback-python")
+    parser.add_argument("--rollback-main")
+    args = parser.parse_args(argv)
+
+    deadline = time.monotonic() + DEFERRED_ACTIVATION_TIMEOUT_SECONDS
+    while runtime.pid_alive(args.parent_pid):
+        if args.parent_started_at is not None:
+            observed = runtime.process_create_time(args.parent_pid)
+            if observed is not None and observed != args.parent_started_at:
+                break
+        if time.monotonic() >= deadline:
+            print("deferred upgrade activation timed out waiting for the parent launcher", file=sys.stderr)
+            return 1
+        time.sleep(0.1)
+
+    source_generation = Path(args.source_generation) if args.source_generation else None
+    activation = AtomicActivation(
+        launcher=Path(args.launcher),
+        candidate_launcher=Path(args.candidate),
+        source_generation=source_generation,
+    )
+    try:
+        with atomic_upgrade_lock():
+            if source_generation is not None and not atomic_activation_source_is_current(activation):
+                discard_atomic_uv_install_generation(activation.candidate_launcher)
+                print("deferred upgrade activation was superseded by another activation", file=sys.stderr)
+                return 1
+            activate_upgrade_candidate(activation)
+    except Exception as exc:
+        discard_atomic_uv_install_generation(activation.candidate_launcher)
+        print(f"deferred upgrade activation failed: {exc}", file=sys.stderr)
+        return 1
+
+    if not args.restart:
+        return 0
+    if args.rollback_to and (not args.rollback_python or not args.rollback_main):
+        print("deferred upgrade restart is missing its rollback launcher", file=sys.stderr)
+        return 1
+    rollback_to = (
+        RollbackTarget(
+            version=args.rollback_to,
+            package=args.rollback_package,
+            launcher=runtime.ServiceLauncher(python=args.rollback_python, main=args.rollback_main),
+        )
+        if args.rollback_to
+        else None
+    )
+    try:
+        schedule_restart(
+            delay_seconds=0.0,
+            vibe_path=args.launcher,
+            trigger="upgrade",
+            prepare_show_runtime=args.prepare_show_runtime,
+            rollback_to=rollback_to,
+            python_executable=sys.executable,
+        )
+    except Exception as exc:
+        print(f"deferred upgrade restart scheduling failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
 def main():
     cache_running_vibe_path()
     argv = sys.argv[1:]
     if argv and argv[0] == "__restart-supervisor":
         sys.exit(_dispatch_restart_supervisor(argv[1:]))
+    if argv and argv[0] == "__activate-upgrade":
+        sys.exit(_dispatch_deferred_upgrade_activation(argv[1:]))
     parser = build_parser()
     args = parser.parse_args()
 

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -32,6 +32,7 @@ from vibe.upgrade import (
     RollbackTarget,
     activate_launcher_target,
     atomic_uv_install_root,
+    get_cli_launcher_path,
     _names_a_published_release,
     build_upgrade_plan,
     get_restart_command,
@@ -668,7 +669,8 @@ def _roll_back_failed_upgrade(
     # A staged upgrade leaves the previous tool generation untouched. Reuse it
     # directly during rollback; reinstalling the old wheel would reintroduce a
     # long, mutable operation into the one path that exists to recover quickly.
-    if restore_stable_launcher and vibe_path and Path(rollback_to.launcher.main).is_file():
+    rollback_cli_launcher = get_cli_launcher_path(rollback_to.launcher) if restore_stable_launcher else None
+    if restore_stable_launcher and vibe_path and rollback_cli_launcher is not None:
         rollback["install"] = {"method": "atomic", "ok": True, "reused": True}
         record(rollback)
         write(f"reusing the previous {version} generation")
@@ -710,14 +712,14 @@ def _roll_back_failed_upgrade(
         record(rollback)
         write(f"installed {version} using {plan.method}")
 
-    if restore_stable_launcher and vibe_path:
+    if restore_stable_launcher and vibe_path and rollback_cli_launcher is not None:
         try:
-            activate_launcher_target(vibe_path, rollback_to.launcher.main)
+            activate_launcher_target(vibe_path, rollback_cli_launcher)
         except Exception as exc:  # noqa: BLE001
             rollback.update(state="failed", error=f"restoring the active launcher failed: {exc}")
             record(rollback)
             return rollback
-        rollback["launcher"] = {"restored": True, "path": rollback_to.launcher.main}
+        rollback["launcher"] = {"restored": True, "path": str(rollback_cli_launcher)}
         record(rollback)
 
     try:

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -30,6 +30,8 @@ from vibe.upgrade import (
     LEGACY_PACKAGE_NAME,
     PACKAGE_NAME,
     RollbackTarget,
+    activate_launcher_target,
+    atomic_uv_install_root,
     _names_a_published_release,
     build_upgrade_plan,
     get_restart_command,
@@ -627,6 +629,14 @@ def _roll_back_failed_upgrade(
     """
 
     version = rollback_to.version
+    restore_stable_launcher = False
+    if vibe_path:
+        try:
+            restore_stable_launcher = Path(vibe_path).expanduser().resolve().is_relative_to(
+                atomic_uv_install_root().expanduser().resolve()
+            )
+        except (OSError, RuntimeError, ValueError):
+            restore_stable_launcher = False
     rollback: dict = {"target_version": version, "state": "running", "started_at": _now_iso()}
     record(rollback)
     write(f"rolling back to {version}: no service is running after the failed restart")
@@ -655,42 +665,60 @@ def _roll_back_failed_upgrade(
         write(f"cannot roll back to {version}: the failed generation did not stop")
         return rollback
 
-    try:
-        plan = build_upgrade_plan(vibe_path=vibe_path, version=version, package_name=rollback_to.package)
-    except Exception as exc:
-        rollback.update(state="failed", error=f"cannot build a pinned install for {version}: {exc}")
+    # A staged upgrade leaves the previous tool generation untouched. Reuse it
+    # directly during rollback; reinstalling the old wheel would reintroduce a
+    # long, mutable operation into the one path that exists to recover quickly.
+    if restore_stable_launcher and vibe_path and Path(rollback_to.launcher.main).is_file():
+        rollback["install"] = {"method": "atomic", "ok": True, "reused": True}
         record(rollback)
-        return rollback
+        write(f"reusing the previous {version} generation")
+    else:
+        try:
+            plan = build_upgrade_plan(vibe_path=vibe_path, version=version, package_name=rollback_to.package)
+        except Exception as exc:
+            rollback.update(state="failed", error=f"cannot build a pinned install for {version}: {exc}")
+            record(rollback)
+            return rollback
 
-    rollback["install"] = {"method": plan.method, "ok": None}
-    record(rollback)
-    try:
-        result = subprocess.run(
-            plan.command,
-            capture_output=True,
-            text=True,
-            env=plan.env,
-            cwd=get_safe_cwd(),
-            timeout=_ROLLBACK_INSTALL_TIMEOUT_SECONDS,
-        )
-    except Exception as exc:
-        rollback["install"] = {"method": plan.method, "ok": False, "error": str(exc)}
-        rollback.update(state="failed", error=f"installing {version} failed: {exc}")
+        rollback["install"] = {"method": plan.method, "ok": None}
         record(rollback)
-        return rollback
-    if result.returncode != 0:
-        # The installer's own stderr, trimmed: it is the only account of why the
-        # rollback could not proceed, and the full text can be megabytes of
-        # resolver output.
-        detail = (result.stderr or result.stdout or "").strip()[-2000:]
-        rollback["install"] = {"method": plan.method, "ok": False, "error": detail or f"exit code {result.returncode}"}
-        rollback.update(state="failed", error=f"installing {version} failed with exit code {result.returncode}")
+        try:
+            result = subprocess.run(
+                plan.command,
+                capture_output=True,
+                text=True,
+                env=plan.env,
+                cwd=get_safe_cwd(),
+                timeout=_ROLLBACK_INSTALL_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            rollback["install"] = {"method": plan.method, "ok": False, "error": str(exc)}
+            rollback.update(state="failed", error=f"installing {version} failed: {exc}")
+            record(rollback)
+            return rollback
+        if result.returncode != 0:
+            # The installer's own stderr, trimmed: it is the only account of why the
+            # rollback could not proceed, and the full text can be megabytes of
+            # resolver output.
+            detail = (result.stderr or result.stdout or "").strip()[-2000:]
+            rollback["install"] = {"method": plan.method, "ok": False, "error": detail or f"exit code {result.returncode}"}
+            rollback.update(state="failed", error=f"installing {version} failed with exit code {result.returncode}")
+            record(rollback)
+            write(f"pinned install of {version} failed: {detail}")
+            return rollback
+        rollback["install"] = {"method": plan.method, "ok": True}
         record(rollback)
-        write(f"pinned install of {version} failed: {detail}")
-        return rollback
-    rollback["install"] = {"method": plan.method, "ok": True}
-    record(rollback)
-    write(f"installed {version} using {plan.method}")
+        write(f"installed {version} using {plan.method}")
+
+    if restore_stable_launcher and vibe_path:
+        try:
+            activate_launcher_target(vibe_path, rollback_to.launcher.main)
+        except Exception as exc:  # noqa: BLE001
+            rollback.update(state="failed", error=f"restoring the active launcher failed: {exc}")
+            record(rollback)
+            return rollback
+        rollback["launcher"] = {"restored": True, "path": rollback_to.launcher.main}
+        record(rollback)
 
     try:
         rollback["database"] = _restore_database_for_rollback(backup_watermark, write)

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -32,6 +32,7 @@ from vibe.upgrade import (
     RollbackTarget,
     activate_launcher_target,
     atomic_uv_install_root,
+    atomic_upgrade_lock,
     get_cli_launcher_path,
     _names_a_published_release,
     build_upgrade_plan,
@@ -714,7 +715,8 @@ def _roll_back_failed_upgrade(
 
     if restore_stable_launcher and vibe_path and rollback_cli_launcher is not None:
         try:
-            activate_launcher_target(vibe_path, rollback_cli_launcher)
+            with atomic_upgrade_lock():
+                activate_launcher_target(vibe_path, rollback_cli_launcher)
         except Exception as exc:  # noqa: BLE001
             rollback.update(state="failed", error=f"restoring the active launcher failed: {exc}")
             record(rollback)

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -33,6 +33,7 @@ from vibe.upgrade import (
     activate_launcher_target,
     atomic_uv_install_root,
     atomic_upgrade_lock,
+    _launcher_generation,
     get_cli_launcher_path,
     _names_a_published_release,
     build_upgrade_plan,
@@ -631,14 +632,9 @@ def _roll_back_failed_upgrade(
     """
 
     version = rollback_to.version
-    restore_stable_launcher = False
-    if vibe_path:
-        try:
-            restore_stable_launcher = Path(vibe_path).expanduser().resolve().is_relative_to(
-                atomic_uv_install_root().expanduser().resolve()
-            )
-        except (OSError, RuntimeError, ValueError):
-            restore_stable_launcher = False
+    restore_stable_launcher = bool(
+        vibe_path and _launcher_generation(Path(vibe_path).expanduser(), atomic_uv_install_root()) is not None
+    )
     rollback: dict = {"target_version": version, "state": "running", "started_at": _now_iso()}
     record(rollback)
     write(f"rolling back to {version}: no service is running after the failed restart")

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -1079,6 +1079,7 @@ def schedule_restart(
     prepare_show_runtime: bool = False,
     memory_ui_secret: str | None = None,
     rollback_to: RollbackTarget | None = None,
+    python_executable: str | None = None,
 ) -> dict:
     """Spawn the detached restart job.
 
@@ -1104,7 +1105,10 @@ def schedule_restart(
     memory_ui_secret = memory_ui_secret or process_ui_read_secret()
     guard_source_checkout_default_state_bootstrap()
     job_id = uuid.uuid4().hex[:12]
-    invocation = get_restart_invocation_command(vibe_path=vibe_path)
+    if python_executable:
+        invocation = [python_executable, "-c", "from vibe.cli import main; main()", "restart"]
+    else:
+        invocation = get_restart_invocation_command(vibe_path=vibe_path)
     command = [*invocation[:-1], "__restart-supervisor"] if invocation and invocation[-1] == "restart" else [
         *(invocation or ["vibe"]),
         "__restart-supervisor",

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -1081,6 +1081,32 @@ def schedule_restart(
     rollback_to: RollbackTarget | None = None,
     python_executable: str | None = None,
 ) -> dict:
+    """Serialize every restart seed with install activation and pruning."""
+
+    with atomic_upgrade_lock():
+        return _schedule_restart_locked(
+            delay_seconds=delay_seconds,
+            vibe_path=vibe_path,
+            trigger=trigger,
+            scope=scope,
+            prepare_show_runtime=prepare_show_runtime,
+            memory_ui_secret=memory_ui_secret,
+            rollback_to=rollback_to,
+            python_executable=python_executable,
+        )
+
+
+def _schedule_restart_locked(
+    *,
+    delay_seconds: float,
+    vibe_path: str | None,
+    trigger: str,
+    scope: str,
+    prepare_show_runtime: bool,
+    memory_ui_secret: str | None,
+    rollback_to: RollbackTarget | None,
+    python_executable: str | None,
+) -> dict:
     """Spawn the detached restart job.
 
     `rollback_to` is the install currently on the machine, and passing it is what

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -1083,6 +1083,12 @@ def schedule_restart(
 ) -> dict:
     """Serialize every restart seed with install activation and pruning."""
 
+    from storage.migrations import guard_source_checkout_default_state_bootstrap
+
+    # The lock lives under the runtime directory. Preserve the development
+    # guard's contract by checking it before lock acquisition can create that
+    # directory.
+    guard_source_checkout_default_state_bootstrap()
     with atomic_upgrade_lock():
         return _schedule_restart_locked(
             delay_seconds=delay_seconds,
@@ -1126,10 +1132,7 @@ def _schedule_restart_locked(
     is the only place they are put back together.
     """
     from core.memory.ui_access import process_ui_read_secret
-    from storage.migrations import guard_source_checkout_default_state_bootstrap
-
     memory_ui_secret = memory_ui_secret or process_ui_read_secret()
-    guard_source_checkout_default_state_bootstrap()
     job_id = uuid.uuid4().hex[:12]
     if python_executable:
         invocation = [python_executable, "-c", "from vibe.cli import main; main()", "restart"]

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -1139,6 +1139,12 @@ def schedule_restart(
         if rollback_to.package:
             command.extend(["--rollback-package", rollback_to.package])
     env = get_restart_environment(vibe_path=vibe_path)
+    if python_executable:
+        # A candidate supervisor must import the staged wheel, never a source
+        # checkout inherited from the parent process.
+        env = dict(os.environ if env is None else env)
+        env.pop("PYTHONPATH", None)
+        env.pop("PYTHONHOME", None)
     log_path = _restart_log_path(job_id)
     log_path.parent.mkdir(parents=True, exist_ok=True)
     # Seed the status BEFORE spawning the job so the child's own writes (which set

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -13,7 +14,10 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import NamedTuple, cast
+from uuid import uuid4
 
+from config import paths as config_paths
+from core.install_integrity import IntegrityResult, verify_python_environment
 from vibe import runtime as runtime_mod
 
 
@@ -26,6 +30,7 @@ CURRENT_VIBE_EXECUTABLE_ENV = "VIBE_CURRENT_EXECUTABLE"
 SHOW_RUNTIME_SKIP_ENV = "VIBE_INSTALL_SKIP_SHOW_RUNTIME"
 TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
 UV_FALLBACK_BIN_DIRS = (".local/bin", ".cargo/bin")
+UPGRADE_INSTALL_TIMEOUT_SECONDS = 30 * 60
 # A spec that names nothing but a package, so appending ``==<version>`` to it
 # yields a requirement rather than a broken string. PEP 508 names only:
 # anything with a path separator, a URL scheme, extras, a marker, or a version
@@ -84,6 +89,101 @@ class UpgradePlan:
     env: dict[str, str] | None
     method: str
     rollback_to: RollbackTarget | None = None
+    activation: "AtomicActivation | None" = None
+
+
+@dataclass(frozen=True)
+class AtomicActivation:
+    """A validated candidate and the stable launcher it will replace."""
+
+    launcher: Path
+    candidate_launcher: Path
+
+
+def atomic_uv_install_root() -> Path:
+    """Return the durable root for versioned uv tool environments."""
+
+    return config_paths.get_vibe_remote_dir() / "runtime" / "install-generations"
+
+
+def _staged_uv_environment(vibe_path: str | None) -> tuple[Path, Path, AtomicActivation | None]:
+    generation = atomic_uv_install_root() / uuid4().hex
+    tools_dir = generation / "tools"
+    bin_dir = generation / "bin"
+    if not vibe_path:
+        return tools_dir, bin_dir, None
+
+    launcher = Path(vibe_path).expanduser()
+    # Only replace a stable launcher link. A direct path into a virtualenv may
+    # be the user's intentional installation and cannot be switched safely by
+    # replacing the file the current process is executing.
+    if not launcher.is_symlink():
+        return tools_dir, bin_dir, None
+    candidate = bin_dir / launcher.name
+    return tools_dir, bin_dir, AtomicActivation(launcher=launcher, candidate_launcher=candidate)
+
+
+def _candidate_python(candidate_launcher: Path) -> Path | None:
+    roots = [candidate_launcher.parent]
+    with contextlib.suppress(OSError, RuntimeError):
+        resolved_parent = candidate_launcher.resolve().parent
+        if resolved_parent not in roots:
+            roots.append(resolved_parent)
+    names = ("python.exe", "python3.exe", "python3", "python") if os.name == "nt" else ("python3", "python")
+    for root in roots:
+        for name in names:
+            candidate = root / name
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return candidate
+    return None
+
+
+def verify_upgrade_candidate(activation: AtomicActivation) -> IntegrityResult:
+    """Prove a staged tool is runnable and its package tree is complete."""
+
+    candidate = activation.candidate_launcher
+    if not candidate.is_file() or not os.access(candidate, os.X_OK):
+        return IntegrityResult(False, failures=(f"candidate launcher missing: {candidate}",))
+    python = _candidate_python(candidate)
+    if python is None:
+        return IntegrityResult(False, failures=(f"candidate Python missing beside {candidate}",))
+    return verify_python_environment(python)
+
+
+def activate_upgrade_candidate(activation: AtomicActivation) -> None:
+    """Atomically switch the stable launcher to a validated candidate."""
+
+    result = verify_upgrade_candidate(activation)
+    if not result.ok:
+        raise RuntimeError(f"staged Avibe install failed integrity checks: {result.detail}")
+    launcher = activation.launcher
+    launcher.parent.mkdir(parents=True, exist_ok=True)
+    replacement = launcher.parent / f".{launcher.name}.avibe-{uuid4().hex}.new"
+    try:
+        replacement.symlink_to(activation.candidate_launcher)
+        os.replace(replacement, launcher)
+    except Exception:
+        with contextlib.suppress(OSError):
+            replacement.unlink()
+        raise
+
+
+def activate_launcher_target(launcher: str | os.PathLike[str], target: str | os.PathLike[str]) -> None:
+    """Atomically point a stable launcher at an already installed target."""
+
+    launcher_path = Path(launcher).expanduser()
+    target_path = Path(target).expanduser()
+    if not target_path.is_file() or not os.access(target_path, os.X_OK):
+        raise RuntimeError(f"rollback launcher is not executable: {target_path}")
+    launcher_path.parent.mkdir(parents=True, exist_ok=True)
+    replacement = launcher_path.parent / f".{launcher_path.name}.avibe-{uuid4().hex}.new"
+    try:
+        replacement.symlink_to(target_path)
+        os.replace(replacement, launcher_path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            replacement.unlink()
+        raise
 
 
 def resolve_command_path(command: str | None, search_path: str | None = None) -> str | None:
@@ -459,7 +559,12 @@ def get_latest_version_info(current_version: str) -> dict:
 
 def is_uv_tool_install(python_executable: str | None = None) -> bool:
     executable = (python_executable or sys.executable or "").replace("\\", "/")
-    return "/uv/tools/" in executable
+    if "/uv/tools/" in executable:
+        return True
+    try:
+        return Path(executable).expanduser().resolve().is_relative_to(atomic_uv_install_root().resolve())
+    except (OSError, ValueError, RuntimeError):
+        return False
 
 
 def is_legacy_uv_tool_install(python_executable: str | None = None) -> bool:
@@ -789,9 +894,15 @@ def build_upgrade_plan(
 
     if is_uv_tool_install(executable) and uv_binary:
         env = dict(base_env or os.environ)
-        vibe_bin_dir = get_current_vibe_bin_dir(vibe_path)
-        if vibe_bin_dir:
-            env["UV_TOOL_BIN_DIR"] = vibe_bin_dir
+        atomic = None
+        if version is None:
+            tool_dir, bin_dir, atomic = _staged_uv_environment(vibe_path)
+            env["UV_TOOL_DIR"] = str(tool_dir)
+            env["UV_TOOL_BIN_DIR"] = str(bin_dir)
+        else:
+            vibe_bin_dir = get_current_vibe_bin_dir(vibe_path)
+            if vibe_bin_dir:
+                env["UV_TOOL_BIN_DIR"] = vibe_bin_dir
         command = [uv_binary, "tool", "install", package_spec]
         if not version:
             command.append("--upgrade")
@@ -802,6 +913,7 @@ def build_upgrade_plan(
             env=env,
             method="uv",
             rollback_to=rollback_to,
+            activation=atomic,
         )
 
     command = [executable, "-m", "pip", "install"]

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -173,13 +173,11 @@ def launcher_is_current_process(launcher: Path | str) -> bool:
     if os.name != "nt":
         return False
     target = os.path.normcase(os.path.abspath(os.path.expanduser(str(launcher))))
-    for candidate in (sys.argv[0], os.environ.get(CURRENT_VIBE_EXECUTABLE_ENV)):
-        if not candidate:
-            continue
-        current = os.path.normcase(os.path.abspath(os.path.expanduser(candidate)))
-        if current == target:
-            return True
-    return False
+    # ``VIBE_CURRENT_EXECUTABLE`` is inherited by the long-lived Web process
+    # from the CLI that started it. It identifies a PATH entry, not the image
+    # currently holding the file open, so only argv[0] is authoritative here.
+    current = os.path.normcase(os.path.abspath(os.path.expanduser(sys.argv[0])))
+    return current == target
 
 
 def _staged_uv_environment(vibe_path: str | None) -> tuple[Path, Path, AtomicActivation | None]:

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -130,6 +130,17 @@ def restart_is_pending() -> bool:
 
     path = runtime_mod.get_restart_status_path()
     payload = runtime_mod.read_json(path) or {}
+    return restart_record_is_pending(payload, path)
+
+
+def restart_record_is_pending(
+    payload: Mapping[str, object],
+    path: Path,
+    *,
+    grace_seconds: float = RESTART_PENDING_GRACE_SECONDS,
+) -> bool:
+    """Apply the restart ownership policy to one persisted status record."""
+
     if payload.get("state") not in {"scheduled", "running"}:
         return False
     supervisor_pid = payload.get("supervisor_pid")
@@ -137,14 +148,16 @@ def restart_is_pending() -> bool:
         started_at = payload.get("supervisor_started_at")
         if started_at is not None:
             current_started_at = runtime_mod.process_create_time(supervisor_pid)
-            if current_started_at is not None and current_started_at != started_at:
-                return False
-        return True
+            if current_started_at is not None:
+                return current_started_at == started_at
+        # Legacy records do not carry a process identity, and process metadata
+        # can be unavailable. In both cases a reused PID must not block upgrades
+        # for the lifetime of an unrelated process, so fall through to age.
     try:
         age = time.time() - path.stat().st_mtime
     except OSError:
         return False
-    return age <= RESTART_PENDING_GRACE_SECONDS
+    return age <= grace_seconds
 
 
 def _is_stable_launcher_path(launcher: Path) -> bool:
@@ -391,6 +404,52 @@ def atomic_activation_source_is_current(activation: AtomicActivation) -> bool:
     return _launcher_generation(activation.launcher, atomic_uv_install_root()) == activation.source_generation
 
 
+def activation_block_reason(activation: AtomicActivation) -> str | None:
+    """Return why an activation cannot own the current install boundary."""
+
+    if restart_is_pending():
+        return "restart_pending"
+    if not atomic_activation_source_is_current(activation):
+        return "superseded"
+    return None
+
+
+def _process_python_path(pid: int | None) -> Path | None:
+    if not pid:
+        return None
+    command = runtime_mod.get_process_command(pid)
+    if not command:
+        return None
+    try:
+        argv = [part.strip("\"'") for part in shlex.split(command, posix=(os.name != "nt"))]
+    except ValueError:
+        return None
+    if argv and Path(argv[0]).name.lower() == "systemd-run" and "--" in argv:
+        argv = argv[argv.index("--") + 1 :]
+    if not argv or not Path(argv[0]).name.lower().startswith("python"):
+        return None
+    return Path(argv[0]).expanduser()
+
+
+def running_install_paths() -> tuple[Path, ...]:
+    """Paths whose generations are still executing and therefore cannot be pruned."""
+
+    paths: list[Path] = [Path(sys.executable).expanduser()]
+    pids = [runtime_mod.resolve_service_owner_pid(include_starting=True)]
+    pids.extend(runtime_mod.extra_service_process_pids())
+    ui_pid_path = config_paths.get_runtime_ui_pid_path()
+    try:
+        ui_pid = int(ui_pid_path.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        ui_pid = None
+    if ui_pid and runtime_mod.ui_pid_file_points_to_running_ui(ui_pid_path):
+        pids.append(ui_pid)
+    for pid in pids:
+        if (python_path := _process_python_path(pid)) is not None:
+            paths.append(python_path)
+    return tuple(dict.fromkeys(paths))
+
+
 def prune_atomic_uv_install_generations(
     *,
     keep: Iterable[Path] = (),
@@ -518,13 +577,25 @@ def activate_upgrade_candidate(activation: AtomicActivation) -> None:
         raise
     _update_launcher_generation_marker(launcher, activation.candidate_launcher, root)
     if _generation_for_path(activation.candidate_launcher, root) is not None:
-        keep_paths = [activation.candidate_launcher]
+        keep_paths = [activation.candidate_launcher, *running_install_paths()]
         if previous_target:
             keep_paths.append(previous_target)
         if previous_generation:
             keep_paths.append(previous_generation)
         keep = tuple(keep_paths)
         prune_atomic_uv_install_generations(keep=keep)
+
+
+def activate_installer_candidate(activation: AtomicActivation) -> None:
+    """Activate an installer candidate through the shared lifecycle owner."""
+
+    with atomic_upgrade_lock():
+        reason = activation_block_reason(activation)
+        if reason == "restart_pending":
+            raise RuntimeError("an Avibe restart is still in progress")
+        if reason == "superseded":
+            raise RuntimeError("the active Avibe generation changed while the installer was staging")
+        activate_upgrade_candidate(activation)
 
 
 def activate_launcher_target(launcher: str | os.PathLike[str], target: str | os.PathLike[str]) -> None:

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import filecmp
 import json
 import logging
 import os
@@ -375,10 +376,14 @@ def _generation_for_hardlink(launcher: Path, root: Path) -> Path | None:
         identity = (launcher_stat.st_dev, launcher_stat.st_ino)
     except OSError:
         return None
-    root = root.expanduser().resolve()
-    if not root.is_dir():
+    try:
+        root = root.expanduser().resolve()
+        if not root.is_dir():
+            return None
+        generations = list(root.iterdir())
+    except OSError:
         return None
-    for generation in root.iterdir():
+    for generation in generations:
         candidate = generation / "bin" / launcher.name
         try:
             candidate_stat = candidate.stat()
@@ -404,7 +409,15 @@ def _launcher_generation(launcher: Path, root: Path) -> Path | None:
     except (OSError, UnicodeError):
         return None
     generation = _generation_for_path(marked, root)
-    return generation if generation is not None and generation.is_dir() else None
+    if generation is None or not generation.is_dir():
+        return None
+    # A marker is necessary only for the cross-volume copy fallback. Treat it
+    # as a hint and prove that it still describes the live launcher before use.
+    candidate = generation / "bin" / launcher.name
+    try:
+        return generation if filecmp.cmp(launcher, candidate, shallow=False) else None
+    except OSError:
+        return None
 
 
 def _update_launcher_generation_marker(launcher: Path, target: Path, root: Path) -> None:

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -16,7 +16,7 @@ import urllib.request
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, NamedTuple, cast
+from typing import NamedTuple, cast
 from uuid import uuid4
 
 from config import paths as config_paths
@@ -42,9 +42,6 @@ UV_FALLBACK_BIN_DIRS = (".local/bin", ".cargo/bin")
 UPGRADE_INSTALL_TIMEOUT_SECONDS = 30 * 60
 RESTART_PENDING_GRACE_SECONDS = 5 * 60
 DEFERRED_ACTIVATION_TIMEOUT_SECONDS = 5 * 60
-# Once a new generation is validated, only active and rollback generations are
-# retained. Failed candidates are discarded by the callers before activation.
-ATOMIC_GENERATION_RETENTION_SECONDS = 0
 # A spec that names nothing but a package, so appending ``==<version>`` to it
 # yields a requirement rather than a broken string. PEP 508 names only:
 # anything with a path separator, a URL scheme, extras, a marker, or a version
@@ -459,82 +456,6 @@ def activation_block_reason(activation: AtomicActivation) -> str | None:
     return None
 
 
-def _process_python_path(pid: int | None) -> Path | None:
-    if not pid:
-        return None
-    command = runtime_mod.get_process_command(pid)
-    if not command:
-        return None
-    try:
-        argv = [part.strip("\"'") for part in shlex.split(command, posix=(os.name != "nt"))]
-    except ValueError:
-        return None
-    if argv and Path(argv[0]).name.lower() == "systemd-run" and "--" in argv:
-        argv = argv[argv.index("--") + 1 :]
-    if not argv or not Path(argv[0]).name.lower().startswith("python"):
-        return None
-    return Path(argv[0]).expanduser()
-
-
-def running_install_paths() -> tuple[Path, ...]:
-    """Paths whose generations are still executing and therefore cannot be pruned."""
-
-    paths: list[Path] = [Path(sys.executable).expanduser()]
-    pids = [runtime_mod.resolve_service_owner_pid(include_starting=True)]
-    pids.extend(runtime_mod.extra_service_process_pids())
-    ui_pid_path = config_paths.get_runtime_ui_pid_path()
-    try:
-        ui_pid = int(ui_pid_path.read_text(encoding="utf-8").strip())
-    except (OSError, ValueError):
-        ui_pid = None
-    if ui_pid and runtime_mod.ui_pid_file_points_to_running_ui(ui_pid_path):
-        pids.append(ui_pid)
-    for pid in pids:
-        if (python_path := _process_python_path(pid)) is not None:
-            paths.append(python_path)
-    return tuple(dict.fromkeys(paths))
-
-
-def prune_atomic_uv_install_generations(
-    *,
-    keep: Iterable[Path] = (),
-    min_age_seconds: float = ATOMIC_GENERATION_RETENTION_SECONDS,
-) -> list[Path]:
-    """Remove old abandoned generations while retaining active/rollback installs."""
-
-    try:
-        root = atomic_uv_install_root().expanduser().resolve()
-        if not root.is_dir():
-            return []
-    except OSError:
-        logger.warning("failed to access atomic Avibe install generations", exc_info=True)
-        return []
-    kept = {
-        generation
-        for path in keep
-        if (generation := _generation_for_path(Path(path), root)) is not None
-    }
-    now = time.time()
-    try:
-        generations = list(root.iterdir())
-    except OSError:
-        logger.warning("failed to enumerate atomic Avibe install generations %s", root, exc_info=True)
-        return []
-    removed: list[Path] = []
-    for generation in generations:
-        if not generation.is_dir() or generation in kept:
-            continue
-        try:
-            if now - generation.stat().st_mtime < min_age_seconds:
-                continue
-            shutil.rmtree(generation)
-        except OSError:
-            logger.warning("failed to prune atomic Avibe install generation %s", generation, exc_info=True)
-            continue
-        removed.append(generation)
-    return removed
-
-
 def discard_atomic_uv_install_generation(path: Path | str) -> bool:
     """Remove one failed candidate generation without touching active installs."""
 
@@ -599,12 +520,7 @@ def activate_upgrade_candidate(activation: AtomicActivation) -> None:
     launcher = activation.launcher
     launcher.parent.mkdir(parents=True, exist_ok=True)
     replacement = launcher.parent / f".{launcher.name}.avibe-{uuid4().hex}.new"
-    previous_target: Path | None = None
     root = atomic_uv_install_root().expanduser().resolve()
-    previous_generation = _launcher_generation(launcher, root)
-    with contextlib.suppress(OSError, RuntimeError):
-        if launcher.exists() or launcher.is_symlink():
-            previous_target = launcher.resolve()
     try:
         _prepare_launcher_replacement(replacement, activation.candidate_launcher)
         os.replace(replacement, launcher)
@@ -613,14 +529,6 @@ def activate_upgrade_candidate(activation: AtomicActivation) -> None:
             replacement.unlink()
         raise
     _update_launcher_generation_marker(launcher, activation.candidate_launcher, root)
-    if _generation_for_path(activation.candidate_launcher, root) is not None:
-        keep_paths = [activation.candidate_launcher, *running_install_paths()]
-        if previous_target:
-            keep_paths.append(previous_target)
-        if previous_generation:
-            keep_paths.append(previous_generation)
-        keep = tuple(keep_paths)
-        prune_atomic_uv_install_generations(keep=keep)
 
 
 def activate_installer_candidate(activation: AtomicActivation) -> None:

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -328,13 +328,34 @@ def get_cli_launcher_path(launcher: runtime_mod.ServiceLauncher) -> Path | None:
 
 
 def _generation_for_path(path: Path, root: Path) -> Path | None:
+    """Return the canonical generation containing a logical install path.
+
+    The leaf may itself be a symlink, as uv-managed Python launchers commonly
+    are. Walk its logical ancestors and resolve only the candidate generation
+    directory so the shared interpreter target cannot erase generation
+    ownership.
+    """
+
     try:
-        relative = path.expanduser().resolve().relative_to(root.expanduser().resolve())
-    except (OSError, RuntimeError, ValueError):
+        root = root.expanduser().resolve()
+        expanded = path.expanduser()
+    except (OSError, RuntimeError):
         return None
-    if not relative.parts:
-        return None
-    return root.expanduser().resolve() / relative.parts[0]
+    ancestors = [expanded, *expanded.parents]
+    try:
+        resolved_path = expanded.resolve()
+    except (OSError, RuntimeError):
+        resolved_path = None
+    if resolved_path is not None:
+        ancestors.extend((resolved_path, *resolved_path.parents))
+    for ancestor in dict.fromkeys(ancestors):
+        try:
+            resolved = ancestor.resolve()
+        except (OSError, RuntimeError):
+            continue
+        if resolved.parent == root:
+            return resolved
+    return None
 
 
 def _generation_for_hardlink(launcher: Path, root: Path) -> Path | None:
@@ -401,7 +422,12 @@ def _update_launcher_generation_marker(launcher: Path, target: Path, root: Path)
 def atomic_activation_source_is_current(activation: AtomicActivation) -> bool:
     """Check that the stable launcher still points at the source we measured."""
 
-    return _launcher_generation(activation.launcher, atomic_uv_install_root()) == activation.source_generation
+    root = atomic_uv_install_root()
+    current = _launcher_generation(activation.launcher, root)
+    if activation.source_generation is None:
+        return current is None
+    source = _generation_for_path(activation.source_generation, root)
+    return source is not None and current == source
 
 
 def activation_block_reason(activation: AtomicActivation) -> str | None:

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -169,23 +169,16 @@ def restart_record_is_pending(
 
 
 def _is_stable_launcher_path(launcher: Path) -> bool:
-    if launcher.is_symlink():
-        return True
-    # Windows falls back to a hard link when creating a symlink requires
-    # developer mode. The user-facing launcher is still a stable activation
-    # point; a direct virtualenv path is not. Honor uv's configured bin too.
     if launcher.name.lower() not in {"vibe", "vibe.exe"}:
         return False
-    if launcher.parent.name.lower() == "bin" and launcher.parent.parent.name.lower() == ".local":
-        return True
-    if (launcher.parent / f".{launcher.name}.avibe-generation").is_file():
-        return True
-    stable_dirs = {Path.home() / ".local" / "bin"}
-    configured = os.environ.get("UV_TOOL_BIN_DIR")
-    if configured:
-        stable_dirs.add(Path(configured).expanduser())
-    launcher_dir = os.path.normcase(os.path.abspath(str(launcher.parent.expanduser())))
-    return any(os.path.normcase(os.path.abspath(str(directory))) == launcher_dir for directory in stable_dirs)
+    # ``vibe_path`` has already been resolved to the command that launched this
+    # installation. Its role, not the directory uv happened to use when it was
+    # installed, makes it the stable activation point. The only unsafe shape is
+    # the entry point inside the mutable uv tool environment itself.
+    logical = os.path.normcase(os.path.abspath(os.path.expanduser(str(launcher))))
+    atomic_root = os.path.normcase(os.path.abspath(os.path.expanduser(str(atomic_uv_install_root()))))
+    uv_layout = logical.replace("\\", "/").lower()
+    return "/uv/tools/" not in uv_layout and not Path(logical).is_relative_to(Path(atomic_root))
 
 
 def launcher_is_current_process(launcher: Path | str) -> bool:

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -7,6 +7,7 @@ import os
 import re
 import shlex
 import shutil
+import subprocess
 import sys
 import tempfile
 import time
@@ -104,6 +105,7 @@ class AtomicActivation:
 
     launcher: Path
     candidate_launcher: Path
+    source_generation: Path | None = None
 
 
 def atomic_uv_install_root() -> Path:
@@ -148,7 +150,11 @@ def _staged_uv_environment(vibe_path: str | None) -> tuple[Path, Path, AtomicAct
     if not _is_stable_launcher_path(launcher):
         return tools_dir, bin_dir, None
     candidate = bin_dir / launcher.name
-    return tools_dir, bin_dir, AtomicActivation(launcher=launcher, candidate_launcher=candidate)
+    return tools_dir, bin_dir, AtomicActivation(
+        launcher=launcher,
+        candidate_launcher=candidate,
+        source_generation=_launcher_generation(launcher, atomic_uv_install_root()),
+    )
 
 
 def _candidate_python(candidate_launcher: Path) -> Path | None:
@@ -219,6 +225,19 @@ def _generation_for_hardlink(launcher: Path, root: Path) -> Path | None:
     return None
 
 
+def _launcher_generation(launcher: Path, root: Path) -> Path | None:
+    """Return the generation currently represented by a stable launcher."""
+
+    root = root.expanduser().resolve()
+    return _generation_for_path(launcher, root) or _generation_for_hardlink(launcher, root)
+
+
+def atomic_activation_source_is_current(activation: AtomicActivation) -> bool:
+    """Check that the stable launcher still points at the source we measured."""
+
+    return _launcher_generation(activation.launcher, atomic_uv_install_root()) == activation.source_generation
+
+
 def prune_atomic_uv_install_generations(
     *,
     keep: Iterable[Path] = (),
@@ -274,7 +293,42 @@ def verify_upgrade_candidate(activation: AtomicActivation) -> IntegrityResult:
     python = _candidate_python(candidate)
     if python is None:
         return IntegrityResult(False, failures=(f"candidate Python missing beside {candidate}",))
-    return verify_python_environment(python)
+    result = verify_python_environment(python)
+    if not result.ok:
+        return result
+    try:
+        probe = subprocess.run(
+            [str(candidate), "--help"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+            cwd=tempfile.gettempdir(),
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return IntegrityResult(False, failures=(f"candidate launcher probe failed: {exc}",))
+    if probe.returncode != 0:
+        detail = (probe.stderr or probe.stdout or "").strip().splitlines()
+        suffix = detail[-1] if detail else f"exit code {probe.returncode}"
+        return IntegrityResult(False, failures=(f"candidate launcher probe failed: {suffix}",))
+    return result
+
+
+def _prepare_launcher_replacement(replacement: Path, target: Path) -> None:
+    """Create a replacement launcher, using copy when links cannot cross volumes."""
+
+    try:
+        replacement.symlink_to(target)
+        return
+    except OSError:
+        pass
+    try:
+        os.link(target, replacement)
+        return
+    except OSError:
+        # A regular copy is the only portable option when the stable bin and
+        # the runtime home are on different Windows volumes.
+        shutil.copy2(target, replacement)
 
 
 def activate_upgrade_candidate(activation: AtomicActivation) -> None:
@@ -293,12 +347,7 @@ def activate_upgrade_candidate(activation: AtomicActivation) -> None:
         if launcher.exists() or launcher.is_symlink():
             previous_target = launcher.resolve()
     try:
-        try:
-            replacement.symlink_to(activation.candidate_launcher)
-        except OSError:
-            # Windows without Developer Mode cannot create the stable symlink;
-            # a same-volume hard link still gives Move/Replace atomicity.
-            os.link(activation.candidate_launcher, replacement)
+        _prepare_launcher_replacement(replacement, activation.candidate_launcher)
         os.replace(replacement, launcher)
     except Exception:
         with contextlib.suppress(OSError):
@@ -324,10 +373,7 @@ def activate_launcher_target(launcher: str | os.PathLike[str], target: str | os.
     launcher_path.parent.mkdir(parents=True, exist_ok=True)
     replacement = launcher_path.parent / f".{launcher_path.name}.avibe-{uuid4().hex}.new"
     try:
-        try:
-            replacement.symlink_to(target_path)
-        except OSError:
-            os.link(target_path, replacement)
+        _prepare_launcher_replacement(replacement, target_path)
         os.replace(replacement, launcher_path)
     except Exception:
         with contextlib.suppress(OSError):
@@ -711,7 +757,14 @@ def is_uv_tool_install(python_executable: str | None = None) -> bool:
     if "/uv/tools/" in executable:
         return True
     try:
-        return Path(executable).expanduser().resolve().is_relative_to(atomic_uv_install_root().resolve())
+        logical = Path(os.path.abspath(os.path.expanduser(executable)))
+        logical_root = Path(os.path.abspath(os.path.expanduser(str(atomic_uv_install_root()))))
+        if logical.is_relative_to(logical_root):
+            return True
+        # A logical path may contain a symlinked parent. Resolving is only the
+        # fallback: uv's tool Python is itself commonly a symlink to a shared
+        # interpreter outside the generation.
+        return logical.resolve().is_relative_to(logical_root.resolve())
     except (OSError, ValueError, RuntimeError):
         return False
 

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -19,7 +19,7 @@ from typing import Iterable, NamedTuple, cast
 from uuid import uuid4
 
 from config import paths as config_paths
-from core.install_integrity import IntegrityResult, verify_python_environment
+from core.install_integrity import IntegrityResult, isolated_probe_environment, verify_python_environment
 from storage.lock import MigrationFileLock
 from vibe import runtime as runtime_mod
 
@@ -34,6 +34,7 @@ SHOW_RUNTIME_SKIP_ENV = "VIBE_INSTALL_SKIP_SHOW_RUNTIME"
 TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
 UV_FALLBACK_BIN_DIRS = (".local/bin", ".cargo/bin")
 UPGRADE_INSTALL_TIMEOUT_SECONDS = 30 * 60
+RESTART_PENDING_GRACE_SECONDS = 5 * 60
 # Once a new generation is validated, only active and rollback generations are
 # retained. Failed candidates are discarded by the callers before activation.
 ATOMIC_GENERATION_RETENTION_SECONDS = 0
@@ -123,17 +124,46 @@ def atomic_upgrade_lock():
         yield
 
 
+def restart_is_pending() -> bool:
+    """Whether a scheduled restart still owns the next activation boundary."""
+
+    path = runtime_mod.get_restart_status_path()
+    payload = runtime_mod.read_json(path) or {}
+    if payload.get("state") not in {"scheduled", "running"}:
+        return False
+    supervisor_pid = payload.get("supervisor_pid")
+    if isinstance(supervisor_pid, int) and supervisor_pid > 0 and runtime_mod.pid_alive(supervisor_pid):
+        started_at = payload.get("supervisor_started_at")
+        if started_at is not None:
+            current_started_at = runtime_mod.process_create_time(supervisor_pid)
+            if current_started_at is not None and current_started_at != started_at:
+                return False
+        return True
+    try:
+        age = time.time() - path.stat().st_mtime
+    except OSError:
+        return False
+    return age <= RESTART_PENDING_GRACE_SECONDS
+
+
 def _is_stable_launcher_path(launcher: Path) -> bool:
     if launcher.is_symlink():
         return True
     # Windows falls back to a hard link when creating a symlink requires
-    # developer mode. The user-facing .local/bin launcher is still a stable
-    # activation point; a direct virtualenv path is not.
-    return (
-        launcher.name.lower() in {"vibe", "vibe.exe"}
-        and launcher.parent.name.lower() == "bin"
-        and launcher.parent.parent.name.lower() == ".local"
-    )
+    # developer mode. The user-facing launcher is still a stable activation
+    # point; a direct virtualenv path is not. Honor uv's configured bin too.
+    if launcher.name.lower() not in {"vibe", "vibe.exe"}:
+        return False
+    if launcher.parent.name.lower() == "bin" and launcher.parent.parent.name.lower() == ".local":
+        return True
+    if (launcher.parent / f".{launcher.name}.avibe-generation").is_file():
+        return True
+    stable_dirs = {Path.home() / ".local" / "bin"}
+    configured = os.environ.get("UV_TOOL_BIN_DIR")
+    if configured:
+        stable_dirs.add(Path(configured).expanduser())
+    launcher_dir = os.path.normcase(os.path.abspath(str(launcher.parent.expanduser())))
+    return any(os.path.normcase(os.path.abspath(str(directory))) == launcher_dir for directory in stable_dirs)
 
 
 def _staged_uv_environment(vibe_path: str | None) -> tuple[Path, Path, AtomicActivation | None]:
@@ -244,7 +274,37 @@ def _launcher_generation(launcher: Path, root: Path) -> Path | None:
     """Return the generation currently represented by a stable launcher."""
 
     root = root.expanduser().resolve()
-    return _generation_for_path(launcher, root) or _generation_for_hardlink(launcher, root)
+    generation = _generation_for_path(launcher, root) or _generation_for_hardlink(launcher, root)
+    if generation is not None:
+        return generation
+    if not _is_stable_launcher_path(launcher):
+        return None
+    marker = launcher.parent / f".{launcher.name}.avibe-generation"
+    try:
+        marked = Path(marker.read_text(encoding="utf-8").lstrip("\ufeff").strip())
+    except (OSError, UnicodeError):
+        return None
+    generation = _generation_for_path(marked, root)
+    return generation if generation is not None and generation.is_dir() else None
+
+
+def _update_launcher_generation_marker(launcher: Path, target: Path, root: Path) -> None:
+    """Record a copied launcher's generation without making cleanup mandatory."""
+
+    marker = launcher.parent / f".{launcher.name}.avibe-generation"
+    generation = _generation_for_path(target, root)
+    if generation is None:
+        with contextlib.suppress(OSError):
+            marker.unlink()
+        return
+    replacement = marker.parent / f".{marker.name}.{uuid4().hex}.new"
+    try:
+        replacement.write_text(str(generation), encoding="utf-8")
+        os.replace(replacement, marker)
+    except OSError:
+        with contextlib.suppress(OSError):
+            replacement.unlink()
+        logger.warning("failed to update launcher generation marker %s", marker, exc_info=True)
 
 
 def atomic_activation_source_is_current(activation: AtomicActivation) -> bool:
@@ -260,8 +320,12 @@ def prune_atomic_uv_install_generations(
 ) -> list[Path]:
     """Remove old abandoned generations while retaining active/rollback installs."""
 
-    root = atomic_uv_install_root().expanduser().resolve()
-    if not root.is_dir():
+    try:
+        root = atomic_uv_install_root().expanduser().resolve()
+        if not root.is_dir():
+            return []
+    except OSError:
+        logger.warning("failed to access atomic Avibe install generations", exc_info=True)
         return []
     kept = {
         generation
@@ -269,8 +333,13 @@ def prune_atomic_uv_install_generations(
         if (generation := _generation_for_path(Path(path), root)) is not None
     }
     now = time.time()
+    try:
+        generations = list(root.iterdir())
+    except OSError:
+        logger.warning("failed to enumerate atomic Avibe install generations %s", root, exc_info=True)
+        return []
     removed: list[Path] = []
-    for generation in root.iterdir():
+    for generation in generations:
         if not generation.is_dir() or generation in kept:
             continue
         try:
@@ -319,6 +388,7 @@ def verify_upgrade_candidate(activation: AtomicActivation) -> IntegrityResult:
             timeout=60,
             check=False,
             cwd=tempfile.gettempdir(),
+            env=isolated_probe_environment(),
         )
     except (OSError, subprocess.SubprocessError) as exc:
         return IntegrityResult(False, failures=(f"candidate launcher probe failed: {exc}",))
@@ -357,7 +427,7 @@ def activate_upgrade_candidate(activation: AtomicActivation) -> None:
     replacement = launcher.parent / f".{launcher.name}.avibe-{uuid4().hex}.new"
     previous_target: Path | None = None
     root = atomic_uv_install_root().expanduser().resolve()
-    previous_generation = _generation_for_hardlink(launcher, root)
+    previous_generation = _launcher_generation(launcher, root)
     with contextlib.suppress(OSError, RuntimeError):
         if launcher.exists() or launcher.is_symlink():
             previous_target = launcher.resolve()
@@ -368,6 +438,7 @@ def activate_upgrade_candidate(activation: AtomicActivation) -> None:
         with contextlib.suppress(OSError):
             replacement.unlink()
         raise
+    _update_launcher_generation_marker(launcher, activation.candidate_launcher, root)
     if _generation_for_path(activation.candidate_launcher, root) is not None:
         keep_paths = [activation.candidate_launcher]
         if previous_target:
@@ -394,6 +465,7 @@ def activate_launcher_target(launcher: str | os.PathLike[str], target: str | os.
         with contextlib.suppress(OSError):
             replacement.unlink()
         raise
+    _update_launcher_generation_marker(launcher_path, target_path, atomic_uv_install_root().expanduser().resolve())
 
 
 def resolve_command_path(command: str | None, search_path: str | None = None) -> str | None:
@@ -775,6 +847,8 @@ def is_uv_tool_install(python_executable: str | None = None) -> bool:
         logical = Path(os.path.abspath(os.path.expanduser(executable)))
         logical_root = Path(os.path.abspath(os.path.expanduser(str(atomic_uv_install_root()))))
         if logical.is_relative_to(logical_root):
+            return True
+        if _launcher_generation(logical, logical_root) is not None:
             return True
         # A logical path may contain a symlinked parent. Resolving is only the
         # fallback: uv's tool Python is itself commonly a symlink to a shared

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -32,7 +32,9 @@ SHOW_RUNTIME_SKIP_ENV = "VIBE_INSTALL_SKIP_SHOW_RUNTIME"
 TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
 UV_FALLBACK_BIN_DIRS = (".local/bin", ".cargo/bin")
 UPGRADE_INSTALL_TIMEOUT_SECONDS = 30 * 60
-ATOMIC_GENERATION_RETENTION_SECONDS = 24 * 60 * 60
+# Once a new generation is validated, only active and rollback generations are
+# retained. Failed candidates are discarded by the callers before activation.
+ATOMIC_GENERATION_RETENTION_SECONDS = 0
 # A spec that names nothing but a package, so appending ``==<version>`` to it
 # yields a requirement rather than a broken string. PEP 508 names only:
 # anything with a path separator, a URL scheme, extras, a marker, or a version
@@ -226,6 +228,21 @@ def prune_atomic_uv_install_generations(
             continue
         removed.append(generation)
     return removed
+
+
+def discard_atomic_uv_install_generation(path: Path | str) -> bool:
+    """Remove one failed candidate generation without touching active installs."""
+
+    root = atomic_uv_install_root().expanduser().resolve()
+    generation = _generation_for_path(Path(path), root)
+    if generation is None or not generation.is_dir():
+        return False
+    try:
+        shutil.rmtree(generation)
+    except OSError:
+        logger.warning("failed to discard atomic Avibe install generation %s", generation, exc_info=True)
+        return False
+    return True
 
 
 def verify_upgrade_candidate(activation: AtomicActivation) -> IntegrityResult:

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 
 from config import paths as config_paths
 from core.install_integrity import IntegrityResult, verify_python_environment
+from storage.lock import MigrationFileLock
 from vibe import runtime as runtime_mod
 
 
@@ -94,6 +95,7 @@ class UpgradePlan:
     method: str
     rollback_to: RollbackTarget | None = None
     activation: "AtomicActivation | None" = None
+    preflight_error: str | None = None
 
 
 @dataclass(frozen=True)
@@ -108,6 +110,15 @@ def atomic_uv_install_root() -> Path:
     """Return the durable root for versioned uv tool environments."""
 
     return config_paths.get_vibe_remote_dir() / "runtime" / "install-generations"
+
+
+@contextlib.contextmanager
+def atomic_upgrade_lock():
+    """Serialize staged installation, launcher activation, and pruning."""
+
+    lock_path = atomic_uv_install_root().expanduser().parent / ".install.lock"
+    with MigrationFileLock(lock_path, timeout_seconds=UPGRADE_INSTALL_TIMEOUT_SECONDS):
+        yield
 
 
 def _is_stable_launcher_path(launcher: Path) -> bool:
@@ -146,12 +157,21 @@ def _candidate_python(candidate_launcher: Path) -> Path | None:
         resolved_parent = candidate_launcher.resolve().parent
         if resolved_parent not in roots:
             roots.append(resolved_parent)
+    with contextlib.suppress(OSError, RuntimeError, ValueError):
+        generation = _generation_for_path(candidate_launcher, atomic_uv_install_root())
+        if generation is not None:
+            roots.append(generation / "tools")
     names = ("python.exe", "python3.exe", "python3", "python") if os.name == "nt" else ("python3", "python")
     for root in roots:
         for name in names:
             candidate = root / name
             if candidate.is_file() and os.access(candidate, os.X_OK):
                 return candidate
+        if root.name == "tools" and root.is_dir():
+            for name in names:
+                for candidate in sorted(root.rglob(name)):
+                    if candidate.is_file() and os.access(candidate, os.X_OK):
+                        return candidate
     return None
 
 
@@ -273,7 +293,12 @@ def activate_upgrade_candidate(activation: AtomicActivation) -> None:
         if launcher.exists() or launcher.is_symlink():
             previous_target = launcher.resolve()
     try:
-        replacement.symlink_to(activation.candidate_launcher)
+        try:
+            replacement.symlink_to(activation.candidate_launcher)
+        except OSError:
+            # Windows without Developer Mode cannot create the stable symlink;
+            # a same-volume hard link still gives Move/Replace atomicity.
+            os.link(activation.candidate_launcher, replacement)
         os.replace(replacement, launcher)
     except Exception:
         with contextlib.suppress(OSError):
@@ -299,7 +324,10 @@ def activate_launcher_target(launcher: str | os.PathLike[str], target: str | os.
     launcher_path.parent.mkdir(parents=True, exist_ok=True)
     replacement = launcher_path.parent / f".{launcher_path.name}.avibe-{uuid4().hex}.new"
     try:
-        replacement.symlink_to(target_path)
+        try:
+            replacement.symlink_to(target_path)
+        except OSError:
+            os.link(target_path, replacement)
         os.replace(replacement, launcher_path)
     except Exception:
         with contextlib.suppress(OSError):
@@ -1016,10 +1044,14 @@ def build_upgrade_plan(
     if is_uv_tool_install(executable) and uv_binary:
         env = dict(base_env or os.environ)
         atomic = None
+        preflight_error = None
         if version is None:
             tool_dir, bin_dir, atomic = _staged_uv_environment(vibe_path)
-            env["UV_TOOL_DIR"] = str(tool_dir)
-            env["UV_TOOL_BIN_DIR"] = str(bin_dir)
+            if atomic is None:
+                preflight_error = "Cannot atomically upgrade uv installation: stable vibe launcher is unavailable"
+            else:
+                env["UV_TOOL_DIR"] = str(tool_dir)
+                env["UV_TOOL_BIN_DIR"] = str(bin_dir)
         else:
             vibe_bin_dir = get_current_vibe_bin_dir(vibe_path)
             if vibe_bin_dir:
@@ -1035,6 +1067,7 @@ def build_upgrade_plan(
             method="uv",
             rollback_to=rollback_to,
             activation=atomic,
+            preflight_error=preflight_error,
         )
 
     command = [executable, "-m", "pip", "install"]

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -19,7 +19,12 @@ from typing import Iterable, NamedTuple, cast
 from uuid import uuid4
 
 from config import paths as config_paths
-from core.install_integrity import IntegrityResult, isolated_probe_environment, verify_python_environment
+from core.install_integrity import (
+    IntegrityResult,
+    isolated_probe_environment,
+    run_isolated_probe,
+    verify_python_environment,
+)
 from storage.lock import MigrationFileLock
 from vibe import runtime as runtime_mod
 
@@ -129,7 +134,9 @@ def restart_is_pending() -> bool:
     """Whether a scheduled restart still owns the next activation boundary."""
 
     path = runtime_mod.get_restart_status_path()
-    payload = runtime_mod.read_json(path) or {}
+    payload = runtime_mod.read_json(path)
+    if not isinstance(payload, Mapping):
+        return False
     return restart_record_is_pending(payload, path)
 
 
@@ -427,7 +434,13 @@ def atomic_activation_source_is_current(activation: AtomicActivation) -> bool:
     if activation.source_generation is None:
         return current is None
     source = _generation_for_path(activation.source_generation, root)
-    return source is not None and current == source
+    if current is not None or source is not None:
+        return current == source
+    try:
+        current_target = activation.launcher.resolve(strict=True)
+        return os.path.samefile(current_target, activation.source_generation)
+    except (OSError, RuntimeError, ValueError):
+        return False
 
 
 def activation_block_reason(activation: AtomicActivation) -> str | None:
@@ -544,15 +557,7 @@ def verify_upgrade_candidate(activation: AtomicActivation) -> IntegrityResult:
     if not result.ok:
         return result
     try:
-        probe = subprocess.run(
-            [str(candidate), "--help"],
-            capture_output=True,
-            text=True,
-            timeout=60,
-            check=False,
-            cwd=tempfile.gettempdir(),
-            env=isolated_probe_environment(),
-        )
+        probe = run_isolated_probe([str(candidate), "--help"], timeout=60)
     except (OSError, subprocess.SubprocessError) as exc:
         return IntegrityResult(False, failures=(f"candidate launcher probe failed: {exc}",))
     if probe.returncode != 0:

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -35,6 +35,7 @@ TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
 UV_FALLBACK_BIN_DIRS = (".local/bin", ".cargo/bin")
 UPGRADE_INSTALL_TIMEOUT_SECONDS = 30 * 60
 RESTART_PENDING_GRACE_SECONDS = 5 * 60
+DEFERRED_ACTIVATION_TIMEOUT_SECONDS = 5 * 60
 # Once a new generation is validated, only active and rollback generations are
 # retained. Failed candidates are discarded by the callers before activation.
 ATOMIC_GENERATION_RETENTION_SECONDS = 0
@@ -166,6 +167,21 @@ def _is_stable_launcher_path(launcher: Path) -> bool:
     return any(os.path.normcase(os.path.abspath(str(directory))) == launcher_dir for directory in stable_dirs)
 
 
+def launcher_is_current_process(launcher: Path | str) -> bool:
+    """Whether this Windows process is holding the stable launcher open."""
+
+    if os.name != "nt":
+        return False
+    target = os.path.normcase(os.path.abspath(os.path.expanduser(str(launcher))))
+    for candidate in (sys.argv[0], os.environ.get(CURRENT_VIBE_EXECUTABLE_ENV)):
+        if not candidate:
+            continue
+        current = os.path.normcase(os.path.abspath(os.path.expanduser(candidate)))
+        if current == target:
+            return True
+    return False
+
+
 def _staged_uv_environment(vibe_path: str | None) -> tuple[Path, Path, AtomicActivation | None]:
     generation = atomic_uv_install_root() / uuid4().hex
     tools_dir = generation / "tools"
@@ -211,6 +227,68 @@ def _candidate_python(candidate_launcher: Path) -> Path | None:
     return None
 
 
+def defer_upgrade_activation(
+    activation: AtomicActivation,
+    *,
+    parent_pid: int,
+    rollback_to: "RollbackTarget | None" = None,
+    restart_required: bool = False,
+    prepare_show_runtime: bool = False,
+) -> subprocess.Popen:
+    """Run activation after a Windows CLI process releases its launcher."""
+
+    candidate_python = _candidate_python(activation.candidate_launcher)
+    if candidate_python is None:
+        raise RuntimeError(f"candidate Python missing beside {activation.candidate_launcher}")
+    command = [
+        str(candidate_python),
+        "-c",
+        "from vibe.cli import main; main()",
+        "__activate-upgrade",
+        "--parent-pid",
+        str(parent_pid),
+        "--launcher",
+        str(activation.launcher),
+        "--candidate",
+        str(activation.candidate_launcher),
+    ]
+    if activation.source_generation is not None:
+        command.extend(["--source-generation", str(activation.source_generation)])
+    if restart_required:
+        command.append("--restart")
+    if prepare_show_runtime:
+        command.append("--prepare-show-runtime")
+    if rollback_to is not None:
+        command.extend(
+            [
+                "--rollback-to",
+                rollback_to.version,
+                "--rollback-python",
+                rollback_to.launcher.python,
+                "--rollback-main",
+                rollback_to.launcher.main,
+            ]
+        )
+        if rollback_to.package:
+            command.extend(["--rollback-package", rollback_to.package])
+    parent_started_at = runtime_mod.process_create_time(parent_pid)
+    if parent_started_at is not None:
+        command.extend(["--parent-started-at", str(parent_started_at)])
+    log_path = config_paths.get_logs_dir() / f"upgrade-activation-{uuid4().hex}.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as log:
+        return subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            close_fds=True,
+            cwd=get_safe_cwd(),
+            env=isolated_probe_environment(),
+        )
+
+
 def get_cli_launcher_path(launcher: runtime_mod.ServiceLauncher) -> Path | None:
     """Find the CLI launcher next to a saved service interpreter."""
 
@@ -254,7 +332,8 @@ def _generation_for_hardlink(launcher: Path, root: Path) -> Path | None:
     if launcher.is_symlink() or not _is_stable_launcher_path(launcher):
         return None
     try:
-        inode = launcher.stat().st_ino
+        launcher_stat = launcher.stat()
+        identity = (launcher_stat.st_dev, launcher_stat.st_ino)
     except OSError:
         return None
     root = root.expanduser().resolve()
@@ -263,7 +342,8 @@ def _generation_for_hardlink(launcher: Path, root: Path) -> Path | None:
     for generation in root.iterdir():
         candidate = generation / "bin" / launcher.name
         try:
-            if generation.is_dir() and candidate.stat().st_ino == inode:
+            candidate_stat = candidate.stat()
+            if generation.is_dir() and (candidate_stat.st_dev, candidate_stat.st_ino) == identity:
                 return generation
         except OSError:
             continue

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -9,11 +9,12 @@ import shlex
 import shutil
 import sys
 import tempfile
+import time
 import urllib.request
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import NamedTuple, cast
+from typing import Iterable, NamedTuple, cast
 from uuid import uuid4
 
 from config import paths as config_paths
@@ -31,6 +32,7 @@ SHOW_RUNTIME_SKIP_ENV = "VIBE_INSTALL_SKIP_SHOW_RUNTIME"
 TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
 UV_FALLBACK_BIN_DIRS = (".local/bin", ".cargo/bin")
 UPGRADE_INSTALL_TIMEOUT_SECONDS = 30 * 60
+ATOMIC_GENERATION_RETENTION_SECONDS = 24 * 60 * 60
 # A spec that names nothing but a package, so appending ``==<version>`` to it
 # yields a requirement rather than a broken string. PEP 508 names only:
 # anything with a path separator, a URL scheme, extras, a marker, or a version
@@ -106,6 +108,19 @@ def atomic_uv_install_root() -> Path:
     return config_paths.get_vibe_remote_dir() / "runtime" / "install-generations"
 
 
+def _is_stable_launcher_path(launcher: Path) -> bool:
+    if launcher.is_symlink():
+        return True
+    # Windows falls back to a hard link when creating a symlink requires
+    # developer mode. The user-facing .local/bin launcher is still a stable
+    # activation point; a direct virtualenv path is not.
+    return (
+        launcher.name.lower() in {"vibe", "vibe.exe"}
+        and launcher.parent.name.lower() == "bin"
+        and launcher.parent.parent.name.lower() == ".local"
+    )
+
+
 def _staged_uv_environment(vibe_path: str | None) -> tuple[Path, Path, AtomicActivation | None]:
     generation = atomic_uv_install_root() / uuid4().hex
     tools_dir = generation / "tools"
@@ -117,7 +132,7 @@ def _staged_uv_environment(vibe_path: str | None) -> tuple[Path, Path, AtomicAct
     # Only replace a stable launcher link. A direct path into a virtualenv may
     # be the user's intentional installation and cannot be switched safely by
     # replacing the file the current process is executing.
-    if not launcher.is_symlink():
+    if not _is_stable_launcher_path(launcher):
         return tools_dir, bin_dir, None
     candidate = bin_dir / launcher.name
     return tools_dir, bin_dir, AtomicActivation(launcher=launcher, candidate_launcher=candidate)
@@ -136,6 +151,81 @@ def _candidate_python(candidate_launcher: Path) -> Path | None:
             if candidate.is_file() and os.access(candidate, os.X_OK):
                 return candidate
     return None
+
+
+def get_cli_launcher_path(launcher: runtime_mod.ServiceLauncher) -> Path | None:
+    """Find the CLI launcher next to a saved service interpreter."""
+
+    python_bin = Path(launcher.python).expanduser().parent
+    names = ("vibe.exe", "vibe") if os.name == "nt" else ("vibe", "vibe.exe")
+    for name in names:
+        candidate = python_bin / name
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def _generation_for_path(path: Path, root: Path) -> Path | None:
+    try:
+        relative = path.expanduser().resolve().relative_to(root.expanduser().resolve())
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if not relative.parts:
+        return None
+    return root.expanduser().resolve() / relative.parts[0]
+
+
+def _generation_for_hardlink(launcher: Path, root: Path) -> Path | None:
+    """Find an atomic generation sharing the stable launcher's inode."""
+
+    if launcher.is_symlink() or not _is_stable_launcher_path(launcher):
+        return None
+    try:
+        inode = launcher.stat().st_ino
+    except OSError:
+        return None
+    root = root.expanduser().resolve()
+    if not root.is_dir():
+        return None
+    for generation in root.iterdir():
+        candidate = generation / "bin" / launcher.name
+        try:
+            if generation.is_dir() and candidate.stat().st_ino == inode:
+                return generation
+        except OSError:
+            continue
+    return None
+
+
+def prune_atomic_uv_install_generations(
+    *,
+    keep: Iterable[Path] = (),
+    min_age_seconds: float = ATOMIC_GENERATION_RETENTION_SECONDS,
+) -> list[Path]:
+    """Remove old abandoned generations while retaining active/rollback installs."""
+
+    root = atomic_uv_install_root().expanduser().resolve()
+    if not root.is_dir():
+        return []
+    kept = {
+        generation
+        for path in keep
+        if (generation := _generation_for_path(Path(path), root)) is not None
+    }
+    now = time.time()
+    removed: list[Path] = []
+    for generation in root.iterdir():
+        if not generation.is_dir() or generation in kept:
+            continue
+        try:
+            if now - generation.stat().st_mtime < min_age_seconds:
+                continue
+            shutil.rmtree(generation)
+        except OSError:
+            logger.warning("failed to prune atomic Avibe install generation %s", generation, exc_info=True)
+            continue
+        removed.append(generation)
+    return removed
 
 
 def verify_upgrade_candidate(activation: AtomicActivation) -> IntegrityResult:
@@ -159,6 +249,12 @@ def activate_upgrade_candidate(activation: AtomicActivation) -> None:
     launcher = activation.launcher
     launcher.parent.mkdir(parents=True, exist_ok=True)
     replacement = launcher.parent / f".{launcher.name}.avibe-{uuid4().hex}.new"
+    previous_target: Path | None = None
+    root = atomic_uv_install_root().expanduser().resolve()
+    previous_generation = _generation_for_hardlink(launcher, root)
+    with contextlib.suppress(OSError, RuntimeError):
+        if launcher.exists() or launcher.is_symlink():
+            previous_target = launcher.resolve()
     try:
         replacement.symlink_to(activation.candidate_launcher)
         os.replace(replacement, launcher)
@@ -166,6 +262,14 @@ def activate_upgrade_candidate(activation: AtomicActivation) -> None:
         with contextlib.suppress(OSError):
             replacement.unlink()
         raise
+    if _generation_for_path(activation.candidate_launcher, root) is not None:
+        keep_paths = [activation.candidate_launcher]
+        if previous_target:
+            keep_paths.append(previous_target)
+        if previous_generation:
+            keep_paths.append(previous_generation)
+        keep = tuple(keep_paths)
+        prune_atomic_uv_install_generations(keep=keep)
 
 
 def activate_launcher_target(launcher: str | os.PathLike[str], target: str | os.PathLike[str]) -> None:

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -184,8 +184,23 @@ def _candidate_python(candidate_launcher: Path) -> Path | None:
 def get_cli_launcher_path(launcher: runtime_mod.ServiceLauncher) -> Path | None:
     """Find the CLI launcher next to a saved service interpreter."""
 
-    python_bin = Path(launcher.python).expanduser().parent
     names = ("vibe.exe", "vibe") if os.name == "nt" else ("vibe", "vibe.exe")
+    python_path = Path(launcher.python).expanduser()
+    root = atomic_uv_install_root()
+    generation = _launcher_generation(python_path, root)
+    if generation is not None:
+        generation_bin = generation / "bin"
+        for name in names:
+            candidate = generation_bin / name
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return candidate
+        with contextlib.suppress(OSError):
+            for name in names:
+                candidate = next(generation.rglob(name), None)
+                if candidate is not None and candidate.is_file() and os.access(candidate, os.X_OK):
+                    return candidate
+
+    python_bin = python_path.parent
     for name in names:
         candidate = python_bin / name
         if candidate.is_file() and os.access(candidate, os.X_OK):


### PR DESCRIPTION
## Summary

- stage every uv-managed Avibe install in a durable generation and atomically switch the stable launcher only after validation
- verify the exact transitive dependency closure declared by Avibe's wheel metadata, plus every registered transport import, before activation; surface the same integrity result in `vibe doctor`
- keep previous successful generations intact so restart rollback, live processes, concurrent staging, and alternate stable launchers cannot be invalidated by activation
- route Unix and Windows installer activation through the wheel's shared Python lifecycle owner instead of duplicating activation policy in shell
- serialize installer activation, runtime upgrades, and restart seeding on one install lock
- handle hard-linked and cross-volume Windows launchers, deferred CLI activation, and protocol stdout/stderr as distinct channels
- keep pip fallback upgrades bounded and post-validated

This closes the failure mode behind the Feishu/Lark outage: an interrupted in-place uv copy could leave satisfied metadata beside a partial dependency tree, so later upgrades skipped repair. The guard is package-wide and does not name a single SDK.

## Known by design

- **Successful generation reclamation is not automatic in this PR.** The review inventory demonstrated that activation cannot prove an old generation is disposable: it may still be staging in another installer, serving a live service or UI, retained for rollback, or referenced by another stable launcher. Activation therefore owns validation and the atomic launcher switch only; uninstall removes the complete generation root. Safe automatic GC needs a separate explicit ownership model (generation leases, a stable-launcher registry, and a terminal-restart handoff) rather than more path/process heuristics. The accepted trade-off is that repeated upgrades consume additional disk until uninstall or that GC owner lands.

## Verification

- `178 passed` across the focused integrity, upgrade, installer, and restart-supervisor suites before the final protocol-boundary patch
- `32 passed` for the Windows/Unix installer suite after separating protocol stdout from diagnostics
- `bash -n install.sh`
- Ruff, compileall, and `git diff --check` pass
- live repaired environment verified through the dependency-closure integrity probe

The full suite was also run from the task worktree: 12,220 passed, 60 skipped, 1 xfailed, and 44 failures in unrelated existing/order-sensitive UI, memory classifier, scheduling, and remote-authorization tests.
