### PR TITLE
test(show-pages): cover published Markdown runtime integration

### DIFF
--- a/tests/e2e/test_show_markdown_runtime_integration.py
+++ b/tests/e2e/test_show_markdown_runtime_integration.py
@@ -4,15 +4,16 @@ import json
 import os
 import shutil
 import subprocess
+import uuid
 from pathlib import Path
 
 import pytest
 import requests
 
 
-SESSION_ID = "ses-issue-1617"
 CALLER_SECRET = "AVIBE_CALLER_SECRET_NEVER_FORWARD"
 FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "show_markdown_integration"
+REGRESSION_METADATA = Path("/var/lib/avibe-regression/metadata.json")
 
 
 def _vibe(*args: str) -> dict:
@@ -25,13 +26,30 @@ def _vibe(*args: str) -> dict:
     return json.loads(result.stdout)
 
 
-def _install_fixture() -> Path:
-    workspace = Path(_vibe("show", "path", "--session-id", SESSION_ID)["path"])
+def _assert_isolated_regression(expected_slug: str) -> None:
+    assert os.environ.get("VIBE_DEPLOYMENT_ENV") == "regression"
+    metadata = json.loads(REGRESSION_METADATA.read_text())
+    assert metadata["target"] == "worktree"
+    assert metadata["slug"] == expected_slug
+    assert metadata["project"] == f"avr-wt-{expected_slug}"
+    assert metadata["instance"] == f"avibe-wt-{expected_slug}"
+
+
+def _create_workspace(session_id: str) -> Path:
+    workspace = Path(_vibe("show", "path", "--session-id", session_id)["path"])
+    assert workspace.resolve().is_relative_to((Path.home() / ".avibe" / "show-pages").resolve())
+    return workspace
+
+
+def _install_fixture(workspace: Path, session_id: str) -> None:
     for relative in (Path("src/pages"), Path("api")):
         destination = workspace / relative
         shutil.rmtree(destination, ignore_errors=True)
         shutil.copytree(FIXTURE_ROOT / relative, destination)
-    return workspace
+    index = workspace / "src/pages/index.tsx"
+    source = index.read_text()
+    assert source.count("__SESSION_ID__") == 1
+    index.write_text(source.replace("__SESSION_ID__", session_id))
 
 
 def _assert_markdown(response: requests.Response, *, cache: str | None = None) -> str:
@@ -53,15 +71,17 @@ def _assert_html(response: requests.Response) -> None:
 @pytest.mark.integration
 def test_published_show_runtime_renders_private_and_public_markdown() -> None:
     base_url = os.environ.get("AVIBE_SHOW_MARKDOWN_BASE_URL")
+    expected_slug = os.environ.get("AVIBE_SHOW_MARKDOWN_EXPECT_REGRESSION_SLUG")
     expected_runtime = os.environ.get("AVIBE_SHOW_MARKDOWN_EXPECT_RUNTIME_VERSION")
     expected_manifest = os.environ.get("AVIBE_SHOW_MARKDOWN_EXPECT_MANIFEST_SHA256")
     expected_archive = os.environ.get("AVIBE_SHOW_MARKDOWN_EXPECT_ARCHIVE_SHA256")
-    if not base_url or not expected_runtime or not expected_manifest or not expected_archive:
+    if not base_url or not expected_slug or not expected_runtime or not expected_manifest or not expected_archive:
         pytest.skip(
-            "set the Show Markdown base URL, runtime version, manifest digest, and archive digest "
+            "set the Show Markdown base URL, regression slug, runtime version, manifest digest, and archive digest "
             "inside an isolated Incus regression environment"
         )
 
+    _assert_isolated_regression(expected_slug)
     runtime_status = _vibe("runtime", "status")
     assert runtime_status["manifest"]["runtime_version"] == expected_runtime
     assert runtime_status["manifest"]["sha256"] == expected_manifest
@@ -82,9 +102,11 @@ def test_published_show_runtime_renders_private_and_public_markdown() -> None:
         assert not any(shutil.which(target) for target in browser_targets)
         assert not list(browser_cache.glob("chromium_headless_shell-*"))
 
-    _install_fixture()
-    _vibe("show", "update", "--session-id", SESSION_ID, "--visibility", "private")
-    private_url = f"{base_url.rstrip('/')}/show/{SESSION_ID}/"
+    session_id = f"sesmd{uuid.uuid4().hex[:16]}"
+    workspace = _create_workspace(session_id)
+    _install_fixture(workspace, session_id)
+    _vibe("show", "update", "--session-id", session_id, "--visibility", "private")
+    private_url = f"{base_url.rstrip('/')}/show/{session_id}/"
     markdown_headers = {"Accept": "text/markdown"}
     caller_headers = {
         **markdown_headers,
@@ -115,6 +137,8 @@ def test_published_show_runtime_renders_private_and_public_markdown() -> None:
         assert "Daily report" in report_body
         assert "week" in report_body
         assert "Asia/Shanghai" in report_body
+        assert "Identity probe" in report_body
+        assert "ready" in report_body
         assert CALLER_SECRET not in report_body
         assert report_body.count("none") >= 3
 
@@ -122,7 +146,7 @@ def test_published_show_runtime_renders_private_and_public_markdown() -> None:
             "show",
             "update",
             "--session-id",
-            SESSION_ID,
+            session_id,
             "--visibility",
             "public",
         )
@@ -141,9 +165,14 @@ def test_published_show_runtime_renders_private_and_public_markdown() -> None:
         assert "Daily report" in public_report_body
         assert "week" in public_report_body
         assert "Asia/Shanghai" in public_report_body
+        assert "Identity probe" in public_report_body
+        assert "ready" in public_report_body
         assert CALLER_SECRET not in public_report_body
 
         if expected_browserless:
             assert len(list(browser_cache.glob("chromium_headless_shell-*"))) == 1
     finally:
-        _vibe("show", "update", "--session-id", SESSION_ID, "--visibility", "offline")
+        try:
+            _vibe("show", "update", "--session-id", session_id, "--visibility", "offline")
+        finally:
+            shutil.rmtree(workspace)

--- a/tests/e2e/test_show_markdown_runtime_integration.py
+++ b/tests/e2e/test_show_markdown_runtime_integration.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import requests
+
+
+SESSION_ID = "ses-issue-1617"
+CALLER_SECRET = "AVIBE_CALLER_SECRET_NEVER_FORWARD"
+FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "show_markdown_integration"
+
+
+def _vibe(*args: str) -> dict:
+    result = subprocess.run(
+        ["vibe", *args, "--json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def _install_fixture() -> Path:
+    workspace = Path(_vibe("show", "path", "--session-id", SESSION_ID)["path"])
+    for relative in (Path("src/pages"), Path("api")):
+        destination = workspace / relative
+        shutil.rmtree(destination, ignore_errors=True)
+        shutil.copytree(FIXTURE_ROOT / relative, destination)
+    return workspace
+
+
+def _assert_markdown(response: requests.Response, *, cache: str | None = None) -> str:
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"].lower() == "text/markdown; charset=utf-8"
+    assert "accept" in {part.strip().lower() for part in response.headers["vary"].split(",")}
+    assert "no-store" in response.headers["cache-control"].lower()
+    if cache is not None:
+        assert response.headers["x-avibe-render-cache"] == cache
+    return response.text
+
+
+def _assert_html(response: requests.Response) -> None:
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"].lower().startswith("text/html")
+    assert "<!doctype html>" in response.text.lower()
+
+
+@pytest.mark.integration
+def test_published_show_runtime_renders_private_and_public_markdown() -> None:
+    base_url = os.environ.get("AVIBE_SHOW_MARKDOWN_BASE_URL")
+    expected_runtime = os.environ.get("AVIBE_SHOW_MARKDOWN_EXPECT_RUNTIME_VERSION")
+    expected_manifest = os.environ.get("AVIBE_SHOW_MARKDOWN_EXPECT_MANIFEST_SHA256")
+    expected_archive = os.environ.get("AVIBE_SHOW_MARKDOWN_EXPECT_ARCHIVE_SHA256")
+    if not base_url or not expected_runtime or not expected_manifest or not expected_archive:
+        pytest.skip(
+            "set the Show Markdown base URL, runtime version, manifest digest, and archive digest "
+            "inside an isolated Incus regression environment"
+        )
+
+    runtime_status = _vibe("runtime", "status")
+    assert runtime_status["manifest"]["runtime_version"] == expected_runtime
+    assert runtime_status["manifest"]["sha256"] == expected_manifest
+    assert runtime_status["archive"]["sha256"] == expected_archive
+    assert runtime_status["install"]["runtime_version"] == expected_runtime
+    assert runtime_status["install"]["matches_manifest"] is True
+
+    expected_browserless = os.environ.get("AVIBE_SHOW_MARKDOWN_EXPECT_BROWSERLESS") == "1"
+    browser_cache = Path.home() / ".cache" / "ms-playwright"
+    browser_targets = (
+        "google-chrome-stable",
+        "google-chrome",
+        "microsoft-edge",
+        "chromium",
+        "chromium-browser",
+    )
+    if expected_browserless:
+        assert not any(shutil.which(target) for target in browser_targets)
+        assert not list(browser_cache.glob("chromium_headless_shell-*"))
+
+    _install_fixture()
+    _vibe("show", "update", "--session-id", SESSION_ID, "--visibility", "private")
+    private_url = f"{base_url.rstrip('/')}/show/{SESSION_ID}/"
+    markdown_headers = {"Accept": "text/markdown"}
+    caller_headers = {
+        **markdown_headers,
+        "Authorization": f"Bearer {CALLER_SECRET}",
+        "Cookie": f"caller={CALLER_SECRET}",
+        "X-Vibe-CSRF-Token": CALLER_SECRET,
+    }
+
+    try:
+        _assert_html(requests.get(private_url, timeout=30))
+
+        first = requests.get(private_url, headers=markdown_headers, timeout=420)
+        first_body = _assert_markdown(first, cache="miss")
+        assert "AVIBE_MARKDOWN_VISIBLE" in first_body
+        assert "AVIBE_MARKDOWN_HIDDEN" not in first_body
+        assert "Preserve the verified release source" in first_body
+
+        if expected_browserless:
+            provisioned = list(browser_cache.glob("chromium_headless_shell-*"))
+            assert len(provisioned) == 1
+
+        second = requests.get(private_url, headers=markdown_headers, timeout=60)
+        assert _assert_markdown(second, cache="hit") == first_body
+
+        query_path = "reports/daily?view=week&timezone=Asia%2FShanghai"
+        report = requests.get(f"{private_url}{query_path}", headers=caller_headers, timeout=120)
+        report_body = _assert_markdown(report)
+        assert "Daily report" in report_body
+        assert "week" in report_body
+        assert "Asia/Shanghai" in report_body
+        assert CALLER_SECRET not in report_body
+        assert report_body.count("none") >= 3
+
+        public_state = _vibe(
+            "show",
+            "update",
+            "--session-id",
+            SESSION_ID,
+            "--visibility",
+            "public",
+        )
+        share_id = public_state["share_id"]
+        public_url = f"{base_url.rstrip('/')}/p/{share_id}/"
+
+        public_markdown = requests.get(public_url, headers=markdown_headers, timeout=120)
+        public_body = _assert_markdown(public_markdown)
+        assert "/show/" not in public_body
+        assert "NEVER_EXPOSE" not in public_body
+        assert f"/p/{share_id}/reports/daily?view=week" in public_body
+
+        _assert_html(requests.get(public_url, timeout=30))
+        public_report = requests.get(f"{public_url}{query_path}", headers=markdown_headers, timeout=120)
+        public_report_body = _assert_markdown(public_report)
+        assert "Daily report" in public_report_body
+        assert "week" in public_report_body
+        assert "Asia/Shanghai" in public_report_body
+        assert CALLER_SECRET not in public_report_body
+
+        if expected_browserless:
+            assert len(list(browser_cache.glob("chromium_headless_shell-*"))) == 1
+    finally:
+        _vibe("show", "update", "--session-id", SESSION_ID, "--visibility", "offline")

--- a/tests/fixtures/show_markdown_integration/api/identity.ts
+++ b/tests/fixtures/show_markdown_integration/api/identity.ts
@@ -1,0 +1,7 @@
+export function GET(request: Request) {
+  return Response.json({
+    authorization: request.headers.get("authorization"),
+    cookie: request.headers.get("cookie"),
+    csrf: request.headers.get("x-vibe-csrf-token"),
+  })
+}

--- a/tests/fixtures/show_markdown_integration/src/pages/index.tsx
+++ b/tests/fixtures/show_markdown_integration/src/pages/index.tsx
@@ -7,7 +7,7 @@ export default function IntegrationHome() {
       <p agent-note="Preserve the verified release source">Annotated content</p>
       <nav>
         <a href="reports/daily?view=week&timezone=Asia%2FShanghai">Daily report</a>
-        <a href="/show/ses-issue-1617/reports/daily?view=week">Same-page private link</a>
+        <a href="/show/__SESSION_ID__/reports/daily?view=week">Same-page private link</a>
         <a href="/show/private-neighbor/secret?credential=NEVER_EXPOSE">Other private link</a>
       </nav>
     </main>

--- a/tests/fixtures/show_markdown_integration/src/pages/index.tsx
+++ b/tests/fixtures/show_markdown_integration/src/pages/index.tsx
@@ -1,0 +1,15 @@
+export default function IntegrationHome() {
+  return (
+    <main>
+      <h1>Issue 1617 Markdown Integration</h1>
+      <p id="visible-marker">Visible marker: AVIBE_MARKDOWN_VISIBLE</p>
+      <p data-agent-hidden>Hidden marker: AVIBE_MARKDOWN_HIDDEN</p>
+      <p agent-note="Preserve the verified release source">Annotated content</p>
+      <nav>
+        <a href="reports/daily?view=week&timezone=Asia%2FShanghai">Daily report</a>
+        <a href="/show/ses-issue-1617/reports/daily?view=week">Same-page private link</a>
+        <a href="/show/private-neighbor/secret?credential=NEVER_EXPOSE">Other private link</a>
+      </nav>
+    </main>
+  )
+}

--- a/tests/fixtures/show_markdown_integration/src/pages/reports/daily.tsx
+++ b/tests/fixtures/show_markdown_integration/src/pages/reports/daily.tsx
@@ -6,15 +6,29 @@ type IdentityProbe = {
   csrf: string | null
 }
 
+type IdentityState =
+  | { status: "loading" }
+  | { status: "ready"; value: IdentityProbe }
+  | { status: "error"; message: string }
+
 export default function DailyReport() {
-  const [identity, setIdentity] = useState<IdentityProbe | null>(null)
+  const [identity, setIdentity] = useState<IdentityState>({ status: "loading" })
   const params = new URLSearchParams(window.location.search)
 
   useEffect(() => {
     fetch(new URL("api/identity", document.baseURI))
-      .then((response) => response.json())
-      .then((payload: IdentityProbe) => setIdentity(payload))
+      .then((response) => {
+        if (!response.ok) throw new Error(`identity probe returned ${response.status}`)
+        return response.json()
+      })
+      .then((payload: IdentityProbe) => setIdentity({ status: "ready", value: payload }))
+      .catch((error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error)
+        setIdentity({ status: "error", message })
+      })
   }, [])
+
+  const value = identity.status === "ready" ? identity.value : null
 
   return (
     <main>
@@ -24,12 +38,14 @@ export default function DailyReport() {
         <dd>{params.get("view") ?? "missing"}</dd>
         <dt>Timezone</dt>
         <dd>{params.get("timezone") ?? "missing"}</dd>
+        <dt>Identity probe</dt>
+        <dd>{identity.status === "error" ? `error: ${identity.message}` : identity.status}</dd>
         <dt>Authorization forwarded</dt>
-        <dd>{identity?.authorization ?? "none"}</dd>
+        <dd>{value ? value.authorization ?? "none" : "pending"}</dd>
         <dt>Cookie forwarded</dt>
-        <dd>{identity?.cookie ?? "none"}</dd>
+        <dd>{value ? value.cookie ?? "none" : "pending"}</dd>
         <dt>CSRF forwarded</dt>
-        <dd>{identity?.csrf ?? "none"}</dd>
+        <dd>{value ? value.csrf ?? "none" : "pending"}</dd>
       </dl>
     </main>
   )

--- a/tests/fixtures/show_markdown_integration/src/pages/reports/daily.tsx
+++ b/tests/fixtures/show_markdown_integration/src/pages/reports/daily.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react"
+
+type IdentityProbe = {
+  authorization: string | null
+  cookie: string | null
+  csrf: string | null
+}
+
+export default function DailyReport() {
+  const [identity, setIdentity] = useState<IdentityProbe | null>(null)
+  const params = new URLSearchParams(window.location.search)
+
+  useEffect(() => {
+    fetch(new URL("api/identity", document.baseURI))
+      .then((response) => response.json())
+      .then((payload: IdentityProbe) => setIdentity(payload))
+  }, [])
+
+  return (
+    <main>
+      <h1>Daily report</h1>
+      <dl>
+        <dt>View</dt>
+        <dd>{params.get("view") ?? "missing"}</dd>
+        <dt>Timezone</dt>
+        <dd>{params.get("timezone") ?? "missing"}</dd>
+        <dt>Authorization forwarded</dt>
+        <dd>{identity?.authorization ?? "none"}</dd>
+        <dt>Cookie forwarded</dt>
+        <dd>{identity?.cookie ?? "none"}</dd>
+        <dt>CSRF forwarded</dt>
+        <dd>{identity?.csrf ?? "none"}</dd>
+      </dl>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

- add an opt-in local Incus E2E that exercises the published Show Runtime through Avibe's real private and public proxy surfaces
- bind the run to the expected release manifest, Runtime commit, and platform archive digest
- cover HTML compatibility, SPA routes and query parameters, DOM cleanup, caller credential isolation, public-link privacy, render caching, and browserless managed-shell provisioning

## Validation

- Runtime check, lint, smoke, and bundle pass at `4de89a3904cf5659fdde2f2249007dc1b1a8e9a5`
- 114 focused Show Markdown, protocol, and manifest tests pass
- Ruff/pre-commit passes across the repository
- UI theme validation, lint, 3,252 tests, and production build pass
- wheel build succeeds with the verified `gh-v3.0.14rc2` Show Runtime manifest embedded byte-for-byte
- final private/public Incus execution is in progress on the local regression host

Refs #1617
