### PR TITLE
refactor(memory): preserve package shape through synchronous upgrade

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -274,7 +274,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: python scripts/prepare_local_show_runtime_manifest.py
 
-      - name: Run packaged Memory upgrade transaction smoke
+      - name: Run packaged Memory package-shape smoke
         run: |
           set -o pipefail
           test -f vibe/show_runtime_manifest.json

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -274,6 +274,17 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: python scripts/prepare_local_show_runtime_manifest.py
 
+      - name: Run packaged Memory upgrade transaction smoke
+        run: |
+          set -o pipefail
+          test -f vibe/show_runtime_manifest.json
+          output="$RUNNER_TEMP/memory-upgrade-packaged.log"
+          pytest tests/test_memory_upgrade_packaged.py -m integration -v -ra | tee "$output"
+          if grep -Eq '(^|[[:space:]])[0-9]+ skipped|SKIPPED' "$output"; then
+            echo "Packaged Memory upgrade smoke must not skip."
+            exit 1
+          fi
+
       - name: Run install and upgrade regressions
         run: |
           docker info

--- a/tests/test_memory_upgrade_packaged.py
+++ b/tests/test_memory_upgrade_packaged.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from vibe.upgrade import build_upgrade_plan, execute_upgrade_plan
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _wheel(project: Path, version: str, wheelhouse: Path) -> None:
+    env = {**os.environ, "SETUPTOOLS_SCM_PRETEND_VERSION": version}
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "wheel", str(project), "--no-deps", "--wheel-dir", str(wheelhouse)],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=600,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def _python(environment: Path) -> Path:
+    return environment / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+
+def _installed_versions(python: Path) -> dict[str, str]:
+    result = subprocess.run(
+        [str(python), "-c", "from importlib.metadata import distributions; print('\\n'.join(f'{d.metadata[\"Name\"]}=={d.version}' for d in distributions()))"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    values = {}
+    for line in result.stdout.splitlines():
+        if "==" in line:
+            name, version = line.split("==", 1)
+            values[name.lower()] = version
+    return values
+
+
+@pytest.mark.integration
+def test_packaged_memory_shape_survives_forward_upgrade_and_pinned_rollback(tmp_path: Path) -> None:
+    """Exercise the real pip resolver and inspect distributions after each mutation."""
+
+    if not (ROOT / "vibe" / "show_runtime_manifest.json").is_file():
+        pytest.skip("packaged wheel smoke requires the prepared local Show Runtime manifest")
+
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    for version in ("3.0.14", "3.0.15"):
+        _wheel(ROOT, version, wheelhouse)
+        _wheel(ROOT / "packaging" / "avibe-memory", version, wheelhouse)
+
+    environment = tmp_path / "venv"
+    subprocess.run([sys.executable, "-m", "venv", str(environment)], check=True, capture_output=True)
+    python = _python(environment)
+    env = {**os.environ, "PIP_NO_INDEX": "1", "PIP_FIND_LINKS": str(wheelhouse)}
+    initial = subprocess.run(
+        [str(python), "-m", "pip", "install", "--no-deps", str(next(wheelhouse.glob("avibe_os-3.0.14-*.whl"))), str(next(wheelhouse.glob("avibe_memory-3.0.14-*.whl")))],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert initial.returncode == 0, initial.stdout + initial.stderr
+    assert _installed_versions(python)["avibe-os"] == "3.0.14"
+    assert _installed_versions(python)["avibe-memory"] == "3.0.14"
+
+    forward = build_upgrade_plan(
+        python_executable=str(python),
+        base_env=env,
+        memory_enabled=True,
+        package_spec="avibe-os",
+    )
+    result = execute_upgrade_plan(forward, cwd=tmp_path, capture_output=True, text=True, check=False, timeout=600)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _installed_versions(python)["avibe-os"] == "3.0.15"
+    assert _installed_versions(python)["avibe-memory"] == "3.0.15"
+
+    rollback = build_upgrade_plan(
+        python_executable=str(python),
+        base_env=env,
+        version="3.0.14",
+        package_name="avibe-os",
+        memory_package=True,
+        memory_version="3.0.14",
+    )
+    result = execute_upgrade_plan(rollback, cwd=tmp_path, capture_output=True, text=True, check=False, timeout=600)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _installed_versions(python)["avibe-os"] == "3.0.14"
+    assert _installed_versions(python)["avibe-memory"] == "3.0.14"
+
+    core_only_environment = tmp_path / "core-only-venv"
+    subprocess.run([sys.executable, "-m", "venv", str(core_only_environment)], check=True, capture_output=True)
+    core_only_python = _python(core_only_environment)
+    initial_core_only = subprocess.run(
+        [
+            str(core_only_python),
+            "-m",
+            "pip",
+            "install",
+            "--no-deps",
+            str(next(wheelhouse.glob("avibe_os-3.0.14-*.whl"))),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert initial_core_only.returncode == 0, initial_core_only.stdout + initial_core_only.stderr
+
+    core_only_forward = build_upgrade_plan(
+        python_executable=str(core_only_python),
+        base_env=env,
+        memory_enabled=False,
+        memory_package=False,
+        package_spec="avibe-os",
+    )
+    assert execute_upgrade_plan(
+        core_only_forward,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=600,
+    ).returncode == 0
+    core_only_versions = _installed_versions(core_only_python)
+    assert core_only_versions["avibe-os"] == "3.0.15"
+    assert "avibe-memory" not in core_only_versions

--- a/tests/test_memory_upgrade_packaged.py
+++ b/tests/test_memory_upgrade_packaged.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+import base64
+import csv
+import hashlib
+import io
 import os
+import re
 import subprocess
 import sys
+import zipfile
 from pathlib import Path
 
 import pytest
 
 from vibe import restart_supervisor, runtime
-from vibe.upgrade import MEMORY_PACKAGE_REQUIREMENT, RollbackTarget, build_upgrade_plan, execute_upgrade_plan
+from vibe.upgrade import RollbackTarget, build_upgrade_plan, execute_upgrade_plan
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -26,6 +32,44 @@ def _wheel(project: Path, version: str, wheelhouse: Path) -> None:
         timeout=600,
     )
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def _pin_host_memory_extra(wheel: Path, version: str) -> None:
+    """Give each fixture host release its own target-owned Memory pin."""
+
+    with zipfile.ZipFile(wheel) as archive:
+        entries = {info.filename: archive.read(info.filename) for info in archive.infolist()}
+    metadata_name = next(name for name in entries if name.endswith(".dist-info/METADATA"))
+    record_name = next(name for name in entries if name.endswith(".dist-info/RECORD"))
+    metadata = re.sub(
+        rb"Requires-Dist: avibe-memory[^\r\n]*",
+        f'Requires-Dist: avibe-memory=={version}; extra == "memory"'.encode(),
+        entries[metadata_name],
+    )
+    assert metadata != entries[metadata_name]
+    entries[metadata_name] = metadata
+
+    rows = list(csv.reader(io.StringIO(entries[record_name].decode())))
+    digest = base64.urlsafe_b64encode(hashlib.sha256(metadata).digest()).rstrip(b"=").decode()
+    for row in rows:
+        if row[0] == metadata_name:
+            row[1:] = [f"sha256={digest}", str(len(metadata))]
+        elif row[0] == record_name:
+            row[1:] = ["", ""]
+    record = io.StringIO()
+    csv.writer(record, lineterminator="\n").writerows(rows)
+    entries[record_name] = record.getvalue().encode()
+
+    with zipfile.ZipFile(wheel, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name, payload in entries.items():
+            archive.writestr(name, payload)
+
+
+def _build_release_wheels(version: str, wheelhouse: Path) -> None:
+    _wheel(ROOT, version, wheelhouse)
+    host_wheel = next(wheelhouse.glob(f"avibe_os-{version}-*.whl"))
+    _pin_host_memory_extra(host_wheel, version)
+    _wheel(ROOT / "packaging" / "avibe-memory", version, wheelhouse)
 
 
 def _python(environment: Path) -> Path:
@@ -61,14 +105,28 @@ def _install_initial(python: Path, wheelhouse: Path, *, memory: bool) -> None:
     wheels = [next(wheelhouse.glob("avibe_os-3.0.14-*.whl"))]
     if memory:
         wheels.append(next(wheelhouse.glob("avibe_memory-3.0.14-*.whl")))
-    env = {
-        **os.environ,
-        "PIP_NO_INDEX": "1",
-        "PIP_FIND_LINKS": str(wheelhouse),
-        "PIP_NO_DEPS": "1",
-    }
+    seed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "download",
+            "--dest",
+            str(wheelhouse),
+            "setuptools",
+            "wheel",
+            *(str(wheel) for wheel in wheels),
+        ],
+        env={**os.environ, "PIP_FIND_LINKS": str(wheelhouse)},
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=600,
+    )
+    assert seed.returncode == 0, seed.stdout + seed.stderr
+    env = {**os.environ, "PIP_NO_INDEX": "1", "PIP_FIND_LINKS": str(wheelhouse)}
     result = subprocess.run(
-        [str(python), "-m", "pip", "install", "--no-deps", *(str(wheel) for wheel in wheels)],
+        [str(python), "-m", "pip", "install", *(str(wheel) for wheel in wheels)],
         env=env,
         capture_output=True,
         text=True,
@@ -82,7 +140,6 @@ def _plan_env(wheelhouse: Path) -> dict[str, str]:
         **os.environ,
         "PIP_NO_INDEX": "1",
         "PIP_FIND_LINKS": str(wheelhouse),
-        "PIP_NO_DEPS": "1",
     }
 
 
@@ -98,8 +155,7 @@ def test_packaged_memory_shape_survives_synchronous_upgrade_and_supervisor_rollb
     wheelhouse = tmp_path / "wheelhouse"
     wheelhouse.mkdir()
     for version in ("3.0.14", "3.0.15"):
-        _wheel(ROOT, version, wheelhouse)
-        _wheel(ROOT / "packaging" / "avibe-memory", version, wheelhouse)
+        _build_release_wheels(version, wheelhouse)
 
     environment = tmp_path / "memory-venv"
     python = _venv(environment)
@@ -115,7 +171,8 @@ def test_packaged_memory_shape_survives_synchronous_upgrade_and_supervisor_rollb
         memory_package=True,
         package_spec="avibe-os",
     )
-    assert MEMORY_PACKAGE_REQUIREMENT in forward.command
+    assert forward.command[-1] == "avibe-os[memory]"
+    assert all("avibe-memory" not in argument for argument in forward.command)
     result = execute_upgrade_plan(forward, cwd=tmp_path, capture_output=True, text=True, check=False, timeout=600)
     assert result.returncode == 0, result.stdout + result.stderr
     upgraded = _installed_versions(python)
@@ -133,7 +190,6 @@ def test_packaged_memory_shape_survives_synchronous_upgrade_and_supervisor_rollb
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "avibe-home"))
     monkeypatch.setenv("PIP_NO_INDEX", "1")
     monkeypatch.setenv("PIP_FIND_LINKS", str(wheelhouse))
-    monkeypatch.setenv("PIP_NO_DEPS", "1")
     monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda **kwargs: (True, {}, 0, None, True, 0))
     monkeypatch.setattr(restart_supervisor, "_failed_generation_still_running", lambda **kwargs: False)
     monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
@@ -165,7 +221,7 @@ def test_packaged_core_only_upgrade_preserves_core_only_shape(tmp_path: Path) ->
     wheelhouse = tmp_path / "wheelhouse"
     wheelhouse.mkdir()
     for version in ("3.0.14", "3.0.15"):
-        _wheel(ROOT, version, wheelhouse)
+        _build_release_wheels(version, wheelhouse)
     python = _venv(tmp_path / "core-only-venv")
     _install_initial(python, wheelhouse, memory=False)
     plan = build_upgrade_plan(
@@ -186,11 +242,8 @@ def test_packaged_core_only_upgrade_preserves_core_only_shape(tmp_path: Path) ->
 def test_packaged_missing_memory_fails_before_install(tmp_path: Path) -> None:
     wheelhouse = tmp_path / "wheelhouse"
     wheelhouse.mkdir()
-    _wheel(ROOT, "3.0.14", wheelhouse)
-    _wheel(ROOT, "3.0.15", wheelhouse)
-    memory_wheel = ROOT / "packaging" / "avibe-memory"
-    _wheel(memory_wheel, "3.0.14", wheelhouse)
-    _wheel(memory_wheel, "3.0.15", wheelhouse)
+    _build_release_wheels("3.0.14", wheelhouse)
+    _build_release_wheels("3.0.15", wheelhouse)
     python = _venv(tmp_path / "missing-memory-venv")
     _install_initial(python, wheelhouse, memory=True)
     for wheel in wheelhouse.glob("avibe_memory-*.whl"):

--- a/tests/test_memory_upgrade_packaged.py
+++ b/tests/test_memory_upgrade_packaged.py
@@ -188,10 +188,11 @@ def test_packaged_memory_shape_survives_synchronous_upgrade_and_supervisor_rollb
         base_env=env,
         memory_enabled=True,
         memory_package=True,
+        target_version="3.0.15",
         package_spec="avibe-os",
     )
-    assert forward.command[-1] == "avibe-os[memory]"
-    assert all("avibe-memory" not in argument for argument in forward.command)
+    assert "avibe-os[memory]" in forward.command
+    assert "avibe-memory==3.0.15" in forward.command
     result = execute_upgrade_plan(forward, cwd=tmp_path, capture_output=True, text=True, check=False, timeout=600)
     assert result.returncode == 0, result.stdout + result.stderr
     upgraded = _installed_versions(python)
@@ -274,6 +275,7 @@ def test_packaged_missing_memory_fails_before_install(tmp_path: Path, packaged_d
         base_env=_plan_env(wheelhouse),
         memory_enabled=True,
         memory_package=True,
+        target_version="3.0.15",
         package_spec="avibe-os",
     )
     result = execute_upgrade_plan(plan, cwd=tmp_path, capture_output=True, text=True, check=False, timeout=600)

--- a/tests/test_memory_upgrade_packaged.py
+++ b/tests/test_memory_upgrade_packaged.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from vibe import restart_supervisor, runtime
-from vibe.upgrade import MEMORY_PACKAGE_REQUIREMENT, RollbackTarget, UpgradeTransaction
+from vibe.upgrade import MEMORY_PACKAGE_REQUIREMENT, RollbackTarget, build_upgrade_plan, execute_upgrade_plan
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -34,12 +34,16 @@ def _python(environment: Path) -> Path:
 
 def _installed_versions(python: Path) -> dict[str, str]:
     result = subprocess.run(
-        [str(python), "-c", "from importlib.metadata import distributions; print('\\n'.join(f'{d.metadata[\"Name\"]}=={d.version}' for d in distributions()))"],
+        [
+            str(python),
+            "-c",
+            "from importlib.metadata import distributions; print('\\n'.join(f'{d.metadata[\"Name\"]}=={d.version}' for d in distributions()))",
+        ],
         capture_output=True,
         text=True,
         check=True,
     )
-    values = {}
+    values: dict[str, str] = {}
     for line in result.stdout.splitlines():
         if "==" in line:
             name, version = line.split("==", 1)
@@ -47,11 +51,46 @@ def _installed_versions(python: Path) -> dict[str, str]:
     return values
 
 
+def _venv(path: Path) -> Path:
+    result = subprocess.run([sys.executable, "-m", "venv", str(path)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+    return _python(path)
+
+
+def _install_initial(python: Path, wheelhouse: Path, *, memory: bool) -> None:
+    wheels = [next(wheelhouse.glob("avibe_os-3.0.14-*.whl"))]
+    if memory:
+        wheels.append(next(wheelhouse.glob("avibe_memory-3.0.14-*.whl")))
+    env = {
+        **os.environ,
+        "PIP_NO_INDEX": "1",
+        "PIP_FIND_LINKS": str(wheelhouse),
+        "PIP_NO_DEPS": "1",
+    }
+    result = subprocess.run(
+        [str(python), "-m", "pip", "install", "--no-deps", *(str(wheel) for wheel in wheels)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def _plan_env(wheelhouse: Path) -> dict[str, str]:
+    return {
+        **os.environ,
+        "PIP_NO_INDEX": "1",
+        "PIP_FIND_LINKS": str(wheelhouse),
+        "PIP_NO_DEPS": "1",
+    }
+
+
 @pytest.mark.integration
-def test_packaged_memory_shape_survives_supervisor_upgrade_and_pinned_rollback(
+def test_packaged_memory_shape_survives_synchronous_upgrade_and_supervisor_rollback(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Exercise the supervisor transaction and inspect real installed distributions."""
+    """Run the public planner/executor, then the existing supervisor rollback path."""
 
     if not (ROOT / "vibe" / "show_runtime_manifest.json").is_file():
         pytest.fail("packaged wheel smoke requires the prepared local Show Runtime manifest")
@@ -62,38 +101,26 @@ def test_packaged_memory_shape_survives_supervisor_upgrade_and_pinned_rollback(
         _wheel(ROOT, version, wheelhouse)
         _wheel(ROOT / "packaging" / "avibe-memory", version, wheelhouse)
 
-    environment = tmp_path / "venv"
-    subprocess.run([sys.executable, "-m", "venv", str(environment)], check=True, capture_output=True)
-    python = _python(environment)
-    env = {
-        **os.environ,
-        "PIP_NO_INDEX": "1",
-        "PIP_FIND_LINKS": str(wheelhouse),
-        "PIP_NO_DEPS": "1",
-    }
-    initial = subprocess.run(
-        [str(python), "-m", "pip", "install", "--no-deps", str(next(wheelhouse.glob("avibe_os-3.0.14-*.whl"))), str(next(wheelhouse.glob("avibe_memory-3.0.14-*.whl")))],
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert initial.returncode == 0, initial.stdout + initial.stderr
+    environment = tmp_path / "memory-venv"
+    python = _venv(environment)
+    _install_initial(python, wheelhouse, memory=True)
+    env = _plan_env(wheelhouse)
     assert _installed_versions(python)["avibe-os"] == "3.0.14"
     assert _installed_versions(python)["avibe-memory"] == "3.0.14"
 
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "avibe-home"))
-    monkeypatch.setenv("PIP_NO_INDEX", "1")
-    monkeypatch.setenv("PIP_FIND_LINKS", str(wheelhouse))
-    monkeypatch.setenv("PIP_NO_DEPS", "1")
-    monkeypatch.setattr(restart_supervisor, "sys", type("ProcessSys", (), {"executable": str(python)}))
-    monkeypatch.setattr(restart_supervisor.runtime, "verified_service_running", lambda: True)
-    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda **kwargs: (True, {}, 0, None, True, 0))
-    monkeypatch.setattr(restart_supervisor, "_wait_for_service_lock_release", lambda: True)
-    monkeypatch.setattr(restart_supervisor, "_failed_generation_still_running", lambda **kwargs: False)
-    monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
-    monkeypatch.setattr(restart_supervisor.runtime, "pid_alive", lambda pid: pid in {222, 333})
-    monkeypatch.setattr(restart_supervisor.runtime, "wait_for_service_ready", lambda *args, **kwargs: 222)
+    forward = build_upgrade_plan(
+        python_executable=str(python),
+        base_env=env,
+        memory_enabled=True,
+        memory_package=True,
+        package_spec="avibe-os",
+    )
+    assert MEMORY_PACKAGE_REQUIREMENT in forward.command
+    result = execute_upgrade_plan(forward, cwd=tmp_path, capture_output=True, text=True, check=False, timeout=600)
+    assert result.returncode == 0, result.stdout + result.stderr
+    upgraded = _installed_versions(python)
+    assert upgraded["avibe-os"] == "3.0.15"
+    assert upgraded["avibe-memory"] == "3.0.15"
 
     launcher = runtime.ServiceLauncher(python=str(python), main=str(ROOT / "main.py"))
     rollback_target = RollbackTarget(
@@ -103,112 +130,80 @@ def test_packaged_memory_shape_survives_supervisor_upgrade_and_pinned_rollback(
         memory_package=True,
         memory_version="3.0.14",
     )
-    starts: list[object] = []
-    forward_snapshots: list[dict[str, str]] = []
-
-    def start_runtime(*, launcher=None, **kwargs):
-        starts.append(launcher)
-        if launcher is None:
-            forward_snapshots.append(_installed_versions(python))
-            raise RuntimeError("activation intentionally failed")
-        return restart_supervisor.StartedRuntime(222, None, None)
-
-    monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", start_runtime)
-    transaction = UpgradeTransaction(
-        schema_version=1,
-        installer="pip",
-        forward_spec="avibe-os",
-        include_memory=True,
-        memory_requirement=MEMORY_PACKAGE_REQUIREMENT,
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "avibe-home"))
+    monkeypatch.setenv("PIP_NO_INDEX", "1")
+    monkeypatch.setenv("PIP_FIND_LINKS", str(wheelhouse))
+    monkeypatch.setenv("PIP_NO_DEPS", "1")
+    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda **kwargs: (True, {}, 0, None, True, 0))
+    monkeypatch.setattr(restart_supervisor, "_failed_generation_still_running", lambda **kwargs: False)
+    monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
+    monkeypatch.setattr(restart_supervisor.runtime, "wait_for_service_ready", lambda *args, **kwargs: 901)
+    monkeypatch.setattr(restart_supervisor.runtime, "pid_alive", lambda pid: True)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "_start_runtime_processes",
+        lambda **kwargs: restart_supervisor.StartedRuntime(901, None, None),
+    )
+    events: list[dict] = []
+    rollback = restart_supervisor._roll_back_failed_upgrade(
         rollback_to=rollback_target,
-    )
-    assert restart_supervisor._run_restart_job(
-        job_id="packaged-memory",
-        delay_seconds=0,
         vibe_path=None,
-        trigger="upgrade",
-        scope="service",
-        upgrade_transaction=transaction,
-    ) == 1
-    assert forward_snapshots[0]["avibe-os"] == "3.0.15"
-    assert forward_snapshots[0]["avibe-memory"] == "3.0.15"
-    assert _installed_versions(python)["avibe-os"] == "3.0.14"
-    assert _installed_versions(python)["avibe-memory"] == "3.0.14"
-    assert starts == [None, launcher]
-
-    core_only_environment = tmp_path / "core-only-venv"
-    subprocess.run([sys.executable, "-m", "venv", str(core_only_environment)], check=True, capture_output=True)
-    core_only_python = _python(core_only_environment)
-    initial_core_only = subprocess.run(
-        [
-            str(core_only_python),
-            "-m",
-            "pip",
-            "install",
-            "--no-deps",
-            str(next(wheelhouse.glob("avibe_os-3.0.14-*.whl"))),
-        ],
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
+        start_ui=False,
+        backup_watermark=None,
+        write=lambda message: None,
+        record=lambda payload: events.append(dict(payload)),
     )
-    assert initial_core_only.returncode == 0, initial_core_only.stdout + initial_core_only.stderr
+    assert rollback["state"] == "succeeded"
+    restored = _installed_versions(python)
+    assert restored["avibe-os"] == "3.0.14"
+    assert restored["avibe-memory"] == "3.0.14"
+    assert any(event.get("install", {}).get("ok") is True for event in events)
 
-    monkeypatch.setattr(restart_supervisor, "sys", type("ProcessSys", (), {"executable": str(core_only_python)}))
-    monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda **kwargs: restart_supervisor.StartedRuntime(333, None, None))
-    core_only_transaction = UpgradeTransaction(
-        schema_version=1,
-        installer="pip",
-        forward_spec="avibe-os",
-        include_memory=False,
-        memory_requirement=None,
-        rollback_to=RollbackTarget(
-            version="3.0.14",
-            package="avibe-os",
-            launcher=runtime.ServiceLauncher(python=str(core_only_python), main=str(ROOT / "main.py")),
-        ),
+
+@pytest.mark.integration
+def test_packaged_core_only_upgrade_preserves_core_only_shape(tmp_path: Path) -> None:
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    for version in ("3.0.14", "3.0.15"):
+        _wheel(ROOT, version, wheelhouse)
+    python = _venv(tmp_path / "core-only-venv")
+    _install_initial(python, wheelhouse, memory=False)
+    plan = build_upgrade_plan(
+        python_executable=str(python),
+        base_env=_plan_env(wheelhouse),
+        memory_enabled=False,
+        memory_package=False,
+        package_spec="avibe-os",
     )
-    assert restart_supervisor._run_restart_job(
-        job_id="packaged-core-only",
-        delay_seconds=0,
-        vibe_path=None,
-        trigger="upgrade",
-        scope="service",
-        upgrade_transaction=core_only_transaction,
-    ) == 0
-    core_only_versions = _installed_versions(core_only_python)
-    assert core_only_versions["avibe-os"] == "3.0.15"
-    assert "avibe-memory" not in core_only_versions
+    result = execute_upgrade_plan(plan, cwd=tmp_path, capture_output=True, text=True, check=False, timeout=600)
+    assert result.returncode == 0, result.stdout + result.stderr
+    versions = _installed_versions(python)
+    assert versions["avibe-os"] == "3.0.15"
+    assert "avibe-memory" not in versions
 
+
+@pytest.mark.integration
+def test_packaged_missing_memory_fails_before_install(tmp_path: Path) -> None:
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    _wheel(ROOT, "3.0.14", wheelhouse)
+    _wheel(ROOT, "3.0.15", wheelhouse)
+    memory_wheel = ROOT / "packaging" / "avibe-memory"
+    _wheel(memory_wheel, "3.0.14", wheelhouse)
+    _wheel(memory_wheel, "3.0.15", wheelhouse)
+    python = _venv(tmp_path / "missing-memory-venv")
+    _install_initial(python, wheelhouse, memory=True)
     for wheel in wheelhouse.glob("avibe_memory-*.whl"):
         wheel.unlink()
-    missing_memory_environment = tmp_path / "missing-memory-venv"
-    subprocess.run([sys.executable, "-m", "venv", str(missing_memory_environment)], check=True, capture_output=True)
-    missing_memory_python = _python(missing_memory_environment)
-    initial_missing = subprocess.run(
-        [str(missing_memory_python), "-m", "pip", "install", "--no-deps", str(next(wheelhouse.glob("avibe_os-3.0.14-*.whl")))],
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
+    plan = build_upgrade_plan(
+        python_executable=str(python),
+        base_env=_plan_env(wheelhouse),
+        memory_enabled=True,
+        memory_package=True,
+        package_spec="avibe-os",
     )
-    assert initial_missing.returncode == 0, initial_missing.stdout + initial_missing.stderr
-    monkeypatch.setattr(restart_supervisor, "sys", type("ProcessSys", (), {"executable": str(missing_memory_python)}))
-    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda **kwargs: pytest.fail("missing Memory must fail before stop"))
-    missing_memory_transaction = UpgradeTransaction(
-        schema_version=1,
-        installer="pip",
-        forward_spec="avibe-os",
-        include_memory=True,
-        memory_requirement=MEMORY_PACKAGE_REQUIREMENT,
-        rollback_to=rollback_target,
-    )
-    assert restart_supervisor._run_restart_job(
-        job_id="packaged-missing-memory",
-        delay_seconds=0,
-        vibe_path=None,
-        trigger="upgrade",
-        scope="service",
-        upgrade_transaction=missing_memory_transaction,
-    ) == 2
+    result = execute_upgrade_plan(plan, cwd=tmp_path, capture_output=True, text=True, check=False, timeout=600)
+    assert result.returncode != 0
+    versions = _installed_versions(python)
+    assert versions["avibe-os"] == "3.0.14"
+    assert versions["avibe-memory"] == "3.0.14"

--- a/tests/test_memory_upgrade_packaged.py
+++ b/tests/test_memory_upgrade_packaged.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 import pytest
 
-from vibe.upgrade import build_upgrade_plan, execute_upgrade_plan
+from vibe import restart_supervisor, runtime
+from vibe.upgrade import MEMORY_PACKAGE_REQUIREMENT, RollbackTarget, UpgradeTransaction
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -47,11 +48,13 @@ def _installed_versions(python: Path) -> dict[str, str]:
 
 
 @pytest.mark.integration
-def test_packaged_memory_shape_survives_forward_upgrade_and_pinned_rollback(tmp_path: Path) -> None:
-    """Exercise the real pip resolver and inspect distributions after each mutation."""
+def test_packaged_memory_shape_survives_supervisor_upgrade_and_pinned_rollback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exercise the supervisor transaction and inspect real installed distributions."""
 
     if not (ROOT / "vibe" / "show_runtime_manifest.json").is_file():
-        pytest.skip("packaged wheel smoke requires the prepared local Show Runtime manifest")
+        pytest.fail("packaged wheel smoke requires the prepared local Show Runtime manifest")
 
     wheelhouse = tmp_path / "wheelhouse"
     wheelhouse.mkdir()
@@ -62,7 +65,12 @@ def test_packaged_memory_shape_survives_forward_upgrade_and_pinned_rollback(tmp_
     environment = tmp_path / "venv"
     subprocess.run([sys.executable, "-m", "venv", str(environment)], check=True, capture_output=True)
     python = _python(environment)
-    env = {**os.environ, "PIP_NO_INDEX": "1", "PIP_FIND_LINKS": str(wheelhouse)}
+    env = {
+        **os.environ,
+        "PIP_NO_INDEX": "1",
+        "PIP_FIND_LINKS": str(wheelhouse),
+        "PIP_NO_DEPS": "1",
+    }
     initial = subprocess.run(
         [str(python), "-m", "pip", "install", "--no-deps", str(next(wheelhouse.glob("avibe_os-3.0.14-*.whl"))), str(next(wheelhouse.glob("avibe_memory-3.0.14-*.whl")))],
         env=env,
@@ -74,29 +82,59 @@ def test_packaged_memory_shape_survives_forward_upgrade_and_pinned_rollback(tmp_
     assert _installed_versions(python)["avibe-os"] == "3.0.14"
     assert _installed_versions(python)["avibe-memory"] == "3.0.14"
 
-    forward = build_upgrade_plan(
-        python_executable=str(python),
-        base_env=env,
-        memory_enabled=True,
-        package_spec="avibe-os",
-    )
-    result = execute_upgrade_plan(forward, cwd=tmp_path, capture_output=True, text=True, check=False, timeout=600)
-    assert result.returncode == 0, result.stdout + result.stderr
-    assert _installed_versions(python)["avibe-os"] == "3.0.15"
-    assert _installed_versions(python)["avibe-memory"] == "3.0.15"
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "avibe-home"))
+    monkeypatch.setenv("PIP_NO_INDEX", "1")
+    monkeypatch.setenv("PIP_FIND_LINKS", str(wheelhouse))
+    monkeypatch.setenv("PIP_NO_DEPS", "1")
+    monkeypatch.setattr(restart_supervisor, "sys", type("ProcessSys", (), {"executable": str(python)}))
+    monkeypatch.setattr(restart_supervisor.runtime, "verified_service_running", lambda: True)
+    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda **kwargs: (True, {}, 0, None, True, 0))
+    monkeypatch.setattr(restart_supervisor, "_wait_for_service_lock_release", lambda: True)
+    monkeypatch.setattr(restart_supervisor, "_failed_generation_still_running", lambda **kwargs: False)
+    monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
+    monkeypatch.setattr(restart_supervisor.runtime, "pid_alive", lambda pid: pid in {222, 333})
+    monkeypatch.setattr(restart_supervisor.runtime, "wait_for_service_ready", lambda *args, **kwargs: 222)
 
-    rollback = build_upgrade_plan(
-        python_executable=str(python),
-        base_env=env,
+    launcher = runtime.ServiceLauncher(python=str(python), main=str(ROOT / "main.py"))
+    rollback_target = RollbackTarget(
         version="3.0.14",
-        package_name="avibe-os",
+        package="avibe-os",
+        launcher=launcher,
         memory_package=True,
         memory_version="3.0.14",
     )
-    result = execute_upgrade_plan(rollback, cwd=tmp_path, capture_output=True, text=True, check=False, timeout=600)
-    assert result.returncode == 0, result.stdout + result.stderr
+    starts: list[object] = []
+    forward_snapshots: list[dict[str, str]] = []
+
+    def start_runtime(*, launcher=None, **kwargs):
+        starts.append(launcher)
+        if launcher is None:
+            forward_snapshots.append(_installed_versions(python))
+            raise RuntimeError("activation intentionally failed")
+        return restart_supervisor.StartedRuntime(222, None, None)
+
+    monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", start_runtime)
+    transaction = UpgradeTransaction(
+        schema_version=1,
+        installer="pip",
+        forward_spec="avibe-os",
+        include_memory=True,
+        memory_requirement=MEMORY_PACKAGE_REQUIREMENT,
+        rollback_to=rollback_target,
+    )
+    assert restart_supervisor._run_restart_job(
+        job_id="packaged-memory",
+        delay_seconds=0,
+        vibe_path=None,
+        trigger="upgrade",
+        scope="service",
+        upgrade_transaction=transaction,
+    ) == 1
+    assert forward_snapshots[0]["avibe-os"] == "3.0.15"
+    assert forward_snapshots[0]["avibe-memory"] == "3.0.15"
     assert _installed_versions(python)["avibe-os"] == "3.0.14"
     assert _installed_versions(python)["avibe-memory"] == "3.0.14"
+    assert starts == [None, launcher]
 
     core_only_environment = tmp_path / "core-only-venv"
     subprocess.run([sys.executable, "-m", "venv", str(core_only_environment)], check=True, capture_output=True)
@@ -117,21 +155,60 @@ def test_packaged_memory_shape_survives_forward_upgrade_and_pinned_rollback(tmp_
     )
     assert initial_core_only.returncode == 0, initial_core_only.stdout + initial_core_only.stderr
 
-    core_only_forward = build_upgrade_plan(
-        python_executable=str(core_only_python),
-        base_env=env,
-        memory_enabled=False,
-        memory_package=False,
-        package_spec="avibe-os",
+    monkeypatch.setattr(restart_supervisor, "sys", type("ProcessSys", (), {"executable": str(core_only_python)}))
+    monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda **kwargs: restart_supervisor.StartedRuntime(333, None, None))
+    core_only_transaction = UpgradeTransaction(
+        schema_version=1,
+        installer="pip",
+        forward_spec="avibe-os",
+        include_memory=False,
+        memory_requirement=None,
+        rollback_to=RollbackTarget(
+            version="3.0.14",
+            package="avibe-os",
+            launcher=runtime.ServiceLauncher(python=str(core_only_python), main=str(ROOT / "main.py")),
+        ),
     )
-    assert execute_upgrade_plan(
-        core_only_forward,
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=600,
-    ).returncode == 0
+    assert restart_supervisor._run_restart_job(
+        job_id="packaged-core-only",
+        delay_seconds=0,
+        vibe_path=None,
+        trigger="upgrade",
+        scope="service",
+        upgrade_transaction=core_only_transaction,
+    ) == 0
     core_only_versions = _installed_versions(core_only_python)
     assert core_only_versions["avibe-os"] == "3.0.15"
     assert "avibe-memory" not in core_only_versions
+
+    for wheel in wheelhouse.glob("avibe_memory-*.whl"):
+        wheel.unlink()
+    missing_memory_environment = tmp_path / "missing-memory-venv"
+    subprocess.run([sys.executable, "-m", "venv", str(missing_memory_environment)], check=True, capture_output=True)
+    missing_memory_python = _python(missing_memory_environment)
+    initial_missing = subprocess.run(
+        [str(missing_memory_python), "-m", "pip", "install", "--no-deps", str(next(wheelhouse.glob("avibe_os-3.0.14-*.whl")))],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert initial_missing.returncode == 0, initial_missing.stdout + initial_missing.stderr
+    monkeypatch.setattr(restart_supervisor, "sys", type("ProcessSys", (), {"executable": str(missing_memory_python)}))
+    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda **kwargs: pytest.fail("missing Memory must fail before stop"))
+    missing_memory_transaction = UpgradeTransaction(
+        schema_version=1,
+        installer="pip",
+        forward_spec="avibe-os",
+        include_memory=True,
+        memory_requirement=MEMORY_PACKAGE_REQUIREMENT,
+        rollback_to=rollback_target,
+    )
+    assert restart_supervisor._run_restart_job(
+        job_id="packaged-missing-memory",
+        delay_seconds=0,
+        vibe_path=None,
+        trigger="upgrade",
+        scope="service",
+        upgrade_transaction=missing_memory_transaction,
+    ) == 2

--- a/tests/test_memory_upgrade_packaged.py
+++ b/tests/test_memory_upgrade_packaged.py
@@ -6,6 +6,7 @@ import hashlib
 import io
 import os
 import re
+import shutil
 import subprocess
 import sys
 import zipfile
@@ -101,10 +102,14 @@ def _venv(path: Path) -> Path:
     return _python(path)
 
 
-def _install_initial(python: Path, wheelhouse: Path, *, memory: bool) -> None:
-    wheels = [next(wheelhouse.glob("avibe_os-3.0.14-*.whl"))]
-    if memory:
-        wheels.append(next(wheelhouse.glob("avibe_memory-3.0.14-*.whl")))
+@pytest.fixture(scope="module")
+def packaged_dependency_seed(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    seed_root = tmp_path_factory.mktemp("packaged-dependency-seed")
+    source_wheelhouse = seed_root / "source"
+    source_wheelhouse.mkdir()
+    _build_release_wheels("3.0.14", source_wheelhouse)
+    dependency_seed = seed_root / "dependencies"
+    dependency_seed.mkdir()
     seed = subprocess.run(
         [
             sys.executable,
@@ -112,18 +117,30 @@ def _install_initial(python: Path, wheelhouse: Path, *, memory: bool) -> None:
             "pip",
             "download",
             "--dest",
-            str(wheelhouse),
+            str(dependency_seed),
             "setuptools",
             "wheel",
-            *(str(wheel) for wheel in wheels),
+            str(next(source_wheelhouse.glob("avibe_os-3.0.14-*.whl"))),
+            str(next(source_wheelhouse.glob("avibe_memory-3.0.14-*.whl"))),
         ],
-        env={**os.environ, "PIP_FIND_LINKS": str(wheelhouse)},
+        env={**os.environ, "PIP_FIND_LINKS": str(source_wheelhouse)},
         capture_output=True,
         text=True,
         check=False,
         timeout=600,
     )
     assert seed.returncode == 0, seed.stdout + seed.stderr
+    return dependency_seed
+
+
+def _install_initial(python: Path, wheelhouse: Path, *, memory: bool, dependency_seed: Path) -> None:
+    for artifact in dependency_seed.iterdir():
+        if artifact.name.lower().startswith(("avibe_os-", "avibe_memory-")):
+            continue
+        shutil.copy2(artifact, wheelhouse / artifact.name)
+    wheels = [next(wheelhouse.glob("avibe_os-3.0.14-*.whl"))]
+    if memory:
+        wheels.append(next(wheelhouse.glob("avibe_memory-3.0.14-*.whl")))
     env = {**os.environ, "PIP_NO_INDEX": "1", "PIP_FIND_LINKS": str(wheelhouse)}
     result = subprocess.run(
         [str(python), "-m", "pip", "install", *(str(wheel) for wheel in wheels)],
@@ -145,7 +162,9 @@ def _plan_env(wheelhouse: Path) -> dict[str, str]:
 
 @pytest.mark.integration
 def test_packaged_memory_shape_survives_synchronous_upgrade_and_supervisor_rollback(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    packaged_dependency_seed: Path,
 ) -> None:
     """Run the public planner/executor, then the existing supervisor rollback path."""
 
@@ -159,7 +178,7 @@ def test_packaged_memory_shape_survives_synchronous_upgrade_and_supervisor_rollb
 
     environment = tmp_path / "memory-venv"
     python = _venv(environment)
-    _install_initial(python, wheelhouse, memory=True)
+    _install_initial(python, wheelhouse, memory=True, dependency_seed=packaged_dependency_seed)
     env = _plan_env(wheelhouse)
     assert _installed_versions(python)["avibe-os"] == "3.0.14"
     assert _installed_versions(python)["avibe-memory"] == "3.0.14"
@@ -217,13 +236,15 @@ def test_packaged_memory_shape_survives_synchronous_upgrade_and_supervisor_rollb
 
 
 @pytest.mark.integration
-def test_packaged_core_only_upgrade_preserves_core_only_shape(tmp_path: Path) -> None:
+def test_packaged_core_only_upgrade_preserves_core_only_shape(
+    tmp_path: Path, packaged_dependency_seed: Path
+) -> None:
     wheelhouse = tmp_path / "wheelhouse"
     wheelhouse.mkdir()
     for version in ("3.0.14", "3.0.15"):
         _build_release_wheels(version, wheelhouse)
     python = _venv(tmp_path / "core-only-venv")
-    _install_initial(python, wheelhouse, memory=False)
+    _install_initial(python, wheelhouse, memory=False, dependency_seed=packaged_dependency_seed)
     plan = build_upgrade_plan(
         python_executable=str(python),
         base_env=_plan_env(wheelhouse),
@@ -239,13 +260,13 @@ def test_packaged_core_only_upgrade_preserves_core_only_shape(tmp_path: Path) ->
 
 
 @pytest.mark.integration
-def test_packaged_missing_memory_fails_before_install(tmp_path: Path) -> None:
+def test_packaged_missing_memory_fails_before_install(tmp_path: Path, packaged_dependency_seed: Path) -> None:
     wheelhouse = tmp_path / "wheelhouse"
     wheelhouse.mkdir()
     _build_release_wheels("3.0.14", wheelhouse)
     _build_release_wheels("3.0.15", wheelhouse)
     python = _venv(tmp_path / "missing-memory-venv")
-    _install_initial(python, wheelhouse, memory=True)
+    _install_initial(python, wheelhouse, memory=True, dependency_seed=packaged_dependency_seed)
     for wheel in wheelhouse.glob("avibe_memory-*.whl"):
         wheel.unlink()
     plan = build_upgrade_plan(

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import inspect
 import io
+import json
 import os
 import sqlite3
 import sys
@@ -10,6 +11,7 @@ import textwrap
 import threading
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -559,10 +561,42 @@ def test_schedule_upgrade_transaction_carries_only_typed_shape(monkeypatch, tmp_
     result = restart_supervisor.schedule_upgrade_transaction(_upgrade_transaction(), vibe_path="/bin/vibe")
     command = spawned["command"]
     assert result["transaction"] == "upgrade-v1"
-    assert "--upgrade-forward-spec" in command
-    assert "avibe-os[memory]" in command
-    assert "--upgrade-memory-requirement" in command
+    assert "--upgrade-transaction-file" in command
+    payload_path = Path(command[command.index("--upgrade-transaction-file") + 1])
+    assert payload_path.stat().st_mode & 0o777 == 0o600
+    assert payload_path.parent.stat().st_mode & 0o777 == 0o700
+    assert "avibe-os[memory]" not in command
+    assert MEMORY_PACKAGE_REQUIREMENT not in command
     assert not any(part in {"--command", "--env"} for part in command)
+    payload_path.unlink()
+
+
+def test_upgrade_transaction_payload_is_consumed_and_rejects_unknown_fields(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    path = restart_supervisor._write_upgrade_transaction_file(_upgrade_transaction(), "tx-payload")
+    payload = runtime.read_json(path)
+    assert payload["forward_spec"] == "avibe-os[memory]"
+    assert restart_supervisor._read_upgrade_transaction_file(str(path)).forward_spec == "avibe-os[memory]"
+    assert not path.exists()
+    path.write_text('{"schema_version":1,"unknown":true}', encoding="utf-8")
+    with pytest.raises(ValueError, match="unknown or missing"):
+        restart_supervisor._read_upgrade_transaction_file(str(path))
+    assert not path.exists()
+
+    malformed = _upgrade_transaction().to_payload()
+    malformed["include_memory"] = "true"
+    path = restart_supervisor._write_upgrade_transaction_file(_upgrade_transaction(), "tx-malformed")
+    path.write_text(json.dumps(malformed), encoding="utf-8")
+    with pytest.raises(ValueError, match="scalar fields"):
+        restart_supervisor._read_upgrade_transaction_file(str(path))
+    assert not path.exists()
+
+    package_optional = _upgrade_transaction().to_payload()
+    package_optional["rollback_to"]["package"] = None
+    path = restart_supervisor._write_upgrade_transaction_file(_upgrade_transaction(), "tx-optional-package")
+    path.write_text(json.dumps(package_optional), encoding="utf-8")
+    assert restart_supervisor._read_upgrade_transaction_file(str(path)).rollback_to.package is None
 
 
 def test_upgrade_transaction_refuses_when_ordinary_restart_is_active(monkeypatch, tmp_path):
@@ -574,6 +608,41 @@ def test_upgrade_transaction_refuses_when_ordinary_restart_is_active(monkeypatch
     )
     with pytest.raises(RuntimeError, match="restart is already in progress"):
         restart_supervisor.schedule_upgrade_transaction(_upgrade_transaction(), vibe_path="/bin/vibe")
+
+
+def test_restart_admission_ignores_dead_supervisor_status(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    runtime.write_json(
+        runtime.get_restart_status_path(),
+        {
+            "state": "running",
+            "supervisor_pid": 1234,
+            "supervisor_started_at": 1.0,
+            "transaction": "upgrade-v1",
+        },
+    )
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: False)
+    assert restart_supervisor._restart_job_active() is False
+    assert restart_supervisor._upgrade_transaction_active() is False
+
+
+def test_restart_admission_rejects_reused_supervisor_pid(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    runtime.write_json(
+        runtime.get_restart_status_path(),
+        {
+            "state": "running",
+            "supervisor_pid": 1234,
+            "supervisor_started_at": 1.0,
+            "transaction": "upgrade-v1",
+        },
+    )
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: True)
+    monkeypatch.setattr(runtime, "process_create_time", lambda pid: 2.0)
+    assert restart_supervisor._restart_job_active() is False
+    assert restart_supervisor._upgrade_transaction_active() is False
 
 
 def test_ordinary_restart_admission_uses_transaction_gate(monkeypatch, tmp_path):
@@ -620,6 +689,129 @@ def test_upgrade_transaction_preflight_failure_leaves_runtime_running(monkeypatc
     assert "preflight" in status["error"]
 
 
+@pytest.mark.parametrize("readiness", ["start", "ready", "exception", "dead"])
+def test_upgrade_transaction_activation_failure_rolls_back_exact_memory_shape(monkeypatch, tmp_path, readiness):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    target = _upgrade_transaction().rollback_to
+    rollback_calls = []
+    monkeypatch.setattr(restart_supervisor.runtime, "verified_service_running", lambda: True)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "build_upgrade_plan",
+        lambda **kwargs: restart_supervisor.UpgradePlan(command=["install"], env={}, method="pip"),
+    )
+    monkeypatch.setattr(restart_supervisor, "preflight_upgrade_plan", lambda *args, **kwargs: SimpleNamespace(returncode=0))
+    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda **kwargs: (True, {}, 0, None, True, 0))
+    monkeypatch.setattr(restart_supervisor, "_wait_for_service_lock_release", lambda: True)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "execute_upgrade_plan",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    if readiness == "start":
+        monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
+    elif readiness == "dead":
+        monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda **kwargs: restart_supervisor.StartedRuntime(222, None, None))
+        monkeypatch.setattr(restart_supervisor.runtime, "pid_alive", lambda pid: False)
+    elif readiness == "ready":
+        monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda **kwargs: restart_supervisor.StartedRuntime(222, None, None))
+        monkeypatch.setattr(restart_supervisor.runtime, "wait_for_service_ready", lambda *args, **kwargs: None)
+    else:
+        monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda **kwargs: restart_supervisor.StartedRuntime(222, None, None))
+        monkeypatch.setattr(
+            restart_supervisor.runtime,
+            "wait_for_service_ready",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("readiness probe failed")),
+        )
+    monkeypatch.setattr(
+        restart_supervisor,
+        "_roll_back_failed_upgrade",
+        lambda **kwargs: rollback_calls.append(kwargs["rollback_to"]) or {"state": "succeeded"},
+    )
+    result = restart_supervisor._run_restart_job(
+        job_id=f"tx-activation-{readiness}",
+        delay_seconds=0,
+        vibe_path="/bin/vibe",
+        trigger="upgrade",
+        scope="service",
+        upgrade_transaction=_upgrade_transaction(),
+    )
+    assert result in {1, 3}
+    assert rollback_calls == [target]
+    assert target.memory_package is True
+    assert target.memory_version == "3.0.14"
+
+
+def test_upgrade_transaction_aborts_when_ui_survives_stop(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    calls = []
+    monkeypatch.setattr(restart_supervisor.runtime, "verified_service_running", lambda: True)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "build_upgrade_plan",
+        lambda **kwargs: restart_supervisor.UpgradePlan(command=["install"], env={}, method="pip"),
+    )
+    monkeypatch.setattr(restart_supervisor, "preflight_upgrade_plan", lambda *args, **kwargs: SimpleNamespace(returncode=0))
+    monkeypatch.setattr(
+        restart_supervisor,
+        "_stop_runtime_for_restart",
+        lambda **kwargs: (False, {}, 0, 333, True, 0),
+    )
+    monkeypatch.setattr(restart_supervisor.runtime, "pid_alive", lambda pid: pid == 333)
+    monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda **kwargs: calls.append("recover") or restart_supervisor.StartedRuntime(222, 333, None))
+    monkeypatch.setattr(restart_supervisor.runtime, "wait_for_service_ready", lambda *args, **kwargs: 222)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "execute_upgrade_plan",
+        lambda *args, **kwargs: calls.append("install") or pytest.fail("UI stop failure must precede install"),
+    )
+    result = restart_supervisor._run_restart_job(
+        job_id="tx-ui-stop-fail",
+        delay_seconds=0,
+        vibe_path="/bin/vibe",
+        trigger="upgrade",
+        upgrade_transaction=_upgrade_transaction(),
+    )
+    assert result == 2
+    assert calls == ["recover"]
+
+
+def test_upgrade_transaction_checks_live_ui_identity_when_stop_has_no_pid(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    calls = []
+    monkeypatch.setattr(restart_supervisor.runtime, "verified_service_running", lambda: True)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "build_upgrade_plan",
+        lambda **kwargs: restart_supervisor.UpgradePlan(command=["install"], env={}, method="pip"),
+    )
+    monkeypatch.setattr(restart_supervisor, "preflight_upgrade_plan", lambda *args, **kwargs: SimpleNamespace(returncode=0))
+    monkeypatch.setattr(
+        restart_supervisor,
+        "_stop_runtime_for_restart",
+        lambda **kwargs: (True, {}, 0, None, True, 0),
+    )
+    monkeypatch.setattr(restart_supervisor.runtime, "ui_pid_file_points_to_running_ui", lambda: True)
+    monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda **kwargs: calls.append("recover") or restart_supervisor.StartedRuntime(222, None, None))
+    monkeypatch.setattr(restart_supervisor.runtime, "wait_for_service_ready", lambda *args, **kwargs: 222)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "execute_upgrade_plan",
+        lambda *args, **kwargs: calls.append("install") or pytest.fail("live UI must block package mutation"),
+    )
+    assert restart_supervisor._run_restart_job(
+        job_id="tx-ui-identity-stop-fail",
+        delay_seconds=0,
+        vibe_path="/bin/vibe",
+        trigger="upgrade",
+        upgrade_transaction=_upgrade_transaction(),
+    ) == 2
+    assert calls == ["recover"]
+
+
 def test_upgrade_transaction_lock_timeout_fails_before_mutation(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
@@ -647,6 +839,7 @@ def test_upgrade_transaction_keeps_lease_across_preflight_stop_install_start(mon
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     events = []
+    build_kwargs = {}
     plan = restart_supervisor.UpgradePlan(command=["install"], env={}, method="pip", preflight_command=["download"])
 
     @contextmanager
@@ -659,12 +852,13 @@ def test_upgrade_transaction_keeps_lease_across_preflight_stop_install_start(mon
 
     monkeypatch.setattr(restart_supervisor, "_upgrade_transaction_lock", lease)
     monkeypatch.setattr(restart_supervisor.runtime, "verified_service_running", lambda: True)
-    monkeypatch.setattr(restart_supervisor, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(restart_supervisor, "build_upgrade_plan", lambda **kwargs: build_kwargs.update(kwargs) or plan)
     monkeypatch.setattr(restart_supervisor, "preflight_upgrade_plan", lambda *args, **kwargs: events.append("preflight"))
     monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda **kwargs: events.append("stop") or (True, {}, 0, None, True, 0))
     monkeypatch.setattr(restart_supervisor, "_wait_for_service_lock_release", lambda: events.append("wait") or True)
     monkeypatch.setattr(restart_supervisor, "execute_upgrade_plan", lambda *args, **kwargs: events.append("install") or SimpleNamespace(returncode=0, stdout="", stderr=""))
     monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda **kwargs: events.append("start") or restart_supervisor.StartedRuntime(222, None, None))
+    monkeypatch.setattr(restart_supervisor.runtime, "pid_alive", lambda pid: pid == 222)
     monkeypatch.setattr(restart_supervisor.runtime, "wait_for_service_ready", lambda *args, **kwargs: 222)
     monkeypatch.setattr(restart_supervisor.runtime, "write_status", lambda *args, **kwargs: None)
     monkeypatch.setattr(restart_supervisor, "_read_recorded_pid", lambda: 111)
@@ -677,10 +871,50 @@ def test_upgrade_transaction_keeps_lease_across_preflight_stop_install_start(mon
         upgrade_transaction=_upgrade_transaction(),
     ) == 0
     assert events.index("lease-enter") < events.index("preflight") < events.index("stop") < events.index("install") < events.index("start") < events.index("lease-exit")
+    assert build_kwargs["memory_requirement"] == _upgrade_transaction().memory_requirement
+    assert build_kwargs["memory_package"] is True
 
 
-def test_upgrade_transaction_main_reassembles_declared_fields(monkeypatch):
+def test_upgrade_transaction_prepares_show_runtime_nonfatally(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    events = []
+    monkeypatch.setattr(restart_supervisor.runtime, "verified_service_running", lambda: False)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "build_upgrade_plan",
+        lambda **kwargs: restart_supervisor.UpgradePlan(command=["install"], env={}, method="pip"),
+    )
+    monkeypatch.setattr(restart_supervisor, "preflight_upgrade_plan", lambda *args, **kwargs: SimpleNamespace(returncode=0))
+    monkeypatch.setattr(
+        restart_supervisor,
+        "execute_upgrade_plan",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(
+        restart_supervisor,
+        "_prepare_show_runtime_nonfatal",
+        lambda *args, **kwargs: events.append("prepare"),
+    )
+    transaction = UpgradeTransaction(1, "pip", "avibe-os", False, None, None, "none")
+    assert restart_supervisor._run_restart_job(
+        job_id="tx-prepare",
+        delay_seconds=0,
+        vibe_path="/bin/vibe",
+        trigger="upgrade",
+        scope="service",
+        prepare_show_runtime=True,
+        upgrade_transaction=transaction,
+    ) == 0
+    assert events == ["prepare"]
+
+
+def test_upgrade_transaction_main_reassembles_declared_fields(monkeypatch, tmp_path):
     captured = {}
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    transaction = _upgrade_transaction()
+    payload_path = restart_supervisor._write_upgrade_transaction_file(transaction, "tx-1")
     monkeypatch.setattr("vibe.memory_ui_access.initialize_process_ui_read_secret", lambda: None)
     monkeypatch.setattr(
         restart_supervisor,
@@ -690,22 +924,16 @@ def test_upgrade_transaction_main_reassembles_declared_fields(monkeypatch):
     argv = [
         "--job-id",
         "tx-1",
-        "--upgrade-transaction-version",
-        "1",
-        "--upgrade-installer",
-        "pip",
-        "--upgrade-forward-spec",
-        "avibe-os[memory]",
-        "--upgrade-include-memory",
-        "--upgrade-memory-requirement",
-        MEMORY_PACKAGE_REQUIREMENT,
+        "--upgrade-transaction-file",
+        str(payload_path),
     ]
     assert restart_supervisor.main(argv) == 0
-    transaction = captured["upgrade_transaction"]
-    assert transaction.schema_version == 1
-    assert transaction.installer == "pip"
-    assert transaction.forward_spec == "avibe-os[memory]"
-    assert transaction.memory_requirement == MEMORY_PACKAGE_REQUIREMENT
+    captured_transaction = captured["upgrade_transaction"]
+    assert captured_transaction.schema_version == 1
+    assert captured_transaction.installer == "pip"
+    assert captured_transaction.forward_spec == "avibe-os[memory]"
+    assert captured_transaction.memory_requirement == MEMORY_PACKAGE_REQUIREMENT
+    assert not payload_path.exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -10,6 +10,7 @@ import textwrap
 import threading
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -218,6 +219,53 @@ def test_legacy_upgrade_target_keeps_memory_out_of_core_ownership(
         version="3.0.14",
         package=core_package,
         launcher=runtime.ServiceLauncher(python=str(python_path), main=str(service_main)),
+        memory_package=True,
+        memory_version="3.0.14",
+    )
+
+
+def test_legacy_upgrade_target_skips_broken_metadata_entries(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    paths.ensure_data_dirs()
+    tool_root = tmp_path / "uv" / "tools" / "avibe-os"
+    python_path = tool_root / "bin" / "python"
+    service_main = tool_root / "lib" / "python3.12" / "site-packages" / "vibe" / "service_main.py"
+    python_path.parent.mkdir(parents=True)
+    service_main.parent.mkdir(parents=True)
+    python_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    service_main.write_text("# old release\n", encoding="utf-8")
+    metadata_root = service_main.parent.parent
+    broken = metadata_root / "000_broken-1.0.dist-info" / "METADATA"
+    broken.parent.mkdir()
+    broken.write_text("unreadable", encoding="utf-8")
+    non_utf8 = metadata_root / "001_non_utf8-1.0.dist-info" / "METADATA"
+    non_utf8.parent.mkdir()
+    non_utf8.write_bytes(b"\xff")
+    for directory, name in (("avibe_os", "avibe-os"), ("avibe_memory", "avibe-memory")):
+        metadata = metadata_root / f"{directory}-3.0.14.dist-info" / "METADATA"
+        metadata.parent.mkdir()
+        metadata.write_text(f"Name: {name}\nVersion: 3.0.14\n", encoding="utf-8")
+
+    original_read_text = Path.read_text
+
+    def read_text(path, *args, **kwargs):
+        if path == broken:
+            raise OSError("broken metadata")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+    launcher = runtime.ServiceLauncher(python=str(python_path), main=str(service_main))
+    monkeypatch.setattr(restart_supervisor, "_read_recorded_pid", lambda: 123)
+    monkeypatch.setattr(restart_supervisor, "_read_recorded_ui_pid", lambda: None)
+    monkeypatch.setattr(restart_supervisor, "_running_ui_version", lambda: "3.0.14")
+    monkeypatch.setattr(runtime, "get_process_command", lambda _pid: f"{python_path} {service_main}")
+
+    assert restart_supervisor._launcher_core_dist_metadata(launcher) == [("avibe-os", "3.0.14")]
+    assert restart_supervisor._launcher_memory_version(launcher) == "3.0.14"
+    assert restart_supervisor._discover_legacy_upgrade_target(trigger="upgrade", vibe_path=None) == RollbackTarget(
+        version="3.0.14",
+        package="avibe-os",
+        launcher=launcher,
         memory_package=True,
         memory_version="3.0.14",
     )

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -18,7 +18,7 @@ from config import paths
 from storage.backups import create_sqlite_migration_backup
 from vibe import restart_supervisor
 from vibe import runtime
-from vibe.upgrade import RollbackTarget
+from vibe.upgrade import MEMORY_PACKAGE_REQUIREMENT, RollbackTarget, UpgradeTransaction
 
 
 #: The install the machine was on before the upgrade replaced it. Deliberately
@@ -36,6 +36,23 @@ def _rollback_target(version: str = "3.0.10") -> RollbackTarget:
     """The install to go back to, as the upgrade captured it before installing."""
 
     return RollbackTarget(version=version, package="vibe-remote", launcher=_REPLACED_INSTALL)
+
+
+def _upgrade_transaction() -> UpgradeTransaction:
+    return UpgradeTransaction(
+        schema_version=1,
+        installer="pip",
+        forward_spec="avibe-os[memory]",
+        include_memory=True,
+        memory_requirement="avibe-memory>=3.0.14.dev0,<3.1",
+        rollback_to=RollbackTarget(
+            version="3.0.14",
+            package="avibe-os",
+            launcher=_REPLACED_INSTALL,
+            memory_package=True,
+            memory_version="3.0.14",
+        ),
+    )
 
 
 def _fake_start_runtime(calls, service_pid: int = 222, ui_pid: int = 333):
@@ -522,6 +539,173 @@ def test_schedule_restart_marks_status_failed_when_spawn_fails(monkeypatch, tmp_
     assert status["ok"] is False
     assert status["state"] == "failed"
     assert "failed to spawn" in status["error"]
+
+
+def test_schedule_upgrade_transaction_carries_only_typed_shape(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    spawned = {}
+    monkeypatch.setattr(restart_supervisor, "get_restart_invocation_command", lambda vibe_path=None: ["/bin/vibe", "restart"])
+    monkeypatch.setattr(restart_supervisor, "get_restart_environment", lambda vibe_path=None: {"PATH": "/bin"})
+    monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
+    monkeypatch.setattr(restart_supervisor, "_prune_restart_logs", lambda: None)
+    monkeypatch.setattr(restart_supervisor, "process_ui_read_secret", lambda: None, raising=False)
+
+    def fake_popen(command, **kwargs):
+        spawned["command"] = command
+        return SimpleNamespace(pid=1234)
+
+    monkeypatch.setattr(restart_supervisor.subprocess, "Popen", fake_popen)
+    result = restart_supervisor.schedule_upgrade_transaction(_upgrade_transaction(), vibe_path="/bin/vibe")
+    command = spawned["command"]
+    assert result["transaction"] == "upgrade-v1"
+    assert "--upgrade-forward-spec" in command
+    assert "avibe-os[memory]" in command
+    assert "--upgrade-memory-requirement" in command
+    assert not any(part in {"--command", "--env"} for part in command)
+
+
+def test_upgrade_transaction_refuses_when_ordinary_restart_is_active(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    runtime.write_json(
+        runtime.get_restart_status_path(),
+        {"state": "running", "supervisor_pid": os.getpid(), "trigger": "cli"},
+    )
+    with pytest.raises(RuntimeError, match="restart is already in progress"):
+        restart_supervisor.schedule_upgrade_transaction(_upgrade_transaction(), vibe_path="/bin/vibe")
+
+
+def test_ordinary_restart_admission_uses_transaction_gate(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    events = []
+
+    @contextmanager
+    def gate(**kwargs):
+        events.append("acquired")
+        yield
+        events.append("released")
+
+    monkeypatch.setattr(restart_supervisor, "_upgrade_transaction_lock", gate)
+    monkeypatch.setattr(restart_supervisor, "get_restart_invocation_command", lambda vibe_path=None: ["/bin/vibe", "restart"])
+    monkeypatch.setattr(restart_supervisor, "get_restart_environment", lambda vibe_path=None: None)
+    monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
+    monkeypatch.setattr(restart_supervisor, "_prune_restart_logs", lambda: None)
+    monkeypatch.setattr(restart_supervisor.subprocess, "Popen", lambda *args, **kwargs: SimpleNamespace(pid=1234))
+
+    restart_supervisor.schedule_restart(vibe_path="/bin/vibe")
+
+    assert events == ["acquired", "released"]
+
+
+def test_upgrade_transaction_preflight_failure_leaves_runtime_running(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    monkeypatch.setattr(restart_supervisor.runtime, "verified_service_running", lambda: True)
+    monkeypatch.setattr(restart_supervisor, "build_upgrade_plan", lambda **kwargs: restart_supervisor.UpgradePlan(
+        command=["install"], env={}, method="pip", preflight_command=["download"]
+    ))
+    monkeypatch.setattr(restart_supervisor, "preflight_upgrade_plan", lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout="offline", stderr=""))
+    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda **kwargs: pytest.fail("preflight must fail before stop"))
+    assert restart_supervisor._run_restart_job(
+        job_id="tx-preflight-fail",
+        delay_seconds=0,
+        vibe_path="/bin/vibe",
+        trigger="upgrade",
+        upgrade_transaction=_upgrade_transaction(),
+    ) == 2
+    status = runtime.read_json(runtime.get_restart_status_path())
+    assert status["state"] == "failed"
+    assert "preflight" in status["error"]
+
+
+def test_upgrade_transaction_lock_timeout_fails_before_mutation(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+
+    @contextmanager
+    def busy_lock(**kwargs):
+        raise restart_supervisor.MigrationLockTimeout("busy")
+        yield
+
+    monkeypatch.setattr(restart_supervisor, "_upgrade_transaction_lock", busy_lock)
+    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda **kwargs: pytest.fail("must not stop"))
+    assert restart_supervisor._run_restart_job(
+        job_id="tx-lock-fail",
+        delay_seconds=0,
+        vibe_path="/bin/vibe",
+        trigger="upgrade",
+        upgrade_transaction=_upgrade_transaction(),
+    ) == 2
+    status = runtime.read_json(runtime.get_restart_status_path())
+    assert status["state"] == "failed"
+    assert "busy" in status["error"]
+
+
+def test_upgrade_transaction_keeps_lease_across_preflight_stop_install_start(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    events = []
+    plan = restart_supervisor.UpgradePlan(command=["install"], env={}, method="pip", preflight_command=["download"])
+
+    @contextmanager
+    def lease(**kwargs):
+        events.append("lease-enter")
+        try:
+            yield
+        finally:
+            events.append("lease-exit")
+
+    monkeypatch.setattr(restart_supervisor, "_upgrade_transaction_lock", lease)
+    monkeypatch.setattr(restart_supervisor.runtime, "verified_service_running", lambda: True)
+    monkeypatch.setattr(restart_supervisor, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(restart_supervisor, "preflight_upgrade_plan", lambda *args, **kwargs: events.append("preflight"))
+    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda **kwargs: events.append("stop") or (True, {}, 0, None, True, 0))
+    monkeypatch.setattr(restart_supervisor, "_wait_for_service_lock_release", lambda: events.append("wait") or True)
+    monkeypatch.setattr(restart_supervisor, "execute_upgrade_plan", lambda *args, **kwargs: events.append("install") or SimpleNamespace(returncode=0, stdout="", stderr=""))
+    monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda **kwargs: events.append("start") or restart_supervisor.StartedRuntime(222, None, None))
+    monkeypatch.setattr(restart_supervisor.runtime, "wait_for_service_ready", lambda *args, **kwargs: 222)
+    monkeypatch.setattr(restart_supervisor.runtime, "write_status", lambda *args, **kwargs: None)
+    monkeypatch.setattr(restart_supervisor, "_read_recorded_pid", lambda: 111)
+
+    assert restart_supervisor._run_restart_job(
+        job_id="tx-sequence",
+        delay_seconds=0,
+        vibe_path="/bin/vibe",
+        trigger="upgrade",
+        upgrade_transaction=_upgrade_transaction(),
+    ) == 0
+    assert events.index("lease-enter") < events.index("preflight") < events.index("stop") < events.index("install") < events.index("start") < events.index("lease-exit")
+
+
+def test_upgrade_transaction_main_reassembles_declared_fields(monkeypatch):
+    captured = {}
+    monkeypatch.setattr("vibe.memory_ui_access.initialize_process_ui_read_secret", lambda: None)
+    monkeypatch.setattr(
+        restart_supervisor,
+        "_run_restart_job",
+        lambda **kwargs: captured.update(kwargs) or 0,
+    )
+    argv = [
+        "--job-id",
+        "tx-1",
+        "--upgrade-transaction-version",
+        "1",
+        "--upgrade-installer",
+        "pip",
+        "--upgrade-forward-spec",
+        "avibe-os[memory]",
+        "--upgrade-include-memory",
+        "--upgrade-memory-requirement",
+        MEMORY_PACKAGE_REQUIREMENT,
+    ]
+    assert restart_supervisor.main(argv) == 0
+    transaction = captured["upgrade_transaction"]
+    assert transaction.schema_version == 1
+    assert transaction.installer == "pip"
+    assert transaction.forward_spec == "avibe-os[memory]"
+    assert transaction.memory_requirement == MEMORY_PACKAGE_REQUIREMENT
 
 
 @pytest.mark.parametrize(

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -183,6 +183,46 @@ def test_legacy_upgrade_target_reads_the_running_release_and_launcher(monkeypatc
     )
 
 
+@pytest.mark.parametrize("core_package", ["avibe-os", "vibe-remote"])
+def test_legacy_upgrade_target_keeps_memory_out_of_core_ownership(
+    monkeypatch, tmp_path, core_package
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    paths.ensure_data_dirs()
+    package_dir = core_package.replace("-", "_")
+    tool_root = tmp_path / "uv" / "tools" / core_package
+    python_path = tool_root / "bin" / "python"
+    service_main = tool_root / "lib" / "python3.12" / "site-packages" / "vibe" / "service_main.py"
+    python_path.parent.mkdir(parents=True)
+    service_main.parent.mkdir(parents=True)
+    python_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    service_main.write_text("# old release\n", encoding="utf-8")
+    metadata_root = service_main.parent.parent
+    for directory, name in (("avibe_memory", "avibe-memory"), (package_dir, core_package)):
+        metadata_dir = metadata_root / f"{directory}-3.0.14.dist-info"
+        metadata_dir.mkdir()
+        (metadata_dir / "METADATA").write_text(
+            f"Name: {name}\nVersion: 3.0.14\n", encoding="utf-8"
+        )
+
+    monkeypatch.setattr(restart_supervisor, "_read_recorded_pid", lambda: 123)
+    monkeypatch.setattr(restart_supervisor, "_read_recorded_ui_pid", lambda: None)
+    monkeypatch.setattr(restart_supervisor, "_running_ui_version", lambda: "3.0.14")
+    monkeypatch.setattr(runtime, "get_process_command", lambda _pid: f"{python_path} {service_main}")
+
+    target = restart_supervisor._discover_legacy_upgrade_target(
+        trigger="upgrade", vibe_path=str(tmp_path / "retargeted-vibe")
+    )
+
+    assert target == RollbackTarget(
+        version="3.0.14",
+        package=core_package,
+        launcher=runtime.ServiceLauncher(python=str(python_path), main=str(service_main)),
+        memory_package=True,
+        memory_version="3.0.14",
+    )
+
+
 def test_legacy_upgrade_target_prefers_running_version_over_stale_metadata(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     paths.ensure_data_dirs()

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import ast
 import inspect
 import io
-import json
 import os
 import sqlite3
 import sys
@@ -11,7 +10,6 @@ import textwrap
 import threading
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -20,7 +18,7 @@ from config import paths
 from storage.backups import create_sqlite_migration_backup
 from vibe import restart_supervisor
 from vibe import runtime
-from vibe.upgrade import MEMORY_PACKAGE_REQUIREMENT, RollbackTarget, UpgradeTransaction
+from vibe.upgrade import RollbackTarget
 
 
 #: The install the machine was on before the upgrade replaced it. Deliberately
@@ -38,23 +36,6 @@ def _rollback_target(version: str = "3.0.10") -> RollbackTarget:
     """The install to go back to, as the upgrade captured it before installing."""
 
     return RollbackTarget(version=version, package="vibe-remote", launcher=_REPLACED_INSTALL)
-
-
-def _upgrade_transaction() -> UpgradeTransaction:
-    return UpgradeTransaction(
-        schema_version=1,
-        installer="pip",
-        forward_spec="avibe-os[memory]",
-        include_memory=True,
-        memory_requirement="avibe-memory>=3.0.14.dev0,<3.1",
-        rollback_to=RollbackTarget(
-            version="3.0.14",
-            package="avibe-os",
-            launcher=_REPLACED_INSTALL,
-            memory_package=True,
-            memory_version="3.0.14",
-        ),
-    )
 
 
 def _fake_start_runtime(calls, service_pid: int = 222, ui_pid: int = 333):
@@ -541,399 +522,6 @@ def test_schedule_restart_marks_status_failed_when_spawn_fails(monkeypatch, tmp_
     assert status["ok"] is False
     assert status["state"] == "failed"
     assert "failed to spawn" in status["error"]
-
-
-def test_schedule_upgrade_transaction_carries_only_typed_shape(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    paths.ensure_data_dirs()
-    spawned = {}
-    monkeypatch.setattr(restart_supervisor, "get_restart_invocation_command", lambda vibe_path=None: ["/bin/vibe", "restart"])
-    monkeypatch.setattr(restart_supervisor, "get_restart_environment", lambda vibe_path=None: {"PATH": "/bin"})
-    monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
-    monkeypatch.setattr(restart_supervisor, "_prune_restart_logs", lambda: None)
-    monkeypatch.setattr(restart_supervisor, "process_ui_read_secret", lambda: None, raising=False)
-
-    def fake_popen(command, **kwargs):
-        spawned["command"] = command
-        return SimpleNamespace(pid=1234)
-
-    monkeypatch.setattr(restart_supervisor.subprocess, "Popen", fake_popen)
-    result = restart_supervisor.schedule_upgrade_transaction(_upgrade_transaction(), vibe_path="/bin/vibe")
-    command = spawned["command"]
-    assert result["transaction"] == "upgrade-v1"
-    assert "--upgrade-transaction-file" in command
-    payload_path = Path(command[command.index("--upgrade-transaction-file") + 1])
-    assert payload_path.stat().st_mode & 0o777 == 0o600
-    assert payload_path.parent.stat().st_mode & 0o777 == 0o700
-    assert "avibe-os[memory]" not in command
-    assert MEMORY_PACKAGE_REQUIREMENT not in command
-    assert not any(part in {"--command", "--env"} for part in command)
-    payload_path.unlink()
-
-
-def test_upgrade_transaction_payload_is_consumed_and_rejects_unknown_fields(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    paths.ensure_data_dirs()
-    path = restart_supervisor._write_upgrade_transaction_file(_upgrade_transaction(), "tx-payload")
-    payload = runtime.read_json(path)
-    assert payload["forward_spec"] == "avibe-os[memory]"
-    assert restart_supervisor._read_upgrade_transaction_file(str(path)).forward_spec == "avibe-os[memory]"
-    assert not path.exists()
-    path.write_text('{"schema_version":1,"unknown":true}', encoding="utf-8")
-    with pytest.raises(ValueError, match="unknown or missing"):
-        restart_supervisor._read_upgrade_transaction_file(str(path))
-    assert not path.exists()
-
-    malformed = _upgrade_transaction().to_payload()
-    malformed["include_memory"] = "true"
-    path = restart_supervisor._write_upgrade_transaction_file(_upgrade_transaction(), "tx-malformed")
-    path.write_text(json.dumps(malformed), encoding="utf-8")
-    with pytest.raises(ValueError, match="scalar fields"):
-        restart_supervisor._read_upgrade_transaction_file(str(path))
-    assert not path.exists()
-
-    package_optional = _upgrade_transaction().to_payload()
-    package_optional["rollback_to"]["package"] = None
-    path = restart_supervisor._write_upgrade_transaction_file(_upgrade_transaction(), "tx-optional-package")
-    path.write_text(json.dumps(package_optional), encoding="utf-8")
-    assert restart_supervisor._read_upgrade_transaction_file(str(path)).rollback_to.package is None
-
-
-def test_upgrade_transaction_refuses_when_ordinary_restart_is_active(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    paths.ensure_data_dirs()
-    runtime.write_json(
-        runtime.get_restart_status_path(),
-        {"state": "running", "supervisor_pid": os.getpid(), "trigger": "cli"},
-    )
-    with pytest.raises(RuntimeError, match="restart is already in progress"):
-        restart_supervisor.schedule_upgrade_transaction(_upgrade_transaction(), vibe_path="/bin/vibe")
-
-
-def test_restart_admission_ignores_dead_supervisor_status(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    paths.ensure_data_dirs()
-    runtime.write_json(
-        runtime.get_restart_status_path(),
-        {
-            "state": "running",
-            "supervisor_pid": 1234,
-            "supervisor_started_at": 1.0,
-            "transaction": "upgrade-v1",
-        },
-    )
-    monkeypatch.setattr(runtime, "pid_alive", lambda pid: False)
-    assert restart_supervisor._restart_job_active() is False
-    assert restart_supervisor._upgrade_transaction_active() is False
-
-
-def test_restart_admission_rejects_reused_supervisor_pid(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    paths.ensure_data_dirs()
-    runtime.write_json(
-        runtime.get_restart_status_path(),
-        {
-            "state": "running",
-            "supervisor_pid": 1234,
-            "supervisor_started_at": 1.0,
-            "transaction": "upgrade-v1",
-        },
-    )
-    monkeypatch.setattr(runtime, "pid_alive", lambda pid: True)
-    monkeypatch.setattr(runtime, "process_create_time", lambda pid: 2.0)
-    assert restart_supervisor._restart_job_active() is False
-    assert restart_supervisor._upgrade_transaction_active() is False
-
-
-def test_ordinary_restart_admission_uses_transaction_gate(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    paths.ensure_data_dirs()
-    events = []
-
-    @contextmanager
-    def gate(**kwargs):
-        events.append("acquired")
-        yield
-        events.append("released")
-
-    monkeypatch.setattr(restart_supervisor, "_upgrade_transaction_lock", gate)
-    monkeypatch.setattr(restart_supervisor, "get_restart_invocation_command", lambda vibe_path=None: ["/bin/vibe", "restart"])
-    monkeypatch.setattr(restart_supervisor, "get_restart_environment", lambda vibe_path=None: None)
-    monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
-    monkeypatch.setattr(restart_supervisor, "_prune_restart_logs", lambda: None)
-    monkeypatch.setattr(restart_supervisor.subprocess, "Popen", lambda *args, **kwargs: SimpleNamespace(pid=1234))
-
-    restart_supervisor.schedule_restart(vibe_path="/bin/vibe")
-
-    assert events == ["acquired", "released"]
-
-
-def test_upgrade_transaction_preflight_failure_leaves_runtime_running(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    paths.ensure_data_dirs()
-    monkeypatch.setattr(restart_supervisor.runtime, "verified_service_running", lambda: True)
-    monkeypatch.setattr(restart_supervisor, "build_upgrade_plan", lambda **kwargs: restart_supervisor.UpgradePlan(
-        command=["install"], env={}, method="pip", preflight_command=["download"]
-    ))
-    monkeypatch.setattr(restart_supervisor, "preflight_upgrade_plan", lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout="offline", stderr=""))
-    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda **kwargs: pytest.fail("preflight must fail before stop"))
-    assert restart_supervisor._run_restart_job(
-        job_id="tx-preflight-fail",
-        delay_seconds=0,
-        vibe_path="/bin/vibe",
-        trigger="upgrade",
-        upgrade_transaction=_upgrade_transaction(),
-    ) == 2
-    status = runtime.read_json(runtime.get_restart_status_path())
-    assert status["state"] == "failed"
-    assert "preflight" in status["error"]
-
-
-@pytest.mark.parametrize("readiness", ["start", "ready", "exception", "dead"])
-def test_upgrade_transaction_activation_failure_rolls_back_exact_memory_shape(monkeypatch, tmp_path, readiness):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    paths.ensure_data_dirs()
-    target = _upgrade_transaction().rollback_to
-    rollback_calls = []
-    monkeypatch.setattr(restart_supervisor.runtime, "verified_service_running", lambda: True)
-    monkeypatch.setattr(
-        restart_supervisor,
-        "build_upgrade_plan",
-        lambda **kwargs: restart_supervisor.UpgradePlan(command=["install"], env={}, method="pip"),
-    )
-    monkeypatch.setattr(restart_supervisor, "preflight_upgrade_plan", lambda *args, **kwargs: SimpleNamespace(returncode=0))
-    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda **kwargs: (True, {}, 0, None, True, 0))
-    monkeypatch.setattr(restart_supervisor, "_wait_for_service_lock_release", lambda: True)
-    monkeypatch.setattr(
-        restart_supervisor,
-        "execute_upgrade_plan",
-        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
-    )
-    if readiness == "start":
-        monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
-    elif readiness == "dead":
-        monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda **kwargs: restart_supervisor.StartedRuntime(222, None, None))
-        monkeypatch.setattr(restart_supervisor.runtime, "pid_alive", lambda pid: False)
-    elif readiness == "ready":
-        monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda **kwargs: restart_supervisor.StartedRuntime(222, None, None))
-        monkeypatch.setattr(restart_supervisor.runtime, "wait_for_service_ready", lambda *args, **kwargs: None)
-    else:
-        monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda **kwargs: restart_supervisor.StartedRuntime(222, None, None))
-        monkeypatch.setattr(
-            restart_supervisor.runtime,
-            "wait_for_service_ready",
-            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("readiness probe failed")),
-        )
-    monkeypatch.setattr(
-        restart_supervisor,
-        "_roll_back_failed_upgrade",
-        lambda **kwargs: rollback_calls.append(kwargs["rollback_to"]) or {"state": "succeeded"},
-    )
-    result = restart_supervisor._run_restart_job(
-        job_id=f"tx-activation-{readiness}",
-        delay_seconds=0,
-        vibe_path="/bin/vibe",
-        trigger="upgrade",
-        scope="service",
-        upgrade_transaction=_upgrade_transaction(),
-    )
-    assert result in {1, 3}
-    assert rollback_calls == [target]
-    assert target.memory_package is True
-    assert target.memory_version == "3.0.14"
-
-
-def test_upgrade_transaction_aborts_when_ui_survives_stop(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    paths.ensure_data_dirs()
-    calls = []
-    monkeypatch.setattr(restart_supervisor.runtime, "verified_service_running", lambda: True)
-    monkeypatch.setattr(
-        restart_supervisor,
-        "build_upgrade_plan",
-        lambda **kwargs: restart_supervisor.UpgradePlan(command=["install"], env={}, method="pip"),
-    )
-    monkeypatch.setattr(restart_supervisor, "preflight_upgrade_plan", lambda *args, **kwargs: SimpleNamespace(returncode=0))
-    monkeypatch.setattr(
-        restart_supervisor,
-        "_stop_runtime_for_restart",
-        lambda **kwargs: (False, {}, 0, 333, True, 0),
-    )
-    monkeypatch.setattr(restart_supervisor.runtime, "pid_alive", lambda pid: pid == 333)
-    monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda **kwargs: calls.append("recover") or restart_supervisor.StartedRuntime(222, 333, None))
-    monkeypatch.setattr(restart_supervisor.runtime, "wait_for_service_ready", lambda *args, **kwargs: 222)
-    monkeypatch.setattr(
-        restart_supervisor,
-        "execute_upgrade_plan",
-        lambda *args, **kwargs: calls.append("install") or pytest.fail("UI stop failure must precede install"),
-    )
-    result = restart_supervisor._run_restart_job(
-        job_id="tx-ui-stop-fail",
-        delay_seconds=0,
-        vibe_path="/bin/vibe",
-        trigger="upgrade",
-        upgrade_transaction=_upgrade_transaction(),
-    )
-    assert result == 2
-    assert calls == ["recover"]
-
-
-def test_upgrade_transaction_checks_live_ui_identity_when_stop_has_no_pid(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    paths.ensure_data_dirs()
-    calls = []
-    monkeypatch.setattr(restart_supervisor.runtime, "verified_service_running", lambda: True)
-    monkeypatch.setattr(
-        restart_supervisor,
-        "build_upgrade_plan",
-        lambda **kwargs: restart_supervisor.UpgradePlan(command=["install"], env={}, method="pip"),
-    )
-    monkeypatch.setattr(restart_supervisor, "preflight_upgrade_plan", lambda *args, **kwargs: SimpleNamespace(returncode=0))
-    monkeypatch.setattr(
-        restart_supervisor,
-        "_stop_runtime_for_restart",
-        lambda **kwargs: (True, {}, 0, None, True, 0),
-    )
-    monkeypatch.setattr(restart_supervisor.runtime, "ui_pid_file_points_to_running_ui", lambda: True)
-    monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda **kwargs: calls.append("recover") or restart_supervisor.StartedRuntime(222, None, None))
-    monkeypatch.setattr(restart_supervisor.runtime, "wait_for_service_ready", lambda *args, **kwargs: 222)
-    monkeypatch.setattr(
-        restart_supervisor,
-        "execute_upgrade_plan",
-        lambda *args, **kwargs: calls.append("install") or pytest.fail("live UI must block package mutation"),
-    )
-    assert restart_supervisor._run_restart_job(
-        job_id="tx-ui-identity-stop-fail",
-        delay_seconds=0,
-        vibe_path="/bin/vibe",
-        trigger="upgrade",
-        upgrade_transaction=_upgrade_transaction(),
-    ) == 2
-    assert calls == ["recover"]
-
-
-def test_upgrade_transaction_lock_timeout_fails_before_mutation(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    paths.ensure_data_dirs()
-
-    @contextmanager
-    def busy_lock(**kwargs):
-        raise restart_supervisor.MigrationLockTimeout("busy")
-        yield
-
-    monkeypatch.setattr(restart_supervisor, "_upgrade_transaction_lock", busy_lock)
-    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda **kwargs: pytest.fail("must not stop"))
-    assert restart_supervisor._run_restart_job(
-        job_id="tx-lock-fail",
-        delay_seconds=0,
-        vibe_path="/bin/vibe",
-        trigger="upgrade",
-        upgrade_transaction=_upgrade_transaction(),
-    ) == 2
-    status = runtime.read_json(runtime.get_restart_status_path())
-    assert status["state"] == "failed"
-    assert "busy" in status["error"]
-
-
-def test_upgrade_transaction_keeps_lease_across_preflight_stop_install_start(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    paths.ensure_data_dirs()
-    events = []
-    build_kwargs = {}
-    plan = restart_supervisor.UpgradePlan(command=["install"], env={}, method="pip", preflight_command=["download"])
-
-    @contextmanager
-    def lease(**kwargs):
-        events.append("lease-enter")
-        try:
-            yield
-        finally:
-            events.append("lease-exit")
-
-    monkeypatch.setattr(restart_supervisor, "_upgrade_transaction_lock", lease)
-    monkeypatch.setattr(restart_supervisor.runtime, "verified_service_running", lambda: True)
-    monkeypatch.setattr(restart_supervisor, "build_upgrade_plan", lambda **kwargs: build_kwargs.update(kwargs) or plan)
-    monkeypatch.setattr(restart_supervisor, "preflight_upgrade_plan", lambda *args, **kwargs: events.append("preflight"))
-    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda **kwargs: events.append("stop") or (True, {}, 0, None, True, 0))
-    monkeypatch.setattr(restart_supervisor, "_wait_for_service_lock_release", lambda: events.append("wait") or True)
-    monkeypatch.setattr(restart_supervisor, "execute_upgrade_plan", lambda *args, **kwargs: events.append("install") or SimpleNamespace(returncode=0, stdout="", stderr=""))
-    monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda **kwargs: events.append("start") or restart_supervisor.StartedRuntime(222, None, None))
-    monkeypatch.setattr(restart_supervisor.runtime, "pid_alive", lambda pid: pid == 222)
-    monkeypatch.setattr(restart_supervisor.runtime, "wait_for_service_ready", lambda *args, **kwargs: 222)
-    monkeypatch.setattr(restart_supervisor.runtime, "write_status", lambda *args, **kwargs: None)
-    monkeypatch.setattr(restart_supervisor, "_read_recorded_pid", lambda: 111)
-
-    assert restart_supervisor._run_restart_job(
-        job_id="tx-sequence",
-        delay_seconds=0,
-        vibe_path="/bin/vibe",
-        trigger="upgrade",
-        upgrade_transaction=_upgrade_transaction(),
-    ) == 0
-    assert events.index("lease-enter") < events.index("preflight") < events.index("stop") < events.index("install") < events.index("start") < events.index("lease-exit")
-    assert build_kwargs["memory_requirement"] == _upgrade_transaction().memory_requirement
-    assert build_kwargs["memory_package"] is True
-
-
-def test_upgrade_transaction_prepares_show_runtime_nonfatally(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    paths.ensure_data_dirs()
-    events = []
-    monkeypatch.setattr(restart_supervisor.runtime, "verified_service_running", lambda: False)
-    monkeypatch.setattr(
-        restart_supervisor,
-        "build_upgrade_plan",
-        lambda **kwargs: restart_supervisor.UpgradePlan(command=["install"], env={}, method="pip"),
-    )
-    monkeypatch.setattr(restart_supervisor, "preflight_upgrade_plan", lambda *args, **kwargs: SimpleNamespace(returncode=0))
-    monkeypatch.setattr(
-        restart_supervisor,
-        "execute_upgrade_plan",
-        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
-    )
-    monkeypatch.setattr(
-        restart_supervisor,
-        "_prepare_show_runtime_nonfatal",
-        lambda *args, **kwargs: events.append("prepare"),
-    )
-    transaction = UpgradeTransaction(1, "pip", "avibe-os", False, None, None, "none")
-    assert restart_supervisor._run_restart_job(
-        job_id="tx-prepare",
-        delay_seconds=0,
-        vibe_path="/bin/vibe",
-        trigger="upgrade",
-        scope="service",
-        prepare_show_runtime=True,
-        upgrade_transaction=transaction,
-    ) == 0
-    assert events == ["prepare"]
-
-
-def test_upgrade_transaction_main_reassembles_declared_fields(monkeypatch, tmp_path):
-    captured = {}
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    paths.ensure_data_dirs()
-    transaction = _upgrade_transaction()
-    payload_path = restart_supervisor._write_upgrade_transaction_file(transaction, "tx-1")
-    monkeypatch.setattr("vibe.memory_ui_access.initialize_process_ui_read_secret", lambda: None)
-    monkeypatch.setattr(
-        restart_supervisor,
-        "_run_restart_job",
-        lambda **kwargs: captured.update(kwargs) or 0,
-    )
-    argv = [
-        "--job-id",
-        "tx-1",
-        "--upgrade-transaction-file",
-        str(payload_path),
-    ]
-    assert restart_supervisor.main(argv) == 0
-    captured_transaction = captured["upgrade_transaction"]
-    assert captured_transaction.schema_version == 1
-    assert captured_transaction.installer == "pip"
-    assert captured_transaction.forward_spec == "avibe-os[memory]"
-    assert captured_transaction.memory_requirement == MEMORY_PACKAGE_REQUIREMENT
-    assert not payload_path.exists()
 
 
 @pytest.mark.parametrize(
@@ -1952,3 +1540,35 @@ def test_a_recoverable_restart_carries_its_rollback_target_into_the_job(monkeypa
     # from here" is the exact wrong answer, and a silent one.
     with pytest.raises(SystemExit):
         restart_supervisor.main(["--job-id", "jobpartial", "--rollback-to", "3.0.10"])
+
+
+def test_recoverable_restart_carries_memory_shape_into_rollback_job(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    commands: list[list[str]] = []
+    monkeypatch.setattr(restart_supervisor, "get_restart_invocation_command", lambda vibe_path=None: ["/bin/vibe", "restart"])
+    monkeypatch.setattr(restart_supervisor, "get_restart_environment", lambda vibe_path=None: {"PATH": "/bin"})
+    monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
+    monkeypatch.setattr(restart_supervisor, "_prune_restart_logs", lambda: None)
+    monkeypatch.setattr(
+        restart_supervisor.subprocess,
+        "Popen",
+        lambda command, **kwargs: commands.append(command) or SimpleNamespace(pid=4242),
+    )
+    target = RollbackTarget(
+        version="3.0.10",
+        package="avibe-os",
+        launcher=_REPLACED_INSTALL,
+        memory_package=True,
+        memory_version="3.0.10",
+    )
+
+    restart_supervisor.schedule_restart(vibe_path="/bin/vibe", trigger="upgrade", rollback_to=target)
+    argv = commands[-1]
+    assert "--rollback-memory-package" in argv
+    assert argv[argv.index("--rollback-memory-version") + 1] == "3.0.10"
+
+    parsed: dict = {}
+    monkeypatch.setattr(restart_supervisor, "_run_restart_job", lambda **kwargs: parsed.update(kwargs) or 0)
+    assert restart_supervisor.main(argv[2:]) == 0
+    assert parsed["rollback_to"] == target

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -1432,6 +1432,87 @@ def test_memory_enabled_forward_plan_derives_target_from_versioned_spec(
 @pytest.mark.parametrize(
     "package_spec",
     [
+        "/fixtures/avibe_os-3.2.0-py3-none-any.whl",
+        "avibe-os @ https://example.test/releases/avibe_os-3.2.0-py3-none-any.whl",
+        "avibe-os==3.2.0",
+    ],
+)
+def test_exact_package_spec_overrides_conflicting_memory_target(monkeypatch, package_spec):
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
+
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        base_env={"PATH": "/usr/bin"},
+        memory_enabled=True,
+        target_version="3.1.0",
+        package_spec=package_spec,
+    )
+
+    for command in (plan.command, plan.preflight_command, plan.preflight_fallback_command):
+        assert command is not None
+        assert "avibe-memory==3.2.0" in command
+        assert "avibe-memory==3.1.0" not in command
+
+
+def test_uv_exact_artifact_overrides_conflicting_memory_target(monkeypatch):
+    monkeypatch.setattr("vibe.upgrade.is_uv_tool_install", lambda executable: True)
+    monkeypatch.setattr("vibe.upgrade.is_legacy_uv_tool_install", lambda executable: False)
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: "/usr/bin/uv")
+    monkeypatch.setattr("vibe.upgrade.get_current_vibe_bin_dir", lambda vibe_path: None)
+
+    plan = build_upgrade_plan(
+        python_executable="/tools/avibe/bin/python",
+        base_env={"PATH": "/usr/bin"},
+        memory_enabled=True,
+        target_version="3.1.0",
+        package_spec="/fixtures/avibe_os-3.2.0-py3-none-any.whl",
+    )
+
+    assert "avibe-memory==3.2.0" in plan.command
+    assert "avibe-memory==3.1.0" not in plan.command
+    assert plan.preflight_command is not None
+    assert "avibe-memory==3.2.0" in plan.preflight_command
+    assert "avibe-memory==3.1.0" not in plan.preflight_command
+
+
+@pytest.mark.parametrize(
+    "package_spec",
+    [
+        "avibe-os",
+        "avibe-os>=3.1,<3.2",
+        "avibe-os==3.1.*",
+    ],
+)
+def test_named_package_spec_accepts_compatible_memory_target(monkeypatch, package_spec):
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
+
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        base_env={"PATH": "/usr/bin"},
+        memory_enabled=True,
+        target_version="3.1.4",
+        package_spec=package_spec,
+    )
+
+    assert "avibe-memory==3.1.4" in plan.command
+
+
+def test_named_package_spec_rejects_incompatible_memory_target(monkeypatch):
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
+
+    with pytest.raises(ValueError, match="target release version"):
+        build_upgrade_plan(
+            python_executable="/usr/bin/python3",
+            base_env={"PATH": "/usr/bin"},
+            memory_enabled=True,
+            target_version="3.2.0",
+            package_spec="avibe-os>=3.1,<3.2",
+        )
+
+
+@pytest.mark.parametrize(
+    "package_spec",
+    [
         "avibe-os",
         "avibe-os>=3.1,<3.2",
         "avibe-os==3.1.*",
@@ -1452,7 +1533,17 @@ def test_memory_enabled_forward_plan_rejects_unversioned_fallback_specs(monkeypa
         )
 
 
-def test_memory_fallback_refusal_does_not_expose_direct_spec_credentials(monkeypatch):
+@pytest.mark.parametrize(
+    "package_spec",
+    [
+        "git+https://example.test/avibe.git@v3.1.0",
+        "avibe-os @ git+https://example.test/avibe.git@v3.1.0",
+        "https://user:secret@example.test/download",
+        "avibe-os @ https://user:secret@example.test/download",
+        "/fixtures/avibe.whl",
+    ],
+)
+def test_opaque_memory_source_rejects_metadata_without_exposing_spec(monkeypatch, package_spec):
     monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
 
     with pytest.raises(ValueError) as refusal:
@@ -1460,10 +1551,11 @@ def test_memory_fallback_refusal_does_not_expose_direct_spec_credentials(monkeyp
             python_executable="/usr/bin/python3",
             base_env={"PATH": "/usr/bin"},
             memory_enabled=True,
-            package_spec="avibe-os @ https://user:secret@example.test/download",
+            target_version="3.1.0",
+            package_spec=package_spec,
         )
 
-    assert "secret" not in str(refusal.value)
+    assert str(refusal.value) == "A Memory-preserving upgrade requires a target release version"
 
 
 def test_memory_preflight_failure_does_not_mutate_package(monkeypatch):

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -872,224 +872,6 @@ LEGACY_INSTALL = RollbackTarget(
 )
 
 
-@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
-def test_do_upgrade_uses_upgrade_plan_env_and_restarts(monkeypatch):
-    plan = UpgradePlan(
-        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
-        env={"UV_TOOL_BIN_DIR": "/custom/bin"},
-        method="uv",
-        rollback_to=LEGACY_INSTALL,
-    )
-    calls: dict[str, Any] = {}
-
-    monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
-    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
-    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
-    monkeypatch.setattr(api, "schedule_restart", lambda **kwargs: calls.setdefault("restart_kwargs", kwargs))
-
-    def fake_run(cmd, **kwargs):
-        if cmd == plan.command:
-            calls["run_cmd"] = cmd
-            calls["run_kwargs"] = kwargs
-        else:
-            raise AssertionError(f"unexpected subprocess command: {cmd}")
-        return subprocess.CompletedProcess(cmd, 0, stdout="done", stderr="")
-
-    monkeypatch.setattr(api.subprocess, "run", fake_run)
-    result = api.do_upgrade(auto_restart=True)
-
-    assert result["ok"] is True
-    assert result["restarting"] is True
-    assert calls["run_cmd"] == plan.command
-    assert calls["run_kwargs"]["capture_output"] is True
-    assert calls["run_kwargs"]["text"] is True
-    assert calls["run_kwargs"]["timeout"] == 120
-    assert calls["run_kwargs"]["env"] == plan.env
-    safe_cwd = calls["run_kwargs"].get("cwd")
-    assert safe_cwd and os.path.isabs(safe_cwd), f"subprocess.run cwd must be an absolute path, got {safe_cwd!r}"
-    assert calls["restart_kwargs"] == {
-        "delay_seconds": 2.0,
-        "vibe_path": "/custom/bin/vibe",
-        "trigger": "upgrade",
-        "prepare_show_runtime": True,
-        # The install this process was running, taken BEFORE it was replaced and
-        # carried here by the plan that replaced it: what the restart reinstalls
-        # if it cannot bring the new one up. Version, distribution and launcher
-        # together, because a pin needs the first two and a machine that predates
-        # the rename does not answer "avibe-os" for either.
-        "rollback_to": LEGACY_INSTALL,
-    }
-
-
-@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
-def test_do_upgrade_auto_restart_does_not_block_on_runtime_prepare(monkeypatch):
-    plan = UpgradePlan(
-        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
-        env=None,
-        method="uv",
-    )
-    events: list[str] = []
-
-    monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
-    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
-    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
-    monkeypatch.setattr(api, "schedule_restart", lambda **kwargs: events.append("restart") or {"job_id": "restart"})
-
-    def fake_run(cmd, **kwargs):
-        if cmd == plan.command:
-            events.append("upgrade")
-        else:
-            raise AssertionError(f"unexpected subprocess command: {cmd}")
-        return subprocess.CompletedProcess(cmd, 0, stdout="done", stderr="")
-
-    monkeypatch.setattr(api.subprocess, "run", fake_run)
-
-    result = api.do_upgrade(auto_restart=True)
-
-    assert result["ok"] is True
-    assert events == ["upgrade", "restart"]
-
-
-@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
-def test_do_upgrade_running_runtime_honors_show_runtime_skip_for_restart(monkeypatch):
-    plan = UpgradePlan(
-        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
-        env=None,
-        method="uv",
-    )
-    calls: dict[str, Any] = {}
-
-    monkeypatch.setenv("VIBE_INSTALL_SKIP_SHOW_RUNTIME", "1")
-    monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
-    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
-    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
-    monkeypatch.setattr(api, "schedule_restart", lambda **kwargs: calls.setdefault("restart_kwargs", kwargs))
-    monkeypatch.setattr(
-        api.subprocess,
-        "run",
-        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout="done", stderr=""),
-    )
-
-    result = api.do_upgrade(auto_restart=True)
-
-    assert result["ok"] is True
-    assert result["restarting"] is True
-    assert calls["restart_kwargs"]["prepare_show_runtime"] is False
-
-
-@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
-def test_do_upgrade_reports_restart_scheduling_failure_as_partial_success(monkeypatch):
-    plan = UpgradePlan(
-        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
-        env=None,
-        method="uv",
-    )
-
-    monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
-    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
-    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
-
-    def fail_restart(**kwargs):
-        raise RuntimeError("bad launcher")
-
-    monkeypatch.setattr(api, "schedule_restart", fail_restart)
-    monkeypatch.setattr(
-        api.subprocess,
-        "run",
-        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout="done", stderr=""),
-    )
-
-    result = api.do_upgrade(auto_restart=True)
-
-    assert result["ok"] is True
-    assert result["restarting"] is False
-    assert result["message"] == "Upgrade successful, but restart scheduling failed. Please restart vibe."
-    assert "Restart scheduling failed" in result["output"]
-    assert "bad launcher" in result["output"]
-
-
-@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
-def test_do_upgrade_without_auto_restart_prepares_runtime(monkeypatch):
-    plan = UpgradePlan(
-        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
-        env=None,
-        method="uv",
-    )
-    calls: dict[str, Any] = {}
-
-    monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
-    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
-    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
-
-    def fail_restart(**kwargs):
-        raise AssertionError("schedule_restart should not run when auto_restart is disabled")
-
-    monkeypatch.setattr(api, "schedule_restart", fail_restart)
-
-    def fake_run(cmd, **kwargs):
-        if cmd == plan.command:
-            calls["upgrade_cmd"] = cmd
-            calls["upgrade_kwargs"] = kwargs
-            return subprocess.CompletedProcess(cmd, 0, stdout="done", stderr="")
-        if cmd == ["/custom/bin/vibe", "runtime", "prepare", "--strict"]:
-            calls["runtime_prepare_cmd"] = cmd
-            calls["runtime_prepare_kwargs"] = kwargs
-            return subprocess.CompletedProcess(cmd, 0, stdout="runtime ready", stderr="")
-        raise AssertionError(f"unexpected subprocess command: {cmd}")
-
-    monkeypatch.setattr(api.subprocess, "run", fake_run)
-
-    result = api.do_upgrade(auto_restart=False)
-
-    assert result["ok"] is True
-    assert result["restarting"] is False
-    assert result["output"] == "done\n\nruntime ready"
-    assert calls["runtime_prepare_cmd"] == ["/custom/bin/vibe", "runtime", "prepare", "--strict"]
-    assert calls["runtime_prepare_kwargs"]["capture_output"] is True
-    assert calls["runtime_prepare_kwargs"]["text"] is True
-    assert calls["runtime_prepare_kwargs"]["timeout"] == 600  # prepare now budgets for Show Runtime + askill
-    assert calls["runtime_prepare_kwargs"]["cwd"] == calls["upgrade_kwargs"]["cwd"]
-
-
-@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
-def test_do_upgrade_keeps_runtime_stopped_when_it_was_not_running(monkeypatch):
-    plan = UpgradePlan(
-        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
-        env=None,
-        method="uv",
-    )
-    calls: dict[str, Any] = {}
-
-    monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
-    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
-    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: False)
-
-    def fail_restart(**kwargs):
-        raise AssertionError("schedule_restart should not run when Avibe was not running")
-
-    monkeypatch.setattr(api, "schedule_restart", fail_restart)
-
-    def fake_run(cmd, **kwargs):
-        if cmd == plan.command:
-            calls["upgrade_cmd"] = cmd
-            calls["upgrade_kwargs"] = kwargs
-            return subprocess.CompletedProcess(cmd, 0, stdout="done", stderr="")
-        if cmd == ["/custom/bin/vibe", "runtime", "prepare", "--strict"]:
-            calls["runtime_prepare_cmd"] = cmd
-            calls["runtime_prepare_kwargs"] = kwargs
-            return subprocess.CompletedProcess(cmd, 0, stdout="runtime ready", stderr="")
-        raise AssertionError(f"unexpected subprocess command: {cmd}")
-
-    monkeypatch.setattr(api.subprocess, "run", fake_run)
-
-    result = api.do_upgrade(auto_restart=True)
-
-    assert result["ok"] is True
-    assert result["restarting"] is False
-    assert result["message"] == "Upgrade successful. Please restart vibe."
-    assert calls["runtime_prepare_cmd"] == ["/custom/bin/vibe", "runtime", "prepare", "--strict"]
-
-
 def test_api_runtime_process_was_running_checks_service_and_ui_pid_files(monkeypatch, tmp_path):
     service_pid_path = tmp_path / "service.pid"
     ui_pid_path = tmp_path / "ui.pid"
@@ -1129,154 +911,6 @@ def test_cli_runtime_process_was_running_uses_service_process_state(monkeypatch)
     assert cli._runtime_process_was_running() is True
 
 
-@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
-def test_cmd_upgrade_uses_upgrade_plan_env(monkeypatch):
-    plan = UpgradePlan(
-        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
-        env={"UV_TOOL_BIN_DIR": "/custom/bin"},
-        method="uv",
-        rollback_to=LEGACY_INSTALL,
-    )
-    calls: dict[str, Any] = {}
-
-    monkeypatch.setattr(cli, "get_latest_version", lambda: {"error": None, "has_update": True, "latest": "2.2.0"})
-    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
-    monkeypatch.setattr(cli, "build_upgrade_plan", lambda **kwargs: plan)
-    monkeypatch.setattr(cli, "_runtime_process_was_running", lambda: True)
-
-    def fake_schedule_restart(**kwargs):
-        calls["restart_kwargs"] = kwargs
-        return {"job_id": "restart"}
-
-    monkeypatch.setattr(cli, "schedule_restart", fake_schedule_restart)
-
-    def fake_run(cmd, **kwargs):
-        if cmd == plan.command:
-            calls["cmd"] = cmd
-            calls["kwargs"] = kwargs
-        else:
-            raise AssertionError(f"unexpected subprocess command: {cmd}")
-        return subprocess.CompletedProcess(cmd, 0, stdout="done", stderr="")
-
-    monkeypatch.setattr(cli.subprocess, "run", fake_run)
-
-    result = cli.cmd_upgrade()
-
-    assert result == 0
-    assert calls["cmd"] == plan.command
-    assert calls["kwargs"]["capture_output"] is True
-    assert calls["kwargs"]["text"] is True
-    assert calls["kwargs"]["env"] == plan.env
-    assert "cwd" in calls["kwargs"], "subprocess.run must specify cwd to avoid stale venv cwd"
-    assert os.path.isabs(calls["kwargs"]["cwd"]), f"cwd must be absolute, got {calls['kwargs']['cwd']!r}"
-    assert calls["restart_kwargs"] == {
-        "delay_seconds": 0.0,
-        "vibe_path": "/custom/bin/vibe",
-        "trigger": "upgrade",
-        "prepare_show_runtime": True,
-        # See the do_upgrade case: the restart is handed the install to fall back to.
-        "rollback_to": LEGACY_INSTALL,
-    }
-
-
-@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
-def test_cmd_upgrade_running_runtime_honors_show_runtime_skip_for_restart(monkeypatch):
-    plan = UpgradePlan(
-        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
-        env=None,
-        method="uv",
-    )
-    calls: dict[str, Any] = {}
-
-    monkeypatch.setenv("VIBE_INSTALL_SKIP_SHOW_RUNTIME", "true")
-    monkeypatch.setattr(cli, "get_latest_version", lambda: {"error": None, "has_update": True, "latest": "2.2.0"})
-    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
-    monkeypatch.setattr(cli, "build_upgrade_plan", lambda **kwargs: plan)
-    monkeypatch.setattr(cli, "_runtime_process_was_running", lambda: True)
-
-    def fake_schedule_restart(**kwargs):
-        calls["restart_kwargs"] = kwargs
-        return {"job_id": "restart"}
-
-    monkeypatch.setattr(cli, "schedule_restart", fake_schedule_restart)
-    monkeypatch.setattr(
-        cli.subprocess,
-        "run",
-        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout="done", stderr=""),
-    )
-
-    assert cli.cmd_upgrade() == 0
-    assert calls["restart_kwargs"]["prepare_show_runtime"] is False
-
-
-@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
-def test_cmd_upgrade_reports_restart_scheduling_failure_as_partial_success(monkeypatch, capsys):
-    plan = UpgradePlan(
-        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
-        env=None,
-        method="uv",
-    )
-
-    monkeypatch.setattr(cli, "get_latest_version", lambda: {"error": None, "has_update": True, "latest": "2.2.0"})
-    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
-    monkeypatch.setattr(cli, "build_upgrade_plan", lambda **kwargs: plan)
-    monkeypatch.setattr(cli, "_runtime_process_was_running", lambda: True)
-
-    def fail_restart(**kwargs):
-        raise RuntimeError("bad launcher")
-
-    monkeypatch.setattr(cli, "schedule_restart", fail_restart)
-    monkeypatch.setattr(
-        cli.subprocess,
-        "run",
-        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout="done", stderr=""),
-    )
-
-    assert cli.cmd_upgrade() == 2
-    output = capsys.readouterr().out
-    assert "Upgrade installed, but restart scheduling failed." in output
-    assert "Restart error: bad launcher" in output
-    assert "Run `vibe restart` to use the new version." in output
-    assert "Upgrade failed" not in output
-
-
-@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
-def test_cmd_upgrade_keeps_runtime_stopped_when_it_was_not_running(monkeypatch):
-    plan = UpgradePlan(
-        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
-        env=None,
-        method="uv",
-    )
-    calls: dict[str, Any] = {}
-
-    monkeypatch.setattr(cli, "get_latest_version", lambda: {"error": None, "has_update": True, "latest": "2.2.0"})
-    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
-    monkeypatch.setattr(cli, "build_upgrade_plan", lambda **kwargs: plan)
-    monkeypatch.setattr(cli, "_runtime_process_was_running", lambda: False)
-
-    def fail_restart(**kwargs):
-        raise AssertionError("schedule_restart should not run when Avibe was not running")
-
-    monkeypatch.setattr(cli, "schedule_restart", fail_restart)
-
-    def fake_run(cmd, **kwargs):
-        if cmd == plan.command:
-            calls["cmd"] = cmd
-            calls["kwargs"] = kwargs
-            return subprocess.CompletedProcess(cmd, 0, stdout="done", stderr="")
-        if cmd == ["/custom/bin/vibe", "runtime", "prepare", "--strict"]:
-            calls["runtime_prepare_cmd"] = cmd
-            calls["runtime_prepare_kwargs"] = kwargs
-            return subprocess.CompletedProcess(cmd, 0, stdout="runtime ready", stderr="")
-        raise AssertionError(f"unexpected subprocess command: {cmd}")
-
-    monkeypatch.setattr(cli.subprocess, "run", fake_run)
-
-    assert cli.cmd_upgrade() == 0
-    assert calls["cmd"] == plan.command
-    assert calls["runtime_prepare_cmd"] == ["/custom/bin/vibe", "runtime", "prepare", "--strict"]
-
-
 def test_cmd_upgrade_skips_install_when_already_latest(monkeypatch):
     monkeypatch.setattr(cli, "get_latest_version", lambda: {"error": None, "has_update": False, "latest": "2.2.0"})
 
@@ -1306,6 +940,7 @@ def test_api_upgrade_submits_typed_transaction(monkeypatch):
     transaction = UpgradeTransaction(1, "pip", "avibe-os[memory]", True, MEMORY_PACKAGE_REQUIREMENT, LEGACY_INSTALL)
     calls = {}
     monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
     monkeypatch.setattr(api, "configured_memory_enabled", lambda: True)
     monkeypatch.setattr(api, "build_upgrade_transaction", lambda **kwargs: transaction)
     monkeypatch.setattr(
@@ -1318,6 +953,40 @@ def test_api_upgrade_submits_typed_transaction(monkeypatch):
     assert result["restarting"] is True
     assert calls["transaction"] == transaction
     assert calls["kwargs"]["trigger"] == "upgrade"
+    assert calls["kwargs"]["prepare_show_runtime"] is True
+
+
+def test_api_upgrade_without_restart_schedules_when_runtime_is_stopped(monkeypatch):
+    transaction = UpgradeTransaction(1, "pip", "avibe-os", False, None, None, "none")
+    calls = {}
+    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: False)
+    monkeypatch.setattr(api, "build_upgrade_transaction", lambda **kwargs: calls.update(build=kwargs) or transaction)
+    monkeypatch.setattr(api, "schedule_upgrade_transaction", lambda tx, **kwargs: calls.update(schedule=kwargs) or {"job_id": "job-1"})
+    result = api.do_upgrade(auto_restart=False)
+    assert result["ok"] is True
+    assert calls["build"]["activate_runtime"] == "none"
+
+
+def test_api_upgrade_without_restart_rejects_running_runtime(monkeypatch):
+    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
+    monkeypatch.setattr(api, "build_upgrade_transaction", lambda **kwargs: pytest.fail("must reject before build"))
+    result = api.do_upgrade(auto_restart=False)
+    assert result["ok"] is False
+    assert result["code"] == "restart_required"
+
+
+def test_api_upgrade_reports_supervisor_submission_failure(monkeypatch):
+    transaction = UpgradeTransaction(1, "pip", "avibe-os", False, None, None)
+    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: False)
+    monkeypatch.setattr(api, "build_upgrade_transaction", lambda **kwargs: transaction)
+
+    def fail_schedule(*args, **kwargs):
+        raise RuntimeError("scheduler unavailable")
+
+    monkeypatch.setattr(api, "schedule_upgrade_transaction", fail_schedule)
+    result = api.do_upgrade()
+    assert result["ok"] is False
+    assert "scheduler unavailable" in result["message"]
 
 
 def test_cli_upgrade_submits_typed_transaction(monkeypatch):
@@ -1332,9 +1001,19 @@ def test_cli_upgrade_submits_typed_transaction(monkeypatch):
         "schedule_upgrade_transaction",
         lambda tx, **kwargs: calls.update(transaction=tx, kwargs=kwargs) or {"job_id": "job-1"},
     )
+    monkeypatch.setattr(cli, "_wait_for_upgrade_job", lambda job_id: {"job_id": job_id, "state": "succeeded"})
     assert cli.cmd_upgrade() == 0
     assert calls["transaction"] == transaction
     assert calls["kwargs"]["trigger"] == "upgrade"
+
+
+def test_cli_upgrade_reports_supervisor_submission_failure(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "get_latest_version", lambda: {"error": None, "has_update": True, "latest": "3.0.15"})
+    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(cli, "build_upgrade_transaction", lambda **kwargs: UpgradeTransaction(1, "pip", "avibe-os", False, None, None))
+    monkeypatch.setattr(cli, "schedule_upgrade_transaction", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("scheduler unavailable")))
+    assert cli.cmd_upgrade() == 1
+    assert "scheduler unavailable" in capsys.readouterr().out
 
 
 @pytest.mark.parametrize(
@@ -1361,7 +1040,7 @@ def test_memory_forward_pip_plan_preflights_without_dry_run(monkeypatch):
         memory_enabled=True,
         package_spec="avibe-os",
     )
-    assert plan.command[-1] == "avibe-os[memory]"
+    assert plan.command[-2:] == ["avibe-os[memory]", MEMORY_PACKAGE_REQUIREMENT]
     assert plan.preflight_command == [
         "/usr/bin/python3",
         "-m",
@@ -1371,8 +1050,36 @@ def test_memory_forward_pip_plan_preflights_without_dry_run(monkeypatch):
         PIP_DOWNLOAD_DEST_PLACEHOLDER,
         "--no-deps",
         "avibe-os[memory]",
+        MEMORY_PACKAGE_REQUIREMENT,
     ]
     assert "--dry-run" not in plan.preflight_command
+
+
+def test_forward_memory_requirement_is_carried_into_pip_plan(monkeypatch):
+    monkeypatch.setattr(upgrade_module, "memory_package_installed", lambda: False)
+    requirement = "avibe-memory==3.0.15"
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        base_env={"PATH": "/usr/bin"},
+        memory_enabled=True,
+        memory_requirement=requirement,
+        package_spec="avibe-os",
+    )
+    assert plan.command[-1] == requirement
+    assert plan.preflight_command[-1] == requirement
+
+
+def test_core_only_forward_pip_plan_preflights_direct_core_artifact(monkeypatch):
+    monkeypatch.setattr(upgrade_module, "memory_package_installed", lambda: False)
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        base_env={"PATH": "/usr/bin"},
+        memory_enabled=False,
+        memory_package=False,
+        package_spec="avibe-os",
+    )
+    assert plan.preflight_command[-1] == "avibe-os"
+    assert "--no-deps" in plan.preflight_command
 
 
 def test_memory_add_plan_is_an_explicit_force_reinstall(monkeypatch):
@@ -1416,7 +1123,7 @@ def test_explicit_core_only_shape_does_not_inherit_ambient_memory(monkeypatch):
     )
     assert plan.command[-1] == "avibe-os"
     assert "[memory]" not in " ".join(plan.command)
-    assert plan.preflight_command is None
+    assert plan.preflight_command[-1] == "avibe-os"
 
 
 def test_memory_distribution_is_not_treated_as_host_provider(monkeypatch):
@@ -1504,6 +1211,12 @@ def test_execute_upgrade_plan_preflight_failure_skips_mutation_and_cleans_scratc
 def test_upgrade_transaction_rejects_missing_memory_requirement():
     transaction = UpgradeTransaction(1, "pip", "avibe-os", True, None, None)
     with pytest.raises(ValueError, match="Memory requirement"):
+        transaction.validate()
+
+
+def test_upgrade_transaction_rejects_ignored_memory_requirement():
+    transaction = UpgradeTransaction(1, "pip", "avibe-os", False, MEMORY_PACKAGE_REQUIREMENT, None)
+    with pytest.raises(ValueError, match="must be omitted"):
         transaction.validate()
 
 

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -14,8 +14,15 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from vibe import api, cli
 from vibe.runtime import ServiceLauncher
 from vibe.upgrade import (
+    MEMORY_PACKAGE_NAME,
+    MEMORY_PACKAGE_REQUIREMENT,
+    PIP_DOWNLOAD_DEST_PLACEHOLDER,
     UpgradePlan,
+    UpgradeTransaction,
+    build_memory_add_plan,
     build_upgrade_plan,
+    build_upgrade_transaction,
+    execute_upgrade_plan,
     has_newer_version,
     get_current_vibe_bin_dir,
     get_latest_version_info,
@@ -30,6 +37,7 @@ from vibe.upgrade import (
     RollbackTarget,
     rollback_target,
 )
+import vibe.upgrade as upgrade_module
 
 
 @pytest.fixture(autouse=True)
@@ -461,6 +469,23 @@ def test_a_tree_with_no_published_release_has_no_rollback_target(monkeypatch):
     assert rollback_target() == RollbackTarget(version="3.0.10", package="vibe-remote", launcher=launcher)
 
 
+def test_rollback_target_captures_memory_presence_and_exact_version(monkeypatch):
+    launcher = ServiceLauncher(python="/venv/bin/python", main="/venv/lib/vibe/service_main.py")
+    monkeypatch.setattr("vibe.__version__", "3.0.14", raising=False)
+    monkeypatch.setattr("vibe.upgrade.installed_package_name", lambda *args, **kwargs: "avibe-os")
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: True)
+    monkeypatch.setattr("vibe.upgrade.installed_memory_package_version", lambda: "3.0.14")
+    monkeypatch.setattr("vibe.runtime.current_service_launcher", lambda: launcher)
+
+    assert rollback_target() == RollbackTarget(
+        version="3.0.14",
+        package="avibe-os",
+        launcher=launcher,
+        memory_package=True,
+        memory_version="3.0.14",
+    )
+
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 #: Everything shipped to a user's machine.
 SHIPPED_SOURCE_ROOTS = ("main.py", "config", "core", "modules", "storage", "vibe")
@@ -847,6 +872,7 @@ LEGACY_INSTALL = RollbackTarget(
 )
 
 
+@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
 def test_do_upgrade_uses_upgrade_plan_env_and_restarts(monkeypatch):
     plan = UpgradePlan(
         command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
@@ -895,6 +921,7 @@ def test_do_upgrade_uses_upgrade_plan_env_and_restarts(monkeypatch):
     }
 
 
+@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
 def test_do_upgrade_auto_restart_does_not_block_on_runtime_prepare(monkeypatch):
     plan = UpgradePlan(
         command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
@@ -923,6 +950,7 @@ def test_do_upgrade_auto_restart_does_not_block_on_runtime_prepare(monkeypatch):
     assert events == ["upgrade", "restart"]
 
 
+@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
 def test_do_upgrade_running_runtime_honors_show_runtime_skip_for_restart(monkeypatch):
     plan = UpgradePlan(
         command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
@@ -949,6 +977,7 @@ def test_do_upgrade_running_runtime_honors_show_runtime_skip_for_restart(monkeyp
     assert calls["restart_kwargs"]["prepare_show_runtime"] is False
 
 
+@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
 def test_do_upgrade_reports_restart_scheduling_failure_as_partial_success(monkeypatch):
     plan = UpgradePlan(
         command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
@@ -979,6 +1008,7 @@ def test_do_upgrade_reports_restart_scheduling_failure_as_partial_success(monkey
     assert "bad launcher" in result["output"]
 
 
+@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
 def test_do_upgrade_without_auto_restart_prepares_runtime(monkeypatch):
     plan = UpgradePlan(
         command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
@@ -1021,6 +1051,7 @@ def test_do_upgrade_without_auto_restart_prepares_runtime(monkeypatch):
     assert calls["runtime_prepare_kwargs"]["cwd"] == calls["upgrade_kwargs"]["cwd"]
 
 
+@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
 def test_do_upgrade_keeps_runtime_stopped_when_it_was_not_running(monkeypatch):
     plan = UpgradePlan(
         command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
@@ -1098,6 +1129,7 @@ def test_cli_runtime_process_was_running_uses_service_process_state(monkeypatch)
     assert cli._runtime_process_was_running() is True
 
 
+@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
 def test_cmd_upgrade_uses_upgrade_plan_env(monkeypatch):
     plan = UpgradePlan(
         command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
@@ -1147,6 +1179,7 @@ def test_cmd_upgrade_uses_upgrade_plan_env(monkeypatch):
     }
 
 
+@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
 def test_cmd_upgrade_running_runtime_honors_show_runtime_skip_for_restart(monkeypatch):
     plan = UpgradePlan(
         command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
@@ -1176,6 +1209,7 @@ def test_cmd_upgrade_running_runtime_honors_show_runtime_skip_for_restart(monkey
     assert calls["restart_kwargs"]["prepare_show_runtime"] is False
 
 
+@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
 def test_cmd_upgrade_reports_restart_scheduling_failure_as_partial_success(monkeypatch, capsys):
     plan = UpgradePlan(
         command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
@@ -1206,6 +1240,7 @@ def test_cmd_upgrade_reports_restart_scheduling_failure_as_partial_success(monke
     assert "Upgrade failed" not in output
 
 
+@pytest.mark.skip(reason="upgrade execution is now supervisor-owned")
 def test_cmd_upgrade_keeps_runtime_stopped_when_it_was_not_running(monkeypatch):
     plan = UpgradePlan(
         command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
@@ -1265,3 +1300,214 @@ def test_get_safe_cwd_falls_back_when_home_invalid(monkeypatch):
     assert os.path.isabs(cwd)
     assert os.path.isdir(cwd)
     assert cwd != "/nonexistent_dir_for_test"
+
+
+def test_api_upgrade_submits_typed_transaction(monkeypatch):
+    transaction = UpgradeTransaction(1, "pip", "avibe-os[memory]", True, MEMORY_PACKAGE_REQUIREMENT, LEGACY_INSTALL)
+    calls = {}
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(api, "configured_memory_enabled", lambda: True)
+    monkeypatch.setattr(api, "build_upgrade_transaction", lambda **kwargs: transaction)
+    monkeypatch.setattr(
+        api,
+        "schedule_upgrade_transaction",
+        lambda tx, **kwargs: calls.update(transaction=tx, kwargs=kwargs) or {"job_id": "job-1"},
+    )
+    result = api.do_upgrade()
+    assert result["ok"] is True
+    assert result["restarting"] is True
+    assert calls["transaction"] == transaction
+    assert calls["kwargs"]["trigger"] == "upgrade"
+
+
+def test_cli_upgrade_submits_typed_transaction(monkeypatch):
+    transaction = UpgradeTransaction(1, "pip", "avibe-os[memory]", True, MEMORY_PACKAGE_REQUIREMENT, LEGACY_INSTALL)
+    calls = {}
+    monkeypatch.setattr(cli, "get_latest_version", lambda: {"error": None, "has_update": True, "latest": "3.0.15"})
+    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(cli, "configured_memory_enabled", lambda: True)
+    monkeypatch.setattr(cli, "build_upgrade_transaction", lambda **kwargs: transaction)
+    monkeypatch.setattr(
+        cli,
+        "schedule_upgrade_transaction",
+        lambda tx, **kwargs: calls.update(transaction=tx, kwargs=kwargs) or {"job_id": "job-1"},
+    )
+    assert cli.cmd_upgrade() == 0
+    assert calls["transaction"] == transaction
+    assert calls["kwargs"]["trigger"] == "upgrade"
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        ("https://example.invalid/avibe.whl", "avibe-os[memory] @ https://example.invalid/avibe.whl"),
+        (
+            "git+https://example.invalid/avibe.git@abc123#subdirectory=src",
+            "avibe-os[memory] @ git+https://example.invalid/avibe.git@abc123#subdirectory=src",
+        ),
+        ("/tmp/avibe-os.whl", "/tmp/avibe-os.whl[memory]"),
+        ("avibe-os>=3.0", "avibe-os[memory]>=3.0"),
+    ],
+)
+def test_memory_extra_preserves_supported_spec_shapes(spec, expected):
+    assert upgrade_module._with_memory_extra(spec) == expected
+
+
+def test_memory_forward_pip_plan_preflights_without_dry_run(monkeypatch):
+    monkeypatch.setattr(upgrade_module, "memory_package_installed", lambda: False)
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        base_env={"PATH": "/usr/bin"},
+        memory_enabled=True,
+        package_spec="avibe-os",
+    )
+    assert plan.command[-1] == "avibe-os[memory]"
+    assert plan.preflight_command == [
+        "/usr/bin/python3",
+        "-m",
+        "pip",
+        "download",
+        "--dest",
+        PIP_DOWNLOAD_DEST_PLACEHOLDER,
+        "--no-deps",
+        "avibe-os[memory]",
+    ]
+    assert "--dry-run" not in plan.preflight_command
+
+
+def test_memory_add_plan_is_an_explicit_force_reinstall(monkeypatch):
+    plan = build_memory_add_plan(
+        python_executable="/usr/bin/python3",
+        uv_path=None,
+        base_env={"PATH": "/usr/bin"},
+    )
+    assert plan.command == [
+        "/usr/bin/python3",
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "--force-reinstall",
+        "--no-deps",
+        MEMORY_PACKAGE_REQUIREMENT,
+    ]
+    assert plan.preflight_command == [
+        "/usr/bin/python3",
+        "-m",
+        "pip",
+        "download",
+        "--dest",
+        PIP_DOWNLOAD_DEST_PLACEHOLDER,
+        "--no-deps",
+        MEMORY_PACKAGE_REQUIREMENT,
+    ]
+
+
+def test_explicit_core_only_shape_does_not_inherit_ambient_memory(monkeypatch):
+    """A target interpreter's explicit shape takes precedence over this process."""
+
+    monkeypatch.setattr(upgrade_module, "memory_package_installed", lambda: True)
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        base_env={"PATH": "/usr/bin"},
+        memory_enabled=False,
+        memory_package=False,
+        package_spec="avibe-os",
+    )
+    assert plan.command[-1] == "avibe-os"
+    assert "[memory]" not in " ".join(plan.command)
+    assert plan.preflight_command is None
+
+
+def test_memory_distribution_is_not_treated_as_host_provider(monkeypatch):
+    import importlib.metadata
+    import importlib
+
+    # The module fixture isolates the rest of this file from ambient metadata;
+    # reload just this function so the test can exercise its real filter.
+    importlib.reload(upgrade_module)
+
+    monkeypatch.setattr(
+        importlib.metadata,
+        "packages_distributions",
+        lambda: {"vibe": ["avibe-os", "avibe-memory"]},
+    )
+    assert upgrade_module._distributions_providing_this_package() == ["avibe-os"]
+
+
+def test_memory_only_version_skew_does_not_mark_host_metadata_stale(monkeypatch):
+    monkeypatch.setattr(upgrade_module, "_distributions_providing_this_package", lambda: ["avibe-os"])
+    monkeypatch.setattr("importlib.metadata.version", lambda _name: "3.0.14")
+    monkeypatch.setattr("vibe.__version__", "3.0.14", raising=False)
+    assert upgrade_module.installed_metadata_describes_running_code() is True
+
+
+def test_rename_pair_version_skew_still_marks_host_metadata_stale(monkeypatch):
+    monkeypatch.setattr(
+        upgrade_module,
+        "_distributions_providing_this_package",
+        lambda: ["avibe-os", "vibe-remote"],
+    )
+    versions = {"avibe-os": "3.0.15", "vibe-remote": "3.0.14"}
+    monkeypatch.setattr("importlib.metadata.version", lambda name: versions[name])
+    monkeypatch.setattr("vibe.__version__", "3.0.14", raising=False)
+    assert upgrade_module.installed_metadata_describes_running_code() is False
+
+
+@pytest.mark.parametrize(
+    ("target", "cleanup_after"),
+    [("3.0.13", False), ("3.0.14", True), ("not-a-version", False)],
+)
+def test_pinned_rollback_records_core_only_cleanup_order(monkeypatch, target, cleanup_after):
+    monkeypatch.setattr(upgrade_module, "memory_package_installed", lambda: True)
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        base_env={"PATH": "/usr/bin"},
+        version=target,
+        package_name="avibe-os",
+        memory_package=False,
+    )
+    assert plan.cleanup_command == ["/usr/bin/python3", "-m", "pip", "uninstall", "--yes", MEMORY_PACKAGE_NAME]
+    assert plan.cleanup_after_command is cleanup_after
+    assert plan.preflight_command and "download" in plan.preflight_command
+
+
+def test_execute_upgrade_plan_preflight_failure_skips_mutation_and_cleans_scratch(monkeypatch, tmp_path):
+    calls = []
+    scratch_paths = []
+
+    class Result:
+        returncode = 1
+        stdout = "resolution failed"
+        stderr = ""
+
+    def run(command, **kwargs):
+        calls.append(command)
+        scratch = Path(command[command.index("--dest") + 1])
+        scratch_paths.append(scratch)
+        assert scratch.is_dir()
+        return Result()
+
+    plan = UpgradePlan(
+        command=["install"],
+        env={},
+        method="pip",
+        preflight_command=["download", "--dest", PIP_DOWNLOAD_DEST_PLACEHOLDER, "target"],
+        cleanup_command=["cleanup"],
+    )
+    result = execute_upgrade_plan(plan, run=run)
+    assert result.returncode == 1
+    assert len(calls) == 1
+    assert scratch_paths and not scratch_paths[0].exists()
+
+
+def test_upgrade_transaction_rejects_missing_memory_requirement():
+    transaction = UpgradeTransaction(1, "pip", "avibe-os", True, None, None)
+    with pytest.raises(ValueError, match="Memory requirement"):
+        transaction.validate()
+
+
+def test_upgrade_transaction_rejects_untrusted_memory_requirement():
+    transaction = UpgradeTransaction(1, "pip", "avibe-os", True, "evil-package", None)
+    with pytest.raises(ValueError, match="invalid Memory requirement"):
+        transaction.validate()

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -1267,6 +1267,86 @@ def test_cmd_upgrade_skips_install_when_already_latest(monkeypatch):
     assert cli.cmd_upgrade() == 0
 
 
+@pytest.mark.parametrize("source", ["local", "direct"])
+def test_cmd_upgrade_metadata_failure_uses_exact_memory_artifact(monkeypatch, tmp_path, capsys, source):
+    artifact = tmp_path / "avibe_os-3.1.0-py3-none-any.whl"
+    package_spec = (
+        str(artifact)
+        if source == "local"
+        else "avibe-os @ https://example.test/releases/avibe_os-3.1.0-py3-none-any.whl"
+    )
+    calls: dict[str, Any] = {}
+
+    monkeypatch.setenv("VIBE_UPGRADE_PACKAGE_SPEC", package_spec)
+    monkeypatch.setattr(
+        cli,
+        "get_latest_version",
+        lambda: {"error": "metadata unavailable", "has_update": False, "latest": None},
+    )
+    monkeypatch.setattr(cli, "configured_memory_enabled", lambda: True)
+    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(cli, "_runtime_process_was_running", lambda: True)
+    monkeypatch.setattr(cli, "schedule_restart", lambda **kwargs: {"job_id": "restart"})
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
+
+    def execute(plan, **kwargs):
+        calls["plan"] = plan
+        return subprocess.CompletedProcess(plan.command, 0, stdout="done", stderr="")
+
+    monkeypatch.setattr(cli, "execute_upgrade_plan", execute)
+
+    assert cli.cmd_upgrade() == 0
+    assert "Attempting upgrade anyway..." in capsys.readouterr().out
+    assert "avibe-memory==3.1.0" in calls["plan"].command
+
+
+def test_cmd_upgrade_metadata_failure_refuses_unversioned_memory_source(monkeypatch, capsys):
+    monkeypatch.setenv("VIBE_UPGRADE_PACKAGE_SPEC", "avibe-os")
+    monkeypatch.setattr(
+        cli,
+        "get_latest_version",
+        lambda: {"error": "metadata unavailable", "has_update": False, "latest": None},
+    )
+    monkeypatch.setattr(cli, "configured_memory_enabled", lambda: True)
+    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(
+        cli,
+        "execute_upgrade_plan",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("upgrade must not execute")),
+    )
+
+    assert cli.cmd_upgrade() == 1
+    output = capsys.readouterr().out
+    assert "Attempting upgrade anyway..." not in output
+    assert "Upgrade failed" in output
+
+
+def test_cmd_upgrade_metadata_failure_keeps_core_only_fallback(monkeypatch, capsys):
+    calls: dict[str, Any] = {}
+
+    monkeypatch.setenv("VIBE_UPGRADE_PACKAGE_SPEC", "avibe-os")
+    monkeypatch.setattr(
+        cli,
+        "get_latest_version",
+        lambda: {"error": "metadata unavailable", "has_update": False, "latest": None},
+    )
+    monkeypatch.setattr(cli, "configured_memory_enabled", lambda: False)
+    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(cli, "_runtime_process_was_running", lambda: True)
+    monkeypatch.setattr(cli, "schedule_restart", lambda **kwargs: {"job_id": "restart"})
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
+
+    def execute(plan, **kwargs):
+        calls["plan"] = plan
+        return subprocess.CompletedProcess(plan.command, 0, stdout="done", stderr="")
+
+    monkeypatch.setattr(cli, "execute_upgrade_plan", execute)
+
+    assert cli.cmd_upgrade() == 0
+    assert "Attempting upgrade anyway..." in capsys.readouterr().out
+    assert calls["plan"].command[-1] == "avibe-os"
+
+
 def test_memory_enabled_forward_plan_locks_memory_to_target_release(monkeypatch):
     monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
     monkeypatch.setattr("vibe.upgrade.installed_metadata_describes_running_code", lambda: True)
@@ -1318,6 +1398,72 @@ def test_memory_enabled_forward_plan_requires_target_release(monkeypatch):
             memory_package=True,
             package_spec="avibe-os",
         )
+
+
+@pytest.mark.parametrize(
+    ("package_spec", "target_version"),
+    [
+        ("avibe-os==3.1.0", "3.1.0"),
+        (
+            "avibe-os @ https://example.test/releases/avibe_os-3.1.1-py3-none-any.whl",
+            "3.1.1",
+        ),
+        ("/fixtures/avibe_os-3.1.2.tar.gz", "3.1.2"),
+    ],
+)
+def test_memory_enabled_forward_plan_derives_target_from_versioned_spec(
+    monkeypatch, package_spec, target_version
+):
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
+
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        base_env={"PATH": "/usr/bin"},
+        memory_enabled=True,
+        package_spec=package_spec,
+    )
+
+    memory_pin = f"avibe-memory=={target_version}"
+    assert memory_pin in plan.command
+    assert plan.preflight_command is not None and memory_pin in plan.preflight_command
+    assert plan.preflight_fallback_command is not None and memory_pin in plan.preflight_fallback_command
+
+
+@pytest.mark.parametrize(
+    "package_spec",
+    [
+        "avibe-os",
+        "avibe-os>=3.1,<3.2",
+        "avibe-os==3.1.*",
+        "git+https://example.test/avibe.git@v3.1.0",
+        "avibe-os @ git+https://example.test/avibe.git@v3.1.0",
+        "/fixtures/avibe.whl",
+    ],
+)
+def test_memory_enabled_forward_plan_rejects_unversioned_fallback_specs(monkeypatch, package_spec):
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
+
+    with pytest.raises(ValueError, match="target release version"):
+        build_upgrade_plan(
+            python_executable="/usr/bin/python3",
+            base_env={"PATH": "/usr/bin"},
+            memory_enabled=True,
+            package_spec=package_spec,
+        )
+
+
+def test_memory_fallback_refusal_does_not_expose_direct_spec_credentials(monkeypatch):
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
+
+    with pytest.raises(ValueError) as refusal:
+        build_upgrade_plan(
+            python_executable="/usr/bin/python3",
+            base_env={"PATH": "/usr/bin"},
+            memory_enabled=True,
+            package_spec="avibe-os @ https://user:secret@example.test/download",
+        )
+
+    assert "secret" not in str(refusal.value)
 
 
 def test_memory_preflight_failure_does_not_mutate_package(monkeypatch):

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -1478,7 +1478,7 @@ def test_pinned_rollback_keeps_exact_memory_version(monkeypatch):
     assert "avibe-memory==3.0.14" in plan.preflight_command
 
 
-def test_with_memory_extra_preserves_vcs_and_url_specs():
+def test_with_memory_extra_preserves_vcs_url_and_local_specs(tmp_path, monkeypatch):
     from vibe.upgrade import _with_memory_extra
 
     assert _with_memory_extra("git+https://example.test/avibe.git@abc123#subdirectory=src") == (
@@ -1486,7 +1486,13 @@ def test_with_memory_extra_preserves_vcs_and_url_specs():
     )
     assert _with_memory_extra("https://example.test/avibe.whl") == "avibe-os[memory] @ https://example.test/avibe.whl"
     assert _with_memory_extra("file:///tmp/avibe.whl") == "avibe-os[memory] @ file:///tmp/avibe.whl"
-    assert _with_memory_extra("/tmp/avibe.whl") == "/tmp/avibe.whl[memory]"
+    assert _with_memory_extra("/fixtures/avibe.whl") == "avibe-os[memory] @ file:///fixtures/avibe.whl"
+
+    monkeypatch.chdir(tmp_path)
+    relative_artifact = Path("dist/avibe.whl")
+    assert _with_memory_extra(str(relative_artifact)) == (
+        f"avibe-os[memory] @ {(tmp_path / relative_artifact).resolve().as_uri()}"
+    )
 
 
 def test_get_safe_cwd_returns_absolute_existing_dir():

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -14,9 +14,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from vibe import api, cli
 from vibe.runtime import ServiceLauncher
 from vibe.upgrade import (
-    MEMORY_PACKAGE_REQUIREMENT,
     UpgradePlan,
     build_upgrade_plan,
+    configured_memory_enabled,
     has_newer_version,
     get_current_vibe_bin_dir,
     get_latest_version_info,
@@ -1256,7 +1256,7 @@ def test_cmd_upgrade_skips_install_when_already_latest(monkeypatch):
     assert cli.cmd_upgrade() == 0
 
 
-def test_memory_enabled_forward_plan_carries_extra_and_explicit_preflight_target(monkeypatch):
+def test_memory_enabled_forward_plan_uses_only_target_extra(monkeypatch):
     monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
     monkeypatch.setattr("vibe.upgrade.installed_metadata_describes_running_code", lambda: True)
 
@@ -1265,23 +1265,48 @@ def test_memory_enabled_forward_plan_carries_extra_and_explicit_preflight_target
         base_env={"PATH": "/usr/bin"},
         memory_enabled=True,
         memory_package=True,
-        package_spec="avibe-os",
+        package_spec="avibe-os>=3.1,<3.2",
     )
 
-    assert "avibe-os[memory]" in plan.command
-    assert MEMORY_PACKAGE_REQUIREMENT in plan.command
-    assert plan.preflight_command is not None
-    assert "avibe-os[memory]" in plan.preflight_command
-    assert MEMORY_PACKAGE_REQUIREMENT in plan.preflight_command
-    assert "--no-deps" in plan.preflight_command
+    target = "avibe-os[memory]<3.2,>=3.1"
+    assert plan.command == ["/usr/bin/python3", "-m", "pip", "install", "--upgrade", target]
+    assert plan.preflight_command == [
+        "/usr/bin/python3",
+        "-m",
+        "pip",
+        "install",
+        "--dry-run",
+        "--upgrade",
+        target,
+    ]
+    assert plan.preflight_fallback_command == [
+        "/usr/bin/python3",
+        "-m",
+        "pip",
+        "download",
+        "--dest",
+        "{avibe-pip-download-destination}",
+        target,
+    ]
+    assert "avibe-memory" not in " ".join(plan.command + plan.preflight_command)
+    assert "<3.1" not in " ".join(plan.command + plan.preflight_command)
 
 
 def test_memory_preflight_failure_does_not_mutate_package(monkeypatch):
     plan = UpgradePlan(
-        command=["python", "-m", "pip", "install", "avibe-os[memory]", MEMORY_PACKAGE_REQUIREMENT],
+        command=["python", "-m", "pip", "install", "avibe-os[memory]"],
         env={},
         method="pip",
-        preflight_command=["python", "-m", "pip", "download", "--dest", "{avibe-pip-download-destination}", "--no-deps"],
+        preflight_command=["python", "-m", "pip", "install", "--dry-run", "avibe-os[memory]"],
+        preflight_fallback_command=[
+            "python",
+            "-m",
+            "pip",
+            "download",
+            "--dest",
+            "{avibe-pip-download-destination}",
+            "avibe-os[memory]",
+        ],
     )
     calls: list[list[str]] = []
 
@@ -1292,8 +1317,165 @@ def test_memory_preflight_failure_does_not_mutate_package(monkeypatch):
     result = execute_upgrade_plan(plan, run=run)
 
     assert result.returncode == 1
-    assert calls and calls[0][3] == "download"
-    assert all("install" not in command for command in calls)
+    assert calls == [plan.preflight_command]
+
+
+def test_legacy_pip_fallback_resolves_target_extra_before_install(tmp_path):
+    plan = UpgradePlan(
+        command=["python", "-m", "pip", "install", "avibe-os[memory]"],
+        env={},
+        method="pip",
+        preflight_command=["python", "-m", "pip", "install", "--dry-run", "avibe-os[memory]"],
+        preflight_fallback_command=[
+            "python",
+            "-m",
+            "pip",
+            "download",
+            "--dest",
+            "{avibe-pip-download-destination}",
+            "avibe-os[memory]",
+        ],
+    )
+    calls: list[list[str]] = []
+    scratch: Path | None = None
+
+    def run(command, **kwargs):
+        nonlocal scratch
+        calls.append(command)
+        if "--dry-run" in command:
+            return subprocess.CompletedProcess(command, 2, stdout="", stderr="no such option: --dry-run")
+        if "download" in command:
+            scratch = Path(command[command.index("--dest") + 1])
+            assert scratch.is_dir()
+            assert "--no-deps" not in command
+            return subprocess.CompletedProcess(command, 0, stdout="resolved", stderr="")
+        return subprocess.CompletedProcess(command, 0, stdout="installed", stderr="")
+
+    result = execute_upgrade_plan(plan, run=run)
+
+    assert result.returncode == 0
+    assert [command[3] for command in calls] == ["install", "download", "install"]
+    assert scratch is not None and not scratch.exists()
+
+
+def test_legacy_pip_fallback_failure_stops_before_install():
+    plan = UpgradePlan(
+        command=["python", "-m", "pip", "install", "avibe-os[memory]"],
+        env={},
+        method="pip",
+        preflight_command=["python", "-m", "pip", "install", "--dry-run", "avibe-os[memory]"],
+        preflight_fallback_command=[
+            "python",
+            "-m",
+            "pip",
+            "download",
+            "--dest",
+            "{avibe-pip-download-destination}",
+            "avibe-os[memory]",
+        ],
+    )
+    calls: list[list[str]] = []
+
+    def run(command, **kwargs):
+        calls.append(command)
+        if "--dry-run" in command:
+            return subprocess.CompletedProcess(command, 2, stdout="", stderr="no such option: --dry-run")
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="missing target Memory wheel")
+
+    result = execute_upgrade_plan(plan, run=run)
+
+    assert result.returncode == 1
+    assert len(calls) == 2
+    assert calls[1][3] == "download"
+    assert "--no-deps" not in calls[1]
+    assert plan.command not in calls
+
+
+def test_pip_preflight_does_not_fallback_on_resolver_failure():
+    plan = UpgradePlan(
+        command=["python", "-m", "pip", "install", "avibe-os[memory]"],
+        env={},
+        method="pip",
+        preflight_command=["python", "-m", "pip", "install", "--dry-run", "avibe-os[memory]"],
+        preflight_fallback_command=["python", "-m", "pip", "download", "avibe-os[memory]"],
+    )
+    calls: list[list[str]] = []
+
+    def run(command, **kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="No matching distribution found")
+
+    result = execute_upgrade_plan(plan, run=run)
+
+    assert result.returncode == 1
+    assert calls == [plan.preflight_command]
+
+
+@pytest.mark.parametrize("memory_installed", [False, True])
+def test_unreadable_memory_config_preserves_only_an_installed_package(monkeypatch, memory_installed):
+    monkeypatch.setattr("config.v2_config.V2Config.load", lambda: (_ for _ in ()).throw(ValueError("bad config")))
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: memory_installed)
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
+    monkeypatch.setattr("vibe.upgrade.installed_metadata_describes_running_code", lambda: True)
+
+    enabled = configured_memory_enabled()
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        base_env={"PATH": "/usr/bin"},
+        memory_enabled=enabled,
+        package_spec="avibe-os",
+    )
+
+    assert enabled is False
+    assert ("avibe-os[memory]" in plan.command) is memory_installed
+
+
+def test_uv_forward_plan_resolves_only_target_extra(monkeypatch):
+    monkeypatch.setattr("vibe.upgrade.is_uv_tool_install", lambda executable: True)
+    monkeypatch.setattr("vibe.upgrade.is_legacy_uv_tool_install", lambda executable: False)
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: "/usr/bin/uv")
+    monkeypatch.setattr("vibe.upgrade.get_current_vibe_bin_dir", lambda vibe_path: None)
+
+    plan = build_upgrade_plan(
+        python_executable="/tools/avibe/bin/python",
+        base_env={"PATH": "/usr/bin"},
+        memory_enabled=True,
+        memory_package=True,
+        package_spec="avibe-os>=3.1,<3.2",
+    )
+
+    target = "avibe-os[memory]<3.2,>=3.1"
+    assert plan.command == ["/usr/bin/uv", "tool", "install", target, "--upgrade", "--force"]
+    assert plan.preflight_command == [
+        "/usr/bin/uv",
+        "pip",
+        "install",
+        "--dry-run",
+        "--python",
+        "/tools/avibe/bin/python",
+        "--upgrade",
+        target,
+    ]
+    assert "--with" not in plan.command
+
+
+def test_pinned_rollback_keeps_exact_memory_version(monkeypatch):
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: True)
+
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        base_env={"PATH": "/usr/bin"},
+        version="3.0.14",
+        package_name="avibe-os",
+        memory_package=True,
+        memory_version="3.0.14",
+    )
+
+    assert "avibe-os[memory]==3.0.14" in plan.command
+    assert "avibe-memory==3.0.14" in plan.command
+    assert plan.preflight_command is not None
+    assert "avibe-memory==3.0.14" in plan.preflight_command
 
 
 def test_with_memory_extra_preserves_vcs_and_url_specs():
@@ -1303,6 +1485,8 @@ def test_with_memory_extra_preserves_vcs_and_url_specs():
         "avibe-os[memory] @ git+https://example.test/avibe.git@abc123#subdirectory=src"
     )
     assert _with_memory_extra("https://example.test/avibe.whl") == "avibe-os[memory] @ https://example.test/avibe.whl"
+    assert _with_memory_extra("file:///tmp/avibe.whl") == "avibe-os[memory] @ file:///tmp/avibe.whl"
+    assert _with_memory_extra("/tmp/avibe.whl") == "/tmp/avibe.whl[memory]"
 
 
 def test_get_safe_cwd_returns_absolute_existing_dir():

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -859,7 +859,12 @@ def test_do_upgrade_uses_upgrade_plan_env_and_restarts(monkeypatch):
     )
     calls: dict[str, Any] = {}
 
-    monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(api, "get_version_info", lambda: {"latest": "3.0.15"})
+    monkeypatch.setattr(
+        api,
+        "build_upgrade_plan",
+        lambda **kwargs: calls.setdefault("plan_kwargs", kwargs) and plan,
+    )
     monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
     monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
     monkeypatch.setattr(api, "schedule_restart", lambda **kwargs: calls.setdefault("restart_kwargs", kwargs))
@@ -882,6 +887,7 @@ def test_do_upgrade_uses_upgrade_plan_env_and_restarts(monkeypatch):
     assert calls["run_kwargs"]["text"] is True
     assert calls["run_kwargs"]["timeout"] == 120
     assert calls["run_kwargs"]["env"] == plan.env
+    assert calls["plan_kwargs"]["target_version"] == "3.0.15"
     safe_cwd = calls["run_kwargs"].get("cwd")
     assert safe_cwd and os.path.isabs(safe_cwd), f"subprocess.run cwd must be an absolute path, got {safe_cwd!r}"
     assert calls["restart_kwargs"] == {
@@ -1112,7 +1118,11 @@ def test_cmd_upgrade_uses_upgrade_plan_env(monkeypatch):
 
     monkeypatch.setattr(cli, "get_latest_version", lambda: {"error": None, "has_update": True, "latest": "2.2.0"})
     monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
-    monkeypatch.setattr(cli, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(
+        cli,
+        "build_upgrade_plan",
+        lambda **kwargs: calls.setdefault("plan_kwargs", kwargs) and plan,
+    )
     monkeypatch.setattr(cli, "_runtime_process_was_running", lambda: True)
 
     def fake_schedule_restart(**kwargs):
@@ -1138,6 +1148,7 @@ def test_cmd_upgrade_uses_upgrade_plan_env(monkeypatch):
     assert calls["kwargs"]["capture_output"] is True
     assert calls["kwargs"]["text"] is True
     assert calls["kwargs"]["env"] == plan.env
+    assert calls["plan_kwargs"]["target_version"] == "2.2.0"
     assert "cwd" in calls["kwargs"], "subprocess.run must specify cwd to avoid stale venv cwd"
     assert os.path.isabs(calls["kwargs"]["cwd"]), f"cwd must be absolute, got {calls['kwargs']['cwd']!r}"
     assert calls["restart_kwargs"] == {
@@ -1256,7 +1267,7 @@ def test_cmd_upgrade_skips_install_when_already_latest(monkeypatch):
     assert cli.cmd_upgrade() == 0
 
 
-def test_memory_enabled_forward_plan_uses_only_target_extra(monkeypatch):
+def test_memory_enabled_forward_plan_locks_memory_to_target_release(monkeypatch):
     monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
     monkeypatch.setattr("vibe.upgrade.installed_metadata_describes_running_code", lambda: True)
 
@@ -1265,11 +1276,14 @@ def test_memory_enabled_forward_plan_uses_only_target_extra(monkeypatch):
         base_env={"PATH": "/usr/bin"},
         memory_enabled=True,
         memory_package=True,
+        memory_version="3.0.14",
+        target_version="3.1.0",
         package_spec="avibe-os>=3.1,<3.2",
     )
 
     target = "avibe-os[memory]<3.2,>=3.1"
-    assert plan.command == ["/usr/bin/python3", "-m", "pip", "install", "--upgrade", target]
+    memory = "avibe-memory==3.1.0"
+    assert plan.command == ["/usr/bin/python3", "-m", "pip", "install", "--upgrade", target, memory]
     assert plan.preflight_command == [
         "/usr/bin/python3",
         "-m",
@@ -1278,6 +1292,7 @@ def test_memory_enabled_forward_plan_uses_only_target_extra(monkeypatch):
         "--dry-run",
         "--upgrade",
         target,
+        memory,
     ]
     assert plan.preflight_fallback_command == [
         "/usr/bin/python3",
@@ -1287,9 +1302,22 @@ def test_memory_enabled_forward_plan_uses_only_target_extra(monkeypatch):
         "--dest",
         "{avibe-pip-download-destination}",
         target,
+        memory,
     ]
-    assert "avibe-memory" not in " ".join(plan.command + plan.preflight_command)
     assert "<3.1" not in " ".join(plan.command + plan.preflight_command)
+
+
+def test_memory_enabled_forward_plan_requires_target_release(monkeypatch):
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
+
+    with pytest.raises(ValueError, match="target release version"):
+        build_upgrade_plan(
+            python_executable="/usr/bin/python3",
+            base_env={"PATH": "/usr/bin"},
+            memory_enabled=True,
+            memory_package=True,
+            package_spec="avibe-os",
+        )
 
 
 def test_memory_preflight_failure_does_not_mutate_package(monkeypatch):
@@ -1423,6 +1451,7 @@ def test_unreadable_memory_config_preserves_only_an_installed_package(monkeypatc
         python_executable="/usr/bin/python3",
         base_env={"PATH": "/usr/bin"},
         memory_enabled=enabled,
+        target_version="3.1.0",
         package_spec="avibe-os",
     )
 
@@ -1430,7 +1459,7 @@ def test_unreadable_memory_config_preserves_only_an_installed_package(monkeypatc
     assert ("avibe-os[memory]" in plan.command) is memory_installed
 
 
-def test_uv_forward_plan_resolves_only_target_extra(monkeypatch):
+def test_uv_forward_plan_locks_memory_to_target_release(monkeypatch):
     monkeypatch.setattr("vibe.upgrade.is_uv_tool_install", lambda executable: True)
     monkeypatch.setattr("vibe.upgrade.is_legacy_uv_tool_install", lambda executable: False)
     monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: "/usr/bin/uv")
@@ -1441,11 +1470,22 @@ def test_uv_forward_plan_resolves_only_target_extra(monkeypatch):
         base_env={"PATH": "/usr/bin"},
         memory_enabled=True,
         memory_package=True,
+        target_version="3.1.0",
         package_spec="avibe-os>=3.1,<3.2",
     )
 
     target = "avibe-os[memory]<3.2,>=3.1"
-    assert plan.command == ["/usr/bin/uv", "tool", "install", target, "--upgrade", "--force"]
+    memory = "avibe-memory==3.1.0"
+    assert plan.command == [
+        "/usr/bin/uv",
+        "tool",
+        "install",
+        target,
+        "--with",
+        memory,
+        "--upgrade",
+        "--force",
+    ]
     assert plan.preflight_command == [
         "/usr/bin/uv",
         "pip",
@@ -1455,8 +1495,8 @@ def test_uv_forward_plan_resolves_only_target_extra(monkeypatch):
         "/tools/avibe/bin/python",
         "--upgrade",
         target,
+        memory,
     ]
-    assert "--with" not in plan.command
 
 
 def test_pinned_rollback_keeps_exact_memory_version(monkeypatch):

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -14,15 +14,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from vibe import api, cli
 from vibe.runtime import ServiceLauncher
 from vibe.upgrade import (
-    MEMORY_PACKAGE_NAME,
     MEMORY_PACKAGE_REQUIREMENT,
-    PIP_DOWNLOAD_DEST_PLACEHOLDER,
     UpgradePlan,
-    UpgradeTransaction,
-    build_memory_add_plan,
     build_upgrade_plan,
-    build_upgrade_transaction,
-    execute_upgrade_plan,
     has_newer_version,
     get_current_vibe_bin_dir,
     get_latest_version_info,
@@ -36,8 +30,8 @@ from vibe.upgrade import (
     pinned_package_spec,
     RollbackTarget,
     rollback_target,
+    execute_upgrade_plan,
 )
-import vibe.upgrade as upgrade_module
 
 
 @pytest.fixture(autouse=True)
@@ -60,6 +54,7 @@ def _tree_is_not_an_installed_distribution(monkeypatch):
     """
 
     monkeypatch.setattr("vibe.upgrade._distributions_providing_this_package", lambda: [])
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: False)
 
 
 def test_build_upgrade_plan_uses_uv_and_preserves_tool_bin_dir(monkeypatch):
@@ -469,23 +464,6 @@ def test_a_tree_with_no_published_release_has_no_rollback_target(monkeypatch):
     assert rollback_target() == RollbackTarget(version="3.0.10", package="vibe-remote", launcher=launcher)
 
 
-def test_rollback_target_captures_memory_presence_and_exact_version(monkeypatch):
-    launcher = ServiceLauncher(python="/venv/bin/python", main="/venv/lib/vibe/service_main.py")
-    monkeypatch.setattr("vibe.__version__", "3.0.14", raising=False)
-    monkeypatch.setattr("vibe.upgrade.installed_package_name", lambda *args, **kwargs: "avibe-os")
-    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: True)
-    monkeypatch.setattr("vibe.upgrade.installed_memory_package_version", lambda: "3.0.14")
-    monkeypatch.setattr("vibe.runtime.current_service_launcher", lambda: launcher)
-
-    assert rollback_target() == RollbackTarget(
-        version="3.0.14",
-        package="avibe-os",
-        launcher=launcher,
-        memory_package=True,
-        memory_version="3.0.14",
-    )
-
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 #: Everything shipped to a user's machine.
 SHIPPED_SOURCE_ROOTS = ("main.py", "config", "core", "modules", "storage", "vibe")
@@ -872,6 +850,218 @@ LEGACY_INSTALL = RollbackTarget(
 )
 
 
+def test_do_upgrade_uses_upgrade_plan_env_and_restarts(monkeypatch):
+    plan = UpgradePlan(
+        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
+        env={"UV_TOOL_BIN_DIR": "/custom/bin"},
+        method="uv",
+        rollback_to=LEGACY_INSTALL,
+    )
+    calls: dict[str, Any] = {}
+
+    monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
+    monkeypatch.setattr(api, "schedule_restart", lambda **kwargs: calls.setdefault("restart_kwargs", kwargs))
+
+    def fake_run(cmd, **kwargs):
+        if cmd == plan.command:
+            calls["run_cmd"] = cmd
+            calls["run_kwargs"] = kwargs
+        else:
+            raise AssertionError(f"unexpected subprocess command: {cmd}")
+        return subprocess.CompletedProcess(cmd, 0, stdout="done", stderr="")
+
+    monkeypatch.setattr(api.subprocess, "run", fake_run)
+    result = api.do_upgrade(auto_restart=True)
+
+    assert result["ok"] is True
+    assert result["restarting"] is True
+    assert calls["run_cmd"] == plan.command
+    assert calls["run_kwargs"]["capture_output"] is True
+    assert calls["run_kwargs"]["text"] is True
+    assert calls["run_kwargs"]["timeout"] == 120
+    assert calls["run_kwargs"]["env"] == plan.env
+    safe_cwd = calls["run_kwargs"].get("cwd")
+    assert safe_cwd and os.path.isabs(safe_cwd), f"subprocess.run cwd must be an absolute path, got {safe_cwd!r}"
+    assert calls["restart_kwargs"] == {
+        "delay_seconds": 2.0,
+        "vibe_path": "/custom/bin/vibe",
+        "trigger": "upgrade",
+        "prepare_show_runtime": True,
+        # The install this process was running, taken BEFORE it was replaced and
+        # carried here by the plan that replaced it: what the restart reinstalls
+        # if it cannot bring the new one up. Version, distribution and launcher
+        # together, because a pin needs the first two and a machine that predates
+        # the rename does not answer "avibe-os" for either.
+        "rollback_to": LEGACY_INSTALL,
+    }
+
+
+def test_do_upgrade_auto_restart_does_not_block_on_runtime_prepare(monkeypatch):
+    plan = UpgradePlan(
+        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
+        env=None,
+        method="uv",
+    )
+    events: list[str] = []
+
+    monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
+    monkeypatch.setattr(api, "schedule_restart", lambda **kwargs: events.append("restart") or {"job_id": "restart"})
+
+    def fake_run(cmd, **kwargs):
+        if cmd == plan.command:
+            events.append("upgrade")
+        else:
+            raise AssertionError(f"unexpected subprocess command: {cmd}")
+        return subprocess.CompletedProcess(cmd, 0, stdout="done", stderr="")
+
+    monkeypatch.setattr(api.subprocess, "run", fake_run)
+
+    result = api.do_upgrade(auto_restart=True)
+
+    assert result["ok"] is True
+    assert events == ["upgrade", "restart"]
+
+
+def test_do_upgrade_running_runtime_honors_show_runtime_skip_for_restart(monkeypatch):
+    plan = UpgradePlan(
+        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
+        env=None,
+        method="uv",
+    )
+    calls: dict[str, Any] = {}
+
+    monkeypatch.setenv("VIBE_INSTALL_SKIP_SHOW_RUNTIME", "1")
+    monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
+    monkeypatch.setattr(api, "schedule_restart", lambda **kwargs: calls.setdefault("restart_kwargs", kwargs))
+    monkeypatch.setattr(
+        api.subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout="done", stderr=""),
+    )
+
+    result = api.do_upgrade(auto_restart=True)
+
+    assert result["ok"] is True
+    assert result["restarting"] is True
+    assert calls["restart_kwargs"]["prepare_show_runtime"] is False
+
+
+def test_do_upgrade_reports_restart_scheduling_failure_as_partial_success(monkeypatch):
+    plan = UpgradePlan(
+        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
+        env=None,
+        method="uv",
+    )
+
+    monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
+
+    def fail_restart(**kwargs):
+        raise RuntimeError("bad launcher")
+
+    monkeypatch.setattr(api, "schedule_restart", fail_restart)
+    monkeypatch.setattr(
+        api.subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout="done", stderr=""),
+    )
+
+    result = api.do_upgrade(auto_restart=True)
+
+    assert result["ok"] is True
+    assert result["restarting"] is False
+    assert result["message"] == "Upgrade successful, but restart scheduling failed. Please restart vibe."
+    assert "Restart scheduling failed" in result["output"]
+    assert "bad launcher" in result["output"]
+
+
+def test_do_upgrade_without_auto_restart_prepares_runtime(monkeypatch):
+    plan = UpgradePlan(
+        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
+        env=None,
+        method="uv",
+    )
+    calls: dict[str, Any] = {}
+
+    monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
+
+    def fail_restart(**kwargs):
+        raise AssertionError("schedule_restart should not run when auto_restart is disabled")
+
+    monkeypatch.setattr(api, "schedule_restart", fail_restart)
+
+    def fake_run(cmd, **kwargs):
+        if cmd == plan.command:
+            calls["upgrade_cmd"] = cmd
+            calls["upgrade_kwargs"] = kwargs
+            return subprocess.CompletedProcess(cmd, 0, stdout="done", stderr="")
+        if cmd == ["/custom/bin/vibe", "runtime", "prepare", "--strict"]:
+            calls["runtime_prepare_cmd"] = cmd
+            calls["runtime_prepare_kwargs"] = kwargs
+            return subprocess.CompletedProcess(cmd, 0, stdout="runtime ready", stderr="")
+        raise AssertionError(f"unexpected subprocess command: {cmd}")
+
+    monkeypatch.setattr(api.subprocess, "run", fake_run)
+
+    result = api.do_upgrade(auto_restart=False)
+
+    assert result["ok"] is True
+    assert result["restarting"] is False
+    assert result["output"] == "done\n\nruntime ready"
+    assert calls["runtime_prepare_cmd"] == ["/custom/bin/vibe", "runtime", "prepare", "--strict"]
+    assert calls["runtime_prepare_kwargs"]["capture_output"] is True
+    assert calls["runtime_prepare_kwargs"]["text"] is True
+    assert calls["runtime_prepare_kwargs"]["timeout"] == 600  # prepare now budgets for Show Runtime + askill
+    assert calls["runtime_prepare_kwargs"]["cwd"] == calls["upgrade_kwargs"]["cwd"]
+
+
+def test_do_upgrade_keeps_runtime_stopped_when_it_was_not_running(monkeypatch):
+    plan = UpgradePlan(
+        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
+        env=None,
+        method="uv",
+    )
+    calls: dict[str, Any] = {}
+
+    monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: False)
+
+    def fail_restart(**kwargs):
+        raise AssertionError("schedule_restart should not run when Avibe was not running")
+
+    monkeypatch.setattr(api, "schedule_restart", fail_restart)
+
+    def fake_run(cmd, **kwargs):
+        if cmd == plan.command:
+            calls["upgrade_cmd"] = cmd
+            calls["upgrade_kwargs"] = kwargs
+            return subprocess.CompletedProcess(cmd, 0, stdout="done", stderr="")
+        if cmd == ["/custom/bin/vibe", "runtime", "prepare", "--strict"]:
+            calls["runtime_prepare_cmd"] = cmd
+            calls["runtime_prepare_kwargs"] = kwargs
+            return subprocess.CompletedProcess(cmd, 0, stdout="runtime ready", stderr="")
+        raise AssertionError(f"unexpected subprocess command: {cmd}")
+
+    monkeypatch.setattr(api.subprocess, "run", fake_run)
+
+    result = api.do_upgrade(auto_restart=True)
+
+    assert result["ok"] is True
+    assert result["restarting"] is False
+    assert result["message"] == "Upgrade successful. Please restart vibe."
+    assert calls["runtime_prepare_cmd"] == ["/custom/bin/vibe", "runtime", "prepare", "--strict"]
+
+
 def test_api_runtime_process_was_running_checks_service_and_ui_pid_files(monkeypatch, tmp_path):
     service_pid_path = tmp_path / "service.pid"
     ui_pid_path = tmp_path / "ui.pid"
@@ -911,6 +1101,150 @@ def test_cli_runtime_process_was_running_uses_service_process_state(monkeypatch)
     assert cli._runtime_process_was_running() is True
 
 
+def test_cmd_upgrade_uses_upgrade_plan_env(monkeypatch):
+    plan = UpgradePlan(
+        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
+        env={"UV_TOOL_BIN_DIR": "/custom/bin"},
+        method="uv",
+        rollback_to=LEGACY_INSTALL,
+    )
+    calls: dict[str, Any] = {}
+
+    monkeypatch.setattr(cli, "get_latest_version", lambda: {"error": None, "has_update": True, "latest": "2.2.0"})
+    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(cli, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(cli, "_runtime_process_was_running", lambda: True)
+
+    def fake_schedule_restart(**kwargs):
+        calls["restart_kwargs"] = kwargs
+        return {"job_id": "restart"}
+
+    monkeypatch.setattr(cli, "schedule_restart", fake_schedule_restart)
+
+    def fake_run(cmd, **kwargs):
+        if cmd == plan.command:
+            calls["cmd"] = cmd
+            calls["kwargs"] = kwargs
+        else:
+            raise AssertionError(f"unexpected subprocess command: {cmd}")
+        return subprocess.CompletedProcess(cmd, 0, stdout="done", stderr="")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    result = cli.cmd_upgrade()
+
+    assert result == 0
+    assert calls["cmd"] == plan.command
+    assert calls["kwargs"]["capture_output"] is True
+    assert calls["kwargs"]["text"] is True
+    assert calls["kwargs"]["env"] == plan.env
+    assert "cwd" in calls["kwargs"], "subprocess.run must specify cwd to avoid stale venv cwd"
+    assert os.path.isabs(calls["kwargs"]["cwd"]), f"cwd must be absolute, got {calls['kwargs']['cwd']!r}"
+    assert calls["restart_kwargs"] == {
+        "delay_seconds": 0.0,
+        "vibe_path": "/custom/bin/vibe",
+        "trigger": "upgrade",
+        "prepare_show_runtime": True,
+        # See the do_upgrade case: the restart is handed the install to fall back to.
+        "rollback_to": LEGACY_INSTALL,
+    }
+
+
+def test_cmd_upgrade_running_runtime_honors_show_runtime_skip_for_restart(monkeypatch):
+    plan = UpgradePlan(
+        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
+        env=None,
+        method="uv",
+    )
+    calls: dict[str, Any] = {}
+
+    monkeypatch.setenv("VIBE_INSTALL_SKIP_SHOW_RUNTIME", "true")
+    monkeypatch.setattr(cli, "get_latest_version", lambda: {"error": None, "has_update": True, "latest": "2.2.0"})
+    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(cli, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(cli, "_runtime_process_was_running", lambda: True)
+
+    def fake_schedule_restart(**kwargs):
+        calls["restart_kwargs"] = kwargs
+        return {"job_id": "restart"}
+
+    monkeypatch.setattr(cli, "schedule_restart", fake_schedule_restart)
+    monkeypatch.setattr(
+        cli.subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout="done", stderr=""),
+    )
+
+    assert cli.cmd_upgrade() == 0
+    assert calls["restart_kwargs"]["prepare_show_runtime"] is False
+
+
+def test_cmd_upgrade_reports_restart_scheduling_failure_as_partial_success(monkeypatch, capsys):
+    plan = UpgradePlan(
+        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
+        env=None,
+        method="uv",
+    )
+
+    monkeypatch.setattr(cli, "get_latest_version", lambda: {"error": None, "has_update": True, "latest": "2.2.0"})
+    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(cli, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(cli, "_runtime_process_was_running", lambda: True)
+
+    def fail_restart(**kwargs):
+        raise RuntimeError("bad launcher")
+
+    monkeypatch.setattr(cli, "schedule_restart", fail_restart)
+    monkeypatch.setattr(
+        cli.subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout="done", stderr=""),
+    )
+
+    assert cli.cmd_upgrade() == 2
+    output = capsys.readouterr().out
+    assert "Upgrade installed, but restart scheduling failed." in output
+    assert "Restart error: bad launcher" in output
+    assert "Run `vibe restart` to use the new version." in output
+    assert "Upgrade failed" not in output
+
+
+def test_cmd_upgrade_keeps_runtime_stopped_when_it_was_not_running(monkeypatch):
+    plan = UpgradePlan(
+        command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
+        env=None,
+        method="uv",
+    )
+    calls: dict[str, Any] = {}
+
+    monkeypatch.setattr(cli, "get_latest_version", lambda: {"error": None, "has_update": True, "latest": "2.2.0"})
+    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(cli, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(cli, "_runtime_process_was_running", lambda: False)
+
+    def fail_restart(**kwargs):
+        raise AssertionError("schedule_restart should not run when Avibe was not running")
+
+    monkeypatch.setattr(cli, "schedule_restart", fail_restart)
+
+    def fake_run(cmd, **kwargs):
+        if cmd == plan.command:
+            calls["cmd"] = cmd
+            calls["kwargs"] = kwargs
+            return subprocess.CompletedProcess(cmd, 0, stdout="done", stderr="")
+        if cmd == ["/custom/bin/vibe", "runtime", "prepare", "--strict"]:
+            calls["runtime_prepare_cmd"] = cmd
+            calls["runtime_prepare_kwargs"] = kwargs
+            return subprocess.CompletedProcess(cmd, 0, stdout="runtime ready", stderr="")
+        raise AssertionError(f"unexpected subprocess command: {cmd}")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    assert cli.cmd_upgrade() == 0
+    assert calls["cmd"] == plan.command
+    assert calls["runtime_prepare_cmd"] == ["/custom/bin/vibe", "runtime", "prepare", "--strict"]
+
+
 def test_cmd_upgrade_skips_install_when_already_latest(monkeypatch):
     monkeypatch.setattr(cli, "get_latest_version", lambda: {"error": None, "has_update": False, "latest": "2.2.0"})
 
@@ -920,6 +1254,55 @@ def test_cmd_upgrade_skips_install_when_already_latest(monkeypatch):
     monkeypatch.setattr(cli.subprocess, "run", fail_run)
 
     assert cli.cmd_upgrade() == 0
+
+
+def test_memory_enabled_forward_plan_carries_extra_and_explicit_preflight_target(monkeypatch):
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
+    monkeypatch.setattr("vibe.upgrade.installed_metadata_describes_running_code", lambda: True)
+
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        base_env={"PATH": "/usr/bin"},
+        memory_enabled=True,
+        memory_package=True,
+        package_spec="avibe-os",
+    )
+
+    assert "avibe-os[memory]" in plan.command
+    assert MEMORY_PACKAGE_REQUIREMENT in plan.command
+    assert plan.preflight_command is not None
+    assert "avibe-os[memory]" in plan.preflight_command
+    assert MEMORY_PACKAGE_REQUIREMENT in plan.preflight_command
+    assert "--no-deps" in plan.preflight_command
+
+
+def test_memory_preflight_failure_does_not_mutate_package(monkeypatch):
+    plan = UpgradePlan(
+        command=["python", "-m", "pip", "install", "avibe-os[memory]", MEMORY_PACKAGE_REQUIREMENT],
+        env={},
+        method="pip",
+        preflight_command=["python", "-m", "pip", "download", "--dest", "{avibe-pip-download-destination}", "--no-deps"],
+    )
+    calls: list[list[str]] = []
+
+    def run(command, **kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="missing memory")
+
+    result = execute_upgrade_plan(plan, run=run)
+
+    assert result.returncode == 1
+    assert calls and calls[0][3] == "download"
+    assert all("install" not in command for command in calls)
+
+
+def test_with_memory_extra_preserves_vcs_and_url_specs():
+    from vibe.upgrade import _with_memory_extra
+
+    assert _with_memory_extra("git+https://example.test/avibe.git@abc123#subdirectory=src") == (
+        "avibe-os[memory] @ git+https://example.test/avibe.git@abc123#subdirectory=src"
+    )
+    assert _with_memory_extra("https://example.test/avibe.whl") == "avibe-os[memory] @ https://example.test/avibe.whl"
 
 
 def test_get_safe_cwd_returns_absolute_existing_dir():
@@ -934,293 +1317,3 @@ def test_get_safe_cwd_falls_back_when_home_invalid(monkeypatch):
     assert os.path.isabs(cwd)
     assert os.path.isdir(cwd)
     assert cwd != "/nonexistent_dir_for_test"
-
-
-def test_api_upgrade_submits_typed_transaction(monkeypatch):
-    transaction = UpgradeTransaction(1, "pip", "avibe-os[memory]", True, MEMORY_PACKAGE_REQUIREMENT, LEGACY_INSTALL)
-    calls = {}
-    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
-    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
-    monkeypatch.setattr(api, "configured_memory_enabled", lambda: True)
-    monkeypatch.setattr(api, "build_upgrade_transaction", lambda **kwargs: transaction)
-    monkeypatch.setattr(
-        api,
-        "schedule_upgrade_transaction",
-        lambda tx, **kwargs: calls.update(transaction=tx, kwargs=kwargs) or {"job_id": "job-1"},
-    )
-    result = api.do_upgrade()
-    assert result["ok"] is True
-    assert result["restarting"] is True
-    assert calls["transaction"] == transaction
-    assert calls["kwargs"]["trigger"] == "upgrade"
-    assert calls["kwargs"]["prepare_show_runtime"] is True
-
-
-def test_api_upgrade_without_restart_schedules_when_runtime_is_stopped(monkeypatch):
-    transaction = UpgradeTransaction(1, "pip", "avibe-os", False, None, None, "none")
-    calls = {}
-    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: False)
-    monkeypatch.setattr(api, "build_upgrade_transaction", lambda **kwargs: calls.update(build=kwargs) or transaction)
-    monkeypatch.setattr(api, "schedule_upgrade_transaction", lambda tx, **kwargs: calls.update(schedule=kwargs) or {"job_id": "job-1"})
-    result = api.do_upgrade(auto_restart=False)
-    assert result["ok"] is True
-    assert calls["build"]["activate_runtime"] == "none"
-
-
-def test_api_upgrade_without_restart_rejects_running_runtime(monkeypatch):
-    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
-    monkeypatch.setattr(api, "build_upgrade_transaction", lambda **kwargs: pytest.fail("must reject before build"))
-    result = api.do_upgrade(auto_restart=False)
-    assert result["ok"] is False
-    assert result["code"] == "restart_required"
-
-
-def test_api_upgrade_reports_supervisor_submission_failure(monkeypatch):
-    transaction = UpgradeTransaction(1, "pip", "avibe-os", False, None, None)
-    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: False)
-    monkeypatch.setattr(api, "build_upgrade_transaction", lambda **kwargs: transaction)
-
-    def fail_schedule(*args, **kwargs):
-        raise RuntimeError("scheduler unavailable")
-
-    monkeypatch.setattr(api, "schedule_upgrade_transaction", fail_schedule)
-    result = api.do_upgrade()
-    assert result["ok"] is False
-    assert "scheduler unavailable" in result["message"]
-
-
-def test_cli_upgrade_submits_typed_transaction(monkeypatch):
-    transaction = UpgradeTransaction(1, "pip", "avibe-os[memory]", True, MEMORY_PACKAGE_REQUIREMENT, LEGACY_INSTALL)
-    calls = {}
-    monkeypatch.setattr(cli, "get_latest_version", lambda: {"error": None, "has_update": True, "latest": "3.0.15"})
-    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
-    monkeypatch.setattr(cli, "configured_memory_enabled", lambda: True)
-    monkeypatch.setattr(cli, "build_upgrade_transaction", lambda **kwargs: transaction)
-    monkeypatch.setattr(
-        cli,
-        "schedule_upgrade_transaction",
-        lambda tx, **kwargs: calls.update(transaction=tx, kwargs=kwargs) or {"job_id": "job-1"},
-    )
-    monkeypatch.setattr(cli, "_wait_for_upgrade_job", lambda job_id: {"job_id": job_id, "state": "succeeded"})
-    assert cli.cmd_upgrade() == 0
-    assert calls["transaction"] == transaction
-    assert calls["kwargs"]["trigger"] == "upgrade"
-
-
-def test_cli_upgrade_reports_supervisor_submission_failure(monkeypatch, capsys):
-    monkeypatch.setattr(cli, "get_latest_version", lambda: {"error": None, "has_update": True, "latest": "3.0.15"})
-    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
-    monkeypatch.setattr(cli, "build_upgrade_transaction", lambda **kwargs: UpgradeTransaction(1, "pip", "avibe-os", False, None, None))
-    monkeypatch.setattr(cli, "schedule_upgrade_transaction", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("scheduler unavailable")))
-    assert cli.cmd_upgrade() == 1
-    assert "scheduler unavailable" in capsys.readouterr().out
-
-
-@pytest.mark.parametrize(
-    ("spec", "expected"),
-    [
-        ("https://example.invalid/avibe.whl", "avibe-os[memory] @ https://example.invalid/avibe.whl"),
-        (
-            "git+https://example.invalid/avibe.git@abc123#subdirectory=src",
-            "avibe-os[memory] @ git+https://example.invalid/avibe.git@abc123#subdirectory=src",
-        ),
-        ("/tmp/avibe-os.whl", "/tmp/avibe-os.whl[memory]"),
-        ("avibe-os>=3.0", "avibe-os[memory]>=3.0"),
-    ],
-)
-def test_memory_extra_preserves_supported_spec_shapes(spec, expected):
-    assert upgrade_module._with_memory_extra(spec) == expected
-
-
-def test_memory_forward_pip_plan_preflights_without_dry_run(monkeypatch):
-    monkeypatch.setattr(upgrade_module, "memory_package_installed", lambda: False)
-    plan = build_upgrade_plan(
-        python_executable="/usr/bin/python3",
-        base_env={"PATH": "/usr/bin"},
-        memory_enabled=True,
-        package_spec="avibe-os",
-    )
-    assert plan.command[-2:] == ["avibe-os[memory]", MEMORY_PACKAGE_REQUIREMENT]
-    assert plan.preflight_command == [
-        "/usr/bin/python3",
-        "-m",
-        "pip",
-        "download",
-        "--dest",
-        PIP_DOWNLOAD_DEST_PLACEHOLDER,
-        "--no-deps",
-        "avibe-os[memory]",
-        MEMORY_PACKAGE_REQUIREMENT,
-    ]
-    assert "--dry-run" not in plan.preflight_command
-
-
-def test_forward_memory_requirement_is_carried_into_pip_plan(monkeypatch):
-    monkeypatch.setattr(upgrade_module, "memory_package_installed", lambda: False)
-    requirement = "avibe-memory==3.0.15"
-    plan = build_upgrade_plan(
-        python_executable="/usr/bin/python3",
-        base_env={"PATH": "/usr/bin"},
-        memory_enabled=True,
-        memory_requirement=requirement,
-        package_spec="avibe-os",
-    )
-    assert plan.command[-1] == requirement
-    assert plan.preflight_command[-1] == requirement
-
-
-def test_core_only_forward_pip_plan_preflights_direct_core_artifact(monkeypatch):
-    monkeypatch.setattr(upgrade_module, "memory_package_installed", lambda: False)
-    plan = build_upgrade_plan(
-        python_executable="/usr/bin/python3",
-        base_env={"PATH": "/usr/bin"},
-        memory_enabled=False,
-        memory_package=False,
-        package_spec="avibe-os",
-    )
-    assert plan.preflight_command[-1] == "avibe-os"
-    assert "--no-deps" in plan.preflight_command
-
-
-def test_memory_add_plan_is_an_explicit_force_reinstall(monkeypatch):
-    plan = build_memory_add_plan(
-        python_executable="/usr/bin/python3",
-        uv_path=None,
-        base_env={"PATH": "/usr/bin"},
-    )
-    assert plan.command == [
-        "/usr/bin/python3",
-        "-m",
-        "pip",
-        "install",
-        "--upgrade",
-        "--force-reinstall",
-        "--no-deps",
-        MEMORY_PACKAGE_REQUIREMENT,
-    ]
-    assert plan.preflight_command == [
-        "/usr/bin/python3",
-        "-m",
-        "pip",
-        "download",
-        "--dest",
-        PIP_DOWNLOAD_DEST_PLACEHOLDER,
-        "--no-deps",
-        MEMORY_PACKAGE_REQUIREMENT,
-    ]
-
-
-def test_explicit_core_only_shape_does_not_inherit_ambient_memory(monkeypatch):
-    """A target interpreter's explicit shape takes precedence over this process."""
-
-    monkeypatch.setattr(upgrade_module, "memory_package_installed", lambda: True)
-    plan = build_upgrade_plan(
-        python_executable="/usr/bin/python3",
-        base_env={"PATH": "/usr/bin"},
-        memory_enabled=False,
-        memory_package=False,
-        package_spec="avibe-os",
-    )
-    assert plan.command[-1] == "avibe-os"
-    assert "[memory]" not in " ".join(plan.command)
-    assert plan.preflight_command[-1] == "avibe-os"
-
-
-def test_memory_distribution_is_not_treated_as_host_provider(monkeypatch):
-    import importlib.metadata
-    import importlib
-
-    # The module fixture isolates the rest of this file from ambient metadata;
-    # reload just this function so the test can exercise its real filter.
-    importlib.reload(upgrade_module)
-
-    monkeypatch.setattr(
-        importlib.metadata,
-        "packages_distributions",
-        lambda: {"vibe": ["avibe-os", "avibe-memory"]},
-    )
-    assert upgrade_module._distributions_providing_this_package() == ["avibe-os"]
-
-
-def test_memory_only_version_skew_does_not_mark_host_metadata_stale(monkeypatch):
-    monkeypatch.setattr(upgrade_module, "_distributions_providing_this_package", lambda: ["avibe-os"])
-    monkeypatch.setattr("importlib.metadata.version", lambda _name: "3.0.14")
-    monkeypatch.setattr("vibe.__version__", "3.0.14", raising=False)
-    assert upgrade_module.installed_metadata_describes_running_code() is True
-
-
-def test_rename_pair_version_skew_still_marks_host_metadata_stale(monkeypatch):
-    monkeypatch.setattr(
-        upgrade_module,
-        "_distributions_providing_this_package",
-        lambda: ["avibe-os", "vibe-remote"],
-    )
-    versions = {"avibe-os": "3.0.15", "vibe-remote": "3.0.14"}
-    monkeypatch.setattr("importlib.metadata.version", lambda name: versions[name])
-    monkeypatch.setattr("vibe.__version__", "3.0.14", raising=False)
-    assert upgrade_module.installed_metadata_describes_running_code() is False
-
-
-@pytest.mark.parametrize(
-    ("target", "cleanup_after"),
-    [("3.0.13", False), ("3.0.14", True), ("not-a-version", False)],
-)
-def test_pinned_rollback_records_core_only_cleanup_order(monkeypatch, target, cleanup_after):
-    monkeypatch.setattr(upgrade_module, "memory_package_installed", lambda: True)
-    plan = build_upgrade_plan(
-        python_executable="/usr/bin/python3",
-        base_env={"PATH": "/usr/bin"},
-        version=target,
-        package_name="avibe-os",
-        memory_package=False,
-    )
-    assert plan.cleanup_command == ["/usr/bin/python3", "-m", "pip", "uninstall", "--yes", MEMORY_PACKAGE_NAME]
-    assert plan.cleanup_after_command is cleanup_after
-    assert plan.preflight_command and "download" in plan.preflight_command
-
-
-def test_execute_upgrade_plan_preflight_failure_skips_mutation_and_cleans_scratch(monkeypatch, tmp_path):
-    calls = []
-    scratch_paths = []
-
-    class Result:
-        returncode = 1
-        stdout = "resolution failed"
-        stderr = ""
-
-    def run(command, **kwargs):
-        calls.append(command)
-        scratch = Path(command[command.index("--dest") + 1])
-        scratch_paths.append(scratch)
-        assert scratch.is_dir()
-        return Result()
-
-    plan = UpgradePlan(
-        command=["install"],
-        env={},
-        method="pip",
-        preflight_command=["download", "--dest", PIP_DOWNLOAD_DEST_PLACEHOLDER, "target"],
-        cleanup_command=["cleanup"],
-    )
-    result = execute_upgrade_plan(plan, run=run)
-    assert result.returncode == 1
-    assert len(calls) == 1
-    assert scratch_paths and not scratch_paths[0].exists()
-
-
-def test_upgrade_transaction_rejects_missing_memory_requirement():
-    transaction = UpgradeTransaction(1, "pip", "avibe-os", True, None, None)
-    with pytest.raises(ValueError, match="Memory requirement"):
-        transaction.validate()
-
-
-def test_upgrade_transaction_rejects_ignored_memory_requirement():
-    transaction = UpgradeTransaction(1, "pip", "avibe-os", False, MEMORY_PACKAGE_REQUIREMENT, None)
-    with pytest.raises(ValueError, match="must be omitted"):
-        transaction.validate()
-
-
-def test_upgrade_transaction_rejects_untrusted_memory_requirement():
-    transaction = UpgradeTransaction(1, "pip", "avibe-os", True, "evil-package", None)
-    with pytest.raises(ValueError, match="invalid Memory requirement"):
-        transaction.validate()

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -6126,6 +6126,14 @@ def do_upgrade(auto_restart: bool = True) -> dict:
         {"ok": bool, "message": str, "output": str | None, "restarting": bool}
     """
     current_vibe_path = get_running_vibe_path()
+    if not auto_restart and _runtime_process_was_running():
+        return {
+            "ok": False,
+            "message": "Upgrade requires a restart while Avibe is running.",
+            "output": None,
+            "restarting": False,
+            "code": "restart_required",
+        }
     try:
         transaction = build_upgrade_transaction(
             vibe_path=current_vibe_path,

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -60,13 +60,15 @@ from vibe.opencode_config import (
 )
 from vibe.build_identity import get_build_identity
 from vibe.upgrade import (
-    build_upgrade_transaction,
+    build_upgrade_plan,
     configured_memory_enabled,
+    execute_upgrade_plan,
     get_latest_version_info,
     get_running_vibe_path,
+    get_safe_cwd,
     should_skip_show_runtime_prepare,
 )
-from vibe.restart_supervisor import schedule_upgrade_transaction
+from vibe.restart_supervisor import schedule_restart
 from vibe import backend_model_catalog
 from vibe.i18n import t as backend_t
 from modules.agents.catalog import (
@@ -6126,36 +6128,74 @@ def do_upgrade(auto_restart: bool = True) -> dict:
         {"ok": bool, "message": str, "output": str | None, "restarting": bool}
     """
     current_vibe_path = get_running_vibe_path()
-    if not auto_restart and _runtime_process_was_running():
+    plan = build_upgrade_plan(
+        vibe_path=current_vibe_path,
+        memory_enabled=configured_memory_enabled(),
+    )
+    runtime_was_running = _runtime_process_was_running()
+
+    # Use a stable directory as cwd to avoid "Current directory does not exist"
+    # errors.  The vibe service process cwd may be inside the uv tool venv
+    # directory, which uv deletes and recreates during upgrade.
+    safe_cwd = get_safe_cwd()
+
+    try:
+        result = execute_upgrade_plan(
+            plan,
+            run=subprocess.run,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            cwd=safe_cwd,
+        )
+        if result.returncode == 0:
+            restarting = False
+            restart_failed = False
+            runtime_output = None
+            if auto_restart and runtime_was_running:
+                try:
+                    schedule_restart(
+                        delay_seconds=2.0,
+                        vibe_path=current_vibe_path,
+                        trigger="upgrade",
+                        prepare_show_runtime=not should_skip_show_runtime_prepare(),
+                        rollback_to=plan.rollback_to,
+                    )
+                    restarting = True
+                except Exception as exc:
+                    restart_failed = True
+                    runtime_output = f"Restart scheduling failed; run `vibe restart` to use the new version.\n{exc}"
+            else:
+                runtime_output = _prepare_show_runtime_after_upgrade(current_vibe_path, safe_cwd)
+            if restarting:
+                message = "Upgrade successful. Restarting..."
+            elif restart_failed:
+                message = "Upgrade successful, but restart scheduling failed. Please restart vibe."
+            else:
+                message = "Upgrade successful. Please restart vibe."
+
+            return {
+                "ok": True,
+                "message": message,
+                "output": _append_upgrade_output(result.stdout, runtime_output),
+                "restarting": restarting,
+            }
+        else:
+            return {
+                "ok": False,
+                "message": "Upgrade failed",
+                "output": result.stderr or result.stdout,
+                "restarting": False,
+            }
+    except subprocess.TimeoutExpired:
         return {
             "ok": False,
-            "message": "Upgrade requires a restart while Avibe is running.",
+            "message": "Upgrade timed out",
             "output": None,
             "restarting": False,
-            "code": "restart_required",
         }
-    try:
-        transaction = build_upgrade_transaction(
-            vibe_path=current_vibe_path,
-            memory_enabled=configured_memory_enabled(),
-            activate_runtime="restart_if_running" if auto_restart else "none",
-        )
-        restart = schedule_upgrade_transaction(
-            transaction,
-            delay_seconds=2.0,
-            vibe_path=current_vibe_path,
-            trigger="upgrade",
-            prepare_show_runtime=not should_skip_show_runtime_prepare(),
-        )
-    except Exception as exc:
-        return {"ok": False, "message": str(exc), "output": None, "restarting": False}
-    return {
-        "ok": True,
-        "message": "Upgrade scheduled; the supervisor will replace the package and restart Avibe.",
-        "output": None,
-        "restarting": bool(restart.get("job_id")),
-        "job_id": restart.get("job_id"),
-    }
+    except Exception as e:
+        return {"ok": False, "message": str(e), "output": None, "restarting": False}
 
 
 def _append_upgrade_output(output: str | None, runtime_output: str | None) -> str | None:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -6128,10 +6128,14 @@ def do_upgrade(auto_restart: bool = True) -> dict:
         {"ok": bool, "message": str, "output": str | None, "restarting": bool}
     """
     current_vibe_path = get_running_vibe_path()
-    plan = build_upgrade_plan(
-        vibe_path=current_vibe_path,
-        memory_enabled=configured_memory_enabled(),
-    )
+    try:
+        plan = build_upgrade_plan(
+            vibe_path=current_vibe_path,
+            memory_enabled=configured_memory_enabled(),
+            target_version=get_version_info().get("latest"),
+        )
+    except ValueError as exc:
+        return {"ok": False, "message": "Upgrade failed.", "output": str(exc), "restarting": False}
     runtime_was_running = _runtime_process_was_running()
 
     # Use a stable directory as cwd to avoid "Current directory does not exist"

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -60,13 +60,13 @@ from vibe.opencode_config import (
 )
 from vibe.build_identity import get_build_identity
 from vibe.upgrade import (
-    build_upgrade_plan,
+    build_upgrade_transaction,
+    configured_memory_enabled,
     get_latest_version_info,
     get_running_vibe_path,
-    get_safe_cwd,
     should_skip_show_runtime_prepare,
 )
-from vibe.restart_supervisor import schedule_restart
+from vibe.restart_supervisor import schedule_upgrade_transaction
 from vibe import backend_model_catalog
 from vibe.i18n import t as backend_t
 from modules.agents.catalog import (
@@ -6126,71 +6126,28 @@ def do_upgrade(auto_restart: bool = True) -> dict:
         {"ok": bool, "message": str, "output": str | None, "restarting": bool}
     """
     current_vibe_path = get_running_vibe_path()
-    plan = build_upgrade_plan(vibe_path=current_vibe_path)
-    runtime_was_running = _runtime_process_was_running()
-
-    # Use a stable directory as cwd to avoid "Current directory does not exist"
-    # errors.  The vibe service process cwd may be inside the uv tool venv
-    # directory, which uv deletes and recreates during upgrade.
-    safe_cwd = get_safe_cwd()
-
     try:
-        result = subprocess.run(
-            plan.command,
-            capture_output=True,
-            text=True,
-            timeout=120,
-            env=plan.env,
-            cwd=safe_cwd,
+        transaction = build_upgrade_transaction(
+            vibe_path=current_vibe_path,
+            memory_enabled=configured_memory_enabled(),
+            activate_runtime="restart_if_running" if auto_restart else "none",
         )
-        if result.returncode == 0:
-            restarting = False
-            restart_failed = False
-            runtime_output = None
-            if auto_restart and runtime_was_running:
-                try:
-                    schedule_restart(
-                        delay_seconds=2.0,
-                        vibe_path=current_vibe_path,
-                        trigger="upgrade",
-                        prepare_show_runtime=not should_skip_show_runtime_prepare(),
-                        rollback_to=plan.rollback_to,
-                    )
-                    restarting = True
-                except Exception as exc:
-                    restart_failed = True
-                    runtime_output = f"Restart scheduling failed; run `vibe restart` to use the new version.\n{exc}"
-            else:
-                runtime_output = _prepare_show_runtime_after_upgrade(current_vibe_path, safe_cwd)
-            if restarting:
-                message = "Upgrade successful. Restarting..."
-            elif restart_failed:
-                message = "Upgrade successful, but restart scheduling failed. Please restart vibe."
-            else:
-                message = "Upgrade successful. Please restart vibe."
-
-            return {
-                "ok": True,
-                "message": message,
-                "output": _append_upgrade_output(result.stdout, runtime_output),
-                "restarting": restarting,
-            }
-        else:
-            return {
-                "ok": False,
-                "message": "Upgrade failed",
-                "output": result.stderr or result.stdout,
-                "restarting": False,
-            }
-    except subprocess.TimeoutExpired:
-        return {
-            "ok": False,
-            "message": "Upgrade timed out",
-            "output": None,
-            "restarting": False,
-        }
-    except Exception as e:
-        return {"ok": False, "message": str(e), "output": None, "restarting": False}
+        restart = schedule_upgrade_transaction(
+            transaction,
+            delay_seconds=2.0,
+            vibe_path=current_vibe_path,
+            trigger="upgrade",
+            prepare_show_runtime=not should_skip_show_runtime_prepare(),
+        )
+    except Exception as exc:
+        return {"ok": False, "message": str(exc), "output": None, "restarting": False}
+    return {
+        "ok": True,
+        "message": "Upgrade scheduled; the supervisor will replace the package and restart Avibe.",
+        "output": None,
+        "restarting": bool(restart.get("job_id")),
+        "job_id": restart.get("job_id"),
+    }
 
 
 def _append_upgrade_output(output: str | None, runtime_output: str | None) -> str | None:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -62,13 +62,14 @@ from core.watches import (
 )
 from vibe import __version__, api, runtime
 from vibe.i18n import normalize_language, t as i18n_t
-from vibe.restart_supervisor import schedule_restart
+from vibe.restart_supervisor import schedule_restart, schedule_upgrade_transaction
 from vibe.screenshot import ScreenshotError, capture_screenshot
 from vibe.upgrade import (
     CURRENT_VIBE_EXECUTABLE_ENV,
     LEGACY_PACKAGE_NAME,
     PACKAGE_NAME,
-    build_upgrade_plan,
+    build_upgrade_transaction,
+    configured_memory_enabled,
     cache_running_vibe_path,
     get_latest_version_info,
     get_safe_cwd,
@@ -14396,46 +14397,25 @@ def cmd_upgrade():
     print("\nUpgrading...")
 
     current_vibe_path = cache_running_vibe_path()
-    plan = build_upgrade_plan(vibe_path=current_vibe_path)
-    print(f"Using {plan.method}: {' '.join(plan.command)}")
-    runtime_was_running = _runtime_process_was_running()
-
-    # Use a stable directory as cwd to avoid issues when running from a
-    # directory that uv may delete during upgrade (e.g. inside the uv tool venv).
-    safe_cwd = get_safe_cwd()
-
     try:
-        result = subprocess.run(plan.command, capture_output=True, text=True, env=plan.env, cwd=safe_cwd)
-        if result.returncode == 0:
-            print("\033[32mUpgrade successful!\033[0m")
-            if runtime_was_running:
-                try:
-                    restart = schedule_restart(
-                        delay_seconds=0.0,
-                        vibe_path=current_vibe_path,
-                        trigger="upgrade",
-                        prepare_show_runtime=not should_skip_show_runtime_prepare(),
-                        rollback_to=plan.rollback_to,
-                    )
-                except Exception as exc:
-                    print("\033[33mUpgrade installed, but restart scheduling failed.\033[0m")
-                    print(f"Restart error: {exc}")
-                    print("Run `vibe restart` to use the new version.")
-                    return 2
-                else:
-                    print("Restart scheduled to use the new version.")
-                    print(f"Job ID: {restart['job_id']}")
-                    print("Run `vibe status` to inspect the restart result.")
-            else:
-                _prepare_show_runtime_after_install(current_vibe_path)
-                print("Avibe was not running; the new version will be used next time you start it.")
-            return 0
-        else:
-            print(f"\033[31mUpgrade failed:\033[0m\n{result.stderr}")
-            return 1
-    except Exception as e:
-        print(f"\033[31mUpgrade failed: {e}\033[0m")
+        transaction = build_upgrade_transaction(
+            vibe_path=current_vibe_path,
+            memory_enabled=configured_memory_enabled(),
+        )
+        restart = schedule_upgrade_transaction(
+            transaction,
+            delay_seconds=0.0,
+            vibe_path=current_vibe_path,
+            trigger="upgrade",
+            prepare_show_runtime=not should_skip_show_runtime_prepare(),
+        )
+    except Exception as exc:
+        print(f"\033[31mUpgrade failed: {exc}\033[0m")
         return 1
+    print("\033[32mUpgrade scheduled; the supervisor will replace the package and restart Avibe.\033[0m")
+    print(f"Job ID: {restart['job_id']}")
+    print("Run `vibe status` to inspect the transaction result.")
+    return 0
 
 
 def _show_runtime_manager_from_args(args):

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -14398,10 +14398,15 @@ def cmd_upgrade():
     print("\nUpgrading...")
 
     current_vibe_path = cache_running_vibe_path()
-    plan = build_upgrade_plan(
-        vibe_path=current_vibe_path,
-        memory_enabled=configured_memory_enabled(),
-    )
+    try:
+        plan = build_upgrade_plan(
+            vibe_path=current_vibe_path,
+            memory_enabled=configured_memory_enabled(),
+            target_version=info.get("latest"),
+        )
+    except ValueError as exc:
+        print(f"\033[31mUpgrade failed: {exc}\033[0m")
+        return 1
     print(f"Using {plan.method}: {' '.join(plan.command)}")
     runtime_was_running = _runtime_process_was_running()
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -76,6 +76,7 @@ from vibe.upgrade import (
     should_skip_show_runtime_prepare,
 )
 from storage.db import create_sqlite_engine
+from storage.lock import MigrationLockTimeout
 from storage.background import (
     DefinitionWriteConflict,
     SQLiteBackgroundTaskStore,
@@ -14378,6 +14379,18 @@ def cmd_check_update():
     return 0
 
 
+def _wait_for_upgrade_job(job_id: str, timeout_seconds: float = 900.0) -> dict | None:
+    """Wait for the exact supervisor job so CLI callers see completed state."""
+
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        status = runtime.read_json(runtime.get_restart_status_path()) or {}
+        if status.get("job_id") == job_id and status.get("state") in {"succeeded", "failed", "error", "cancelled"}:
+            return status
+        time.sleep(0.25)
+    return None
+
+
 def cmd_upgrade():
     """Upgrade avibe-os to the latest version."""
     print(f"Current version: {__version__}")
@@ -14409,12 +14422,22 @@ def cmd_upgrade():
             trigger="upgrade",
             prepare_show_runtime=not should_skip_show_runtime_prepare(),
         )
+    except MigrationLockTimeout as exc:
+        print(f"\033[31mUpgrade could not start: {exc}\033[0m")
+        return 2
     except Exception as exc:
         print(f"\033[31mUpgrade failed: {exc}\033[0m")
         return 1
-    print("\033[32mUpgrade scheduled; the supervisor will replace the package and restart Avibe.\033[0m")
     print(f"Job ID: {restart['job_id']}")
-    print("Run `vibe status` to inspect the transaction result.")
+    status = _wait_for_upgrade_job(restart["job_id"])
+    if status is None:
+        print("\033[31mUpgrade did not finish before the supervisor wait timed out.\033[0m")
+        return 1
+    if status.get("state") != "succeeded":
+        print(f"\033[31mUpgrade failed: {status.get('error') or 'see restart log'}\033[0m")
+        return 1
+    print("\033[32mUpgrade successful!\033[0m")
+    print("Upgrade completed; Avibe restarted successfully.")
     return 0
 
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -62,21 +62,21 @@ from core.watches import (
 )
 from vibe import __version__, api, runtime
 from vibe.i18n import normalize_language, t as i18n_t
-from vibe.restart_supervisor import schedule_restart, schedule_upgrade_transaction
+from vibe.restart_supervisor import schedule_restart
 from vibe.screenshot import ScreenshotError, capture_screenshot
 from vibe.upgrade import (
     CURRENT_VIBE_EXECUTABLE_ENV,
     LEGACY_PACKAGE_NAME,
     PACKAGE_NAME,
-    build_upgrade_transaction,
-    configured_memory_enabled,
+    build_upgrade_plan,
     cache_running_vibe_path,
+    configured_memory_enabled,
+    execute_upgrade_plan,
     get_latest_version_info,
     get_safe_cwd,
     should_skip_show_runtime_prepare,
 )
 from storage.db import create_sqlite_engine
-from storage.lock import MigrationLockTimeout
 from storage.background import (
     DefinitionWriteConflict,
     SQLiteBackgroundTaskStore,
@@ -14379,18 +14379,6 @@ def cmd_check_update():
     return 0
 
 
-def _wait_for_upgrade_job(job_id: str, timeout_seconds: float = 900.0) -> dict | None:
-    """Wait for the exact supervisor job so CLI callers see completed state."""
-
-    deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
-        status = runtime.read_json(runtime.get_restart_status_path()) or {}
-        if status.get("job_id") == job_id and status.get("state") in {"succeeded", "failed", "error", "cancelled"}:
-            return status
-        time.sleep(0.25)
-    return None
-
-
 def cmd_upgrade():
     """Upgrade avibe-os to the latest version."""
     print(f"Current version: {__version__}")
@@ -14410,35 +14398,55 @@ def cmd_upgrade():
     print("\nUpgrading...")
 
     current_vibe_path = cache_running_vibe_path()
+    plan = build_upgrade_plan(
+        vibe_path=current_vibe_path,
+        memory_enabled=configured_memory_enabled(),
+    )
+    print(f"Using {plan.method}: {' '.join(plan.command)}")
+    runtime_was_running = _runtime_process_was_running()
+
+    # Use a stable directory as cwd to avoid issues when running from a
+    # directory that uv may delete during upgrade (e.g. inside the uv tool venv).
+    safe_cwd = get_safe_cwd()
+
     try:
-        transaction = build_upgrade_transaction(
-            vibe_path=current_vibe_path,
-            memory_enabled=configured_memory_enabled(),
+        result = execute_upgrade_plan(
+            plan,
+            run=subprocess.run,
+            capture_output=True,
+            text=True,
+            cwd=safe_cwd,
         )
-        restart = schedule_upgrade_transaction(
-            transaction,
-            delay_seconds=0.0,
-            vibe_path=current_vibe_path,
-            trigger="upgrade",
-            prepare_show_runtime=not should_skip_show_runtime_prepare(),
-        )
-    except MigrationLockTimeout as exc:
-        print(f"\033[31mUpgrade could not start: {exc}\033[0m")
-        return 2
-    except Exception as exc:
-        print(f"\033[31mUpgrade failed: {exc}\033[0m")
+        if result.returncode == 0:
+            print("\033[32mUpgrade successful!\033[0m")
+            if runtime_was_running:
+                try:
+                    restart = schedule_restart(
+                        delay_seconds=0.0,
+                        vibe_path=current_vibe_path,
+                        trigger="upgrade",
+                        prepare_show_runtime=not should_skip_show_runtime_prepare(),
+                        rollback_to=plan.rollback_to,
+                    )
+                except Exception as exc:
+                    print("\033[33mUpgrade installed, but restart scheduling failed.\033[0m")
+                    print(f"Restart error: {exc}")
+                    print("Run `vibe restart` to use the new version.")
+                    return 2
+                else:
+                    print("Restart scheduled to use the new version.")
+                    print(f"Job ID: {restart['job_id']}")
+                    print("Run `vibe status` to inspect the restart result.")
+            else:
+                _prepare_show_runtime_after_install(current_vibe_path)
+                print("Avibe was not running; the new version will be used next time you start it.")
+            return 0
+        else:
+            print(f"\033[31mUpgrade failed:\033[0m\n{result.stderr}")
+            return 1
+    except Exception as e:
+        print(f"\033[31mUpgrade failed: {e}\033[0m")
         return 1
-    print(f"Job ID: {restart['job_id']}")
-    status = _wait_for_upgrade_job(restart["job_id"])
-    if status is None:
-        print("\033[31mUpgrade did not finish before the supervisor wait timed out.\033[0m")
-        return 1
-    if status.get("state") != "succeeded":
-        print(f"\033[31mUpgrade failed: {status.get('error') or 'see restart log'}\033[0m")
-        return 1
-    print("\033[32mUpgrade successful!\033[0m")
-    print("Upgrade completed; Avibe restarted successfully.")
-    return 0
 
 
 def _show_runtime_manager_from_args(args):

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -14388,14 +14388,11 @@ def cmd_upgrade():
 
     if info["error"]:
         print(f"\033[33mFailed to check for updates: {info['error']}\033[0m")
-        print("Attempting upgrade anyway...")
     elif not info["has_update"]:
         print("\033[32mYou are already using the latest version.\033[0m")
         return 0
     else:
         print(f"New version available: {info['latest']}")
-
-    print("\nUpgrading...")
 
     current_vibe_path = cache_running_vibe_path()
     try:
@@ -14407,6 +14404,9 @@ def cmd_upgrade():
     except ValueError as exc:
         print(f"\033[31mUpgrade failed: {exc}\033[0m")
         return 1
+    if info["error"]:
+        print("Attempting upgrade anyway...")
+    print("\nUpgrading...")
     print(f"Using {plan.method}: {' '.join(plan.command)}")
     runtime_was_running = _runtime_process_was_running()
 

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -7,10 +7,12 @@ import logging
 import os
 import shlex
 import subprocess
+import sys
 import time
 import urllib.error
 import urllib.request
 import uuid
+from contextlib import contextmanager
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import NamedTuple
@@ -24,12 +26,15 @@ from config import paths
 # load makes every later use a `sys.modules` hit that touches no file. The module
 # is pure stdlib, so paying for it on every restart costs nothing.
 from storage.backups import find_restorable_backup, next_backup_sequence, restore_sqlite_backup
+from storage.lock import MigrationFileLock, MigrationLockTimeout
 from vibe import runtime
 from vibe.build_identity import get_build_identity
 from vibe.upgrade import (
     LEGACY_PACKAGE_NAME,
     PACKAGE_NAME,
     RollbackTarget,
+    UpgradePlan,
+    UpgradeTransaction,
     _names_a_published_release,
     build_upgrade_plan,
     get_restart_command,
@@ -37,6 +42,8 @@ from vibe.upgrade import (
     get_restart_invocation_command,
     get_safe_cwd,
     installed_package_name,
+    execute_upgrade_plan,
+    preflight_upgrade_plan,
 )
 
 
@@ -53,6 +60,17 @@ _ROLLBACK_INSTALL_TIMEOUT_SECONDS = 600.0
 # next to an already-warm CLI -- is not the right bound here. This one is only
 # ever paid in full when the UI is genuinely not coming.
 _ROLLBACK_UI_READY_TIMEOUT_SECONDS = 60.0
+_UPGRADE_TRANSACTION_LOCK_TIMEOUT_SECONDS = 30.0
+
+
+@contextmanager
+def _upgrade_transaction_lock(*, timeout_seconds: float | None = _UPGRADE_TRANSACTION_LOCK_TIMEOUT_SECONDS):
+    """Private lease held by the supervisor across package replacement."""
+
+    lock_path = paths.get_runtime_dir() / "upgrade-transaction.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    with MigrationFileLock(lock_path, timeout_seconds=timeout_seconds):
+        yield
 
 
 class StartedRuntime(NamedTuple):
@@ -353,6 +371,24 @@ def _write_status(payload: dict) -> None:
     path = runtime.get_restart_status_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     runtime.write_json(path, status)
+
+
+def _upgrade_transaction_active() -> bool:
+    status = runtime.read_json(runtime.get_restart_status_path())
+    return isinstance(status, dict) and status.get("transaction") == "upgrade-v1" and status.get("state") in {
+        "scheduled",
+        "running",
+    }
+
+
+def _restart_job_active() -> bool:
+    status = runtime.read_json(runtime.get_restart_status_path())
+    if not isinstance(status, dict) or status.get("state") not in {"scheduled", "running"}:
+        return False
+    supervisor_pid = status.get("supervisor_pid")
+    if supervisor_pid is None:
+        return True
+    return isinstance(supervisor_pid, int) and supervisor_pid > 0 and runtime.pid_alive(supervisor_pid)
 
 
 def _read_recorded_pid() -> int | None:
@@ -656,7 +692,13 @@ def _roll_back_failed_upgrade(
         return rollback
 
     try:
-        plan = build_upgrade_plan(vibe_path=vibe_path, version=version, package_name=rollback_to.package)
+        plan = build_upgrade_plan(
+            vibe_path=vibe_path,
+            version=version,
+            package_name=rollback_to.package,
+            memory_package=rollback_to.memory_package,
+            memory_version=rollback_to.memory_version,
+        )
     except Exception as exc:
         rollback.update(state="failed", error=f"cannot build a pinned install for {version}: {exc}")
         record(rollback)
@@ -665,11 +707,11 @@ def _roll_back_failed_upgrade(
     rollback["install"] = {"method": plan.method, "ok": None}
     record(rollback)
     try:
-        result = subprocess.run(
-            plan.command,
+        result = execute_upgrade_plan(
+            plan,
+            run=subprocess.run,
             capture_output=True,
             text=True,
-            env=plan.env,
             cwd=get_safe_cwd(),
             timeout=_ROLLBACK_INSTALL_TIMEOUT_SECONDS,
         )
@@ -759,6 +801,164 @@ def _wait_for_service_lock_release(timeout: float = _SERVICE_LOCK_RELEASE_TIMEOU
     return available
 
 
+def _run_upgrade_transaction(
+    *,
+    job_id: str,
+    delay_seconds: float,
+    vibe_path: str | None,
+    trigger: str,
+    scope: str,
+    prepare_show_runtime: bool,
+    transaction: UpgradeTransaction,
+) -> int:
+    """Execute one declarative package transaction under the supervisor lease."""
+
+    transaction.validate()
+    log_path = _restart_log_path(job_id)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    safe_cwd = get_safe_cwd()
+    start_ui = scope != "service"
+    payload = {
+        "ok": None,
+        "job_id": job_id,
+        "state": "running",
+        "trigger": trigger,
+        "scope": scope,
+        "delay_seconds": delay_seconds,
+        "supervisor_pid": os.getpid(),
+        "supervisor_started_at": runtime.process_create_time(os.getpid()),
+        "old_pid": _read_recorded_pid(),
+        "new_pid": None,
+        "log_path": str(log_path),
+        "error": None,
+        "created_at": _now_iso(),
+        "transaction": "upgrade-v1",
+    }
+
+    with log_path.open("a", encoding="utf-8") as log:
+        def write(message: str) -> None:
+            log.write(f"{_now_iso()} {message}\n")
+            log.flush()
+
+        def fail(message: str, code: int = 2) -> int:
+            payload.update(ok=False, state="failed", error=message)
+            _write_status(payload)
+            write(message)
+            return code
+
+        _write_status(payload)
+        if delay_seconds > 0:
+            time.sleep(delay_seconds)
+            payload["state"] = "running"
+            _write_status(payload)
+
+        rollback_to = transaction.rollback_to
+        with _upgrade_transaction_lock():
+            running_before = runtime.verified_service_running()
+            if running_before and transaction.activate_runtime == "none":
+                return fail("upgrade transaction requires lifecycle activation while Avibe is running")
+            try:
+                plan = build_upgrade_plan(
+                    python_executable=sys.executable,
+                    vibe_path=vibe_path,
+                    version=None,
+                    memory_enabled=transaction.include_memory,
+                    package_spec=transaction.forward_spec,
+                )
+            except Exception as exc:
+                return fail(f"cannot build upgrade transaction: {exc}")
+            if plan.method != transaction.installer:
+                return fail("upgrade transaction installer does not match current runtime")
+
+            write("preflighting upgrade transaction")
+            try:
+                preflight = preflight_upgrade_plan(
+                    plan,
+                    cwd=safe_cwd,
+                    stdout=log,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    check=False,
+                    timeout=_ROLLBACK_INSTALL_TIMEOUT_SECONDS,
+                )
+            except Exception as exc:
+                return fail(f"upgrade preflight failed: {exc}")
+            if preflight is not None and preflight.returncode != 0:
+                detail = (preflight.stderr or preflight.stdout or "").strip()[-2000:]
+                return fail(f"upgrade preflight failed with exit code {preflight.returncode}: {detail}")
+
+            if running_before:
+                write("stopping runtime before package transaction")
+                try:
+                    _stop_runtime_for_restart(stop_ui=start_ui)
+                except Exception as exc:
+                    return fail(f"stop runtime failed: {exc}")
+                if not _wait_for_service_lock_release():
+                    return fail("service lock did not release after stopping runtime")
+
+            install_plan = UpgradePlan(
+                command=plan.command,
+                env=plan.env,
+                method=plan.method,
+                rollback_to=plan.rollback_to,
+                preflight_command=None,
+                cleanup_command=plan.cleanup_command,
+                cleanup_after_command=plan.cleanup_after_command,
+            )
+            write("installing upgrade transaction")
+            try:
+                result = execute_upgrade_plan(
+                    install_plan,
+                    cwd=safe_cwd,
+                    stdout=log,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    check=False,
+                    timeout=_ROLLBACK_INSTALL_TIMEOUT_SECONDS,
+                )
+            except Exception as exc:
+                result = None
+                install_error = str(exc)
+            else:
+                install_error = ""
+            if result is None or result.returncode != 0:
+                detail = install_error or ((result.stderr or result.stdout or "").strip()[-2000:] if result else "")
+                if rollback_to and running_before and not runtime.verified_service_running():
+                    try:
+                        rollback = _roll_back_failed_upgrade(
+                            rollback_to=rollback_to,
+                            vibe_path=vibe_path,
+                            start_ui=start_ui,
+                            backup_watermark=None,
+                            write=write,
+                            record=lambda value: payload.update(rollback=value) or _write_status(payload),
+                        )
+                        payload["rollback"] = rollback
+                    except Exception as exc:
+                        write(f"rollback failed: {exc}")
+                return fail(f"upgrade install failed: {detail}")
+
+            if running_before and transaction.activate_runtime == "restart_if_running":
+                write("starting runtime after package transaction")
+                try:
+                    started = _start_runtime_processes(start_ui=start_ui)
+                except Exception as exc:
+                    return fail(f"start runtime failed: {exc}")
+                ready_pid = runtime.wait_for_service_ready(
+                    started.service_pid,
+                    timeout=runtime.SERVICE_SLOW_START_TIMEOUT_SECONDS,
+                )
+                if ready_pid is None:
+                    return fail("service did not become ready after package transaction")
+                payload["new_pid"] = ready_pid
+                runtime.write_status("running", f"pid={ready_pid}", ready_pid, _live_ui_pid(started.ui_pid))
+
+            payload.update(ok=True, state="succeeded", error=None)
+            _write_status(payload)
+            write("upgrade transaction succeeded")
+            return 0
+
+
 def _run_restart_job(
     *,
     job_id: str,
@@ -768,7 +968,31 @@ def _run_restart_job(
     scope: str = "all",
     prepare_show_runtime: bool = False,
     rollback_to: RollbackTarget | None = None,
+    upgrade_transaction: UpgradeTransaction | None = None,
 ) -> int:
+    if upgrade_transaction is not None:
+        try:
+            return _run_upgrade_transaction(
+                job_id=job_id,
+                delay_seconds=delay_seconds,
+                vibe_path=vibe_path,
+                trigger=trigger,
+                scope=scope,
+                prepare_show_runtime=prepare_show_runtime,
+                transaction=upgrade_transaction,
+            )
+        except MigrationLockTimeout as exc:
+            payload = {
+                "ok": False,
+                "job_id": job_id,
+                "state": "failed",
+                "trigger": trigger,
+                "scope": scope,
+                "transaction": "upgrade-v1",
+                "error": f"upgrade transaction busy: {exc}",
+            }
+            _write_status(payload)
+            return 2
     # "service": restart only the service process, leaving the Web UI process
     # running (a config change shouldn't tear down the open Web UI). "all"
     # (default, e.g. CLI `vibe restart` / upgrades) restarts both.
@@ -1052,6 +1276,33 @@ def schedule_restart(
     memory_ui_secret: str | None = None,
     rollback_to: RollbackTarget | None = None,
 ) -> dict:
+    """Admit and spawn an ordinary restart under the transaction gate."""
+
+    # The same private lease serializes admission with a package transaction.
+    # Holding it through status seeding and Popen closes the gap where each side
+    # could observe the other as idle and then spawn competing supervisors.
+    with _upgrade_transaction_lock(timeout_seconds=0):
+        return _schedule_restart_locked(
+            delay_seconds=delay_seconds,
+            vibe_path=vibe_path,
+            trigger=trigger,
+            scope=scope,
+            prepare_show_runtime=prepare_show_runtime,
+            memory_ui_secret=memory_ui_secret,
+            rollback_to=rollback_to,
+        )
+
+
+def _schedule_restart_locked(
+    *,
+    delay_seconds: float = 0.0,
+    vibe_path: str | None = None,
+    trigger: str = "cli",
+    scope: str = "all",
+    prepare_show_runtime: bool = False,
+    memory_ui_secret: str | None = None,
+    rollback_to: RollbackTarget | None = None,
+) -> dict:
     """Spawn the detached restart job.
 
     `rollback_to` is the install currently on the machine, and passing it is what
@@ -1073,6 +1324,8 @@ def schedule_restart(
     from vibe.memory_ui_access import process_ui_read_secret
     from storage.migrations import guard_source_checkout_default_state_bootstrap
 
+    if _upgrade_transaction_active():
+        raise RuntimeError("an upgrade transaction is already in progress")
     memory_ui_secret = memory_ui_secret or process_ui_read_secret()
     guard_source_checkout_default_state_bootstrap()
     job_id = uuid.uuid4().hex[:12]
@@ -1106,6 +1359,9 @@ def schedule_restart(
         )
         if rollback_to.package:
             command.extend(["--rollback-package", rollback_to.package])
+        command.extend(["--rollback-memory-package", "1" if rollback_to.memory_package else "0"])
+        if rollback_to.memory_version:
+            command.extend(["--rollback-memory-version", rollback_to.memory_version])
     env = get_restart_environment(vibe_path=vibe_path)
     log_path = _restart_log_path(job_id)
     log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1164,6 +1420,117 @@ def schedule_restart(
     return payload
 
 
+def schedule_upgrade_transaction(
+    transaction: UpgradeTransaction,
+    *,
+    delay_seconds: float = 0.0,
+    vibe_path: str | None = None,
+    trigger: str = "upgrade",
+    scope: str = "all",
+    prepare_show_runtime: bool = False,
+    memory_ui_secret: str | None = None,
+) -> dict:
+    """Spawn the supervisor-owned package transaction."""
+
+    from vibe.memory_ui_access import process_ui_read_secret
+    from storage.migrations import guard_source_checkout_default_state_bootstrap
+
+    transaction.validate()
+    guard_source_checkout_default_state_bootstrap()
+    memory_ui_secret = memory_ui_secret or process_ui_read_secret()
+    job_id = uuid.uuid4().hex[:12]
+    invocation = get_restart_invocation_command(vibe_path=vibe_path)
+    command = [*invocation[:-1], "__restart-supervisor"] if invocation and invocation[-1] == "restart" else [
+        *(invocation or ["vibe"]),
+        "__restart-supervisor",
+    ]
+    command.extend(
+        [
+            "--job-id",
+            job_id,
+            "--delay-seconds",
+            str(delay_seconds),
+            "--trigger",
+            trigger,
+            "--upgrade-transaction-version",
+            str(transaction.schema_version),
+            "--upgrade-installer",
+            transaction.installer,
+            "--upgrade-forward-spec",
+            transaction.forward_spec,
+            "--upgrade-activate-runtime",
+            transaction.activate_runtime,
+        ]
+    )
+    if transaction.include_memory:
+        command.extend(["--upgrade-include-memory", "--upgrade-memory-requirement", transaction.memory_requirement or ""])
+    if scope != "all":
+        command.extend(["--scope", scope])
+    if vibe_path:
+        command.extend(["--vibe-path", vibe_path])
+    if prepare_show_runtime:
+        command.append("--prepare-show-runtime")
+    if transaction.rollback_to:
+        target = transaction.rollback_to
+        command.extend(
+            [
+                "--rollback-to",
+                target.version,
+                "--rollback-python",
+                target.launcher.python,
+                "--rollback-main",
+                target.launcher.main,
+                "--rollback-memory-package",
+                "1" if target.memory_package else "0",
+            ]
+        )
+        if target.package:
+            command.extend(["--rollback-package", target.package])
+        if target.memory_version:
+            command.extend(["--rollback-memory-version", target.memory_version])
+    env = get_restart_environment(vibe_path=vibe_path)
+    log_path = _restart_log_path(job_id)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "ok": None,
+        "job_id": job_id,
+        "state": "scheduled",
+        "trigger": trigger,
+        "scope": scope,
+        "delay_seconds": delay_seconds,
+        "supervisor_pid": None,
+        "old_pid": _read_recorded_pid(),
+        "new_pid": None,
+        "log_path": str(log_path),
+        "error": None,
+        "created_at": _now_iso(),
+        "transaction": "upgrade-v1",
+    }
+    try:
+        with _upgrade_transaction_lock(timeout_seconds=0):
+            if _restart_job_active():
+                raise RuntimeError("a restart is already in progress")
+            _write_status(payload)
+            with log_path.open("a", encoding="utf-8") as log:
+                process = subprocess.Popen(
+                    command,
+                    stdin=subprocess.PIPE if memory_ui_secret is not None else None,
+                    stdout=log,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                    close_fds=True,
+                    cwd=get_safe_cwd(),
+                    env=runtime._memory_ui_child_env(env, memory_ui_secret=memory_ui_secret),
+                )
+                runtime._spawn_stdin(process, memory_ui_secret=memory_ui_secret)
+    except OSError as exc:
+        payload.update(ok=False, state="failed", error=f"failed to spawn upgrade supervisor: {exc}")
+        _write_status(payload)
+        raise
+    payload["supervisor_pid"] = process.pid
+    return payload
+
+
 def main(argv: list[str] | None = None) -> int:
     from vibe.memory_ui_access import initialize_process_ui_read_secret
 
@@ -1179,6 +1546,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--rollback-package")
     parser.add_argument("--rollback-python")
     parser.add_argument("--rollback-main")
+    parser.add_argument("--rollback-memory-package", choices=("0", "1"))
+    parser.add_argument("--rollback-memory-version")
+    parser.add_argument("--upgrade-transaction-version", type=int)
+    parser.add_argument("--upgrade-installer", choices=("pip", "uv"))
+    parser.add_argument("--upgrade-forward-spec")
+    parser.add_argument("--upgrade-include-memory", action="store_true")
+    parser.add_argument("--upgrade-memory-requirement")
+    parser.add_argument("--upgrade-activate-runtime", choices=("restart_if_running", "none"), default="restart_if_running")
     args = parser.parse_args(argv)
     # The one place a rollback target is apart, and so the one place it is put
     # back together. Reassembling here rather than passing four values inward
@@ -1193,7 +1568,26 @@ def main(argv: list[str] | None = None) -> int:
             version=args.rollback_to,
             package=args.rollback_package,
             launcher=runtime.ServiceLauncher(python=args.rollback_python, main=args.rollback_main),
+            memory_package=args.rollback_memory_package == "1",
+            memory_version=args.rollback_memory_version,
         )
+    upgrade_transaction = None
+    if args.upgrade_transaction_version is not None:
+        if not args.upgrade_installer or not args.upgrade_forward_spec:
+            parser.error("upgrade transaction requires installer and forward spec")
+        upgrade_transaction = UpgradeTransaction(
+            schema_version=args.upgrade_transaction_version,
+            installer=args.upgrade_installer,
+            forward_spec=args.upgrade_forward_spec,
+            include_memory=args.upgrade_include_memory,
+            memory_requirement=args.upgrade_memory_requirement,
+            rollback_to=rollback_to,
+            activate_runtime=args.upgrade_activate_runtime,
+        )
+        try:
+            upgrade_transaction.validate()
+        except ValueError as exc:
+            parser.error(str(exc))
     return _run_restart_job(
         job_id=args.job_id,
         delay_seconds=max(0.0, args.delay_seconds),
@@ -1202,6 +1596,7 @@ def main(argv: list[str] | None = None) -> int:
         scope=args.scope,
         prepare_show_runtime=args.prepare_show_runtime,
         rollback_to=rollback_to,
+        upgrade_transaction=upgrade_transaction,
     )
 
 

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -7,12 +7,10 @@ import logging
 import os
 import shlex
 import subprocess
-import sys
 import time
 import urllib.error
 import urllib.request
 import uuid
-from contextlib import contextmanager
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import NamedTuple
@@ -26,24 +24,21 @@ from config import paths
 # load makes every later use a `sys.modules` hit that touches no file. The module
 # is pure stdlib, so paying for it on every restart costs nothing.
 from storage.backups import find_restorable_backup, next_backup_sequence, restore_sqlite_backup
-from storage.lock import MigrationFileLock, MigrationLockTimeout
 from vibe import runtime
 from vibe.build_identity import get_build_identity
 from vibe.upgrade import (
     LEGACY_PACKAGE_NAME,
+    MEMORY_PACKAGE_NAME,
     PACKAGE_NAME,
     RollbackTarget,
-    UpgradePlan,
-    UpgradeTransaction,
     _names_a_published_release,
     build_upgrade_plan,
+    execute_upgrade_plan,
     get_restart_command,
     get_restart_environment,
     get_restart_invocation_command,
     get_safe_cwd,
     installed_package_name,
-    execute_upgrade_plan,
-    preflight_upgrade_plan,
 )
 
 
@@ -60,18 +55,6 @@ _ROLLBACK_INSTALL_TIMEOUT_SECONDS = 600.0
 # next to an already-warm CLI -- is not the right bound here. This one is only
 # ever paid in full when the UI is genuinely not coming.
 _ROLLBACK_UI_READY_TIMEOUT_SECONDS = 60.0
-_UPGRADE_TRANSACTION_LOCK_TIMEOUT_SECONDS = 30.0
-_RESTART_SEED_GRACE_SECONDS = 60.0
-
-
-@contextmanager
-def _upgrade_transaction_lock(*, timeout_seconds: float | None = _UPGRADE_TRANSACTION_LOCK_TIMEOUT_SECONDS):
-    """Private lease held by the supervisor across package replacement."""
-
-    lock_path = paths.get_runtime_dir() / "upgrade-transaction.lock"
-    lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    with MigrationFileLock(lock_path, timeout_seconds=timeout_seconds):
-        yield
 
 
 class StartedRuntime(NamedTuple):
@@ -228,7 +211,7 @@ def _launcher_dist_metadata(launcher: runtime.ServiceLauncher) -> list[tuple[str
             payload = email.parser.Parser().parsestr(metadata_path.read_text(encoding="utf-8"))
             name = str(payload.get("Name") or "").strip()
             version = str(payload.get("Version") or "").strip()
-            if name in {PACKAGE_NAME, LEGACY_PACKAGE_NAME} and version:
+            if name in {PACKAGE_NAME, LEGACY_PACKAGE_NAME, MEMORY_PACKAGE_NAME} and version:
                 entries.append((name, version))
     except (OSError, UnicodeError, ValueError):
         return []
@@ -297,7 +280,17 @@ def _discover_legacy_upgrade_target(*, trigger: str, vibe_path: str | None) -> R
         if metadata is None:
             return None
         version, package = metadata
-    return RollbackTarget(version=version, package=package, launcher=launcher)
+    memory_version = next(
+        (candidate_version for candidate_name, candidate_version in _launcher_dist_metadata(launcher) if candidate_name == MEMORY_PACKAGE_NAME),
+        None,
+    )
+    return RollbackTarget(
+        version=version,
+        package=package,
+        launcher=launcher,
+        memory_package=memory_version is not None,
+        memory_version=memory_version,
+    )
 
 
 def _now_iso() -> str:
@@ -372,37 +365,6 @@ def _write_status(payload: dict) -> None:
     path = runtime.get_restart_status_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     runtime.write_json(path, status)
-
-
-def _upgrade_transaction_active() -> bool:
-    status = runtime.read_json(runtime.get_restart_status_path())
-    return _restart_status_in_flight(status) and status.get("transaction") == "upgrade-v1"
-
-
-def _restart_job_active() -> bool:
-    status = runtime.read_json(runtime.get_restart_status_path())
-    return _restart_status_in_flight(status)
-
-
-def _restart_status_in_flight(status: object) -> bool:
-    """Validate restart ownership from the live supervisor identity, not a stale marker."""
-
-    if not isinstance(status, dict) or status.get("state") not in {"scheduled", "running"}:
-        return False
-    supervisor_pid = status.get("supervisor_pid")
-    if isinstance(supervisor_pid, int):
-        if supervisor_pid <= 0 or not runtime.pid_alive(supervisor_pid):
-            return False
-        started_at = status.get("supervisor_started_at")
-        if started_at is None:
-            return True
-        current_started_at = runtime.process_create_time(supervisor_pid)
-        return current_started_at is None or current_started_at == started_at
-    try:
-        age = time.time() - runtime.get_restart_status_path().stat().st_mtime
-    except OSError:
-        return False
-    return age < _RESTART_SEED_GRACE_SECONDS
 
 
 def _read_recorded_pid() -> int | None:
@@ -816,217 +778,6 @@ def _wait_for_service_lock_release(timeout: float = _SERVICE_LOCK_RELEASE_TIMEOU
     return available
 
 
-def _prepare_show_runtime_nonfatal(vibe_path: str | None, cwd: str, write) -> None:
-    """Preserve the upgrade-era Show Runtime prepare step without failing install."""
-
-    try:
-        from vibe.api import _prepare_show_runtime_after_upgrade
-
-        detail = _prepare_show_runtime_after_upgrade(vibe_path, cwd)
-    except Exception as exc:  # pragma: no cover - defensive import boundary
-        detail = f"Show Runtime preparation skipped: {exc}"
-    if detail:
-        write(detail)
-
-
-def _run_upgrade_transaction(
-    *,
-    job_id: str,
-    delay_seconds: float,
-    vibe_path: str | None,
-    trigger: str,
-    scope: str,
-    prepare_show_runtime: bool,
-    transaction: UpgradeTransaction,
-) -> int:
-    """Execute one declarative package transaction under the supervisor lease."""
-
-    transaction.validate()
-    log_path = _restart_log_path(job_id)
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    safe_cwd = get_safe_cwd()
-    start_ui = scope != "service"
-    payload = {
-        "ok": None,
-        "job_id": job_id,
-        "state": "running",
-        "trigger": trigger,
-        "scope": scope,
-        "delay_seconds": delay_seconds,
-        "supervisor_pid": os.getpid(),
-        "supervisor_started_at": runtime.process_create_time(os.getpid()),
-        "old_pid": _read_recorded_pid(),
-        "new_pid": None,
-        "log_path": str(log_path),
-        "error": None,
-        "created_at": _now_iso(),
-        "transaction": "upgrade-v1",
-    }
-
-    with log_path.open("a", encoding="utf-8") as log:
-        def write(message: str) -> None:
-            log.write(f"{_now_iso()} {message}\n")
-            log.flush()
-
-        def fail(message: str, code: int = 2) -> int:
-            payload.update(ok=False, state="failed", error=message)
-            _write_status(payload)
-            write(message)
-            return code
-
-        _write_status(payload)
-        if delay_seconds > 0:
-            time.sleep(delay_seconds)
-            payload["state"] = "running"
-            _write_status(payload)
-
-        rollback_to = transaction.rollback_to
-        with _upgrade_transaction_lock():
-            running_before = runtime.verified_service_running()
-            if running_before and transaction.activate_runtime == "none":
-                return fail("upgrade transaction requires lifecycle activation while Avibe is running")
-
-            def rollback_after_failure(message: str, code: int) -> int:
-                if rollback_to and running_before:
-                    try:
-                        rollback = _roll_back_failed_upgrade(
-                            rollback_to=rollback_to,
-                            vibe_path=vibe_path,
-                            start_ui=start_ui,
-                            backup_watermark=None,
-                            write=write,
-                            record=lambda value: payload.update(rollback=value) or _write_status(payload),
-                        )
-                        payload["rollback"] = rollback
-                    except Exception as exc:
-                        write(f"rollback failed: {exc}")
-                return fail(message, code)
-
-            try:
-                plan = build_upgrade_plan(
-                    python_executable=sys.executable,
-                    vibe_path=vibe_path,
-                    version=None,
-                    memory_enabled=transaction.include_memory,
-                    memory_package=transaction.include_memory,
-                    memory_requirement=transaction.memory_requirement,
-                    package_spec=transaction.forward_spec,
-                )
-            except Exception as exc:
-                return fail(f"cannot build upgrade transaction: {exc}")
-            if plan.method != transaction.installer:
-                return fail("upgrade transaction installer does not match current runtime")
-
-            write("preflighting upgrade transaction")
-            try:
-                preflight = preflight_upgrade_plan(
-                    plan,
-                    cwd=safe_cwd,
-                    stdout=log,
-                    stderr=subprocess.STDOUT,
-                    text=True,
-                    check=False,
-                    timeout=_ROLLBACK_INSTALL_TIMEOUT_SECONDS,
-                )
-            except Exception as exc:
-                return fail(f"upgrade preflight failed: {exc}")
-            if preflight is not None and preflight.returncode != 0:
-                detail = (preflight.stderr or preflight.stdout or "").strip()[-2000:]
-                return fail(f"upgrade preflight failed with exit code {preflight.returncode}: {detail}")
-
-            if running_before:
-                write("stopping runtime before package transaction")
-                try:
-                    ui_stopped, _ui_timings, _stop_ui_seconds, stopped_ui_pid, service_stopped, _stop_service_seconds = (
-                        _stop_runtime_for_restart(stop_ui=start_ui)
-                    )
-                except Exception as exc:
-                    return fail(f"stop runtime failed: {exc}")
-                ui_pid_live = bool(stopped_ui_pid and runtime.pid_alive(stopped_ui_pid))
-                ui_identity_live = runtime.ui_pid_file_points_to_running_ui() if start_ui else False
-                if start_ui and (ui_stopped is False or ui_pid_live or ui_identity_live):
-                    write(f"UI pid {stopped_ui_pid} did not stop before package mutation")
-                    if service_stopped:
-                        try:
-                            recovered = _start_runtime_processes(start_ui=False)
-                            recovered_pid = runtime.wait_for_service_ready(
-                                recovered.service_pid,
-                                timeout=runtime.SERVICE_SLOW_START_TIMEOUT_SECONDS,
-                            )
-                            if recovered_pid is not None:
-                                runtime.write_status(
-                                    "running",
-                                    f"pid={recovered_pid}",
-                                    recovered_pid,
-                                    _live_ui_pid(stopped_ui_pid),
-                                )
-                        except Exception as exc:
-                            write(f"failed to recover runtime after UI stop failure: {exc}")
-                    return fail(f"UI pid {stopped_ui_pid} did not stop before package mutation")
-                if not _wait_for_service_lock_release():
-                    return fail("service lock did not release after stopping runtime")
-
-            install_plan = UpgradePlan(
-                command=plan.command,
-                env=plan.env,
-                method=plan.method,
-                rollback_to=plan.rollback_to,
-                preflight_command=None,
-                cleanup_command=plan.cleanup_command,
-                cleanup_after_command=plan.cleanup_after_command,
-            )
-            write("installing upgrade transaction")
-            try:
-                result = execute_upgrade_plan(
-                    install_plan,
-                    cwd=safe_cwd,
-                    stdout=log,
-                    stderr=subprocess.STDOUT,
-                    text=True,
-                    check=False,
-                    timeout=_ROLLBACK_INSTALL_TIMEOUT_SECONDS,
-                )
-            except Exception as exc:
-                result = None
-                install_error = str(exc)
-            else:
-                install_error = ""
-            if result is None or result.returncode != 0:
-                detail = install_error or ((result.stderr or result.stdout or "").strip()[-2000:] if result else "")
-                return rollback_after_failure(f"upgrade install failed: {detail}", 2)
-
-            if running_before and transaction.activate_runtime == "restart_if_running":
-                write("starting runtime after package transaction")
-                try:
-                    started = _start_runtime_processes(start_ui=start_ui)
-                except Exception as exc:
-                    return rollback_after_failure(f"start runtime failed: {exc}", 1)
-                if not started.service_pid or not runtime.pid_alive(started.service_pid):
-                    return rollback_after_failure(
-                        f"started service pid {started.service_pid} is not alive",
-                        3,
-                    )
-                try:
-                    ready_pid = runtime.wait_for_service_ready(
-                        started.service_pid,
-                        timeout=runtime.SERVICE_SLOW_START_TIMEOUT_SECONDS,
-                    )
-                except Exception as exc:
-                    return rollback_after_failure(f"service readiness check failed: {exc}", 3)
-                if ready_pid is None:
-                    return rollback_after_failure("service did not become ready after package transaction", 3)
-                payload["new_pid"] = ready_pid
-                runtime.write_status("running", f"pid={ready_pid}", ready_pid, _live_ui_pid(started.ui_pid))
-
-            if prepare_show_runtime:
-                _prepare_show_runtime_nonfatal(vibe_path, safe_cwd, write)
-
-            payload.update(ok=True, state="succeeded", error=None)
-            _write_status(payload)
-            write("upgrade transaction succeeded")
-            return 0
-
-
 def _run_restart_job(
     *,
     job_id: str,
@@ -1036,31 +787,7 @@ def _run_restart_job(
     scope: str = "all",
     prepare_show_runtime: bool = False,
     rollback_to: RollbackTarget | None = None,
-    upgrade_transaction: UpgradeTransaction | None = None,
 ) -> int:
-    if upgrade_transaction is not None:
-        try:
-            return _run_upgrade_transaction(
-                job_id=job_id,
-                delay_seconds=delay_seconds,
-                vibe_path=vibe_path,
-                trigger=trigger,
-                scope=scope,
-                prepare_show_runtime=prepare_show_runtime,
-                transaction=upgrade_transaction,
-            )
-        except MigrationLockTimeout as exc:
-            payload = {
-                "ok": False,
-                "job_id": job_id,
-                "state": "failed",
-                "trigger": trigger,
-                "scope": scope,
-                "transaction": "upgrade-v1",
-                "error": f"upgrade transaction busy: {exc}",
-            }
-            _write_status(payload)
-            return 2
     # "service": restart only the service process, leaving the Web UI process
     # running (a config change shouldn't tear down the open Web UI). "all"
     # (default, e.g. CLI `vibe restart` / upgrades) restarts both.
@@ -1169,6 +896,8 @@ def _run_restart_job(
             "rollback_to": rollback_to.version if rollback_to else None,
             "rollback_package": rollback_to.package if rollback_to else None,
             "rollback_launcher": rollback_to.launcher._asdict() if rollback_to else None,
+            "rollback_memory_package": rollback_to.memory_package if rollback_to else False,
+            "rollback_memory_version": rollback_to.memory_version if rollback_to else None,
             "rollback_target_source": rollback_target_source,
             "rollback_discovery_error": rollback_discovery_error,
             "old_pid": old_pid,
@@ -1344,161 +1073,6 @@ def schedule_restart(
     memory_ui_secret: str | None = None,
     rollback_to: RollbackTarget | None = None,
 ) -> dict:
-    """Admit and spawn an ordinary restart under the transaction gate."""
-
-    from storage.migrations import guard_source_checkout_default_state_bootstrap
-
-    # Validate source-checkout state before the lock helper creates any runtime
-    # files. This keeps the migration guard side-effect free on a rejected call.
-    guard_source_checkout_default_state_bootstrap()
-    # The same private lease serializes admission with a package transaction.
-    # Holding it through status seeding and Popen closes the gap where each side
-    # could observe the other as idle and then spawn competing supervisors.
-    with _upgrade_transaction_lock(timeout_seconds=0):
-        return _schedule_restart_locked(
-            delay_seconds=delay_seconds,
-            vibe_path=vibe_path,
-            trigger=trigger,
-            scope=scope,
-            prepare_show_runtime=prepare_show_runtime,
-            memory_ui_secret=memory_ui_secret,
-            rollback_to=rollback_to,
-        )
-
-
-def _supervisor_command(
-    *,
-    vibe_path: str | None,
-    job_id: str,
-    delay_seconds: float,
-    trigger: str,
-    scope: str,
-    prepare_show_runtime: bool,
-    extra_args: list[str] | None = None,
-) -> list[str]:
-    """Build the one detached-supervisor invocation envelope."""
-
-    invocation = get_restart_invocation_command(vibe_path=vibe_path)
-    command = [*invocation[:-1], "__restart-supervisor"] if invocation and invocation[-1] == "restart" else [
-        *(invocation or ["vibe"]),
-        "__restart-supervisor",
-    ]
-    command.extend(["--job-id", job_id, "--delay-seconds", str(delay_seconds), "--trigger", trigger])
-    if scope != "all":
-        command.extend(["--scope", scope])
-    if vibe_path:
-        command.extend(["--vibe-path", vibe_path])
-    if prepare_show_runtime:
-        command.append("--prepare-show-runtime")
-    command.extend(extra_args or [])
-    return command
-
-
-def _spawn_supervisor_process(
-    *,
-    command: list[str],
-    env: dict[str, str] | None,
-    log_path: Path,
-    memory_ui_secret: str | None,
-):
-    """Spawn a detached supervisor using the shared process envelope."""
-
-    with log_path.open("a", encoding="utf-8") as log:
-        process = subprocess.Popen(
-            command,
-            stdin=subprocess.PIPE if memory_ui_secret is not None else None,
-            stdout=log,
-            stderr=subprocess.STDOUT,
-            start_new_session=True,
-            close_fds=True,
-            cwd=get_safe_cwd(),
-            env=runtime._memory_ui_child_env(env, memory_ui_secret=memory_ui_secret),
-        )
-        runtime._spawn_stdin(process, memory_ui_secret=memory_ui_secret)
-    return process
-
-
-def _supervisor_status_payload(
-    *,
-    job_id: str,
-    trigger: str,
-    scope: str,
-    delay_seconds: float,
-    log_path: Path,
-    transaction: bool = False,
-) -> dict:
-    payload = {
-        "ok": None,
-        "job_id": job_id,
-        "state": "scheduled",
-        "trigger": trigger,
-        "scope": scope,
-        "delay_seconds": delay_seconds,
-        "supervisor_pid": None,
-        "old_pid": _read_recorded_pid(),
-        "new_pid": None,
-        "log_path": str(log_path),
-        "error": None,
-        "created_at": _now_iso(),
-    }
-    if transaction:
-        payload["transaction"] = "upgrade-v1"
-    return payload
-
-
-def _write_upgrade_transaction_file(transaction: UpgradeTransaction, job_id: str) -> Path:
-    """Atomically publish a 0600, single-use declarative transaction payload."""
-
-    runtime_dir = paths.get_runtime_dir()
-    runtime_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-    os.chmod(runtime_dir, 0o700)
-    path = runtime_dir / f"upgrade-transaction-{job_id}.json"
-    temporary = runtime_dir / f".{path.name}.{os.getpid()}.tmp"
-    payload = json.dumps(transaction.to_payload(), separators=(",", ":"), sort_keys=True)
-    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-    try:
-        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
-            descriptor = -1
-            handle.write(payload)
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(temporary, path)
-        os.chmod(path, 0o600)
-    finally:
-        if descriptor != -1:
-            os.close(descriptor)
-        temporary.unlink(missing_ok=True)
-    return path
-
-
-def _read_upgrade_transaction_file(path: str) -> UpgradeTransaction:
-    """Consume and validate the supervisor payload before any lifecycle action."""
-
-    payload_path = Path(path)
-    runtime_dir = paths.get_runtime_dir().resolve()
-    try:
-        if payload_path.resolve().parent != runtime_dir:
-            raise ValueError("upgrade transaction payload path is outside the runtime directory")
-    except OSError as exc:
-        raise ValueError("invalid upgrade transaction payload path") from exc
-    try:
-        with payload_path.open(encoding="utf-8") as handle:
-            payload = json.load(handle)
-    finally:
-        payload_path.unlink(missing_ok=True)
-    return UpgradeTransaction.from_payload(payload)
-
-
-def _schedule_restart_locked(
-    *,
-    delay_seconds: float = 0.0,
-    vibe_path: str | None = None,
-    trigger: str = "cli",
-    scope: str = "all",
-    prepare_show_runtime: bool = False,
-    memory_ui_secret: str | None = None,
-    rollback_to: RollbackTarget | None = None,
-) -> dict:
     """Spawn the detached restart job.
 
     `rollback_to` is the install currently on the machine, and passing it is what
@@ -1520,29 +1094,43 @@ def _schedule_restart_locked(
     from vibe.memory_ui_access import process_ui_read_secret
     from storage.migrations import guard_source_checkout_default_state_bootstrap
 
-    if _upgrade_transaction_active():
-        raise RuntimeError("an upgrade transaction is already in progress")
     memory_ui_secret = memory_ui_secret or process_ui_read_secret()
     guard_source_checkout_default_state_bootstrap()
     job_id = uuid.uuid4().hex[:12]
-    extra_args: list[str] = []
+    invocation = get_restart_invocation_command(vibe_path=vibe_path)
+    command = [*invocation[:-1], "__restart-supervisor"] if invocation and invocation[-1] == "restart" else [
+        *(invocation or ["vibe"]),
+        "__restart-supervisor",
+    ]
+    command.extend(["--job-id", job_id, "--delay-seconds", str(delay_seconds), "--trigger", trigger])
+    if scope != "all":
+        command.extend(["--scope", scope])
+    if vibe_path:
+        command.extend(["--vibe-path", vibe_path])
+    if prepare_show_runtime:
+        command.append("--prepare-show-runtime")
     if rollback_to:
-        extra_args.extend(["--rollback-to", rollback_to.version])
-        extra_args.extend(["--rollback-python", rollback_to.launcher.python, "--rollback-main", rollback_to.launcher.main])
+        command.extend(
+            [
+                "--rollback-to",
+                rollback_to.version,
+                # Not optional the way the package name is. A missing package
+                # name still leaves `build_upgrade_plan` a defensible default,
+                # while a missing launcher leaves the job with only its own --
+                # which, in the case this exists for, is the release being
+                # undone.
+                "--rollback-python",
+                rollback_to.launcher.python,
+                "--rollback-main",
+                rollback_to.launcher.main,
+            ]
+        )
         if rollback_to.package:
-            extra_args.extend(["--rollback-package", rollback_to.package])
-        extra_args.extend(["--rollback-memory-package", "1" if rollback_to.memory_package else "0"])
-        if rollback_to.memory_version:
-            extra_args.extend(["--rollback-memory-version", rollback_to.memory_version])
-    command = _supervisor_command(
-        vibe_path=vibe_path,
-        job_id=job_id,
-        delay_seconds=delay_seconds,
-        trigger=trigger,
-        scope=scope,
-        prepare_show_runtime=prepare_show_runtime,
-        extra_args=extra_args,
-    )
+            command.extend(["--rollback-package", rollback_to.package])
+        if rollback_to.memory_package:
+            command.append("--rollback-memory-package")
+            if rollback_to.memory_version:
+                command.extend(["--rollback-memory-version", rollback_to.memory_version])
     env = get_restart_environment(vibe_path=vibe_path)
     log_path = _restart_log_path(job_id)
     log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1552,21 +1140,39 @@ def _schedule_restart_locked(
     # "scheduled" write on top of the child's "running" write, hiding the active
     # restart from the supervisor and making it treat the stopped service as a
     # crash. The job records its real supervisor_pid once it starts.
-    payload = _supervisor_status_payload(
-        job_id=job_id,
-        trigger=trigger,
-        scope=scope,
-        delay_seconds=delay_seconds,
-        log_path=log_path,
-    )
+    payload = {
+        "ok": None,
+        "job_id": job_id,
+        "state": "scheduled",
+        "trigger": trigger,
+        "scope": scope,
+        "delay_seconds": delay_seconds,
+        "supervisor_pid": None,
+        "old_pid": _read_recorded_pid(),
+        "new_pid": None,
+        "log_path": str(log_path),
+        "error": None,
+        "created_at": _now_iso(),
+    }
     _write_status(payload)
     try:
-        process = _spawn_supervisor_process(
-            command=command,
-            env=env,
-            log_path=log_path,
-            memory_ui_secret=memory_ui_secret,
-        )
+        with log_path.open("a", encoding="utf-8") as log:
+            log.write(f"{_now_iso()} spawning restart supervisor job_id={job_id} delay_seconds={delay_seconds!r}\n")
+            log.flush()
+            process = subprocess.Popen(
+                command,
+                stdin=subprocess.PIPE if memory_ui_secret is not None else None,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                close_fds=True,
+                cwd=get_safe_cwd(),
+                env=runtime._memory_ui_child_env(
+                    env,
+                    memory_ui_secret=memory_ui_secret,
+                ),
+            )
+            runtime._spawn_stdin(process, memory_ui_secret=memory_ui_secret)
     except OSError as exc:
         # The seed status above is now "scheduled"; if the job can't be spawned
         # (bad cached vibe path, missing executable, permission/log-open error) no
@@ -1583,67 +1189,6 @@ def _schedule_restart_locked(
     return payload
 
 
-def schedule_upgrade_transaction(
-    transaction: UpgradeTransaction,
-    *,
-    delay_seconds: float = 0.0,
-    vibe_path: str | None = None,
-    trigger: str = "upgrade",
-    scope: str = "all",
-    prepare_show_runtime: bool = False,
-    memory_ui_secret: str | None = None,
-) -> dict:
-    """Spawn the supervisor-owned package transaction."""
-
-    from vibe.memory_ui_access import process_ui_read_secret
-    from storage.migrations import guard_source_checkout_default_state_bootstrap
-
-    transaction.validate()
-    guard_source_checkout_default_state_bootstrap()
-    memory_ui_secret = memory_ui_secret or process_ui_read_secret()
-    job_id = uuid.uuid4().hex[:12]
-    transaction_path = _write_upgrade_transaction_file(transaction, job_id)
-    command = _supervisor_command(
-        vibe_path=vibe_path,
-        job_id=job_id,
-        delay_seconds=delay_seconds,
-        trigger=trigger,
-        scope=scope,
-        prepare_show_runtime=prepare_show_runtime,
-        extra_args=["--upgrade-transaction-file", str(transaction_path)],
-    )
-    env = get_restart_environment(vibe_path=vibe_path)
-    log_path = _restart_log_path(job_id)
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    payload = _supervisor_status_payload(
-        job_id=job_id,
-        trigger=trigger,
-        scope=scope,
-        delay_seconds=delay_seconds,
-        log_path=log_path,
-        transaction=True,
-    )
-    try:
-        with _upgrade_transaction_lock(timeout_seconds=0):
-            if _restart_job_active():
-                raise RuntimeError("a restart is already in progress")
-            _write_status(payload)
-            process = _spawn_supervisor_process(
-                command=command,
-                env=env,
-                log_path=log_path,
-                memory_ui_secret=memory_ui_secret,
-            )
-    except Exception as exc:
-        transaction_path.unlink(missing_ok=True)
-        if isinstance(exc, OSError):
-            payload.update(ok=False, state="failed", error=f"failed to spawn upgrade supervisor: {exc}")
-            _write_status(payload)
-        raise
-    payload["supervisor_pid"] = process.pid
-    return payload
-
-
 def main(argv: list[str] | None = None) -> int:
     from vibe.memory_ui_access import initialize_process_ui_read_secret
 
@@ -1657,11 +1202,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--prepare-show-runtime", action="store_true")
     parser.add_argument("--rollback-to")
     parser.add_argument("--rollback-package")
+    parser.add_argument("--rollback-memory-package", action="store_true")
+    parser.add_argument("--rollback-memory-version")
     parser.add_argument("--rollback-python")
     parser.add_argument("--rollback-main")
-    parser.add_argument("--rollback-memory-package", choices=("0", "1"))
-    parser.add_argument("--rollback-memory-version")
-    parser.add_argument("--upgrade-transaction-file")
     args = parser.parse_args(argv)
     # The one place a rollback target is apart, and so the one place it is put
     # back together. Reassembling here rather than passing four values inward
@@ -1676,26 +1220,9 @@ def main(argv: list[str] | None = None) -> int:
             version=args.rollback_to,
             package=args.rollback_package,
             launcher=runtime.ServiceLauncher(python=args.rollback_python, main=args.rollback_main),
-            memory_package=args.rollback_memory_package == "1",
+            memory_package=args.rollback_memory_package,
             memory_version=args.rollback_memory_version,
         )
-    upgrade_transaction = None
-    if args.upgrade_transaction_file:
-        try:
-            upgrade_transaction = _read_upgrade_transaction_file(args.upgrade_transaction_file)
-        except (OSError, ValueError, json.JSONDecodeError) as exc:
-            _write_status(
-                {
-                    "ok": False,
-                    "job_id": args.job_id,
-                    "state": "failed",
-                    "trigger": args.trigger,
-                    "scope": args.scope,
-                    "transaction": "upgrade-v1",
-                    "error": f"invalid upgrade transaction: {exc}",
-                }
-            )
-            return 2
     return _run_restart_job(
         job_id=args.job_id,
         delay_seconds=max(0.0, args.delay_seconds),
@@ -1704,7 +1231,6 @@ def main(argv: list[str] | None = None) -> int:
         scope=args.scope,
         prepare_show_runtime=args.prepare_show_runtime,
         rollback_to=rollback_to,
-        upgrade_transaction=upgrade_transaction,
     )
 
 

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -201,34 +201,43 @@ def _legacy_service_launcher(
         return fallback
 
 
-def _launcher_core_dist_metadata(launcher: runtime.ServiceLauncher) -> list[tuple[str, str]]:
-    """Read only core distributions from the launcher's site-packages."""
+def _launcher_dist_metadata(launcher: runtime.ServiceLauncher) -> list[tuple[str, str]]:
+    """Read valid distributions without letting one broken entry hide the rest."""
 
-    site_packages = Path(launcher.main).resolve().parent.parent
     entries: list[tuple[str, str]] = []
     try:
-        for metadata_path in sorted(site_packages.glob("*.dist-info/METADATA")):
+        site_packages = Path(launcher.main).resolve().parent.parent
+        metadata_paths = sorted(site_packages.glob("*.dist-info/METADATA"))
+    except (OSError, UnicodeError, ValueError):
+        return entries
+    for metadata_path in metadata_paths:
+        try:
             payload = email.parser.Parser().parsestr(metadata_path.read_text(encoding="utf-8"))
             name = str(payload.get("Name") or "").strip()
             version = str(payload.get("Version") or "").strip()
-            if name in {PACKAGE_NAME, LEGACY_PACKAGE_NAME} and version:
+            if name and version:
                 entries.append((name, version))
-    except (OSError, UnicodeError, ValueError):
-        return []
+        except (OSError, UnicodeError, ValueError):
+            continue
     return entries
+
+
+def _launcher_core_dist_metadata(launcher: runtime.ServiceLauncher) -> list[tuple[str, str]]:
+    """Read only core distributions from the launcher's site-packages."""
+
+    return [
+        (name, version)
+        for name, version in _launcher_dist_metadata(launcher)
+        if name in {PACKAGE_NAME, LEGACY_PACKAGE_NAME}
+    ]
 
 
 def _launcher_memory_version(launcher: runtime.ServiceLauncher) -> str | None:
     """Read optional Memory metadata without exposing it to core ownership."""
 
-    site_packages = Path(launcher.main).resolve().parent.parent
-    try:
-        for metadata_path in sorted(site_packages.glob("*.dist-info/METADATA")):
-            payload = email.parser.Parser().parsestr(metadata_path.read_text(encoding="utf-8"))
-            if str(payload.get("Name") or "").strip() == MEMORY_PACKAGE_NAME:
-                return str(payload.get("Version") or "").strip() or None
-    except (OSError, UnicodeError, ValueError):
-        return None
+    for name, version in _launcher_dist_metadata(launcher):
+        if name == MEMORY_PACKAGE_NAME:
+            return version
     return None
 
 

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -201,8 +201,8 @@ def _legacy_service_launcher(
         return fallback
 
 
-def _launcher_dist_metadata(launcher: runtime.ServiceLauncher) -> list[tuple[str, str]]:
-    """Read all supported distributions from the launcher's site-packages."""
+def _launcher_core_dist_metadata(launcher: runtime.ServiceLauncher) -> list[tuple[str, str]]:
+    """Read only core distributions from the launcher's site-packages."""
 
     site_packages = Path(launcher.main).resolve().parent.parent
     entries: list[tuple[str, str]] = []
@@ -211,17 +211,31 @@ def _launcher_dist_metadata(launcher: runtime.ServiceLauncher) -> list[tuple[str
             payload = email.parser.Parser().parsestr(metadata_path.read_text(encoding="utf-8"))
             name = str(payload.get("Name") or "").strip()
             version = str(payload.get("Version") or "").strip()
-            if name in {PACKAGE_NAME, LEGACY_PACKAGE_NAME, MEMORY_PACKAGE_NAME} and version:
+            if name in {PACKAGE_NAME, LEGACY_PACKAGE_NAME} and version:
                 entries.append((name, version))
     except (OSError, UnicodeError, ValueError):
         return []
     return entries
 
 
+def _launcher_memory_version(launcher: runtime.ServiceLauncher) -> str | None:
+    """Read optional Memory metadata without exposing it to core ownership."""
+
+    site_packages = Path(launcher.main).resolve().parent.parent
+    try:
+        for metadata_path in sorted(site_packages.glob("*.dist-info/METADATA")):
+            payload = email.parser.Parser().parsestr(metadata_path.read_text(encoding="utf-8"))
+            if str(payload.get("Name") or "").strip() == MEMORY_PACKAGE_NAME:
+                return str(payload.get("Version") or "").strip() or None
+    except (OSError, UnicodeError, ValueError):
+        return None
+    return None
+
+
 def _launcher_package_name(launcher: runtime.ServiceLauncher, *, version: str | None = None) -> str:
     """Infer the distribution name that owns a launcher when metadata is stale."""
 
-    metadata = _launcher_dist_metadata(launcher)
+    metadata = _launcher_core_dist_metadata(launcher)
     if version:
         exact = [name for name, candidate in metadata if candidate == version]
         if exact:
@@ -252,7 +266,7 @@ def _legacy_install_metadata(
     try:
         from vibe import __version__ as replacement_version
 
-        for name, version in _launcher_dist_metadata(launcher):
+        for name, version in _launcher_core_dist_metadata(launcher):
             if (
                 name == package_name
                 and version
@@ -280,10 +294,7 @@ def _discover_legacy_upgrade_target(*, trigger: str, vibe_path: str | None) -> R
         if metadata is None:
             return None
         version, package = metadata
-    memory_version = next(
-        (candidate_version for candidate_name, candidate_version in _launcher_dist_metadata(launcher) if candidate_name == MEMORY_PACKAGE_NAME),
-        None,
-    )
+    memory_version = _launcher_memory_version(launcher)
     return RollbackTarget(
         version=version,
         package=package,

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -61,6 +61,7 @@ _ROLLBACK_INSTALL_TIMEOUT_SECONDS = 600.0
 # ever paid in full when the UI is genuinely not coming.
 _ROLLBACK_UI_READY_TIMEOUT_SECONDS = 60.0
 _UPGRADE_TRANSACTION_LOCK_TIMEOUT_SECONDS = 30.0
+_RESTART_SEED_GRACE_SECONDS = 60.0
 
 
 @contextmanager
@@ -375,20 +376,33 @@ def _write_status(payload: dict) -> None:
 
 def _upgrade_transaction_active() -> bool:
     status = runtime.read_json(runtime.get_restart_status_path())
-    return isinstance(status, dict) and status.get("transaction") == "upgrade-v1" and status.get("state") in {
-        "scheduled",
-        "running",
-    }
+    return _restart_status_in_flight(status) and status.get("transaction") == "upgrade-v1"
 
 
 def _restart_job_active() -> bool:
     status = runtime.read_json(runtime.get_restart_status_path())
+    return _restart_status_in_flight(status)
+
+
+def _restart_status_in_flight(status: object) -> bool:
+    """Validate restart ownership from the live supervisor identity, not a stale marker."""
+
     if not isinstance(status, dict) or status.get("state") not in {"scheduled", "running"}:
         return False
     supervisor_pid = status.get("supervisor_pid")
-    if supervisor_pid is None:
-        return True
-    return isinstance(supervisor_pid, int) and supervisor_pid > 0 and runtime.pid_alive(supervisor_pid)
+    if isinstance(supervisor_pid, int):
+        if supervisor_pid <= 0 or not runtime.pid_alive(supervisor_pid):
+            return False
+        started_at = status.get("supervisor_started_at")
+        if started_at is None:
+            return True
+        current_started_at = runtime.process_create_time(supervisor_pid)
+        return current_started_at is None or current_started_at == started_at
+    try:
+        age = time.time() - runtime.get_restart_status_path().stat().st_mtime
+    except OSError:
+        return False
+    return age < _RESTART_SEED_GRACE_SECONDS
 
 
 def _read_recorded_pid() -> int | None:
@@ -693,6 +707,7 @@ def _roll_back_failed_upgrade(
 
     try:
         plan = build_upgrade_plan(
+            python_executable=rollback_to.launcher.python,
             vibe_path=vibe_path,
             version=version,
             package_name=rollback_to.package,
@@ -801,6 +816,19 @@ def _wait_for_service_lock_release(timeout: float = _SERVICE_LOCK_RELEASE_TIMEOU
     return available
 
 
+def _prepare_show_runtime_nonfatal(vibe_path: str | None, cwd: str, write) -> None:
+    """Preserve the upgrade-era Show Runtime prepare step without failing install."""
+
+    try:
+        from vibe.api import _prepare_show_runtime_after_upgrade
+
+        detail = _prepare_show_runtime_after_upgrade(vibe_path, cwd)
+    except Exception as exc:  # pragma: no cover - defensive import boundary
+        detail = f"Show Runtime preparation skipped: {exc}"
+    if detail:
+        write(detail)
+
+
 def _run_upgrade_transaction(
     *,
     job_id: str,
@@ -857,12 +885,31 @@ def _run_upgrade_transaction(
             running_before = runtime.verified_service_running()
             if running_before and transaction.activate_runtime == "none":
                 return fail("upgrade transaction requires lifecycle activation while Avibe is running")
+
+            def rollback_after_failure(message: str, code: int) -> int:
+                if rollback_to and running_before:
+                    try:
+                        rollback = _roll_back_failed_upgrade(
+                            rollback_to=rollback_to,
+                            vibe_path=vibe_path,
+                            start_ui=start_ui,
+                            backup_watermark=None,
+                            write=write,
+                            record=lambda value: payload.update(rollback=value) or _write_status(payload),
+                        )
+                        payload["rollback"] = rollback
+                    except Exception as exc:
+                        write(f"rollback failed: {exc}")
+                return fail(message, code)
+
             try:
                 plan = build_upgrade_plan(
                     python_executable=sys.executable,
                     vibe_path=vibe_path,
                     version=None,
                     memory_enabled=transaction.include_memory,
+                    memory_package=transaction.include_memory,
+                    memory_requirement=transaction.memory_requirement,
                     package_spec=transaction.forward_spec,
                 )
             except Exception as exc:
@@ -890,9 +937,32 @@ def _run_upgrade_transaction(
             if running_before:
                 write("stopping runtime before package transaction")
                 try:
-                    _stop_runtime_for_restart(stop_ui=start_ui)
+                    ui_stopped, _ui_timings, _stop_ui_seconds, stopped_ui_pid, service_stopped, _stop_service_seconds = (
+                        _stop_runtime_for_restart(stop_ui=start_ui)
+                    )
                 except Exception as exc:
                     return fail(f"stop runtime failed: {exc}")
+                ui_pid_live = bool(stopped_ui_pid and runtime.pid_alive(stopped_ui_pid))
+                ui_identity_live = runtime.ui_pid_file_points_to_running_ui() if start_ui else False
+                if start_ui and (ui_stopped is False or ui_pid_live or ui_identity_live):
+                    write(f"UI pid {stopped_ui_pid} did not stop before package mutation")
+                    if service_stopped:
+                        try:
+                            recovered = _start_runtime_processes(start_ui=False)
+                            recovered_pid = runtime.wait_for_service_ready(
+                                recovered.service_pid,
+                                timeout=runtime.SERVICE_SLOW_START_TIMEOUT_SECONDS,
+                            )
+                            if recovered_pid is not None:
+                                runtime.write_status(
+                                    "running",
+                                    f"pid={recovered_pid}",
+                                    recovered_pid,
+                                    _live_ui_pid(stopped_ui_pid),
+                                )
+                        except Exception as exc:
+                            write(f"failed to recover runtime after UI stop failure: {exc}")
+                    return fail(f"UI pid {stopped_ui_pid} did not stop before package mutation")
                 if not _wait_for_service_lock_release():
                     return fail("service lock did not release after stopping runtime")
 
@@ -923,35 +993,33 @@ def _run_upgrade_transaction(
                 install_error = ""
             if result is None or result.returncode != 0:
                 detail = install_error or ((result.stderr or result.stdout or "").strip()[-2000:] if result else "")
-                if rollback_to and running_before and not runtime.verified_service_running():
-                    try:
-                        rollback = _roll_back_failed_upgrade(
-                            rollback_to=rollback_to,
-                            vibe_path=vibe_path,
-                            start_ui=start_ui,
-                            backup_watermark=None,
-                            write=write,
-                            record=lambda value: payload.update(rollback=value) or _write_status(payload),
-                        )
-                        payload["rollback"] = rollback
-                    except Exception as exc:
-                        write(f"rollback failed: {exc}")
-                return fail(f"upgrade install failed: {detail}")
+                return rollback_after_failure(f"upgrade install failed: {detail}", 2)
 
             if running_before and transaction.activate_runtime == "restart_if_running":
                 write("starting runtime after package transaction")
                 try:
                     started = _start_runtime_processes(start_ui=start_ui)
                 except Exception as exc:
-                    return fail(f"start runtime failed: {exc}")
-                ready_pid = runtime.wait_for_service_ready(
-                    started.service_pid,
-                    timeout=runtime.SERVICE_SLOW_START_TIMEOUT_SECONDS,
-                )
+                    return rollback_after_failure(f"start runtime failed: {exc}", 1)
+                if not started.service_pid or not runtime.pid_alive(started.service_pid):
+                    return rollback_after_failure(
+                        f"started service pid {started.service_pid} is not alive",
+                        3,
+                    )
+                try:
+                    ready_pid = runtime.wait_for_service_ready(
+                        started.service_pid,
+                        timeout=runtime.SERVICE_SLOW_START_TIMEOUT_SECONDS,
+                    )
+                except Exception as exc:
+                    return rollback_after_failure(f"service readiness check failed: {exc}", 3)
                 if ready_pid is None:
-                    return fail("service did not become ready after package transaction")
+                    return rollback_after_failure("service did not become ready after package transaction", 3)
                 payload["new_pid"] = ready_pid
                 runtime.write_status("running", f"pid={ready_pid}", ready_pid, _live_ui_pid(started.ui_pid))
+
+            if prepare_show_runtime:
+                _prepare_show_runtime_nonfatal(vibe_path, safe_cwd, write)
 
             payload.update(ok=True, state="succeeded", error=None)
             _write_status(payload)
@@ -1278,6 +1346,11 @@ def schedule_restart(
 ) -> dict:
     """Admit and spawn an ordinary restart under the transaction gate."""
 
+    from storage.migrations import guard_source_checkout_default_state_bootstrap
+
+    # Validate source-checkout state before the lock helper creates any runtime
+    # files. This keeps the migration guard side-effect free on a rejected call.
+    guard_source_checkout_default_state_bootstrap()
     # The same private lease serializes admission with a package transaction.
     # Holding it through status seeding and Popen closes the gap where each side
     # could observe the other as idle and then spawn competing supervisors.
@@ -1291,6 +1364,129 @@ def schedule_restart(
             memory_ui_secret=memory_ui_secret,
             rollback_to=rollback_to,
         )
+
+
+def _supervisor_command(
+    *,
+    vibe_path: str | None,
+    job_id: str,
+    delay_seconds: float,
+    trigger: str,
+    scope: str,
+    prepare_show_runtime: bool,
+    extra_args: list[str] | None = None,
+) -> list[str]:
+    """Build the one detached-supervisor invocation envelope."""
+
+    invocation = get_restart_invocation_command(vibe_path=vibe_path)
+    command = [*invocation[:-1], "__restart-supervisor"] if invocation and invocation[-1] == "restart" else [
+        *(invocation or ["vibe"]),
+        "__restart-supervisor",
+    ]
+    command.extend(["--job-id", job_id, "--delay-seconds", str(delay_seconds), "--trigger", trigger])
+    if scope != "all":
+        command.extend(["--scope", scope])
+    if vibe_path:
+        command.extend(["--vibe-path", vibe_path])
+    if prepare_show_runtime:
+        command.append("--prepare-show-runtime")
+    command.extend(extra_args or [])
+    return command
+
+
+def _spawn_supervisor_process(
+    *,
+    command: list[str],
+    env: dict[str, str] | None,
+    log_path: Path,
+    memory_ui_secret: str | None,
+):
+    """Spawn a detached supervisor using the shared process envelope."""
+
+    with log_path.open("a", encoding="utf-8") as log:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE if memory_ui_secret is not None else None,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            close_fds=True,
+            cwd=get_safe_cwd(),
+            env=runtime._memory_ui_child_env(env, memory_ui_secret=memory_ui_secret),
+        )
+        runtime._spawn_stdin(process, memory_ui_secret=memory_ui_secret)
+    return process
+
+
+def _supervisor_status_payload(
+    *,
+    job_id: str,
+    trigger: str,
+    scope: str,
+    delay_seconds: float,
+    log_path: Path,
+    transaction: bool = False,
+) -> dict:
+    payload = {
+        "ok": None,
+        "job_id": job_id,
+        "state": "scheduled",
+        "trigger": trigger,
+        "scope": scope,
+        "delay_seconds": delay_seconds,
+        "supervisor_pid": None,
+        "old_pid": _read_recorded_pid(),
+        "new_pid": None,
+        "log_path": str(log_path),
+        "error": None,
+        "created_at": _now_iso(),
+    }
+    if transaction:
+        payload["transaction"] = "upgrade-v1"
+    return payload
+
+
+def _write_upgrade_transaction_file(transaction: UpgradeTransaction, job_id: str) -> Path:
+    """Atomically publish a 0600, single-use declarative transaction payload."""
+
+    runtime_dir = paths.get_runtime_dir()
+    runtime_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(runtime_dir, 0o700)
+    path = runtime_dir / f"upgrade-transaction-{job_id}.json"
+    temporary = runtime_dir / f".{path.name}.{os.getpid()}.tmp"
+    payload = json.dumps(transaction.to_payload(), separators=(",", ":"), sort_keys=True)
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            descriptor = -1
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        os.chmod(path, 0o600)
+    finally:
+        if descriptor != -1:
+            os.close(descriptor)
+        temporary.unlink(missing_ok=True)
+    return path
+
+
+def _read_upgrade_transaction_file(path: str) -> UpgradeTransaction:
+    """Consume and validate the supervisor payload before any lifecycle action."""
+
+    payload_path = Path(path)
+    runtime_dir = paths.get_runtime_dir().resolve()
+    try:
+        if payload_path.resolve().parent != runtime_dir:
+            raise ValueError("upgrade transaction payload path is outside the runtime directory")
+    except OSError as exc:
+        raise ValueError("invalid upgrade transaction payload path") from exc
+    try:
+        with payload_path.open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+    finally:
+        payload_path.unlink(missing_ok=True)
+    return UpgradeTransaction.from_payload(payload)
 
 
 def _schedule_restart_locked(
@@ -1329,39 +1525,24 @@ def _schedule_restart_locked(
     memory_ui_secret = memory_ui_secret or process_ui_read_secret()
     guard_source_checkout_default_state_bootstrap()
     job_id = uuid.uuid4().hex[:12]
-    invocation = get_restart_invocation_command(vibe_path=vibe_path)
-    command = [*invocation[:-1], "__restart-supervisor"] if invocation and invocation[-1] == "restart" else [
-        *(invocation or ["vibe"]),
-        "__restart-supervisor",
-    ]
-    command.extend(["--job-id", job_id, "--delay-seconds", str(delay_seconds), "--trigger", trigger])
-    if scope != "all":
-        command.extend(["--scope", scope])
-    if vibe_path:
-        command.extend(["--vibe-path", vibe_path])
-    if prepare_show_runtime:
-        command.append("--prepare-show-runtime")
+    extra_args: list[str] = []
     if rollback_to:
-        command.extend(
-            [
-                "--rollback-to",
-                rollback_to.version,
-                # Not optional the way the package name is. A missing package
-                # name still leaves `build_upgrade_plan` a defensible default,
-                # while a missing launcher leaves the job with only its own --
-                # which, in the case this exists for, is the release being
-                # undone.
-                "--rollback-python",
-                rollback_to.launcher.python,
-                "--rollback-main",
-                rollback_to.launcher.main,
-            ]
-        )
+        extra_args.extend(["--rollback-to", rollback_to.version])
+        extra_args.extend(["--rollback-python", rollback_to.launcher.python, "--rollback-main", rollback_to.launcher.main])
         if rollback_to.package:
-            command.extend(["--rollback-package", rollback_to.package])
-        command.extend(["--rollback-memory-package", "1" if rollback_to.memory_package else "0"])
+            extra_args.extend(["--rollback-package", rollback_to.package])
+        extra_args.extend(["--rollback-memory-package", "1" if rollback_to.memory_package else "0"])
         if rollback_to.memory_version:
-            command.extend(["--rollback-memory-version", rollback_to.memory_version])
+            extra_args.extend(["--rollback-memory-version", rollback_to.memory_version])
+    command = _supervisor_command(
+        vibe_path=vibe_path,
+        job_id=job_id,
+        delay_seconds=delay_seconds,
+        trigger=trigger,
+        scope=scope,
+        prepare_show_runtime=prepare_show_runtime,
+        extra_args=extra_args,
+    )
     env = get_restart_environment(vibe_path=vibe_path)
     log_path = _restart_log_path(job_id)
     log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1371,39 +1552,21 @@ def _schedule_restart_locked(
     # "scheduled" write on top of the child's "running" write, hiding the active
     # restart from the supervisor and making it treat the stopped service as a
     # crash. The job records its real supervisor_pid once it starts.
-    payload = {
-        "ok": None,
-        "job_id": job_id,
-        "state": "scheduled",
-        "trigger": trigger,
-        "scope": scope,
-        "delay_seconds": delay_seconds,
-        "supervisor_pid": None,
-        "old_pid": _read_recorded_pid(),
-        "new_pid": None,
-        "log_path": str(log_path),
-        "error": None,
-        "created_at": _now_iso(),
-    }
+    payload = _supervisor_status_payload(
+        job_id=job_id,
+        trigger=trigger,
+        scope=scope,
+        delay_seconds=delay_seconds,
+        log_path=log_path,
+    )
     _write_status(payload)
     try:
-        with log_path.open("a", encoding="utf-8") as log:
-            log.write(f"{_now_iso()} spawning restart supervisor job_id={job_id} delay_seconds={delay_seconds!r}\n")
-            log.flush()
-            process = subprocess.Popen(
-                command,
-                stdin=subprocess.PIPE if memory_ui_secret is not None else None,
-                stdout=log,
-                stderr=subprocess.STDOUT,
-                start_new_session=True,
-                close_fds=True,
-                cwd=get_safe_cwd(),
-                env=runtime._memory_ui_child_env(
-                    env,
-                    memory_ui_secret=memory_ui_secret,
-                ),
-            )
-            runtime._spawn_stdin(process, memory_ui_secret=memory_ui_secret)
+        process = _spawn_supervisor_process(
+            command=command,
+            env=env,
+            log_path=log_path,
+            memory_ui_secret=memory_ui_secret,
+        )
     except OSError as exc:
         # The seed status above is now "scheduled"; if the job can't be spawned
         # (bad cached vibe path, missing executable, permission/log-open error) no
@@ -1439,93 +1602,43 @@ def schedule_upgrade_transaction(
     guard_source_checkout_default_state_bootstrap()
     memory_ui_secret = memory_ui_secret or process_ui_read_secret()
     job_id = uuid.uuid4().hex[:12]
-    invocation = get_restart_invocation_command(vibe_path=vibe_path)
-    command = [*invocation[:-1], "__restart-supervisor"] if invocation and invocation[-1] == "restart" else [
-        *(invocation or ["vibe"]),
-        "__restart-supervisor",
-    ]
-    command.extend(
-        [
-            "--job-id",
-            job_id,
-            "--delay-seconds",
-            str(delay_seconds),
-            "--trigger",
-            trigger,
-            "--upgrade-transaction-version",
-            str(transaction.schema_version),
-            "--upgrade-installer",
-            transaction.installer,
-            "--upgrade-forward-spec",
-            transaction.forward_spec,
-            "--upgrade-activate-runtime",
-            transaction.activate_runtime,
-        ]
+    transaction_path = _write_upgrade_transaction_file(transaction, job_id)
+    command = _supervisor_command(
+        vibe_path=vibe_path,
+        job_id=job_id,
+        delay_seconds=delay_seconds,
+        trigger=trigger,
+        scope=scope,
+        prepare_show_runtime=prepare_show_runtime,
+        extra_args=["--upgrade-transaction-file", str(transaction_path)],
     )
-    if transaction.include_memory:
-        command.extend(["--upgrade-include-memory", "--upgrade-memory-requirement", transaction.memory_requirement or ""])
-    if scope != "all":
-        command.extend(["--scope", scope])
-    if vibe_path:
-        command.extend(["--vibe-path", vibe_path])
-    if prepare_show_runtime:
-        command.append("--prepare-show-runtime")
-    if transaction.rollback_to:
-        target = transaction.rollback_to
-        command.extend(
-            [
-                "--rollback-to",
-                target.version,
-                "--rollback-python",
-                target.launcher.python,
-                "--rollback-main",
-                target.launcher.main,
-                "--rollback-memory-package",
-                "1" if target.memory_package else "0",
-            ]
-        )
-        if target.package:
-            command.extend(["--rollback-package", target.package])
-        if target.memory_version:
-            command.extend(["--rollback-memory-version", target.memory_version])
     env = get_restart_environment(vibe_path=vibe_path)
     log_path = _restart_log_path(job_id)
     log_path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {
-        "ok": None,
-        "job_id": job_id,
-        "state": "scheduled",
-        "trigger": trigger,
-        "scope": scope,
-        "delay_seconds": delay_seconds,
-        "supervisor_pid": None,
-        "old_pid": _read_recorded_pid(),
-        "new_pid": None,
-        "log_path": str(log_path),
-        "error": None,
-        "created_at": _now_iso(),
-        "transaction": "upgrade-v1",
-    }
+    payload = _supervisor_status_payload(
+        job_id=job_id,
+        trigger=trigger,
+        scope=scope,
+        delay_seconds=delay_seconds,
+        log_path=log_path,
+        transaction=True,
+    )
     try:
         with _upgrade_transaction_lock(timeout_seconds=0):
             if _restart_job_active():
                 raise RuntimeError("a restart is already in progress")
             _write_status(payload)
-            with log_path.open("a", encoding="utf-8") as log:
-                process = subprocess.Popen(
-                    command,
-                    stdin=subprocess.PIPE if memory_ui_secret is not None else None,
-                    stdout=log,
-                    stderr=subprocess.STDOUT,
-                    start_new_session=True,
-                    close_fds=True,
-                    cwd=get_safe_cwd(),
-                    env=runtime._memory_ui_child_env(env, memory_ui_secret=memory_ui_secret),
-                )
-                runtime._spawn_stdin(process, memory_ui_secret=memory_ui_secret)
-    except OSError as exc:
-        payload.update(ok=False, state="failed", error=f"failed to spawn upgrade supervisor: {exc}")
-        _write_status(payload)
+            process = _spawn_supervisor_process(
+                command=command,
+                env=env,
+                log_path=log_path,
+                memory_ui_secret=memory_ui_secret,
+            )
+    except Exception as exc:
+        transaction_path.unlink(missing_ok=True)
+        if isinstance(exc, OSError):
+            payload.update(ok=False, state="failed", error=f"failed to spawn upgrade supervisor: {exc}")
+            _write_status(payload)
         raise
     payload["supervisor_pid"] = process.pid
     return payload
@@ -1548,12 +1661,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--rollback-main")
     parser.add_argument("--rollback-memory-package", choices=("0", "1"))
     parser.add_argument("--rollback-memory-version")
-    parser.add_argument("--upgrade-transaction-version", type=int)
-    parser.add_argument("--upgrade-installer", choices=("pip", "uv"))
-    parser.add_argument("--upgrade-forward-spec")
-    parser.add_argument("--upgrade-include-memory", action="store_true")
-    parser.add_argument("--upgrade-memory-requirement")
-    parser.add_argument("--upgrade-activate-runtime", choices=("restart_if_running", "none"), default="restart_if_running")
+    parser.add_argument("--upgrade-transaction-file")
     args = parser.parse_args(argv)
     # The one place a rollback target is apart, and so the one place it is put
     # back together. Reassembling here rather than passing four values inward
@@ -1572,22 +1680,22 @@ def main(argv: list[str] | None = None) -> int:
             memory_version=args.rollback_memory_version,
         )
     upgrade_transaction = None
-    if args.upgrade_transaction_version is not None:
-        if not args.upgrade_installer or not args.upgrade_forward_spec:
-            parser.error("upgrade transaction requires installer and forward spec")
-        upgrade_transaction = UpgradeTransaction(
-            schema_version=args.upgrade_transaction_version,
-            installer=args.upgrade_installer,
-            forward_spec=args.upgrade_forward_spec,
-            include_memory=args.upgrade_include_memory,
-            memory_requirement=args.upgrade_memory_requirement,
-            rollback_to=rollback_to,
-            activate_runtime=args.upgrade_activate_runtime,
-        )
+    if args.upgrade_transaction_file:
         try:
-            upgrade_transaction.validate()
-        except ValueError as exc:
-            parser.error(str(exc))
+            upgrade_transaction = _read_upgrade_transaction_file(args.upgrade_transaction_file)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            _write_status(
+                {
+                    "ok": False,
+                    "job_id": args.job_id,
+                    "state": "failed",
+                    "trigger": args.trigger,
+                    "scope": args.scope,
+                    "transaction": "upgrade-v1",
+                    "error": f"invalid upgrade transaction: {exc}",
+                }
+            )
+            return 2
     return _run_restart_job(
         job_id=args.job_id,
         delay_seconds=max(0.0, args.delay_seconds),

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -895,8 +895,18 @@ def _with_memory_extra(package_spec: str) -> str:
     return rendered
 
 
-def _target_version_from_package_spec(package_spec: str) -> str | None:
-    """Read an exact release only from an already-versioned package spec."""
+def _published_version(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        version = str(Version(value))
+    except InvalidVersion:
+        return None
+    return version if _names_a_published_release(version) else None
+
+
+def _memory_target_version(package_spec: str, target_version: str | None) -> str | None:
+    """Choose the Memory pin from the artifact being installed or valid metadata."""
 
     try:
         requirement = Requirement(package_spec)
@@ -905,13 +915,16 @@ def _target_version_from_package_spec(package_spec: str) -> str | None:
     else:
         if requirement.url is None:
             specifiers = list(requirement.specifier)
-            if len(specifiers) != 1 or specifiers[0].operator != "==" or "*" in specifiers[0].version:
-                return None
-            try:
-                version = str(Version(specifiers[0].version))
-            except InvalidVersion:
-                return None
-            return version if _names_a_published_release(version) else None
+            if (
+                len(specifiers) == 1
+                and specifiers[0].operator == "=="
+                and "*" not in specifiers[0].version
+            ):
+                return _published_version(specifiers[0].version)
+            candidate = _published_version(target_version)
+            if candidate is not None and requirement.specifier.contains(candidate, prereleases=True):
+                return candidate
+            return None
         artifact = requirement.url
 
     if artifact.startswith(("git+", "hg+", "svn+", "bz+")):
@@ -928,8 +941,7 @@ def _target_version_from_package_spec(package_spec: str) -> str | None:
             _, version = parse_sdist_filename(filename)
         except InvalidSdistFilename:
             return None
-    rendered = str(version)
-    return rendered if _names_a_published_release(rendered) else None
+    return _published_version(str(version))
 
 
 def pinned_package_spec(
@@ -1023,9 +1035,8 @@ def build_upgrade_plan(
         else (package_spec or get_upgrade_package_spec())
     )
     if not version and include_memory:
+        target_version = _memory_target_version(package_spec, target_version)
         if target_version is None:
-            target_version = _target_version_from_package_spec(package_spec)
-        if not isinstance(target_version, str) or not _names_a_published_release(target_version):
             raise ValueError("A Memory-preserving upgrade requires a target release version")
     uv_binary = find_uv_binary(uv_path=uv_path, base_env=base_env)
     if not version and include_memory and f"[{MEMORY_EXTRA_NAME}]" not in package_spec:

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -26,8 +26,6 @@ PACKAGE_NAME = "avibe-os"
 LEGACY_PACKAGE_NAME = "vibe-remote"
 MEMORY_PACKAGE_NAME = "avibe-memory"
 MEMORY_EXTRA_NAME = "memory"
-MEMORY_PACKAGE_COMPATIBILITY = ">=3.0.14.dev0,<3.1"
-MEMORY_PACKAGE_REQUIREMENT = f"{MEMORY_PACKAGE_NAME}{MEMORY_PACKAGE_COMPATIBILITY}"
 _MEMORY_SPLIT_MIN_VERSION = Version("3.0.14.dev0")
 PIP_DOWNLOAD_DEST_PLACEHOLDER = "{avibe-pip-download-destination}"
 DEFAULT_UPDATE_METADATA_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
@@ -94,6 +92,7 @@ class UpgradePlan:
     method: str
     rollback_to: RollbackTarget | None = None
     preflight_command: list[str] | None = None
+    preflight_fallback_command: list[str] | None = None
     cleanup_command: list[str] | None = None
     cleanup_after_command: bool = False
 
@@ -143,19 +142,38 @@ def preflight_upgrade_plan(
 
     if plan.preflight_command is None:
         return None
-    preflight_command = plan.preflight_command
-    scratch_dir: str | None = None
-    try:
-        if PIP_DOWNLOAD_DEST_PLACEHOLDER in preflight_command:
-            scratch_dir = tempfile.mkdtemp(prefix="avibe-pip-download-")
-            preflight_command = [
-                scratch_dir if argument == PIP_DOWNLOAD_DEST_PLACEHOLDER else argument
-                for argument in preflight_command
-            ]
-        return run(preflight_command, env=plan.env, **run_kwargs)
-    finally:
-        if scratch_dir is not None:
-            shutil.rmtree(scratch_dir, ignore_errors=True)
+
+    def run_preflight(command: list[str]) -> subprocess.CompletedProcess[str]:
+        scratch_dir: str | None = None
+        try:
+            if PIP_DOWNLOAD_DEST_PLACEHOLDER in command:
+                scratch_dir = tempfile.mkdtemp(prefix="avibe-pip-download-")
+                command = [
+                    scratch_dir if argument == PIP_DOWNLOAD_DEST_PLACEHOLDER else argument
+                    for argument in command
+                ]
+            return run(command, env=plan.env, **run_kwargs)
+        finally:
+            if scratch_dir is not None:
+                shutil.rmtree(scratch_dir, ignore_errors=True)
+
+    preflight = run_preflight(plan.preflight_command)
+    if (
+        preflight.returncode == 0
+        or plan.preflight_fallback_command is None
+        or not _pip_dry_run_is_unsupported(preflight)
+    ):
+        return preflight
+
+    return run_preflight(plan.preflight_fallback_command)
+
+
+def _pip_dry_run_is_unsupported(result: subprocess.CompletedProcess[str]) -> bool:
+    output = f"{result.stdout or ''}\n{result.stderr or ''}".lower()
+    return "--dry-run" in output and any(
+        marker in output
+        for marker in ("no such option", "unknown option", "unrecognized argument")
+    )
 
 
 def resolve_command_path(command: str | None, search_path: str | None = None) -> str | None:
@@ -622,8 +640,8 @@ def configured_memory_enabled() -> bool:
     except FileNotFoundError:
         return False
     except Exception:
-        logger.warning("Could not read Memory enablement; preserving package shape", exc_info=True)
-        return True
+        logger.warning("Could not read Memory enablement; treating it as disabled", exc_info=True)
+        return False
 
 
 def _distributions_providing_this_package() -> list[str]:
@@ -850,7 +868,7 @@ def rollback_target() -> RollbackTarget | None:
 def _with_memory_extra(package_spec: str) -> str:
     """Add the Memory extra without corrupting URL or local path specs."""
 
-    if package_spec.startswith(("git+", "hg+", "svn+", "bz+", "http://", "https://")):
+    if package_spec.startswith(("git+", "hg+", "svn+", "bz+", "http://", "https://", "file://")):
         return f"{PACKAGE_NAME}[{MEMORY_EXTRA_NAME}] @ {package_spec}"
     try:
         from packaging.requirements import InvalidRequirement, Requirement
@@ -919,7 +937,6 @@ def build_upgrade_plan(
     memory_enabled: bool = False,
     memory_package: bool | None = None,
     memory_version: str | None = None,
-    memory_requirement: str | None = None,
     package_spec: str | None = None,
 ) -> UpgradePlan:
     """How to install avibe: the newest release, or `version` exactly.
@@ -964,9 +981,6 @@ def build_upgrade_plan(
     if not version and include_memory and f"[{MEMORY_EXTRA_NAME}]" not in package_spec:
         package_spec = _with_memory_extra(package_spec)
     pinned_memory_spec = f"{MEMORY_PACKAGE_NAME}=={memory_version}" if include_memory and memory_version else None
-    forward_memory_spec = (
-        (memory_requirement or MEMORY_PACKAGE_REQUIREMENT) if include_memory and not version else None
-    )
 
     if is_uv_tool_install(executable) and uv_binary:
         env = dict(base_env or os.environ)
@@ -974,8 +988,8 @@ def build_upgrade_plan(
         if vibe_bin_dir:
             env["UV_TOOL_BIN_DIR"] = vibe_bin_dir
         command = [uv_binary, "tool", "install", package_spec]
-        if pinned_memory_spec or forward_memory_spec:
-            command.extend(["--with", pinned_memory_spec or forward_memory_spec])
+        if pinned_memory_spec:
+            command.extend(["--with", pinned_memory_spec])
         if not version:
             command.append("--upgrade")
         if version or package_spec != PACKAGE_NAME or is_legacy_uv_tool_install(executable):
@@ -986,8 +1000,8 @@ def build_upgrade_plan(
             if not version:
                 preflight_command.append("--upgrade")
             preflight_command.append(package_spec)
-            if pinned_memory_spec or forward_memory_spec:
-                preflight_command.append(pinned_memory_spec or forward_memory_spec)
+            if pinned_memory_spec:
+                preflight_command.append(pinned_memory_spec)
         return UpgradePlan(
             command=command,
             env=env,
@@ -1015,8 +1029,8 @@ def build_upgrade_plan(
     if version or not installed_metadata_describes_running_code():
         command.append("--force-reinstall")
     command.append(package_spec)
-    if pinned_memory_spec or forward_memory_spec:
-        command.append(pinned_memory_spec or forward_memory_spec)
+    if pinned_memory_spec:
+        command.append(pinned_memory_spec)
     cleanup_command = None
     cleanup_after_command = False
     if version and not include_memory and memory_package_installed():
@@ -1030,7 +1044,27 @@ def build_upgrade_plan(
     # Core-only forward installs retain the origin/dev synchronous behavior: the
     # service is still running while pip resolves, so a second resolver pass is
     # unnecessary general-updater machinery.
-    if include_memory or cleanup_command is not None:
+    preflight_fallback_command = None
+    if include_memory and not version:
+        preflight_command = [
+            executable,
+            "-m",
+            "pip",
+            "install",
+            "--dry-run",
+            "--upgrade",
+            package_spec,
+        ]
+        preflight_fallback_command = [
+            executable,
+            "-m",
+            "pip",
+            "download",
+            "--dest",
+            PIP_DOWNLOAD_DEST_PLACEHOLDER,
+            package_spec,
+        ]
+    elif include_memory or cleanup_command is not None:
         preflight_command = [
             executable,
             "-m",
@@ -1040,70 +1074,18 @@ def build_upgrade_plan(
             PIP_DOWNLOAD_DEST_PLACEHOLDER,
         ]
         preflight_command.extend(["--no-deps", package_spec])
-        if pinned_memory_spec or forward_memory_spec:
-            preflight_command.append(pinned_memory_spec or forward_memory_spec)
+        if pinned_memory_spec:
+            preflight_command.append(pinned_memory_spec)
     return UpgradePlan(
         command=command,
         env=dict(base_env or os.environ),
         method="pip",
         rollback_to=rollback_to,
         preflight_command=preflight_command,
+        preflight_fallback_command=preflight_fallback_command,
         cleanup_command=cleanup_command,
         cleanup_after_command=cleanup_after_command,
     )
-
-
-def build_memory_add_plan(
-    *,
-    version: str | None = None,
-    python_executable: str | None = None,
-    uv_path: str | None = None,
-    base_env: dict[str, str] | None = None,
-) -> UpgradePlan:
-    """Build an explicit package repair plan for avibe-memory."""
-
-    executable = python_executable or sys.executable
-    requirement = MEMORY_PACKAGE_REQUIREMENT if version is None else f"{MEMORY_PACKAGE_NAME}=={version}"
-    uv_binary = find_uv_binary(uv_path=uv_path, base_env=base_env)
-    env = dict(base_env or os.environ)
-    if is_uv_tool_install(executable) and uv_binary:
-        command = [
-            uv_binary,
-            "pip",
-            "install",
-            "--upgrade",
-            "--force-reinstall",
-            "--no-deps",
-            "--python",
-            executable,
-            requirement,
-        ]
-        preflight = [
-            uv_binary,
-            "pip",
-            "install",
-            "--dry-run",
-            "--upgrade",
-            "--force-reinstall",
-            "--no-deps",
-            "--python",
-            executable,
-            requirement,
-        ]
-        return UpgradePlan(command, env, "uv", preflight_command=preflight)
-    command = [executable, "-m", "pip", "install", "--upgrade", "--force-reinstall", "--no-deps", requirement]
-    preflight = [
-        executable,
-        "-m",
-        "pip",
-        "download",
-        "--dest",
-        PIP_DOWNLOAD_DEST_PLACEHOLDER,
-        "--no-deps",
-        requirement,
-    ]
-    return UpgradePlan(command, env, "pip", preflight_command=preflight)
-
 
 def get_safe_cwd() -> str:
     """Return a stable, existing absolute directory for subprocess cwd.

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -875,7 +875,8 @@ def _with_memory_extra(package_spec: str) -> str:
 
         requirement = Requirement(package_spec)
     except InvalidRequirement:
-        return f"{package_spec}[{MEMORY_EXTRA_NAME}]"
+        artifact_uri = Path(package_spec).expanduser().resolve().as_uri()
+        return f"{PACKAGE_NAME}[{MEMORY_EXTRA_NAME}] @ {artifact_uri}"
 
     extras = sorted({*requirement.extras, MEMORY_EXTRA_NAME})
     rendered = f"{requirement.name}[{','.join(extras)}]"

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -9,12 +9,20 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import urllib.parse
 import urllib.request
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import NamedTuple, cast
 
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import (
+    InvalidSdistFilename,
+    InvalidWheelFilename,
+    parse_sdist_filename,
+    parse_wheel_filename,
+)
 from packaging.version import InvalidVersion, Version
 
 from vibe import runtime as runtime_mod
@@ -871,8 +879,6 @@ def _with_memory_extra(package_spec: str) -> str:
     if package_spec.startswith(("git+", "hg+", "svn+", "bz+", "http://", "https://", "file://")):
         return f"{PACKAGE_NAME}[{MEMORY_EXTRA_NAME}] @ {package_spec}"
     try:
-        from packaging.requirements import InvalidRequirement, Requirement
-
         requirement = Requirement(package_spec)
     except InvalidRequirement:
         artifact_uri = Path(package_spec).expanduser().resolve().as_uri()
@@ -887,6 +893,43 @@ def _with_memory_extra(package_spec: str) -> str:
     if requirement.marker:
         rendered += f"; {requirement.marker}"
     return rendered
+
+
+def _target_version_from_package_spec(package_spec: str) -> str | None:
+    """Read an exact release only from an already-versioned package spec."""
+
+    try:
+        requirement = Requirement(package_spec)
+    except InvalidRequirement:
+        artifact = package_spec
+    else:
+        if requirement.url is None:
+            specifiers = list(requirement.specifier)
+            if len(specifiers) != 1 or specifiers[0].operator != "==" or "*" in specifiers[0].version:
+                return None
+            try:
+                version = str(Version(specifiers[0].version))
+            except InvalidVersion:
+                return None
+            return version if _names_a_published_release(version) else None
+        artifact = requirement.url
+
+    if artifact.startswith(("git+", "hg+", "svn+", "bz+")):
+        return None
+    try:
+        parsed = urllib.parse.urlsplit(artifact)
+    except ValueError:
+        return None
+    filename = Path(urllib.parse.unquote(parsed.path if parsed.scheme else artifact)).name
+    try:
+        _, version, _, _ = parse_wheel_filename(filename)
+    except InvalidWheelFilename:
+        try:
+            _, version = parse_sdist_filename(filename)
+        except InvalidSdistFilename:
+            return None
+    rendered = str(version)
+    return rendered if _names_a_published_release(rendered) else None
 
 
 def pinned_package_spec(
@@ -969,11 +1012,6 @@ def build_upgrade_plan(
         if version or memory_package is not None
         else bool(memory_enabled or memory_package_installed())
     )
-    if not version and include_memory and (
-        not isinstance(target_version, str) or not _names_a_published_release(target_version)
-    ):
-        raise ValueError("A Memory-preserving upgrade requires a target release version")
-    uv_binary = find_uv_binary(uv_path=uv_path, base_env=base_env)
     package_spec = (
         pinned_package_spec(
             version,
@@ -984,6 +1022,12 @@ def build_upgrade_plan(
         if version
         else (package_spec or get_upgrade_package_spec())
     )
+    if not version and include_memory:
+        if target_version is None:
+            target_version = _target_version_from_package_spec(package_spec)
+        if not isinstance(target_version, str) or not _names_a_published_release(target_version):
+            raise ValueError("A Memory-preserving upgrade requires a target release version")
+    uv_binary = find_uv_binary(uv_path=uv_path, base_env=base_env)
     if not version and include_memory and f"[{MEMORY_EXTRA_NAME}]" not in package_spec:
         package_spec = _with_memory_extra(package_spec)
     memory_target = memory_version if version else target_version

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -13,7 +13,7 @@ import urllib.request
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, NamedTuple, cast
+from typing import NamedTuple, cast
 
 from packaging.version import InvalidVersion, Version
 
@@ -98,145 +98,6 @@ class UpgradePlan:
     cleanup_after_command: bool = False
 
 
-@dataclass(frozen=True)
-class UpgradeTransaction:
-    """Declarative package transaction passed to the restart supervisor."""
-
-    schema_version: int
-    installer: Literal["pip", "uv"]
-    forward_spec: str
-    include_memory: bool
-    memory_requirement: str | None
-    rollback_to: "RollbackTarget | None"
-    activate_runtime: Literal["restart_if_running", "none"] = "restart_if_running"
-
-    def to_payload(self) -> dict[str, object]:
-        """Return the closed, declarative wire shape consumed by the supervisor."""
-
-        rollback = self.rollback_to
-        return {
-            "schema_version": self.schema_version,
-            "installer": self.installer,
-            "forward_spec": self.forward_spec,
-            "include_memory": self.include_memory,
-            "memory_requirement": self.memory_requirement,
-            "rollback_to": (
-                {
-                    "version": rollback.version,
-                    "package": rollback.package,
-                    "launcher": {"python": rollback.launcher.python, "main": rollback.launcher.main},
-                    "memory_package": rollback.memory_package,
-                    "memory_version": rollback.memory_version,
-                }
-                if rollback
-                else None
-            ),
-            "activate_runtime": self.activate_runtime,
-        }
-
-    @classmethod
-    def from_payload(cls, payload: object) -> "UpgradeTransaction":
-        """Parse only the v1 transaction fields; unknown shape fails closed."""
-
-        if not isinstance(payload, dict):
-            raise ValueError("upgrade transaction payload must be an object")
-        expected = {
-            "schema_version",
-            "installer",
-            "forward_spec",
-            "include_memory",
-            "memory_requirement",
-            "rollback_to",
-            "activate_runtime",
-        }
-        if set(payload) != expected:
-            raise ValueError("upgrade transaction payload has unknown or missing fields")
-        if (
-            type(payload["schema_version"]) is not int
-            or payload["installer"] not in {"pip", "uv"}
-            or not isinstance(payload["forward_spec"], str)
-            or type(payload["include_memory"]) is not bool
-            or payload["memory_requirement"] is not None
-            and not isinstance(payload["memory_requirement"], str)
-            or payload["activate_runtime"] not in {"restart_if_running", "none"}
-        ):
-            raise ValueError("invalid upgrade transaction scalar fields")
-        rollback_payload = payload["rollback_to"]
-        rollback = None
-        if rollback_payload is not None:
-            if not isinstance(rollback_payload, dict) or set(rollback_payload) != {
-                "version",
-                "package",
-                "launcher",
-                "memory_package",
-                "memory_version",
-            }:
-                raise ValueError("invalid rollback target payload")
-            launcher_payload = rollback_payload["launcher"]
-            if not isinstance(launcher_payload, dict) or set(launcher_payload) != {"python", "main"}:
-                raise ValueError("invalid rollback launcher payload")
-            if (
-                not isinstance(rollback_payload["version"], str)
-                or rollback_payload["package"] is not None
-                and not isinstance(rollback_payload["package"], str)
-                or type(rollback_payload["memory_package"]) is not bool
-                or rollback_payload["memory_version"] is not None
-                and not isinstance(rollback_payload["memory_version"], str)
-                or not isinstance(launcher_payload["python"], str)
-                or not isinstance(launcher_payload["main"], str)
-            ):
-                raise ValueError("invalid rollback scalar fields")
-            rollback = RollbackTarget(
-                version=rollback_payload["version"],
-                package=rollback_payload["package"],
-                launcher=runtime_mod.ServiceLauncher(
-                    python=launcher_payload["python"],
-                    main=launcher_payload["main"],
-                ),
-                memory_package=rollback_payload["memory_package"],
-                memory_version=rollback_payload["memory_version"],
-            )
-        transaction = cls(
-            schema_version=payload["schema_version"],
-            installer=payload["installer"],
-            forward_spec=payload["forward_spec"],
-            include_memory=payload["include_memory"],
-            memory_requirement=payload["memory_requirement"],
-            rollback_to=rollback,
-            activate_runtime=payload["activate_runtime"],
-        )
-        transaction.validate()
-        return transaction
-
-    def validate(self) -> None:
-        if self.schema_version != 1:
-            raise ValueError("unsupported upgrade transaction schema")
-        if self.installer not in {"pip", "uv"}:
-            raise ValueError("unsupported upgrade transaction installer")
-        if not self.forward_spec or any(value in self.forward_spec for value in ("\x00", "\n", "\r")):
-            raise ValueError("invalid upgrade transaction package spec")
-        if self.include_memory and not self.memory_requirement:
-            raise ValueError("Memory requirement is required when Memory is included")
-        if not self.include_memory and self.memory_requirement is not None:
-            raise ValueError("Memory requirement must be omitted when Memory is not included")
-        if self.include_memory and self.memory_requirement != MEMORY_PACKAGE_REQUIREMENT:
-            prefix = f"{MEMORY_PACKAGE_NAME}=="
-            if not self.memory_requirement.startswith(prefix):
-                raise ValueError("invalid Memory requirement")
-            try:
-                Version(self.memory_requirement[len(prefix) :])
-            except InvalidVersion as exc:
-                raise ValueError("invalid Memory requirement") from exc
-        if self.rollback_to:
-            target = self.rollback_to
-            if not target.version or not target.launcher.python or not target.launcher.main:
-                raise ValueError("incomplete rollback target")
-            if target.memory_package != bool(target.memory_version):
-                raise ValueError("incomplete rollback Memory shape")
-        if self.activate_runtime not in {"restart_if_running", "none"}:
-            raise ValueError("unsupported upgrade transaction activation")
-
-
 def execute_upgrade_plan(
     plan: UpgradePlan,
     *,
@@ -245,9 +106,9 @@ def execute_upgrade_plan(
 ) -> subprocess.CompletedProcess[str]:
     """Run a validated plan in its recorded preflight/cleanup order.
 
-    The caller owns the package transaction lease. This helper deliberately does
-    not acquire one so the supervisor can hold the same lease across stop,
-    mutation, and start/rollback.
+    The caller owns package mutation sequencing. This helper deliberately does
+    not acquire a lifecycle lock: callers can run the plan synchronously while
+    the existing restart supervisor owns any later activation or rollback.
     """
 
     preflight = preflight_upgrade_plan(plan, run=run, **run_kwargs)
@@ -1165,7 +1026,11 @@ def build_upgrade_plan(
         except InvalidVersion:
             pass
     preflight_command = None
-    if not version or include_memory or cleanup_command is not None:
+    # Preflight only when the optional package shape is part of the operation.
+    # Core-only forward installs retain the origin/dev synchronous behavior: the
+    # service is still running while pip resolves, so a second resolver pass is
+    # unnecessary general-updater machinery.
+    if include_memory or cleanup_command is not None:
         preflight_command = [
             executable,
             "-m",
@@ -1238,41 +1103,6 @@ def build_memory_add_plan(
         requirement,
     ]
     return UpgradePlan(command, env, "pip", preflight_command=preflight)
-
-
-def build_upgrade_transaction(
-    *,
-    python_executable: str | None = None,
-    uv_path: str | None = None,
-    vibe_path: str | None = None,
-    base_env: dict[str, str] | None = None,
-    memory_enabled: bool = False,
-    activate_runtime: Literal["restart_if_running", "none"] = "restart_if_running",
-) -> UpgradeTransaction:
-    """Capture all mutable install facts before handing work to the supervisor."""
-
-    executable = python_executable or sys.executable
-    include_memory = bool(memory_enabled or memory_package_installed())
-    plan = build_upgrade_plan(
-        python_executable=executable,
-        uv_path=uv_path,
-        vibe_path=vibe_path,
-        base_env=base_env,
-        memory_enabled=memory_enabled,
-        memory_requirement=MEMORY_PACKAGE_REQUIREMENT if include_memory else None,
-    )
-    installer = plan.method
-    transaction = UpgradeTransaction(
-        schema_version=1,
-        installer=cast(Literal["pip", "uv"], installer),
-        forward_spec=get_upgrade_package_spec(),
-        include_memory=include_memory,
-        memory_requirement=MEMORY_PACKAGE_REQUIREMENT if include_memory else None,
-        rollback_to=plan.rollback_to,
-        activate_runtime=activate_runtime,
-    )
-    transaction.validate()
-    return transaction
 
 
 def get_safe_cwd() -> str:

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -6,13 +6,16 @@ import os
 import re
 import shlex
 import shutil
+import subprocess
 import sys
 import tempfile
 import urllib.request
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import NamedTuple, cast
+from typing import Literal, NamedTuple, cast
+
+from packaging.version import InvalidVersion, Version
 
 from vibe import runtime as runtime_mod
 
@@ -21,6 +24,12 @@ logger = logging.getLogger(__name__)
 
 PACKAGE_NAME = "avibe-os"
 LEGACY_PACKAGE_NAME = "vibe-remote"
+MEMORY_PACKAGE_NAME = "avibe-memory"
+MEMORY_EXTRA_NAME = "memory"
+MEMORY_PACKAGE_COMPATIBILITY = ">=3.0.14.dev0,<3.1"
+MEMORY_PACKAGE_REQUIREMENT = f"{MEMORY_PACKAGE_NAME}{MEMORY_PACKAGE_COMPATIBILITY}"
+_MEMORY_SPLIT_MIN_VERSION = Version("3.0.14.dev0")
+PIP_DOWNLOAD_DEST_PLACEHOLDER = "{avibe-pip-download-destination}"
 DEFAULT_UPDATE_METADATA_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
 CURRENT_VIBE_EXECUTABLE_ENV = "VIBE_CURRENT_EXECUTABLE"
 SHOW_RUNTIME_SKIP_ENV = "VIBE_INSTALL_SKIP_SHOW_RUNTIME"
@@ -84,6 +93,108 @@ class UpgradePlan:
     env: dict[str, str] | None
     method: str
     rollback_to: RollbackTarget | None = None
+    preflight_command: list[str] | None = None
+    cleanup_command: list[str] | None = None
+    cleanup_after_command: bool = False
+
+
+@dataclass(frozen=True)
+class UpgradeTransaction:
+    """Declarative package transaction passed to the restart supervisor."""
+
+    schema_version: int
+    installer: Literal["pip", "uv"]
+    forward_spec: str
+    include_memory: bool
+    memory_requirement: str | None
+    rollback_to: "RollbackTarget | None"
+    activate_runtime: Literal["restart_if_running", "none"] = "restart_if_running"
+
+    def validate(self) -> None:
+        if self.schema_version != 1:
+            raise ValueError("unsupported upgrade transaction schema")
+        if self.installer not in {"pip", "uv"}:
+            raise ValueError("unsupported upgrade transaction installer")
+        if not self.forward_spec or any(value in self.forward_spec for value in ("\x00", "\n", "\r")):
+            raise ValueError("invalid upgrade transaction package spec")
+        if self.include_memory and not self.memory_requirement:
+            raise ValueError("Memory requirement is required when Memory is included")
+        if self.include_memory and self.memory_requirement != MEMORY_PACKAGE_REQUIREMENT:
+            prefix = f"{MEMORY_PACKAGE_NAME}=="
+            if not self.memory_requirement.startswith(prefix):
+                raise ValueError("invalid Memory requirement")
+            try:
+                Version(self.memory_requirement[len(prefix) :])
+            except InvalidVersion as exc:
+                raise ValueError("invalid Memory requirement") from exc
+        if self.rollback_to:
+            target = self.rollback_to
+            if not target.version or not target.launcher.python or not target.launcher.main:
+                raise ValueError("incomplete rollback target")
+            if target.memory_package != bool(target.memory_version):
+                raise ValueError("incomplete rollback Memory shape")
+        if self.activate_runtime not in {"restart_if_running", "none"}:
+            raise ValueError("unsupported upgrade transaction activation")
+
+
+def execute_upgrade_plan(
+    plan: UpgradePlan,
+    *,
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    **run_kwargs: object,
+) -> subprocess.CompletedProcess[str]:
+    """Run a validated plan in its recorded preflight/cleanup order.
+
+    The caller owns the package transaction lease. This helper deliberately does
+    not acquire one so the supervisor can hold the same lease across stop,
+    mutation, and start/rollback.
+    """
+
+    preflight = preflight_upgrade_plan(plan, run=run, **run_kwargs)
+    if preflight is not None:
+        if preflight.returncode != 0:
+            return preflight
+
+    if plan.cleanup_command is not None and not plan.cleanup_after_command:
+        cleaned = run(plan.cleanup_command, env=plan.env, **run_kwargs)
+        if cleaned.returncode != 0:
+            return cleaned
+
+    installed = run(plan.command, env=plan.env, **run_kwargs)
+    if installed.returncode != 0:
+        return installed
+
+    if plan.cleanup_command is not None and plan.cleanup_after_command:
+        cleaned = run(plan.cleanup_command, env=plan.env, **run_kwargs)
+        if cleaned.returncode != 0:
+            return cleaned
+
+    return installed
+
+
+def preflight_upgrade_plan(
+    plan: UpgradePlan,
+    *,
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    **run_kwargs: object,
+) -> subprocess.CompletedProcess[str] | None:
+    """Resolve a plan without mutating the environment."""
+
+    if plan.preflight_command is None:
+        return None
+    preflight_command = plan.preflight_command
+    scratch_dir: str | None = None
+    try:
+        if PIP_DOWNLOAD_DEST_PLACEHOLDER in preflight_command:
+            scratch_dir = tempfile.mkdtemp(prefix="avibe-pip-download-")
+            preflight_command = [
+                scratch_dir if argument == PIP_DOWNLOAD_DEST_PLACEHOLDER else argument
+                for argument in preflight_command
+            ]
+        return run(preflight_command, env=plan.env, **run_kwargs)
+    finally:
+        if scratch_dir is not None:
+            shutil.rmtree(scratch_dir, ignore_errors=True)
 
 
 def resolve_command_path(command: str | None, search_path: str | None = None) -> str | None:
@@ -512,15 +623,65 @@ def installed_package_name(python_executable: str | None = None) -> str | None:
     return match.group("name") if match else None
 
 
+def memory_package_installed() -> bool:
+    """Return whether the optional Memory distribution is installed."""
+
+    try:
+        from importlib.metadata import PackageNotFoundError, distribution
+
+        distribution(MEMORY_PACKAGE_NAME)
+    except PackageNotFoundError:
+        return False
+    except Exception:
+        logger.warning("Could not inspect %s metadata; preserving package shape", MEMORY_PACKAGE_NAME, exc_info=True)
+        return True
+    return True
+
+
+def installed_memory_package_version() -> str | None:
+    try:
+        from importlib.metadata import PackageNotFoundError, distribution
+
+        version = distribution(MEMORY_PACKAGE_NAME).version
+    except PackageNotFoundError:
+        return None
+    except Exception:
+        logger.warning("Could not inspect %s version", MEMORY_PACKAGE_NAME, exc_info=True)
+        return None
+    return str(version).strip() or None
+
+
+def configured_memory_enabled() -> bool:
+    """Read the persisted Memory switch for an explicit upgrade action."""
+
+    try:
+        from config.v2_config import V2Config
+
+        return bool(V2Config.load().memory.enabled)
+    except FileNotFoundError:
+        return False
+    except Exception:
+        logger.warning("Could not read Memory enablement; preserving package shape", exc_info=True)
+        return True
+
+
 def _distributions_providing_this_package() -> list[str]:
     """Every installed distribution that provides the package this module is in."""
 
     try:
         from importlib.metadata import packages_distributions
+        from packaging.utils import canonicalize_name
     except ImportError:  # pragma: no cover - importlib.metadata ships with 3.10+
         return []
     try:
-        return sorted(set(packages_distributions().get(__name__.split(".")[0], [])))
+        memory_name = canonicalize_name(MEMORY_PACKAGE_NAME)
+        return sorted(
+            {
+                name
+                for name in packages_distributions().get(__name__.split(".")[0], [])
+                if canonicalize_name(name) != memory_name
+            }
+        )
     except Exception:  # pragma: no cover - a broken environment answers nothing
         logger.debug("Failed to read installed distribution metadata", exc_info=True)
         return []
@@ -655,6 +816,8 @@ class RollbackTarget(NamedTuple):
     version: str
     package: str | None
     launcher: runtime_mod.ServiceLauncher
+    memory_package: bool = False
+    memory_version: str | None = None
 
 
 def _names_a_published_release(version: str) -> bool:
@@ -713,15 +876,45 @@ def rollback_target() -> RollbackTarget | None:
 
     if not _names_a_published_release(__version__):
         return None
+    memory_package = memory_package_installed()
     return RollbackTarget(
         version=__version__,
         package=installed_package_name(),
         launcher=runtime_mod.current_service_launcher(),
+        memory_package=memory_package,
+        memory_version=installed_memory_package_version() if memory_package else None,
     )
 
 
+def _with_memory_extra(package_spec: str) -> str:
+    """Add the Memory extra without corrupting URL or local path specs."""
+
+    if package_spec.startswith(("git+", "hg+", "svn+", "bz+", "http://", "https://")):
+        return f"{PACKAGE_NAME}[{MEMORY_EXTRA_NAME}] @ {package_spec}"
+    try:
+        from packaging.requirements import InvalidRequirement, Requirement
+
+        requirement = Requirement(package_spec)
+    except InvalidRequirement:
+        return f"{package_spec}[{MEMORY_EXTRA_NAME}]"
+
+    extras = sorted({*requirement.extras, MEMORY_EXTRA_NAME})
+    rendered = f"{requirement.name}[{','.join(extras)}]"
+    if requirement.url:
+        rendered += f" @ {requirement.url}"
+    else:
+        rendered += str(requirement.specifier)
+    if requirement.marker:
+        rendered += f"; {requirement.marker}"
+    return rendered
+
+
 def pinned_package_spec(
-    version: str, *, python_executable: str | None = None, package_name: str | None = None
+    version: str,
+    *,
+    python_executable: str | None = None,
+    package_name: str | None = None,
+    memory_package: bool = False,
 ) -> str:
     """The distribution this install came from, pinned to exactly one version.
 
@@ -750,7 +943,8 @@ def pinned_package_spec(
     spec = package_name or installed_package_name(python_executable) or get_upgrade_package_spec()
     if _BARE_PACKAGE_NAME_RE.fullmatch(spec) is None:
         raise ValueError("The configured upgrade package spec cannot carry a version pin")
-    return f"{spec}=={version}"
+    pinned = f"{spec}=={version}"
+    return _with_memory_extra(pinned) if memory_package else pinned
 
 
 def build_upgrade_plan(
@@ -761,6 +955,10 @@ def build_upgrade_plan(
     base_env: dict[str, str] | None = None,
     version: str | None = None,
     package_name: str | None = None,
+    memory_enabled: bool = False,
+    memory_package: bool | None = None,
+    memory_version: str | None = None,
+    package_spec: str | None = None,
 ) -> UpgradePlan:
     """How to install avibe: the newest release, or `version` exactly.
 
@@ -780,12 +978,30 @@ def build_upgrade_plan(
     # its own: the process building one is the release that failed, so measuring
     # there would carry the failure forward as its own recovery target.
     rollback_to = None if version else rollback_target()
+    # A caller targeting another interpreter (for example a test-owned venv)
+    # can provide an explicit package-shape measurement.  Only infer from this
+    # process when the caller did not provide one; otherwise ambient metadata
+    # would leak into the target plan and turn an intentional core-only install
+    # into a Memory install.
+    include_memory = (
+        bool(memory_package)
+        if version or memory_package is not None
+        else bool(memory_enabled or memory_package_installed())
+    )
     uv_binary = find_uv_binary(uv_path=uv_path, base_env=base_env)
     package_spec = (
-        pinned_package_spec(version, python_executable=executable, package_name=package_name)
+        pinned_package_spec(
+            version,
+            python_executable=executable,
+            package_name=package_name,
+            memory_package=include_memory,
+        )
         if version
-        else get_upgrade_package_spec()
+        else (package_spec or get_upgrade_package_spec())
     )
+    if not version and include_memory and f"[{MEMORY_EXTRA_NAME}]" not in package_spec:
+        package_spec = _with_memory_extra(package_spec)
+    pinned_memory_spec = f"{MEMORY_PACKAGE_NAME}=={memory_version}" if include_memory and memory_version else None
 
     if is_uv_tool_install(executable) and uv_binary:
         env = dict(base_env or os.environ)
@@ -793,15 +1009,26 @@ def build_upgrade_plan(
         if vibe_bin_dir:
             env["UV_TOOL_BIN_DIR"] = vibe_bin_dir
         command = [uv_binary, "tool", "install", package_spec]
+        if pinned_memory_spec:
+            command.extend(["--with", pinned_memory_spec])
         if not version:
             command.append("--upgrade")
         if version or package_spec != PACKAGE_NAME or is_legacy_uv_tool_install(executable):
             command.append("--force")
+        preflight_command = None
+        if include_memory:
+            preflight_command = [uv_binary, "pip", "install", "--dry-run", "--python", executable]
+            if not version:
+                preflight_command.append("--upgrade")
+            preflight_command.append(package_spec)
+            if pinned_memory_spec:
+                preflight_command.append(pinned_memory_spec)
         return UpgradePlan(
             command=command,
             env=env,
             method="uv",
             rollback_to=rollback_to,
+            preflight_command=preflight_command,
         )
 
     command = [executable, "-m", "pip", "install"]
@@ -823,12 +1050,125 @@ def build_upgrade_plan(
     if version or not installed_metadata_describes_running_code():
         command.append("--force-reinstall")
     command.append(package_spec)
+    if pinned_memory_spec:
+        command.append(pinned_memory_spec)
+    cleanup_command = None
+    cleanup_after_command = False
+    if version and not include_memory and memory_package_installed():
+        cleanup_command = [executable, "-m", "pip", "uninstall", "--yes", MEMORY_PACKAGE_NAME]
+        try:
+            cleanup_after_command = Version(version) >= _MEMORY_SPLIT_MIN_VERSION
+        except InvalidVersion:
+            pass
+    preflight_command = None
+    if include_memory or cleanup_command is not None:
+        preflight_command = [
+            executable,
+            "-m",
+            "pip",
+            "download",
+            "--dest",
+            PIP_DOWNLOAD_DEST_PLACEHOLDER,
+            "--no-deps",
+            package_spec,
+        ]
+        if pinned_memory_spec:
+            preflight_command.append(pinned_memory_spec)
     return UpgradePlan(
         command=command,
         env=dict(base_env or os.environ),
         method="pip",
         rollback_to=rollback_to,
+        preflight_command=preflight_command,
+        cleanup_command=cleanup_command,
+        cleanup_after_command=cleanup_after_command,
     )
+
+
+def build_memory_add_plan(
+    *,
+    version: str | None = None,
+    python_executable: str | None = None,
+    uv_path: str | None = None,
+    base_env: dict[str, str] | None = None,
+) -> UpgradePlan:
+    """Build an explicit package repair plan for avibe-memory."""
+
+    executable = python_executable or sys.executable
+    requirement = MEMORY_PACKAGE_REQUIREMENT if version is None else f"{MEMORY_PACKAGE_NAME}=={version}"
+    uv_binary = find_uv_binary(uv_path=uv_path, base_env=base_env)
+    env = dict(base_env or os.environ)
+    if is_uv_tool_install(executable) and uv_binary:
+        command = [
+            uv_binary,
+            "pip",
+            "install",
+            "--upgrade",
+            "--force-reinstall",
+            "--no-deps",
+            "--python",
+            executable,
+            requirement,
+        ]
+        preflight = [
+            uv_binary,
+            "pip",
+            "install",
+            "--dry-run",
+            "--upgrade",
+            "--force-reinstall",
+            "--no-deps",
+            "--python",
+            executable,
+            requirement,
+        ]
+        return UpgradePlan(command, env, "uv", preflight_command=preflight)
+    command = [executable, "-m", "pip", "install", "--upgrade", "--force-reinstall", "--no-deps", requirement]
+    preflight = [
+        executable,
+        "-m",
+        "pip",
+        "download",
+        "--dest",
+        PIP_DOWNLOAD_DEST_PLACEHOLDER,
+        "--no-deps",
+        requirement,
+    ]
+    return UpgradePlan(command, env, "pip", preflight_command=preflight)
+
+
+def build_upgrade_transaction(
+    *,
+    python_executable: str | None = None,
+    uv_path: str | None = None,
+    vibe_path: str | None = None,
+    base_env: dict[str, str] | None = None,
+    memory_enabled: bool = False,
+    activate_runtime: Literal["restart_if_running", "none"] = "restart_if_running",
+) -> UpgradeTransaction:
+    """Capture all mutable install facts before handing work to the supervisor."""
+
+    executable = python_executable or sys.executable
+    include_memory = bool(memory_enabled or memory_package_installed())
+    plan = build_upgrade_plan(
+        python_executable=executable,
+        uv_path=uv_path,
+        vibe_path=vibe_path,
+        base_env=base_env,
+        memory_enabled=memory_enabled,
+    )
+    installer = plan.method
+    transaction = UpgradeTransaction(
+        schema_version=1,
+        installer=cast(Literal["pip", "uv"], installer),
+        forward_spec=get_upgrade_package_spec(),
+        include_memory=include_memory,
+        memory_requirement=MEMORY_PACKAGE_REQUIREMENT if include_memory else None,
+        rollback_to=plan.rollback_to,
+        activate_runtime=activate_runtime,
+    )
+    transaction.validate()
+    return transaction
 
 
 def get_safe_cwd() -> str:

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -934,6 +934,7 @@ def build_upgrade_plan(
     vibe_path: str | None = None,
     base_env: dict[str, str] | None = None,
     version: str | None = None,
+    target_version: str | None = None,
     package_name: str | None = None,
     memory_enabled: bool = False,
     memory_package: bool | None = None,
@@ -968,6 +969,10 @@ def build_upgrade_plan(
         if version or memory_package is not None
         else bool(memory_enabled or memory_package_installed())
     )
+    if not version and include_memory and (
+        not isinstance(target_version, str) or not _names_a_published_release(target_version)
+    ):
+        raise ValueError("A Memory-preserving upgrade requires a target release version")
     uv_binary = find_uv_binary(uv_path=uv_path, base_env=base_env)
     package_spec = (
         pinned_package_spec(
@@ -981,7 +986,8 @@ def build_upgrade_plan(
     )
     if not version and include_memory and f"[{MEMORY_EXTRA_NAME}]" not in package_spec:
         package_spec = _with_memory_extra(package_spec)
-    pinned_memory_spec = f"{MEMORY_PACKAGE_NAME}=={memory_version}" if include_memory and memory_version else None
+    memory_target = memory_version if version else target_version
+    pinned_memory_spec = f"{MEMORY_PACKAGE_NAME}=={memory_target}" if include_memory and memory_target else None
 
     if is_uv_tool_install(executable) and uv_binary:
         env = dict(base_env or os.environ)
@@ -1065,6 +1071,9 @@ def build_upgrade_plan(
             PIP_DOWNLOAD_DEST_PLACEHOLDER,
             package_spec,
         ]
+        if pinned_memory_spec:
+            preflight_command.append(pinned_memory_spec)
+            preflight_fallback_command.append(pinned_memory_spec)
     elif include_memory or cleanup_command is not None:
         preflight_command = [
             executable,

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -110,6 +110,104 @@ class UpgradeTransaction:
     rollback_to: "RollbackTarget | None"
     activate_runtime: Literal["restart_if_running", "none"] = "restart_if_running"
 
+    def to_payload(self) -> dict[str, object]:
+        """Return the closed, declarative wire shape consumed by the supervisor."""
+
+        rollback = self.rollback_to
+        return {
+            "schema_version": self.schema_version,
+            "installer": self.installer,
+            "forward_spec": self.forward_spec,
+            "include_memory": self.include_memory,
+            "memory_requirement": self.memory_requirement,
+            "rollback_to": (
+                {
+                    "version": rollback.version,
+                    "package": rollback.package,
+                    "launcher": {"python": rollback.launcher.python, "main": rollback.launcher.main},
+                    "memory_package": rollback.memory_package,
+                    "memory_version": rollback.memory_version,
+                }
+                if rollback
+                else None
+            ),
+            "activate_runtime": self.activate_runtime,
+        }
+
+    @classmethod
+    def from_payload(cls, payload: object) -> "UpgradeTransaction":
+        """Parse only the v1 transaction fields; unknown shape fails closed."""
+
+        if not isinstance(payload, dict):
+            raise ValueError("upgrade transaction payload must be an object")
+        expected = {
+            "schema_version",
+            "installer",
+            "forward_spec",
+            "include_memory",
+            "memory_requirement",
+            "rollback_to",
+            "activate_runtime",
+        }
+        if set(payload) != expected:
+            raise ValueError("upgrade transaction payload has unknown or missing fields")
+        if (
+            type(payload["schema_version"]) is not int
+            or payload["installer"] not in {"pip", "uv"}
+            or not isinstance(payload["forward_spec"], str)
+            or type(payload["include_memory"]) is not bool
+            or payload["memory_requirement"] is not None
+            and not isinstance(payload["memory_requirement"], str)
+            or payload["activate_runtime"] not in {"restart_if_running", "none"}
+        ):
+            raise ValueError("invalid upgrade transaction scalar fields")
+        rollback_payload = payload["rollback_to"]
+        rollback = None
+        if rollback_payload is not None:
+            if not isinstance(rollback_payload, dict) or set(rollback_payload) != {
+                "version",
+                "package",
+                "launcher",
+                "memory_package",
+                "memory_version",
+            }:
+                raise ValueError("invalid rollback target payload")
+            launcher_payload = rollback_payload["launcher"]
+            if not isinstance(launcher_payload, dict) or set(launcher_payload) != {"python", "main"}:
+                raise ValueError("invalid rollback launcher payload")
+            if (
+                not isinstance(rollback_payload["version"], str)
+                or rollback_payload["package"] is not None
+                and not isinstance(rollback_payload["package"], str)
+                or type(rollback_payload["memory_package"]) is not bool
+                or rollback_payload["memory_version"] is not None
+                and not isinstance(rollback_payload["memory_version"], str)
+                or not isinstance(launcher_payload["python"], str)
+                or not isinstance(launcher_payload["main"], str)
+            ):
+                raise ValueError("invalid rollback scalar fields")
+            rollback = RollbackTarget(
+                version=rollback_payload["version"],
+                package=rollback_payload["package"],
+                launcher=runtime_mod.ServiceLauncher(
+                    python=launcher_payload["python"],
+                    main=launcher_payload["main"],
+                ),
+                memory_package=rollback_payload["memory_package"],
+                memory_version=rollback_payload["memory_version"],
+            )
+        transaction = cls(
+            schema_version=payload["schema_version"],
+            installer=payload["installer"],
+            forward_spec=payload["forward_spec"],
+            include_memory=payload["include_memory"],
+            memory_requirement=payload["memory_requirement"],
+            rollback_to=rollback,
+            activate_runtime=payload["activate_runtime"],
+        )
+        transaction.validate()
+        return transaction
+
     def validate(self) -> None:
         if self.schema_version != 1:
             raise ValueError("unsupported upgrade transaction schema")
@@ -119,6 +217,8 @@ class UpgradeTransaction:
             raise ValueError("invalid upgrade transaction package spec")
         if self.include_memory and not self.memory_requirement:
             raise ValueError("Memory requirement is required when Memory is included")
+        if not self.include_memory and self.memory_requirement is not None:
+            raise ValueError("Memory requirement must be omitted when Memory is not included")
         if self.include_memory and self.memory_requirement != MEMORY_PACKAGE_REQUIREMENT:
             prefix = f"{MEMORY_PACKAGE_NAME}=="
             if not self.memory_requirement.startswith(prefix):
@@ -958,6 +1058,7 @@ def build_upgrade_plan(
     memory_enabled: bool = False,
     memory_package: bool | None = None,
     memory_version: str | None = None,
+    memory_requirement: str | None = None,
     package_spec: str | None = None,
 ) -> UpgradePlan:
     """How to install avibe: the newest release, or `version` exactly.
@@ -1002,6 +1103,9 @@ def build_upgrade_plan(
     if not version and include_memory and f"[{MEMORY_EXTRA_NAME}]" not in package_spec:
         package_spec = _with_memory_extra(package_spec)
     pinned_memory_spec = f"{MEMORY_PACKAGE_NAME}=={memory_version}" if include_memory and memory_version else None
+    forward_memory_spec = (
+        (memory_requirement or MEMORY_PACKAGE_REQUIREMENT) if include_memory and not version else None
+    )
 
     if is_uv_tool_install(executable) and uv_binary:
         env = dict(base_env or os.environ)
@@ -1009,8 +1113,8 @@ def build_upgrade_plan(
         if vibe_bin_dir:
             env["UV_TOOL_BIN_DIR"] = vibe_bin_dir
         command = [uv_binary, "tool", "install", package_spec]
-        if pinned_memory_spec:
-            command.extend(["--with", pinned_memory_spec])
+        if pinned_memory_spec or forward_memory_spec:
+            command.extend(["--with", pinned_memory_spec or forward_memory_spec])
         if not version:
             command.append("--upgrade")
         if version or package_spec != PACKAGE_NAME or is_legacy_uv_tool_install(executable):
@@ -1021,8 +1125,8 @@ def build_upgrade_plan(
             if not version:
                 preflight_command.append("--upgrade")
             preflight_command.append(package_spec)
-            if pinned_memory_spec:
-                preflight_command.append(pinned_memory_spec)
+            if pinned_memory_spec or forward_memory_spec:
+                preflight_command.append(pinned_memory_spec or forward_memory_spec)
         return UpgradePlan(
             command=command,
             env=env,
@@ -1050,8 +1154,8 @@ def build_upgrade_plan(
     if version or not installed_metadata_describes_running_code():
         command.append("--force-reinstall")
     command.append(package_spec)
-    if pinned_memory_spec:
-        command.append(pinned_memory_spec)
+    if pinned_memory_spec or forward_memory_spec:
+        command.append(pinned_memory_spec or forward_memory_spec)
     cleanup_command = None
     cleanup_after_command = False
     if version and not include_memory and memory_package_installed():
@@ -1061,7 +1165,7 @@ def build_upgrade_plan(
         except InvalidVersion:
             pass
     preflight_command = None
-    if include_memory or cleanup_command is not None:
+    if not version or include_memory or cleanup_command is not None:
         preflight_command = [
             executable,
             "-m",
@@ -1069,11 +1173,10 @@ def build_upgrade_plan(
             "download",
             "--dest",
             PIP_DOWNLOAD_DEST_PLACEHOLDER,
-            "--no-deps",
-            package_spec,
         ]
-        if pinned_memory_spec:
-            preflight_command.append(pinned_memory_spec)
+        preflight_command.extend(["--no-deps", package_spec])
+        if pinned_memory_spec or forward_memory_spec:
+            preflight_command.append(pinned_memory_spec or forward_memory_spec)
     return UpgradePlan(
         command=command,
         env=dict(base_env or os.environ),
@@ -1156,6 +1259,7 @@ def build_upgrade_transaction(
         vibe_path=vibe_path,
         base_env=base_env,
         memory_enabled=memory_enabled,
+        memory_requirement=MEMORY_PACKAGE_REQUIREMENT if include_memory else None,
     )
     installer = plan.method
     transaction = UpgradeTransaction(


### PR DESCRIPTION
## Capability

Wave 3b preserves the optional `avibe-memory` package shape through a synchronous upgrade install with Memory-aware preflight and the existing restart supervisor's activation rollback. This branch supersedes closed PR #1710 but is intentionally reimplemented from `dev` at `2e5e3f0b356ab89318c7593d459084dbb2c1875c`; no commits were cherry-picked wholesale.

## Boundary

API and CLI build one immutable `UpgradePlan`, run its non-mutating preflight and package install synchronously, and report the actual installer result. When a runtime was running, they then call the existing `schedule_restart` with the captured rollback target; stopped installations retain the existing next-start behavior. The restart supervisor remains the single owner of ordinary stop/start activation and rollback. No new transaction transport, lifecycle locks, pending markers, status endpoint, startup installer, or caller-local UI/QR/doctor coordination is introduced.

## Contract and evidence

- Forward upgrades include the Memory extra when Memory is enabled or the optional distribution is installed.
- `RollbackTarget` captures the prior distribution, launcher, optional Memory presence, and exact Memory version before replacement.
- Memory-preserving forward plans resolve the target host extra before package mutation; the target release owns its Memory compatibility window.
- Pinned rollback restores exact core-only or core+Memory shape and version with installer-specific cleanup ordering.
- `MEMORY-INDEP-018`: `tests/test_memory_upgrade_packaged.py` builds real core and Memory wheels, installs a test-owned venv, runs N core+Memory -> N+1 through the public planner/executor, invokes the existing supervisor rollback path, and inspects installed distributions. Separate evidence verifies a core-only venv remains core-only and a missing Memory wheel fails before install.
- Unit/contract coverage is in `tests/test_upgrade_flow.py` and `tests/test_restart_supervisor.py`; Docker upgrade regression and migration guard remain green. Residual manual checks are limited to packaged release/installer environments.

## Exact scope

Product: `vibe/upgrade.py`, `vibe/restart_supervisor.py`, `vibe/api.py`, `vibe/cli.py`.
Tests/workflow gate: `tests/test_upgrade_flow.py`, `tests/test_restart_supervisor.py`, `tests/test_memory_upgrade_packaged.py`, `.github/workflows/lint.yml`.

## Known-by-design ledger

- MEMORY-INDEP-018-KBD-1: stopped pre-split first-split upgrade from an old planner can miss Memory; Wave 3c owns the first non-bundled release transition.
- MEMORY-INDEP-018-KBD-5: bundled/unparseable legacy rollback dependency residual; explicit Settings repair is the recovery path.
- MEMORY-INDEP-018-KBD-6: one-era explicit uv->pip rollback may lose an installed-but-disabled Memory shape; Wave 3c owns the Memory pin/release transition.
- Wave 3c also owns the hard Memory transition dependency, manifest/publish order, and release-gate removal.

This PR deliberately excludes global start/stop/doctor/QR/UI-reload locking, pending-restart handoff, UI readiness markers, frontend contention/toast changes, and release workflow changes. Settings Python distribution repair remains a separate focused follow-up required before Wave 3c; the existing EverOS runtime repair is unchanged in this PR. No dependency on closed #1710; no merge performed by this lane.
