### PR TITLE
docs(skills): keep the decision out of custom watch waiters

### DIFF
--- a/skills/background-watch-hook/SKILL.md
+++ b/skills/background-watch-hook/SKILL.md
@@ -211,10 +211,11 @@ the shapes its author has already seen. A wrong predicate then produces silence,
 which is indistinguishable from "nothing has happened yet", so it can sit on a retry
 exit code for hours after the state it was armed for arrived. The bundled waiters
 avoid that by reporting the change and leaving the judgment to the turn that has the
-whole picture. They keep one silent-pending mode of their own: a `--workflow` value
-that never matches — renamed, misspelled, or never triggered on this branch — holds a
-combined watch quiet indefinitely under `--timeout 0`, so check the name against a
-head that actually ran it before arming.
+whole picture. One caveat on the CI half: `render_actions_result` reports nothing
+while a requested workflow is missing, so a `--workflow` value that never matches —
+renamed, misspelled, or never triggered on this branch — never yields a CI event. PR
+activity still comes through, so the watch keeps firing; it is the CI verdict that
+silently never arrives. Check the name against a head that actually ran it.
 
 A predicate never seen to fire has not been tested. Verify it the way the delivery
 loop below is armed — seed the baseline, produce one event, confirm exit `0` — not by
@@ -461,15 +462,14 @@ GitHub-specific notes:
   so edits and deletions remain observable, reactions are filtered server-side with
   `content=+1`, and unchanged pages revalidate to `304`, which GitHub does not charge
   against the rate limit — an idle watch can poll for hours for free
-- a Codex verdict arrives in more than one shape, and the waiter watches all of them:
+- a Codex verdict arrives in more than one shape and the waiter reports all of them:
   findings as a review with inline comments, and a pass as either a `+1` reaction on
-  the PR body or a PR conversation comment carrying the pass phrase. Either shape is a
-  pass only when all three hold: the author is the Codex bot
-  (`chatgpt-codex-connector` / `chatgpt-codex-connector[bot]`), the pass phrase is
-  present, and the reviewed commit it names is the current head. A contributor quoting
-  a pass, and the bot's own pass on an earlier head, are both not one. Pass reactions
-  remain visible even when `--event-limit` is reached. A predicate keyed to reviews
-  alone never sees a pass
+  the PR body or a PR conversation comment. Pass reactions remain visible even when
+  `--event-limit` is reached. A predicate keyed to reviews alone never sees a pass.
+  Whether a reported pass *counts* — bot author, pass phrase, reviewed SHA against the
+  current head, and the different qualification a bodyless reaction carries — is a
+  judgment the follow-up turn makes against this repo's review rules, and is not
+  something a waiter should encode
 - PR activity also includes lifecycle changes on the PR itself, for example draft/ready, closed, reopened, or merged transitions
 - a changed PR head is reported as activity so a new push cannot leave the review
   loop asleep

--- a/skills/background-watch-hook/SKILL.md
+++ b/skills/background-watch-hook/SKILL.md
@@ -204,19 +204,24 @@ opts into retrying that code. Exit code `64` with the
 turn.
 
 **A waiter detects change; the follow-up Agent Run makes the decision.** Keep that
-split when writing your own. A hand-written waiter that fires only once a composite
-gate is satisfied — CI green *and* a verdict bound to the exact head *and* zero
-unresolved threads — has to match the shape of every signal in that gate, and it can
-only match the shapes its author has already seen. A wrong predicate then produces
-silence, which is indistinguishable from "nothing has happened yet": it can sit on a
-retry exit code for hours while the state it was armed for has already arrived. The
-bundled waiters report the change and leave the judgment to the turn that has the
-whole picture, which is why they cannot fail that way.
+split when writing your own. A waiter that fires only once a composite gate is
+satisfied — CI green *and* a verdict bound to the exact head *and* zero unresolved
+threads — must match the shape of every signal in that gate, and it can only match
+the shapes its author has already seen. A wrong predicate then produces silence,
+which is indistinguishable from "nothing has happened yet", so it can sit on a retry
+exit code for hours after the state it was armed for arrived. The bundled waiters
+avoid that by reporting the change and leaving the judgment to the turn that has the
+whole picture. They keep one silent-pending mode of their own: a `--workflow` value
+that never matches — renamed, misspelled, or never triggered on this branch — holds a
+combined watch quiet indefinitely under `--timeout 0`, so check the name against a
+head that actually ran it before arming.
 
-Before arming any custom waiter, run it once against a PR or resource that **already**
-carries the event and confirm it exits `0`. A predicate written from observed failures
-alone can be blind to success, and a waiter that has never been seen to fire has not
-been tested.
+A predicate never seen to fire has not been tested. Verify it the way the delivery
+loop below is armed — seed the baseline, produce one event, confirm exit `0` — not by
+starting it on an event that already exists: an edge-triggered waiter is supposed to
+adopt that as its baseline, and one that fires there is level-triggered and will
+re-report forever. `--catch-up` is the bundled waiters' explicit replay mode for
+deliberately processing history.
 
 Run bundled waiters relative to the directory containing this loaded `SKILL.md`.
 The examples below use `BACKGROUND_WATCH_HOOK_DIR` for that directory:
@@ -458,9 +463,13 @@ GitHub-specific notes:
   against the rate limit — an idle watch can poll for hours for free
 - a Codex verdict arrives in more than one shape, and the waiter watches all of them:
   findings as a review with inline comments, and a pass as either a `+1` reaction on
-  the PR body from `chatgpt-codex-connector` / `chatgpt-codex-connector[bot]` or a PR
-  conversation comment naming the reviewed commit. Pass reactions remain visible even
-  when `--event-limit` is reached. A predicate keyed to reviews alone never sees a pass
+  the PR body or a PR conversation comment carrying the pass phrase. Either shape is a
+  pass only when all three hold: the author is the Codex bot
+  (`chatgpt-codex-connector` / `chatgpt-codex-connector[bot]`), the pass phrase is
+  present, and the reviewed commit it names is the current head. A contributor quoting
+  a pass, and the bot's own pass on an earlier head, are both not one. Pass reactions
+  remain visible even when `--event-limit` is reached. A predicate keyed to reviews
+  alone never sees a pass
 - PR activity also includes lifecycle changes on the PR itself, for example draft/ready, closed, reopened, or merged transitions
 - a changed PR head is reported as activity so a new push cannot leave the review
   loop asleep

--- a/skills/background-watch-hook/SKILL.md
+++ b/skills/background-watch-hook/SKILL.md
@@ -2,7 +2,7 @@
 name: background-watch-hook
 slug: background-watch-hook
 description: Use `vibe watch` to run a managed Harness waiter that returns to the same conversation later. Best for reviews, CI, files, logs, and other wait-now-continue-later workflows.
-version: 0.17.2
+version: 0.17.3
 ---
 
 # Background Watch Hook
@@ -202,6 +202,21 @@ cycle-oriented waiter may use exit code `75` only when its supervisor explicitly
 opts into retrying that code. Exit code `64` with the
 `avibe-watch: no-event` marker means a cycle finished with nothing worth an Agent
 turn.
+
+**A waiter detects change; the follow-up Agent Run makes the decision.** Keep that
+split when writing your own. A hand-written waiter that fires only once a composite
+gate is satisfied — CI green *and* a verdict bound to the exact head *and* zero
+unresolved threads — has to match the shape of every signal in that gate, and it can
+only match the shapes its author has already seen. A wrong predicate then produces
+silence, which is indistinguishable from "nothing has happened yet": it can sit on a
+retry exit code for hours while the state it was armed for has already arrived. The
+bundled waiters report the change and leave the judgment to the turn that has the
+whole picture, which is why they cannot fail that way.
+
+Before arming any custom waiter, run it once against a PR or resource that **already**
+carries the event and confirm it exits `0`. A predicate written from observed failures
+alone can be blind to success, and a waiter that has never been seen to fire has not
+been tested.
 
 Run bundled waiters relative to the directory containing this loaded `SKILL.md`.
 The examples below use `BACKGROUND_WATCH_HOOK_DIR` for that directory:
@@ -441,10 +456,11 @@ GitHub-specific notes:
   so edits and deletions remain observable, reactions are filtered server-side with
   `content=+1`, and unchanged pages revalidate to `304`, which GitHub does not charge
   against the rate limit — an idle watch can poll for hours for free
-- PR activity also includes the special case where `chatgpt-codex-connector` or
-  `chatgpt-codex-connector[bot]` leaves a `+1` reaction on the PR body instead of
-  posting a comment; pass reactions remain visible even when `--event-limit` is
-  reached
+- a Codex verdict arrives in more than one shape, and the waiter watches all of them:
+  findings as a review with inline comments, and a pass as either a `+1` reaction on
+  the PR body from `chatgpt-codex-connector` / `chatgpt-codex-connector[bot]` or a PR
+  conversation comment naming the reviewed commit. Pass reactions remain visible even
+  when `--event-limit` is reached. A predicate keyed to reviews alone never sees a pass
 - PR activity also includes lifecycle changes on the PR itself, for example draft/ready, closed, reopened, or merged transitions
 - a changed PR head is reported as activity so a new push cannot leave the review
   loop asleep


### PR DESCRIPTION
## What happened

A hand-written waiter for a PR review loop bound its whole predicate to
`pulls/N/reviews[].commit_id == HEAD`. Codex delivers *findings* that way, but delivers
a *pass* as a PR conversation comment carrying the pass phrase and `Reviewed commit`.
The predicate could therefore only ever match failure. It sat on its retry exit code
for roughly eleven hours on a PR that had been green (14/14), passed, and fully
resolved the whole time.

## Why this is a docs change and not a script change

`scripts/wait_pr.py` already reports that comment. Verified rather than assumed — run
against the PR in question with `--catch-up --actionable-only`, the pass shows up as a
reported event:

```
- issue_comment #5420476037 by chatgpt-codex-connector[bot]
  Codex Review: Didn't find any major issues. Breezy! **Reviewed commit:** `825185e3e5` ...
```

`--actionable-only` does not filter it: the default noise patterns are anchored trigger
comments and bare slash commands. So the bundled waiter would have woken the follow-up
turn on time.

What was missing was guidance. Two gaps:

1. Nothing said **where the decision belongs**. The bundled waiters report a change and
   let the follow-up Agent Run judge whether the state is now actionable. A custom waiter
   that instead encodes a composite gate — CI green *and* a verdict at the exact head
   *and* zero unresolved threads — has to match the shape of every signal in that gate,
   and it can only match shapes its author has already seen. When it is wrong it emits
   *silence*, which is indistinguishable from "nothing has happened yet". That is a worse
   failure mode than a wrong report, and the skill never warned about it.
2. The only place describing a Codex pass named the `+1` reaction shape, phrased as
   happening "instead of posting a comment" — which reads as *the* pass shape. The
   comment shape was not documented anywhere a waiter author would look.

## The change

- The waiter/decision split, stated after the waiter-contract mechanics, with the one
  silent-pending mode the bundled waiters do keep: `render_actions_result` returns no
  event while any requested workflow is missing, so a `--workflow` value that never
  resolves holds a combined watch quiet indefinitely under `--timeout 0`. Check the name
  against a head that actually ran it before arming.
- How to test a predicate that has never been seen to fire: seed the baseline, produce
  one event, confirm exit `0` — the same order the delivery loop below it is armed in.
  Not by pointing a waiter at an event that already exists; an edge-triggered waiter is
  supposed to adopt that as its baseline, and one that fires there is level-triggered.
  `--catch-up` is the explicit replay mode when history should be processed on purpose.
- The GitHub note now names both pass shapes with the three conditions a pass requires
  (Codex-bot author, pass phrase, reviewed SHA equal to the current head), so a quoted
  or stale pass is not mistaken for current-head approval.

Skill version 0.17.2 → 0.17.3.

## Verification

- `pytest tests/test_harness_skill_guidance.py tests/test_skills_service.py -q` → 43 passed.
- The `--catch-up` probe above.
- Each of the three review findings on the first head was checked against the
  implementation before editing: `_github_actions_wait.py:133` for the workflow-missing
  path, `AGENTS.md` for the pass conditions and the seed-once rule.

Docs only: +30 / −5 in one file against `master`, no behavior change.
