### PR TITLE
feat(ui): add mobile settings navigation

### DIFF
--- a/ui/src/components/VersionBadge.tsx
+++ b/ui/src/components/VersionBadge.tsx
@@ -5,7 +5,11 @@ import { Download, X, RefreshCw, Check, AlertCircle, GitCommitHorizontal } from 
 import clsx from 'clsx';
 import { ToggleSwitch } from './settings/SettingsPrimitives';
 import { Button } from './ui/button';
-import { badgeVariants } from './ui/badge-variants';
+import {
+  badgeVariants,
+  interactiveBadgeTriggerClassName,
+  mobileHeaderPopoverClassName,
+} from './ui/badge-variants';
 import { cn } from '@/lib/utils';
 import { setConfigField } from '@/lib/configMutations';
 import { scheduleUpgradeReload } from '../lib/upgradeReload';
@@ -128,7 +132,8 @@ export const VersionBadge: React.FC<{ openUpward?: boolean }> = ({ openUpward = 
         onClick={() => setIsPopupOpen(!isPopupOpen)}
         className={cn(
           badgeVariants({ variant: hasUpdate ? 'warning' : 'secondary' }),
-          'relative cursor-pointer rounded-md font-medium tracking-normal hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+          interactiveBadgeTriggerClassName,
+          'relative rounded-md font-medium tracking-normal hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
         )}
         title={badgeTitle}
       >
@@ -145,7 +150,7 @@ export const VersionBadge: React.FC<{ openUpward?: boolean }> = ({ openUpward = 
           className={clsx(
             'z-50 rounded-lg border border-border bg-popover text-popover-foreground shadow-xl',
             // Mobile: full-width fixed below sticky header, with scroll
-            'fixed inset-x-3 top-[4.5rem] max-h-[calc(100dvh-5.5rem)] overflow-auto',
+            mobileHeaderPopoverClassName,
             // Desktop: anchor to trigger, fixed width
             'md:absolute md:inset-x-auto md:max-h-none md:w-72 md:overflow-visible',
             openUpward

--- a/ui/src/components/settings/BackendLifecycleChip.tsx
+++ b/ui/src/components/settings/BackendLifecycleChip.tsx
@@ -5,7 +5,11 @@ import clsx from 'clsx';
 import { useApi, type BackendRuntimeInfo } from '../../context/ApiContext';
 import { useToast } from '../../context/ToastContext';
 import { Button } from '../ui/button';
-import { badgeVariants } from '../ui/badge-variants';
+import {
+  badgeVariants,
+  interactiveBadgeTriggerClassName,
+  mobileHeaderPopoverClassName,
+} from '../ui/badge-variants';
 import { cn } from '@/lib/utils';
 
 type CliStatus = 'unknown' | 'ok' | 'missing';
@@ -216,7 +220,8 @@ export const BackendLifecycleChip: React.FC<BackendLifecycleChipProps> = ({
         onClick={() => setIsOpen((prev) => !prev)}
         className={cn(
           badgeVariants({ variant: BADGE_VARIANT[visual] }),
-          'cursor-pointer font-medium tracking-normal hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+          interactiveBadgeTriggerClassName,
+          'font-medium tracking-normal hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
         )}
         aria-label={chipLabel}
       >
@@ -228,7 +233,7 @@ export const BackendLifecycleChip: React.FC<BackendLifecycleChipProps> = ({
         <div
           className={clsx(
             'z-50 rounded-lg border border-border bg-popover text-popover-foreground shadow-xl',
-            'fixed inset-x-3 top-[4.5rem] max-h-[calc(100dvh-5.5rem)] overflow-auto',
+            mobileHeaderPopoverClassName,
             'md:absolute md:inset-x-auto md:right-0 md:top-full md:mt-2 md:w-72 md:max-h-none md:overflow-visible',
           )}
         >

--- a/ui/src/components/settings/SettingsLayout.test.tsx
+++ b/ui/src/components/settings/SettingsLayout.test.tsx
@@ -68,6 +68,8 @@ const renderLayout = (path: string) => render(
   <MemoryRouter initialEntries={[path]}>
     <Routes>
       <Route path="/settings" element={<SettingsLayoutHarness />}>
+        <Route path="backends" element={<div>backends-body</div>} />
+        <Route path="backends/claude" element={<div>claude-body</div>} />
         <Route path="models" element={<div>models-body</div>} />
         <Route path="replies" element={<div>replies-body</div>} />
         <Route path="shortcuts" element={<div>shortcuts-body</div>} />
@@ -299,6 +301,13 @@ describe('SettingsLayout', () => {
     expect(screen.getByRole('banner').className).toContain('pt-[env(safe-area-inset-top)]');
   });
 
+  it('keeps mobile navigation and header actions touch-sized', () => {
+    renderLayout('/settings');
+
+    expect(screen.getByRole('link', { name: 'settings.sections.replies' }).className).toContain('min-h-11');
+    expect(screen.getByRole('link', { name: 'settings.close' }).className).toContain('size-10');
+  });
+
   it('keeps mobile navigation and detail controls above the bottom safe-area inset', () => {
     renderLayout('/settings/replies');
 
@@ -308,5 +317,25 @@ describe('SettingsLayout', () => {
     expect(screen.getByText('replies-body').closest('section')?.firstElementChild?.className).toContain(
       'env(safe-area-inset-bottom)',
     );
+  });
+
+  it.each([
+    ['/settings/replies', '/settings', 'settings.backToSections'],
+    ['/settings/platforms/groups', '/settings', 'settings.backToSections'],
+    ['/settings/backends/claude', '/settings/backends', 'settings.backToSection'],
+  ])('returns one mobile level from %s', (path, target, label) => {
+    renderLayout(path);
+
+    const back = screen.getByRole('link', { name: label });
+    expect(back.getAttribute('href')).toBe(target);
+    expect(back.className).toContain('md:hidden');
+  });
+
+  it('animates a mobile detail screen without carrying that motion onto desktop', () => {
+    renderLayout('/settings/replies');
+
+    const frame = screen.getByText('replies-body').parentElement;
+    expect(frame?.className).toContain('slide-in-from-right-4');
+    expect(frame?.className).toContain('md:animate-none');
   });
 });

--- a/ui/src/components/settings/SettingsLayout.test.tsx
+++ b/ui/src/components/settings/SettingsLayout.test.tsx
@@ -12,6 +12,7 @@ const api = vi.hoisted(() => {
   return {
     configChangedHandlers,
     getConfig: vi.fn(),
+    getVersion: vi.fn(),
     getMemorySettings: vi.fn(),
     onConfigChanged: vi.fn((handler: (config: unknown) => void) => {
       configChangedHandlers.add(handler);
@@ -40,7 +41,6 @@ vi.mock('../LanguageSwitcher', () => ({
   ),
 }));
 vi.mock('../ThemeToggle', () => ({ ThemeToggle: () => <div data-testid="theme-toggle" /> }));
-vi.mock('../VersionBadge', () => ({ VersionBadge: () => <div data-testid="version-badge" /> }));
 vi.mock('../AccountMenu', () => ({
   AccountMenu: ({ openUpward }: { openUpward?: boolean }) => (
     <div data-testid="account-menu" data-open-upward={String(openUpward)} />
@@ -90,6 +90,13 @@ beforeEach(() => {
   media.listeners.clear();
   api.configChangedHandlers.clear();
   api.getConfig.mockResolvedValue({ capabilities: { model_hub: { enabled: true } } });
+  api.getVersion.mockResolvedValue({
+    current: '3.1.4',
+    latest: '3.1.4',
+    has_update: false,
+    error: null,
+    build: { kind: 'package' },
+  });
   api.getMemorySettings.mockResolvedValue({ status: 'ok', enabled: true });
   vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
     get matches() {
@@ -267,7 +274,7 @@ describe('SettingsLayout', () => {
     expect(screen.getByRole('link', { name: 'settings.sections.shortcuts' })).toBeTruthy();
     expect(screen.getByRole('link', { name: 'settings.sections.access' })).toBeTruthy();
     expect(screen.queryByRole('link', { name: 'settings.sections.service' })).toBeNull();
-    expect(screen.queryByTestId('version-badge')).toBeNull();
+    expect(api.getVersion).not.toHaveBeenCalled();
     expect(api.getConfig).not.toHaveBeenCalled();
   });
 
@@ -303,14 +310,28 @@ describe('SettingsLayout', () => {
     expect(screen.getByRole('banner').className).toContain('pt-[env(safe-area-inset-top)]');
   });
 
-  it('keeps mobile navigation and header actions touch-sized', () => {
+  it('keeps mobile navigation and the Back action touch-sized', () => {
     renderLayout('/settings');
 
     expect(screen.getByRole('link', { name: 'settings.sections.replies' }).className).toContain('min-h-11');
     const back = screen.getByRole('link', { name: 'settings.backToWorkbench' });
     expect(back.getAttribute('href')).toBe('/');
     expect(back.className).toContain('size-11');
-    expect(screen.getByTestId('version-badge').parentElement?.className).toContain('md:hidden');
+  });
+
+  it('shows a touch-sized current version with a safe-area-aware mobile popup', async () => {
+    const user = userEvent.setup();
+    renderLayout('/settings');
+
+    const version = await screen.findByTitle('v3.1.4');
+    expect(version.className).toContain('min-h-11');
+    expect(version.className).toContain('min-w-11');
+    expect(version.parentElement?.parentElement?.className).toContain('md:hidden');
+
+    await user.click(version);
+    const popup = screen.getByText('dashboard.versionAndUpdate').closest('.fixed');
+    expect(popup?.className).toContain('top-[calc(4.5rem+env(safe-area-inset-top))]');
+    expect(popup?.className).toContain('max-h-[calc(100dvh-5.5rem-env(safe-area-inset-top))]');
   });
 
   it('keeps mobile navigation and detail controls above the bottom safe-area inset', () => {

--- a/ui/src/components/settings/SettingsLayout.test.tsx
+++ b/ui/src/components/settings/SettingsLayout.test.tsx
@@ -40,6 +40,7 @@ vi.mock('../LanguageSwitcher', () => ({
   ),
 }));
 vi.mock('../ThemeToggle', () => ({ ThemeToggle: () => <div data-testid="theme-toggle" /> }));
+vi.mock('../VersionBadge', () => ({ VersionBadge: () => <div data-testid="version-badge" /> }));
 vi.mock('../AccountMenu', () => ({
   AccountMenu: ({ openUpward }: { openUpward?: boolean }) => (
     <div data-testid="account-menu" data-open-upward={String(openUpward)} />
@@ -266,6 +267,7 @@ describe('SettingsLayout', () => {
     expect(screen.getByRole('link', { name: 'settings.sections.shortcuts' })).toBeTruthy();
     expect(screen.getByRole('link', { name: 'settings.sections.access' })).toBeTruthy();
     expect(screen.queryByRole('link', { name: 'settings.sections.service' })).toBeNull();
+    expect(screen.queryByTestId('version-badge')).toBeNull();
     expect(api.getConfig).not.toHaveBeenCalled();
   });
 
@@ -305,7 +307,10 @@ describe('SettingsLayout', () => {
     renderLayout('/settings');
 
     expect(screen.getByRole('link', { name: 'settings.sections.replies' }).className).toContain('min-h-11');
-    expect(screen.getByRole('link', { name: 'settings.close' }).className).toContain('size-10');
+    const back = screen.getByRole('link', { name: 'settings.backToWorkbench' });
+    expect(back.getAttribute('href')).toBe('/');
+    expect(back.className).toContain('size-10');
+    expect(screen.getByTestId('version-badge').parentElement?.className).toContain('md:hidden');
   });
 
   it('keeps mobile navigation and detail controls above the bottom safe-area inset', () => {

--- a/ui/src/components/settings/SettingsLayout.test.tsx
+++ b/ui/src/components/settings/SettingsLayout.test.tsx
@@ -309,7 +309,7 @@ describe('SettingsLayout', () => {
     expect(screen.getByRole('link', { name: 'settings.sections.replies' }).className).toContain('min-h-11');
     const back = screen.getByRole('link', { name: 'settings.backToWorkbench' });
     expect(back.getAttribute('href')).toBe('/');
-    expect(back.className).toContain('size-10');
+    expect(back.className).toContain('size-11');
     expect(screen.getByTestId('version-badge').parentElement?.className).toContain('md:hidden');
   });
 

--- a/ui/src/components/settings/SettingsLayout.tsx
+++ b/ui/src/components/settings/SettingsLayout.tsx
@@ -105,6 +105,8 @@ const pathMatches = (pathname: string, itemPath: string): boolean =>
 const itemMatches = (pathname: string, item: SettingsItem): boolean =>
   item.exact ? pathname === item.path : pathMatches(pathname, item.path);
 
+const normalizedSettingsPath = (path: string): string => path.replace(/\/+$/, '') || '/';
+
 const SettingsNavLink: React.FC<{ item: SettingsItem }> = ({ item }) => {
   const { t } = useTranslation();
   const location = useLocation();
@@ -117,7 +119,7 @@ const SettingsNavLink: React.FC<{ item: SettingsItem }> = ({ item }) => {
       end={item.exact}
       title={t(item.labelKey)}
       className={clsx(
-        'flex items-center gap-2 rounded-lg px-2 py-2 text-[12.5px] font-medium transition-colors',
+        'flex min-h-11 items-center gap-2 rounded-lg px-2 py-2 text-[12.5px] font-medium transition-colors md:min-h-0',
         'md:justify-center lg:justify-start',
         active
           ? 'bg-mint/[0.09] text-foreground'
@@ -147,7 +149,7 @@ const SettingsNavGroup: React.FC<{ item: SettingsItem }> = ({ item }) => {
         aria-expanded={open}
         onClick={() => setManualOpen(!open)}
         className={clsx(
-          'flex w-full items-center gap-2 rounded-lg px-2 py-2 text-[12.5px] font-medium transition-colors',
+          'flex min-h-11 w-full items-center gap-2 rounded-lg px-2 py-2 text-[12.5px] font-medium transition-colors md:min-h-0',
           'md:justify-center lg:justify-start',
           childActive
             ? 'text-foreground'
@@ -254,7 +256,10 @@ export const SettingsLayout: React.FC = () => {
   );
 
   const activeTrail = useMemo(() => {
-    for (const group of visibleGroups) {
+    // Route hierarchy must stay stable while capability/config projections load;
+    // otherwise a mobile deep link can briefly point its Back action at the
+    // wrong parent before its rail item becomes visible.
+    for (const group of SETTINGS_GROUPS) {
       for (const item of group.items) {
         const child = item.children?.find((candidate) => itemMatches(location.pathname, candidate));
         if (child) return [item, child];
@@ -262,7 +267,22 @@ export const SettingsLayout: React.FC = () => {
       }
     }
     return [];
-  }, [location.pathname, visibleGroups]);
+  }, [location.pathname]);
+
+  const mobileBackTarget = useMemo(() => {
+    if (atRoot) return null;
+    const activeSection = activeTrail.at(-1);
+    if (!activeSection) return '/settings';
+    return normalizedSettingsPath(location.pathname) === normalizedSettingsPath(activeSection.path)
+      ? '/settings'
+      : activeSection.path;
+  }, [activeTrail, atRoot, location.pathname]);
+
+  const mobileBackLabel = mobileBackTarget === '/settings'
+    ? t('settings.backToSections')
+    : t('settings.backToSection', {
+      section: t(activeTrail.at(-1)?.labelKey ?? 'nav.settings'),
+    });
 
   useEffect(() => {
     if (atRoot || !location.pathname.startsWith('/settings/')) return;
@@ -278,7 +298,16 @@ export const SettingsLayout: React.FC = () => {
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-background md:h-[var(--app-shell-h)]">
       <header className="flex h-[calc(3.5rem+env(safe-area-inset-top))] shrink-0 items-center justify-between border-b border-border bg-surface px-4 pt-[env(safe-area-inset-top)] md:h-14 md:pt-0">
         <div className="flex min-w-0 items-center gap-2 text-[13px] font-semibold text-foreground">
-          <Settings className="size-4 text-mint-ink" />
+          {mobileBackTarget && (
+            <NavLink
+              to={mobileBackTarget}
+              aria-label={mobileBackLabel}
+              className="-ml-2 grid size-10 shrink-0 place-items-center rounded-lg text-muted transition hover:bg-foreground/[0.05] hover:text-foreground md:hidden"
+            >
+              <ChevronLeft className="size-5" />
+            </NavLink>
+          )}
+          <Settings className={clsx('size-4 text-mint-ink', mobileBackTarget && 'hidden md:block')} />
           <span>{t('nav.settings')}</span>
           {!atRoot && (
             <>
@@ -292,7 +321,7 @@ export const SettingsLayout: React.FC = () => {
         <NavLink
           to="/"
           aria-label={t('settings.close')}
-          className="grid size-8 place-items-center rounded-lg text-muted transition hover:bg-foreground/[0.05] hover:text-foreground"
+          className="grid size-10 shrink-0 place-items-center rounded-lg text-muted transition hover:bg-foreground/[0.05] hover:text-foreground md:size-8"
         >
           <X className="size-4" />
         </NavLink>
@@ -335,20 +364,12 @@ export const SettingsLayout: React.FC = () => {
 
         <section className={clsx('min-w-0 flex-1 overflow-y-auto', atRoot && 'hidden md:block')}>
           <div
+            key={location.pathname}
             className={clsx(
-              'w-full px-4 pb-[calc(1.25rem+env(safe-area-inset-bottom))] pt-5 md:px-6 md:pb-7 md:pt-7 lg:px-8',
+              'w-full px-4 pb-[calc(1.25rem+env(safe-area-inset-bottom))] pt-5 motion-safe:animate-in motion-safe:slide-in-from-right-4 motion-safe:duration-200 md:px-6 md:pb-7 md:pt-7 md:animate-none lg:px-8',
               isModelHub ? 'min-h-full' : 'mx-auto max-w-[1180px]',
             )}
           >
-            {!atRoot && (
-              <NavLink
-                to="/settings"
-                className="mb-4 inline-flex items-center gap-1.5 text-[12px] font-medium text-muted hover:text-foreground md:hidden"
-              >
-                <ChevronLeft className="size-3.5" />
-                {t('settings.backToSections')}
-              </NavLink>
-            )}
             <Outlet />
           </div>
         </section>

--- a/ui/src/components/settings/SettingsLayout.tsx
+++ b/ui/src/components/settings/SettingsLayout.tsx
@@ -31,6 +31,7 @@ import { useIsDesktop } from '@/lib/useIsDesktop';
 import { AccountMenu } from '../AccountMenu';
 import { LanguageSwitcher } from '../LanguageSwitcher';
 import { ThemeToggle } from '../ThemeToggle';
+import { VersionBadge } from '../VersionBadge';
 import { modelHubEnabledFromConfig } from './models/featureFlags';
 
 type SettingsItem = {
@@ -270,7 +271,7 @@ export const SettingsLayout: React.FC = () => {
   }, [location.pathname]);
 
   const mobileBackTarget = useMemo(() => {
-    if (atRoot) return null;
+    if (atRoot) return '/';
     const activeSection = activeTrail.at(-1);
     if (!activeSection) return '/settings';
     return normalizedSettingsPath(location.pathname) === normalizedSettingsPath(activeSection.path)
@@ -278,11 +279,13 @@ export const SettingsLayout: React.FC = () => {
       : activeSection.path;
   }, [activeTrail, atRoot, location.pathname]);
 
-  const mobileBackLabel = mobileBackTarget === '/settings'
-    ? t('settings.backToSections')
-    : t('settings.backToSection', {
-      section: t(activeTrail.at(-1)?.labelKey ?? 'nav.settings'),
-    });
+  const mobileBackLabel = mobileBackTarget === '/'
+    ? t('settings.backToWorkbench')
+    : mobileBackTarget === '/settings'
+      ? t('settings.backToSections')
+      : t('settings.backToSection', {
+        section: t(activeTrail.at(-1)?.labelKey ?? 'nav.settings'),
+      });
 
   useEffect(() => {
     if (atRoot || !location.pathname.startsWith('/settings/')) return;
@@ -318,13 +321,20 @@ export const SettingsLayout: React.FC = () => {
             </>
           )}
         </div>
-        <NavLink
-          to="/"
-          aria-label={t('settings.close')}
-          className="grid size-10 shrink-0 place-items-center rounded-lg text-muted transition hover:bg-foreground/[0.05] hover:text-foreground md:size-8"
-        >
-          <X className="size-4" />
-        </NavLink>
+        <div className="flex shrink-0 items-center gap-1">
+          {capabilities.can_manage_instance && (
+            <div className="md:hidden">
+              <VersionBadge />
+            </div>
+          )}
+          <NavLink
+            to="/"
+            aria-label={t('settings.close')}
+            className="hidden size-8 shrink-0 place-items-center rounded-lg text-muted transition hover:bg-foreground/[0.05] hover:text-foreground md:grid"
+          >
+            <X className="size-4" />
+          </NavLink>
+        </div>
       </header>
 
       <div className="flex min-h-0 flex-1">

--- a/ui/src/components/settings/SettingsLayout.tsx
+++ b/ui/src/components/settings/SettingsLayout.tsx
@@ -305,7 +305,7 @@ export const SettingsLayout: React.FC = () => {
             <NavLink
               to={mobileBackTarget}
               aria-label={mobileBackLabel}
-              className="-ml-2 grid size-10 shrink-0 place-items-center rounded-lg text-muted transition hover:bg-foreground/[0.05] hover:text-foreground md:hidden"
+              className="-ml-2 grid size-11 shrink-0 place-items-center rounded-lg text-muted transition hover:bg-foreground/[0.05] hover:text-foreground md:hidden"
             >
               <ChevronLeft className="size-5" />
             </NavLink>

--- a/ui/src/components/settings/SettingsPageShell.test.tsx
+++ b/ui/src/components/settings/SettingsPageShell.test.tsx
@@ -1,0 +1,26 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { SettingsPageShell } from './SettingsPageShell';
+
+afterEach(cleanup);
+
+describe('SettingsPageShell', () => {
+  it('leaves inline detail breadcrumbs to the desktop rail layout', () => {
+    render(
+      <SettingsPageShell
+        activeTab="backends"
+        title="Claude"
+        subtitle="Provider settings"
+        breadcrumb={<span>Backends</span>}
+      >
+        <div>body</div>
+      </SettingsPageShell>,
+    );
+
+    expect(screen.getByText('Backends').parentElement?.className).toContain('hidden');
+    expect(screen.getByText('Backends').parentElement?.className).toContain('md:block');
+  });
+});

--- a/ui/src/components/settings/SettingsPageShell.tsx
+++ b/ui/src/components/settings/SettingsPageShell.tsx
@@ -32,7 +32,7 @@ export const SettingsPageShell: React.FC<SettingsPageShellProps> = ({
       </div>
 
       {/* Provider/platform detail remains within the active Settings section. */}
-      {breadcrumb && <div className="font-mono text-[11px] text-muted">{breadcrumb}</div>}
+      {breadcrumb && <div className="hidden font-mono text-[11px] text-muted md:block">{breadcrumb}</div>}
 
       <div className="flex flex-col gap-4">{children}</div>
     </div>

--- a/ui/src/components/ui/badge-variants.ts
+++ b/ui/src/components/ui/badge-variants.ts
@@ -27,3 +27,13 @@ export const badgeVariants = cva(
     },
   }
 );
+
+// Native buttons styled as badges remain compact on desktop, but every mobile
+// projection needs a complete touch target rather than the visual chip alone.
+export const interactiveBadgeTriggerClassName =
+  'min-h-11 min-w-11 cursor-pointer justify-center md:min-h-0 md:min-w-0';
+
+// Mobile badge popovers sit below shell headers and must reserve the notch area
+// in both their origin and their available height.
+export const mobileHeaderPopoverClassName =
+  'fixed inset-x-3 top-[calc(4.5rem+env(safe-area-inset-top))] max-h-[calc(100dvh-5.5rem-env(safe-area-inset-top))] overflow-auto';

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -289,6 +289,7 @@
     },
     "navigationLabel": "Settings sections",
     "backToSections": "All settings",
+    "backToSection": "Back to {{section}}",
     "close": "Close Settings",
     "shortcuts": {
       "title": "Shortcuts",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -288,6 +288,7 @@
       "access": "Access"
     },
     "navigationLabel": "Settings sections",
+    "backToWorkbench": "Back to Workbench",
     "backToSections": "All settings",
     "backToSection": "Back to {{section}}",
     "close": "Close Settings",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -289,6 +289,7 @@
     },
     "navigationLabel": "设置分区",
     "backToSections": "全部设置",
+    "backToSection": "返回{{section}}",
     "close": "关闭设置",
     "shortcuts": {
       "title": "快捷键",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -288,6 +288,7 @@
       "access": "访问"
     },
     "navigationLabel": "设置分区",
+    "backToWorkbench": "返回工作台",
     "backToSections": "全部设置",
     "backToSection": "返回{{section}}",
     "close": "关闭设置",


### PR DESCRIPTION
## Capability
- Completes the mobile navigation projection for #1412: Settings sections push into full-screen detail routes, and nested provider/log detail routes return one level at a time.
- Moves the mobile Back action into the safe-area-aware header, shows the current version in the mobile header, removes duplicate mobile breadcrumbs, adds route transition motion, and uses 44px touch targets.

## Evidence
- Unit: `npm test -- --run src/components/settings/SettingsLayout.test.tsx src/components/settings/SettingsPageShell.test.tsx` (23 passed).
- Contract: mobile parent-route behavior covers section, nested platform, and provider routes; interactive badge triggers share mobile touch-target and safe-area popover geometry.
- Scenario: none (no Settings scenario catalog exists).
- Build/lint: `npm run build`; `npm run lint`.
- Residual manual: phone-sized visual/touch verification remains for Incus regression.

Closes #1412