### PR TITLE
fix(memory): align payload contract with EverOS

### DIFF
--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -1691,6 +1691,7 @@ def create_app(
             parse_ui_search_project,
         )
         from core.memory.runtime import MEMORY_LIST_CURSOR_MAX_BYTES
+        from core.memory.types import MAX_MEMORY_LIST_PAGE_SIZE
 
         is_ui = bool(str(request.headers.get(MEMORY_USER_KEY_HEADER) or "").strip())
         limit = payload.get("limit", 20)
@@ -1711,7 +1712,7 @@ def create_app(
         if (
             isinstance(limit, bool)
             or not isinstance(limit, int)
-            or not 1 <= limit <= 20
+            or not 1 <= limit <= MAX_MEMORY_LIST_PAGE_SIZE
             or origin not in ("user", "agent")
             or ("origin" in payload and not is_ui)
         ):
@@ -1826,7 +1827,6 @@ def create_app(
             or set(payload) - {"text", "project"}
             or not isinstance(payload.get("text"), str)
             or not payload["text"].strip()
-            or len(payload["text"]) > 4_000
         ):
             return JSONResponse(status_code=400, content={"status": "failed", "error": "memory_invalid_input"})
         from core.memory.project_ids import omitted_project_to_default, parse_writable_memory_project

--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -20,6 +20,7 @@ import httpx
 
 from core.memory.types import (
     CaptureAttachment,
+    MAX_MEMORY_LIST_PAGE_SIZE,
     MemoryErrorCode,
     MemoryItem,
     MemoryListItem,
@@ -48,8 +49,6 @@ from core.memory.observations import (
 logger = logging.getLogger(__name__)
 
 _APP_ID = "avibe"
-_MAX_RESPONSE_DEPTH = 8
-_MAX_RESPONSE_COLLECTION = 200
 _SIDECAR_TIMEOUT_SECONDS = 20.0
 _AGENTIC_TIMEOUT_HEADER = "X-Avibe-Memory-Agentic-Timeout-Seconds"
 _AGENTIC_ROUND_HEADER = "X-Avibe-Memory-Agentic-Round"
@@ -65,6 +64,7 @@ PROCESSING_PROBE_MAX_DEADLINE_SECONDS = (
 )
 _PROCESSING_TIMEOUT_SECONDS = PROCESSING_PROBE_REQUEST_TIMEOUT_SECONDS
 _MAX_PROCESSING_PROBE_RESPONSE_BYTES = 2 * 1024 * 1024
+_MAX_PROCESSING_PROBE_VECTOR_ITEMS = 200_000
 _PREFLIGHT_TIMEOUT_SECONDS = 30.0
 _CHAT_PROBE_MAX_TOKENS = 8
 _CHAT_PROBE_TERMINAL_FINISH_REASONS = frozenset(
@@ -82,7 +82,6 @@ MemoryRerankProvider = Literal["deepinfra", "vllm", "dashscope"]
 DEFAULT_MEMORY_RERANK_PROVIDER: MemoryRerankProvider = "deepinfra"
 DASHSCOPE_RERANK_PATH = "api/v1/services/rerank/text-rerank/text-rerank"
 
-_MAX_LIST_PAGE_SIZE = 20
 _EVEROS_EXACT_SORT_WINDOW = 20_000
 _MAX_PROFILE_TIMESTAMP_MS = 4_102_444_800_000
 # The pinned EverOS 1.2.3 `/add` route emits these only while ingesting attachment
@@ -535,7 +534,7 @@ class EverOSPort:
             require_json=True,
         )
         data = body.get("data") if isinstance(body, dict) else None
-        if not isinstance(data, dict) or not _is_bounded_json_value(data):
+        if not isinstance(data, dict) or not _is_json_value(data):
             raise MemoryProviderFailure("memory_provider_response_invalid")
         profile = _map_profile_item(data, principal_id=principal_id)
         # "Valid response, no profile payload" is exactly "zero items returned",
@@ -558,7 +557,7 @@ class EverOSPort:
             or page < 1
             or isinstance(page_size, bool)
             or not isinstance(page_size, int)
-            or not 1 <= page_size <= _MAX_LIST_PAGE_SIZE
+            or not 1 <= page_size <= MAX_MEMORY_LIST_PAGE_SIZE
         ):
             raise MemoryProviderFailure("memory_invalid_input", retryable=False)
         body = await self._sidecar_request(
@@ -824,7 +823,7 @@ class EverOSPort:
             if not isinstance(body, dict):
                 raise MemoryProviderFailure("memory_provider_response_invalid")
             data = body.get("data")
-            if not isinstance(data, dict) or not _is_bounded_json_value(data):
+            if not isinstance(data, dict) or not _is_json_value(data):
                 raise MemoryProviderFailure("memory_provider_response_invalid")
         except asyncio.TimeoutError as exc:
             raise MemoryProviderFailure("memory_provider_timeout") from exc
@@ -1078,8 +1077,6 @@ def _map_search_items(
     episodes = data.get("episodes", [])
     if not isinstance(episodes, list):
         raise MemoryProviderFailure("memory_provider_response_invalid")
-    if len(episodes) > _MAX_RESPONSE_COLLECTION:
-        raise MemoryProviderFailure("memory_provider_response_invalid")
 
     items: list[ProviderSearchItem] = []
     for episode in episodes:
@@ -1109,7 +1106,7 @@ def _map_search_items(
         facts = episode.get("atomic_facts", [])
         if facts is None:
             facts = []
-        if not isinstance(facts, list) or len(facts) > _MAX_RESPONSE_COLLECTION:
+        if not isinstance(facts, list):
             raise MemoryProviderFailure("memory_provider_response_invalid")
         for fact in facts:
             if len(items) >= limit:
@@ -1175,7 +1172,7 @@ def _map_episode_page(
         not request_id
         or not isinstance(data, dict)
         or set(data) != data_keys
-        or not _is_bounded_json_value(data)
+        or not _is_json_value(data)
     ):
         raise MemoryProviderFailure("memory_provider_response_invalid")
     episodes = data.get("episodes")
@@ -1269,7 +1266,6 @@ def _map_list_episode(
         or value.get("project_id") != project_id
         or value.get("type") != "Conversation"
         or not isinstance(sender_ids, list)
-        or len(sender_ids) > _MAX_RESPONSE_COLLECTION
         or any(not _strict_receipt_id(sender_id) for sender_id in sender_ids)
         or subject is None
         or summary is None
@@ -1289,7 +1285,7 @@ def _map_list_episode(
 
 def _map_profile_item(data: dict[str, Any], *, principal_id: str) -> MemoryItem | None:
     profiles = data.get("profiles", [])
-    if not isinstance(profiles, list) or len(profiles) > _MAX_RESPONSE_COLLECTION:
+    if not isinstance(profiles, list):
         raise MemoryProviderFailure("memory_provider_response_invalid")
     for profile in profiles:
         if not isinstance(profile, dict) or profile.get("user_id") != principal_id:
@@ -1362,7 +1358,7 @@ def _structured_explicit_info(value: dict[str, Any]) -> tuple[MemoryProfileExpli
     if "explicit_info" not in value:
         return ()
     entries = value["explicit_info"]
-    if not isinstance(entries, list) or len(entries) > _MAX_RESPONSE_COLLECTION:
+    if not isinstance(entries, list):
         raise MemoryProviderFailure("memory_provider_response_invalid")
     mapped: list[MemoryProfileExplicitInfo] = []
     for entry in entries:
@@ -1385,7 +1381,7 @@ def _structured_implicit_traits(value: dict[str, Any]) -> tuple[MemoryProfileTra
     if "implicit_traits" not in value:
         return ()
     entries = value["implicit_traits"]
-    if not isinstance(entries, list) or len(entries) > _MAX_RESPONSE_COLLECTION:
+    if not isinstance(entries, list):
         raise MemoryProviderFailure("memory_provider_response_invalid")
     mapped: list[MemoryProfileTrait] = []
     for entry in entries:
@@ -1429,11 +1425,11 @@ def _episode_text(episode: dict[str, Any]) -> str | None:
 def _canonical_profile_text(value: Any) -> str | None:
     if isinstance(value, str):
         return _safe_text(value)
-    if not isinstance(value, (dict, list)) or not _is_bounded_json_value(value):
+    if not isinstance(value, (dict, list)) or not _is_json_value(value):
         return None
     try:
         rendered = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-    except (TypeError, ValueError):
+    except (RecursionError, TypeError, ValueError):
         return None
     return _safe_text(rendered)
 
@@ -1506,28 +1502,33 @@ def _record_timestamp(value: Any) -> str | None:
     return instant.isoformat().replace("+00:00", "Z")
 
 
-def _is_bounded_json_value(value: Any, *, depth: int = 0) -> bool:
-    if depth > _MAX_RESPONSE_DEPTH:
+def _is_json_value(value: Any) -> bool:
+    """Validate JSON value types without imposing Avibe payload limits."""
+
+    pending = [value]
+    while pending:
+        item = pending.pop()
+        if item is None or isinstance(item, bool):
+            continue
+        if isinstance(item, str):
+            if _utf8_bytes(item) is None:
+                return False
+            continue
+        if isinstance(item, (int, float)):
+            if isinstance(item, float) and not math.isfinite(item):
+                return False
+            continue
+        if isinstance(item, list):
+            pending.extend(item)
+            continue
+        if isinstance(item, dict):
+            for key, nested in item.items():
+                if not isinstance(key, str) or _utf8_bytes(key) is None:
+                    return False
+                pending.append(nested)
+            continue
         return False
-    if value is None or isinstance(value, bool):
-        return True
-    if isinstance(value, str):
-        return _utf8_bytes(value) is not None
-    if isinstance(value, (int, float)):
-        return not isinstance(value, float) or math.isfinite(value)
-    if isinstance(value, list):
-        return len(value) <= _MAX_RESPONSE_COLLECTION and all(
-            _is_bounded_json_value(item, depth=depth + 1) for item in value
-        )
-    if isinstance(value, dict):
-        return len(value) <= _MAX_RESPONSE_COLLECTION and all(
-            isinstance(key, str)
-            and (raw := _utf8_bytes(key)) is not None
-            and len(raw) <= 128
-            and _is_bounded_json_value(item, depth=depth + 1)
-            for key, item in value.items()
-        )
-    return False
+    return True
 
 
 def _valid_chat_probe_response(value: Any) -> bool:
@@ -1578,7 +1579,7 @@ def _valid_embedding_probe_response(value: Any) -> bool:
     return (
         isinstance(vector, list)
         and bool(vector)
-        and len(vector) <= _MAX_RESPONSE_COLLECTION * 1000
+        and len(vector) <= _MAX_PROCESSING_PROBE_VECTOR_ITEMS
         and all(isinstance(item, (int, float)) and not isinstance(item, bool) and math.isfinite(item) for item in vector)
     )
 
@@ -1744,7 +1745,7 @@ def _optional_json_object(raw: bytes | None) -> dict[str, Any] | None:
         value = json.loads(raw)
     except (TypeError, ValueError):
         return None
-    return value if isinstance(value, dict) and _is_bounded_json_value(value) else None
+    return value if isinstance(value, dict) and _is_json_value(value) else None
 
 
 def _provider_health_snapshot(payload: dict[str, Any] | None) -> ProviderHealthSnapshot | None:
@@ -1933,7 +1934,7 @@ class FakeMemoryProvider:
         default_factory=lambda: MemoryListPage(
             items=(),
             page=1,
-            page_size=_MAX_LIST_PAGE_SIZE,
+            page_size=20,
             count=0,
             total_count=0,
         )

--- a/core/memory/module.py
+++ b/core/memory/module.py
@@ -62,6 +62,8 @@ from core.memory.types import (
     MemoryProfileExplicitInfo,
     MemoryProfileTrait,
     MemoryResult,
+    MAX_MEMORY_LIST_PAGE_SIZE,
+    MAX_MEMORY_SEARCH_RESULTS,
     OperationFailed,
     ProviderSearchItem,
     RecallItems,
@@ -79,18 +81,12 @@ if TYPE_CHECKING:
     from core.inbound_attachment_lease import InboundAttachmentLease
 
 
-MAX_CAPTURE_TEXT_BYTES = 32 * 1024
 MAX_CAPTURE_IDENTIFIER_BYTES = 1024
 MAX_CAPTURE_ATTACHMENTS = 8
-MAX_CAPTURE_ATTACHMENT_METADATA_BYTES = 16 * 1024
 MIN_FREE_DISK_BYTES = 512 * 1024 * 1024
 MAX_PROVIDER_TIMESTAMP_MS = 4_102_444_800_000
-MAX_QUERY_BYTES = 8 * 1024
-MAX_SEARCH_LIMIT = 20
-MAX_LIST_PAGE_SIZE = 20
 DEFAULT_SEARCH_LIMIT = 8
-MAX_PROVIDER_RESULT_BYTES = 256 * 1024
-MAX_PROVIDER_RESULT_ITEMS = 20
+DEFAULT_LIST_PAGE_SIZE = 20
 PROVIDER_READ_TIMEOUT_SECONDS = 20.0
 
 
@@ -826,16 +822,12 @@ class MemoryModule:
         if not isinstance(policy, RecallPolicy):
             return OperationFailed(error="memory_invalid_input")
         normalized_query = self._normalize_text(query)
-        query_bytes = _utf8_bytes(normalized_query)
-        if query_bytes is None or not normalized_query.strip():
+        if _utf8_bytes(normalized_query) is None or not normalized_query.strip():
             return OperationFailed(error="memory_invalid_input")
         if not is_principal_id(principal_id):
             return OperationFailed(error="memory_access_denied")
         if not is_new_stored_memory_project_id(project_id):
             return OperationFailed(error="memory_access_denied")
-        if len(query_bytes) > MAX_QUERY_BYTES:
-            return OperationFailed(error="memory_input_too_large")
-
         if self._retired:
             return OperationFailed(error="memory_operation_in_progress")
 
@@ -1122,7 +1114,7 @@ class MemoryModule:
                 if first_failure is None:
                     first_failure = result
                 continue
-            bounded = self._bounded_items(result, limit=MAX_PROVIDER_RESULT_ITEMS)
+            bounded = self._bounded_items(result, limit=MAX_MEMORY_SEARCH_RESULTS)
             if isinstance(bounded, OperationFailed):
                 if first_failure is None:
                     first_failure = bounded
@@ -1142,7 +1134,7 @@ class MemoryModule:
         principal_id: str,
         project_id: str,
         page: int = 1,
-        page_size: int = MAX_LIST_PAGE_SIZE,
+        page_size: int = DEFAULT_LIST_PAGE_SIZE,
         origin: MemoryOrigin = "user",
     ) -> MemoryListResult:
         """Return one bounded page of processed episodes or a closed error."""
@@ -1236,7 +1228,7 @@ class MemoryModule:
             or page < 1
             or isinstance(page_size, bool)
             or not isinstance(page_size, int)
-            or not 1 <= page_size <= MAX_LIST_PAGE_SIZE
+            or not 1 <= page_size <= MAX_MEMORY_LIST_PAGE_SIZE
             or origin not in ("user", "agent")
         ):
             return OperationFailed(error="memory_invalid_input")
@@ -1440,7 +1432,6 @@ class MemoryModule:
             or any(warning != "memory_list_truncated" for warning in result.warnings)
         ):
             return OperationFailed(error="memory_provider_response_invalid")
-        total_bytes = 0
         seen_ids: set[str] = set()
         previous_instant: datetime | None = None
         for item in result.items:
@@ -1469,30 +1460,19 @@ class MemoryModule:
                 (item.summary, True),
                 (item.body, False),
             ):
-                encoded = _list_text_bytes(value, allow_empty=allow_empty)
-                if encoded is None:
+                if _list_text_bytes(value, allow_empty=allow_empty) is None:
                     return OperationFailed(error="memory_provider_response_invalid")
-                total_bytes += len(encoded)
-            total_bytes += len(item.id.encode("utf-8"))
-            total_bytes += len(item.timestamp.encode("utf-8"))
-            total_bytes += len(item.project.encode("utf-8"))
-            if total_bytes > MAX_PROVIDER_RESULT_BYTES:
-                return OperationFailed(error="memory_provider_response_invalid")
         return result
 
     def _bounded_items(self, items: tuple[MemoryItem, ...], *, limit: int) -> MemoryResult:
         if not isinstance(items, tuple) or len(items) > limit:
             return OperationFailed(error="memory_provider_response_invalid")
-        total_bytes = 0
         for item in items:
             if not isinstance(item, MemoryItem) or item.kind not in {"profile", "episode", "fact"}:
                 return OperationFailed(error="memory_provider_response_invalid")
             item_text = _utf8_bytes(item.text) if isinstance(item.text, str) else None
             if item_text is None or not item.text or "\x00" in item.text:
                 return OperationFailed(error="memory_provider_response_invalid")
-            total_bytes += len(item.kind.encode("utf-8"))
-            if item.kind != "profile":
-                total_bytes += len(item_text)
             if item.date is not None:
                 date_bytes = _utf8_bytes(item.date) if isinstance(item.date, str) else None
                 if date_bytes is None or len(date_bytes) > 64:
@@ -1501,7 +1481,6 @@ class MemoryModule:
                     date.fromisoformat(item.date)
                 except ValueError:
                     return OperationFailed(error="memory_provider_response_invalid")
-                total_bytes += len(date_bytes)
             if item.profile is not None:
                 if item.kind != "profile":
                     return OperationFailed(error="memory_provider_response_invalid")
@@ -1510,8 +1489,6 @@ class MemoryModule:
                 if _profile_bytes(item.profile) is None:
                     return OperationFailed(error="memory_provider_response_invalid")
             if item.origin not in {None, "user", "agent", "both"}:
-                return OperationFailed(error="memory_provider_response_invalid")
-            if total_bytes > MAX_PROVIDER_RESULT_BYTES:
                 return OperationFailed(error="memory_provider_response_invalid")
         return MemoryItems(items=items)
 
@@ -1540,22 +1517,10 @@ class MemoryModule:
             or any(not self._valid_capture_attachment(item) for item in request.attachments)
         ):
             return "memory_invalid_input"
-        attachment_metadata = "\0".join(
-            f"{item.kind}\0{item.name}\0{item.ext}"
-            for item in request.attachments
-        )
-        attachment_bytes = _utf8_bytes(attachment_metadata)
-        if attachment_bytes is None:
-            return "memory_invalid_input"
-        if len(attachment_bytes) > MAX_CAPTURE_ATTACHMENT_METADATA_BYTES:
-            return "memory_input_too_large"
-        text_bytes = _utf8_bytes(normalized_text)
-        if text_bytes is None:
+        if _utf8_bytes(normalized_text) is None:
             return "memory_invalid_input"
         if not normalized_text.strip() and not request.attachments:
             return "memory_invalid_input"
-        if len(text_bytes) > MAX_CAPTURE_TEXT_BYTES:
-            return "memory_input_too_large"
         return None
 
     @staticmethod
@@ -1781,7 +1746,7 @@ def _profile_bytes(profile: object) -> int | None:
         return None
     total += summary_bytes
 
-    if not isinstance(profile.explicit_info, tuple) or len(profile.explicit_info) > MAX_PROVIDER_RESULT_ITEMS * 10:
+    if not isinstance(profile.explicit_info, tuple):
         return None
     for info in profile.explicit_info:
         if not isinstance(info, MemoryProfileExplicitInfo):
@@ -1796,7 +1761,7 @@ def _profile_bytes(profile: object) -> int | None:
                 return None
             total += value_bytes
 
-    if not isinstance(profile.implicit_traits, tuple) or len(profile.implicit_traits) > MAX_PROVIDER_RESULT_ITEMS * 10:
+    if not isinstance(profile.implicit_traits, tuple):
         return None
     for trait in profile.implicit_traits:
         if not isinstance(trait, MemoryProfileTrait):

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -85,6 +85,7 @@ from core.memory.project_ids import (
 )
 from core.memory.store import MemoryStore, is_principal_id
 from core.memory.types import (
+    MAX_MEMORY_LIST_PAGE_SIZE,
     MemoryFailureLogEntry,
     MemoryItem,
     MemoryItems,
@@ -1291,7 +1292,7 @@ class MemoryRuntime:
             not is_principal_id(principal_id)
             or isinstance(limit, bool)
             or not isinstance(limit, int)
-            or not 1 <= limit <= _MEMORY_LIST_PROVIDER_PAGE_SIZE
+            or not 1 <= limit <= MAX_MEMORY_LIST_PAGE_SIZE
             or origin not in ("user", "agent")
         ):
             return {"status": "failed", "error": "memory_invalid_input"}

--- a/core/memory/sidecar.py
+++ b/core/memory/sidecar.py
@@ -25,7 +25,11 @@ from core.memory.project_ids import (
 from core.memory.secret_scrubber import install_error_scrubbers
 from core.memory.modality import SUPPORTED_ATTACHMENT_EXTENSIONS
 from core.memory.store import is_memory_owner_id
-from core.memory.types import MAX_AGENTIC_TIMEOUT_SECONDS
+from core.memory.types import (
+    MAX_AGENTIC_TIMEOUT_SECONDS,
+    MAX_MEMORY_LIST_PAGE_SIZE,
+    MAX_MEMORY_SEARCH_RESULTS,
+)
 
 
 _APP_ID = "avibe"
@@ -427,7 +431,7 @@ def _validate_search(payload: dict[str, Any]) -> str | None:
         or payload.get("method") not in {"keyword", "vector", "hybrid", "agentic"}
         or not isinstance(payload.get("top_k"), int)
         or isinstance(payload.get("top_k"), bool)
-        or not 1 <= payload["top_k"] <= 20
+        or not 1 <= payload["top_k"] <= MAX_MEMORY_SEARCH_RESULTS
         or type(payload.get("include_profile")) is not bool
         or payload.get("enable_llm_rerank") is not False
     ):
@@ -470,7 +474,7 @@ def _validate_get(payload: dict[str, Any]) -> str | None:
         or page < 1
         or isinstance(page_size, bool)
         or not isinstance(page_size, int)
-        or not 1 <= page_size <= 20
+        or not 1 <= page_size <= MAX_MEMORY_LIST_PAGE_SIZE
         or payload.get("sort_by") != "timestamp"
         or payload.get("sort_order") != "desc"
     ):

--- a/core/memory/types.py
+++ b/core/memory/types.py
@@ -11,6 +11,10 @@ MemoryKind = Literal["profile", "episode", "fact"]
 MemoryOrigin = Literal["user", "agent"]
 RecallMode = Literal["auto", "keyword", "vector", "hybrid", "agentic"]
 MAX_AGENTIC_TIMEOUT_SECONDS = 30.0
+# Pinned EverOS 1.2.3 request bounds. Keep every Avibe entry point aligned
+# with the provider contract instead of layering a smaller product limit on top.
+MAX_MEMORY_SEARCH_RESULTS = 100
+MAX_MEMORY_LIST_PAGE_SIZE = 100
 MemoryContentKind = Literal["image", "audio", "doc", "pdf", "html", "email"]
 MemoryFailureKind = Literal[
     "boot_recovery",
@@ -472,7 +476,7 @@ class RecallPolicy:
         if (
             isinstance(self.max_results, bool)
             or not isinstance(self.max_results, int)
-            or not 1 <= self.max_results <= 20
+            or not 1 <= self.max_results <= MAX_MEMORY_SEARCH_RESULTS
         ):
             raise ValueError("invalid recall result limit")
         if type(self.include_profile) is not bool or type(self.include_current_session) is not bool:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -130,8 +130,8 @@ context; running them from a normal terminal returns `memory_access_denied`.
 ```bash
 vibe memory status [--json]
 vibe memory profile [--json]
-vibe memory list [--project <slug>] [--page N] [--limit 1..20] [--json]
-vibe memory search <query> [--project <slug>] [--mode {hybrid|keyword|vector|agentic}] [--limit 1..20] [--json]
+vibe memory list [--project <slug>] [--page N] [--limit 1..100] [--json]
+vibe memory search <query> [--project <slug>] [--mode {hybrid|keyword|vector|agentic}] [--limit 1..100] [--json]
 vibe memory remember <text> [--project <slug>] [--json]
 ```
 

--- a/docs/CLI_ZH.md
+++ b/docs/CLI_ZH.md
@@ -111,8 +111,8 @@ Avibe 已注入当前 Session 上下文的合规 Agent shell 中运行；从普�
 ```bash
 vibe memory status [--json]
 vibe memory profile [--json]
-vibe memory list [--project <slug>] [--page N] [--limit 1..20] [--json]
-vibe memory search <查询> [--project <slug>] [--limit 1..20] [--json]
+vibe memory list [--project <slug>] [--page N] [--limit 1..100] [--json]
+vibe memory search <查询> [--project <slug>] [--limit 1..100] [--json]
 vibe memory remember <文本> [--project <slug>] [--json]
 ```
 

--- a/tests/scenarios/memory_list/catalog.yaml
+++ b/tests/scenarios/memory_list/catalog.yaml
@@ -61,3 +61,9 @@ scenarios:
     kind: authorization
     layer: scenario
     test: tests/scenarios/memory_list/test_memory_list_scenarios.py::test_settings_can_browse_agent_episodes_without_crossing_owner_scopes
+  - id: MEMORY-LIST-009
+    name: Episode pages use the pinned EverOS size contract without an Avibe byte cap
+    status: covered
+    kind: boundary
+    layer: contract
+    test: tests/test_memory_module.py::test_list_page_accepts_payloads_larger_than_legacy_aggregate_cap

--- a/tests/scenarios/memory_list/observations.yaml
+++ b/tests/scenarios/memory_list/observations.yaml
@@ -26,3 +26,7 @@ observations:
     scenarios:
       - MEMORY-LIST-008
     observation: Settings selects an owner origin rather than accepting a raw owner id; the controller derives the Agent owner from the authenticated principal and every returned row identifies its origin.
+  - id: MEMORY-LIST-OBS-006
+    scenarios:
+      - MEMORY-LIST-009
+    observation: The pinned EverOS contract accepts pages up to 100 items and owns episode payload sizing; Avibe retains shape and scope validation without imposing a smaller aggregate byte limit.

--- a/tests/scenarios/memory_search/catalog.yaml
+++ b/tests/scenarios/memory_search/catalog.yaml
@@ -116,3 +116,9 @@ scenarios:
     kind: lifecycle
     layer: contract
     test: tests/test_memory_module.py::test_lifecycle_barrier_does_not_wait_for_writer
+  - id: MEMORY-SEARCH-018
+    name: Memory payload sizing and result limits follow the pinned EverOS contract
+    status: covered
+    kind: boundary
+    layer: contract
+    test: tests/test_memory_module.py::test_capture_and_search_delegate_payload_size_to_everos

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -676,7 +676,9 @@ def test_memory_search_accepts_bounded_agentic_policy_from_cli_session() -> None
     assert current_session_id == "ses-memory"
 
 
-def test_memory_list_binds_cli_session_and_uses_exact_provider_page() -> None:
+def test_memory_list_accepts_everos_maximum_at_controller_boundary() -> None:
+    """MEMORY-LIST-009: the internal socket accepts the EverOS maximum."""
+
     from core.memory.http_headers import CALLER_SESSION_HEADER
 
     runtime = SimpleNamespace(
@@ -699,7 +701,7 @@ def test_memory_list_binds_cli_session_and_uses_exact_provider_page() -> None:
             return await client.post(
                 "/internal/memory/list",
                 headers={CALLER_SESSION_HEADER: "ses-memory-list"},
-                json={"project": "notes", "page": 2, "limit": 5},
+                json={"project": "notes", "page": 2, "limit": 100},
             )
 
     response = asyncio.run(_exercise())
@@ -714,7 +716,7 @@ def test_memory_list_binds_cli_session_and_uses_exact_provider_page() -> None:
         "u-11111111111111111111111111111111",
         "notes",
         page=2,
-        page_size=5,
+        page_size=100,
     )
 
 
@@ -1598,6 +1600,43 @@ def test_memory_remember_route_rejects_capture_queued_across_runtime_replacement
     }
     assert old_module.calls == 0
     assert fresh_module.calls == 0
+
+
+def test_memory_remember_accepts_text_over_legacy_controller_limit() -> None:
+    """MEMORY-SEARCH-018: the internal socket delegates large remember text."""
+
+    from core.memory import CaptureAccepted
+    from core.memory.http_headers import CALLER_SESSION_HEADER
+
+    text = "remember this detail " * 300
+    controller = _build_controller_double()
+    controller.memory_scope_for_cli_session.return_value = (
+        "u-11111111111111111111111111111111",
+        "default",
+    )
+    controller.memory_runtime = SimpleNamespace()
+    controller.capture_memory = AsyncMock(return_value=CaptureAccepted())
+    app = internal_server.create_app(controller)
+
+    async def _exercise() -> httpx.Response:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://test",
+        ) as client:
+            return await client.post(
+                "/internal/memory/remember",
+                json={"text": text},
+                headers={CALLER_SESSION_HEADER: "session-1"},
+            )
+
+    response = asyncio.run(_exercise())
+
+    assert len(text) > 4_000
+    assert response.status_code == 200
+    assert response.json() == {"status": "accepted"}
+    request = controller.capture_memory.await_args.args[0]
+    assert request.text == text
 
 
 # ---------------------------------------------------------------------

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -28,16 +28,16 @@ _MEMORY_HELP_BY_LANGUAGE = {
         "profile": ("Print machine-readable output",),
         "list": (
             "Page number (1-based)",
-            "Episodes per page (1-20)",
+            "Episodes per page (1-100)",
             "Print machine-readable output",
         ),
         "search": (
             "Search query",
-            "Maximum results (1-20)",
+            "Maximum results (1-100)",
             "Recall mode (default: hybrid)",
             "Print machine-readable output",
         ),
-        "remember": ("Text to remember (maximum 4,000 characters)", "Print machine-readable output"),
+        "remember": ("Text to remember", "Print machine-readable output"),
     },
     "zh": {
         "top": ("通过运行中的控制器使用本地记忆",),
@@ -50,9 +50,9 @@ _MEMORY_HELP_BY_LANGUAGE = {
         ),
         "status": ("输出机器可读格式",),
         "profile": ("输出机器可读格式",),
-        "list": ("页码（从 1 开始）", "每页记忆片段数（1-20）", "输出机器可读格式"),
-        "search": ("搜索内容", "最大结果数（1-20）", "召回模式（默认：hybrid）", "输出机器可读格式"),
-        "remember": ("要记住的文本（最多 4,000 个字符）", "输出机器可读格式"),
+        "list": ("页码（从 1 开始）", "每页记忆片段数（1-100）", "输出机器可读格式"),
+        "search": ("搜索内容", "最大结果数（1-100）", "召回模式（默认：hybrid）", "输出机器可读格式"),
+        "remember": ("要记住的文本", "输出机器可读格式"),
     },
 }
 
@@ -263,7 +263,7 @@ def test_memory_list_parser_defaults_match_everos_page_semantics() -> None:
     [
         ["memory", "list", "--page", "0", "--json"],
         ["memory", "list", "--limit", "0", "--json"],
-        ["memory", "list", "--limit", "21", "--json"],
+        ["memory", "list", "--limit", "101", "--json"],
     ],
 )
 def test_memory_list_rejects_invalid_bounds_before_transport(
@@ -280,6 +280,23 @@ def test_memory_list_rejects_invalid_bounds_before_transport(
 
     assert cli.cmd_memory(args) == 1
     assert json.loads(capsys.readouterr().out)["code"] == "memory_invalid_input"
+
+
+def test_memory_list_accepts_everos_max_page_size(monkeypatch, capsys) -> None:
+    args = cli.build_parser().parse_args(
+        ["memory", "list", "--limit", "100", "--json"]
+    )
+    calls: list[int] = []
+
+    def list_sync(**kwargs):
+        calls.append(kwargs["limit"])
+        return {"status_code": 200, "body": {"status": "ok", "items": []}}
+
+    monkeypatch.setattr(internal_client, "memory_list_sync", list_sync)
+
+    assert cli.cmd_memory(args) == 0
+    assert calls == [100]
+    assert json.loads(capsys.readouterr().out)["ok"] is True
 
 
 def test_memory_list_all_rejection_comes_from_controller(monkeypatch, capsys) -> None:
@@ -401,7 +418,7 @@ def test_memory_cli_passes_agent_session_to_the_internal_boundary(monkeypatch, c
 
 
 def test_memory_cli_rejects_out_of_range_search_without_transport(monkeypatch, capsys) -> None:
-    args = cli.build_parser().parse_args(["memory", "search", "query", "--limit", "21", "--json"])
+    args = cli.build_parser().parse_args(["memory", "search", "query", "--limit", "101", "--json"])
 
     def transport_must_not_run(*_args, **_kwargs):
         raise AssertionError("invalid CLI input reached the UDS")
@@ -410,6 +427,28 @@ def test_memory_cli_rejects_out_of_range_search_without_transport(monkeypatch, c
 
     assert cli.cmd_memory(args) == 1
     assert json.loads(capsys.readouterr().out)["code"] == "memory_invalid_input"
+
+
+def test_memory_cli_accepts_everos_max_results_and_large_query(
+    monkeypatch,
+    capsys,
+) -> None:
+    query = "find this detail " * 700
+    args = cli.build_parser().parse_args(
+        ["memory", "search", query, "--limit", "100", "--json"]
+    )
+    calls: list[tuple[str, int]] = []
+
+    def search_sync(text, limit, **_kwargs):
+        calls.append((text, limit))
+        return {"status_code": 200, "body": {"status": "ok", "items": []}}
+
+    monkeypatch.setattr(internal_client, "memory_search_sync", search_sync)
+
+    assert len(query.encode()) > 8 * 1024
+    assert cli.cmd_memory(args) == 0
+    assert calls == [(query.strip(), 100)]
+    assert json.loads(capsys.readouterr().out)["ok"] is True
 
 
 def test_memory_cli_human_output_uses_configured_i18n(monkeypatch, capsys) -> None:
@@ -611,13 +650,17 @@ def test_memory_remember_nonqueued_outcomes_exit_nonzero(monkeypatch, capsys, bo
     assert json.loads(capsys.readouterr().out)["code"] == expected
 
 
-def test_memory_remember_rejects_over_limit_text_before_transport(monkeypatch, capsys) -> None:
-    args = cli.build_parser().parse_args(["memory", "remember", "x" * 4_001, "--json"])
-    monkeypatch.setattr(
-        internal_client,
-        "memory_remember_sync",
-        lambda *_args, **_kwargs: pytest.fail("invalid input reached the controller"),
-    )
+def test_memory_remember_accepts_text_over_legacy_cli_limit(monkeypatch, capsys) -> None:
+    text = "x" * 4_001
+    args = cli.build_parser().parse_args(["memory", "remember", text, "--json"])
+    calls: list[str] = []
 
-    assert cli.cmd_memory(args) == 1
-    assert json.loads(capsys.readouterr().out)["code"] == "memory_invalid_input"
+    def remember_sync(value, **_kwargs):
+        calls.append(value)
+        return {"status_code": 200, "body": {"status": "accepted"}}
+
+    monkeypatch.setattr(internal_client, "memory_remember_sync", remember_sync)
+
+    assert cli.cmd_memory(args) == 0
+    assert calls == [text]
+    assert json.loads(capsys.readouterr().out)["ok"] is True

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -258,6 +258,15 @@ def test_memory_list_parser_defaults_match_everos_page_semantics() -> None:
     assert args.json is False
 
 
+@pytest.mark.parametrize("filename", ["CLI.md", "CLI_ZH.md"])
+def test_checked_in_memory_cli_references_match_everos_limits(filename: str) -> None:
+    reference = (Path(__file__).parents[1] / "docs" / filename).read_text()
+    memory_section = reference.split("### `vibe memory`", 1)[1].split("\n### ", 1)[0]
+
+    assert memory_section.count("[--limit 1..100]") == 2
+    assert "[--limit 1..20]" not in memory_section
+
+
 @pytest.mark.parametrize(
     "arguments",
     [

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -732,7 +732,7 @@ def test_search_uses_public_search_only_and_maps_episode_and_nested_fact() -> No
             PRINCIPAL,
             PROJECT,
             "language",
-            2,
+            100,
             session_ref=SESSION_REF,
         )
 
@@ -748,7 +748,7 @@ def test_search_uses_public_search_only_and_maps_episode_and_nested_fact() -> No
                 "project_id": PROJECT,
                 "query": "language",
                 "method": "hybrid",
-                "top_k": 2,
+                "top_k": 100,
                 "include_profile": True,
                 "enable_llm_rerank": False,
                 "filters": {"session_id": WIRE_SESSION_ID},
@@ -1107,6 +1107,40 @@ def test_list_episodes_uses_exact_get_shape_and_projects_a_bounded_page() -> Non
     )
 
 
+def test_list_episodes_accepts_everos_max_page_size() -> None:
+    requests: list[dict[str, object]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "request_id": "empty-page",
+                "data": {
+                    "episodes": [],
+                    "profiles": [],
+                    "agent_cases": [],
+                    "agent_skills": [],
+                    "total_count": 0,
+                    "count": 0,
+                },
+            },
+        )
+
+    with _sidecar_transport(handler):
+        result = asyncio.run(
+            EverOSPort(Path("/tmp/everos.sock")).list_episodes(
+                PRINCIPAL,
+                PROJECT,
+                1,
+                100,
+            )
+        )
+
+    assert requests[0]["page_size"] == 100
+    assert result.page_size == 100
+
+
 @pytest.mark.parametrize(
     "mutation",
     [
@@ -1313,6 +1347,48 @@ def test_profile_accepts_large_everos_payloads(owner_id: str) -> None:
     assert len(summary.encode()) > 64 * 1024
     assert items[0].profile is not None
     assert items[0].profile.summary == summary.strip()
+
+
+def test_profile_accepts_everos_structures_beyond_legacy_avibe_limits() -> None:
+    """MEMORY-SEARCH-018: profile structure is governed by EverOS."""
+
+    nested: object = "value"
+    for _index in range(12):
+        nested = {"nested": nested}
+    long_key = "k" * 129
+    profile_data = {
+        "summary": "Complete profile",
+        "explicit_info": [
+            {"description": f"fact-{index}"} for index in range(201)
+        ],
+        "implicit_traits": [
+            {"description": f"trait-{index}"} for index in range(201)
+        ],
+        long_key: nested,
+    }
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "profiles": [
+                        {"user_id": "owner-1", "profile_data": profile_data}
+                    ],
+                    "provider_metadata": list(range(201)),
+                }
+            },
+        )
+
+    with _sidecar_transport(handler):
+        items = asyncio.run(
+            EverOSPort(Path("/tmp/everos.sock")).profile("owner-1", PROJECT)
+        )
+
+    assert items[0].profile is not None
+    assert len(items[0].profile.explicit_info) == 201
+    assert len(items[0].profile.implicit_traits) == 201
+    assert json.loads(items[0].text)[long_key] == nested
 
 
 def test_profile_maps_known_fields_without_collapsing_basis_and_evidence() -> None:

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -24,7 +24,11 @@ from core.memory.types import (
     CaptureSkipped,
     MemoryItem,
     MemoryItems,
+    MemoryListItem,
+    MemoryListPage,
     MemoryProfile,
+    MemoryProfileExplicitInfo,
+    MemoryProfileTrait,
     OperationFailed,
     ProviderSearchItem,
 )
@@ -151,14 +155,72 @@ async def test_agent_remember_round_trips_through_dual_owner_search(
 
 
 @pytest.mark.asyncio
+async def test_capture_and_search_delegate_payload_size_to_everos(
+    tmp_path: Path,
+) -> None:
+    """MEMORY-SEARCH-018: Avibe adds no smaller text or query byte cap."""
+
+    class RecordingProvider(FakeMemoryProvider):
+        def __init__(self) -> None:
+            super().__init__()
+            self.queries: list[tuple[str, str, int]] = []
+
+        async def search(self, principal_id, project_id, query, limit, **options):
+            self.queries.append((principal_id, query, limit))
+            return await super().search(
+                principal_id,
+                project_id,
+                query,
+                limit,
+                **options,
+            )
+
+    provider = RecordingProvider()
+    module, _store, _provider = _module(tmp_path, provider=provider)
+    capture_text = "remember this detail " * 2_000
+    query = "find this detail " * 700
+
+    assert len(capture_text.encode()) > 32 * 1024
+    assert len(query.encode()) > 8 * 1024
+    assert await module.capture(_request(text=capture_text)) == CaptureAccepted()
+    await module.wait_writer_idle_for_tests()
+    result = await module.search(
+        query,
+        principal_id=PRINCIPAL,
+        project_id="default",
+        limit=100,
+    )
+
+    assert provider.captures[0].text == capture_text
+    assert provider.queries == [
+        (PRINCIPAL, query, 100),
+        (f"{PRINCIPAL}-agent", query, 100),
+    ]
+    assert result == MemoryItems()
+
+
+@pytest.mark.asyncio
 async def test_profile_accepts_large_items_from_both_everos_owners(
     tmp_path: Path,
 ) -> None:
     summary = "profile " * 40_000
+    explicit_info = tuple(
+        MemoryProfileExplicitInfo(description=f"fact-{index}")
+        for index in range(201)
+    )
+    implicit_traits = tuple(
+        MemoryProfileTrait(description=f"trait-{index}")
+        for index in range(201)
+    )
+    profile = MemoryProfile(
+        summary=summary,
+        explicit_info=explicit_info,
+        implicit_traits=implicit_traits,
+    )
     item = MemoryItem(
         kind="profile",
         text=summary,
-        profile=MemoryProfile(summary=summary),
+        profile=profile,
     )
     provider = FakeMemoryProvider(
         profile_items_by_owner={
@@ -176,28 +238,64 @@ async def test_profile_accepts_large_items_from_both_everos_owners(
             MemoryItem(
                 kind="profile",
                 text=summary,
-                profile=MemoryProfile(summary=summary),
+                profile=profile,
                 origin="user",
             ),
             MemoryItem(
                 kind="profile",
                 text=summary,
-                profile=MemoryProfile(summary=summary),
+                profile=profile,
                 origin="agent",
             ),
         )
     )
 
 
-def test_non_profile_items_keep_provider_aggregate_cap(tmp_path: Path) -> None:
+def test_non_profile_items_accept_payloads_larger_than_legacy_aggregate_cap(
+    tmp_path: Path,
+) -> None:
+    """MEMORY-SEARCH-018: EverOS owns result payload sizing."""
+
     module, _store, _provider = _module(tmp_path)
+    item = MemoryItem(kind="fact", text="x" * (256 * 1024 + 1))
 
     result = module._bounded_items(
-        (MemoryItem(kind="fact", text="x" * (256 * 1024)),),
-        limit=20,
+        (item,),
+        limit=100,
     )
 
-    assert result == OperationFailed(error="memory_provider_response_invalid")
+    assert result == MemoryItems(items=(item,))
+
+
+def test_list_page_accepts_payloads_larger_than_legacy_aggregate_cap(
+    tmp_path: Path,
+) -> None:
+    """MEMORY-LIST-009: list payload sizing follows EverOS."""
+
+    module, _store, _provider = _module(tmp_path)
+    page = MemoryListPage(
+        items=(
+            MemoryListItem(
+                id="episode-1",
+                subject="subject",
+                summary="summary",
+                body="x" * (256 * 1024 + 1),
+                timestamp="2026-08-27T00:00:00Z",
+                project="default",
+            ),
+        ),
+        page=1,
+        page_size=100,
+        count=1,
+        total_count=1,
+    )
+
+    assert module._bounded_list_page(
+        page,
+        project_id="default",
+        page=1,
+        page_size=100,
+    ) == page
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_recall_policy.py
+++ b/tests/test_memory_recall_policy.py
@@ -11,6 +11,12 @@ def test_non_agentic_policy_defaults_only_an_omitted_limit() -> None:
         RecallPolicy.from_payload({"mode": "keyword", "max_results": None})
 
 
+def test_policy_matches_everos_result_limit() -> None:
+    assert RecallPolicy(mode="hybrid", max_results=100).max_results == 100
+    with pytest.raises(ValueError):
+        RecallPolicy(mode="hybrid", max_results=101)
+
+
 @pytest.mark.parametrize(
     "field",
     ["timeout_seconds", "max_model_calls", "cost_budget_tokens"],

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import sqlite3
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -12,7 +13,7 @@ from core.memory.everos import ProviderHealthSnapshot
 from core.memory.processing_record import RuntimeHealthProjection, SourceObservation
 from core.memory.runtime import MemoryConfig, MemoryRuntime
 from core.memory.store import MemoryStore
-from core.memory.types import MemoryItems
+from core.memory.types import MemoryItems, MemoryListItem, MemoryListPage
 
 
 def _runtime(tmp_path: Path) -> MemoryRuntime:
@@ -55,6 +56,66 @@ async def test_profile_payload_only_labels_confirmed_empty_results(
         "warnings": list(warnings),
         "profile_warning": expected_warning,
     }
+    await runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_all_project_list_accepts_everos_maximum_page_size(
+    tmp_path: Path,
+) -> None:
+    """MEMORY-LIST-009: the aggregate route accepts EverOS's 100-item maximum."""
+
+    runtime = _runtime(tmp_path)
+    calls: list[tuple[int, int]] = []
+    items = tuple(
+        MemoryListItem(
+            id=f"episode-{index:03d}",
+            subject=f"subject-{index}",
+            summary=f"summary-{index}",
+            body=f"body-{index}",
+            timestamp=(
+                datetime(2026, 8, 27, tzinfo=timezone.utc) - timedelta(minutes=index)
+            ).isoformat(),
+            project="default",
+        )
+        for index in range(100)
+    )
+
+    runtime.list_memory_projects = lambda _principal_id: ("default",)
+
+    async def list_episodes(**kwargs: object) -> MemoryListPage:
+        page = int(kwargs["page"])
+        page_size = int(kwargs["page_size"])
+        calls.append((page, page_size))
+        start = (page - 1) * page_size
+        page_items = items[start : start + page_size]
+        return MemoryListPage(
+            items=page_items,
+            page=page,
+            page_size=page_size,
+            count=len(page_items),
+            total_count=len(items),
+        )
+
+    runtime.module.list_episodes = list_episodes
+    runtime.module.concurrent_episode_lists = None
+    principal_id = "u-11111111111111111111111111111111"
+
+    payload = await runtime.list_all_episodes_payload(
+        principal_id,
+        cursor=None,
+        limit=100,
+    )
+
+    assert payload["status"] == "ok"
+    assert payload["count"] == 100
+    assert {page for page, _page_size in calls} == set(range(1, 6))
+    assert all(page_size == 20 for _page, page_size in calls)
+    assert await runtime.list_all_episodes_payload(
+        principal_id,
+        cursor=None,
+        limit=101,
+    ) == {"status": "failed", "error": "memory_invalid_input"}
     await runtime.close()
 
 

--- a/tests/test_memory_sidecar.py
+++ b/tests/test_memory_sidecar.py
@@ -455,6 +455,22 @@ def test_sidecar_guard_accepts_agentic_but_rejects_untrusted_search_scope() -> N
     agentic_body = json.dumps({**search, "method": "agentic"}).encode()
     assert _request_rejection("POST", "/api/v2/memory/search", agentic_body) is None
     assert (
+        _request_rejection(
+            "POST",
+            "/api/v2/memory/search",
+            json.dumps({**search, "top_k": 100}).encode(),
+        )
+        is None
+    )
+    assert (
+        _request_rejection(
+            "POST",
+            "/api/v2/memory/search",
+            json.dumps({**search, "top_k": 101}).encode(),
+        )
+        == "search"
+    )
+    assert (
         sidecar._agentic_request_timeout(
             "/api/v2/memory/search",
             agentic_body,
@@ -486,7 +502,7 @@ def test_sidecar_guard_accepts_agentic_but_rejects_untrusted_search_scope() -> N
         )
 
 
-def test_sidecar_guard_keeps_profile_exact_and_allows_only_bounded_episode_lists() -> None:
+def test_sidecar_guard_keeps_profile_exact_and_uses_everos_episode_page_limit() -> None:
     principal = "u-11111111111111111111111111111111"
     profile = {
         "user_id": principal,
@@ -502,7 +518,7 @@ def test_sidecar_guard_keeps_profile_exact_and_allows_only_bounded_episode_lists
         "project_id": "notes",
         "memory_type": "episode",
         "page": 2,
-        "page_size": 20,
+        "page_size": 100,
         "sort_by": "timestamp",
         "sort_order": "desc",
     }
@@ -520,7 +536,7 @@ def test_sidecar_guard_keeps_profile_exact_and_allows_only_bounded_episode_lists
         {**episode, "project_id": "all"},
         {**episode, "project_id": "p-" + "a" * 32},
         {**episode, "page": 0},
-        {**episode, "page_size": 21},
+        {**episode, "page_size": 101},
         {**episode, "sort_by": "updated_at"},
         {**episode, "sort_order": "asc"},
         {**episode, "filters": {}},

--- a/tests/test_ui_memory_routes.py
+++ b/tests/test_ui_memory_routes.py
@@ -551,7 +551,7 @@ def test_memory_list_route_forwards_agent_origin(
         json={
             "project": "write",
             "page": 1,
-            "limit": 20,
+            "limit": 100,
             "origin": "agent",
         },
         headers=csrf_headers(client, BASE_URL),
@@ -565,7 +565,7 @@ def test_memory_list_route_forwards_agent_origin(
             "project": "write",
             "page": 1,
             "cursor": None,
-            "limit": 20,
+            "limit": 100,
             "origin": "agent",
         }
     ]
@@ -581,4 +581,11 @@ def test_memory_list_route_forwards_agent_origin(
         "status": "failed",
         "error": "memory_invalid_input",
     }
+    over_limit = client.post(
+        "/api/memory/list",
+        json={"project": "write", "page": 1, "limit": 101},
+        headers=csrf_headers(client, BASE_URL),
+        **_request_options(),
+    )
+    assert over_limit.status_code == 400
     assert len(calls) == 1

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -618,6 +618,10 @@ def cmd_memory(args) -> int:
 
     from vibe import internal_client
     from core.caller_context import caller_context_from_env
+    from core.memory.types import (
+        MAX_MEMORY_LIST_PAGE_SIZE,
+        MAX_MEMORY_SEARCH_RESULTS,
+    )
 
     operation = args.memory_command
     as_json = bool(getattr(args, "json", False))
@@ -629,10 +633,9 @@ def cmd_memory(args) -> int:
         query = args.query.strip() if isinstance(args.query, str) else ""
         if (
             not query
-            or len(query.encode("utf-8")) > 8 * 1024
             or not isinstance(args.limit, int)
             or isinstance(args.limit, bool)
-            or not 1 <= args.limit <= 20
+            or not 1 <= args.limit <= MAX_MEMORY_SEARCH_RESULTS
         ):
             return _print_memory_cli_error(operation, "memory_invalid_input", as_json=as_json, language=language)
     if operation == "list" and (
@@ -641,12 +644,12 @@ def cmd_memory(args) -> int:
         or args.page < 1
         or not isinstance(args.limit, int)
         or isinstance(args.limit, bool)
-        or not 1 <= args.limit <= 20
+        or not 1 <= args.limit <= MAX_MEMORY_LIST_PAGE_SIZE
     ):
         return _print_memory_cli_error(operation, "memory_invalid_input", as_json=as_json, language=language)
     if operation == "remember":
         query = args.text if isinstance(args.text, str) else ""
-        if not query.strip() or len(query) > 4_000:
+        if not query.strip():
             return _print_memory_cli_error(operation, "memory_invalid_input", as_json=as_json, language=language)
     try:
         caller = caller_context_from_env()

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -758,10 +758,10 @@
         "query": "Search query",
         "project": "Memory project: default or a named slug such as billing",
         "page": "Page number (1-based)",
-        "pageLimit": "Episodes per page (1-20)",
-        "limit": "Maximum results (1-20)",
+        "pageLimit": "Episodes per page (1-100)",
+        "limit": "Maximum results (1-100)",
         "mode": "Recall mode (default: hybrid)",
-        "text": "Text to remember (maximum 4,000 characters)",
+        "text": "Text to remember",
         "json": "Print machine-readable output"
       },
       "error": "Memory {operation} failed: {code}",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -758,10 +758,10 @@
         "query": "搜索内容",
         "project": "记忆项目：default，或 billing 这类小写 slug",
         "page": "页码（从 1 开始）",
-        "pageLimit": "每页记忆片段数（1-20）",
-        "limit": "最大结果数（1-20）",
+        "pageLimit": "每页记忆片段数（1-100）",
+        "limit": "最大结果数（1-100）",
         "mode": "召回模式（默认：hybrid）",
-        "text": "要记住的文本（最多 4,000 个字符）",
+        "text": "要记住的文本",
         "json": "输出机器可读格式"
       },
       "error": "记忆 {operation} 失败：{code}",

--- a/vibe/ui_memory_routes.py
+++ b/vibe/ui_memory_routes.py
@@ -796,6 +796,7 @@ def register_memory_routes(app) -> None:
             limit = payload.get("limit", 20)
             origin = payload.get("origin")
             from core.memory.runtime import MEMORY_LIST_CURSOR_MAX_BYTES
+            from core.memory.types import MAX_MEMORY_LIST_PAGE_SIZE
 
             cursor_bytes: int | None = None
             if isinstance(cursor, str):
@@ -809,7 +810,7 @@ def register_memory_routes(app) -> None:
                 or (origin is not None and origin not in ("user", "agent"))
                 or isinstance(limit, bool)
                 or not isinstance(limit, int)
-                or not 1 <= limit <= 20
+                or not 1 <= limit <= MAX_MEMORY_LIST_PAGE_SIZE
                 or (
                     page is not None
                     and (


### PR DESCRIPTION
## Capability

Align Avibe Memory payload handling with the pinned EverOS 1.2.3 contract instead of rejecting content that EverOS accepts.

## Changes

- remove Avibe-only capture, query, profile-shape, and 256 KiB result caps
- remove the CLI remember 4,000-character cap
- align search and list maxima across CLI, Web, controller, sidecar, and aggregate-list paths to EverOS max 100
- keep existing defaults (search 8, list 20) and internal 20-item provider fetch windows
- retain the 2 MiB processing health-probe response cap and operational attachment, timeout, queue, disk, identifier, and project safeguards

## Scenario coverage

- `MEMORY-SEARCH-018`: large capture/query payloads are delegated to EverOS
- `MEMORY-LIST-009`: large list payloads and the EverOS 100-item maximum are accepted

## Evidence

- Unit/contract: 324 relevant tests passed
- Scenario: memory search/list catalogs updated; list scenario suite passed
- Lint: Ruff passed on every changed Python file
- Residual manual checks: none; the local Avibe service was not restarted