### PR TITLE
fix(model-hub): isolate OpenCode gateway provider

### DIFF
--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -39,6 +39,7 @@ from modules.agents.opencode.message_processor import (
     is_empty_terminal_opencode_message,
 )
 from modules.agents.opencode.utils import (
+    find_opencode_model_info,
     resolve_opencode_configured_default_model,
     resolve_opencode_model_id,
     resolve_opencode_reasoning_effort,
@@ -2811,7 +2812,8 @@ class AgentAuthService:
 
         ``model`` is the model id (e.g. ``"gpt-4o-mini"``); we wrap it
         into the ``{providerID, modelID}`` shape OpenCode expects. When
-        ``None``, the probe resolves Avibe's effective Agent default first.
+        ``None``, the probe prefers Avibe's effective Agent default only
+        when the provider's native catalog confirms that model.
         """
         provider_id = (provider_id or "").strip()
         if not provider_id:
@@ -2821,8 +2823,15 @@ class AgentAuthService:
         if server is None:
             return {"ok": False, "error": "opencode_server_unavailable"}
 
-        # Match normal OpenCode turns: caller override, the selected OpenCode
-        # Agent's model, then the provider catalog.
+        directory = os.path.expanduser("~")
+        try:
+            catalog = await server.get_native_available_models(directory)
+        except Exception:  # noqa: BLE001
+            catalog = None
+
+        # A provider probe tests native connectivity, so its inferred model
+        # must come from the native catalog even when the selected Agent uses
+        # a public model projected by Model Hub.
         chosen_model = (model or "").strip()
         backend_config = self._resolve_backend_config("opencode")
         default_provider = getattr(backend_config, "default_provider", None)
@@ -2832,7 +2841,7 @@ class AgentAuthService:
                 runtime_agent_model = server.get_agent_model_from_config(default_agent)
             except Exception:  # noqa: BLE001
                 runtime_agent_model = None
-            chosen_model = (
+            inferred_model = (
                 resolve_opencode_configured_default_model(
                     runtime_agent_model,
                     default_provider=default_provider,
@@ -2840,17 +2849,43 @@ class AgentAuthService:
                 )
                 or ""
             )
+            if inferred_model and isinstance(catalog, dict):
+                resolved_inferred_model = resolve_opencode_model_id(
+                    catalog,
+                    provider_id,
+                    inferred_model,
+                )
+                if (
+                    resolved_inferred_model
+                    and find_opencode_model_info(
+                        catalog,
+                        provider_id,
+                        resolved_inferred_model,
+                    )
+                    is not None
+                ):
+                    chosen_model = resolved_inferred_model
         if not chosen_model:
-            try:
-                catalog = await server.get_native_available_models(os.path.expanduser("~"))
-            except Exception:  # noqa: BLE001
-                catalog = None
             if isinstance(catalog, dict):
                 default_map = catalog.get("default") or {}
                 if isinstance(default_map, dict):
                     raw_default = default_map.get(provider_id)
                     if isinstance(raw_default, str) and raw_default.strip():
-                        chosen_model = raw_default.strip()
+                        resolved_default = resolve_opencode_model_id(
+                            catalog,
+                            provider_id,
+                            raw_default.strip(),
+                        )
+                        if (
+                            resolved_default
+                            and find_opencode_model_info(
+                                catalog,
+                                provider_id,
+                                resolved_default,
+                            )
+                            is not None
+                        ):
+                            chosen_model = resolved_default
                 if not chosen_model:
                     providers = catalog.get("providers") or []
                     if isinstance(providers, list):
@@ -2879,7 +2914,6 @@ class AgentAuthService:
         # OpenCode picks a workdir per request; the probe doesn't touch
         # files so the home dir is fine and matches what the IM /setup
         # flow uses.
-        directory = os.path.expanduser("~")
         started = time.monotonic()
         session_id: str | None = None
         active_registered = False
@@ -2915,10 +2949,6 @@ class AgentAuthService:
             except Exception:  # noqa: BLE001
                 pass
 
-            try:
-                catalog = await server.get_native_available_models(directory)
-            except Exception:  # noqa: BLE001
-                catalog = None
             model_dict = {"providerID": provider_id, "modelID": chosen_model}
             if isinstance(catalog, dict):
                 resolved_model_id = resolve_opencode_model_id(catalog, provider_id, chosen_model)

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -2842,7 +2842,7 @@ class AgentAuthService:
             )
         if not chosen_model:
             try:
-                catalog = await server.get_available_models(os.path.expanduser("~"))
+                catalog = await server.get_native_available_models(os.path.expanduser("~"))
             except Exception:  # noqa: BLE001
                 catalog = None
             if isinstance(catalog, dict):
@@ -2916,7 +2916,7 @@ class AgentAuthService:
                 pass
 
             try:
-                catalog = await server.get_available_models(directory)
+                catalog = await server.get_native_available_models(directory)
             except Exception:  # noqa: BLE001
                 catalog = None
             model_dict = {"providerID": provider_id, "modelID": chosen_model}

--- a/core/handlers/model_hub/__init__.py
+++ b/core/handlers/model_hub/__init__.py
@@ -1,6 +1,17 @@
 """Model Hub configuration, resolution policy, and API services."""
 
 from .adapter import EngineAdapter
-from .service import ModelHubError, ModelHubService, create_default_service
+from .service import (
+    ModelHubError,
+    ModelHubService,
+    create_default_service,
+    load_opencode_public_models,
+)
 
-__all__ = ["EngineAdapter", "ModelHubError", "ModelHubService", "create_default_service"]
+__all__ = [
+    "EngineAdapter",
+    "ModelHubError",
+    "ModelHubService",
+    "create_default_service",
+    "load_opencode_public_models",
+]

--- a/core/handlers/model_hub/rpc.py
+++ b/core/handlers/model_hub/rpc.py
@@ -145,6 +145,8 @@ async def dispatch_model_hub_rpc(
         return service.agent_chain(payload.get("backend"), payload.get("model_id"))
     if operation == "get_agent_chains":
         return service.agent_chains(payload.get("backend"))
+    if operation == "get_opencode_public_models":
+        return service.opencode_public_models()
     if operation == "probe_agent":
         return await service.probe_agent(
             payload.get("backend"),

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -365,6 +365,40 @@ def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _project_opencode_public_models(
+    config: ModelHubConfig,
+    *,
+    now: datetime,
+    unavailable_source_ids: frozenset[str] = frozenset(),
+) -> dict[str, dict[str, Any]]:
+    agent = config.agents["opencode"]
+    if agent.mode == "direct" or agent.menu is None:
+        return {}
+    projected: dict[str, dict[str, Any]] = {}
+    for identifier in dict.fromkeys(agent.menu.checked):
+        resolution = resolve_model_hub_turn(
+            config,
+            "opencode",
+            identifier,
+            now=now,
+            unavailable_source_ids=unavailable_source_ids,
+            supply_channel="hub",
+        )
+        model = project_opencode_public_model(identifier, resolution)
+        if model is not None:
+            projected[identifier] = model
+    return projected
+
+
+def load_opencode_public_models() -> dict[str, dict[str, Any]]:
+    """Load the persisted, credential-free OpenCode projection for local callers."""
+
+    return _project_opencode_public_models(
+        V2ModelHubConfigStore().load(),
+        now=_utc_now(),
+    )
+
+
 def _source_id() -> str:
     return f"src_{uuid.uuid4().hex[:12]}"
 
@@ -3881,25 +3915,14 @@ class ModelHubService:
         """Return the safe public projection owned by persisted Hub config."""
 
         config = self.store.load()
-        agent = config.agents["opencode"]
-        if agent.mode == "direct" or agent.menu is None:
-            return {}
-        now = self.now()
-        unavailable_source_ids = self._unavailable_native_sources(config, "opencode")
-        projected: dict[str, dict[str, Any]] = {}
-        for identifier in dict.fromkeys(agent.menu.checked):
-            resolution = resolve_model_hub_turn(
+        return _project_opencode_public_models(
+            config,
+            now=self.now(),
+            unavailable_source_ids=self._unavailable_native_sources(
                 config,
                 "opencode",
-                identifier,
-                now=now,
-                unavailable_source_ids=unavailable_source_ids,
-                supply_channel="hub",
-            )
-            model = project_opencode_public_model(identifier, resolution)
-            if model is not None:
-                projected[identifier] = model
-        return projected
+            ),
+        )
 
     @staticmethod
     def _probe_request(

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -122,6 +122,42 @@ PROBE_RESULT_CONTRACT_VERSION = 6
 # than any attempt this runtime can start, yet still able to settle a Source that
 # this runtime has not attempted again.
 PRE_ATTEMPT_SETTLEMENT_GENERATION = 0
+
+
+def project_opencode_public_model(
+    identifier: str,
+    resolution: ModelHubTurnResolution,
+) -> dict[str, Any] | None:
+    """Project one persisted OpenCode route without transport credentials."""
+
+    inspection = (
+        resolution.candidate_hops[0]
+        if resolution.candidate_hops
+        else resolution.projectable_hops[0]
+        if resolution.projectable_hops
+        else None
+    )
+    if inspection is None or inspection.source is None or inspection.model_id is None:
+        return None
+    model = next(
+        (item for item in inspection.source.models if item.id == inspection.model_id),
+        None,
+    )
+    projected: dict[str, Any] = {
+        "id": identifier,
+        "name": (
+            model.display_name
+            if model is not None and model.display_name
+            else identifier
+        ),
+    }
+    variants = {
+        effort: {"reasoningEffort": effort}
+        for effort in (model.reasoning_efforts if model is not None else ())
+    }
+    if variants:
+        projected["variants"] = variants
+    return projected
 logger = logging.getLogger(__name__)
 
 _NATIVE_VENDOR_BACKENDS = {"anthropic": "claude", "openai": "codex"}
@@ -3840,6 +3876,30 @@ class ModelHubService:
             )
             for model_id in self._agent_model_ids(agent, requested_model)
         ]
+
+    def opencode_public_models(self) -> dict[str, dict[str, Any]]:
+        """Return the safe public projection owned by persisted Hub config."""
+
+        config = self.store.load()
+        agent = config.agents["opencode"]
+        if agent.mode == "direct" or agent.menu is None:
+            return {}
+        now = self.now()
+        unavailable_source_ids = self._unavailable_native_sources(config, "opencode")
+        projected: dict[str, dict[str, Any]] = {}
+        for identifier in dict.fromkeys(agent.menu.checked):
+            resolution = resolve_model_hub_turn(
+                config,
+                "opencode",
+                identifier,
+                now=now,
+                unavailable_source_ids=unavailable_source_ids,
+                supply_channel="hub",
+            )
+            model = project_opencode_public_model(identifier, resolution)
+            if model is not None:
+                projected[identifier] = model
+        return projected
 
     @staticmethod
     def _probe_request(

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -459,7 +459,23 @@ class SettingsHandler(BaseHandler):
 
                     cwd = self.controller.get_cwd(context)
                     opencode_agents = await server.get_available_agents(cwd)
-                    opencode_models = await server.get_available_models(cwd)
+                    model_hub_service = getattr(
+                        self.controller,
+                        "model_hub_service",
+                        None,
+                    )
+                    public_models = (
+                        model_hub_service.opencode_public_models()
+                        if model_hub_service is not None
+                        else None
+                    )
+                    if public_models is None:
+                        opencode_models = await server.get_available_models(cwd)
+                    else:
+                        opencode_models = await server.get_available_models(
+                            cwd,
+                            model_hub_models=public_models,
+                        )
                     opencode_default_config = await server.get_default_config(cwd)
             except Exception as e:
                 logger.warning(f"Failed to fetch OpenCode data: {e}")

--- a/modules/agents/model_hub.py
+++ b/modules/agents/model_hub.py
@@ -44,6 +44,7 @@ from core.handlers.model_hub.service import (
 from core.services.settings import load_config_or_default
 from core.handlers.model_hub.turn_gateway import ModelHubTurnGateway
 from vibe.codex_config import format_toml_basic_string
+from vibe.opencode_config import model_hub_runtime_provider_id
 
 
 LaunchChannel = Literal["direct", "native_cli", "hub"]
@@ -336,16 +337,6 @@ def _provider_package() -> str:
     # OpenCode speaks one stable frontend protocol to the local Gateway. The
     # persisted exact hop selects the upstream protocol behind that boundary.
     return "@ai-sdk/openai-compatible"
-
-
-_OPENCODE_MODEL_HUB_PROVIDER_PREFIX = "avibe-model-hub-"
-
-
-def _opencode_model_hub_provider_id(gateway_token: str) -> str:
-    """Derive an overlay-private provider namespace from its runtime credential."""
-
-    digest = hashlib.sha256(gateway_token.encode()).hexdigest()[:24]
-    return f"{_OPENCODE_MODEL_HUB_PROVIDER_PREFIX}{digest}"
 
 
 def _provider_base_url(gateway_base_url: str) -> str:
@@ -978,7 +969,7 @@ class ModelHubRuntimeRouter:
             process_scope="opencode:shared-server",
             turn_id=None,
         )
-        overlay_provider_id = _opencode_model_hub_provider_id(gateway_token)
+        overlay_provider_id = model_hub_runtime_provider_id(gateway_token)
         providers: dict[str, dict[str, Any]] = {}
         projected_identifiers: list[str] = []
         available_identifiers: list[str] = []
@@ -1125,3 +1116,17 @@ def opencode_model_for_overlay(
     if overlay is None or requested_model is None:
         return requested_model
     return f"{overlay.provider_id}/{requested_model}"
+
+
+def opencode_model_catalog_for_overlay(
+    overlay: OpenCodeOverlay,
+) -> dict[str, Any]:
+    """Project the private overlay into the model metadata needed by its turn."""
+
+    payload = json.loads(overlay.content)
+    provider = payload.get("provider", {}).get(overlay.provider_id, {})
+    models = provider.get("models", {}) if isinstance(provider, dict) else {}
+    return {
+        "providers": [{"id": overlay.provider_id, "models": models}],
+        "default": {},
+    }

--- a/modules/agents/model_hub.py
+++ b/modules/agents/model_hub.py
@@ -44,6 +44,7 @@ from core.handlers.model_hub.service import (
 from core.services.settings import load_config_or_default
 from core.handlers.model_hub.turn_gateway import ModelHubTurnGateway
 from vibe.codex_config import format_toml_basic_string
+from vibe.opencode_config import opencode_user_provider_exists
 
 
 LaunchChannel = Literal["direct", "native_cli", "hub"]
@@ -968,6 +969,8 @@ class ModelHubRuntimeRouter:
         checked = tuple(agent.menu.checked if agent.menu else ())
         if not checked:
             return None
+        if opencode_user_provider_exists(_OPENCODE_MODEL_HUB_PROVIDER_ID):
+            raise ModelHubError("mapping_target_unavailable", status=409)
 
         gateway_base_url, gateway_token = await self._gateway_credentials(
             "opencode",
@@ -1029,7 +1032,7 @@ class ModelHubRuntimeRouter:
             if self.turn_gateway is None:
                 prefix = await self._source_prefix(source.id)
                 runtime_model = f"{prefix}/{exact_model_id}"
-            provider["models"][identifier] = {
+            projected_model: dict[str, Any] = {
                 "id": runtime_model,
                 "name": (
                     model.display_name
@@ -1037,6 +1040,13 @@ class ModelHubRuntimeRouter:
                     else identifier
                 ),
             }
+            variants = {
+                effort: {"reasoningEffort": effort}
+                for effort in (model.reasoning_efforts if model is not None else ())
+            }
+            if variants:
+                projected_model["variants"] = variants
+            provider["models"][identifier] = projected_model
             projected_identifiers.append(identifier)
             if resolution.candidate_hops:
                 available_identifiers.append(identifier)

--- a/modules/agents/model_hub.py
+++ b/modules/agents/model_hub.py
@@ -40,6 +40,7 @@ from core.handlers.model_hub.service import (
     ModelHubError,
     ModelHubService,
     create_default_service,
+    project_opencode_public_model,
 )
 from core.services.settings import load_config_or_default
 from core.handlers.model_hub.turn_gateway import ModelHubTurnGateway
@@ -1017,28 +1018,14 @@ class ModelHubRuntimeRouter:
                     "models": {},
                 },
             )
-            model = next(
-                (item for item in source.models if item.id == exact_model_id),
-                None,
-            )
             runtime_model = identifier
             if self.turn_gateway is None:
                 prefix = await self._source_prefix(source.id)
                 runtime_model = f"{prefix}/{exact_model_id}"
-            projected_model: dict[str, Any] = {
-                "id": runtime_model,
-                "name": (
-                    model.display_name
-                    if model is not None and model.display_name
-                    else identifier
-                ),
-            }
-            variants = {
-                effort: {"reasoningEffort": effort}
-                for effort in (model.reasoning_efforts if model is not None else ())
-            }
-            if variants:
-                projected_model["variants"] = variants
+            projected_model = project_opencode_public_model(identifier, resolution)
+            if projected_model is None:
+                continue
+            projected_model["id"] = runtime_model
             provider["models"][identifier] = projected_model
             projected_identifiers.append(identifier)
             if resolution.candidate_hops:

--- a/modules/agents/model_hub.py
+++ b/modules/agents/model_hub.py
@@ -337,6 +337,12 @@ def _provider_package() -> str:
     return "@ai-sdk/openai-compatible"
 
 
+# OpenCode merges custom providers with its built-ins by id. A private id keeps
+# internal title/compaction traffic on OpenCode's own providers instead of
+# sending those unrelated requests through the Model Hub turn gateway.
+_OPENCODE_MODEL_HUB_PROVIDER_ID = "avibe-model-hub"
+
+
 def _provider_base_url(gateway_base_url: str) -> str:
     return f"{gateway_base_url.rstrip('/')}/v1"
 
@@ -1007,9 +1013,9 @@ class ModelHubRuntimeRouter:
             package = _provider_package()
             base_url = _provider_base_url(gateway_base_url)
             provider = providers.setdefault(
-                provider_id,
+                _OPENCODE_MODEL_HUB_PROVIDER_ID,
                 {
-                    "name": provider_id,
+                    "name": "Avibe Model Hub",
                     "npm": package,
                     "options": {"apiKey": gateway_token, "baseURL": base_url},
                     "models": {},
@@ -1023,12 +1029,12 @@ class ModelHubRuntimeRouter:
             if self.turn_gateway is None:
                 prefix = await self._source_prefix(source.id)
                 runtime_model = f"{prefix}/{exact_model_id}"
-            provider["models"][menu_model_id] = {
+            provider["models"][identifier] = {
                 "id": runtime_model,
                 "name": (
                     model.display_name
                     if model is not None and model.display_name
-                    else menu_model_id
+                    else identifier
                 ),
             }
             projected_identifiers.append(identifier)
@@ -1082,7 +1088,10 @@ class ModelHubRuntimeRouter:
         write_atomic(self.overlay_path, content)
 
 
-def opencode_model_for_overlay(model: str | None, overlay: OpenCodeOverlay | None) -> str | None:
+def opencode_requested_model_for_overlay(
+    model: str | None,
+    overlay: OpenCodeOverlay | None,
+) -> str | None:
     if overlay is None:
         return model
     candidate = str(model or "").strip()
@@ -1093,3 +1102,13 @@ def opencode_model_for_overlay(model: str | None, overlay: OpenCodeOverlay | Non
     if candidate in overlay.checked_identifiers:
         return candidate
     raise ModelHubError("mapping_target_unavailable", status=409)
+
+
+def opencode_model_for_overlay(
+    model: str | None,
+    overlay: OpenCodeOverlay | None,
+) -> str | None:
+    requested_model = opencode_requested_model_for_overlay(model, overlay)
+    if overlay is None or requested_model is None:
+        return requested_model
+    return f"{_OPENCODE_MODEL_HUB_PROVIDER_ID}/{requested_model}"

--- a/modules/agents/model_hub.py
+++ b/modules/agents/model_hub.py
@@ -44,7 +44,6 @@ from core.handlers.model_hub.service import (
 from core.services.settings import load_config_or_default
 from core.handlers.model_hub.turn_gateway import ModelHubTurnGateway
 from vibe.codex_config import format_toml_basic_string
-from vibe.opencode_config import opencode_user_provider_exists
 
 
 LaunchChannel = Literal["direct", "native_cli", "hub"]
@@ -98,6 +97,7 @@ class OpenCodeOverlay:
     path: Path
     content_hash: str
     content: bytes
+    provider_id: str
     checked_identifiers: tuple[str, ...]
     available_identifiers: tuple[str, ...]
     launches: tuple[ModelHubLaunch, ...] = field(repr=False)
@@ -338,10 +338,14 @@ def _provider_package() -> str:
     return "@ai-sdk/openai-compatible"
 
 
-# OpenCode merges custom providers with its built-ins by id. A private id keeps
-# internal title/compaction traffic on OpenCode's own providers instead of
-# sending those unrelated requests through the Model Hub turn gateway.
-_OPENCODE_MODEL_HUB_PROVIDER_ID = "avibe-model-hub"
+_OPENCODE_MODEL_HUB_PROVIDER_PREFIX = "avibe-model-hub-"
+
+
+def _opencode_model_hub_provider_id(gateway_token: str) -> str:
+    """Derive an overlay-private provider namespace from its runtime credential."""
+
+    digest = hashlib.sha256(gateway_token.encode()).hexdigest()[:24]
+    return f"{_OPENCODE_MODEL_HUB_PROVIDER_PREFIX}{digest}"
 
 
 def _provider_base_url(gateway_base_url: str) -> str:
@@ -969,14 +973,12 @@ class ModelHubRuntimeRouter:
         checked = tuple(agent.menu.checked if agent.menu else ())
         if not checked:
             return None
-        if opencode_user_provider_exists(_OPENCODE_MODEL_HUB_PROVIDER_ID):
-            raise ModelHubError("mapping_target_unavailable", status=409)
-
         gateway_base_url, gateway_token = await self._gateway_credentials(
             "opencode",
             process_scope="opencode:shared-server",
             turn_id=None,
         )
+        overlay_provider_id = _opencode_model_hub_provider_id(gateway_token)
         providers: dict[str, dict[str, Any]] = {}
         projected_identifiers: list[str] = []
         available_identifiers: list[str] = []
@@ -988,9 +990,9 @@ class ModelHubRuntimeRouter:
                 identifier,
                 supply_channel="hub",
             )
-            provider_id = resolution.menu_provider_id
+            menu_provider_id = resolution.menu_provider_id
             menu_model_id = resolution.menu_model_id
-            if provider_id is None or menu_model_id is None:
+            if menu_provider_id is None or menu_model_id is None:
                 raise ModelHubError("mapping_target_unavailable", status=409)
             inspection = (
                 resolution.candidate_hops[0]
@@ -1016,7 +1018,7 @@ class ModelHubRuntimeRouter:
             package = _provider_package()
             base_url = _provider_base_url(gateway_base_url)
             provider = providers.setdefault(
-                _OPENCODE_MODEL_HUB_PROVIDER_ID,
+                overlay_provider_id,
                 {
                     "name": "Avibe Model Hub",
                     "npm": package,
@@ -1081,6 +1083,7 @@ class ModelHubRuntimeRouter:
             path=self.overlay_path,
             content_hash=content_hash,
             content=content,
+            provider_id=overlay_provider_id,
             checked_identifiers=tuple(projected_identifiers),
             available_identifiers=tuple(available_identifiers),
             launches=tuple(launches),
@@ -1121,4 +1124,4 @@ def opencode_model_for_overlay(
     requested_model = opencode_requested_model_for_overlay(model, overlay)
     if overlay is None or requested_model is None:
         return requested_model
-    return f"{_OPENCODE_MODEL_HUB_PROVIDER_ID}/{requested_model}"
+    return f"{overlay.provider_id}/{requested_model}"

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -52,6 +52,7 @@ from modules.agents.model_hub import (
     bind_launch,
     bind_turn_mode,
     opencode_model_for_overlay,
+    opencode_model_catalog_for_overlay,
     opencode_requested_model_for_overlay,
     persisted_launch_identity,
     resolve_opencode_overlay_launch,
@@ -1217,7 +1218,11 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 reasoning_effort = getattr(opencode_cfg, "default_reasoning_effort", None)
             if model_dict:
                 try:
-                    model_catalog = await server.get_available_models(request.working_path)
+                    model_catalog = (
+                        opencode_model_catalog_for_overlay(model_hub_overlay)
+                        if model_hub_overlay is not None
+                        else await server.get_available_models(request.working_path)
+                    )
                     resolved_model_id = resolve_opencode_model_id(
                         model_catalog,
                         model_dict.get("providerID"),

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -52,6 +52,7 @@ from modules.agents.model_hub import (
     bind_launch,
     bind_turn_mode,
     opencode_model_for_overlay,
+    opencode_requested_model_for_overlay,
     persisted_launch_identity,
     resolve_opencode_overlay_launch,
 )
@@ -1182,14 +1183,21 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             if not model_str:
                 model_str = server.get_agent_model_from_config(agent_to_use)
             opencode_cfg = getattr(self.controller.config, "opencode", None)
-            model_str = opencode_model_for_overlay(model_str, model_hub_overlay)
-            if model_hub_runtime is not None and model_str:
+            requested_model_str = opencode_requested_model_for_overlay(
+                model_str,
+                model_hub_overlay,
+            )
+            if model_hub_runtime is not None and requested_model_str:
                 model_hub_launch = await resolve_opencode_overlay_launch(
                     self.controller,
-                    model_str,
+                    requested_model_str,
                     model_hub_overlay,
                 )
                 bind_launch(request.context, model_hub_launch)
+            model_str = opencode_model_for_overlay(
+                requested_model_str,
+                model_hub_overlay,
+            )
             # Bare model id (no ``provider/`` prefix): only inject ``providerID``
             # when the user has explicitly chosen a default provider in Settings.
             # Otherwise leave ``model_dict`` unset so OpenCode keeps using its own

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -80,6 +80,7 @@ from .utils import resolve_opencode_model_id, resolve_opencode_reasoning_effort
 
 logger = logging.getLogger(__name__)
 _STEERING_SNAPSHOT_KEY = "opencode_native_steering"
+_MODEL_HUB_DISPLAY_MODEL_KEY = "model_hub_display_model"
 _STATUS_RECONCILIATION_FAILURE_LIMIT = 3
 # OpenCode returns 204 after forking prompt work, before that worker necessarily
 # registers the session as busy.
@@ -1204,6 +1205,10 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             # routing for legacy installs.
             default_provider = getattr(opencode_cfg, "default_provider", None)
             model_dict = resolve_opencode_model_dict(model_str, default_provider)
+            display_model_dict = resolve_opencode_model_dict(
+                requested_model_str,
+                default_provider,
+            )
 
             reasoning_effort = override_reasoning
             if not reasoning_effort:
@@ -1326,6 +1331,8 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             launch_identity = persisted_launch_identity(model_hub_launch)
             if launch_identity is not None:
                 processing_indicator["model_hub_launch"] = launch_identity
+            if display_model_dict is not None:
+                processing_indicator[_MODEL_HUB_DISPLAY_MODEL_KEY] = display_model_dict
 
             if model_hub_overlay_reservation is None:
                 await server.mark_run_active(session_id)
@@ -1420,7 +1427,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                     + _ASYNC_PROMPT_START_CONFIRMATION_TIMEOUT_SECONDS
                 ),
                 idle_reconciliation_message=self._idle_reconciliation_message(
-                    model_dict,
+                    display_model_dict,
                     reasoning_effort,
                 ),
             )
@@ -2356,6 +2363,13 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 else ""
             )
             has_steering_identity = bool(target_session_id and logical_turn_id)
+            display_model_dict = (
+                poll_info.processing_indicator.get(_MODEL_HUB_DISPLAY_MODEL_KEY)
+                if isinstance(poll_info.processing_indicator, dict)
+                else None
+            )
+            if not isinstance(display_model_dict, dict):
+                display_model_dict = poll_info.model_dict
             if current_task is not None and (
                 has_steering_identity
                 or reconcile_initial_status
@@ -2389,7 +2403,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                         else None
                     ),
                     idle_reconciliation_message=self._idle_reconciliation_message(
-                        poll_info.model_dict,
+                        display_model_dict,
                         poll_info.reasoning_effort,
                     ),
                     restored=True,

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -1995,12 +1995,13 @@ class OpenCodeServerManager:
                 logger.warning(f"Failed to get available agents: {e}")
                 return []
 
-    async def get_available_models(self, directory: str) -> Dict[str, Any]:
-        """Fetch available models from OpenCode server.
-
-        Returns:
-            Dict with 'providers' list and 'default' dict mapping provider to default model.
-        """
+    async def _get_available_models(
+        self,
+        directory: str,
+        *,
+        project_runtime_models: bool,
+    ) -> Dict[str, Any]:
+        """Fetch the OpenCode catalog with the requested public projection."""
 
         async with self._request_scope():
             session = await self._get_http_session()
@@ -2013,12 +2014,32 @@ class OpenCodeServerManager:
                         return _public_opencode_catalog(
                             await resp.json(),
                             runtime_provider_id=self._active_model_hub_provider_id(),
-                            project_runtime_models=True,
+                            project_runtime_models=project_runtime_models,
                         )
                     return {"providers": [], "default": {}}
             except Exception as e:
                 logger.warning(f"Failed to get available models: {e}")
                 return {"providers": [], "default": {}}
+
+    async def get_available_models(self, directory: str) -> Dict[str, Any]:
+        """Fetch the user-facing catalog, including exact Hub projections.
+
+        Returns:
+            Dict with 'providers' list and 'default' dict mapping provider to default model.
+        """
+
+        return await self._get_available_models(
+            directory,
+            project_runtime_models=True,
+        )
+
+    async def get_native_available_models(self, directory: str) -> Dict[str, Any]:
+        """Fetch models that native provider configuration can probe directly."""
+
+        return await self._get_available_models(
+            directory,
+            project_runtime_models=False,
+        )
 
     async def get_default_config(self, directory: str) -> Dict[str, Any]:
         """Fetch current default config from OpenCode server.

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -63,10 +63,11 @@ def _percent_encode_path(path: str) -> str:
 def _project_model_hub_models(
     providers: list[Any],
     runtime_models: dict[str, Any],
-) -> list[Any]:
+) -> tuple[list[Any], dict[str, str]]:
     """Expose runtime models under their public provider/model identities."""
 
     projected = [dict(entry) if isinstance(entry, dict) else entry for entry in providers]
+    public_defaults: dict[str, str] = {}
     provider_index = {
         entry.get("id"): entry
         for entry in projected
@@ -78,6 +79,7 @@ def _project_model_hub_models(
         provider_id, model_id = public_identifier.split("/", 1)
         if not provider_id or not model_id:
             continue
+        public_defaults.setdefault(provider_id, model_id)
         provider = provider_index.get(provider_id)
         if provider is None:
             provider = {"id": provider_id, "name": provider_id, "models": {}}
@@ -89,7 +91,7 @@ def _project_model_hub_models(
         public_model["id"] = model_id
         models[model_id] = public_model
         provider["models"] = models
-    return projected
+    return projected, public_defaults
 
 
 def _public_opencode_catalog(
@@ -132,10 +134,6 @@ def _public_opencode_catalog(
                 if provider_id != runtime_provider_id
             }
 
-    providers = projected.get("providers")
-    if project_runtime_models and runtime_models and isinstance(providers, list):
-        projected["providers"] = _project_model_hub_models(providers, runtime_models)
-
     connected = projected.get("connected")
     if isinstance(connected, list):
         projected["connected"] = [
@@ -152,6 +150,21 @@ def _public_opencode_catalog(
                 for provider_id, entry in value.items()
                 if provider_id != runtime_provider_id
             }
+
+    providers = projected.get("providers")
+    if project_runtime_models and runtime_models and isinstance(providers, list):
+        public_providers, public_defaults = _project_model_hub_models(
+            providers,
+            runtime_models,
+        )
+        projected["providers"] = public_providers
+        default_models = projected.get("default")
+        projected_defaults = (
+            dict(default_models) if isinstance(default_models, dict) else {}
+        )
+        for provider_id, model_id in public_defaults.items():
+            projected_defaults.setdefault(provider_id, model_id)
+        projected["default"] = projected_defaults
 
     model = projected.get("model")
     if isinstance(model, str) and model.split("/", 1)[0] == runtime_provider_id:

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -63,11 +63,10 @@ def _percent_encode_path(path: str) -> str:
 def _project_model_hub_models(
     providers: list[Any],
     runtime_models: dict[str, Any],
-) -> tuple[list[Any], dict[str, str]]:
+) -> list[Any]:
     """Expose runtime models under their public provider/model identities."""
 
     projected = [dict(entry) if isinstance(entry, dict) else entry for entry in providers]
-    public_defaults: dict[str, str] = {}
     provider_index = {
         entry.get("id"): entry
         for entry in projected
@@ -79,19 +78,39 @@ def _project_model_hub_models(
         provider_id, model_id = public_identifier.split("/", 1)
         if not provider_id or not model_id:
             continue
-        public_defaults.setdefault(provider_id, model_id)
         provider = provider_index.get(provider_id)
         if provider is None:
             provider = {"id": provider_id, "name": provider_id, "models": {}}
             projected.append(provider)
             provider_index[provider_id] = provider
         raw_models = provider.get("models")
-        models = dict(raw_models) if isinstance(raw_models, dict) else {}
-        public_model = dict(model_config) if isinstance(model_config, dict) else {}
+        if isinstance(raw_models, dict):
+            models = dict(raw_models)
+        elif isinstance(raw_models, list):
+            models = {}
+            for entry in raw_models:
+                if isinstance(entry, str) and entry:
+                    models[entry] = {"id": entry}
+                    continue
+                if not isinstance(entry, dict):
+                    continue
+                entry_id = entry.get("id") or entry.get("modelID") or entry.get("model_id")
+                if isinstance(entry_id, str) and entry_id:
+                    models[entry_id] = dict(entry)
+        else:
+            models = {}
+        existing_model = models.get(model_id)
+        public_model = dict(existing_model) if isinstance(existing_model, dict) else {}
+        if isinstance(model_config, dict):
+            public_model.update(model_config)
         public_model["id"] = model_id
+        metadata = public_model.get("vibe_remote")
+        public_metadata = dict(metadata) if isinstance(metadata, dict) else {}
+        public_metadata["model_hub_projected"] = True
+        public_model["vibe_remote"] = public_metadata
         models[model_id] = public_model
         provider["models"] = models
-    return projected, public_defaults
+    return projected
 
 
 def _public_opencode_catalog(
@@ -153,18 +172,10 @@ def _public_opencode_catalog(
 
     providers = projected.get("providers")
     if project_runtime_models and runtime_models and isinstance(providers, list):
-        public_providers, public_defaults = _project_model_hub_models(
+        projected["providers"] = _project_model_hub_models(
             providers,
             runtime_models,
         )
-        projected["providers"] = public_providers
-        default_models = projected.get("default")
-        projected_defaults = (
-            dict(default_models) if isinstance(default_models, dict) else {}
-        )
-        for provider_id, model_id in public_defaults.items():
-            projected_defaults.setdefault(provider_id, model_id)
-        projected["default"] = projected_defaults
 
     model = projected.get("model")
     if isinstance(model, str) and model.split("/", 1)[0] == runtime_provider_id:

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -33,7 +33,6 @@ from modules.agents.opencode.config_reconciler import OpenCodeConfigReconciler
 from vibe import runtime
 from vibe.opencode_config import (
     get_opencode_custom_provider_adapter,
-    is_model_hub_runtime_provider_id,
     load_first_opencode_user_config,
     read_opencode_provider_auth_entries,
 )
@@ -61,12 +60,50 @@ def _percent_encode_path(path: str) -> str:
     return _url_quote(path, safe="/")
 
 
-def _public_opencode_catalog(payload: Any) -> Any:
-    """Remove runtime-only Model Hub providers at the user catalog boundary."""
+def _project_model_hub_models(
+    providers: list[Any],
+    runtime_models: dict[str, Any],
+) -> list[Any]:
+    """Expose runtime models under their public provider/model identities."""
 
-    if not isinstance(payload, dict):
+    projected = [dict(entry) if isinstance(entry, dict) else entry for entry in providers]
+    provider_index = {
+        entry.get("id"): entry
+        for entry in projected
+        if isinstance(entry, dict) and isinstance(entry.get("id"), str)
+    }
+    for public_identifier, model_config in runtime_models.items():
+        if not isinstance(public_identifier, str) or "/" not in public_identifier:
+            continue
+        provider_id, model_id = public_identifier.split("/", 1)
+        if not provider_id or not model_id:
+            continue
+        provider = provider_index.get(provider_id)
+        if provider is None:
+            provider = {"id": provider_id, "name": provider_id, "models": {}}
+            projected.append(provider)
+            provider_index[provider_id] = provider
+        raw_models = provider.get("models")
+        models = dict(raw_models) if isinstance(raw_models, dict) else {}
+        public_model = dict(model_config) if isinstance(model_config, dict) else {}
+        public_model["id"] = model_id
+        models[model_id] = public_model
+        provider["models"] = models
+    return projected
+
+
+def _public_opencode_catalog(
+    payload: Any,
+    *,
+    runtime_provider_id: str | None,
+    project_runtime_models: bool = False,
+) -> Any:
+    """Remove the active runtime provider while retaining its public models."""
+
+    if not isinstance(payload, dict) or not runtime_provider_id:
         return payload
     projected = dict(payload)
+    runtime_models: dict[str, Any] = {}
 
     def _provider_id(entry: object) -> object:
         if isinstance(entry, dict):
@@ -76,24 +113,35 @@ def _public_opencode_catalog(payload: Any) -> Any:
     for key in ("providers", "all"):
         value = projected.get(key)
         if isinstance(value, list):
+            if key == "providers" and project_runtime_models:
+                runtime_entry = next(
+                    (entry for entry in value if _provider_id(entry) == runtime_provider_id),
+                    None,
+                )
+                if isinstance(runtime_entry, dict) and isinstance(runtime_entry.get("models"), dict):
+                    runtime_models = runtime_entry["models"]
             projected[key] = [
                 entry
                 for entry in value
-                if not is_model_hub_runtime_provider_id(_provider_id(entry))
+                if _provider_id(entry) != runtime_provider_id
             ]
         elif isinstance(value, dict):
             projected[key] = {
                 provider_id: entry
                 for provider_id, entry in value.items()
-                if not is_model_hub_runtime_provider_id(provider_id)
+                if provider_id != runtime_provider_id
             }
+
+    providers = projected.get("providers")
+    if project_runtime_models and runtime_models and isinstance(providers, list):
+        projected["providers"] = _project_model_hub_models(providers, runtime_models)
 
     connected = projected.get("connected")
     if isinstance(connected, list):
         projected["connected"] = [
             provider_id
             for provider_id in connected
-            if not is_model_hub_runtime_provider_id(provider_id)
+            if provider_id != runtime_provider_id
         ]
 
     for key in ("default", "provider"):
@@ -102,13 +150,11 @@ def _public_opencode_catalog(payload: Any) -> Any:
             projected[key] = {
                 provider_id: entry
                 for provider_id, entry in value.items()
-                if not is_model_hub_runtime_provider_id(provider_id)
+                if provider_id != runtime_provider_id
             }
 
     model = projected.get("model")
-    if isinstance(model, str) and is_model_hub_runtime_provider_id(
-        model.split("/", 1)[0]
-    ):
+    if isinstance(model, str) and model.split("/", 1)[0] == runtime_provider_id:
         projected.pop("model", None)
     return projected
 
@@ -181,6 +227,7 @@ class OpenCodeServerManager:
         self._model_hub_overlay_path: Optional[str] = None
         self._model_hub_overlay_hash: Optional[str] = None
         self._model_hub_overlay_content: Optional[str] = None
+        self._model_hub_overlay_provider_id: Optional[str] = None
         self._model_hub_overlay_transition: tuple[
             Optional[str], Optional[str], object
         ] | None = None
@@ -510,11 +557,27 @@ class OpenCodeServerManager:
         active = info.get("active_run_sessions") if isinstance(info, dict) else None
         return isinstance(active, list) and bool(active)
 
+    def _active_model_hub_provider_id(self) -> str | None:
+        if self._model_hub_overlay_provider_id:
+            return self._model_hub_overlay_provider_id
+        info = self._read_pid_file()
+        if not self._pid_file_references_current_server(info):
+            return None
+        provider_id = (
+            info.get("model_hub_overlay_provider_id")
+            if isinstance(info, dict)
+            else None
+        )
+        return provider_id if isinstance(provider_id, str) and provider_id else None
+
     async def configure_model_hub_overlay(self, overlay: Any | None) -> object:
         """Select an overlay and reserve it until the caller registers its run."""
 
         desired_path = str(overlay.path) if overlay is not None else None
         desired_hash = str(overlay.content_hash) if overlay is not None else None
+        desired_provider_id = getattr(overlay, "provider_id", None)
+        if overlay is not None and not isinstance(desired_provider_id, str):
+            raise RuntimeError("Model Hub OpenCode overlay provider is unavailable")
         desired_content = None
         if overlay is not None:
             content = getattr(overlay, "content", None)
@@ -558,6 +621,7 @@ class OpenCodeServerManager:
                             self._model_hub_overlay_path = desired_path
                             self._model_hub_overlay_hash = desired_hash
                             self._model_hub_overlay_content = desired_content
+                            self._model_hub_overlay_provider_id = desired_provider_id
                             self._model_hub_overlay_reservations[transition_owner] = (
                                 desired_path,
                                 desired_hash,
@@ -593,6 +657,7 @@ class OpenCodeServerManager:
                                 self._model_hub_overlay_path = desired_path
                                 self._model_hub_overlay_hash = desired_hash
                                 self._model_hub_overlay_content = desired_content
+                                self._model_hub_overlay_provider_id = desired_provider_id
                                 if await self._is_healthy():
                                     logger.info(
                                         "Restarting OpenCode server after Model Hub overlay change"
@@ -711,6 +776,8 @@ class OpenCodeServerManager:
             if self._model_hub_overlay_path and self._model_hub_overlay_hash:
                 payload["model_hub_overlay_path"] = self._model_hub_overlay_path
                 payload["model_hub_overlay_hash"] = self._model_hub_overlay_hash
+            if self._model_hub_overlay_provider_id:
+                payload["model_hub_overlay_provider_id"] = self._model_hub_overlay_provider_id
             self._pid_file.write_text(json.dumps(payload))
         except Exception as e:
             logger.debug(f"Failed to write OpenCode pid file: {e}")
@@ -1919,7 +1986,11 @@ class OpenCodeServerManager:
                     headers={"x-opencode-directory": _percent_encode_path(directory)},
                 ) as resp:
                     if resp.status == 200:
-                        return _public_opencode_catalog(await resp.json())
+                        return _public_opencode_catalog(
+                            await resp.json(),
+                            runtime_provider_id=self._active_model_hub_provider_id(),
+                            project_runtime_models=True,
+                        )
                     return {"providers": [], "default": {}}
             except Exception as e:
                 logger.warning(f"Failed to get available models: {e}")
@@ -1940,7 +2011,10 @@ class OpenCodeServerManager:
                     headers={"x-opencode-directory": _percent_encode_path(directory)},
                 ) as resp:
                     if resp.status == 200:
-                        return _public_opencode_catalog(await resp.json())
+                        return _public_opencode_catalog(
+                            await resp.json(),
+                            runtime_provider_id=self._active_model_hub_provider_id(),
+                        )
                     return {}
             except Exception as e:
                 logger.warning(f"Failed to get default config: {e}")
@@ -2000,7 +2074,10 @@ class OpenCodeServerManager:
             try:
                 async with session.get(f"{self.base_url}/provider") as resp:
                     if resp.status == 200:
-                        return _public_opencode_catalog(await resp.json())
+                        return _public_opencode_catalog(
+                            await resp.json(),
+                            runtime_provider_id=self._active_model_hub_provider_id(),
+                        )
                     return {}
             except Exception as e:
                 logger.warning(f"Failed to get OpenCode providers: {e}")

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -33,6 +33,7 @@ from modules.agents.opencode.config_reconciler import OpenCodeConfigReconciler
 from vibe import runtime
 from vibe.opencode_config import (
     get_opencode_custom_provider_adapter,
+    is_model_hub_runtime_provider_id,
     load_first_opencode_user_config,
     read_opencode_provider_auth_entries,
 )
@@ -58,6 +59,58 @@ def _percent_encode_path(path: str) -> str:
     misinterpreted by the receiving end.
     """
     return _url_quote(path, safe="/")
+
+
+def _public_opencode_catalog(payload: Any) -> Any:
+    """Remove runtime-only Model Hub providers at the user catalog boundary."""
+
+    if not isinstance(payload, dict):
+        return payload
+    projected = dict(payload)
+
+    def _provider_id(entry: object) -> object:
+        if isinstance(entry, dict):
+            return entry.get("id") or entry.get("provider_id") or entry.get("name")
+        return entry
+
+    for key in ("providers", "all"):
+        value = projected.get(key)
+        if isinstance(value, list):
+            projected[key] = [
+                entry
+                for entry in value
+                if not is_model_hub_runtime_provider_id(_provider_id(entry))
+            ]
+        elif isinstance(value, dict):
+            projected[key] = {
+                provider_id: entry
+                for provider_id, entry in value.items()
+                if not is_model_hub_runtime_provider_id(provider_id)
+            }
+
+    connected = projected.get("connected")
+    if isinstance(connected, list):
+        projected["connected"] = [
+            provider_id
+            for provider_id in connected
+            if not is_model_hub_runtime_provider_id(provider_id)
+        ]
+
+    for key in ("default", "provider"):
+        value = projected.get(key)
+        if isinstance(value, dict):
+            projected[key] = {
+                provider_id: entry
+                for provider_id, entry in value.items()
+                if not is_model_hub_runtime_provider_id(provider_id)
+            }
+
+    model = projected.get("model")
+    if isinstance(model, str) and is_model_hub_runtime_provider_id(
+        model.split("/", 1)[0]
+    ):
+        projected.pop("model", None)
+    return projected
 
 
 def native_part_id_for_attempt(attempt_id: str) -> str:
@@ -1866,7 +1919,7 @@ class OpenCodeServerManager:
                     headers={"x-opencode-directory": _percent_encode_path(directory)},
                 ) as resp:
                     if resp.status == 200:
-                        return await resp.json()
+                        return _public_opencode_catalog(await resp.json())
                     return {"providers": [], "default": {}}
             except Exception as e:
                 logger.warning(f"Failed to get available models: {e}")
@@ -1887,7 +1940,7 @@ class OpenCodeServerManager:
                     headers={"x-opencode-directory": _percent_encode_path(directory)},
                 ) as resp:
                     if resp.status == 200:
-                        return await resp.json()
+                        return _public_opencode_catalog(await resp.json())
                     return {}
             except Exception as e:
                 logger.warning(f"Failed to get default config: {e}")
@@ -1931,9 +1984,9 @@ class OpenCodeServerManager:
                 )
 
     async def get_providers(self) -> Dict[str, Any]:
-        """Fetch the full provider catalog from the running OpenCode server.
+        """Fetch the user-visible provider catalog from the OpenCode server.
 
-        Returns the raw shape OpenCode reports: ``{all: {...}, default:
+        Preserves the shape OpenCode reports: ``{all: {...}, default:
         {...}, connected: [...]}``. Callers (``vibe.api.get_opencode_providers``)
         merge this with the auth-method map from ``get_provider_auth`` to
         produce the per-card ``configured`` / ``oauth_available`` /
@@ -1947,7 +2000,7 @@ class OpenCodeServerManager:
             try:
                 async with session.get(f"{self.base_url}/provider") as resp:
                     if resp.status == 200:
-                        return await resp.json()
+                        return _public_opencode_catalog(await resp.json())
                     return {}
             except Exception as e:
                 logger.warning(f"Failed to get OpenCode providers: {e}")

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -117,14 +117,13 @@ def _public_opencode_catalog(
     payload: Any,
     *,
     runtime_provider_id: str | None,
-    project_runtime_models: bool = False,
+    model_hub_models: dict[str, Any] | None = None,
 ) -> Any:
-    """Remove the active runtime provider while retaining its public models."""
+    """Remove private transport state and merge the desired public projection."""
 
-    if not isinstance(payload, dict) or not runtime_provider_id:
+    if not isinstance(payload, dict):
         return payload
     projected = dict(payload)
-    runtime_models: dict[str, Any] = {}
 
     def _provider_id(entry: object) -> object:
         if isinstance(entry, dict):
@@ -134,23 +133,18 @@ def _public_opencode_catalog(
     for key in ("providers", "all"):
         value = projected.get(key)
         if isinstance(value, list):
-            if key == "providers" and project_runtime_models:
-                runtime_entry = next(
-                    (entry for entry in value if _provider_id(entry) == runtime_provider_id),
-                    None,
-                )
-                if isinstance(runtime_entry, dict) and isinstance(runtime_entry.get("models"), dict):
-                    runtime_models = runtime_entry["models"]
             projected[key] = [
                 entry
                 for entry in value
-                if _provider_id(entry) != runtime_provider_id
+                if runtime_provider_id is None
+                or _provider_id(entry) != runtime_provider_id
             ]
         elif isinstance(value, dict):
             projected[key] = {
                 provider_id: entry
                 for provider_id, entry in value.items()
-                if provider_id != runtime_provider_id
+                if runtime_provider_id is None
+                or provider_id != runtime_provider_id
             }
 
     connected = projected.get("connected")
@@ -158,7 +152,7 @@ def _public_opencode_catalog(
         projected["connected"] = [
             provider_id
             for provider_id in connected
-            if provider_id != runtime_provider_id
+            if runtime_provider_id is None or provider_id != runtime_provider_id
         ]
 
     for key in ("default", "provider"):
@@ -167,18 +161,23 @@ def _public_opencode_catalog(
             projected[key] = {
                 provider_id: entry
                 for provider_id, entry in value.items()
-                if provider_id != runtime_provider_id
+                if runtime_provider_id is None
+                or provider_id != runtime_provider_id
             }
 
     providers = projected.get("providers")
-    if project_runtime_models and runtime_models and isinstance(providers, list):
+    if model_hub_models and isinstance(providers, list):
         projected["providers"] = _project_model_hub_models(
             providers,
-            runtime_models,
+            model_hub_models,
         )
 
     model = projected.get("model")
-    if isinstance(model, str) and model.split("/", 1)[0] == runtime_provider_id:
+    if (
+        runtime_provider_id is not None
+        and isinstance(model, str)
+        and model.split("/", 1)[0] == runtime_provider_id
+    ):
         projected.pop("model", None)
     return projected
 
@@ -1999,7 +1998,7 @@ class OpenCodeServerManager:
         self,
         directory: str,
         *,
-        project_runtime_models: bool,
+        model_hub_models: dict[str, Any] | None,
     ) -> Dict[str, Any]:
         """Fetch the OpenCode catalog with the requested public projection."""
 
@@ -2014,14 +2013,19 @@ class OpenCodeServerManager:
                         return _public_opencode_catalog(
                             await resp.json(),
                             runtime_provider_id=self._active_model_hub_provider_id(),
-                            project_runtime_models=project_runtime_models,
+                            model_hub_models=model_hub_models,
                         )
                     return {"providers": [], "default": {}}
             except Exception as e:
                 logger.warning(f"Failed to get available models: {e}")
                 return {"providers": [], "default": {}}
 
-    async def get_available_models(self, directory: str) -> Dict[str, Any]:
+    async def get_available_models(
+        self,
+        directory: str,
+        *,
+        model_hub_models: dict[str, Any] | None = None,
+    ) -> Dict[str, Any]:
         """Fetch the user-facing catalog, including exact Hub projections.
 
         Returns:
@@ -2030,7 +2034,7 @@ class OpenCodeServerManager:
 
         return await self._get_available_models(
             directory,
-            project_runtime_models=True,
+            model_hub_models=model_hub_models,
         )
 
     async def get_native_available_models(self, directory: str) -> Dict[str, Any]:
@@ -2038,7 +2042,7 @@ class OpenCodeServerManager:
 
         return await self._get_available_models(
             directory,
-            project_runtime_models=False,
+            model_hub_models=None,
         )
 
     async def get_default_config(self, directory: str) -> Dict[str, Any]:

--- a/modules/agents/opencode/utils.py
+++ b/modules/agents/opencode/utils.py
@@ -311,13 +311,13 @@ def resolve_opencode_allowed_providers(
 ) -> List[str]:
     """Return provider IDs to include when listing models."""
     providers = _extract_provider_ids_from_config(opencode_default_config)
-    if providers:
-        return providers
     if isinstance(opencode_models, dict):
         defaults = opencode_models.get("default", {})
         if isinstance(defaults, dict) and defaults:
-            return [key for key in defaults.keys() if isinstance(key, str) and key]
-    return []
+            for key in defaults:
+                if isinstance(key, str):
+                    _append_unique(providers, key)
+    return providers
 
 
 def _model_sort_key(model_item: Tuple[str, Any]) -> Tuple[int, int, str]:

--- a/modules/agents/opencode/utils.py
+++ b/modules/agents/opencode/utils.py
@@ -6,7 +6,7 @@ Shared by OpenCode, Claude, and Codex integrations for reasoning-effort option b
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
 _REASONING_FALLBACK_OPTIONS = [
@@ -59,6 +59,87 @@ def _opencode_model_entry_id(model_entry: Any) -> str:
         return ""
     model_id = model_entry.get("id") or model_entry.get("modelID") or model_entry.get("model_id") or ""
     return model_id if isinstance(model_id, str) else ""
+
+
+def _opencode_model_hub_model_ids(provider: dict) -> set[str]:
+    """Return models projected from Model Hub for one public provider."""
+
+    projected: set[str] = set()
+    models = provider.get("models") if isinstance(provider, dict) else None
+    if isinstance(models, dict):
+        entries = models.items()
+    elif isinstance(models, list):
+        entries = ((_opencode_model_entry_id(entry), entry) for entry in models)
+    else:
+        return projected
+
+    for model_id, model_info in entries:
+        if not isinstance(model_id, str) or not isinstance(model_info, dict):
+            continue
+        metadata = model_info.get("vibe_remote")
+        if isinstance(metadata, dict) and metadata.get("model_hub_projected") is True:
+            projected.add(model_id)
+    return projected
+
+
+def filter_opencode_models_to_allowed_providers(
+    opencode_models: dict,
+    allowed_providers: Iterable[str],
+) -> dict:
+    """Keep allowed providers plus exact public models projected by Model Hub."""
+
+    if not isinstance(opencode_models, dict):
+        return opencode_models
+    allowed = {
+        provider_id
+        for provider_id in allowed_providers
+        if isinstance(provider_id, str) and provider_id
+    }
+    providers = []
+    projected_by_provider: dict[str, set[str]] = {}
+    for provider in opencode_models.get("providers", []) or []:
+        if not isinstance(provider, dict):
+            continue
+        provider_id = get_opencode_provider_id(provider)
+        if not provider_id:
+            continue
+        projected_model_ids = _opencode_model_hub_model_ids(provider)
+        if projected_model_ids:
+            projected_by_provider[provider_id] = projected_model_ids
+        if provider_id in allowed:
+            providers.append(provider)
+            continue
+        if not projected_model_ids:
+            continue
+
+        raw_models = provider.get("models")
+        if isinstance(raw_models, dict):
+            models = {
+                model_id: model_info
+                for model_id, model_info in raw_models.items()
+                if model_id in projected_model_ids
+            }
+        elif isinstance(raw_models, list):
+            models = [
+                model_info
+                for model_info in raw_models
+                if _opencode_model_entry_id(model_info) in projected_model_ids
+            ]
+        else:
+            models = {}
+        providers.append({**provider, "models": models})
+
+    defaults = opencode_models.get("default")
+    if isinstance(defaults, dict):
+        defaults = {
+            provider_id: model_id
+            for provider_id, model_id in defaults.items()
+            if provider_id in allowed
+            or model_id in projected_by_provider.get(provider_id, set())
+        }
+    else:
+        defaults = {}
+    return {**opencode_models, "providers": providers, "default": defaults}
 
 
 def find_opencode_model_info(
@@ -311,13 +392,13 @@ def resolve_opencode_allowed_providers(
 ) -> List[str]:
     """Return provider IDs to include when listing models."""
     providers = _extract_provider_ids_from_config(opencode_default_config)
+    if providers:
+        return providers
     if isinstance(opencode_models, dict):
         defaults = opencode_models.get("default", {})
         if isinstance(defaults, dict) and defaults:
-            for key in defaults:
-                if isinstance(key, str):
-                    _append_unique(providers, key)
-    return providers
+            return [key for key in defaults.keys() if isinstance(key, str) and key]
+    return []
 
 
 def _model_sort_key(model_item: Tuple[str, Any]) -> Tuple[int, int, str]:
@@ -357,9 +438,17 @@ def build_opencode_model_option_items(
         providers.append((provider_id, provider))
 
     if allowed_providers:
-        allowed_set = {p for p in allowed_providers if isinstance(p, str) and p}
-        if allowed_set:
-            providers = [entry for entry in providers if entry[0] in allowed_set]
+        visible_models = filter_opencode_models_to_allowed_providers(
+            opencode_models,
+            allowed_providers,
+        )
+        providers_data = visible_models.get("providers", [])
+        defaults = visible_models.get("default", {})
+        providers = []
+        for provider in providers_data:
+            provider_id = get_opencode_provider_id(provider)
+            if provider_id:
+                providers.append((provider_id, provider))
 
     if preferred_providers:
         preferred_set = {p for p in preferred_providers if isinstance(p, str) and p}

--- a/tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py
+++ b/tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py
@@ -278,7 +278,7 @@ def test_unpinned_hub_projection_is_null_while_explicit_turn_resolves(
     [
         ("claude", _requested_model("claude"), "messages"),
         ("codex", _requested_model("codex"), "responses"),
-        ("opencode", _requested_model("opencode"), "messages"),
+        ("opencode", _requested_model("opencode"), "chat/completions"),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -2112,6 +2112,23 @@ def test_agent_presence_refresh_crosses_the_controller_rpc_boundary(monkeypatch)
     assert calls == [("list_agents", {"refresh_cli_presence": True})]
 
 
+def test_opencode_public_models_cross_the_controller_rpc_boundary(monkeypatch):
+    from vibe import model_hub_client
+
+    calls = []
+
+    def rpc(operation, payload=None):
+        calls.append((operation, payload))
+        return {"custom/current-model": {"id": "custom/current-model"}}
+
+    monkeypatch.setattr(model_hub_client, "_rpc_sync", rpc)
+
+    models = ModelHubRemoteService().opencode_public_models()
+
+    assert models == {"custom/current-model": {"id": "custom/current-model"}}
+    assert calls == [("get_opencode_public_models", None)]
+
+
 def test_agents_route_requests_deep_presence_only_when_explicit(monkeypatch):
     calls = []
 
@@ -2469,6 +2486,65 @@ def test_ui_model_hub_default_is_controller_rpc_client(monkeypatch):
 
     assert isinstance(service, ModelHubRemoteService)
     assert not hasattr(service, "adapter")
+
+
+def test_opencode_options_route_passes_controller_projection(monkeypatch):
+    from vibe import api
+
+    projection = {
+        "custom/current-model": {"id": "custom/current-model"},
+    }
+    calls = []
+
+    class RemoteService:
+        def opencode_public_models(self):
+            return projection
+
+    async def options(cwd, *, model_hub_models=None):
+        calls.append((cwd, model_hub_models))
+        return {"ok": True, "data": {"models": {}}}
+
+    monkeypatch.setattr(ui_server, "_model_hub_service", lambda: RemoteService())
+    monkeypatch.setattr(api, "opencode_options_async", options)
+
+    with app.test_request_context(
+        "/api/opencode/options",
+        method="POST",
+        json={"cwd": "/tmp/workspace"},
+    ):
+        response = asyncio.run(ui_server.opencode_options())
+
+    assert response.status_code == 200
+    assert calls == [("/tmp/workspace", projection)]
+
+
+def test_opencode_options_route_keeps_native_catalog_when_projection_is_unavailable(
+    monkeypatch,
+):
+    from vibe import api
+
+    calls = []
+
+    class UnavailableService:
+        def opencode_public_models(self):
+            raise ModelHubError("engine_down", status=503)
+
+    async def options(cwd, *, model_hub_models=None):
+        calls.append((cwd, model_hub_models))
+        return {"ok": True, "data": {"models": {}}}
+
+    monkeypatch.setattr(ui_server, "_model_hub_service", lambda: UnavailableService())
+    monkeypatch.setattr(api, "opencode_options_async", options)
+
+    with app.test_request_context(
+        "/api/opencode/options",
+        method="POST",
+        json={"cwd": "/tmp/workspace"},
+    ):
+        response = asyncio.run(ui_server.opencode_options())
+
+    assert response.status_code == 200
+    assert calls == [("/tmp/workspace", {})]
 
 
 def test_ui_model_hub_rpc_preserves_controller_error_contract():

--- a/tests/test_model_hub_injection.py
+++ b/tests/test_model_hub_injection.py
@@ -182,6 +182,7 @@ def test_codex_hub_launch_uses_toml_safe_catalog_path(tmp_path):
 
 def test_opencode_overlay_requires_exact_checked_identifier():
     overlay = SimpleNamespace(
+        provider_id="avibe-model-hub-runtime",
         checked_identifiers=("openai/gpt-5", "custom/gpt-5"),
         available_identifiers=("openai/gpt-5", "custom/gpt-5"),
     )
@@ -189,7 +190,7 @@ def test_opencode_overlay_requires_exact_checked_identifier():
         "openai/gpt-5"
     )
     assert opencode_model_for_overlay("openai/gpt-5", overlay) == (
-        "avibe-model-hub/openai/gpt-5"
+        "avibe-model-hub-runtime/openai/gpt-5"
     )
     with pytest.raises(ModelHubError):
         opencode_model_for_overlay("gpt-5", overlay)
@@ -197,6 +198,7 @@ def test_opencode_overlay_requires_exact_checked_identifier():
 
 def test_opencode_overlay_never_repeats_add_time_bare_identifier_matching():
     overlay = SimpleNamespace(
+        provider_id="avibe-model-hub-runtime",
         checked_identifiers=("openai/gpt-5",),
         available_identifiers=("openai/gpt-5",),
     )

--- a/tests/test_model_hub_injection.py
+++ b/tests/test_model_hub_injection.py
@@ -24,6 +24,7 @@ from modules.agents.model_hub import (
     claude_setting_sources_for_launch,
     launch_for_context,
     opencode_model_for_overlay,
+    opencode_requested_model_for_overlay,
     persisted_launch_identity,
 )
 
@@ -184,7 +185,12 @@ def test_opencode_overlay_requires_exact_checked_identifier():
         checked_identifiers=("openai/gpt-5", "custom/gpt-5"),
         available_identifiers=("openai/gpt-5", "custom/gpt-5"),
     )
-    assert opencode_model_for_overlay("openai/gpt-5", overlay) == "openai/gpt-5"
+    assert opencode_requested_model_for_overlay("openai/gpt-5", overlay) == (
+        "openai/gpt-5"
+    )
+    assert opencode_model_for_overlay("openai/gpt-5", overlay) == (
+        "avibe-model-hub/openai/gpt-5"
+    )
     with pytest.raises(ModelHubError):
         opencode_model_for_overlay("gpt-5", overlay)
 

--- a/tests/test_model_hub_l3.py
+++ b/tests/test_model_hub_l3.py
@@ -4260,6 +4260,38 @@ def test_opencode_overlay_projects_menu_identity_to_exact_hop_model(tmp_path: Pa
     }
 
 
+def test_opencode_public_models_follow_persisted_config_without_overlay(
+    tmp_path: Path,
+) -> None:
+    source = _source("src_catalog01", "Catalog", model_id="upstream-model")
+    source.models[0].display_name = "Current model"
+    source.models[0].reasoning_efforts = ["low", "high"]
+    config = _config([source])
+    agent = config.agents["opencode"]
+    agent.routes = {
+        "custom/current-model": ModelHubRouteConfig(
+            hops=(ModelHubRouteHopConfig(source.id, "upstream-model"),)
+        )
+    }
+    agent.menu.checked = ["custom/current-model"]
+    service = _service(tmp_path, sources=[source])
+    service.store.config = config
+
+    assert service.opencode_public_models() == {
+        "custom/current-model": {
+            "id": "custom/current-model",
+            "name": "Current model",
+            "variants": {
+                "low": {"reasoningEffort": "low"},
+                "high": {"reasoningEffort": "high"},
+            },
+        }
+    }
+
+    service.store.config.agents["opencode"].mode = "direct"
+    assert service.opencode_public_models() == {}
+
+
 def test_opencode_overlay_private_provider_id_is_credential_scoped(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_model_hub_l3.py
+++ b/tests/test_model_hub_l3.py
@@ -4218,6 +4218,7 @@ def test_settlement_retires_correlation_when_mode_persistence_fails(
 
 def test_opencode_overlay_projects_menu_identity_to_exact_hop_model(tmp_path: Path) -> None:
     source = _source("src_overlay01", "Overlay", model_id="upstream-model")
+    source.models[0].reasoning_efforts = ["low", "high"]
     config = _config([source])
     agent = config.agents["opencode"]
     agent.routes.pop("openai/shared-model")
@@ -4240,7 +4241,37 @@ def test_opencode_overlay_projects_menu_identity_to_exact_hop_model(tmp_path: Pa
     payload = json.loads(overlay.content)
     provider = payload["provider"]["avibe-model-hub"]
     assert provider["models"]["openai/menu-model"]["id"] == "openai/menu-model"
+    assert provider["models"]["openai/menu-model"]["variants"] == {
+        "high": {"reasoningEffort": "high"},
+        "low": {"reasoningEffort": "low"},
+    }
     assert overlay.launches[0].target_model == "upstream-model"
+
+
+def test_opencode_overlay_rejects_a_user_owned_private_provider_id(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source = _source("src_overlay10", "Overlay")
+    service = _service(tmp_path, sources=[source])
+    monkeypatch.setattr(
+        "modules.agents.model_hub.opencode_user_provider_exists",
+        lambda _provider_id: True,
+    )
+    router = ModelHubRuntimeRouter(
+        service=service,
+        turn_gateway=SimpleNamespace(
+            endpoint=AsyncMock(
+                return_value=("http://127.0.0.1:19000/opencode", "gateway-token")
+            ),
+        ),
+        overlay_path=tmp_path / "overlay.json",
+    )
+
+    with pytest.raises(ModelHubError) as exc_info:
+        asyncio.run(router.prepare_opencode_overlay())
+
+    assert exc_info.value.code == "mapping_target_unavailable"
 
 
 def test_opencode_overlay_supports_mixed_protocols_under_one_provider(tmp_path: Path) -> None:

--- a/tests/test_model_hub_l3.py
+++ b/tests/test_model_hub_l3.py
@@ -4163,7 +4163,8 @@ def test_opencode_overlay_projects_menu_identity_to_exact_hop_model(tmp_path: Pa
 
     assert overlay is not None
     payload = json.loads(overlay.content)
-    assert payload["provider"]["openai"]["models"]["menu-model"]["id"] == ("openai/menu-model")
+    provider = payload["provider"]["avibe-model-hub"]
+    assert provider["models"]["openai/menu-model"]["id"] == "openai/menu-model"
     assert overlay.launches[0].target_model == "upstream-model"
 
 
@@ -4202,10 +4203,15 @@ def test_opencode_overlay_supports_mixed_protocols_under_one_provider(tmp_path: 
     overlay = asyncio.run(router.prepare_opencode_overlay())
 
     assert overlay is not None
-    provider = json.loads(overlay.content)["provider"]["custom"]
+    payload = json.loads(overlay.content)
+    assert set(payload["provider"]) == {"avibe-model-hub"}
+    provider = payload["provider"]["avibe-model-hub"]
     assert provider["npm"] == "@ai-sdk/openai-compatible"
     assert provider["options"]["baseURL"] == "http://127.0.0.1:19000/opencode/v1"
-    assert set(provider["models"]) == {"first-model", "second-model"}
+    assert set(provider["models"]) == {
+        "custom/first-model",
+        "custom/second-model",
+    }
     assert {launch.target_model for launch in overlay.launches} == {
         "first-model",
         "second-model",
@@ -4270,11 +4276,11 @@ def test_opencode_overlay_preserves_checked_route_with_stale_exact_hop(
     overlay = asyncio.run(router.prepare_opencode_overlay())
 
     assert overlay is not None
-    provider = json.loads(overlay.content)["provider"]["openai"]
+    provider = json.loads(overlay.content)["provider"]["avibe-model-hub"]
     assert provider["models"] == {
-        "menu-model": {
+        "openai/menu-model": {
             "id": "openai/menu-model",
-            "name": "menu-model",
+            "name": "openai/menu-model",
         }
     }
     assert overlay.checked_identifiers == ("openai/menu-model",)

--- a/tests/test_model_hub_l3.py
+++ b/tests/test_model_hub_l3.py
@@ -4239,7 +4239,9 @@ def test_opencode_overlay_projects_menu_identity_to_exact_hop_model(tmp_path: Pa
 
     assert overlay is not None
     payload = json.loads(overlay.content)
-    provider = payload["provider"]["avibe-model-hub"]
+    assert overlay.provider_id.startswith("avibe-model-hub-")
+    assert overlay.provider_id != "avibe-model-hub"
+    provider = payload["provider"][overlay.provider_id]
     assert provider["models"]["openai/menu-model"]["id"] == "openai/menu-model"
     assert provider["models"]["openai/menu-model"]["variants"] == {
         "high": {"reasoningEffort": "high"},
@@ -4248,30 +4250,31 @@ def test_opencode_overlay_projects_menu_identity_to_exact_hop_model(tmp_path: Pa
     assert overlay.launches[0].target_model == "upstream-model"
 
 
-def test_opencode_overlay_rejects_a_user_owned_private_provider_id(
-    monkeypatch: pytest.MonkeyPatch,
+def test_opencode_overlay_private_provider_id_is_credential_scoped(
     tmp_path: Path,
 ) -> None:
     source = _source("src_overlay10", "Overlay")
     service = _service(tmp_path, sources=[source])
-    monkeypatch.setattr(
-        "modules.agents.model_hub.opencode_user_provider_exists",
-        lambda _provider_id: True,
+    endpoint = AsyncMock(
+        side_effect=(
+            ("http://127.0.0.1:19000/opencode", "gateway-token-one"),
+            ("http://127.0.0.1:19000/opencode", "gateway-token-two"),
+        )
     )
     router = ModelHubRuntimeRouter(
         service=service,
-        turn_gateway=SimpleNamespace(
-            endpoint=AsyncMock(
-                return_value=("http://127.0.0.1:19000/opencode", "gateway-token")
-            ),
-        ),
+        turn_gateway=SimpleNamespace(endpoint=endpoint),
         overlay_path=tmp_path / "overlay.json",
     )
 
-    with pytest.raises(ModelHubError) as exc_info:
-        asyncio.run(router.prepare_opencode_overlay())
+    first = asyncio.run(router.prepare_opencode_overlay())
+    second = asyncio.run(router.prepare_opencode_overlay())
 
-    assert exc_info.value.code == "mapping_target_unavailable"
+    assert first is not None
+    assert second is not None
+    assert first.provider_id != second.provider_id
+    assert set(json.loads(first.content)["provider"]) == {first.provider_id}
+    assert set(json.loads(second.content)["provider"]) == {second.provider_id}
 
 
 def test_opencode_overlay_supports_mixed_protocols_under_one_provider(tmp_path: Path) -> None:
@@ -4310,8 +4313,8 @@ def test_opencode_overlay_supports_mixed_protocols_under_one_provider(tmp_path: 
 
     assert overlay is not None
     payload = json.loads(overlay.content)
-    assert set(payload["provider"]) == {"avibe-model-hub"}
-    provider = payload["provider"]["avibe-model-hub"]
+    assert set(payload["provider"]) == {overlay.provider_id}
+    provider = payload["provider"][overlay.provider_id]
     assert provider["npm"] == "@ai-sdk/openai-compatible"
     assert provider["options"]["baseURL"] == "http://127.0.0.1:19000/opencode/v1"
     assert set(provider["models"]) == {
@@ -4382,7 +4385,7 @@ def test_opencode_overlay_preserves_checked_route_with_stale_exact_hop(
     overlay = asyncio.run(router.prepare_opencode_overlay())
 
     assert overlay is not None
-    provider = json.loads(overlay.content)["provider"]["avibe-model-hub"]
+    provider = json.loads(overlay.content)["provider"][overlay.provider_id]
     assert provider["models"] == {
         "openai/menu-model": {
             "id": "openai/menu-model",

--- a/tests/test_model_hub_l3.py
+++ b/tests/test_model_hub_l3.py
@@ -86,6 +86,7 @@ from modules.agents.model_hub import (
     _localized_launch_error,
     bind_launch,
     bind_turn_mode,
+    opencode_model_catalog_for_overlay,
 )
 from storage.models import agent_sessions, messages, metadata
 from vibe.i18n import t as i18n_t
@@ -4248,6 +4249,15 @@ def test_opencode_overlay_projects_menu_identity_to_exact_hop_model(tmp_path: Pa
         "low": {"reasoningEffort": "low"},
     }
     assert overlay.launches[0].target_model == "upstream-model"
+    assert opencode_model_catalog_for_overlay(overlay) == {
+        "providers": [
+            {
+                "id": overlay.provider_id,
+                "models": provider["models"],
+            }
+        ],
+        "default": {},
+    }
 
 
 def test_opencode_overlay_private_provider_id_is_credential_scoped(

--- a/tests/test_opencode_provider_base_url.py
+++ b/tests/test_opencode_provider_base_url.py
@@ -416,21 +416,6 @@ def test_upsert_custom_provider_allows_documented_dotted_id(tmp_path: Path) -> N
     assert config["provider"]["llama.cpp"]["name"] == "llama.cpp"
 
 
-def test_user_provider_presence_reads_the_raw_config_namespace(tmp_path: Path) -> None:
-    from vibe.opencode_config import opencode_user_provider_exists
-
-    upsert_opencode_custom_provider(
-        "avibe-model-hub",
-        "Existing relay",
-        "openai-compatible",
-        "https://relay.example/v1",
-        home=tmp_path,
-    )
-
-    assert opencode_user_provider_exists("avibe-model-hub", home=tmp_path) is True
-    assert opencode_user_provider_exists("missing", home=tmp_path) is False
-
-
 def test_upsert_custom_provider_refuses_existing_builtin_block(tmp_path: Path) -> None:
     upsert_opencode_provider_base_url("openai", "https://relay.example/v1", home=tmp_path)
 

--- a/tests/test_opencode_provider_base_url.py
+++ b/tests/test_opencode_provider_base_url.py
@@ -416,6 +416,21 @@ def test_upsert_custom_provider_allows_documented_dotted_id(tmp_path: Path) -> N
     assert config["provider"]["llama.cpp"]["name"] == "llama.cpp"
 
 
+def test_user_provider_presence_reads_the_raw_config_namespace(tmp_path: Path) -> None:
+    from vibe.opencode_config import opencode_user_provider_exists
+
+    upsert_opencode_custom_provider(
+        "avibe-model-hub",
+        "Existing relay",
+        "openai-compatible",
+        "https://relay.example/v1",
+        home=tmp_path,
+    )
+
+    assert opencode_user_provider_exists("avibe-model-hub", home=tmp_path) is True
+    assert opencode_user_provider_exists("missing", home=tmp_path) is False
+
+
 def test_upsert_custom_provider_refuses_existing_builtin_block(tmp_path: Path) -> None:
     upsert_opencode_provider_base_url("openai", "https://relay.example/v1", home=tmp_path)
 

--- a/tests/test_opencode_provider_base_url.py
+++ b/tests/test_opencode_provider_base_url.py
@@ -429,17 +429,20 @@ def test_upsert_custom_provider_refuses_existing_builtin_block(tmp_path: Path) -
         )
 
 
-def test_upsert_custom_provider_refuses_model_hub_runtime_namespace(
+def test_upsert_custom_provider_keeps_exact_pattern_legacy_id(
     tmp_path: Path,
 ) -> None:
-    with pytest.raises(ValueError, match="provider_id already exists"):
-        upsert_opencode_custom_provider(
-            "avibe-model-hub-0123456789abcdef01234567",
-            "Runtime Shadow",
-            "openai-compatible",
-            "https://relay.example/v1",
-            home=tmp_path,
-        )
+    provider_id = "avibe-model-hub-0123456789abcdef01234567"
+    upsert_opencode_custom_provider(
+        provider_id,
+        "Legacy Exact Relay",
+        "openai-compatible",
+        "https://relay.example/v1",
+        home=tmp_path,
+    )
+
+    config = _read_config(get_opencode_config_paths(tmp_path)[0])
+    assert config["provider"][provider_id]["name"] == "Legacy Exact Relay"
 
 
 def test_upsert_custom_provider_keeps_legacy_model_hub_prefix_id(

--- a/tests/test_opencode_provider_base_url.py
+++ b/tests/test_opencode_provider_base_url.py
@@ -442,6 +442,21 @@ def test_upsert_custom_provider_refuses_model_hub_runtime_namespace(
         )
 
 
+def test_upsert_custom_provider_keeps_legacy_model_hub_prefix_id(
+    tmp_path: Path,
+) -> None:
+    upsert_opencode_custom_provider(
+        "avibe-model-hub-relay",
+        "Legacy Relay",
+        "openai-compatible",
+        "https://relay.example/v1",
+        home=tmp_path,
+    )
+
+    config = _read_config(get_opencode_config_paths(tmp_path)[0])
+    assert config["provider"]["avibe-model-hub-relay"]["name"] == "Legacy Relay"
+
+
 def test_remove_custom_provider_deletes_only_custom_block(tmp_path: Path) -> None:
     upsert_opencode_provider_base_url("openai", "https://relay.example/v1", home=tmp_path)
     upsert_opencode_custom_provider(

--- a/tests/test_opencode_provider_base_url.py
+++ b/tests/test_opencode_provider_base_url.py
@@ -429,6 +429,19 @@ def test_upsert_custom_provider_refuses_existing_builtin_block(tmp_path: Path) -
         )
 
 
+def test_upsert_custom_provider_refuses_model_hub_runtime_namespace(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match="provider_id already exists"):
+        upsert_opencode_custom_provider(
+            "avibe-model-hub-0123456789abcdef01234567",
+            "Runtime Shadow",
+            "openai-compatible",
+            "https://relay.example/v1",
+            home=tmp_path,
+        )
+
+
 def test_remove_custom_provider_deletes_only_custom_block(tmp_path: Path) -> None:
     upsert_opencode_provider_base_url("openai", "https://relay.example/v1", home=tmp_path)
     upsert_opencode_custom_provider(

--- a/tests/test_opencode_restore_polls.py
+++ b/tests/test_opencode_restore_polls.py
@@ -238,10 +238,17 @@ def test_restore_im_registration_failure_retries_before_releasing_poll() -> None
 
 def test_restored_poll_exposes_the_persisted_guarded_steering_owner() -> None:
     poll = _make_poll(platform="avibe", base_session_id="ses_wb", opencode_session_id="oc-1")
-    poll.model_dict = {"providerID": "openai", "modelID": "gpt-5"}
+    poll.model_dict = {
+        "providerID": "avibe-model-hub",
+        "modelID": "openai/gpt-5",
+    }
     poll.reasoning_effort = "high"
     poll.processing_indicator = {
         "platform": "avibe",
+        "model_hub_display_model": {
+            "providerID": "openai",
+            "modelID": "gpt-5",
+        },
         "opencode_native_steering": {
             "target_session_id": "ses_wb",
             "logical_turn_id": "logical-restored",
@@ -275,6 +282,12 @@ def test_restored_poll_exposes_the_persisted_guarded_steering_owner() -> None:
             expected_logical_turn_id="logical-restored",
         )
         assert identity is not None
+        reconciliation_message = agent._steering_states[
+            "ses_wb"
+        ].idle_reconciliation_message
+        assert "openai" in reconciliation_message
+        assert "gpt-5" in reconciliation_message
+        assert "avibe-model-hub" not in reconciliation_message
         recovery_complete.set()
         await poll_started.wait()
         receipt = await steer_active_turn(
@@ -301,7 +314,10 @@ def test_restored_poll_exposes_the_persisted_guarded_steering_owner() -> None:
             "directory": "/tmp/work",
             "text": "补充：`keep exact`",
             "agent": "build",
-            "model": {"providerID": "openai", "modelID": "gpt-5"},
+            "model": {
+                "providerID": "avibe-model-hub",
+                "modelID": "openai/gpt-5",
+            },
             "reasoning_effort": "high",
             "system": "restored system prompt",
             "tools": {"question": False},

--- a/tests/test_opencode_restore_polls.py
+++ b/tests/test_opencode_restore_polls.py
@@ -239,7 +239,7 @@ def test_restore_im_registration_failure_retries_before_releasing_poll() -> None
 def test_restored_poll_exposes_the_persisted_guarded_steering_owner() -> None:
     poll = _make_poll(platform="avibe", base_session_id="ses_wb", opencode_session_id="oc-1")
     poll.model_dict = {
-        "providerID": "avibe-model-hub",
+        "providerID": "avibe-model-hub-runtime",
         "modelID": "openai/gpt-5",
     }
     poll.reasoning_effort = "high"
@@ -287,7 +287,7 @@ def test_restored_poll_exposes_the_persisted_guarded_steering_owner() -> None:
         ].idle_reconciliation_message
         assert "openai" in reconciliation_message
         assert "gpt-5" in reconciliation_message
-        assert "avibe-model-hub" not in reconciliation_message
+        assert "avibe-model-hub-runtime" not in reconciliation_message
         recovery_complete.set()
         await poll_started.wait()
         receipt = await steer_active_turn(
@@ -315,7 +315,7 @@ def test_restored_poll_exposes_the_persisted_guarded_steering_owner() -> None:
             "text": "补充：`keep exact`",
             "agent": "build",
             "model": {
-                "providerID": "avibe-model-hub",
+                "providerID": "avibe-model-hub-runtime",
                 "modelID": "openai/gpt-5",
             },
             "reasoning_effort": "high",

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -180,6 +180,7 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_user_catalog_boundary_excludes_model_hub_runtime_provider(self):
         private_id = "avibe-model-hub-0123456789abcdef01234567"
+        legacy_custom_id = "avibe-model-hub-relay"
 
         class _CatalogSession(_FakeSession):
             def get(self, url, headers=None, timeout=None):
@@ -188,10 +189,12 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
                     payload = {
                         "providers": [
                             {"id": private_id, "models": {"openai/gpt-5": {}}},
+                            {"id": legacy_custom_id, "models": {"relay-model": {}}},
                             {"id": "openai", "models": {"gpt-5": {}}},
                         ],
                         "default": {
                             private_id: "openai/gpt-5",
+                            legacy_custom_id: "relay-model",
                             "openai": "gpt-5",
                         },
                     }
@@ -199,15 +202,17 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
                     payload = {
                         "all": {
                             private_id: {"id": private_id},
+                            legacy_custom_id: {"id": legacy_custom_id},
                             "openai": {"id": "openai"},
                         },
-                        "connected": [private_id, "openai"],
+                        "connected": [private_id, legacy_custom_id, "openai"],
                     }
                 else:
                     payload = {
                         "model": f"{private_id}/openai/gpt-5",
                         "provider": {
                             private_id: {"options": {"apiKey": "private"}},
+                            legacy_custom_id: {},
                             "openai": {},
                         },
                     }
@@ -222,12 +227,18 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         providers = await manager.get_providers()
         config = await manager.get_default_config("/tmp/work")
 
-        self.assertEqual([row["id"] for row in models["providers"]], ["openai"])
-        self.assertEqual(models["default"], {"openai": "gpt-5"})
-        self.assertEqual(set(providers["all"]), {"openai"})
-        self.assertEqual(providers["connected"], ["openai"])
+        self.assertEqual(
+            [row["id"] for row in models["providers"]],
+            [legacy_custom_id, "openai"],
+        )
+        self.assertEqual(
+            models["default"],
+            {legacy_custom_id: "relay-model", "openai": "gpt-5"},
+        )
+        self.assertEqual(set(providers["all"]), {legacy_custom_id, "openai"})
+        self.assertEqual(providers["connected"], [legacy_custom_id, "openai"])
         self.assertNotIn("model", config)
-        self.assertEqual(set(config["provider"]), {"openai"})
+        self.assertEqual(set(config["provider"]), {legacy_custom_id, "openai"})
 
     async def test_ensure_running_restarts_healthy_server_when_caller_context_plugin_changes(self):
         manager = OpenCodeServerManager(binary="opencode", port=4096)

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -178,6 +178,57 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
             "/tmp/a%2520b",
         )
 
+    async def test_user_catalog_boundary_excludes_model_hub_runtime_provider(self):
+        private_id = "avibe-model-hub-0123456789abcdef01234567"
+
+        class _CatalogSession(_FakeSession):
+            def get(self, url, headers=None, timeout=None):
+                self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+                if url.endswith("/config/providers"):
+                    payload = {
+                        "providers": [
+                            {"id": private_id, "models": {"openai/gpt-5": {}}},
+                            {"id": "openai", "models": {"gpt-5": {}}},
+                        ],
+                        "default": {
+                            private_id: "openai/gpt-5",
+                            "openai": "gpt-5",
+                        },
+                    }
+                elif url.endswith("/provider"):
+                    payload = {
+                        "all": {
+                            private_id: {"id": private_id},
+                            "openai": {"id": "openai"},
+                        },
+                        "connected": [private_id, "openai"],
+                    }
+                else:
+                    payload = {
+                        "model": f"{private_id}/openai/gpt-5",
+                        "provider": {
+                            private_id: {"options": {"apiKey": "private"}},
+                            "openai": {},
+                        },
+                    }
+                return _FakeResponse(status=200, json_data=payload)
+
+        manager = OpenCodeServerManager(binary="opencode", port=4096)
+        session = _CatalogSession()
+        manager._get_http_session = AsyncMock(return_value=session)  # type: ignore[method-assign]
+        manager.ensure_running = AsyncMock()  # type: ignore[method-assign]
+
+        models = await manager.get_available_models("/tmp/work")
+        providers = await manager.get_providers()
+        config = await manager.get_default_config("/tmp/work")
+
+        self.assertEqual([row["id"] for row in models["providers"]], ["openai"])
+        self.assertEqual(models["default"], {"openai": "gpt-5"})
+        self.assertEqual(set(providers["all"]), {"openai"})
+        self.assertEqual(providers["connected"], ["openai"])
+        self.assertNotIn("model", config)
+        self.assertEqual(set(config["provider"]), {"openai"})
+
     async def test_ensure_running_restarts_healthy_server_when_caller_context_plugin_changes(self):
         manager = OpenCodeServerManager(binary="opencode", port=4096)
         restarted = []

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -12,6 +12,10 @@ from unittest.mock import AsyncMock, Mock, patch
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from storage import message_deliveries as delivery_store
+from modules.agents.opencode.utils import (
+    build_opencode_model_option_items,
+    resolve_opencode_allowed_providers,
+)
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "modules" / "agents" / "opencode" / "server.py"
 
@@ -245,7 +249,11 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(
             models["default"],
-            {legacy_custom_id: "relay-model", "openai": "gpt-5"},
+            {
+                legacy_custom_id: "relay-model",
+                "openai": "gpt-5",
+                "custom": "first-model",
+            },
         )
         self.assertEqual(set(providers["all"]), {legacy_custom_id, "openai"})
         self.assertEqual(providers["connected"], [legacy_custom_id, "openai"])
@@ -261,6 +269,26 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             public_models["custom"]["first-model"],
             {"id": "first-model"},
+        )
+        allowed_providers = resolve_opencode_allowed_providers(
+            {"providers": {"openai": {}}},
+            models,
+        )
+        self.assertEqual(
+            allowed_providers,
+            ["openai", legacy_custom_id, "custom"],
+        )
+        picker_values = {
+            item["value"]
+            for item in build_opencode_model_option_items(
+                models,
+                max_total=99,
+                allowed_providers=allowed_providers,
+            )
+        }
+        self.assertIn("custom/first-model", picker_values)
+        self.assertFalse(
+            any(value.startswith(f"{private_id}/") for value in picker_values)
         )
 
     async def test_ensure_running_restarts_healthy_server_when_caller_context_plugin_changes(self):

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -205,7 +205,18 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
                                 },
                             },
                             {"id": legacy_custom_id, "models": {"relay-model": {}}},
-                            {"id": "openai", "models": {"gpt-5": {"id": "gpt-5"}}},
+                            {"id": "custom", "models": {"native-model": {}}},
+                            {
+                                "id": "openai",
+                                "models": [
+                                    {"id": "gpt-4", "name": "GPT-4"},
+                                    {
+                                        "id": "gpt-5",
+                                        "name": "GPT-5",
+                                        "capabilities": {"tools": True},
+                                    },
+                                ],
+                            },
                         ],
                         "default": {
                             private_id: "openai/gpt-5",
@@ -245,14 +256,13 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(
             [row["id"] for row in models["providers"]],
-            [legacy_custom_id, "openai", "custom"],
+            [legacy_custom_id, "custom", "openai"],
         )
         self.assertEqual(
             models["default"],
             {
                 legacy_custom_id: "relay-model",
                 "openai": "gpt-5",
-                "custom": "first-model",
             },
         )
         self.assertEqual(set(providers["all"]), {legacy_custom_id, "openai"})
@@ -262,13 +272,28 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         public_models = {
             row["id"]: row["models"] for row in models["providers"]
         }
+        self.assertEqual(set(public_models["openai"]), {"gpt-4", "gpt-5"})
+        self.assertEqual(public_models["openai"]["gpt-5"]["name"], "GPT-5")
         self.assertEqual(
-            public_models["openai"]["gpt-5"],
-            {"id": "gpt-5", "variants": {"high": {}}},
+            public_models["openai"]["gpt-5"]["capabilities"],
+            {"tools": True},
         )
         self.assertEqual(
+            public_models["openai"]["gpt-5"]["variants"],
+            {"high": {}},
+        )
+        self.assertTrue(
+            public_models["openai"]["gpt-5"]["vibe_remote"][
+                "model_hub_projected"
+            ]
+        )
+        self.assertEqual(set(public_models["custom"]), {"native-model", "first-model"})
+        self.assertEqual(
             public_models["custom"]["first-model"],
-            {"id": "first-model"},
+            {
+                "id": "first-model",
+                "vibe_remote": {"model_hub_projected": True},
+            },
         )
         allowed_providers = resolve_opencode_allowed_providers(
             {"providers": {"openai": {}}},
@@ -276,7 +301,7 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(
             allowed_providers,
-            ["openai", legacy_custom_id, "custom"],
+            ["openai"],
         )
         picker_values = {
             item["value"]
@@ -287,6 +312,8 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
             )
         }
         self.assertIn("custom/first-model", picker_values)
+        self.assertNotIn("custom/native-model", picker_values)
+        self.assertNotIn(f"{legacy_custom_id}/relay-model", picker_values)
         self.assertFalse(
             any(value.startswith(f"{private_id}/") for value in picker_values)
         )

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -251,6 +251,7 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         manager.ensure_running = AsyncMock()  # type: ignore[method-assign]
 
         models = await manager.get_available_models("/tmp/work")
+        native_models = await manager.get_native_available_models("/tmp/work")
         providers = await manager.get_providers()
         config = await manager.get_default_config("/tmp/work")
 
@@ -269,6 +270,15 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(providers["connected"], [legacy_custom_id, "openai"])
         self.assertNotIn("model", config)
         self.assertEqual(set(config["provider"]), {legacy_custom_id, "openai"})
+        native_model_index = {
+            row["id"]: row["models"] for row in native_models["providers"]
+        }
+        self.assertEqual(set(native_model_index), {legacy_custom_id, "custom", "openai"})
+        self.assertEqual(
+            {entry["id"] for entry in native_model_index["openai"]},
+            {"gpt-4", "gpt-5"},
+        )
+        self.assertEqual(set(native_model_index["custom"]), {"native-model"})
         public_models = {
             row["id"]: row["models"] for row in models["providers"]
         }

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -182,6 +182,45 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
             "/tmp/a%2520b",
         )
 
+    async def test_user_catalog_projects_current_hub_models_before_overlay_start(self):
+        class _CatalogSession(_FakeSession):
+            def get(self, url, headers=None, timeout=None):
+                self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+                return _FakeResponse(
+                    status=200,
+                    json_data={
+                        "providers": [
+                            {"id": "openai", "models": {"native-model": {}}},
+                        ],
+                        "default": {"openai": "native-model"},
+                    },
+                )
+
+        manager = OpenCodeServerManager(binary="opencode", port=4096)
+        manager._get_http_session = AsyncMock(return_value=_CatalogSession())  # type: ignore[method-assign]
+
+        models = await manager.get_available_models(
+            "/tmp/work",
+            model_hub_models={
+                "custom/current-model": {
+                    "id": "custom/current-model",
+                    "name": "Current model",
+                },
+            },
+        )
+
+        model_index = {row["id"]: row["models"] for row in models["providers"]}
+        self.assertEqual(set(model_index), {"openai", "custom"})
+        self.assertEqual(set(model_index["openai"]), {"native-model"})
+        self.assertEqual(
+            model_index["custom"]["current-model"],
+            {
+                "id": "current-model",
+                "name": "Current model",
+                "vibe_remote": {"model_hub_projected": True},
+            },
+        )
+
     async def test_user_catalog_boundary_excludes_model_hub_runtime_provider(self):
         private_id = "avibe-model-hub-0123456789abcdef01234567"
         legacy_custom_id = "avibe-model-hub-fedcba9876543210fedcba98"
@@ -250,7 +289,18 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         manager._get_http_session = AsyncMock(return_value=session)  # type: ignore[method-assign]
         manager.ensure_running = AsyncMock()  # type: ignore[method-assign]
 
-        models = await manager.get_available_models("/tmp/work")
+        models = await manager.get_available_models(
+            "/tmp/work",
+            model_hub_models={
+                "openai/gpt-5": {
+                    "id": "openai/gpt-5",
+                    "variants": {"high": {}},
+                },
+                "custom/first-model": {
+                    "id": "custom/first-model",
+                },
+            },
+        )
         native_models = await manager.get_native_available_models("/tmp/work")
         providers = await manager.get_providers()
         config = await manager.get_default_config("/tmp/work")

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -180,7 +180,7 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_user_catalog_boundary_excludes_model_hub_runtime_provider(self):
         private_id = "avibe-model-hub-0123456789abcdef01234567"
-        legacy_custom_id = "avibe-model-hub-relay"
+        legacy_custom_id = "avibe-model-hub-fedcba9876543210fedcba98"
 
         class _CatalogSession(_FakeSession):
             def get(self, url, headers=None, timeout=None):
@@ -188,9 +188,20 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
                 if url.endswith("/config/providers"):
                     payload = {
                         "providers": [
-                            {"id": private_id, "models": {"openai/gpt-5": {}}},
+                            {
+                                "id": private_id,
+                                "models": {
+                                    "openai/gpt-5": {
+                                        "id": "openai/gpt-5",
+                                        "variants": {"high": {}},
+                                    },
+                                    "custom/first-model": {
+                                        "id": "custom/first-model",
+                                    },
+                                },
+                            },
                             {"id": legacy_custom_id, "models": {"relay-model": {}}},
-                            {"id": "openai", "models": {"gpt-5": {}}},
+                            {"id": "openai", "models": {"gpt-5": {"id": "gpt-5"}}},
                         ],
                         "default": {
                             private_id: "openai/gpt-5",
@@ -219,6 +230,7 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
                 return _FakeResponse(status=200, json_data=payload)
 
         manager = OpenCodeServerManager(binary="opencode", port=4096)
+        manager._model_hub_overlay_provider_id = private_id
         session = _CatalogSession()
         manager._get_http_session = AsyncMock(return_value=session)  # type: ignore[method-assign]
         manager.ensure_running = AsyncMock()  # type: ignore[method-assign]
@@ -229,7 +241,7 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(
             [row["id"] for row in models["providers"]],
-            [legacy_custom_id, "openai"],
+            [legacy_custom_id, "openai", "custom"],
         )
         self.assertEqual(
             models["default"],
@@ -239,6 +251,17 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(providers["connected"], [legacy_custom_id, "openai"])
         self.assertNotIn("model", config)
         self.assertEqual(set(config["provider"]), {legacy_custom_id, "openai"})
+        public_models = {
+            row["id"]: row["models"] for row in models["providers"]
+        }
+        self.assertEqual(
+            public_models["openai"]["gpt-5"],
+            {"id": "gpt-5", "variants": {"high": {}}},
+        )
+        self.assertEqual(
+            public_models["custom"]["first-model"],
+            {"id": "first-model"},
+        )
 
     async def test_ensure_running_restarts_healthy_server_when_caller_context_plugin_changes(self):
         manager = OpenCodeServerManager(binary="opencode", port=4096)
@@ -2471,6 +2494,7 @@ def test_changed_overlay_still_waits_for_active_run_before_restart():
         path=Path("/tmp/new-overlay.json"),
         content_hash="new-hash",
         content='{"provider": {}}',
+        provider_id="avibe-model-hub-new",
     )
 
     async def exercise():
@@ -2503,11 +2527,13 @@ def test_mh_runtime_003_pending_overlay_transition_blocks_new_turns_on_the_old_o
         path=Path("/tmp/old-overlay.json"),
         content_hash="old-hash",
         content='{"provider": {}}',
+        provider_id="avibe-model-hub-old",
     )
     new_overlay = types.SimpleNamespace(
         path=Path("/tmp/new-overlay.json"),
         content_hash="new-hash",
         content='{"provider": {}}',
+        provider_id="avibe-model-hub-new",
     )
 
     async def exercise():
@@ -2548,11 +2574,13 @@ def test_mh_runtime_004_overlay_reservation_promotes_atomically_to_active_run():
         path=Path("/tmp/old-overlay.json"),
         content_hash="old-hash",
         content='{"provider": {}}',
+        provider_id="avibe-model-hub-old",
     )
     new_overlay = types.SimpleNamespace(
         path=Path("/tmp/new-overlay.json"),
         content_hash="new-hash",
         content='{"provider": {}}',
+        provider_id="avibe-model-hub-new",
     )
 
     async def exercise():

--- a/tests/test_save_opencode_provider_auth.py
+++ b/tests/test_save_opencode_provider_auth.py
@@ -78,6 +78,8 @@ class _FakeServer:
     async def get_available_models(self, directory):
         return {"providers": [{"id": "openai", "models": {"gpt-5": {}}}]}
 
+    get_native_available_models = get_available_models
+
     async def get_available_agents(self, directory):
         return []
 
@@ -106,6 +108,8 @@ class _FakeModelServer:
         if self.models_error is not None:
             raise self.models_error
         return self.models
+
+    get_native_available_models = get_available_models
 
     async def close_http_session(self, loop) -> None:  # type: ignore[override]
         pass

--- a/tests/test_settings_handler.py
+++ b/tests/test_settings_handler.py
@@ -458,6 +458,7 @@ class _RoutingSettingsManager:
 class _FakeOpenCodeServer:
     def __init__(self) -> None:
         self.calls: list[str] = []
+        self.model_hub_models: list[dict | None] = []
 
     async def ensure_running(self) -> None:
         self.calls.append("ensure_running")
@@ -466,8 +467,14 @@ class _FakeOpenCodeServer:
         self.calls.append(f"agents:{directory}")
         return [{"name": "build"}]
 
-    async def get_available_models(self, directory: str) -> dict:
+    async def get_available_models(
+        self,
+        directory: str,
+        *,
+        model_hub_models: dict | None = None,
+    ) -> dict:
         self.calls.append(f"models:{directory}")
+        self.model_hub_models.append(model_hub_models)
         return {"providers": []}
 
     async def get_default_config(self, directory: str) -> dict:
@@ -529,6 +536,25 @@ def test_gather_routing_modal_data_only_fetches_current_backend() -> None:
         "models:/tmp/workspace",
         "config:/tmp/workspace",
     ]
+
+
+def test_gather_routing_modal_data_uses_current_model_hub_projection() -> None:
+    handler, server = _make_routing_handler()
+    projection = {
+        "custom/current-model": {"id": "custom/current-model"},
+    }
+    handler.controller.model_hub_service = SimpleNamespace(
+        opencode_public_models=lambda: projection,
+    )
+    context = MessageContext(
+        user_id="U1",
+        channel_id="D0APS47LPU2",
+        platform="slack",
+    )
+
+    asyncio.run(handler._gather_routing_modal_data(context))
+
+    assert server.model_hub_models == [projection]
 
 
 def test_gather_routing_modal_data_fetches_selected_backend_on_modal_update() -> None:

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -258,6 +258,85 @@ def test_opencode_options_cache_tracks_current_model_hub_projection(monkeypatch)
     assert projections == [first, second]
 
 
+def test_opencode_options_does_not_fall_back_across_model_hub_projections(
+    monkeypatch,
+):
+    import config.v2_compat as v2_compat
+    import modules.agents.opencode as opencode_module
+
+    class _FakeManager:
+        async def ensure_running(self):
+            raise RuntimeError("daemon unavailable")
+
+        async def close_http_session(self, *, loop=None):
+            pass
+
+    class _FakeServerManager:
+        @staticmethod
+        async def get_instance(**kwargs):
+            return _FakeManager()
+
+    stale_projection = {"custom/old": {"id": "custom/old"}}
+    current_projection = {"custom/new": {"id": "custom/new"}}
+    monkeypatch.setattr(
+        api,
+        "_OPENCODE_OPTIONS_CACHE",
+        {
+            "/tmp/workspace": {
+                "data": {"models": {"providers": []}},
+                "updated_at": time.monotonic(),
+                "model_hub_projection": json.dumps(
+                    stale_projection,
+                    ensure_ascii=True,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+            }
+        },
+    )
+    monkeypatch.setattr(api.V2Config, "load", staticmethod(lambda: object()))
+    monkeypatch.setattr(
+        v2_compat,
+        "to_app_config",
+        lambda config: SimpleNamespace(
+            opencode=SimpleNamespace(
+                binary="opencode",
+                port=4096,
+                request_timeout_seconds=10,
+            )
+        ),
+    )
+    monkeypatch.setattr(opencode_module, "OpenCodeServerManager", _FakeServerManager)
+
+    result = asyncio.run(
+        api.opencode_options_async(
+            "/tmp/workspace",
+            model_hub_models=current_projection,
+        )
+    )
+
+    assert result == {"ok": False, "error": "daemon unavailable"}
+
+
+def test_sync_opencode_options_loads_persisted_model_hub_projection(monkeypatch):
+    from core.handlers import model_hub
+
+    projection = {"custom/current": {"id": "custom/current"}}
+    calls = []
+
+    async def options(cwd, *, model_hub_models=None):
+        calls.append((cwd, model_hub_models))
+        return {"ok": True, "data": {"models": {"providers": []}}}
+
+    monkeypatch.setattr(model_hub, "load_opencode_public_models", lambda: projection)
+    monkeypatch.setattr(api, "opencode_options_async", options)
+
+    result = api.opencode_options("/tmp/workspace")
+
+    assert result["ok"] is True
+    assert calls == [("/tmp/workspace", projection)]
+
+
 def test_opencode_get_server_passes_resource_governor_from_v2_runtime(monkeypatch):
     import config.v2_compat as v2_compat
     import modules.agents.opencode as opencode_module

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -246,6 +246,15 @@ def test_opencode_options_filters_unconfigured_provider_models(monkeypatch, tmp_
                     {"id": "openai", "models": {"gpt-5": {}}},
                     {"id": "poe", "models": {"claude-opus-4": {}}},
                     {"id": "alibaba-cn", "models": {"qwen-max": {}}},
+                    {
+                        "id": "custom",
+                        "models": {
+                            "first-model": {
+                                "vibe_remote": {"model_hub_projected": True}
+                            },
+                            "native-model": {},
+                        },
+                    },
                 ],
                 "default": {
                     "openai": "gpt-5",
@@ -303,7 +312,9 @@ def test_opencode_options_filters_unconfigured_provider_models(monkeypatch, tmp_
     result = asyncio.run(api.opencode_options_async("/tmp/workspace"))
 
     providers = result["data"]["models"]["providers"]
-    assert [p["id"] for p in providers] == ["openai"]
+    assert [p["id"] for p in providers] == ["openai", "custom"]
+    custom = next(provider for provider in providers if provider["id"] == "custom")
+    assert set(custom["models"]) == {"first-model"}
     assert result["data"]["models"]["default"] == {"openai": "gpt-5"}
 
 

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -940,7 +940,9 @@ def test_opencode_options_includes_keyless_custom_provider_models(monkeypatch, t
     assert local["models"] == {"local-model": {"name": "local-model", "vibe_remote": {"user_model": True}}}
 
 
-def test_opencode_provider_catalog_keeps_builtin_overrides_read_only(monkeypatch, tmp_path):
+def test_opencode_provider_catalog_uses_native_models_for_provider_probes(
+    monkeypatch, tmp_path
+):
     class _FakeServer:
         async def get_providers(self):
             return {
@@ -952,6 +954,9 @@ def test_opencode_provider_catalog_keeps_builtin_overrides_read_only(monkeypatch
             return {}
 
         async def get_available_models(self, directory):
+            raise AssertionError("provider probes must not use the projected catalog")
+
+        async def get_native_available_models(self, directory):
             return {
                 "providers": [{"id": "openai", "models": {"gpt-5": {}}}],
                 "default": {"openai": "gpt-5"},
@@ -988,6 +993,7 @@ def test_opencode_provider_catalog_keeps_builtin_overrides_read_only(monkeypatch
     result = asyncio.run(api.get_opencode_providers_async())
 
     entry = result["providers"][0]["model_entries"][0]
+    assert result["providers"][0]["models"] == ["gpt-5"]
     assert entry["id"] == "gpt-5"
     assert entry["reasoning_efforts"] == ["high"]
     assert entry["user_managed"] is False
@@ -1032,6 +1038,8 @@ def test_opencode_provider_catalog_prefers_runtime_agent_model(
                 ],
                 "default": {"openai": "gpt-5.3-chat-latest"},
             }
+
+        get_native_available_models = get_available_models
 
         async def close_http_session(self, *, loop=None):
             pass
@@ -1083,6 +1091,8 @@ def test_opencode_provider_catalog_marks_keyless_custom_provider_configured(
                 "providers": [{"id": "openai", "models": {"gpt-5": {}}}],
                 "default": {"openai": "gpt-5"},
             }
+
+        get_native_available_models = get_available_models
 
         async def close_http_session(self, *, loop=None):
             pass
@@ -1145,6 +1155,8 @@ def test_opencode_provider_catalog_keeps_custom_provider_without_vibe_meta(
                 "providers": [{"id": "openai", "models": {"gpt-5": {}}}],
                 "default": {"openai": "gpt-5"},
             }
+
+        get_native_available_models = get_available_models
 
         async def close_http_session(self, *, loop=None):
             pass

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -180,6 +180,84 @@ def test_opencode_options_passes_resource_governor_from_v2_runtime(monkeypatch):
     assert governor.config["agent_group_name"] == "ui-agents"
 
 
+def test_opencode_options_cache_tracks_current_model_hub_projection(monkeypatch):
+    import config.v2_compat as v2_compat
+    import modules.agents.opencode as opencode_module
+
+    projections = []
+
+    class _FakeManager:
+        async def ensure_running(self):
+            return "http://127.0.0.1:4096"
+
+        async def get_available_agents(self, directory):
+            return []
+
+        async def get_available_models(self, directory, *, model_hub_models=None):
+            projections.append(model_hub_models)
+            return {"providers": []}
+
+        async def get_providers(self):
+            return {"all": [], "connected": []}
+
+        async def get_default_config(self, directory):
+            return {}
+
+        async def close_http_session(self, *, loop=None):
+            pass
+
+    manager = _FakeManager()
+
+    class _FakeServerManager:
+        @staticmethod
+        async def get_instance(**kwargs):
+            return manager
+
+    monkeypatch.setattr(api, "_OPENCODE_OPTIONS_CACHE", {})
+    monkeypatch.setattr(api.V2Config, "load", staticmethod(lambda: object()))
+    monkeypatch.setattr(
+        v2_compat,
+        "to_app_config",
+        lambda config: SimpleNamespace(
+            opencode=SimpleNamespace(
+                binary="opencode",
+                port=4096,
+                request_timeout_seconds=10,
+            )
+        ),
+    )
+    monkeypatch.setattr(opencode_module, "OpenCodeServerManager", _FakeServerManager)
+    monkeypatch.setattr(
+        opencode_module,
+        "build_reasoning_effort_options",
+        lambda models, model_key: [],
+    )
+    first = {"custom/first": {"id": "custom/first"}}
+    second = {"custom/second": {"id": "custom/second"}}
+
+    asyncio.run(
+        api.opencode_options_async(
+            "/tmp/workspace",
+            model_hub_models=first,
+        )
+    )
+    cached = asyncio.run(
+        api.opencode_options_async(
+            "/tmp/workspace",
+            model_hub_models=first,
+        )
+    )
+    asyncio.run(
+        api.opencode_options_async(
+            "/tmp/workspace",
+            model_hub_models=second,
+        )
+    )
+
+    assert cached["cached"] is True
+    assert projections == [first, second]
+
+
 def test_opencode_get_server_passes_resource_governor_from_v2_runtime(monkeypatch):
     import config.v2_compat as v2_compat
     import modules.agents.opencode as opencode_module

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -796,6 +796,8 @@ class _FakeOpencodeServer:
     async def get_available_models(self, _directory):
         return self.catalog
 
+    get_native_available_models = get_available_models
+
     async def create_session(self, _directory, *, title):
         return self.created_session
 

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -1096,6 +1096,53 @@ def test_opencode_provider_test_prefers_runtime_agent_model(
     }
 
 
+def test_opencode_provider_test_rejects_hub_only_runtime_agent_model(
+    service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = _FakeOpencodeServer()
+    fake.agent_model = "openai/custom-model"
+    fake.catalog = {
+        "providers": [
+            {
+                "id": "openai",
+                "models": {
+                    "gpt-5.3-chat-latest": {},
+                    "gpt-5.4": {},
+                },
+            }
+        ],
+        "default": {"openai": "gpt-5.3-chat-latest"},
+    }
+    fake.messages = [
+        {
+            "info": {
+                "id": "msg_assistant",
+                "role": "assistant",
+                "time": {"completed": 123},
+                "finish": "stop",
+            },
+            "parts": [{"type": "text", "text": "OK"}],
+        }
+    ]
+    monkeypatch.setattr(service, "_opencode_server", AsyncMock(return_value=fake))
+    monkeypatch.setattr(
+        service,
+        "_resolve_backend_config",
+        lambda backend: SimpleNamespace(default_provider="openai")
+        if backend == "opencode"
+        else None,
+    )
+
+    result = _run(service.test_opencode_provider("openai"))
+
+    assert result["ok"] is True
+    assert result["model"] == "gpt-5.3-chat-latest"
+    assert fake.prompt_calls[-1]["model"] == {
+        "providerID": "openai",
+        "modelID": "gpt-5.3-chat-latest",
+    }
+
+
 def test_opencode_provider_test_surfaces_non_retryable_log_error_before_timeout(
     service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/ui/src/context/ApiContext.expectedErrors.test.tsx
+++ b/ui/src/context/ApiContext.expectedErrors.test.tsx
@@ -69,6 +69,28 @@ const mountApi = async () => {
 const apiContextSource = () => readFileSync(join(__dirname, 'ApiContext.tsx'), 'utf8');
 
 describe('ApiProvider expected error codes', () => {
+  it('suppresses only the expected refusal for the OpenCode picker POST', async () => {
+    const api = await mountApi();
+
+    apiFetch.mockResolvedValue(codedError('instance_access_forbidden', 403));
+    await expect(api.readOpencodeOptionsForModelPicker()).rejects.toMatchObject({
+      code: 'instance_access_forbidden',
+    });
+    expect(showToast).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(apiFetch).toHaveBeenLastCalledWith('/api/opencode/options', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ cwd: '~' }),
+    }));
+
+    apiFetch.mockResolvedValue(codedError('opencode_runtime_failed', 500));
+    await expect(api.readOpencodeOptionsForModelPicker()).rejects.toMatchObject({
+      code: 'opencode_runtime_failed',
+    });
+    expect(showToast).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  });
+
   it('answers an absent Show Page silently on every read that shares the owner', async () => {
     // The members are DERIVED from the product source rather than restated here, so a read
     // added to `readShowPageJson` later is covered without editing this test — the panel

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -638,7 +638,7 @@ export type ApiContextType = {
     options?: { model?: string },
   ) => Promise<BackendAuthTestResult>;
   getOpencodeProviders: () => Promise<OpencodeProviderListResult>;
-  readOpencodeProvidersForModelPicker: () => Promise<OpencodeProviderListResult>;
+  readOpencodeOptionsForModelPicker: () => Promise<OpencodeOptionsResult>;
   saveOpencodeCustomProvider: (
     payload: OpencodeCustomProviderPayload,
   ) => Promise<OpencodeMutationResult>;
@@ -2478,6 +2478,15 @@ export type OpencodeProviderListResult = {
   permission_allowed?: boolean;
 };
 
+export type OpencodeOptionsResult = {
+  ok: boolean;
+  data?: {
+    models?: { providers?: unknown[] };
+    reasoning_options?: Record<string, { value: string; label: string }[]>;
+    [key: string]: unknown;
+  };
+};
+
 export type OpencodeMutationResult = {
   ok: boolean;
   message?: string;
@@ -3336,11 +3345,19 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     path: string,
     init: RequestInit,
     errorPath = path,
-    { clearCache = true, handleError = true }: { clearCache?: boolean; handleError?: boolean } = {},
+    {
+      clearCache = true,
+      handleError = true,
+      expectedCodes,
+    }: {
+      clearCache?: boolean;
+      handleError?: boolean;
+      expectedCodes?: readonly string[];
+    } = {},
   ) => {
     const res = await apiFetch(path, init);
     if (!res.ok && handleError) {
-      await handleApiError(res, errorPath);
+      await handleApiError(res, errorPath, { expectedCodes });
     }
     const payloadJson = await res.json().catch(() => ({}));
     if (res.ok && clearCache) {
@@ -3438,7 +3455,11 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     void sessionDraftPersistence.retryAll(writeSessionDraft);
   };
 
-  const postJson = async (path: string, payload: any, opts?: { handleError?: boolean }) => {
+  const postJson = async (
+    path: string,
+    payload: any,
+    opts?: { handleError?: boolean; expectedCodes?: readonly string[] },
+  ) => {
     const { payloadJson } = await requestJson(
       path,
       {
@@ -3784,18 +3805,11 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
         ...(options?.model ? { model: options.model } : {}),
       }),
     getOpencodeProviders: () => getJson('/api/backend/opencode/providers'),
-    // The same endpoint, read by the model pickers instead of by Settings, where
-    // a refusal is an answer rather than an incident. OpenCode's only catalog is
-    // this Settings one — it carries provider base URLs, masked keys, and auth
-    // state, and reaching it starts the daemon — so it stays Owner-only while the
-    // pickers render for every rank that may configure an Agent. Those ranks get
-    // no OpenCode suggestions and type the model id, which is what they already
-    // did before the member rank existed; announcing that as an error would put a
-    // toast on a page load the user did nothing wrong on. Declared here rather
-    // than at the three call sites so one of them cannot forget it, and kept off
-    // ``getOpencodeProviders`` so Settings still reports its own 403 loudly.
-    readOpencodeProvidersForModelPicker: () =>
-      getJson('/api/backend/opencode/providers', {
+    // Model pickers absorb the expected Owner-only refusal and retain typed-value
+    // fallback. Keep that policy on this dedicated reader so direct options calls
+    // still report access failures and no picker can forget the suppression.
+    readOpencodeOptionsForModelPicker: () =>
+      postJson('/api/opencode/options', { cwd: '~' }, {
         expectedCodes: ['instance_access_forbidden'],
       }),
     saveOpencodeCustomProvider: (payload) =>

--- a/ui/src/lib/backendModels.test.ts
+++ b/ui/src/lib/backendModels.test.ts
@@ -5,7 +5,7 @@ import { fetchBackendModels, loadBackendModelsWithRefresh } from './backendModel
 
 describe('fetchBackendModels for OpenCode', () => {
   it('reads the public options catalog without borrowing the native Settings surface', async () => {
-    const opencodeOptions = vi.fn().mockResolvedValue({
+    const readOpencodeOptionsForModelPicker = vi.fn().mockResolvedValue({
       ok: true,
       data: {
         models: {
@@ -21,14 +21,14 @@ describe('fetchBackendModels for OpenCode', () => {
     });
     const getOpencodeProviders = vi.fn();
     const api = {
-      opencodeOptions,
+      readOpencodeOptionsForModelPicker,
       getOpencodeProviders,
     } as unknown as ApiContextType;
 
     const result = await fetchBackendModels(api, 'opencode');
 
     expect(getOpencodeProviders).not.toHaveBeenCalled();
-    expect(opencodeOptions).toHaveBeenCalledWith('~');
+    expect(readOpencodeOptionsForModelPicker).toHaveBeenCalledOnce();
     expect(result.models).toEqual([
       'openrouter/anthropic/claude-x',
       'custom/hub-only',
@@ -40,7 +40,7 @@ describe('fetchBackendModels for OpenCode', () => {
 
   it('degrades to an empty catalog when the rank may not read the live options endpoint', async () => {
     const api = {
-      opencodeOptions: vi
+      readOpencodeOptionsForModelPicker: vi
         .fn()
         .mockRejectedValue(new ApiError('forbidden', 403, 'instance_access_forbidden')),
     } as unknown as ApiContextType;
@@ -50,7 +50,7 @@ describe('fetchBackendModels for OpenCode', () => {
 
   it('still propagates a failure that is not the expected refusal', async () => {
     const api = {
-      opencodeOptions: vi
+      readOpencodeOptionsForModelPicker: vi
         .fn()
         .mockRejectedValue(new ApiError('boom', 500, null)),
     } as unknown as ApiContextType;

--- a/ui/src/lib/backendModels.test.ts
+++ b/ui/src/lib/backendModels.test.ts
@@ -4,31 +4,43 @@ import { ApiError, type ApiContextType } from '../context/ApiContext';
 import { fetchBackendModels, loadBackendModelsWithRefresh } from './backendModels';
 
 describe('fetchBackendModels for OpenCode', () => {
-  it('reads the provider catalog through the picker helper, never the Settings one', async () => {
-    const readOpencodeProvidersForModelPicker = vi.fn().mockResolvedValue({
+  it('reads the public options catalog without borrowing the native Settings surface', async () => {
+    const opencodeOptions = vi.fn().mockResolvedValue({
       ok: true,
-      providers: [
-        { id: 'openrouter', configured: true, models: ['anthropic/claude-x'] },
-        { id: 'openai', configured: false, models: ['gpt-5'] },
-      ],
+      data: {
+        models: {
+          providers: [
+            { id: 'openrouter', models: { 'anthropic/claude-x': {} } },
+            { id: 'custom', models: [{ id: 'hub-only' }] },
+          ],
+        },
+        reasoning_options: {
+          'custom/hub-only': [{ value: 'high', label: 'High' }],
+        },
+      },
     });
     const getOpencodeProviders = vi.fn();
     const api = {
-      readOpencodeProvidersForModelPicker,
+      opencodeOptions,
       getOpencodeProviders,
     } as unknown as ApiContextType;
 
     const result = await fetchBackendModels(api, 'opencode');
 
-    // Settings owns the toast-on-403 read; the picker must not borrow it, or a
-    // member's page load announces a refusal it is expected to absorb.
     expect(getOpencodeProviders).not.toHaveBeenCalled();
-    expect(result.models).toEqual(['openrouter/anthropic/claude-x']);
+    expect(opencodeOptions).toHaveBeenCalledWith('~');
+    expect(result.models).toEqual([
+      'openrouter/anthropic/claude-x',
+      'custom/hub-only',
+    ]);
+    expect(result.reasoningOptions).toEqual({
+      'custom/hub-only': [{ value: 'high', label: 'High' }],
+    });
   });
 
-  it('degrades to an empty catalog when the rank may not read the Settings endpoint', async () => {
+  it('degrades to an empty catalog when the rank may not read the live options endpoint', async () => {
     const api = {
-      readOpencodeProvidersForModelPicker: vi
+      opencodeOptions: vi
         .fn()
         .mockRejectedValue(new ApiError('forbidden', 403, 'instance_access_forbidden')),
     } as unknown as ApiContextType;
@@ -38,7 +50,7 @@ describe('fetchBackendModels for OpenCode', () => {
 
   it('still propagates a failure that is not the expected refusal', async () => {
     const api = {
-      readOpencodeProvidersForModelPicker: vi
+      opencodeOptions: vi
         .fn()
         .mockRejectedValue(new ApiError('boom', 500, null)),
     } as unknown as ApiContextType;

--- a/ui/src/lib/backendModels.ts
+++ b/ui/src/lib/backendModels.ts
@@ -22,8 +22,8 @@ export function modelOptionLabel(model: string, labels?: Record<string, string>)
 // shared by ChatPage, the Agents detail panel, and the New Agent dialog so a
 // new backend (or a fix like OpenCode's provider-prefixing) lands in one place.
 //
-// claude / codex expose flat model arrays. OpenCode's catalog is per-provider
-// and the provider endpoint returns RAW model ids (never provider-prefixed), so
+// claude / codex expose flat model arrays. OpenCode's public options catalog is
+// per-provider and returns RAW model ids (never provider-prefixed), so
 // we flatten it into ``providerId/modelId`` keys — ALWAYS provider-prefixed,
 // even when the raw id itself contains "/" (e.g. OpenRouter's
 // ``anthropic/claude-*`` must become ``openrouter/anthropic/claude-*``). The
@@ -54,20 +54,33 @@ export async function fetchBackendModels(
     };
   }
   if (backend === 'opencode') {
-    // Best-effort: OpenCode's catalog lives behind the Owner-only Settings
-    // endpoint, so a rank that may configure an Agent but not the instance gets
-    // no suggestions and types the model id. ``allowCustomValue`` on every
-    // caller's Combobox is what makes that a degraded list rather than a dead
-    // field. See ``readOpencodeProvidersForModelPicker``.
-    const res = await api.readOpencodeProvidersForModelPicker().catch((err) => {
+    // Best-effort: this live catalog remains Owner-only because reading it may
+    // start OpenCode. Lower ranks keep the existing typed-value fallback.
+    const res = await api.opencodeOptions('~').catch((err) => {
       if (err instanceof ApiError && err.code === 'instance_access_forbidden') return null;
       throw err;
     });
     if (!res) return { models: [] };
-    const models = (res.providers ?? []).filter((p) => p.configured).flatMap((p) =>
-      (p.models ?? []).map((m) => `${p.id}/${m}`),
-    );
-    return { models };
+    const providers = res.ok && Array.isArray(res.data?.models?.providers)
+      ? res.data.models.providers
+      : [];
+    const models = providers.flatMap((provider: any) => {
+      const providerId = typeof provider?.id === 'string' ? provider.id : '';
+      if (!providerId) return [];
+      const rawModels = provider.models;
+      const modelIds = Array.isArray(rawModels)
+        ? rawModels.map((model: any) => typeof model === 'string' ? model : model?.id)
+        : rawModels && typeof rawModels === 'object'
+          ? Object.keys(rawModels)
+          : [];
+      return modelIds
+        .filter((modelId: unknown): modelId is string => typeof modelId === 'string' && Boolean(modelId))
+        .map((modelId: string) => `${providerId}/${modelId}`);
+    });
+    return {
+      models,
+      reasoningOptions: res.data?.reasoning_options,
+    };
   }
   return { models: [] };
 }

--- a/ui/src/lib/backendModels.ts
+++ b/ui/src/lib/backendModels.ts
@@ -61,15 +61,22 @@ export async function fetchBackendModels(
       throw err;
     });
     if (!res) return { models: [] };
-    const providers = res.ok && Array.isArray(res.data?.models?.providers)
+    const providers: unknown[] = res.ok && Array.isArray(res.data?.models?.providers)
       ? res.data.models.providers
       : [];
-    const models = providers.flatMap((provider: any) => {
-      const providerId = typeof provider?.id === 'string' ? provider.id : '';
+    const models = providers.flatMap((provider: unknown) => {
+      if (!provider || typeof provider !== 'object') return [];
+      const providerRecord = provider as Record<string, unknown>;
+      const providerId = typeof providerRecord.id === 'string' ? providerRecord.id : '';
       if (!providerId) return [];
-      const rawModels = provider.models;
+      const rawModels = providerRecord.models;
       const modelIds = Array.isArray(rawModels)
-        ? rawModels.map((model: any) => typeof model === 'string' ? model : model?.id)
+        ? rawModels.map((model: unknown) => {
+          if (typeof model === 'string') return model;
+          if (!model || typeof model !== 'object') return undefined;
+          const modelId = (model as Record<string, unknown>).id;
+          return typeof modelId === 'string' ? modelId : undefined;
+        })
         : rawModels && typeof rawModels === 'object'
           ? Object.keys(rawModels)
           : [];

--- a/ui/src/lib/backendModels.ts
+++ b/ui/src/lib/backendModels.ts
@@ -56,7 +56,7 @@ export async function fetchBackendModels(
   if (backend === 'opencode') {
     // Best-effort: this live catalog remains Owner-only because reading it may
     // start OpenCode. Lower ranks keep the existing typed-value fallback.
-    const res = await api.opencodeOptions('~').catch((err) => {
+    const res = await api.readOpencodeOptionsForModelPicker().catch((err) => {
       if (err instanceof ApiError && err.code === 'instance_access_forbidden') return null;
       throw err;
     });

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -10936,36 +10936,32 @@ def _filter_opencode_models_to_configured_providers(
 
     if not isinstance(models, dict):
         return models
+    from modules.agents.opencode.utils import (
+        filter_opencode_models_to_allowed_providers,
+    )
+
     allowed = _configured_opencode_provider_ids(
         providers_raw=providers_raw,
         auth_entries=auth_entries,
         config_api_key_provider_ids=config_api_key_provider_ids,
         custom_config_provider_ids=custom_config_provider_ids,
     )
-    if not allowed:
-        return {**models, "providers": [], "default": {}}
-
-    providers = []
+    filtered = filter_opencode_models_to_allowed_providers(models, allowed)
+    providers = list(filtered.get("providers", []) or [])
     seen: set[str] = set()
-    for provider in models.get("providers", []) or []:
+    for provider in providers:
         if not isinstance(provider, dict):
             continue
         pid = _opencode_provider_id(provider)
-        if isinstance(pid, str) and pid in allowed:
+        if isinstance(pid, str):
             seen.add(pid)
-            providers.append(provider)
 
     for pid in allowed:
         if pid in seen:
             continue
         providers.append({"id": pid, "models": {}})
 
-    defaults = models.get("default")
-    if isinstance(defaults, dict):
-        defaults = {pid: model_id for pid, model_id in defaults.items() if pid in allowed}
-    else:
-        defaults = {}
-    return {**models, "providers": providers, "default": defaults}
+    return {**filtered, "providers": providers}
 
 
 def _merge_opencode_user_models(
@@ -10982,26 +10978,14 @@ def _merge_opencode_user_models(
     if not isinstance(providers_raw, list):
         return models
     if allowed_provider_ids is not None:
-        filtered_providers = []
-        for provider in providers_raw:
-            if not isinstance(provider, dict):
-                continue
-            pid = _opencode_provider_id(provider)
-            if isinstance(pid, str) and pid in allowed_provider_ids:
-                filtered_providers.append(provider)
-        raw_defaults = models.get("default")
-        filtered_defaults = {}
-        if isinstance(raw_defaults, dict):
-            filtered_defaults = {
-                pid: model_id
-                for pid, model_id in raw_defaults.items()
-                if pid in allowed_provider_ids
-            }
-        models = {
-            **models,
-            "providers": filtered_providers,
-            "default": filtered_defaults,
-        }
+        from modules.agents.opencode.utils import (
+            filter_opencode_models_to_allowed_providers,
+        )
+
+        models = filter_opencode_models_to_allowed_providers(
+            models,
+            allowed_provider_ids,
+        )
         providers_raw = models.get("providers", [])
     if not user_model_index:
         return models

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -5723,10 +5723,16 @@ def discord_list_channels_live(bot_token: str, guild_id: str) -> dict:
 
 
 def opencode_options(cwd: str) -> dict:
+    from core.handlers.model_hub import load_opencode_public_models
     from vibe.async_bridge import run_coroutine_blocking
 
     try:
-        return run_coroutine_blocking(opencode_options_async(cwd))
+        return run_coroutine_blocking(
+            opencode_options_async(
+                cwd,
+                model_hub_models=load_opencode_public_models(),
+            )
+        )
     except Exception as exc:
         logger.warning("OpenCode options fetch failed: %s", exc, exc_info=True)
         return {"ok": False, "error": str(exc)}
@@ -5930,10 +5936,13 @@ async def opencode_options_async(
         sort_keys=True,
         separators=(",", ":"),
     )
+    cache_projection_matches = (
+        cache_entry.get("model_hub_projection") == projection_key
+    )
     if (
         cache_data
         and cache_age < _OPENCODE_OPTIONS_TTL_SECONDS
-        and cache_entry.get("model_hub_projection") == projection_key
+        and cache_projection_matches
     ):
         return {"ok": True, "data": cache_data, "cached": True}
 
@@ -6047,7 +6056,7 @@ async def opencode_options_async(
         return {"ok": True, "data": data}
     except Exception as exc:
         logger.warning("OpenCode options fetch failed: %s", exc, exc_info=True)
-        if cache_data:
+        if cache_data and cache_projection_matches:
             return {"ok": True, "data": cache_data, "cached": True, "warning": str(exc)}
         return {"ok": False, "error": str(exc)}
     finally:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -11201,7 +11201,7 @@ async def _get_opencode_providers_async() -> dict:
         providers_raw, auth_raw, config_raw = await asyncio.gather(
             server.get_providers(),
             server.get_provider_auth(),
-            server.get_available_models(os.path.expanduser("~")),
+            server.get_native_available_models(os.path.expanduser("~")),
             return_exceptions=False,
         )
     finally:
@@ -11786,7 +11786,7 @@ async def save_opencode_provider_model_async(provider_id: str, payload: dict) ->
     try:
         if server is not None:
             try:
-                config_raw = await server.get_available_models(os.path.expanduser("~"))
+                config_raw = await server.get_native_available_models(os.path.expanduser("~"))
             except Exception as exc:
                 logger.warning(
                     "OpenCode provider model catalog fetch failed for %s/%s: %s",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -5912,7 +5912,11 @@ async def _telegram_get_me(bot_token: str, proxy_url: str | None = None) -> dict
     return result.get("result") or {}
 
 
-async def opencode_options_async(cwd: str) -> dict:
+async def opencode_options_async(
+    cwd: str,
+    *,
+    model_hub_models: dict[str, Any] | None = None,
+) -> dict:
     # Expand ~ to user home directory
     request_loop = asyncio.get_running_loop()
     expanded_cwd = os.path.expanduser(cwd)
@@ -5920,7 +5924,17 @@ async def opencode_options_async(cwd: str) -> dict:
     cache_data = cache_entry.get("data")
     updated_at = cache_entry.get("updated_at", 0.0)
     cache_age = time.monotonic() - updated_at
-    if cache_data and cache_age < _OPENCODE_OPTIONS_TTL_SECONDS:
+    projection_key = json.dumps(
+        model_hub_models or {},
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    if (
+        cache_data
+        and cache_age < _OPENCODE_OPTIONS_TTL_SECONDS
+        and cache_entry.get("model_hub_projection") == projection_key
+    ):
         return {"ok": True, "data": cache_data, "cached": True}
 
     server = None
@@ -5969,7 +5983,15 @@ async def opencode_options_async(cwd: str) -> dict:
         )
         await asyncio.wait_for(server.ensure_running(), timeout=timeout_seconds)
         agents = await asyncio.wait_for(server.get_available_agents(expanded_cwd), timeout=timeout_seconds)
-        models = await asyncio.wait_for(server.get_available_models(expanded_cwd), timeout=timeout_seconds)
+        model_request = (
+            server.get_available_models(expanded_cwd)
+            if model_hub_models is None
+            else server.get_available_models(
+                expanded_cwd,
+                model_hub_models=model_hub_models,
+            )
+        )
+        models = await asyncio.wait_for(model_request, timeout=timeout_seconds)
         provider_catalog_available = True
         try:
             providers_raw = await asyncio.wait_for(server.get_providers(), timeout=timeout_seconds)
@@ -6020,6 +6042,7 @@ async def opencode_options_async(cwd: str) -> dict:
         _OPENCODE_OPTIONS_CACHE[expanded_cwd] = {
             "data": data,
             "updated_at": time.monotonic(),
+            "model_hub_projection": projection_key,
         }
         return {"ok": True, "data": data}
     except Exception as exc:

--- a/vibe/model_hub_client.py
+++ b/vibe/model_hub_client.py
@@ -225,6 +225,9 @@ class ModelHubRemoteService:
     def agent_chains(self, backend: str) -> list[dict]:
         return _rpc_sync("get_agent_chains", {"backend": backend})
 
+    def opencode_public_models(self) -> dict[str, dict[str, Any]]:
+        return _rpc_sync("get_opencode_public_models")
+
     async def probe_agent(
         self,
         backend: str,

--- a/vibe/opencode_config.py
+++ b/vibe/opencode_config.py
@@ -23,6 +23,9 @@ _CUSTOM_PROVIDER_LABELS = {
     "anthropic-compatible": "Anthropic compatible",
 }
 MODEL_HUB_RUNTIME_PROVIDER_PREFIX = "avibe-model-hub-"
+_MODEL_HUB_RUNTIME_PROVIDER_ID_RE = re.compile(
+    rf"^{re.escape(MODEL_HUB_RUNTIME_PROVIDER_PREFIX)}[0-9a-f]{{24}}$"
+)
 _RESERVED_PROVIDER_IDS = {
     "alibaba-cn",
     "anthropic",
@@ -529,7 +532,8 @@ def is_model_hub_runtime_provider_id(provider_id: object) -> bool:
 
     return (
         isinstance(provider_id, str)
-        and provider_id.lower().startswith(MODEL_HUB_RUNTIME_PROVIDER_PREFIX)
+        and _MODEL_HUB_RUNTIME_PROVIDER_ID_RE.fullmatch(provider_id.lower())
+        is not None
     )
 
 

--- a/vibe/opencode_config.py
+++ b/vibe/opencode_config.py
@@ -435,6 +435,24 @@ def load_first_opencode_user_config(
     return result
 
 
+def opencode_user_provider_exists(
+    provider_id: str,
+    *,
+    home: Path | None = None,
+    logger_instance: Optional[logging.Logger] = None,
+) -> bool:
+    """Return whether the user's config already owns a provider id."""
+
+    if not isinstance(provider_id, str) or not provider_id.strip():
+        return False
+    probe = load_first_opencode_user_config(
+        home=home,
+        logger_instance=logger_instance,
+    )
+    provider_map = probe.config.get("provider") if probe.config is not None else None
+    return isinstance(provider_map, dict) and provider_id.strip() in provider_map
+
+
 def _load_or_create_user_config(
     *,
     home: Path | None = None,

--- a/vibe/opencode_config.py
+++ b/vibe/opencode_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
@@ -21,6 +22,7 @@ _CUSTOM_PROVIDER_LABELS = {
     "openai-compatible": "OpenAI compatible",
     "anthropic-compatible": "Anthropic compatible",
 }
+MODEL_HUB_RUNTIME_PROVIDER_PREFIX = "avibe-model-hub-"
 _RESERVED_PROVIDER_IDS = {
     "alibaba-cn",
     "anthropic",
@@ -500,7 +502,7 @@ def _normalize_custom_provider_id(provider_id: str, *, reject_reserved: bool = F
         raise ValueError("provider_id is too long")
     if not re.fullmatch(r"[a-z0-9][a-z0-9_.-]*", candidate):
         raise ValueError("provider_id must use lowercase letters, numbers, dot, hyphen, or underscore")
-    if reject_reserved and candidate in _RESERVED_PROVIDER_IDS:
+    if reject_reserved and is_reserved_opencode_provider_id(candidate):
         raise ValueError("provider_id already exists")
     return candidate
 
@@ -508,7 +510,27 @@ def _normalize_custom_provider_id(provider_id: str, *, reject_reserved: bool = F
 def is_reserved_opencode_provider_id(provider_id: str) -> bool:
     if not isinstance(provider_id, str):
         return False
-    return provider_id.strip().lower() in _RESERVED_PROVIDER_IDS
+    candidate = provider_id.strip().lower()
+    return (
+        candidate in _RESERVED_PROVIDER_IDS
+        or is_model_hub_runtime_provider_id(candidate)
+    )
+
+
+def model_hub_runtime_provider_id(gateway_token: str) -> str:
+    """Derive the private OpenCode provider namespace for one gateway process."""
+
+    digest = hashlib.sha256(gateway_token.encode()).hexdigest()[:24]
+    return f"{MODEL_HUB_RUNTIME_PROVIDER_PREFIX}{digest}"
+
+
+def is_model_hub_runtime_provider_id(provider_id: object) -> bool:
+    """Return whether an identifier belongs to Avibe's runtime-only namespace."""
+
+    return (
+        isinstance(provider_id, str)
+        and provider_id.lower().startswith(MODEL_HUB_RUNTIME_PROVIDER_PREFIX)
+    )
 
 
 def get_opencode_custom_provider_adapter(

--- a/vibe/opencode_config.py
+++ b/vibe/opencode_config.py
@@ -435,24 +435,6 @@ def load_first_opencode_user_config(
     return result
 
 
-def opencode_user_provider_exists(
-    provider_id: str,
-    *,
-    home: Path | None = None,
-    logger_instance: Optional[logging.Logger] = None,
-) -> bool:
-    """Return whether the user's config already owns a provider id."""
-
-    if not isinstance(provider_id, str) or not provider_id.strip():
-        return False
-    probe = load_first_opencode_user_config(
-        home=home,
-        logger_instance=logger_instance,
-    )
-    provider_map = probe.config.get("provider") if probe.config is not None else None
-    return isinstance(provider_map, dict) and provider_id.strip() in provider_map
-
-
 def _load_or_create_user_config(
     *,
     home: Path | None = None,

--- a/vibe/opencode_config.py
+++ b/vibe/opencode_config.py
@@ -23,9 +23,6 @@ _CUSTOM_PROVIDER_LABELS = {
     "anthropic-compatible": "Anthropic compatible",
 }
 MODEL_HUB_RUNTIME_PROVIDER_PREFIX = "avibe-model-hub-"
-_MODEL_HUB_RUNTIME_PROVIDER_ID_RE = re.compile(
-    rf"^{re.escape(MODEL_HUB_RUNTIME_PROVIDER_PREFIX)}[0-9a-f]{{24}}$"
-)
 _RESERVED_PROVIDER_IDS = {
     "alibaba-cn",
     "anthropic",
@@ -513,11 +510,7 @@ def _normalize_custom_provider_id(provider_id: str, *, reject_reserved: bool = F
 def is_reserved_opencode_provider_id(provider_id: str) -> bool:
     if not isinstance(provider_id, str):
         return False
-    candidate = provider_id.strip().lower()
-    return (
-        candidate in _RESERVED_PROVIDER_IDS
-        or is_model_hub_runtime_provider_id(candidate)
-    )
+    return provider_id.strip().lower() in _RESERVED_PROVIDER_IDS
 
 
 def model_hub_runtime_provider_id(gateway_token: str) -> str:
@@ -525,16 +518,6 @@ def model_hub_runtime_provider_id(gateway_token: str) -> str:
 
     digest = hashlib.sha256(gateway_token.encode()).hexdigest()[:24]
     return f"{MODEL_HUB_RUNTIME_PROVIDER_PREFIX}{digest}"
-
-
-def is_model_hub_runtime_provider_id(provider_id: object) -> bool:
-    """Return whether an identifier belongs to Avibe's runtime-only namespace."""
-
-    return (
-        isinstance(provider_id, str)
-        and _MODEL_HUB_RUNTIME_PROVIDER_ID_RE.fullmatch(provider_id.lower())
-        is not None
-    )
 
 
 def get_opencode_custom_provider_adapter(

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7676,9 +7676,23 @@ def logs():
 @app.route("/api/opencode/options", methods=["POST"])
 async def opencode_options():
     from vibe import api
+    from core.handlers.model_hub import ModelHubError
 
     payload = request.json or {}
-    result = await api.opencode_options_async(payload.get("cwd", "."))
+    try:
+        public_models = await asyncio.to_thread(
+            _model_hub_service().opencode_public_models,
+        )
+    except ModelHubError:
+        logger.warning(
+            "Model Hub public projection unavailable; serving native OpenCode options",
+            exc_info=True,
+        )
+        public_models = {}
+    result = await api.opencode_options_async(
+        payload.get("cwd", "."),
+        model_hub_models=public_models,
+    )
     return jsonify(result)
 
 


### PR DESCRIPTION
## Summary

- isolate the Model Hub OpenCode overlay under a runtime-private provider namespace
- project only exact Hub-routed models back into OpenCode's public model identities
- preserve native provider models while keeping the runtime-private provider out of Web and IM catalogs
- derive the public projection from current persisted Model Hub state so fresh-start and post-configuration-change catalogs do not depend on a prior OpenCode turn
- cover OpenCode's actual Chat Completions request path in live resolution scenarios

## Root cause

OpenCode merges custom provider configuration by provider id. Reusing built-in ids such as `openai` and `anthropic` replaced their base URLs, so unrelated OpenCode-owned title and compaction requests were also redirected into the Model Hub turn gateway. The original live scenario modeled OpenCode as Anthropic Messages traffic and did not exercise its real Chat Completions boundary.

The public-catalog boundary also had no single owner: runtime-private provider rows, configured-provider defaults, and Hub-projected public models were combined independently by server, Web, and IM consumers. The final model separates controller-owned, credential-free public projection from the runtime-private transport overlay, then applies one shared visibility rule across those consumers.

## Verification

- 935 focused Model Hub, OpenCode runtime, server, UI API, settings, auth, and resolution tests passed (1 expected xfail, 3 subtests)
- Ruff and `git diff --check` passed
- exact-head GitHub Actions run [33026861106](https://github.com/avibe-bot/avibe/actions/runs/33026861106) completed successfully
- OpenCode 1.18.18 accepted `avibe-model-hub/openai/gpt-5` and emitted `POST /opencode/v1/chat/completions`
- when the overlay model key and exact upstream id differ, OpenCode sent the exact configured upstream id in the request body
- catalog boundary coverage verifies that the runtime-private provider is absent, exact projected models keep public identities, unrelated defaults and unprojected siblings stay hidden, list-shaped catalogs retain native siblings, and existing model metadata is preserved
- fresh-start, Web RPC, Web cache invalidation, and IM delivery coverage verifies that current persisted Hub mode/menu/routes own the public projection before any OpenCode turn
- local Incus regression deployed exact head `d2503019dad6db51befcd17737683335ec31554a`; the repository runner reports `avibe-master` running with `avibe-regression.service` active, `/health` OK, `/status` running with the internal server ready, and CLIProxyAPI v7.2.95 healthy/listening
- the deployed build identity reports exact revision `d2503019dad6db51befcd17737683335ec31554a` with `dirty=false`
- before any OpenCode Agent turn, the preserved live OpenCode public catalog contained only `anthropic` and `openai`, with no `avibe-model-hub-*` provider and no projected Hub rows, matching the persisted direct-mode configuration

## Live acceptance boundary

The preserved regression configuration keeps OpenCode in `direct` mode with an empty checked-model set and no selected Hub model. Accordingly, the live catalog has zero Hub-projected rows. Per the no-product-state-mutation constraint, this verification did not switch OpenCode to Hub mode or create a Hub-routed OpenCode session. Exact Hub projection, fresh-start synchronization, and filtering are covered at the controller, RPC, server, Web API, and IM boundaries; a real Hub session remains blocked until an environment is already configured for OpenCode Hub mode.
