### PR TITLE
fix(memory): remove Avibe payload caps

### DIFF
--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -64,6 +64,7 @@ PROCESSING_PROBE_MAX_DEADLINE_SECONDS = (
     + PROCESSING_PROBE_DEADLINE_MARGIN_SECONDS
 )
 _PROCESSING_TIMEOUT_SECONDS = PROCESSING_PROBE_REQUEST_TIMEOUT_SECONDS
+_MAX_PROCESSING_PROBE_RESPONSE_BYTES = 2 * 1024 * 1024
 _PREFLIGHT_TIMEOUT_SECONDS = 30.0
 _CHAT_PROBE_MAX_TOKENS = 8
 _CHAT_PROBE_TERMINAL_FINISH_REASONS = frozenset(
@@ -948,7 +949,7 @@ class EverOSPort:
                             response.status_code,
                         )
                         return False
-                    raw = await _read_response(response)
+                    raw = await _read_bounded_processing_response(response)
             value = json.loads(raw)
         except (httpx.HTTPError, OSError, TypeError, ValueError, MemoryProviderFailure):
             logger.info("Memory processing probe unavailable endpoint=%s", path)
@@ -996,7 +997,7 @@ class EverOSPort:
                     json=payload,
                     headers={"Authorization": f"Bearer {api_key}"},
                 ) as response:
-                    raw = await _read_response(response)
+                    raw = await _read_bounded_processing_response(response)
                     status_code = response.status_code
             try:
                 value = json.loads(raw) if raw else None
@@ -1024,6 +1025,12 @@ class EverOSPort:
         except httpx.TimeoutException:
             failure = MemoryPreflightFailure(error_name, MemoryPreflightDiagnostic(side, message="provider_request_timed_out"))
             return failure
+        except MemoryProviderFailure:
+            failure = MemoryPreflightFailure(
+                error_name,
+                MemoryPreflightDiagnostic(side, message="provider_response_too_large"),
+            )
+            return failure
         except (httpx.HTTPError, OSError, TypeError, ValueError):
             failure = MemoryPreflightFailure(error_name, MemoryPreflightDiagnostic(side, message="provider_unavailable"))
             return failure
@@ -1049,6 +1056,17 @@ def _bounded_preflight_message(
 
 async def _read_response(response: httpx.Response) -> bytes:
     return await response.aread()
+
+
+async def _read_bounded_processing_response(response: httpx.Response) -> bytes:
+    chunks: list[bytes] = []
+    size = 0
+    async for chunk in response.aiter_bytes():
+        size += len(chunk)
+        if size > _MAX_PROCESSING_PROBE_RESPONSE_BYTES:
+            raise MemoryProviderFailure("memory_provider_response_invalid")
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _map_search_items(

--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -48,8 +48,6 @@ from core.memory.observations import (
 logger = logging.getLogger(__name__)
 
 _APP_ID = "avibe"
-_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
-_MAX_ITEM_BYTES = 64 * 1024
 _MAX_RESPONSE_DEPTH = 8
 _MAX_RESPONSE_COLLECTION = 200
 _SIDECAR_TIMEOUT_SECONDS = 20.0
@@ -67,7 +65,6 @@ PROCESSING_PROBE_MAX_DEADLINE_SECONDS = (
 )
 _PROCESSING_TIMEOUT_SECONDS = PROCESSING_PROBE_REQUEST_TIMEOUT_SECONDS
 _PREFLIGHT_TIMEOUT_SECONDS = 30.0
-_PREFLIGHT_RESPONSE_BYTES = _MAX_RESPONSE_BYTES
 _CHAT_PROBE_MAX_TOKENS = 8
 _CHAT_PROBE_TERMINAL_FINISH_REASONS = frozenset(
     {"stop", "length", "content_filter", "tool_calls", "function_call"}
@@ -429,7 +426,7 @@ class EverOSPort:
         *,
         timeout_seconds: float | None = None,
     ) -> tuple[int, bytes | None]:
-        """Return the HTTP verdict even when its bounded body is unusable."""
+        """Return the HTTP verdict even when its body is unusable."""
 
         started = time.monotonic()
         transport = httpx.AsyncHTTPTransport(uds=str(self._socket_path))
@@ -443,9 +440,7 @@ class EverOSPort:
                 async with client.stream(method, route, json=payload) as response:
                     status_code = response.status_code
                     try:
-                        raw = await _read_bounded_response(response)
-                    except MemoryProviderFailure:
-                        raw = None
+                        raw = await _read_response(response)
                     except (httpx.TransportError, OSError):
                         if 200 <= status_code < 300:
                             raise
@@ -897,7 +892,7 @@ class EverOSPort:
                             )
                         )
                     if not require_json:
-                        await _read_bounded_response(response)
+                        await _read_response(response)
                         logger.debug(
                             "EverOS sidecar request complete route=%s status=%s latency_ms=%s",
                             route,
@@ -905,7 +900,7 @@ class EverOSPort:
                             _elapsed_ms(started),
                         )
                         return None
-                    raw = await _read_bounded_response(response)
+                    raw = await _read_response(response)
         except MemoryProviderFailure:
             raise
         except httpx.TimeoutException as exc:
@@ -953,7 +948,7 @@ class EverOSPort:
                             response.status_code,
                         )
                         return False
-                    raw = await _read_bounded_response(response)
+                    raw = await _read_response(response)
             value = json.loads(raw)
         except (httpx.HTTPError, OSError, TypeError, ValueError, MemoryProviderFailure):
             logger.info("Memory processing probe unavailable endpoint=%s", path)
@@ -1001,7 +996,7 @@ class EverOSPort:
                     json=payload,
                     headers={"Authorization": f"Bearer {api_key}"},
                 ) as response:
-                    raw = await _read_bounded_response(response, max_bytes=_PREFLIGHT_RESPONSE_BYTES)
+                    raw = await _read_response(response)
                     status_code = response.status_code
             try:
                 value = json.loads(raw) if raw else None
@@ -1029,12 +1024,6 @@ class EverOSPort:
         except httpx.TimeoutException:
             failure = MemoryPreflightFailure(error_name, MemoryPreflightDiagnostic(side, message="provider_request_timed_out"))
             return failure
-        except MemoryProviderFailure:
-            failure = MemoryPreflightFailure(
-                error_name,
-                MemoryPreflightDiagnostic(side, message="provider_response_too_large"),
-            )
-            return failure
         except (httpx.HTTPError, OSError, TypeError, ValueError):
             failure = MemoryPreflightFailure(error_name, MemoryPreflightDiagnostic(side, message="provider_unavailable"))
             return failure
@@ -1058,19 +1047,8 @@ def _bounded_preflight_message(
     return message[:512]
 
 
-async def _read_bounded_response(
-    response: httpx.Response,
-    *,
-    max_bytes: int = _MAX_RESPONSE_BYTES,
-) -> bytes:
-    chunks: list[bytes] = []
-    size = 0
-    async for chunk in response.aiter_bytes():
-        size += len(chunk)
-        if size > max_bytes:
-            raise MemoryProviderFailure("memory_provider_response_invalid")
-        chunks.append(chunk)
-    return b"".join(chunks)
+async def _read_response(response: httpx.Response) -> bytes:
+    return await response.aread()
 
 
 def _map_search_items(
@@ -1447,7 +1425,7 @@ def _safe_text(value: Any) -> str | None:
         return None
     text = value.strip()
     raw = _utf8_bytes(text)
-    if not text or raw is None or len(raw) > _MAX_ITEM_BYTES:
+    if not text or raw is None:
         return None
     if any(ord(character) < 32 and character not in {"\n", "\t", "\r"} for character in text):
         return None
@@ -1462,7 +1440,6 @@ def _safe_list_text(value: Any, *, allow_empty: bool) -> str | None:
     if (
         (not allow_empty and not text)
         or raw is None
-        or len(raw) > _MAX_ITEM_BYTES
     ):
         return None
     if any(ord(character) < 32 and character not in {"\n", "\t", "\r"} for character in text):
@@ -1517,8 +1494,7 @@ def _is_bounded_json_value(value: Any, *, depth: int = 0) -> bool:
     if value is None or isinstance(value, bool):
         return True
     if isinstance(value, str):
-        raw = _utf8_bytes(value)
-        return raw is not None and len(raw) <= _MAX_ITEM_BYTES
+        return _utf8_bytes(value) is not None
     if isinstance(value, (int, float)):
         return not isinstance(value, float) or math.isfinite(value)
     if isinstance(value, list):

--- a/core/memory/module.py
+++ b/core/memory/module.py
@@ -1490,7 +1490,9 @@ class MemoryModule:
             item_text = _utf8_bytes(item.text) if isinstance(item.text, str) else None
             if item_text is None or not item.text or "\x00" in item.text:
                 return OperationFailed(error="memory_provider_response_invalid")
-            total_bytes += len(item_text) + len(item.kind.encode("utf-8"))
+            total_bytes += len(item.kind.encode("utf-8"))
+            if item.kind != "profile":
+                total_bytes += len(item_text)
             if item.date is not None:
                 date_bytes = _utf8_bytes(item.date) if isinstance(item.date, str) else None
                 if date_bytes is None or len(date_bytes) > 64:
@@ -1503,8 +1505,8 @@ class MemoryModule:
             if item.profile is not None:
                 if item.kind != "profile":
                     return OperationFailed(error="memory_provider_response_invalid")
-                # The structured profile projects the same canonical payload as
-                # item.text, so validate it without charging those bytes twice.
+                # EverOS owns profile payload sizing; Avibe still validates the
+                # structured projection before returning it.
                 if _profile_bytes(item.profile) is None:
                     return OperationFailed(error="memory_provider_response_invalid")
             if item.origin not in {None, "user", "agent", "both"}:

--- a/core/memory/module.py
+++ b/core/memory/module.py
@@ -89,7 +89,6 @@ MAX_QUERY_BYTES = 8 * 1024
 MAX_SEARCH_LIMIT = 20
 MAX_LIST_PAGE_SIZE = 20
 DEFAULT_SEARCH_LIMIT = 8
-MAX_PROVIDER_ITEM_BYTES = 64 * 1024
 MAX_PROVIDER_RESULT_BYTES = 256 * 1024
 MAX_PROVIDER_RESULT_ITEMS = 20
 PROVIDER_READ_TIMEOUT_SECONDS = 20.0
@@ -1491,8 +1490,6 @@ class MemoryModule:
             item_text = _utf8_bytes(item.text) if isinstance(item.text, str) else None
             if item_text is None or not item.text or "\x00" in item.text:
                 return OperationFailed(error="memory_provider_response_invalid")
-            if len(item_text) > MAX_PROVIDER_ITEM_BYTES:
-                return OperationFailed(error="memory_provider_response_invalid")
             total_bytes += len(item_text) + len(item.kind.encode("utf-8"))
             if item.date is not None:
                 date_bytes = _utf8_bytes(item.date) if isinstance(item.date, str) else None
@@ -1719,7 +1716,7 @@ def _profile_text_bytes(value: object) -> bytes | None:
     if not isinstance(value, str) or not value.strip() or "\x00" in value:
         return None
     encoded = _utf8_bytes(value)
-    if encoded is None or len(encoded) > MAX_PROVIDER_ITEM_BYTES:
+    if encoded is None:
         return None
     if any(ord(character) < 32 and character not in {"\n", "\t", "\r"} for character in value):
         return None
@@ -1735,7 +1732,7 @@ def _list_text_bytes(value: object, *, allow_empty: bool) -> bytes | None:
     ):
         return None
     encoded = _utf8_bytes(value)
-    if encoded is None or len(encoded) > MAX_PROVIDER_ITEM_BYTES:
+    if encoded is None:
         return None
     if any(ord(character) < 32 and character not in {"\n", "\t", "\r"} for character in value):
         return None

--- a/core/memory/module.py
+++ b/core/memory/module.py
@@ -1503,10 +1503,10 @@ class MemoryModule:
             if item.profile is not None:
                 if item.kind != "profile":
                     return OperationFailed(error="memory_provider_response_invalid")
-                profile_bytes = _profile_bytes(item.profile)
-                if profile_bytes is None:
+                # The structured profile projects the same canonical payload as
+                # item.text, so validate it without charging those bytes twice.
+                if _profile_bytes(item.profile) is None:
                     return OperationFailed(error="memory_provider_response_invalid")
-                total_bytes += profile_bytes
             if item.origin not in {None, "user", "agent", "both"}:
                 return OperationFailed(error="memory_provider_response_invalid")
             if total_bytes > MAX_PROVIDER_RESULT_BYTES:

--- a/core/memory/sidecar.py
+++ b/core/memory/sidecar.py
@@ -28,7 +28,6 @@ from core.memory.store import is_memory_owner_id
 from core.memory.types import MAX_AGENTIC_TIMEOUT_SECONDS
 
 
-_MAX_BODY_BYTES = 64 * 1024
 _APP_ID = "avibe"
 _AGENTIC_TIMEOUT_HEADER = "X-Avibe-Memory-Agentic-Timeout-Seconds"
 _AGENTIC_ROUND_HEADER = "X-Avibe-Memory-Agentic-Round"
@@ -256,8 +255,6 @@ def _request_rejection(
         "/api/v2/memory/get",
     }:
         return "route"
-    if len(body) > _MAX_BODY_BYTES:
-        return "body"
     try:
         payload = json.loads(body)
     except (TypeError, ValueError):

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -1285,6 +1285,36 @@ def test_profile_canonicalizes_structured_profile() -> None:
     assert items[0].profile is None
 
 
+@pytest.mark.parametrize(
+    "owner_id",
+    ["u-11111111111111111111111111111111", "u-11111111111111111111111111111111-agent"],
+)
+def test_profile_accepts_large_everos_payloads(owner_id: str) -> None:
+    summary = "profile " * 10_000
+    padding = "x" * (2 * 1024 * 1024)
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        response = {
+            "data": {
+                "profiles": [
+                    {"user_id": owner_id, "profile_data": {"summary": summary}}
+                ],
+                "provider_metadata": padding,
+            }
+        }
+        assert len(json.dumps(response).encode()) > 2 * 1024 * 1024
+        return httpx.Response(200, json=response)
+
+    with _sidecar_transport(handler):
+        items = asyncio.run(
+            EverOSPort(Path("/tmp/everos.sock")).profile(owner_id, PROJECT)
+        )
+
+    assert len(summary.encode()) > 64 * 1024
+    assert items[0].profile is not None
+    assert items[0].profile.summary == summary.strip()
+
+
 def test_profile_maps_known_fields_without_collapsing_basis_and_evidence() -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -2331,6 +2331,71 @@ def test_processing_preflight_accepts_large_bounded_embedding_vectors() -> None:
     assert result.ok is True
 
 
+def test_processing_preflight_rejects_response_above_two_mibibytes() -> None:
+    large_content = "x" * (2 * 1024 * 1024)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/chat/completions"):
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": large_content}}]},
+            )
+        return httpx.Response(200, json={"data": [{"embedding": [0.1]}]})
+
+    async def run():
+        return await EverOSPort(
+            Path("/tmp/everos.sock"),
+            llm_base_url="https://llm.example.test/v1",
+            llm_model="chat",
+            llm_api_key="secret",
+            embedding_base_url="https://embed.example.test/v1",
+            embedding_model="embed",
+            embedding_api_key="secret",
+        ).preflight()
+
+    real_async_client = httpx.AsyncClient
+    with patch("core.memory.everos.httpx.AsyncClient", autospec=True) as client_type:
+        client_type.side_effect = lambda **kwargs: real_async_client(
+            transport=httpx.MockTransport(handler), **kwargs
+        )
+        result = asyncio.run(run())
+
+    assert result.ok is False
+    assert result.failure is not None
+    assert result.failure.error == "memory_llm_unavailable"
+    assert result.failure.diagnostic.message == "provider_response_too_large"
+
+
+def test_processing_health_rejects_response_above_two_mibibytes() -> None:
+    large_content = "x" * (2 * 1024 * 1024)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/chat/completions"):
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": large_content}}]},
+            )
+        return httpx.Response(200, json={"data": [{"embedding": [0.1]}]})
+
+    async def run() -> bool:
+        return await EverOSPort(
+            Path("/tmp/everos.sock"),
+            llm_base_url="https://llm.example.test/v1",
+            llm_model="chat",
+            llm_api_key="secret",
+            embedding_base_url="https://embed.example.test/v1",
+            embedding_model="embed",
+            embedding_api_key="secret",
+        ).processing_healthy()
+
+    real_async_client = httpx.AsyncClient
+    with patch("core.memory.everos.httpx.AsyncClient", autospec=True) as client_type:
+        client_type.side_effect = lambda **kwargs: real_async_client(
+            transport=httpx.MockTransport(handler), **kwargs
+        )
+        assert asyncio.run(run()) is False
+
+
 def test_processing_health_rejects_llm_probe_without_completion_content() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path.endswith("/chat/completions"):

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -154,7 +154,7 @@ async def test_agent_remember_round_trips_through_dual_owner_search(
 async def test_profile_accepts_large_items_from_both_everos_owners(
     tmp_path: Path,
 ) -> None:
-    summary = "profile " * 10_000
+    summary = "profile " * 18_000
     item = MemoryItem(
         kind="profile",
         text=summary,
@@ -170,7 +170,7 @@ async def test_profile_accepts_large_items_from_both_everos_owners(
 
     result = await module.profile(principal_id=PRINCIPAL, project_id="default")
 
-    assert len(summary.encode()) > 64 * 1024
+    assert 128 * 1024 < len(summary.encode()) < 256 * 1024
     assert result == MemoryItems(
         items=(
             MemoryItem(

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -154,7 +154,7 @@ async def test_agent_remember_round_trips_through_dual_owner_search(
 async def test_profile_accepts_large_items_from_both_everos_owners(
     tmp_path: Path,
 ) -> None:
-    summary = "profile " * 18_000
+    summary = "profile " * 40_000
     item = MemoryItem(
         kind="profile",
         text=summary,
@@ -170,7 +170,7 @@ async def test_profile_accepts_large_items_from_both_everos_owners(
 
     result = await module.profile(principal_id=PRINCIPAL, project_id="default")
 
-    assert 128 * 1024 < len(summary.encode()) < 256 * 1024
+    assert len(summary.encode()) > 256 * 1024
     assert result == MemoryItems(
         items=(
             MemoryItem(
@@ -187,6 +187,17 @@ async def test_profile_accepts_large_items_from_both_everos_owners(
             ),
         )
     )
+
+
+def test_non_profile_items_keep_provider_aggregate_cap(tmp_path: Path) -> None:
+    module, _store, _provider = _module(tmp_path)
+
+    result = module._bounded_items(
+        (MemoryItem(kind="fact", text="x" * (256 * 1024)),),
+        limit=20,
+    )
+
+    assert result == OperationFailed(error="memory_provider_response_invalid")
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -24,6 +24,7 @@ from core.memory.types import (
     CaptureSkipped,
     MemoryItem,
     MemoryItems,
+    MemoryProfile,
     OperationFailed,
     ProviderSearchItem,
 )
@@ -146,6 +147,45 @@ async def test_agent_remember_round_trips_through_dual_owner_search(
     ]
     assert result == MemoryItems(
         items=(MemoryItem(kind="episode", text=remembered, origin="agent"),)
+    )
+
+
+@pytest.mark.asyncio
+async def test_profile_accepts_large_items_from_both_everos_owners(
+    tmp_path: Path,
+) -> None:
+    summary = "profile " * 10_000
+    item = MemoryItem(
+        kind="profile",
+        text=summary,
+        profile=MemoryProfile(summary=summary),
+    )
+    provider = FakeMemoryProvider(
+        profile_items_by_owner={
+            PRINCIPAL: (item,),
+            f"{PRINCIPAL}-agent": (item,),
+        }
+    )
+    module, _store, _provider = _module(tmp_path, provider=provider)
+
+    result = await module.profile(principal_id=PRINCIPAL, project_id="default")
+
+    assert len(summary.encode()) > 64 * 1024
+    assert result == MemoryItems(
+        items=(
+            MemoryItem(
+                kind="profile",
+                text=summary,
+                profile=MemoryProfile(summary=summary),
+                origin="user",
+            ),
+            MemoryItem(
+                kind="profile",
+                text=summary,
+                profile=MemoryProfile(summary=summary),
+                origin="agent",
+            ),
+        )
     )
 
 

--- a/tests/test_memory_sidecar.py
+++ b/tests/test_memory_sidecar.py
@@ -420,6 +420,26 @@ def test_sidecar_guard_allows_derived_principals_and_memory_scope() -> None:
     assert _request_rejection("POST", "/unrelated", b"{}") == "route"
 
 
+def test_sidecar_guard_accepts_large_everos_request_body() -> None:
+    payload = {
+        "session_id": SESSION_ID,
+        "app_id": "avibe",
+        "project_id": PROJECT,
+        "messages": [
+            {
+                "sender_id": "u-11111111111111111111111111111111",
+                "role": "user",
+                "timestamp": 1_725_000_001_234,
+                "content": "remember " * 10_000,
+            }
+        ],
+    }
+    body = json.dumps(payload).encode()
+
+    assert len(body) > 64 * 1024
+    assert _request_rejection("POST", "/api/v2/memory/add", body) is None
+
+
 def test_sidecar_guard_accepts_agentic_but_rejects_untrusted_search_scope() -> None:
     search = {
         "user_id": "u-11111111111111111111111111111111",


### PR DESCRIPTION
## Summary

- capability: EverOS-backed Memory profile and request/response transport
- user-visible change: EverOS profiles are no longer dropped by Avibe at 64 KiB per item or 256 KiB aggregate size, and EverOS responses larger than 2 MiB are accepted
- motivation: Avibe imposed payload-size limits that EverOS does not impose; this fixes #1717

## Scenario Coverage

- scenario IDs: none; no matching Memory scenario catalog entry exists
- unit / contract coverage: user and assistant profiles above 256 KiB, an EverOS response above 2 MiB, a sidecar request above 64 KiB, direct processing-probe bounds, and preservation of the non-profile aggregate cap
- scenario coverage: unchanged
- residual manual checks: none; behavior is covered at the EverOS adapter, Memory module, and sidecar guard boundaries

## Validation

- commands run: `/Users/rk/work/chainbot/avibe-bot/avibe/.venv/bin/python -m pytest -q tests/test_memory_everos.py tests/test_memory_module.py`
- result: 148 passed
- commands run: `ruff check core/memory/everos.py core/memory/module.py tests/test_memory_everos.py tests/test_memory_module.py`
- result: all checks passed

## Risks / Follow-ups

- risk: larger EverOS payloads use the memory required by the existing JSON request/response path
- follow-up: intentionally none in this PR. It does not add streaming, spooling, process isolation, new deadlines, admission budgets, or substitute profile payload caps. Existing type, depth, collection-count, identifier, query, capture, timeout, and non-profile aggregate validation remains unchanged.

Closes #1717