### PR TITLE
fix(model-hub): preserve prepared routes across overlapping turns

### DIFF
--- a/core/handlers/model_hub/provenance.py
+++ b/core/handlers/model_hub/provenance.py
@@ -510,7 +510,16 @@ class ProcessScope:
     token: str
     active_turns: set[str] = field(default_factory=set)
     ambiguous_turns: set[str] = field(default_factory=set)
+    prepared_routes: dict[str, "PreparedGatewayRoute"] = field(default_factory=dict)
+    routing_conflicts: set[str] = field(default_factory=set)
     untracked_use: bool = False
+
+
+@dataclass(frozen=True)
+class PreparedGatewayRoute:
+    requested_model_id: str
+    resolved_model_id: str
+    source_id: str
 
 
 class GatewayTurnTerminalizer:
@@ -557,13 +566,15 @@ class GatewayTurnTerminalizer:
             self.turn_id = None
         return self.turn_id
 
-    def resolution_model(self, gateway_model_id: str) -> str:
-        """Return the caller model retained before the CLI rewrote its request."""
+    def resolution_model(self, gateway_model_id: str) -> Optional[str]:
+        """Return the uniquely prepared caller model for this gateway request."""
 
-        turn_id = self.bind_request_model(gateway_model_id)
-        if turn_id is None:
-            return gateway_model_id
-        return self._registry.gateway_requested_model(turn_id) or gateway_model_id
+        self.bind_request_model(gateway_model_id)
+        return self._registry.gateway_resolution_model(
+            backend=self._backend,
+            token=self._token,
+            gateway_model_id=gateway_model_id,
+        )
 
     def fail(
         self,
@@ -887,22 +898,51 @@ class TurnCorrelationRegistry:
         *,
         backend: str,
         token: str,
+        turn_id: Optional[str] = None,
         requested_model_id: str,
         resolved_model_id: str,
         source_id: str,
         via_mapping: bool,
     ) -> None:
-        """Retain the caller-facing model before the CLI rewrites its request."""
+        """Retain routing independently from best-effort provenance attribution."""
 
         with self._lock:
+            key = self._token_scopes.get(token)
+            if key is None or key[0] != backend:
+                return
+            scope = self._scopes[key]
+            normalized_turn_id = str(turn_id or "").strip()
+            if normalized_turn_id:
+                if normalized_turn_id not in scope.active_turns:
+                    return
+                route_turn_id = normalized_turn_id
+            else:
+                exact = self._exact_turn(backend, token)
+                if exact is None:
+                    return
+                route_turn_id = exact[0]
+            prepared = PreparedGatewayRoute(
+                requested_model_id=requested_model_id,
+                resolved_model_id=resolved_model_id,
+                source_id=source_id,
+            )
+            existing = scope.prepared_routes.get(route_turn_id)
+            if existing is not None and existing != prepared:
+                scope.prepared_routes.pop(route_turn_id, None)
+                scope.routing_conflicts.add(route_turn_id)
+            elif route_turn_id not in scope.routing_conflicts:
+                scope.prepared_routes[route_turn_id] = prepared
+
             exact = self._exact_turn(backend, token)
             if exact is None:
                 return
-            turn_id, key = exact
+            exact_turn_id, key = exact
+            if exact_turn_id != route_turn_id:
+                return
             trace = self._traces.setdefault(
-                turn_id,
+                exact_turn_id,
                 TurnTrace(
-                    turn_id=turn_id,
+                    turn_id=exact_turn_id,
                     agent=key[0],
                     requested_model_id=requested_model_id,
                     scope_key=key,
@@ -920,17 +960,50 @@ class TurnCorrelationRegistry:
                 )
             ):
                 trace.ambiguous = True
-                self._scopes[key].ambiguous_turns.add(turn_id)
+                self._scopes[key].ambiguous_turns.add(exact_turn_id)
                 return
             trace.gateway_source_id = source_id
             trace.gateway_model_id = resolved_model_id
 
-    def gateway_requested_model(self, turn_id: str) -> Optional[str]:
+    def gateway_resolution_model(
+        self,
+        *,
+        backend: str,
+        token: str,
+        gateway_model_id: str,
+    ) -> Optional[str]:
+        """Resolve only a route identity that the launching turn prepared."""
+
         with self._lock:
-            trace = self._traces.get(turn_id)
-            if trace is None or trace.ambiguous:
+            key = self._token_scopes.get(token)
+            if key is None or key[0] != backend:
                 return None
-            return trace.requested_model_id
+            scope = self._scopes[key]
+            if scope.routing_conflicts.intersection(scope.active_turns):
+                return None
+            active_routes = [
+                route
+                for turn_id, route in scope.prepared_routes.items()
+                if turn_id in scope.active_turns
+            ]
+            matching = [
+                route
+                for route in active_routes
+                if route.resolved_model_id == gateway_model_id
+            ]
+            identities = {
+                (
+                    route.requested_model_id,
+                    route.resolved_model_id,
+                    route.source_id,
+                )
+                for route in matching
+            }
+            if len(identities) == 1:
+                return matching[0].requested_model_id
+            if active_routes:
+                return None
+            return gateway_model_id if scope.untracked_use else None
 
     def gateway_terminalizer(
         self,
@@ -1262,6 +1335,8 @@ class TurnCorrelationRegistry:
                 poisoned = poisoned or scope.untracked_use
                 scope.active_turns.discard(normalized_turn_id)
                 scope.ambiguous_turns.discard(normalized_turn_id)
+                scope.prepared_routes.pop(normalized_turn_id, None)
+                scope.routing_conflicts.discard(normalized_turn_id)
             if trace is None or trace.ambiguous or poisoned:
                 return
 

--- a/core/handlers/model_hub/turn_gateway.py
+++ b/core/handlers/model_hub/turn_gateway.py
@@ -315,6 +315,7 @@ class ModelHubTurnGateway:
             self.correlation.prepare_gateway_turn(
                 backend=backend,
                 token=token,
+                turn_id=turn_id,
                 requested_model_id=requested_model_id,
                 resolved_model_id=resolved_model_id,
                 source_id=source_id,
@@ -612,6 +613,15 @@ class ModelHubTurnGateway:
                 turn_outcome=REQUEST_NONFALLBACK_TURN_OUTCOME,
             )
         resolution_model = terminalizer.resolution_model(model_id)
+        if resolution_model is None:
+            terminalizer.fail("protocol_error")
+            return self._terminal_error_response(
+                execution,
+                terminalizer,
+                status=409,
+                code="mapping_target_unavailable",
+                turn_outcome=REQUEST_NONFALLBACK_TURN_OUTCOME,
+            )
 
         def observe_attempt(
             source_id: str,

--- a/tests/test_model_hub_l3.py
+++ b/tests/test_model_hub_l3.py
@@ -3774,6 +3774,81 @@ def test_gateway_uses_persisted_exact_hops_for_failover(
     asyncio.run(exercise())
 
 
+def test_gateway_keeps_prepared_route_during_overlapping_turns(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        requested_model = "claude-opus-4-8"
+        target_model = "gpt-5.6-luna"
+        source = _source(
+            "src_gptrelay01",
+            "GPT relay",
+            model_id=target_model,
+        )
+        outcome = _outcome(
+            RawOutcomeKind.SUCCESS,
+            status=200,
+            source_id=source.id,
+        )
+        response_body = (
+            b'{"id":"msg_fixture","type":"message","role":"assistant",'
+            b'"content":[{"type":"text","text":"ok"}],'
+            b'"model":"gpt-5.6-luna","stop_reason":"end_turn",'
+            b'"usage":{"input_tokens":1,"output_tokens":1}}'
+        )
+        service = _service(
+            tmp_path,
+            sources=[source],
+            live_handles=[LiveInvokeHandle(outcome, (response_body,))],
+        )
+        _canonicalize_fixed_test_routes(service)
+        service.store.config.agents["claude"].routes[requested_model] = ModelHubRouteConfig(
+            hops=(ModelHubRouteHopConfig(source.id, target_model),)
+        )
+        gateway = ModelHubTurnGateway(service)
+        first_base_url, first_token = await gateway.endpoint(
+            "claude",
+            process_scope="session:shared-claude",
+            turn_id="turn_overlap_first",
+            requested_model_id=requested_model,
+            resolved_model_id=target_model,
+            source_id=source.id,
+        )
+        second_base_url, second_token = await gateway.endpoint(
+            "claude",
+            process_scope="session:shared-claude",
+            turn_id="turn_overlap_second",
+            requested_model_id=requested_model,
+            resolved_model_id=target_model,
+            source_id=source.id,
+        )
+        assert first_base_url == second_base_url
+        assert first_token == second_token
+
+        try:
+            async with aiohttp.ClientSession(trust_env=False) as client:
+                response = await client.post(
+                    f"{second_base_url}/v1/messages",
+                    json={
+                        "model": target_model,
+                        "max_tokens": 1,
+                        "messages": [{"role": "user", "content": "ping"}],
+                        "stream": False,
+                    },
+                    headers={"x-api-key": second_token},
+                )
+                assert response.status == 200
+                await response.read()
+        finally:
+            await gateway.close()
+
+        assert service.adapter.invocations == [
+            (source.id, target_model, "claude"),
+        ]
+
+    asyncio.run(exercise())
+
+
 def test_gateway_model_outside_prepared_turn_fails_closed(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- preserve the Model Hub route prepared at Claude process launch even when multiple turns overlap in one process scope
- resolve gateway requests only from a unique prepared route identity and fail closed when prepared routes conflict
- add a regression for `claude-opus-4-8` routing to a GPT Source model (`gpt-5.6-luna`) during overlapping Claude turns

## Root cause

Gateway routing reused the provenance correlation lookup. When a shared Claude process had overlapping turns, provenance correctly became ambiguous, but routing then fell back to the runtime target model as a fresh Model Hub route key. That discarded the already selected logical route and could select a different Source/credential for the target model.

The fix separates the prepared routing fact from best-effort provenance attribution. Provenance may remain unavailable for overlapping turns, while routing still uses the unique Source/model identity chosen before launch.

## Validation

- 1,156 Model Hub tests passed; 1 expected failure
- 160 Model Hub runtime tests passed
- focused overlapping-turn regression passed after rebasing onto `origin/master`
- Ruff passed for all changed files
- real bundled CLIProxyAPI v7.2.95 boundary check confirmed a prefixed GPT Source request uses the GPT credential and `/v1/responses`, isolating the defect to the Avibe Gateway correlation layer

## Regression environment

A fresh isolated Incus worktree environment was attempted without resetting existing state. The new instance remained in `cloud-init status --wait` under concurrent local regression load, so the attempt was stopped before source deployment. No existing master regression environment or configuration was changed.
