### PR TITLE
fix(release): read back draft releases

### DIFF
--- a/scripts/github_release.py
+++ b/scripts/github_release.py
@@ -53,17 +53,9 @@ def _release_path(repo: str, tag: str) -> str:
     return f"repos/{repo}/releases/tags/{quote(tag, safe='')}"
 
 
-def get_release(repo: str, tag: str) -> ReleaseState | None:
-    completed = _run_gh(["api", _release_path(repo, tag)], check=False)
-    if completed.returncode != 0:
-        if "HTTP 404" in completed.stderr:
-            return None
-        detail = completed.stderr.strip() or completed.stdout.strip() or "unknown error"
-        raise ReleaseError(f"Could not inspect GitHub Release {tag}: {detail}")
-
+def _release_state(payload: Any, *, tag: str) -> ReleaseState:
     try:
-        payload = json.loads(completed.stdout)
-        return ReleaseState(
+        state = ReleaseState(
             tag=str(payload["tag_name"]),
             draft=bool(payload["draft"]),
             prerelease=bool(payload["prerelease"]),
@@ -72,6 +64,54 @@ def get_release(repo: str, tag: str) -> ReleaseState | None:
         )
     except (KeyError, TypeError, ValueError) as exc:
         raise ReleaseError(f"Invalid GitHub Release payload for {tag}") from exc
+    if state.tag != tag:
+        raise ReleaseError(f"GitHub Release payload did not match tag {tag}")
+    return state
+
+
+def _get_release_from_list(repo: str, tag: str) -> ReleaseState | None:
+    completed = _run_gh(
+        [
+            "api",
+            "--paginate",
+            "--slurp",
+            f"repos/{repo}/releases?per_page=100",
+        ],
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "unknown error"
+        raise ReleaseError(f"Could not inspect GitHub Release {tag}: {detail}")
+
+    try:
+        pages = json.loads(completed.stdout)
+        matches = [
+            release
+            for page in pages
+            for release in page
+            if release.get("tag_name") == tag
+        ]
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise ReleaseError(f"Invalid GitHub Release list payload for {tag}") from exc
+    if len(matches) > 1:
+        raise ReleaseError(f"Multiple GitHub Releases found for tag {tag}")
+    return _release_state(matches[0], tag=tag) if matches else None
+
+
+def get_release(repo: str, tag: str) -> ReleaseState | None:
+    completed = _run_gh(["api", _release_path(repo, tag)], check=False)
+    if completed.returncode != 0:
+        if "HTTP 404" in completed.stderr:
+            # GitHub's get-by-tag endpoint intentionally omits draft releases.
+            return _get_release_from_list(repo, tag)
+        detail = completed.stderr.strip() or completed.stdout.strip() or "unknown error"
+        raise ReleaseError(f"Could not inspect GitHub Release {tag}: {detail}")
+
+    try:
+        payload = json.loads(completed.stdout)
+    except ValueError as exc:
+        raise ReleaseError(f"Invalid GitHub Release payload for {tag}") from exc
+    return _release_state(payload, tag=tag)
 
 
 def _notes_arguments(*, notes: str | None, notes_file: Path | None) -> list[str]:

--- a/tests/test_github_release.py
+++ b/tests/test_github_release.py
@@ -41,12 +41,23 @@ def _release_payload(*, draft: bool, prerelease: bool = False, body: str = "note
     )
 
 
+def _release_pages(*payloads: str) -> str:
+    return json.dumps([[json.loads(payload) for payload in payloads]])
+
+
 def test_get_release_treats_only_http_404_as_absent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    reads = iter(
+        [
+            _completed([], returncode=1, stderr="gh: Not Found (HTTP 404)\n"),
+            _completed([], stdout=_release_pages()),
+        ]
+    )
+
     def not_found(arguments: list[str], *, check: bool = True):
         assert check is False
-        return _completed(arguments, returncode=1, stderr="gh: Not Found (HTTP 404)\n")
+        return next(reads)
 
     monkeypatch.setattr(github_release, "_run_gh", not_found)
     assert github_release.get_release(REPO, TAG) is None
@@ -60,6 +71,58 @@ def test_get_release_treats_only_http_404_as_absent(
         github_release.get_release(REPO, TAG)
 
 
+def test_get_release_falls_back_to_paginated_drafts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+    reads = iter(
+        [
+            _completed([], returncode=1, stderr="gh: Not Found (HTTP 404)\n"),
+            _completed([], stdout=_release_pages(_release_payload(draft=True))),
+        ]
+    )
+
+    def fake_run(arguments: list[str], *, check: bool = True):
+        calls.append(arguments)
+        return next(reads)
+
+    monkeypatch.setattr(github_release, "_run_gh", fake_run)
+    state = github_release.get_release(REPO, TAG)
+
+    assert state is not None and state.draft is True
+    assert calls[1] == [
+        "api",
+        "--paginate",
+        "--slurp",
+        f"repos/{REPO}/releases?per_page=100",
+    ]
+
+
+def test_get_release_rejects_duplicate_drafts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reads = iter(
+        [
+            _completed([], returncode=1, stderr="gh: Not Found (HTTP 404)\n"),
+            _completed(
+                [],
+                stdout=_release_pages(
+                    _release_payload(draft=True),
+                    _release_payload(draft=True),
+                ),
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        github_release,
+        "_run_gh",
+        lambda _arguments, check=True: next(reads),
+    )
+
+    with pytest.raises(github_release.ReleaseError, match="Multiple GitHub Releases"):
+        github_release.get_release(REPO, TAG)
+
+
 def test_ensure_draft_creates_a_verified_non_latest_draft(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -67,7 +130,9 @@ def test_ensure_draft_creates_a_verified_non_latest_draft(
     release_reads = iter(
         [
             _completed([], returncode=1, stderr="gh: Not Found (HTTP 404)\n"),
-            _completed([], stdout=_release_payload(draft=True)),
+            _completed([], stdout=_release_pages()),
+            _completed([], returncode=1, stderr="gh: Not Found (HTTP 404)\n"),
+            _completed([], stdout=_release_pages(_release_payload(draft=True))),
         ]
     )
 


### PR DESCRIPTION
## What changed

- Fall back to GitHub's paginated release collection when the get-by-tag endpoint returns 404, so draft releases can be read back after creation.
- Reject duplicate releases for one tag instead of selecting an ambiguous draft.
- Cover missing, draft, and duplicate-draft states with focused release automation tests.

## Why

The `gh-v3.0.14rc1` workflow created a draft successfully, then failed because GitHub's get-by-tag REST endpoint excludes drafts. A retry repeated the same behavior and created a second draft for the tag.

## Evidence

- `tests/test_github_release.py`: 15 passed
- Ruff passed for the changed Python files
- Live read-only check against `gh-v3.0.14rc1`: the tag endpoint returns 404 while the paginated release collection returns both drafts; the updated code rejects that duplicate state.

## Release follow-up

After merge, publish a fresh `gh-v3.0.14rc2`. The two failed `gh-v3.0.14rc1` drafts remain unpublished and will be removed during release cleanup.
