### PR TITLE
test(model-hub): cover omitted undeclared effort

### DIFF
--- a/docs/plans/model-hub.md
+++ b/docs/plans/model-hub.md
@@ -571,7 +571,7 @@ repairs or rewrites configuration.
 singleton local login; a `hub` hop uses the local Gateway and may be cross-vendor. The
 system never prepends native supply or chooses a model. If the requested reasoning
 effort exactly appears in the configured hop model's `reasoning_efforts`, pass that one
-value; otherwise pass `null`, with no approximation or downgrade.
+value; otherwise omit the effort field, with no approximation or downgrade.
 
 Parameter, protocol, and tool-compatibility failures are terminal without fallthrough.
 A local Gateway start, listener, or process loss at **any** request phase is terminal

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -409,6 +409,12 @@ scenarios:
     kind: authentication
     layer: scenario
     test: tests/scenarios/model_hub/test_model_hub_turn_contract_scenarios.py::test_mh_static_credential_failure_does_not_retry_or_claim_takeover
+  - id: MH-EFFORT-001
+    name: An undeclared requested effort is omitted from the exact-hop request and the turn still completes
+    status: covered
+    kind: compatibility
+    layer: scenario
+    test: tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py::test_mh_effort_001_undeclared_effort_is_omitted_and_turn_completes
   - id: MH-TURN-RESULT-001
     name: All terminal outcomes are closed schema-valid provenance products
     status: covered

--- a/tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py
+++ b/tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py
@@ -227,13 +227,19 @@ async def _post_turn(
     *,
     endpoint: str = "messages",
     stream: bool = False,
+    payload: dict[str, object] | None = None,
 ) -> tuple[int, bytes]:
     headers = {"Authorization": f"Bearer {launch.gateway_token}"}
+    request_payload = payload or {
+        "model": launch.runtime_model,
+        "messages": [],
+        "stream": stream,
+    }
     async with aiohttp.ClientSession(trust_env=False) as client:
         async with client.post(
             f"{launch.gateway_base_url}/v1/{endpoint}",
             headers=headers,
-            json={"model": launch.runtime_model, "messages": [], "stream": stream},
+            json=request_payload,
         ) as response:
             return response.status, await response.read()
 
@@ -489,6 +495,48 @@ def test_mh_res_live_003_started_stream_never_retries(tmp_path: Path) -> None:
             assert terminal_event["error"]["message"]
             assert [call[0] for call in adapter.invocations] == ["src_primary1"]
             assert store.load().sources[0].state.status == "cooldown"
+        finally:
+            await gateway.close()
+
+    asyncio.run(exercise())
+
+
+def test_mh_effort_001_undeclared_effort_is_omitted_and_turn_completes(
+    tmp_path: Path,
+) -> None:
+    """MH-EFFORT-001: an undeclared effort is omitted from the exact-hop request and the turn still completes."""
+
+    async def exercise() -> None:
+        adapter = AdapterBoundaryFake(
+            [AdapterResult(RawOutcomeKind.SUCCESS, status=200, body=b'{"ok":true}')]
+        )
+        source = _source("src_codex001")
+        store = MemoryStore(_config(source))
+        service = _service(
+            tmp_path,
+            store,
+            adapter,
+            now=lambda: datetime(2026, 8, 26, tzinfo=timezone.utc),
+        )
+        gateway = ModelHubTurnGateway(service)
+        router = ModelHubRuntimeRouter(service=service, turn_gateway=gateway)
+        try:
+            launch = await router.resolve("codex", _requested_model("codex"))
+            status, body = await _post_turn(
+                launch,
+                endpoint="responses",
+                payload={
+                    "model": launch.runtime_model,
+                    "messages": [],
+                    "stream": False,
+                    "reasoning": {"effort": "low", "summary": "auto"},
+                },
+            )
+            assert status == 200
+            assert body == b'{"ok":true}'
+            assert len(adapter.requests) == 1
+            assert "reasoning_effort" not in adapter.requests[0]
+            assert adapter.requests[0]["reasoning"] == {"summary": "auto"}
         finally:
             await gateway.close()
 


### PR DESCRIPTION
## Summary
- align Model Hub §4.3 with the current exact-hop behavior: undeclared reasoning effort is omitted rather than forwarded as a field with a null value
- add fresh-source scenario coverage for the empty-tier codex path that originally failed in #1725
- keep the scenario catalog wired to the new coverage row

## Scenario IDs
- MH-EFFORT-001

## Evidence
- contract: `python3 scripts/check_model_hub_authorities.py`, `tests/test_model_hub_config.py`, `tests/scenarios/model_hub/test_model_hub_catalog.py`
- scenario: `tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py::test_mh_effort_001_undeclared_effort_is_omitted_and_turn_completes`
- residual manual: did not rerun Incus here; issue #1725 already contains the live `master` environment verification and workaround confirmation for the same failing path

## Note
- current `master` already carries the exact-hop runtime filtering change, so this PR closes the remaining spec/regression gap for #1725 on top of that base

Fixes #1725
