### PR TITLE
fix(ui): keep settings sidebar fixed

### DIFF
--- a/ui/src/components/settings/SettingsLayout.test.tsx
+++ b/ui/src/components/settings/SettingsLayout.test.tsx
@@ -103,16 +103,21 @@ afterEach(() => {
 });
 
 describe('SettingsLayout', () => {
-  it('keeps the mobile shell constrained so the route pane owns vertical scrolling', () => {
+  it('keeps the settings rail fixed while the route pane owns vertical scrolling', () => {
     renderLayout('/settings/replies');
 
     const routePane = screen.getByText('replies-body').closest('section');
     const shell = routePane?.parentElement?.parentElement;
+    const navigation = screen.getByRole('navigation', { name: 'settings.navigationLabel' });
 
     expect(routePane?.className).toContain('overflow-y-auto');
+    expect(navigation.className).not.toContain('overflow-y-auto');
+    expect(navigation.firstElementChild?.className).toContain('overflow-y-auto');
     expect(shell?.className).toContain('h-full');
     expect(shell?.className).toContain('min-h-0');
-    expect(shell?.className).toContain('md:h-auto');
+    expect(shell?.className).toContain('overflow-hidden');
+    expect(shell?.className).toContain('md:h-[var(--app-shell-h)]');
+    expect(shell?.className).not.toContain('md:h-auto');
     expect(shell?.className).not.toContain('min-h-full');
   });
 

--- a/ui/src/components/settings/SettingsLayout.tsx
+++ b/ui/src/components/settings/SettingsLayout.tsx
@@ -273,7 +273,7 @@ export const SettingsLayout: React.FC = () => {
   }, [atRoot, capabilities.can_manage_instance, isDesktop, navigate]);
 
   return (
-    <div className="flex h-full min-h-0 flex-col bg-background md:h-auto md:min-h-screen">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-background md:h-[var(--app-shell-h)]">
       <header className="flex h-[calc(3.5rem+env(safe-area-inset-top))] shrink-0 items-center justify-between border-b border-border bg-surface px-4 pt-[env(safe-area-inset-top)] md:h-14 md:pt-0">
         <div className="flex min-w-0 items-center gap-2 text-[13px] font-semibold text-foreground">
           <Settings className="size-4 text-mint-ink" />


### PR DESCRIPTION
## What changed

- Constrain the desktop Settings shell to the dynamic viewport height.
- Keep the settings navigation rail stationary while the route pane owns vertical scrolling.
- Preserve the existing mobile full-height layout and independent navigation overflow.

## Evidence

- Unit: `SettingsLayout.test.tsx` asserts the bounded shell and separate navigation/content scroll owners.
- UI: focused Settings layout suite passes (16 tests).
- Build: UI lint and production build pass.
- Manual: at 1470x797, the document remains at `scrollY=0`; scrolling a forced 1600px route overflow changes only the route pane while the navigation rail remains at top 56px / bottom 797px.

## Residual checks

- Recheck the fixed rail against the packaged UI during the integration pass.

## Dependencies

- None.
