### PR TITLE
refactor(tmux): use shared runtime installer

### DIFF
--- a/core/managed_runtime.py
+++ b/core/managed_runtime.py
@@ -1943,7 +1943,7 @@ class ManagedRuntimeManager:
         *,
         reason: str | None = None,
     ) -> dict[str, Any]:
-        if self.resolve_binary() != binary:
+        if ManagedRuntimeManager.resolve_binary(self) != binary:
             try:
                 self._write_current_pointer(install_dir, manifest, archive)
             except Exception as exc:  # noqa: BLE001

--- a/core/managed_runtime.py
+++ b/core/managed_runtime.py
@@ -132,6 +132,7 @@ class ManagedRuntimeSpec:
     archive_size_field: str = "size"
     platform_aliases: tuple[tuple[str, str], ...] = ()
     binary_artifact: bool = True
+    allow_missing_binary_sha256: bool = False
     record_provider: str = "manifest"
     metadata_filename_override: str | None = None
     allow_legacy_missing_runtime_id: bool = False
@@ -296,7 +297,11 @@ class ManagedRuntimeManager:
                         archive=archive,
                     )
                 binary_sha256 = file_sha256(staged_binary) if self.spec.binary_artifact else None
-                if self.spec.binary_artifact and binary_sha256 != archive.binary_sha256:
+                if (
+                    self.spec.binary_artifact
+                    and archive.binary_sha256 is not None
+                    and binary_sha256 != archive.binary_sha256
+                ):
                     return self._failure(
                         self._reason("binary_checksum_mismatch"),
                         manifest=manifest,
@@ -456,7 +461,16 @@ class ManagedRuntimeManager:
             metadata_bin_path = metadata.get("bin_path", self.spec.default_bin_path)
             binary_sha256 = metadata.get("binary_sha256")
             binary_integrity_valid = (
-                isinstance(binary_sha256, str) and bool(_SHA256_RE.fullmatch(binary_sha256))
+                (
+                    isinstance(binary_sha256, str)
+                    and bool(_SHA256_RE.fullmatch(binary_sha256))
+                )
+                or (
+                    binary_sha256 is None
+                    and self.spec.allow_missing_binary_sha256
+                    and self.spec.allow_legacy_missing_runtime_id
+                    and metadata.get("runtime_id") is None
+                )
                 if self.spec.binary_artifact
                 else (
                     binary_sha256 is None
@@ -1642,7 +1656,14 @@ class ManagedRuntimeManager:
                 if not _SHA256_RE.fullmatch(sha256):
                     raise ValueError("invalid archive sha256")
                 if self.spec.binary_artifact and (
-                    binary_sha256 is None or not _SHA256_RE.fullmatch(binary_sha256)
+                    (
+                        binary_sha256 is None
+                        and not self.spec.allow_missing_binary_sha256
+                    )
+                    or (
+                        binary_sha256 is not None
+                        and not _SHA256_RE.fullmatch(binary_sha256)
+                    )
                 ):
                     raise ValueError("invalid binary sha256")
                 if binary_sha256 is not None and not _SHA256_RE.fullmatch(binary_sha256):
@@ -1802,6 +1823,23 @@ class ManagedRuntimeManager:
         target_platform = target.pop("platform")
         metadata_platform = metadata.get("platform")
         aliases = dict(self.spec.platform_aliases)
+        expected_binary_sha256 = archive.binary_sha256
+        legacy_without_binary_digest = (
+            self.spec.binary_artifact
+            and expected_binary_sha256 is None
+            and metadata.get("binary_sha256") is None
+            and self.spec.allow_missing_binary_sha256
+            and self.spec.allow_legacy_missing_runtime_id
+            and metadata.get("runtime_id") is None
+        )
+        if self.spec.binary_artifact and expected_binary_sha256 is None:
+            persisted_binary_sha256 = metadata.get("binary_sha256")
+            if isinstance(persisted_binary_sha256, str) and _SHA256_RE.fullmatch(
+                persisted_binary_sha256
+            ):
+                expected_binary_sha256 = persisted_binary_sha256
+            elif not legacy_without_binary_digest:
+                return None
         if not (
             self._record_provider_matches(metadata.get("provider"))
             and self._record_runtime_id_matches(metadata.get("runtime_id"))
@@ -1812,7 +1850,12 @@ class ManagedRuntimeManager:
             and bin_path == archive.bin_path
             and (
                 not self.spec.binary_artifact
-                or file_sha256(binary) == archive.binary_sha256
+                or expected_binary_sha256 is None
+                or file_sha256(binary) == expected_binary_sha256
+            )
+            and (
+                not legacy_without_binary_digest
+                or self._binary_matches_manifest(binary, manifest)
             )
         ):
             return None

--- a/core/managed_runtime.py
+++ b/core/managed_runtime.py
@@ -1490,7 +1490,10 @@ class ManagedRuntimeManager:
         return True
 
     def _install_dir_is_protected(self, install_dir: Path, protected: set[Path]) -> bool:
-        return install_dir in protected
+        return any(
+            install_dir == item or install_dir in item.parents or item in install_dir.parents
+            for item in protected
+        )
 
     def _retention_ranked_installs(
         self,

--- a/core/managed_runtime.py
+++ b/core/managed_runtime.py
@@ -138,6 +138,7 @@ class ManagedRuntimeSpec:
     allow_legacy_missing_runtime_id: bool = False
     staging_prefixes: tuple[str, ...] = ("install-",)
     replace_target_on_force: bool = False
+    include_manifest_digest_in_install_fingerprint: bool = False
 
     @property
     def metadata_filename(self) -> str:
@@ -1766,7 +1767,11 @@ class ManagedRuntimeManager:
         manifest: ManagedRuntimeManifest,
         archive: ManagedRuntimeArchive,
     ) -> Path:
-        fingerprint = hashlib.sha256(f"{manifest.runtime_version}:{archive.platform}:{archive.sha256}".encode()).hexdigest()[:16]
+        if self.spec.include_manifest_digest_in_install_fingerprint:
+            fingerprint_input = f"{manifest.digest}:{archive.sha256}"
+        else:
+            fingerprint_input = f"{manifest.runtime_version}:{archive.platform}:{archive.sha256}"
+        fingerprint = hashlib.sha256(fingerprint_input.encode("utf-8")).hexdigest()[:16]
         return (
             self.runtime_dir
             / "versions"

--- a/core/managed_runtime.py
+++ b/core/managed_runtime.py
@@ -138,6 +138,7 @@ class ManagedRuntimeSpec:
     allow_legacy_missing_runtime_id: bool = False
     staging_prefixes: tuple[str, ...] = ("install-",)
     replace_target_on_force: bool = False
+    replace_invalid_target_on_repair: bool = False
     include_manifest_digest_in_install_fingerprint: bool = False
 
     @property
@@ -209,7 +210,11 @@ class ManagedRuntimeManager:
                     manifest=manifest,
                 )
             target = self._install_target_identity(manifest, archive)
-            if expected_target is not None and self._normalized_install_target(expected_target) != target:
+            if (
+                expected_target is not None
+                and self._normalized_install_target(expected_target)
+                != self._normalized_install_target(target)
+            ):
                 return self._failure(
                     self._reason("install_target_changed"),
                     manifest=manifest,
@@ -245,8 +250,11 @@ class ManagedRuntimeManager:
             unique_install_dirs = list(dict.fromkeys(candidate_install_dirs))
             existing_install_dir = unique_install_dirs[0]
             existing: Path | None = None
+            canonical_target_was_rejected = False
             for candidate_install_dir in unique_install_dirs:
                 candidate = self._verified_manifest_binary(candidate_install_dir, manifest, archive)
+                if candidate_install_dir == install_dir and candidate is None:
+                    canonical_target_was_rejected = True
                 if candidate is not None:
                     existing_install_dir = candidate_install_dir
                     existing = candidate
@@ -317,7 +325,13 @@ class ManagedRuntimeManager:
 
                 install_dir.parent.mkdir(parents=True, exist_ok=True)
                 if install_dir.exists():
-                    if force and self.spec.replace_target_on_force:
+                    replace_target = (
+                        force and self.spec.replace_target_on_force
+                    ) or (
+                        canonical_target_was_rejected
+                        and self.spec.replace_invalid_target_on_repair
+                    )
+                    if replace_target:
                         if not self._remove_install_target_for_replacement(install_dir):
                             return self._failure(
                                 self._reason("install_failed"),
@@ -1858,11 +1872,10 @@ class ManagedRuntimeManager:
                 or expected_binary_sha256 is None
                 or file_sha256(binary) == expected_binary_sha256
             )
-            and (
-                not legacy_without_binary_digest
-                or self._binary_matches_manifest(binary, manifest)
-            )
         ):
+            return None
+        if not self._binary_matches_manifest(binary, manifest):
+            self._install_reason = self._reason("binary_not_runnable")
             return None
         return binary
 

--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -696,12 +696,6 @@ class _ShowManifestRuntimeManager(ManagedRuntimeManager):
         ).hexdigest()[:16]
         return parts[2] in {current_fingerprint, previous_fingerprint}
 
-    def _install_dir_is_protected(self, install_dir: Path, protected: set[Path]) -> bool:
-        return any(
-            install_dir == item or install_dir in item.parents or item in install_dir.parents
-            for item in protected
-        )
-
     def _retention_ranked_installs(self, installs, protected):
         resolved_by_path = {install.path: install.path.resolve() for install in installs}
         return [

--- a/core/tmux_runtime.py
+++ b/core/tmux_runtime.py
@@ -51,6 +51,7 @@ _TMUX_SPEC = ManagedRuntimeSpec(
     allow_missing_binary_sha256=True,
     allow_legacy_missing_runtime_id=True,
     staging_prefixes=("install-", "manifest-"),
+    replace_target_on_force=True,
 )
 
 

--- a/core/tmux_runtime.py
+++ b/core/tmux_runtime.py
@@ -1,33 +1,26 @@
 from __future__ import annotations
 
 import hashlib
-import importlib.resources as package_resources
 import json
 import logging
 import os
-import platform
 import shutil
-import stat
 import subprocess
 import sys
-import tarfile
-import tempfile
-import threading
-import urllib.parse
-import urllib.request
-from dataclasses import dataclass
-from pathlib import Path, PurePosixPath, PureWindowsPath
-from sysconfig import get_platform
+from collections.abc import Iterator, Mapping
+from dataclasses import replace
+from pathlib import Path
 from typing import Any
 
 from config import paths
-from core.dependency_network import (
-    dependency_error_details,
-    dependency_error_message,
-    fetch_bytes,
-    fetch_to_path,
-    probe_url,
-    redact_url,
+from core.managed_runtime import (
+    ManagedRuntimeArchive,
+    ManagedRuntimeManager,
+    ManagedRuntimeManifest,
+    ManagedRuntimeSpec,
+    env_flag_enabled,
+    runtime_platform_tag,
+    safe_path_part,
 )
 from core.process_isolation import isolated_subprocess_kwargs
 
@@ -35,34 +28,31 @@ from core.process_isolation import isolated_subprocess_kwargs
 logger = logging.getLogger(__name__)
 
 _TMUX_MANIFEST_RESOURCE = "tmux_runtime_manifest.json"
-_TMUX_RUNTIME_SOURCE_MANIFEST = "manifest"
-_TMUX_INSTALL_LOCK = threading.Lock()
+_RELEASED_PACKAGED_MANIFEST_SHA256 = "ee2826f881c236718ff18b2d1f939afb9417c584df5f29b796129c80691d2e63"
+_RELEASED_BINARY_SHA256_BY_ARCHIVE_SHA256 = {
+    "88323402bd28d21103239caf009b130086ebf334807de485d4a1e1c7188ee810": (
+        "5f8b6a7eda2ccd5bc283368e93e0e5c45b78071b5f90df7e394cf9a7f7ed6373"
+    ),
+    "073f6e2c2baa7eb5d643563600ee6052ca8619f3ec5a0cfdf99c56397fb72c94": (
+        "9adf4f75e12bce1e1a3b53696e38b60854761bb7945a7c09a806999f1995b870"
+    ),
+    "fd4a2206c5e468dd2ee4e9a65f2d40e0762551965d7fdbe849c494ab14f513e9": (
+        "6d1796de251b47b183af1b3eb6e229161e31560e89b9a8a1159533071eae2970"
+    ),
+    "002a6f4fd52212600fa0d72d865dcf328e5b8b6e83c179788144d8587b75677a": (
+        "5a06c01c36998aaf1726ccaaeae01dded2b5bf82dbd22a01889f0d05b4d11c80"
+    ),
+}
+_TMUX_SPEC = ManagedRuntimeSpec(
+    runtime_id="tmux",
+    manifest_resource=_TMUX_MANIFEST_RESOURCE,
+    version_field="tmux_version",
+    default_bin_path="tmux",
+    allow_legacy_missing_runtime_id=True,
+)
 
 
-@dataclass(frozen=True)
-class TmuxArchive:
-    platform: str
-    name: str
-    url: str
-    sha256: str
-    size: int | None = None
-    bin_path: str = "tmux"
-
-
-@dataclass(frozen=True)
-class TmuxManifest:
-    schema_version: int
-    tmux_version: str
-    source: str
-    source_url: str | None
-    requires_utf8proc: bool
-    terminfo: str | None
-    archives: dict[str, TmuxArchive]
-    digest: str
-    loaded_from: str
-
-
-class TmuxRuntimeManager:
+class TmuxRuntimeManager(ManagedRuntimeManager):
     """Install and resolve Avibe's vendored tmux binary.
 
     The future Web Terminal will prefer this deterministic tmux over any system
@@ -80,358 +70,164 @@ class TmuxRuntimeManager:
         manifest_url: str | None = None,
         offline: bool | None = None,
     ) -> None:
-        self.runtime_dir = runtime_dir or paths.get_runtime_dir() / "tmux"
         manifest_path_value = manifest_path or os.environ.get("VIBE_TMUX_MANIFEST_PATH")
-        self.manifest_path = Path(manifest_path_value).expanduser() if manifest_path_value else None
-        self.manifest_url = manifest_url if manifest_url is not None else os.environ.get("VIBE_TMUX_MANIFEST_URL")
-        self.offline = _env_flag_enabled("VIBE_TMUX_OFFLINE", default=False) if offline is None else offline
-        self._install_reason: str | None = None
-        self._download_error: dict[str, Any] | None = None
+        super().__init__(
+            spec=_TMUX_SPEC,
+            runtime_dir=runtime_dir or paths.get_runtime_dir() / "tmux",
+            manifest_path=manifest_path_value,
+            manifest_url=manifest_url if manifest_url is not None else os.environ.get("VIBE_TMUX_MANIFEST_URL"),
+            offline=env_flag_enabled("VIBE_TMUX_OFFLINE") if offline is None else offline,
+        )
 
-    def ensure(self, *, force: bool = False) -> dict[str, Any]:
-        if not _TMUX_INSTALL_LOCK.acquire(blocking=False):
-            return {
-                "ok": False,
-                "skipped": True,
-                "reason": "tmux_install_already_running",
-                "message": "tmux install or repair is already running; try again shortly.",
-            }
+    def _parse_manifest(self, payload: bytes, *, loaded_from: str) -> ManagedRuntimeManifest | None:
+        """Read released schema-1 manifests that predate binary digests."""
+
+        compatible_payload = payload
+        original_data: dict[str, Any] | None = None
+        enriched = False
         try:
-            manifest = self._load_manifest()
-            if not manifest:
-                return self._failure(self._install_reason or "tmux_manifest_missing")
-            archive = self._manifest_archive_for_platform(manifest)
-            if not archive:
-                return self._failure(self._install_reason or "tmux_platform_unsupported", manifest=manifest)
-            install_dir = self._manifest_install_dir(manifest, archive)
-            existing = self._verified_manifest_binary(install_dir, manifest, archive)
-            if existing and not force:
-                return {
-                    "ok": True,
-                    "installed": True,
-                    "changed": False,
-                    "path": str(existing),
-                    "version": manifest.tmux_version,
-                    "platform": archive.platform,
-                    "install_dir": str(install_dir),
-                }
-            archive_path = self._resolve_manifest_archive(archive)
-            if not archive_path:
-                if existing:
-                    return {
-                        "ok": True,
-                        "installed": True,
-                        "changed": False,
-                        "path": str(existing),
-                        "version": manifest.tmux_version,
-                        "platform": archive.platform,
-                        "install_dir": str(install_dir),
-                        "reason": self._install_reason,
-                    }
-                return self._failure(self._install_reason or "tmux_archive_unavailable", manifest=manifest, archive=archive)
-            self.runtime_dir.mkdir(parents=True, exist_ok=True)
-            tmp_dir = Path(tempfile.mkdtemp(prefix="manifest-", dir=self.runtime_dir))
-            try:
-                with tarfile.open(archive_path, "r:gz") as tar:
-                    _safe_extract_tar(tar, tmp_dir)
-                binary = tmp_dir / archive.bin_path
-                if not binary.is_file():
-                    return self._failure("tmux_install_missing_bin", manifest=manifest, archive=archive)
-                _make_executable(binary)
-                signing = self._prepare_macos_binary(binary)
-                if not signing.get("ok"):
-                    return {
-                        **self._failure(str(signing.get("reason") or "tmux_codesign_failed"), manifest=manifest, archive=archive),
-                        "signing": signing,
-                    }
-                if not _tmux_binary_runnable(binary):
-                    return self._failure("tmux_binary_not_runnable", manifest=manifest, archive=archive)
-                if install_dir.exists():
-                    shutil.rmtree(install_dir)
-                install_dir.parent.mkdir(parents=True, exist_ok=True)
-                shutil.move(str(tmp_dir), str(install_dir))
-                binary = install_dir / archive.bin_path
-                self._write_manifest_install_metadata(install_dir, manifest, archive)
-                self._write_current_pointer(manifest, archive, install_dir)
-                self._install_reason = None
-                return {
-                    "ok": True,
-                    "installed": True,
-                    "changed": True,
-                    "path": str(binary),
-                    "version": manifest.tmux_version,
-                    "platform": archive.platform,
-                    "install_dir": str(install_dir),
-                    "signing": signing,
-                }
-            except Exception as exc:  # noqa: BLE001
-                logger.exception("Failed to install tmux runtime")
-                return self._failure("tmux_install_failed", manifest=manifest, archive=archive, message=str(exc))
-            finally:
-                if tmp_dir.exists():
-                    shutil.rmtree(tmp_dir, ignore_errors=True)
-        finally:
-            _TMUX_INSTALL_LOCK.release()
+            data = json.loads(payload.decode("utf-8"))
+            if isinstance(data, dict) and isinstance(data.get("archives"), dict):
+                original_data = data
+                archives: dict[str, Any] = {}
+                for platform_tag, raw_archive in data["archives"].items():
+                    if not isinstance(raw_archive, dict):
+                        archives[platform_tag] = raw_archive
+                        continue
+                    archive = dict(raw_archive)
+                    if archive.get("binary_sha256") is None:
+                        archive_sha256 = str(archive.get("sha256") or "").lower()
+                        binary_sha256 = _RELEASED_BINARY_SHA256_BY_ARCHIVE_SHA256.get(archive_sha256)
+                        if binary_sha256 is not None:
+                            archive["binary_sha256"] = binary_sha256
+                            enriched = True
+                    archives[platform_tag] = archive
+                if enriched:
+                    compatible_payload = json.dumps(
+                        {**data, "archives": archives},
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+        except (UnicodeError, ValueError, TypeError):
+            pass
+
+        manifest = super()._parse_manifest(compatible_payload, loaded_from=loaded_from)
+        if manifest is None or not enriched or original_data is None:
+            return manifest
+        return replace(
+            manifest,
+            digest=hashlib.sha256(payload).hexdigest(),
+            payload=original_data,
+        )
+
+    def _manifest_install_candidates(
+        self,
+        manifest: ManagedRuntimeManifest,
+        archive: ManagedRuntimeArchive,
+    ) -> Iterator[Path]:
+        """Include the two install layouts written by released tmux managers."""
+
+        version_dir = (
+            self.runtime_dir
+            / "versions"
+            / safe_path_part(manifest.runtime_version)
+            / safe_path_part(archive.platform)
+        )
+        released_manifest_digests = [manifest.digest]
+        if archive.sha256 in _RELEASED_BINARY_SHA256_BY_ARCHIVE_SHA256:
+            released_manifest_digests.append(_RELEASED_PACKAGED_MANIFEST_SHA256)
+        released_fingerprints = (
+            hashlib.sha256(f"{manifest_sha256}:{archive.sha256}".encode("utf-8")).hexdigest()[:16]
+            for manifest_sha256 in dict.fromkeys(released_manifest_digests)
+        )
+        candidates = (
+            *super()._manifest_install_candidates(manifest, archive),
+            *(version_dir / fingerprint for fingerprint in released_fingerprints),
+            version_dir,
+        )
+        yield from dict.fromkeys(candidates)
+
+    def _metadata_matches_install_target(
+        self,
+        metadata: Mapping[str, Any],
+        target: Mapping[str, str],
+    ) -> bool:
+        if super()._metadata_matches_install_target(metadata, target):
+            return True
+        archive_sha256 = target.get("archive_sha256")
+        return (
+            metadata.get("runtime_id") is None
+            and metadata.get("provider") == self.spec.record_provider
+            and metadata.get("manifest_sha256") == _RELEASED_PACKAGED_MANIFEST_SHA256
+            and metadata.get("tmux_version") == target.get("runtime_version")
+            and metadata.get("archive_sha256") == archive_sha256
+            and metadata.get("bin_path") == self.spec.default_bin_path
+            and archive_sha256 in _RELEASED_BINARY_SHA256_BY_ARCHIVE_SHA256
+            and target.get("binary_sha256")
+            == _RELEASED_BINARY_SHA256_BY_ARCHIVE_SHA256.get(archive_sha256)
+        )
 
     def resolve_binary(self) -> Path | None:
-        manifest = self._load_manifest()
-        if not manifest:
+        binary = super().resolve_binary()
+        if binary is not None:
+            return binary
+        manifest = self._load_manifest(allow_network=False)
+        if manifest is None:
             return None
         archive = self._manifest_archive_for_platform(manifest)
-        if not archive:
+        if archive is None:
             return None
-        binary = self._verified_manifest_binary(self._manifest_install_dir(manifest, archive), manifest, archive)
-        if binary:
-            return binary
-        return self._verified_manifest_binary(self._legacy_manifest_install_dir(manifest, archive), manifest, archive)
+        for install_dir in self._manifest_install_candidates(manifest, archive):
+            binary = self._verified_manifest_binary(install_dir, manifest, archive)
+            if binary is not None:
+                self._install_reason = None
+                return binary
+        return None
 
     def status(self) -> dict[str, Any]:
-        manifest = self._load_manifest()
-        platform_tag = _runtime_platform_tag()
-        archive = manifest.archives.get(platform_tag) if manifest else None
-        install_dir = self._manifest_install_dir(manifest, archive) if manifest and archive else None
-        binary = self.resolve_binary() if manifest and archive else None
+        manifest = self.load_manifest_for_diagnostics()
+        archive = self._manifest_archive_for_platform(manifest) if manifest else None
+        shared_status = super().status()
+        binary = Path(shared_status["path"]) if shared_status.get("path") else None
         version = _tmux_binary_version(binary) if binary else None
+        install_dir: str | None = None
+        if binary is not None and manifest is not None and archive is not None:
+            candidates: list[Path] = []
+            if isinstance(shared_status.get("install_dir"), str):
+                candidates.append(Path(shared_status["install_dir"]))
+            candidates.extend(self._manifest_install_candidates(manifest, archive))
+            for candidate in dict.fromkeys(candidates):
+                if self._verified_manifest_binary(candidate, manifest, archive) == binary:
+                    install_dir = str(candidate)
+                    break
         return {
-            "id": "tmux",
-            "provider": _TMUX_RUNTIME_SOURCE_MANIFEST,
-            "platform": platform_tag,
+            "id": self.spec.runtime_id,
+            "provider": self.spec.record_provider,
+            "platform": runtime_platform_tag(),
             "installed": binary is not None,
-            "version": version or (manifest.tmux_version if manifest else None),
+            "version": version or (manifest.runtime_version if manifest else None),
             "status": "ready" if binary else "missing",
             "path": str(binary) if binary else None,
-            "install_dir": str(install_dir) if install_dir else None,
-            "manifest": _manifest_status_payload(manifest),
-            "archive": _archive_status_payload(archive),
-            "reason": self._install_reason,
+            "install_dir": install_dir if binary else None,
+            "manifest": self._manifest_status_payload(manifest),
+            "archive": self._archive_status_payload(archive),
+            "reason": self._install_reason if binary is None else None,
             "download_error": self._download_error,
         }
 
-    def probe_archive_reachability(self, *, timeout: float = 10.0) -> dict[str, Any]:
-        manifest = self._load_manifest()
-        if manifest is None:
-            return {
-                "ok": False,
-                "checked": bool(self._download_error),
-                "reason": self._install_reason or "tmux_manifest_missing",
-                "download_error": self._download_error,
-            }
-        archive = self._manifest_archive_for_platform(manifest)
-        if archive is None:
-            return {"ok": False, "checked": False, "reason": self._install_reason}
-        parsed = urllib.parse.urlparse(archive.url)
-        if parsed.scheme not in {"https", "file"}:
-            return {
-                "ok": False,
-                "checked": False,
-                "reason": "tmux_archive_url_unsupported",
-                "url": redact_url(archive.url),
-            }
-        return probe_url(
-            archive.url,
-            timeout=timeout,
-            opener=urllib.request.urlopen,
-            user_agent="avibe-tmux-doctor",
-        )
-
-    def _load_manifest(self) -> TmuxManifest | None:
-        payload: bytes | None = None
-        loaded_from = ""
-        if self.manifest_path:
-            if not self.manifest_path.exists():
-                self._install_reason = "tmux_manifest_missing"
-                return None
-            payload = self.manifest_path.read_bytes()
-            loaded_from = str(self.manifest_path)
-        elif self.manifest_url:
-            if self.offline:
-                self._install_reason = "tmux_manifest_unavailable_offline"
-                return None
-            try:
-                payload = fetch_bytes(
-                    self.manifest_url,
-                    timeout=30,
-                    opener=urllib.request.urlopen,
-                )
-                loaded_from = self.manifest_url
-            except Exception as exc:
-                logger.exception("Failed to download tmux manifest from %s", self.manifest_url)
-                self._install_reason = "tmux_manifest_download_failed"
-                self._download_error = dependency_error_details(exc, self.manifest_url)
-                return None
-        else:
-            try:
-                resource = package_resources.files("vibe").joinpath(_TMUX_MANIFEST_RESOURCE)
-            except Exception:
-                resource = None
-            if resource is None or not resource.is_file():
-                self._install_reason = "tmux_manifest_missing"
-                return None
-            payload = resource.read_bytes()
-            loaded_from = f"package:{_TMUX_MANIFEST_RESOURCE}"
-        digest = hashlib.sha256(payload).hexdigest()
-        try:
-            data = json.loads(payload.decode("utf-8"))
-            archives = {
-                platform_tag: TmuxArchive(
-                    platform=platform_tag,
-                    name=str(item["name"]),
-                    url=str(item["url"]),
-                    sha256=str(item["sha256"]),
-                    size=int(item["size"]) if item.get("size") is not None else None,
-                    bin_path=str(item.get("bin_path") or "tmux"),
-                )
-                for platform_tag, item in (data.get("archives") or {}).items()
-                if isinstance(item, dict)
-            }
-            manifest = TmuxManifest(
-                schema_version=int(data.get("schema_version")),
-                tmux_version=str(data.get("tmux_version") or ""),
-                source=str(data.get("source") or ""),
-                source_url=str(data.get("source_url") or "") or None,
-                requires_utf8proc=bool(data.get("requires_utf8proc")),
-                terminfo=str(data.get("terminfo") or "") or None,
-                archives=archives,
-                digest=digest,
-                loaded_from=loaded_from,
-            )
-        except Exception:
-            self._install_reason = "tmux_manifest_invalid"
-            return None
-        if manifest.schema_version != 1 or not manifest.tmux_version or not manifest.archives:
-            self._install_reason = "tmux_manifest_invalid"
-            return None
-        return manifest
-
-    def _manifest_archive_for_platform(self, manifest: TmuxManifest) -> TmuxArchive | None:
-        platform_tag = _runtime_platform_tag()
-        archive = manifest.archives.get(platform_tag)
-        if not archive:
-            self._install_reason = "tmux_platform_unsupported"
-            return None
-        return archive
-
-    def _resolve_manifest_archive(self, archive: TmuxArchive) -> Path | None:
-        cached = self.runtime_dir / "downloads" / archive.name
-        if cached.exists() and self._downloaded_archive_matches(cached, archive):
-            return cached
-        if self.offline:
-            self._install_reason = "tmux_archive_unavailable_offline"
-            return None
-        parsed = urllib.parse.urlparse(archive.url)
-        if parsed.scheme not in {"https", "file"}:
-            self._install_reason = "tmux_archive_url_unsupported"
-            return None
-        tmp_path = cached.with_suffix(cached.suffix + ".tmp")
-        cached.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            fetch_to_path(
-                archive.url,
-                tmp_path,
-                timeout=60,
-                opener=urllib.request.urlopen,
-            )
-            self._download_error = None
-            if not self._downloaded_archive_matches(tmp_path, archive):
-                tmp_path.unlink(missing_ok=True)
-                return None
-            tmp_path.replace(cached)
-            return cached
-        except Exception as exc:
-            logger.exception("Failed to download tmux archive from %s", archive.url)
-            tmp_path.unlink(missing_ok=True)
-            self._install_reason = "tmux_archive_download_failed"
-            self._download_error = dependency_error_details(exc, archive.url)
-            return None
-
-    def _downloaded_archive_matches(self, path: Path, archive: TmuxArchive) -> bool:
-        if archive.size is not None and path.stat().st_size != archive.size:
-            self._install_reason = "tmux_archive_size_mismatch"
-            return False
-        if _file_sha256(path) != archive.sha256:
-            self._install_reason = "tmux_archive_checksum_mismatch"
-            return False
-        return True
-
-    def _manifest_install_dir(self, manifest: TmuxManifest, archive: TmuxArchive) -> Path:
-        fingerprint = hashlib.sha256(f"{manifest.digest}:{archive.sha256}".encode("utf-8")).hexdigest()[:16]
-        return (
-            self.runtime_dir
-            / "versions"
-            / _safe_path_part(manifest.tmux_version)
-            / _safe_path_part(archive.platform)
-            / fingerprint
-        )
-
-    def _legacy_manifest_install_dir(self, manifest: TmuxManifest, archive: TmuxArchive) -> Path:
-        return self.runtime_dir / "versions" / _safe_path_part(manifest.tmux_version) / _safe_path_part(archive.platform)
-
-    def _manifest_metadata_path(self, install_dir: Path) -> Path:
-        return install_dir / ".avibe-tmux-runtime.json"
-
-    def _verified_manifest_binary(self, install_dir: Path, manifest: TmuxManifest, archive: TmuxArchive) -> Path | None:
-        binary = install_dir / archive.bin_path
-        if not binary.is_file() or not os.access(binary, os.X_OK):
-            return None
-        if self._manifest_install_matches(install_dir, manifest, archive) and _tmux_binary_runnable(binary):
-            return binary
-        return None
-
-    def _manifest_install_matches(self, install_dir: Path, manifest: TmuxManifest, archive: TmuxArchive) -> bool:
-        try:
-            payload = json.loads(self._manifest_metadata_path(install_dir).read_text(encoding="utf-8"))
-        except Exception:
-            return False
-        return (
-            payload.get("provider") == _TMUX_RUNTIME_SOURCE_MANIFEST
-            and payload.get("manifest_sha256") == manifest.digest
-            and payload.get("tmux_version") == manifest.tmux_version
-            and payload.get("platform") == archive.platform
-            and payload.get("archive_sha256") == archive.sha256
-            and payload.get("bin_path") == archive.bin_path
-        )
-
-    def _write_manifest_install_metadata(self, install_dir: Path, manifest: TmuxManifest, archive: TmuxArchive) -> None:
-        self._manifest_metadata_path(install_dir).write_text(
-            json.dumps(
+    def _manifest_status_payload(self, manifest: ManagedRuntimeManifest | None) -> dict[str, Any] | None:
+        payload = super()._manifest_status_payload(manifest)
+        if payload is not None and manifest is not None:
+            payload.update(
                 {
-                    "provider": _TMUX_RUNTIME_SOURCE_MANIFEST,
-                    "manifest_sha256": manifest.digest,
-                    "tmux_version": manifest.tmux_version,
-                    "platform": archive.platform,
-                    "archive_name": archive.name,
-                    "archive_sha256": archive.sha256,
-                    "bin_path": archive.bin_path,
-                    "manifest_source": manifest.loaded_from,
-                    "source": manifest.source,
-                    "requires_utf8proc": manifest.requires_utf8proc,
-                    "terminfo": manifest.terminfo,
-                },
-                sort_keys=True,
+                    "requires_utf8proc": bool(manifest.payload.get("requires_utf8proc")),
+                    "terminfo": str(manifest.payload.get("terminfo") or "") or None,
+                }
             )
-            + "\n",
-            encoding="utf-8",
-        )
+        return payload
 
-    def _write_current_pointer(self, manifest: TmuxManifest, archive: TmuxArchive, install_dir: Path) -> None:
-        pointer = self.runtime_dir / "current.json"
-        pointer.parent.mkdir(parents=True, exist_ok=True)
-        pointer.write_text(
-            json.dumps(
-                {
-                    "provider": _TMUX_RUNTIME_SOURCE_MANIFEST,
-                    "tmux_version": manifest.tmux_version,
-                    "platform": archive.platform,
-                    "install_dir": str(install_dir),
-                    "manifest_sha256": manifest.digest,
-                    "archive_sha256": archive.sha256,
-                    "bin_path": archive.bin_path,
-                },
-                sort_keys=True,
-            )
-            + "\n",
-            encoding="utf-8",
-        )
+    def _prepare_binary(self, binary: Path) -> dict[str, Any]:
+        return self._prepare_macos_binary(binary)
 
     def _prepare_macos_binary(self, binary: Path) -> dict[str, Any]:
         if sys_platform() != "darwin":
@@ -458,32 +254,12 @@ class TmuxRuntimeManager:
             "quarantine": quarantine,
         }
 
-    def _failure(
-        self,
-        reason: str,
-        *,
-        manifest: TmuxManifest | None = None,
-        archive: TmuxArchive | None = None,
-        message: str | None = None,
-    ) -> dict[str, Any]:
-        self._install_reason = reason
-        return {
-            "ok": False,
-            "installed": False,
-            "changed": False,
-            "reason": reason,
-            "message": message
-            or (
-                dependency_error_message(self._download_error, label="tmux dependency download")
-                if self._download_error
-                else _reason_message(reason)
-            ),
-            "version": manifest.tmux_version if manifest else None,
-            "platform": archive.platform if archive else _runtime_platform_tag(),
-            "path": None,
-            "output": None,
-            "download_error": self._download_error,
-        }
+    def _binary_version(self, binary: Path | None) -> str | None:
+        return _tmux_binary_version(binary)
+
+    def _binary_matches_manifest(self, binary: Path, manifest: ManagedRuntimeManifest) -> bool:
+        del manifest
+        return _tmux_binary_runnable(binary)
 
 
 def get_tmux_runtime_manager(**kwargs: Any) -> TmuxRuntimeManager:
@@ -491,7 +267,15 @@ def get_tmux_runtime_manager(**kwargs: Any) -> TmuxRuntimeManager:
 
 
 def ensure_tmux_installed(force: bool = False) -> dict[str, Any]:
-    return get_tmux_runtime_manager().ensure(force=force)
+    result = get_tmux_runtime_manager().ensure(force=force)
+    if (
+        not result.get("ok")
+        and not result.get("download_error")
+        and result.get("message") == result.get("reason")
+    ):
+        reason = str(result.get("reason") or "tmux_install_failed")
+        result["message"] = _tmux_failure_message(reason)
+    return result
 
 
 def resolve_tmux_binary() -> Path | None:
@@ -500,28 +284,6 @@ def resolve_tmux_binary() -> Path | None:
 
 def tmux_status() -> dict[str, Any]:
     return get_tmux_runtime_manager().status()
-
-
-def _runtime_platform_tag() -> str:
-    raw = get_platform().lower()
-    machine = raw.rsplit("-", 1)[-1]
-    if machine == "universal2":
-        machine = platform.machine().lower()
-    if machine in {"amd64", "x86_64"}:
-        arch = "x64"
-    elif machine in {"arm64", "aarch64"}:
-        arch = "arm64"
-    else:
-        arch = machine
-    if raw.startswith("macosx"):
-        os_name = "darwin"
-    elif raw.startswith("linux"):
-        os_name = "linux"
-    elif raw.startswith("win"):
-        os_name = "win32"
-    else:
-        os_name = os.name
-    return f"{os_name}-{arch}"
 
 
 def sys_platform() -> str:
@@ -561,7 +323,12 @@ def _strip_quarantine(binary: Path) -> dict[str, Any]:
     text = (proc.stderr or proc.stdout or "").lower()
     if "no such xattr" in text or "no such file" in text:
         return {"ok": True, "changed": False}
-    return {"ok": False, "changed": False, "reason": "xattr_failed", "output": _truncate(proc.stderr or proc.stdout or "")}
+    return {
+        "ok": False,
+        "changed": False,
+        "reason": "xattr_failed",
+        "output": _truncate(proc.stderr or proc.stdout or ""),
+    }
 
 
 def _tmux_binary_runnable(binary: Path) -> bool:
@@ -590,101 +357,7 @@ def _tmux_binary_version(binary: Path | None) -> str | None:
     return parts[-1] if parts else text
 
 
-def _safe_extract_tar(tar: tarfile.TarFile, destination: Path) -> None:
-    supports_data_filter = hasattr(tarfile, "data_filter")
-    destination_resolved = destination.resolve()
-    for member in tar.getmembers():
-        if not (member.isfile() or member.isdir() or member.issym() or member.islnk()):
-            raise ValueError(f"Unsupported tmux archive member type: {member.name}")
-        if _tar_archive_path_is_unsafe(member.name):
-            raise ValueError(f"Unsafe tmux archive member path: {member.name}")
-        if (member.issym() or member.islnk()) and _tar_archive_path_is_unsafe(member.linkname):
-            raise ValueError(f"Unsafe tmux archive link target: {member.name}")
-        target = (destination / member.name).resolve()
-        if target != destination_resolved and destination_resolved not in target.parents:
-            raise ValueError(f"Unsafe tmux archive member path: {member.name}")
-        if member.issym():
-            link_target = Path(member.linkname)
-            resolved_link = (target.parent / link_target).resolve() if not link_target.is_absolute() else link_target.resolve()
-            if resolved_link != destination_resolved and destination_resolved not in resolved_link.parents:
-                raise ValueError(f"Unsafe tmux archive link target: {member.name}")
-        if member.islnk():
-            link_target = Path(member.linkname)
-            resolved_link = (destination / link_target).resolve()
-            if resolved_link != destination_resolved and destination_resolved not in resolved_link.parents:
-                raise ValueError(f"Unsafe tmux archive link target: {member.name}")
-    if supports_data_filter:
-        tar.extractall(destination, filter="data")
-    else:
-        tar.extractall(destination)
-
-
-def _tar_archive_path_is_unsafe(value: str) -> bool:
-    if not value:
-        return True
-    posix_path = PurePosixPath(value)
-    windows_path = PureWindowsPath(value)
-    if posix_path.is_absolute() or windows_path.is_absolute():
-        return True
-    if windows_path.drive or windows_path.root:
-        return True
-    return ".." in posix_path.parts or ".." in windows_path.parts
-
-
-def _file_sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _make_executable(path: Path) -> None:
-    mode = path.stat().st_mode
-    path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-
-
-def _safe_path_part(value: str) -> str:
-    cleaned = "".join(ch if ch.isalnum() or ch in {"-", "_", "."} else "-" for ch in value.strip())
-    return cleaned.strip(".-") or "unknown"
-
-
-def _env_flag_enabled(name: str, *, default: bool) -> bool:
-    value = os.environ.get(name)
-    if value is None:
-        return default
-    return value.strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _manifest_status_payload(manifest: TmuxManifest | None) -> dict[str, Any] | None:
-    if manifest is None:
-        return None
-    return {
-        "schema_version": manifest.schema_version,
-        "tmux_version": manifest.tmux_version,
-        "source": manifest.source,
-        "source_url": manifest.source_url,
-        "requires_utf8proc": manifest.requires_utf8proc,
-        "terminfo": manifest.terminfo,
-        "sha256": manifest.digest,
-        "loaded_from": manifest.loaded_from,
-    }
-
-
-def _archive_status_payload(archive: TmuxArchive | None) -> dict[str, Any] | None:
-    if archive is None:
-        return None
-    return {
-        "platform": archive.platform,
-        "name": archive.name,
-        "url": redact_url(archive.url),
-        "sha256": archive.sha256,
-        "size": archive.size,
-        "bin_path": archive.bin_path,
-    }
-
-
-def _reason_message(reason: str) -> str:
+def _tmux_failure_message(reason: str) -> str:
     messages = {
         "tmux_archive_checksum_mismatch": "tmux archive checksum did not match the pinned manifest.",
         "tmux_archive_size_mismatch": "tmux archive size did not match the pinned manifest.",

--- a/core/tmux_runtime.py
+++ b/core/tmux_runtime.py
@@ -52,6 +52,7 @@ _TMUX_SPEC = ManagedRuntimeSpec(
     allow_legacy_missing_runtime_id=True,
     staging_prefixes=("install-", "manifest-"),
     replace_target_on_force=True,
+    replace_invalid_target_on_repair=True,
     include_manifest_digest_in_install_fingerprint=True,
 )
 

--- a/core/tmux_runtime.py
+++ b/core/tmux_runtime.py
@@ -48,6 +48,7 @@ _TMUX_SPEC = ManagedRuntimeSpec(
     manifest_resource=_TMUX_MANIFEST_RESOURCE,
     version_field="tmux_version",
     default_bin_path="tmux",
+    allow_missing_binary_sha256=True,
     allow_legacy_missing_runtime_id=True,
     staging_prefixes=("install-", "manifest-"),
 )
@@ -148,6 +149,9 @@ class TmuxRuntimeManager(ManagedRuntimeManager):
         )
         yield from dict.fromkeys(candidates)
 
+    def _manifest_identity_fields(self, manifest: ManagedRuntimeManifest) -> dict[str, str]:
+        return {"manifest_sha256": manifest.digest}
+
     def _metadata_matches_install_target(
         self,
         metadata: Mapping[str, Any],
@@ -156,16 +160,21 @@ class TmuxRuntimeManager(ManagedRuntimeManager):
         if super()._metadata_matches_install_target(metadata, target):
             return True
         archive_sha256 = target.get("archive_sha256")
-        return (
-            metadata.get("runtime_id") is None
-            and metadata.get("provider") == self.spec.record_provider
-            and metadata.get("manifest_sha256") == _RELEASED_PACKAGED_MANIFEST_SHA256
-            and metadata.get("tmux_version") == target.get("runtime_version")
-            and metadata.get("archive_sha256") == archive_sha256
-            and metadata.get("bin_path") == self.spec.default_bin_path
+        exact_legacy_manifest = metadata.get("manifest_sha256") == target.get(
+            "manifest_sha256"
+        )
+        released_legacy_manifest = (
+            metadata.get("manifest_sha256") == _RELEASED_PACKAGED_MANIFEST_SHA256
             and archive_sha256 in _RELEASED_BINARY_SHA256_BY_ARCHIVE_SHA256
             and target.get("binary_sha256")
             == _RELEASED_BINARY_SHA256_BY_ARCHIVE_SHA256.get(archive_sha256)
+        )
+        return (
+            metadata.get("runtime_id") is None
+            and metadata.get("provider") == self.spec.record_provider
+            and metadata.get("tmux_version") == target.get("runtime_version")
+            and metadata.get("archive_sha256") == archive_sha256
+            and (exact_legacy_manifest or released_legacy_manifest)
         )
 
     def resolve_binary(self) -> Path | None:

--- a/core/tmux_runtime.py
+++ b/core/tmux_runtime.py
@@ -49,6 +49,7 @@ _TMUX_SPEC = ManagedRuntimeSpec(
     version_field="tmux_version",
     default_bin_path="tmux",
     allow_legacy_missing_runtime_id=True,
+    staging_prefixes=("install-", "manifest-"),
 )
 
 
@@ -169,37 +170,58 @@ class TmuxRuntimeManager(ManagedRuntimeManager):
 
     def resolve_binary(self) -> Path | None:
         binary = super().resolve_binary()
-        if binary is not None:
+        if binary is not None and _tmux_binary_runnable(binary):
             return binary
+        non_runnable = binary is not None
         manifest = self._load_manifest(allow_network=False)
         if manifest is None:
+            if non_runnable:
+                self._install_reason = self._reason("binary_not_runnable")
             return None
         archive = self._manifest_archive_for_platform(manifest)
         if archive is None:
+            if non_runnable:
+                self._install_reason = self._reason("binary_not_runnable")
             return None
         for install_dir in self._manifest_install_candidates(manifest, archive):
             binary = self._verified_manifest_binary(install_dir, manifest, archive)
-            if binary is not None:
+            if binary is not None and _tmux_binary_runnable(binary):
                 self._install_reason = None
                 return binary
+            non_runnable = non_runnable or binary is not None
+        if non_runnable:
+            self._install_reason = self._reason("binary_not_runnable")
         return None
 
     def status(self) -> dict[str, Any]:
         manifest = self.load_manifest_for_diagnostics()
         archive = self._manifest_archive_for_platform(manifest) if manifest else None
-        shared_status = super().status()
-        binary = Path(shared_status["path"]) if shared_status.get("path") else None
-        version = _tmux_binary_version(binary) if binary else None
+        binary: Path | None = None
+        version: str | None = None
         install_dir: str | None = None
-        if binary is not None and manifest is not None and archive is not None:
+        if manifest is not None and archive is not None:
             candidates: list[Path] = []
-            if isinstance(shared_status.get("install_dir"), str):
-                candidates.append(Path(shared_status["install_dir"]))
+            try:
+                current = self._current_install_dir(self.runtime_dir / "versions")
+            except OSError:
+                current = None
+                self._install_reason = self._reason("install_inspection_failed")
+            if current is not None:
+                candidates.append(current)
             candidates.extend(self._manifest_install_candidates(manifest, archive))
             for candidate in dict.fromkeys(candidates):
-                if self._verified_manifest_binary(candidate, manifest, archive) == binary:
-                    install_dir = str(candidate)
-                    break
+                admitted = self._verified_manifest_binary(candidate, manifest, archive)
+                if admitted is None:
+                    continue
+                admitted_version = _tmux_binary_version(admitted)
+                if admitted_version is None:
+                    self._install_reason = self._reason("binary_not_runnable")
+                    continue
+                binary = admitted
+                version = admitted_version
+                install_dir = str(candidate)
+                self._install_reason = None
+                break
         return {
             "id": self.spec.runtime_id,
             "provider": self.spec.record_provider,
@@ -232,27 +254,7 @@ class TmuxRuntimeManager(ManagedRuntimeManager):
     def _prepare_macos_binary(self, binary: Path) -> dict[str, Any]:
         if sys_platform() != "darwin":
             return {"ok": True, "skipped": True, "reason": "not_macos"}
-        quarantine = _strip_quarantine(binary)
-        if _codesign_valid(binary):
-            return {"ok": True, "changed": False, "quarantine": quarantine}
-        codesign = shutil.which("codesign")
-        if not codesign:
-            return {"ok": False, "reason": "codesign_missing", "quarantine": quarantine}
-        proc = subprocess.run(
-            [codesign, "-f", "-s", "-", str(binary)],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            **isolated_subprocess_kwargs(),
-        )
-        verified = proc.returncode == 0 and _codesign_valid(binary)
-        return {
-            "ok": verified,
-            "changed": proc.returncode == 0,
-            "reason": None if verified else ("codesign_failed" if proc.returncode != 0 else "codesign_verify_failed"),
-            "output": _truncate((proc.stdout or "") + (proc.stderr or "")),
-            "quarantine": quarantine,
-        }
+        return _strip_quarantine(binary)
 
     def _binary_version(self, binary: Path | None) -> str | None:
         return _tmux_binary_version(binary)
@@ -288,23 +290,6 @@ def tmux_status() -> dict[str, Any]:
 
 def sys_platform() -> str:
     return sys.platform
-
-
-def _codesign_valid(binary: Path) -> bool:
-    codesign = shutil.which("codesign")
-    if not codesign:
-        return False
-    try:
-        proc = subprocess.run(
-            [codesign, "-v", str(binary)],
-            capture_output=True,
-            text=True,
-            timeout=10,
-            **isolated_subprocess_kwargs(),
-        )
-    except Exception:  # noqa: BLE001
-        return False
-    return proc.returncode == 0
 
 
 def _strip_quarantine(binary: Path) -> dict[str, Any]:

--- a/core/tmux_runtime.py
+++ b/core/tmux_runtime.py
@@ -52,6 +52,7 @@ _TMUX_SPEC = ManagedRuntimeSpec(
     allow_legacy_missing_runtime_id=True,
     staging_prefixes=("install-", "manifest-"),
     replace_target_on_force=True,
+    include_manifest_digest_in_install_fingerprint=True,
 )
 
 

--- a/core/tmux_runtime.py
+++ b/core/tmux_runtime.py
@@ -199,7 +199,25 @@ class TmuxRuntimeManager(ManagedRuntimeManager):
         binary: Path | None = None
         version: str | None = None
         install_dir: str | None = None
-        if manifest is not None and archive is not None:
+        if manifest is None:
+            try:
+                before = self._current_install_dir(self.runtime_dir / "versions")
+                admitted = super().resolve_binary()
+                after = self._current_install_dir(self.runtime_dir / "versions")
+            except OSError:
+                before = after = admitted = None
+                self._install_reason = self._reason("install_inspection_failed")
+            admitted_version = _tmux_binary_version(admitted) if admitted is not None else None
+            if before is not None and before == after and admitted_version is not None:
+                binary = admitted
+                version = admitted_version
+                install_dir = str(before)
+                self._install_reason = None
+            elif before != after:
+                self._install_reason = self._reason("install_inspection_failed")
+            elif admitted is not None and admitted_version is None:
+                self._install_reason = self._reason("binary_not_runnable")
+        elif archive is not None:
             candidates: list[Path] = []
             try:
                 current = self._current_install_dir(self.runtime_dir / "versions")

--- a/tests/fixtures/tmux_runtime/README.md
+++ b/tests/fixtures/tmux_runtime/README.md
@@ -1,0 +1,11 @@
+# tmux v3.6b Release Fixtures
+
+`v3.6b-released-manifest.json` is the byte-for-byte packaged manifest from
+Avibe commit `0eb15bea2f573b207caaf6c4a3c6e891a3cc0d2d`.
+`v3.6b-release-artifacts.json` records the archive and extracted `tmux` binary
+digests measured from every archive named by that manifest.
+
+The executable acceptance test verifies the frozen manifest digest, binds all
+four platform rows to their released archive name, URL, size, and SHA-256, and
+checks that the production tmux released-state reader supplies the measured
+binary SHA-256 values to the shared runtime owner.

--- a/tests/fixtures/tmux_runtime/v3.6b-release-artifacts.json
+++ b/tests/fixtures/tmux_runtime/v3.6b-release-artifacts.json
@@ -1,10 +1,11 @@
 {
   "schema_version": 1,
-  "tmux_version": "3.6b",
-  "source": "tmux/tmux-builds",
-  "source_url": "https://github.com/tmux/tmux-builds/releases/tag/v3.6b",
-  "requires_utf8proc": true,
-  "terminfo": "bundled-or-system",
+  "release": {
+    "tag": "v3.6b",
+    "tmux_version": "3.6b",
+    "manifest_name": "v3.6b-released-manifest.json",
+    "manifest_sha256": "ee2826f881c236718ff18b2d1f939afb9417c584df5f29b796129c80691d2e63"
+  },
   "archives": {
     "darwin-arm64": {
       "name": "tmux-3.6b-macos-arm64.tar.gz",

--- a/tests/fixtures/tmux_runtime/v3.6b-released-manifest.json
+++ b/tests/fixtures/tmux_runtime/v3.6b-released-manifest.json
@@ -10,7 +10,6 @@
       "name": "tmux-3.6b-macos-arm64.tar.gz",
       "url": "https://github.com/tmux/tmux-builds/releases/download/v3.6b/tmux-3.6b-macos-arm64.tar.gz",
       "sha256": "88323402bd28d21103239caf009b130086ebf334807de485d4a1e1c7188ee810",
-      "binary_sha256": "5f8b6a7eda2ccd5bc283368e93e0e5c45b78071b5f90df7e394cf9a7f7ed6373",
       "size": 623837,
       "bin_path": "tmux"
     },
@@ -18,7 +17,6 @@
       "name": "tmux-3.6b-macos-x86_64.tar.gz",
       "url": "https://github.com/tmux/tmux-builds/releases/download/v3.6b/tmux-3.6b-macos-x86_64.tar.gz",
       "sha256": "073f6e2c2baa7eb5d643563600ee6052ca8619f3ec5a0cfdf99c56397fb72c94",
-      "binary_sha256": "9adf4f75e12bce1e1a3b53696e38b60854761bb7945a7c09a806999f1995b870",
       "size": 650495,
       "bin_path": "tmux"
     },
@@ -26,7 +24,6 @@
       "name": "tmux-3.6b-linux-arm64.tar.gz",
       "url": "https://github.com/tmux/tmux-builds/releases/download/v3.6b/tmux-3.6b-linux-arm64.tar.gz",
       "sha256": "fd4a2206c5e468dd2ee4e9a65f2d40e0762551965d7fdbe849c494ab14f513e9",
-      "binary_sha256": "6d1796de251b47b183af1b3eb6e229161e31560e89b9a8a1159533071eae2970",
       "size": 956861,
       "bin_path": "tmux"
     },
@@ -34,7 +31,6 @@
       "name": "tmux-3.6b-linux-x86_64.tar.gz",
       "url": "https://github.com/tmux/tmux-builds/releases/download/v3.6b/tmux-3.6b-linux-x86_64.tar.gz",
       "sha256": "002a6f4fd52212600fa0d72d865dcf328e5b8b6e83c179788144d8587b75677a",
-      "binary_sha256": "5a06c01c36998aaf1726ccaaeae01dded2b5bf82dbd22a01889f0d05b4d11c80",
       "size": 958795,
       "bin_path": "tmux"
     }

--- a/tests/test_managed_runtime_composite_artifacts.py
+++ b/tests/test_managed_runtime_composite_artifacts.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import pytest
 
-from core import managed_runtime, show_runtime, tmux_runtime
+from core import managed_runtime, show_runtime
 from core.managed_runtime import ManagedRuntimeManager, ManagedRuntimeSpec
 
 
@@ -21,7 +21,6 @@ ESBUILD_PAYLOAD = b"fixture-esbuild\n"
 Extractor = Callable[[tarfile.TarFile, Path], None]
 EXTRACTORS: tuple[tuple[str, Extractor], ...] = (
     ("shared", managed_runtime.safe_extract_tar),
-    ("tmux", tmux_runtime._safe_extract_tar),
 )
 
 
@@ -554,7 +553,6 @@ def test_order_dependent_link_target_stays_confined(
     ("_name", "extractor", "detects_before_extract"),
     (
         ("shared", managed_runtime.safe_extract_tar, True),
-        ("tmux", tmux_runtime._safe_extract_tar, True),
     ),
 )
 @pytest.mark.parametrize("supports_filter", (True, False), ids=("available", "unavailable"))

--- a/tests/test_tmux_runtime.py
+++ b/tests/test_tmux_runtime.py
@@ -453,6 +453,72 @@ def test_forced_repair_replaces_canonical_install_for_pointerless_recovery(
     assert manager.resolve_binary() == repaired_binary
 
 
+def test_nonforced_repair_replaces_non_runnable_canonical_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = _write_tmux_archive(tmp_path)
+    manifest = _write_manifest(tmp_path, archive)
+    manager = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", manifest_path=manifest)
+    installed = manager.ensure()
+    assert installed["ok"] is True
+    canonical_dir = Path(installed["install_dir"])
+    non_runnable_marker = canonical_dir / "non-runnable"
+    non_runnable_marker.touch()
+    real_binary_version = tmux_runtime._tmux_binary_version
+
+    def binary_version(binary: Path | None) -> str | None:
+        if binary is not None and (binary.parent / non_runnable_marker.name).is_file():
+            return None
+        return real_binary_version(binary)
+
+    monkeypatch.setattr(tmux_runtime, "_tmux_binary_version", binary_version)
+
+    repaired = manager.ensure()
+
+    assert repaired["ok"] is True
+    assert repaired["changed"] is True
+    assert Path(repaired["install_dir"]) == canonical_dir
+    repaired_binary = Path(repaired["path"])
+    assert repaired_binary == canonical_dir / "tmux"
+    assert not non_runnable_marker.exists()
+
+    (manager.runtime_dir / "current.json").unlink()
+    monkeypatch.setattr(
+        manager,
+        "_resolve_manifest_archive",
+        lambda _archive: pytest.fail("pointerless recovery accessed an archive"),
+    )
+    assert manager.resolve_binary() == repaired_binary
+
+
+def test_nonforced_repair_preserves_target_when_staged_binary_is_not_runnable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = _write_tmux_archive(tmp_path)
+    manifest = _write_manifest(tmp_path, archive)
+    manager = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", manifest_path=manifest)
+    installed = manager.ensure()
+    assert installed["ok"] is True
+    install_dir = Path(installed["install_dir"])
+    installed_binary = Path(installed["path"])
+    binary_before = installed_binary.read_bytes()
+    pointer_path = manager.runtime_dir / "current.json"
+    pointer_before = pointer_path.read_bytes()
+    sentinel = install_dir / "preserve-existing"
+    sentinel.touch()
+    monkeypatch.setattr(tmux_runtime, "_tmux_binary_version", lambda _binary: None)
+
+    failed = manager.ensure()
+
+    assert failed["ok"] is False
+    assert failed["reason"] == "tmux_binary_not_runnable"
+    assert installed_binary.read_bytes() == binary_before
+    assert pointer_path.read_bytes() == pointer_before
+    assert sentinel.is_file()
+
+
 def test_updated_manifest_uses_discoverable_deterministic_install(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -498,6 +564,35 @@ def test_updated_manifest_uses_discoverable_deterministic_install(
         lambda _archive: pytest.fail("pointerless recovery accessed an archive"),
     )
     assert manager.resolve_binary() == second_binary
+
+
+def test_replays_returned_install_target_without_archive_or_pointer_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = _write_tmux_archive(tmp_path)
+    manifest = _write_manifest(tmp_path, archive)
+    manager = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", manifest_path=manifest)
+    installed = manager.ensure()
+    assert installed["ok"] is True
+    monkeypatch.setattr(
+        manager,
+        "_resolve_manifest_archive",
+        lambda _archive: pytest.fail("claim replay accessed an archive"),
+    )
+    monkeypatch.setattr(
+        manager,
+        "_write_current_pointer",
+        lambda *_args: pytest.fail("claim replay rewrote the pointer"),
+    )
+
+    replayed = manager.ensure(expected_target=installed["target"])
+
+    assert replayed["ok"] is True
+    assert replayed["changed"] is False
+    assert replayed["path"] == installed["path"]
+    assert replayed["install_dir"] == installed["install_dir"]
+    assert replayed["target"] == installed["target"]
 
 
 def test_resolve_tmux_binary_returns_none_when_absent(tmp_path: Path) -> None:

--- a/tests/test_tmux_runtime.py
+++ b/tests/test_tmux_runtime.py
@@ -56,6 +56,7 @@ def _write_manifest(
     size: int | None = None,
     include_binary_sha256: bool = True,
     bin_path: str = "tmux",
+    version: str = "3.6b",
 ) -> Path:
     digest = sha256 or hashlib.sha256(archive.read_bytes()).hexdigest()
     archive_payload = {
@@ -69,7 +70,7 @@ def _write_manifest(
         archive_payload["binary_sha256"] = _archive_binary_sha256(archive, bin_path=bin_path)
     manifest = {
         "schema_version": 1,
-        "tmux_version": "3.6b",
+        "tmux_version": version,
         "source": "test",
         "source_url": "file://test",
         "requires_utf8proc": True,
@@ -291,12 +292,20 @@ def test_install_rejects_non_runnable_binary_without_replacing_current(
     install_dir = Path(installed["install_dir"])
     sentinel = install_dir / "old-install"
     sentinel.write_text("keep me", encoding="utf-8")
-    monkeypatch.setattr(tmux_runtime, "_tmux_binary_runnable", lambda _binary: False)
+    monkeypatch.setattr(tmux_runtime, "_tmux_binary_version", lambda _binary: None)
+    monkeypatch.setattr(tmux_runtime, "get_tmux_runtime_manager", lambda: manager)
 
-    result = manager.ensure(force=True)
+    result = tmux_runtime.ensure_tmux_installed(force=True)
+    status = manager.status()
 
     assert result["ok"] is False
     assert result["reason"] == "tmux_binary_not_runnable"
+    assert result["message"] == "tmux runtime binary could not be executed after installation."
+    assert manager.resolve_binary() is None
+    assert tmux_runtime.resolve_tmux_binary() is None
+    assert status["installed"] is False
+    assert status["status"] == "missing"
+    assert status["reason"] == "tmux_binary_not_runnable"
     assert sentinel.read_text(encoding="utf-8") == "keep me"
 
 
@@ -346,6 +355,41 @@ def test_status_reports_install_root_for_nested_binary_path(tmp_path: Path) -> N
     assert installed["ok"] is True
     assert status["path"] == str(Path(installed["install_dir"]) / bin_path)
     assert status["install_dir"] == installed["install_dir"]
+
+
+def test_status_uses_one_remote_manifest_snapshot_against_cached_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_archive = _write_tmux_archive(tmp_path, text="#!/bin/sh\necho tmux 3.6b\n")
+    remote_manifest = _write_manifest(tmp_path, old_archive, version="3.6b")
+    manager = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", manifest_url=remote_manifest.as_uri())
+    installed = manager.ensure()
+    assert installed["ok"] is True
+    cached_manifest = manager._remote_manifest_cache_path()
+    cached_payload = cached_manifest.read_bytes()
+
+    new_release = tmp_path / "new-release"
+    new_release.mkdir()
+    new_archive = _write_tmux_archive(new_release, text="#!/bin/sh\necho tmux 3.7\n")
+    new_manifest = _write_manifest(new_release, new_archive, version="3.7")
+    remote_manifest.write_bytes(new_manifest.read_bytes())
+    load_calls: list[tuple[bool, bool]] = []
+    original_load_manifest = manager._load_manifest
+
+    def tracked_load_manifest(*, allow_network: bool, persist_remote_cache: bool = True):
+        load_calls.append((allow_network, persist_remote_cache))
+        return original_load_manifest(allow_network=allow_network, persist_remote_cache=persist_remote_cache)
+
+    monkeypatch.setattr(manager, "_load_manifest", tracked_load_manifest)
+
+    status = manager.status()
+
+    assert load_calls == [(True, False)]
+    assert status["manifest"]["tmux_version"] == "3.7"
+    assert status["installed"] is False
+    assert status["status"] == "missing"
+    assert cached_manifest.read_bytes() == cached_payload
 
 
 def test_exact_released_packaged_install_is_adopted_without_archive_resolution(
@@ -423,6 +467,72 @@ def test_exact_released_packaged_install_is_adopted_without_archive_resolution(
     assert not stale_dir.exists()
 
 
+def test_cleanup_preserves_legacy_parent_containing_current_fingerprinted_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    released_manifest = json.loads(RELEASED_MANIFEST_FIXTURE.read_text(encoding="utf-8"))
+    platform_tag = runtime_platform_tag()
+    archive = released_manifest["archives"][platform_tag]
+    archive_sha256 = archive["sha256"]
+    binary_sha256 = tmux_runtime._RELEASED_BINARY_SHA256_BY_ARCHIVE_SHA256[archive_sha256]
+    manifest_sha256 = hashlib.sha256(RELEASED_MANIFEST_FIXTURE.read_bytes()).hexdigest()
+    runtime_dir = tmp_path / "runtime"
+    legacy_parent = runtime_dir / "versions" / "3.6b" / platform_tag
+    legacy_parent.mkdir(parents=True)
+    legacy_binary = legacy_parent / "tmux"
+    legacy_binary.write_text("#!/bin/sh\necho tmux 3.6b\n", encoding="utf-8")
+    legacy_binary.chmod(0o755)
+    manager = TmuxRuntimeManager(runtime_dir=runtime_dir)
+    released_metadata = {
+        "provider": "manifest",
+        "manifest_sha256": manifest_sha256,
+        "tmux_version": "3.6b",
+        "platform": platform_tag,
+        "archive_name": archive["name"],
+        "archive_sha256": archive_sha256,
+        "bin_path": "tmux",
+        "manifest_source": "package:tmux_runtime_manifest.json",
+        "source": released_manifest["source"],
+        "requires_utf8proc": True,
+        "terminfo": "bundled-or-system",
+    }
+    (legacy_parent / manager.spec.metadata_filename).write_text(
+        json.dumps(released_metadata),
+        encoding="utf-8",
+    )
+    replacement_archive = _write_tmux_archive(tmp_path)
+    original_file_sha256 = managed_runtime.file_sha256
+
+    def released_file_sha256(path: Path) -> str:
+        if path.name == "tmux":
+            return binary_sha256
+        return original_file_sha256(path)
+
+    monkeypatch.setattr(managed_runtime, "file_sha256", released_file_sha256)
+    monkeypatch.setattr(manager, "_resolve_manifest_archive", lambda _archive: replacement_archive)
+
+    repaired = manager.ensure(force=True)
+    current_dir = Path(repaired["install_dir"])
+    stale_sibling = legacy_parent / "stale"
+    stale_sibling.mkdir()
+    (stale_sibling / manager.spec.metadata_filename).write_text(
+        json.dumps(released_metadata),
+        encoding="utf-8",
+    )
+    cleanup = manager.clean(keep_previous=0)
+
+    assert repaired["ok"] is True
+    assert repaired["changed"] is True
+    assert current_dir.parent == legacy_parent
+    assert cleanup["ok"] is True
+    assert cleanup["removed"] == [str(stale_sibling)]
+    assert legacy_parent.is_dir()
+    assert legacy_binary.is_file()
+    assert current_dir.is_dir()
+    assert not stale_sibling.exists()
+
+
 def test_remote_manifest_and_archive_cache_support_offline_reuse(tmp_path: Path) -> None:
     archive = _write_tmux_archive(tmp_path)
     manifest = _write_manifest(tmp_path, archive)
@@ -446,33 +556,58 @@ def test_remote_manifest_and_archive_cache_support_offline_reuse(tmp_path: Path)
     assert Path(second["path"]) == Path(first["path"])
 
 
-def test_macos_codesign_path_is_used(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_macos_preparation_preserves_pinned_binary_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     archive = _write_tmux_archive(tmp_path)
     manifest = _write_manifest(tmp_path, archive)
     manager = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", manifest_path=manifest)
-    calls: list[list[str]] = []
+    source_bytes = (tmp_path / "archive-root" / "tmux").read_bytes()
+    quarantine_paths: list[Path] = []
 
     monkeypatch.setattr(tmux_runtime, "sys_platform", lambda: "darwin")
-    sign_checks = iter([False, True])
-    monkeypatch.setattr(tmux_runtime, "_codesign_valid", lambda _path: next(sign_checks))
-    monkeypatch.setattr(tmux_runtime, "_strip_quarantine", lambda _path: {"ok": True, "changed": False})
-    monkeypatch.setattr(tmux_runtime.shutil, "which", lambda name: f"/usr/bin/{name}" if name == "codesign" else None)
-
-    def fake_run(argv: list[str], **_kwargs: object):
-        calls.append(argv)
-
-        class Proc:
-            returncode = 0
-            stdout = "tmux 3.6b\n" if argv[-1] == "-V" else ""
-            stderr = ""
-
-        return Proc()
-
-    monkeypatch.setattr(tmux_runtime.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        tmux_runtime,
+        "_strip_quarantine",
+        lambda path: quarantine_paths.append(path) or {"ok": True, "changed": False},
+    )
 
     result = manager.ensure()
+    installed = Path(result["path"])
+    metadata = json.loads(
+        (Path(result["install_dir"]) / manager.spec.metadata_filename).read_text(encoding="utf-8")
+    )
 
     assert result["ok"] is True
-    assert result["preparation"]["changed"] is True
-    assert calls[0][:4] == ["/usr/bin/codesign", "-f", "-s", "-"]
-    assert calls[0][4].endswith("/tmux")
+    assert result["preparation"] == {"ok": True, "changed": False}
+    assert len(quarantine_paths) == 1
+    assert quarantine_paths[0].name == "tmux"
+    assert installed.read_bytes() == source_bytes
+    assert metadata["binary_sha256"] == hashlib.sha256(source_bytes).hexdigest()
+
+    installed.write_bytes(source_bytes + b"# changed after install\n")
+    installed.chmod(0o755)
+    assert manager.resolve_binary() is None
+
+
+def test_tmux_cleanup_reclaims_current_and_released_staging_prefixes(tmp_path: Path) -> None:
+    manager = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", offline=True)
+    current_staging = manager.runtime_dir / "install-pending"
+    released_staging = manager.runtime_dir / "manifest-pending"
+    current_staging.mkdir(parents=True)
+    released_staging.mkdir()
+
+    preview = manager.clean(keep_previous=0, dry_run=True)
+
+    assert preview["ok"] is True
+    assert preview["removed"] == [str(current_staging), str(released_staging)]
+    assert current_staging.is_dir()
+    assert released_staging.is_dir()
+
+    cleaned = manager.clean(keep_previous=0)
+
+    assert cleaned["ok"] is True
+    assert cleaned["removed"] == [str(current_staging), str(released_staging)]
+    assert not current_staging.exists()
+    assert not released_staging.exists()

--- a/tests/test_tmux_runtime.py
+++ b/tests/test_tmux_runtime.py
@@ -192,6 +192,112 @@ def test_released_manifest_without_binary_digest_installs_through_shared_owner(
     assert metadata["manifest_sha256"] == hashlib.sha256(manifest.read_bytes()).hexdigest()
 
 
+@pytest.mark.parametrize("manifest_source", ["path", "url"])
+def test_custom_manifest_without_binary_digest_persists_measured_digest_for_offline_resolution(
+    tmp_path: Path,
+    manifest_source: str,
+) -> None:
+    archive = _write_tmux_archive(tmp_path)
+    manifest = _write_manifest(tmp_path, archive, include_binary_sha256=False)
+    runtime_dir = tmp_path / "runtime"
+    source = (
+        {"manifest_path": manifest}
+        if manifest_source == "path"
+        else {"manifest_url": manifest.as_uri()}
+    )
+    manager = TmuxRuntimeManager(runtime_dir=runtime_dir, **source)
+
+    installed = manager.ensure()
+
+    assert installed["ok"] is True
+    installed_binary = Path(installed["path"])
+    measured_digest = hashlib.sha256(installed_binary.read_bytes()).hexdigest()
+    metadata = json.loads(
+        (Path(installed["install_dir"]) / manager.spec.metadata_filename).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert metadata["binary_sha256"] == measured_digest
+
+    manifest.unlink()
+    archive.unlink()
+    for cached in (runtime_dir / "downloads").iterdir():
+        cached.unlink()
+    offline = TmuxRuntimeManager(runtime_dir=runtime_dir, offline=True, **source)
+    assert offline.resolve_binary() == installed_binary
+
+    installed_binary.write_bytes(installed_binary.read_bytes() + b"# tampered\n")
+    installed_binary.chmod(0o755)
+    assert offline.resolve_binary() is None
+
+
+def test_custom_manifest_rejects_malformed_present_binary_digest(tmp_path: Path) -> None:
+    archive = _write_tmux_archive(tmp_path)
+    manifest = _write_manifest(tmp_path, archive)
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    payload["archives"][runtime_platform_tag()]["binary_sha256"] = "invalid"
+    manifest.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = TmuxRuntimeManager(
+        runtime_dir=tmp_path / "runtime",
+        manifest_path=manifest,
+    ).ensure()
+
+    assert result["ok"] is False
+    assert result["reason"] == "tmux_manifest_invalid"
+
+
+def test_pre_digest_custom_fingerprint_install_is_reused_without_archive_access(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = _write_tmux_archive(tmp_path)
+    manifest_path = _write_manifest(tmp_path, archive, include_binary_sha256=False)
+    manifest_payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    platform_tag = runtime_platform_tag()
+    archive_payload = manifest_payload["archives"][platform_tag]
+    manifest_sha256 = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+    fingerprint = hashlib.sha256(
+        f"{manifest_sha256}:{archive_payload['sha256']}".encode("utf-8")
+    ).hexdigest()[:16]
+    runtime_dir = tmp_path / "runtime"
+    install_dir = runtime_dir / "versions" / "3.6b" / platform_tag / fingerprint
+    install_dir.mkdir(parents=True)
+    binary = install_dir / "tmux"
+    binary.write_text("#!/bin/sh\necho tmux 3.6b\n", encoding="utf-8")
+    binary.chmod(0o755)
+    manager = TmuxRuntimeManager(runtime_dir=runtime_dir, manifest_path=manifest_path)
+    legacy_metadata = {
+        "provider": "manifest",
+        "manifest_sha256": manifest_sha256,
+        "tmux_version": "3.6b",
+        "platform": platform_tag,
+        "archive_name": archive_payload["name"],
+        "archive_sha256": archive_payload["sha256"],
+        "bin_path": archive_payload["bin_path"],
+        "manifest_source": str(manifest_path),
+        "source": manifest_payload["source"],
+        "requires_utf8proc": True,
+        "terminfo": "bundled-or-system",
+    }
+    metadata_path = install_dir / manager.spec.metadata_filename
+    metadata_path.write_text(json.dumps(legacy_metadata), encoding="utf-8")
+    metadata_before = metadata_path.read_bytes()
+    monkeypatch.setattr(
+        manager,
+        "_resolve_manifest_archive",
+        lambda _archive: pytest.fail("legacy install reuse accessed an archive"),
+    )
+
+    reused = manager.ensure()
+
+    assert reused["ok"] is True
+    assert reused["changed"] is False
+    assert Path(reused["path"]) == binary
+    assert manager.resolve_binary() == binary
+    assert metadata_path.read_bytes() == metadata_before
+
+
 def test_archive_download_retries_transient_network_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -221,7 +327,12 @@ def test_archive_download_retries_transient_network_failure(
 
 def test_bad_checksum_is_rejected(tmp_path: Path) -> None:
     archive = _write_tmux_archive(tmp_path)
-    manifest = _write_manifest(tmp_path, archive, sha256="0" * 64)
+    manifest = _write_manifest(
+        tmp_path,
+        archive,
+        sha256="0" * 64,
+        include_binary_sha256=False,
+    )
     manager = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", manifest_path=manifest)
 
     result = manager.ensure()

--- a/tests/test_tmux_runtime.py
+++ b/tests/test_tmux_runtime.py
@@ -369,23 +369,27 @@ def test_exact_released_packaged_install_is_adopted_without_archive_resolution(
     binary.write_text("#!/bin/sh\necho tmux 3.6b\n", encoding="utf-8")
     binary.chmod(0o755)
     manager = TmuxRuntimeManager(runtime_dir=runtime_dir)
-    metadata_path = released_dir / manager.spec.metadata_filename
-    metadata_path.write_text(
-        json.dumps(
-            {
-                "provider": "manifest",
-                "manifest_sha256": manifest_sha256,
-                "tmux_version": "3.6b",
-                "platform": platform_tag,
-                "archive_name": archive["name"],
-                "archive_sha256": archive_sha256,
-                "bin_path": "tmux",
-                "manifest_source": "package:tmux_runtime_manifest.json",
-                "source": released_manifest["source"],
-                "requires_utf8proc": True,
-                "terminfo": "bundled-or-system",
-            }
-        ),
+    released_metadata = {
+        "provider": "manifest",
+        "manifest_sha256": manifest_sha256,
+        "tmux_version": "3.6b",
+        "platform": platform_tag,
+        "archive_name": archive["name"],
+        "archive_sha256": archive_sha256,
+        "bin_path": "tmux",
+        "manifest_source": "package:tmux_runtime_manifest.json",
+        "source": released_manifest["source"],
+        "requires_utf8proc": True,
+        "terminfo": "bundled-or-system",
+    }
+    (released_dir / manager.spec.metadata_filename).write_text(
+        json.dumps(released_metadata),
+        encoding="utf-8",
+    )
+    stale_dir = released_dir.parent / "stale"
+    stale_dir.mkdir()
+    (stale_dir / manager.spec.metadata_filename).write_text(
+        json.dumps(released_metadata),
         encoding="utf-8",
     )
     original_file_sha256 = managed_runtime.file_sha256
@@ -403,13 +407,20 @@ def test_exact_released_packaged_install_is_adopted_without_archive_resolution(
     )
 
     result = manager.ensure()
+    pointer = json.loads((manager.runtime_dir / "current.json").read_text(encoding="utf-8"))
+    cleanup = manager.clean(keep_previous=0)
 
     assert result["ok"] is True
     assert result["changed"] is False
     assert Path(result["path"]) == binary
     assert manager.resolve_binary() == binary
     assert result["install_dir"] == str(released_dir)
-    assert not (manager.runtime_dir / "current.json").exists()
+    assert pointer["runtime_id"] == "tmux"
+    assert pointer["install_dir"] == str(released_dir)
+    assert cleanup["ok"] is True
+    assert cleanup["removed"] == [str(stale_dir)]
+    assert released_dir.is_dir()
+    assert not stale_dir.exists()
 
 
 def test_remote_manifest_and_archive_cache_support_offline_reuse(tmp_path: Path) -> None:

--- a/tests/test_tmux_runtime.py
+++ b/tests/test_tmux_runtime.py
@@ -453,6 +453,53 @@ def test_forced_repair_replaces_canonical_install_for_pointerless_recovery(
     assert manager.resolve_binary() == repaired_binary
 
 
+def test_updated_manifest_uses_discoverable_deterministic_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = _write_tmux_archive(tmp_path)
+    manifest = _write_manifest(tmp_path, archive)
+    archive_sha256 = hashlib.sha256(archive.read_bytes()).hexdigest()
+    manager = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", manifest_path=manifest)
+
+    first = manager.ensure()
+    first_dir = Path(first["install_dir"])
+    first_manifest_sha256 = hashlib.sha256(manifest.read_bytes()).hexdigest()
+    first_fingerprint = hashlib.sha256(
+        f"{first_manifest_sha256}:{archive_sha256}".encode("utf-8")
+    ).hexdigest()[:16]
+
+    assert first["ok"] is True
+    assert first_dir.name == first_fingerprint
+
+    updated_manifest = json.loads(manifest.read_text(encoding="utf-8"))
+    updated_manifest["source_url"] = "file://updated-metadata"
+    manifest.write_text(json.dumps(updated_manifest), encoding="utf-8")
+    second_manifest_sha256 = hashlib.sha256(manifest.read_bytes()).hexdigest()
+    second_fingerprint = hashlib.sha256(
+        f"{second_manifest_sha256}:{archive_sha256}".encode("utf-8")
+    ).hexdigest()[:16]
+
+    second = manager.ensure()
+    second_dir = Path(second["install_dir"])
+    second_binary = Path(second["path"])
+
+    assert second["ok"] is True
+    assert second["changed"] is True
+    assert second_dir.name == second_fingerprint
+    assert second_dir.parent == first_dir.parent
+    assert second_dir != first_dir
+    assert first_dir.is_dir()
+
+    (manager.runtime_dir / "current.json").unlink()
+    monkeypatch.setattr(
+        manager,
+        "_resolve_manifest_archive",
+        lambda _archive: pytest.fail("pointerless recovery accessed an archive"),
+    )
+    assert manager.resolve_binary() == second_binary
+
+
 def test_resolve_tmux_binary_returns_none_when_absent(tmp_path: Path) -> None:
     archive = _write_tmux_archive(tmp_path)
     manifest = _write_manifest(tmp_path, archive)

--- a/tests/test_tmux_runtime.py
+++ b/tests/test_tmux_runtime.py
@@ -392,6 +392,26 @@ def test_status_uses_one_remote_manifest_snapshot_against_cached_install(
     assert cached_manifest.read_bytes() == cached_payload
 
 
+def test_status_preserves_admitted_current_install_without_manifest(tmp_path: Path) -> None:
+    bin_path = "usr/local/bin/tmux"
+    archive = _write_tmux_archive(tmp_path, bin_path=bin_path)
+    manifest = _write_manifest(tmp_path, archive, bin_path=bin_path)
+    manager = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", manifest_path=manifest)
+    installed = manager.ensure()
+    assert installed["ok"] is True
+    manifest.unlink()
+
+    resolved = manager.resolve_binary()
+    status = manager.status()
+
+    assert resolved == Path(installed["path"])
+    assert status["installed"] is True
+    assert status["status"] == "ready"
+    assert status["path"] == str(resolved)
+    assert status["install_dir"] == installed["install_dir"]
+    assert status["manifest"] is None
+
+
 def test_exact_released_packaged_install_is_adopted_without_archive_resolution(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_tmux_runtime.py
+++ b/tests/test_tmux_runtime.py
@@ -420,6 +420,39 @@ def test_install_rejects_non_runnable_binary_without_replacing_current(
     assert sentinel.read_text(encoding="utf-8") == "keep me"
 
 
+def test_forced_repair_replaces_canonical_install_for_pointerless_recovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = _write_tmux_archive(tmp_path)
+    manifest = _write_manifest(tmp_path, archive)
+    source_bytes = (tmp_path / "archive-root" / "tmux").read_bytes()
+    manager = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", manifest_path=manifest)
+    installed = manager.ensure()
+    assert installed["ok"] is True
+    canonical_dir = Path(installed["install_dir"])
+    damaged_binary = Path(installed["path"])
+    damaged_binary.write_bytes(b"damaged tmux")
+    damaged_binary.chmod(0o755)
+
+    repaired = manager.ensure(force=True)
+
+    assert repaired["ok"] is True
+    assert repaired["changed"] is True
+    assert Path(repaired["install_dir"]) == canonical_dir
+    repaired_binary = Path(repaired["path"])
+    assert repaired_binary == canonical_dir / "tmux"
+    assert repaired_binary.read_bytes() == source_bytes
+
+    (manager.runtime_dir / "current.json").unlink()
+    monkeypatch.setattr(
+        manager,
+        "_resolve_manifest_archive",
+        lambda _archive: pytest.fail("pointerless recovery accessed an archive"),
+    )
+    assert manager.resolve_binary() == repaired_binary
+
+
 def test_resolve_tmux_binary_returns_none_when_absent(tmp_path: Path) -> None:
     archive = _write_tmux_archive(tmp_path)
     manifest = _write_manifest(tmp_path, archive)

--- a/tests/test_tmux_runtime.py
+++ b/tests/test_tmux_runtime.py
@@ -1,34 +1,72 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import json
 import stat
-import io
 import tarfile
 import urllib.error
-import warnings
 from pathlib import Path
 
 import pytest
 
-from core import tmux_runtime
+from core import managed_runtime, tmux_runtime
+from core.managed_runtime import ManagedRuntimeManager, runtime_platform_tag
 from core.tmux_runtime import TmuxRuntimeManager
 
 
-def _write_tmux_archive(tmp_path: Path, *, text: str = "#!/bin/sh\necho tmux 3.6b\n") -> Path:
+RELEASED_MANIFEST_FIXTURE = (
+    Path(__file__).parent / "fixtures" / "tmux_runtime" / "v3.6b-released-manifest.json"
+)
+RELEASED_ARTIFACT_FIXTURE = (
+    Path(__file__).parent / "fixtures" / "tmux_runtime" / "v3.6b-release-artifacts.json"
+)
+
+
+def _write_tmux_archive(
+    tmp_path: Path,
+    *,
+    text: str = "#!/bin/sh\necho tmux 3.6b\n",
+    bin_path: str = "tmux",
+) -> Path:
     root = tmp_path / "archive-root"
     root.mkdir()
-    binary = root / "tmux"
+    binary = root / bin_path
+    binary.parent.mkdir(parents=True, exist_ok=True)
     binary.write_text(text, encoding="utf-8")
     binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
     archive = tmp_path / "tmux-test.tar.gz"
     with tarfile.open(archive, "w:gz") as tar:
-        tar.add(binary, arcname="tmux")
+        tar.add(binary, arcname=bin_path)
     return archive
 
 
-def _write_manifest(tmp_path: Path, archive: Path, *, sha256: str | None = None, size: int | None = None) -> Path:
+def _archive_binary_sha256(archive: Path, *, bin_path: str = "tmux") -> str:
+    with tarfile.open(archive, "r:gz") as tar:
+        binary = tar.extractfile(bin_path)
+        assert binary is not None
+        return hashlib.sha256(binary.read()).hexdigest()
+
+
+def _write_manifest(
+    tmp_path: Path,
+    archive: Path,
+    *,
+    sha256: str | None = None,
+    size: int | None = None,
+    include_binary_sha256: bool = True,
+    bin_path: str = "tmux",
+) -> Path:
     digest = sha256 or hashlib.sha256(archive.read_bytes()).hexdigest()
+    archive_payload = {
+        "name": archive.name,
+        "url": archive.as_uri(),
+        "sha256": digest,
+        "size": archive.stat().st_size if size is None else size,
+        "bin_path": bin_path,
+    }
+    if include_binary_sha256:
+        archive_payload["binary_sha256"] = _archive_binary_sha256(archive, bin_path=bin_path)
     manifest = {
         "schema_version": 1,
         "tmux_version": "3.6b",
@@ -36,33 +74,76 @@ def _write_manifest(tmp_path: Path, archive: Path, *, sha256: str | None = None,
         "source_url": "file://test",
         "requires_utf8proc": True,
         "terminfo": "bundled-or-system",
-        "archives": {
-            tmux_runtime._runtime_platform_tag(): {
-                "name": archive.name,
-                "url": archive.as_uri(),
-                "sha256": digest,
-                "size": archive.stat().st_size if size is None else size,
-                "bin_path": "tmux",
-            }
-        },
+        "archives": {runtime_platform_tag(): archive_payload},
     }
     manifest_path = tmp_path / "tmux_runtime_manifest.json"
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
     return manifest_path
 
 
-def test_platform_tag_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
-    cases = [
-        ("macosx-14.0-arm64", "ignored", "darwin-arm64"),
-        ("macosx-13.0-x86_64", "ignored", "darwin-x64"),
-        ("macosx-14.0-universal2", "arm64", "darwin-arm64"),
-        ("linux-x86_64", "ignored", "linux-x64"),
-        ("linux-aarch64", "ignored", "linux-arm64"),
-    ]
-    for raw_platform, machine, expected in cases:
-        monkeypatch.setattr(tmux_runtime, "get_platform", lambda value=raw_platform: value)
-        monkeypatch.setattr(tmux_runtime.platform, "machine", lambda value=machine: value)
-        assert tmux_runtime._runtime_platform_tag() == expected
+def test_released_manifest_and_archive_fixtures_pass_through_production_reader(
+    tmp_path: Path,
+) -> None:
+    manifest_path = Path(tmux_runtime.__file__).resolve().parents[1] / "vibe" / "tmux_runtime_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    released_manifest = json.loads(RELEASED_MANIFEST_FIXTURE.read_text(encoding="utf-8"))
+    released_artifacts = json.loads(RELEASED_ARTIFACT_FIXTURE.read_text(encoding="utf-8"))
+    manager = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", offline=True)
+    parsed = manager._parse_manifest(
+        RELEASED_MANIFEST_FIXTURE.read_bytes(),
+        loaded_from="fixture:tmux-v3.6b",
+    )
+
+    assert parsed is not None
+    assert hashlib.sha256(RELEASED_MANIFEST_FIXTURE.read_bytes()).hexdigest() == (
+        tmux_runtime._RELEASED_PACKAGED_MANIFEST_SHA256
+    )
+    assert released_artifacts["release"] == {
+        "tag": "v3.6b",
+        "tmux_version": "3.6b",
+        "manifest_name": RELEASED_MANIFEST_FIXTURE.name,
+        "manifest_sha256": tmux_runtime._RELEASED_PACKAGED_MANIFEST_SHA256,
+    }
+    assert set(parsed.archives) == set(released_artifacts["archives"])
+    for platform_tag, artifact in released_artifacts["archives"].items():
+        released_archive = released_manifest["archives"][platform_tag]
+        current_archive = manifest["archives"][platform_tag]
+        parsed_archive = parsed.archives[platform_tag]
+        assert released_archive == {
+            key: artifact[key]
+            for key in ("name", "url", "sha256", "size", "bin_path")
+        }
+        assert current_archive == artifact
+        assert parsed_archive.binary_sha256 == artifact["binary_sha256"]
+    assert {
+        archive["sha256"]: archive["binary_sha256"]
+        for archive in released_artifacts["archives"].values()
+    } == tmux_runtime._RELEASED_BINARY_SHA256_BY_ARCHIVE_SHA256
+
+
+def test_tmux_is_a_full_shared_manifest_consumer() -> None:
+    assert issubclass(TmuxRuntimeManager, ManagedRuntimeManager)
+    inherited_methods = {
+        "_downloaded_archive_matches",
+        "_failure",
+        "_load_manifest",
+        "_manifest_archive_for_platform",
+        "_manifest_install_dir",
+        "_resolve_manifest_archive",
+        "_verified_manifest_binary",
+        "_write_current_pointer",
+        "_write_manifest_install_metadata",
+        "ensure",
+        "probe_archive_reachability",
+    }
+    for method_name in inherited_methods:
+        assert getattr(TmuxRuntimeManager, method_name) is getattr(ManagedRuntimeManager, method_name)
+    for deleted_method_name in {
+        "_legacy_manifest_install_dir",
+        "_manifest_install_matches",
+        "_manifest_metadata_path",
+    }:
+        assert not hasattr(TmuxRuntimeManager, deleted_method_name)
 
 
 def test_download_verify_install_and_idempotent_reinstall(tmp_path: Path) -> None:
@@ -84,11 +165,40 @@ def test_download_verify_install_and_idempotent_reinstall(tmp_path: Path) -> Non
     assert Path(second["path"]) == installed_path
 
 
-def test_archive_download_retries_transient_network_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_released_manifest_without_binary_digest_installs_through_shared_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = _write_tmux_archive(tmp_path)
+    archive_sha256 = hashlib.sha256(archive.read_bytes()).hexdigest()
+    binary_sha256 = _archive_binary_sha256(archive)
+    manifest = _write_manifest(tmp_path, archive, include_binary_sha256=False)
+    monkeypatch.setattr(
+        tmux_runtime,
+        "_RELEASED_BINARY_SHA256_BY_ARCHIVE_SHA256",
+        {archive_sha256: binary_sha256},
+    )
+
+    manager = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", manifest_path=manifest)
+    result = manager.ensure()
+
+    assert result["ok"] is True
+    metadata = json.loads(
+        (Path(result["install_dir"]) / manager.spec.metadata_filename).read_text(encoding="utf-8")
+    )
+    assert metadata["runtime_id"] == "tmux"
+    assert metadata["binary_sha256"] == binary_sha256
+    assert metadata["manifest_sha256"] == hashlib.sha256(manifest.read_bytes()).hexdigest()
+
+
+def test_archive_download_retries_transient_network_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     archive = _write_tmux_archive(tmp_path)
     manifest = _write_manifest(tmp_path, archive)
     payload = json.loads(manifest.read_text(encoding="utf-8"))
-    payload["archives"][tmux_runtime._runtime_platform_tag()]["url"] = "https://example.test/tmux.tar.gz"
+    payload["archives"][runtime_platform_tag()]["url"] = "https://example.test/tmux.tar.gz"
     manifest.write_text(json.dumps(payload), encoding="utf-8")
     attempts = 0
 
@@ -99,7 +209,7 @@ def test_archive_download_retries_transient_network_failure(tmp_path: Path, monk
             raise urllib.error.URLError(ConnectionResetError("reset"))
         return io.BytesIO(archive.read_bytes())
 
-    monkeypatch.setattr(tmux_runtime.urllib.request, "urlopen", opener)
+    monkeypatch.setattr(managed_runtime.urllib.request, "urlopen", opener)
     monkeypatch.setattr("core.dependency_network.time.sleep", lambda _delay: None)
 
     result = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", manifest_path=manifest).ensure()
@@ -120,16 +230,21 @@ def test_bad_checksum_is_rejected(tmp_path: Path) -> None:
     assert manager.resolve_binary() is None
 
 
-def test_successful_archive_fetch_clears_stale_download_error_before_checksum_failure(tmp_path: Path) -> None:
+def test_successful_archive_fetch_clears_stale_download_error_before_checksum_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     archive = _write_tmux_archive(tmp_path)
     manifest = _write_manifest(tmp_path, archive, sha256="0" * 64)
     manager = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", manifest_path=manifest)
     manager._download_error = {"kind": "timeout", "message": "old timeout"}
 
-    result = manager.ensure()
+    monkeypatch.setattr(tmux_runtime, "get_tmux_runtime_manager", lambda: manager)
+    result = tmux_runtime.ensure_tmux_installed()
 
     assert result["reason"] == "tmux_archive_checksum_mismatch"
     assert "checksum" in result["message"]
+    assert result["message"] == "tmux archive checksum did not match the pinned manifest."
     assert "old timeout" not in result["message"]
     assert result["download_error"] is None
 
@@ -141,17 +256,20 @@ def test_archive_probe_rejects_unsupported_scheme_before_network(
     archive = _write_tmux_archive(tmp_path)
     manifest = _write_manifest(tmp_path, archive)
     payload = json.loads(manifest.read_text(encoding="utf-8"))
-    payload["archives"][tmux_runtime._runtime_platform_tag()]["url"] = (
+    payload["archives"][runtime_platform_tag()]["url"] = (
         "http://user:secret@example.test/tmux.tar.gz?token=secret"
     )
     manifest.write_text(json.dumps(payload), encoding="utf-8")
     monkeypatch.setattr(
-        tmux_runtime,
+        managed_runtime,
         "probe_url",
         lambda *_args, **_kwargs: pytest.fail("unsupported URL must not be probed"),
     )
 
-    result = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", manifest_path=manifest).probe_archive_reachability()
+    result = TmuxRuntimeManager(
+        runtime_dir=tmp_path / "runtime",
+        manifest_path=manifest,
+    ).probe_archive_reachability()
 
     assert result == {
         "ok": False,
@@ -161,19 +279,18 @@ def test_archive_probe_rejects_unsupported_scheme_before_network(
     }
 
 
-def test_install_rejects_non_runnable_binary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_install_rejects_non_runnable_binary_without_replacing_current(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     archive = _write_tmux_archive(tmp_path)
-    manifest_path = _write_manifest(tmp_path, archive)
-    manager = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", manifest_path=manifest_path)
-    manifest = manager._load_manifest()
-    assert manifest is not None
-    archive_spec = manager._manifest_archive_for_platform(manifest)
-    assert archive_spec is not None
-    install_dir = manager._manifest_install_dir(manifest, archive_spec)
-    install_dir.mkdir(parents=True)
+    manifest = _write_manifest(tmp_path, archive)
+    manager = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", manifest_path=manifest)
+    installed = manager.ensure()
+    assert installed["ok"] is True
+    install_dir = Path(installed["install_dir"])
     sentinel = install_dir / "old-install"
     sentinel.write_text("keep me", encoding="utf-8")
-
     monkeypatch.setattr(tmux_runtime, "_tmux_binary_runnable", lambda _binary: False)
 
     result = manager.ensure(force=True)
@@ -206,6 +323,118 @@ def test_tmux_status_shape(tmp_path: Path) -> None:
     assert status["archive"]["bin_path"] == "tmux"
 
 
+def test_runtime_compatibility_accepts_any_runnable_tmux_version(tmp_path: Path) -> None:
+    archive = _write_tmux_archive(tmp_path, text="#!/bin/sh\necho tmux 3.5a\n")
+    manifest = _write_manifest(tmp_path, archive)
+    manager = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", manifest_path=manifest)
+
+    result = manager.ensure()
+
+    assert result["ok"] is True
+    assert manager.status()["version"] == "3.5a"
+
+
+def test_status_reports_install_root_for_nested_binary_path(tmp_path: Path) -> None:
+    bin_path = "usr/local/bin/tmux"
+    archive = _write_tmux_archive(tmp_path, bin_path=bin_path)
+    manifest = _write_manifest(tmp_path, archive, bin_path=bin_path)
+    manager = TmuxRuntimeManager(runtime_dir=tmp_path / "runtime", manifest_path=manifest)
+
+    installed = manager.ensure()
+    status = manager.status()
+
+    assert installed["ok"] is True
+    assert status["path"] == str(Path(installed["install_dir"]) / bin_path)
+    assert status["install_dir"] == installed["install_dir"]
+
+
+def test_exact_released_packaged_install_is_adopted_without_archive_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    released_manifest = json.loads(RELEASED_MANIFEST_FIXTURE.read_text(encoding="utf-8"))
+    platform_tag = runtime_platform_tag()
+    archive = released_manifest["archives"][platform_tag]
+    archive_sha256 = archive["sha256"]
+    binary_sha256 = tmux_runtime._RELEASED_BINARY_SHA256_BY_ARCHIVE_SHA256[archive_sha256]
+    manifest_sha256 = hashlib.sha256(RELEASED_MANIFEST_FIXTURE.read_bytes()).hexdigest()
+    assert manifest_sha256 == tmux_runtime._RELEASED_PACKAGED_MANIFEST_SHA256
+    released_fingerprint = hashlib.sha256(
+        f"{manifest_sha256}:{archive_sha256}".encode("utf-8")
+    ).hexdigest()[:16]
+    runtime_dir = tmp_path / "runtime"
+    released_dir = runtime_dir / "versions" / "3.6b" / platform_tag / released_fingerprint
+    released_dir.mkdir(parents=True)
+    binary = released_dir / "tmux"
+    binary.write_text("#!/bin/sh\necho tmux 3.6b\n", encoding="utf-8")
+    binary.chmod(0o755)
+    manager = TmuxRuntimeManager(runtime_dir=runtime_dir)
+    metadata_path = released_dir / manager.spec.metadata_filename
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "provider": "manifest",
+                "manifest_sha256": manifest_sha256,
+                "tmux_version": "3.6b",
+                "platform": platform_tag,
+                "archive_name": archive["name"],
+                "archive_sha256": archive_sha256,
+                "bin_path": "tmux",
+                "manifest_source": "package:tmux_runtime_manifest.json",
+                "source": released_manifest["source"],
+                "requires_utf8proc": True,
+                "terminfo": "bundled-or-system",
+            }
+        ),
+        encoding="utf-8",
+    )
+    original_file_sha256 = managed_runtime.file_sha256
+
+    def released_file_sha256(path: Path) -> str:
+        if path.resolve() == binary.resolve():
+            return binary_sha256
+        return original_file_sha256(path)
+
+    monkeypatch.setattr(managed_runtime, "file_sha256", released_file_sha256)
+    monkeypatch.setattr(
+        manager,
+        "_resolve_manifest_archive",
+        lambda _archive: pytest.fail("released install must be adopted without archive resolution"),
+    )
+
+    result = manager.ensure()
+
+    assert result["ok"] is True
+    assert result["changed"] is False
+    assert Path(result["path"]) == binary
+    assert manager.resolve_binary() == binary
+    assert result["install_dir"] == str(released_dir)
+    assert not (manager.runtime_dir / "current.json").exists()
+
+
+def test_remote_manifest_and_archive_cache_support_offline_reuse(tmp_path: Path) -> None:
+    archive = _write_tmux_archive(tmp_path)
+    manifest = _write_manifest(tmp_path, archive)
+    runtime_dir = tmp_path / "runtime"
+    online = TmuxRuntimeManager(runtime_dir=runtime_dir, manifest_url=manifest.as_uri())
+
+    first = online.ensure()
+    assert first["ok"] is True
+    manifest.unlink()
+    archive.unlink()
+
+    offline = TmuxRuntimeManager(
+        runtime_dir=runtime_dir,
+        manifest_url=manifest.as_uri(),
+        offline=True,
+    )
+    second = offline.ensure()
+
+    assert second["ok"] is True
+    assert second["changed"] is False
+    assert Path(second["path"]) == Path(first["path"])
+
+
 def test_macos_codesign_path_is_used(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     archive = _write_tmux_archive(tmp_path)
     manifest = _write_manifest(tmp_path, archive)
@@ -233,146 +462,6 @@ def test_macos_codesign_path_is_used(tmp_path: Path, monkeypatch: pytest.MonkeyP
     result = manager.ensure()
 
     assert result["ok"] is True
-    assert result["signing"]["changed"] is True
+    assert result["preparation"]["changed"] is True
     assert calls[0][:4] == ["/usr/bin/codesign", "-f", "-s", "-"]
     assert calls[0][4].endswith("/tmux")
-
-
-def test_safe_extract_tar_omits_filter_when_data_filter_is_unavailable(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    archive = _write_tmux_archive(tmp_path)
-    destination = tmp_path / "extract"
-    destination.mkdir()
-    calls: list[object] = []
-    monkeypatch.delattr(tarfile, "data_filter", raising=False)
-
-    with tarfile.open(archive, "r:gz") as tar:
-        original_extractall = tar.extractall
-
-        def capture_extractall(path, members=None, *, numeric_owner=False, filter=None):
-            calls.append(filter)
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", DeprecationWarning)
-                return original_extractall(path, members=members, numeric_owner=numeric_owner)
-
-        monkeypatch.setattr(tar, "extractall", capture_extractall)
-        tmux_runtime._safe_extract_tar(tar, destination)
-
-    assert calls == [None]
-    assert (destination / "tmux").is_file()
-
-
-def test_safe_extract_tar_uses_available_data_filter(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    archive = _write_tmux_archive(tmp_path)
-    destination = tmp_path / "extract"
-    destination.mkdir()
-    calls: list[object] = []
-    monkeypatch.setattr(tarfile, "data_filter", object(), raising=False)
-
-    with tarfile.open(archive, "r:gz") as tar:
-        original_extractall = tar.extractall
-
-        def capture_extractall(path, members=None, *, numeric_owner=False, filter=None):
-            calls.append(filter)
-            return original_extractall(path, members=members, numeric_owner=numeric_owner, filter=filter)
-
-        monkeypatch.setattr(tar, "extractall", capture_extractall)
-        tmux_runtime._safe_extract_tar(tar, destination)
-
-    assert calls == ["data"]
-    assert (destination / "tmux").is_file()
-
-
-def test_safe_extract_tar_rejects_symlink_assisted_dotdot_member(tmp_path: Path) -> None:
-    archive = tmp_path / "tmux-symlink-dotdot-escape.tar.gz"
-    destination = tmp_path / "extract"
-    destination.mkdir()
-    outside = tmp_path / "victim"
-
-    with tarfile.open(archive, "w:gz") as tar:
-        link = tarfile.TarInfo("link")
-        link.type = tarfile.SYMTYPE
-        link.linkname = "."
-        tar.addfile(link)
-
-        payload = b"escaped"
-        member = tarfile.TarInfo("link/../victim")
-        member.size = len(payload)
-        member.mode = 0o644
-        tar.addfile(member, io.BytesIO(payload))
-
-    with tarfile.open(archive, "r:gz") as tar:
-        with pytest.raises(ValueError, match="Unsafe tmux archive member path"):
-            tmux_runtime._safe_extract_tar(tar, destination)
-
-    assert not outside.exists()
-    assert not (destination / "victim").exists()
-    assert not (destination / "link").exists()
-
-
-def test_safe_extract_tar_rejects_root_escaping_hard_link(tmp_path: Path) -> None:
-    archive = tmp_path / "tmux-hardlink-escape.tar.gz"
-    victim = tmp_path / "victim"
-    victim.write_text("victim", encoding="utf-8")
-    original_victim_stat = victim.stat()
-    destination = tmp_path / "extract"
-    destination.mkdir()
-
-    with tarfile.open(archive, "w:gz") as tar:
-        directory = tarfile.TarInfo("sub")
-        directory.type = tarfile.DIRTYPE
-        directory.mode = 0o755
-        tar.addfile(directory)
-        hard_link = tarfile.TarInfo("sub/tmux")
-        hard_link.type = tarfile.LNKTYPE
-        hard_link.linkname = "../victim"
-        hard_link.mode = 0o755
-        tar.addfile(hard_link)
-
-    with tarfile.open(archive, "r:gz") as tar:
-        with pytest.raises(ValueError, match="Unsafe tmux archive link target"):
-            tmux_runtime._safe_extract_tar(tar, destination)
-
-    assert not (destination / "sub" / "tmux").exists()
-    assert victim.stat().st_nlink == original_victim_stat.st_nlink
-
-
-def test_safe_extract_tar_allows_root_relative_in_tree_hard_link(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    source = tmp_path / "source"
-    source.mkdir()
-    binary = source / "tmux-real"
-    binary.write_text("#!/bin/sh\necho tmux 3.6b\n", encoding="utf-8")
-    binary.chmod(0o755)
-    archive = tmp_path / "tmux-hardlink-safe.tar.gz"
-    destination = tmp_path / "extract"
-    destination.mkdir()
-    monkeypatch.delattr(tarfile, "data_filter", raising=False)
-
-    with tarfile.open(archive, "w:gz") as tar:
-        tar.add(binary, arcname="tmux-real")
-        directory = tarfile.TarInfo("sub")
-        directory.type = tarfile.DIRTYPE
-        directory.mode = 0o755
-        tar.addfile(directory)
-        hard_link = tarfile.TarInfo("sub/tmux")
-        hard_link.type = tarfile.LNKTYPE
-        hard_link.linkname = "tmux-real"
-        hard_link.mode = 0o755
-        tar.addfile(hard_link)
-
-    with tarfile.open(archive, "r:gz") as tar:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            tmux_runtime._safe_extract_tar(tar, destination)
-
-    installed = destination / "sub" / "tmux"
-    assert installed.read_text(encoding="utf-8") == "#!/bin/sh\necho tmux 3.6b\n"
-    assert (destination / "tmux-real").stat().st_ino == installed.stat().st_ino

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -2729,7 +2729,7 @@ def test_runtime_prepare_force_does_not_report_explicit_command_as_replaced(monk
     assert "VIBE_SHOW_RUNTIME_BIN" in captured.err
 
 
-@pytest.mark.parametrize("consumer", ["memory", "model-hub"])
+@pytest.mark.parametrize("consumer", ["memory", "model-hub", "tmux"])
 def test_runtime_clean_reclaims_each_shared_consumer_in_preview_and_real_run(
     monkeypatch,
     capsys,
@@ -2744,11 +2744,18 @@ def test_runtime_clean_reclaims_each_shared_consumer_in_preview_and_real_run(
             provider_root=tmp_path / "memory-provider",
             offline=True,
         )
-    else:
+    elif consumer == "model-hub":
         from vibe.model_hub_runtime.installer import EngineRuntimeManager
 
         manager = EngineRuntimeManager(
             runtime_dir=tmp_path / "model-hub-runtime",
+            offline=True,
+        )
+    else:
+        from core.tmux_runtime import TmuxRuntimeManager
+
+        manager = TmuxRuntimeManager(
+            runtime_dir=tmp_path / "tmux-runtime",
             offline=True,
         )
 
@@ -2844,6 +2851,7 @@ def test_runtime_clean_reclaims_each_shared_consumer_in_preview_and_real_run(
 
 
 def test_runtime_clean_registry_invokes_every_current_shared_consumer(monkeypatch):
+    from core import tmux_runtime
     from core.memory import artifact as memory_artifact
     from vibe.model_hub_runtime import installer as model_hub_installer
 
@@ -2872,6 +2880,11 @@ def test_runtime_clean_registry_invokes_every_current_shared_consumer(monkeypatc
         "EngineRuntimeManager",
         lambda: FakeManager("model_hub_engine"),
     )
+    monkeypatch.setattr(
+        tmux_runtime,
+        "get_tmux_runtime_manager",
+        lambda: FakeManager("tmux"),
+    )
 
     results = cli._clean_managed_runtime_consumers(keep_previous=2, dry_run=True)
 
@@ -2879,11 +2892,13 @@ def test_runtime_clean_registry_invokes_every_current_shared_consumer(monkeypatc
         "git",
         "memory-runtime",
         "model_hub_engine",
+        "tmux",
     ]
     assert calls == [
         ("git", 2, True),
         ("memory-runtime", 2, True),
         ("model_hub_engine", 2, True),
+        ("tmux", 2, True),
     ]
 
 
@@ -3032,6 +3047,7 @@ def test_runtime_clean_success_reports_every_consumer_and_exits_zero(monkeypatch
             ("git", cleaner(1)),
             ("memory-runtime", cleaner(2)),
             ("model_hub_engine", cleaner(3)),
+            ("tmux", cleaner(4)),
         ),
     )
     args = cli.build_parser().parse_args(["runtime", "clean"])
@@ -3041,6 +3057,7 @@ def test_runtime_clean_success_reports_every_consumer_and_exits_zero(monkeypatch
     assert "Removed 1 Git Runtime cache item(s)." in captured.out
     assert "Removed 2 Memory Runtime cache item(s)." in captured.out
     assert "Removed 3 Model Hub Runtime cache item(s)." in captured.out
+    assert "Removed 4 tmux Runtime cache item(s)." in captured.out
     assert captured.err == ""
 
 
@@ -3107,8 +3124,8 @@ def test_runtime_clean_does_not_render_shared_archive_failure_as_zero_success(mo
 @pytest.mark.parametrize(
     ("language", "consumer_scope", "failure_contract"),
     [
-        ("en", "Show, Git, Memory, and Model Hub", "exit nonzero if any cleanup fails"),
-        ("zh", "Show、Git、Memory 和 Model Hub", "任一清理失败时以非零状态退出"),
+        ("en", "Show, Git, Memory, Model Hub, and tmux", "exit nonzero if any cleanup fails"),
+        ("zh", "Show、Git、Memory、Model Hub 和 tmux", "任一清理失败时以非零状态退出"),
     ],
 )
 def test_runtime_clean_help_names_consumers_and_failure_exit(

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -14826,6 +14826,7 @@ def _managed_runtime_cleaners() -> tuple[tuple[str, Callable[..., dict[str, Any]
     """Return the shared-runtime cleanup passes in stable output order."""
 
     from core.memory.artifact import get_memory_artifact_manager
+    from core.tmux_runtime import get_tmux_runtime_manager
     from vibe.model_hub_runtime.installer import EngineRuntimeManager
 
     def clean_memory(*, keep_previous: int, dry_run: bool) -> dict[str, Any]:
@@ -14840,10 +14841,17 @@ def _managed_runtime_cleaners() -> tuple[tuple[str, Callable[..., dict[str, Any]
             dry_run=dry_run,
         )
 
+    def clean_tmux(*, keep_previous: int, dry_run: bool) -> dict[str, Any]:
+        return get_tmux_runtime_manager().clean(
+            keep_previous=keep_previous,
+            dry_run=dry_run,
+        )
+
     return (
         ("git", _clean_git_runtime),
         ("memory-runtime", clean_memory),
         ("model_hub_engine", clean_model_hub),
+        ("tmux", clean_tmux),
     )
 
 
@@ -14904,6 +14912,7 @@ def _managed_runtime_label(runtime_id: str) -> str:
         "git": "Git Runtime",
         "memory-runtime": "Memory Runtime",
         "model_hub_engine": "Model Hub Runtime",
+        "tmux": "tmux Runtime",
     }
     return labels.get(runtime_id, runtime_id.replace("-", " ").replace("_", " ").title())
 

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -973,7 +973,7 @@
       "unsupportedSource": "Show Runtime preparation failed: {reason}. Remove VIBE_SHOW_RUNTIME_SOURCE and use the packaged runtime, or set VIBE_SHOW_RUNTIME_BIN to a runtime you built."
     },
     "clean": {
-      "commandHelp": "Remove stale Show, Git, Memory, and Model Hub runtime installs and archives; exit nonzero if any cleanup fails.",
+      "commandHelp": "Remove stale Show, Git, Memory, Model Hub, and tmux runtime installs and archives; exit nonzero if any cleanup fails.",
       "dryRunHelp": "Report stale archives and cache entries without removing anything.",
       "wouldRemoveItems": "Would remove {count} Show Runtime cache item(s).",
       "wouldRemoveArchives": "Would remove {count} downloaded Show Runtime archive(s) ({size}).",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -973,7 +973,7 @@
       "unsupportedSource": "Show Runtime 准备失败：{reason}。请移除 VIBE_SHOW_RUNTIME_SOURCE 以使用随 Avibe 发布的运行时，或将 VIBE_SHOW_RUNTIME_BIN 指向你自行构建的运行时。"
     },
     "clean": {
-      "commandHelp": "清理过期的 Show、Git、Memory 和 Model Hub 运行时安装与归档；任一清理失败时以非零状态退出。",
+      "commandHelp": "清理过期的 Show、Git、Memory、Model Hub 和 tmux 运行时安装与归档；任一清理失败时以非零状态退出。",
       "dryRunHelp": "\u4ec5\u62a5\u544a\u53ef\u6e05\u7406\u7684\u5f52\u6863\u4e0e\u7f13\u5b58\u6761\u76ee\uff0c\u4e0d\u5220\u9664\u4efb\u4f55\u5185\u5bb9\u3002",
       "wouldRemoveItems": "\u5c06\u6e05\u7406 {count} \u9879 Show Runtime \u7f13\u5b58\u3002",
       "wouldRemoveArchives": "\u5c06\u6e05\u7406 {count} \u4e2a\u5df2\u4e0b\u8f7d\u7684 Show Runtime \u5f52\u6863\uff08{size}\uff09\u3002",


### PR DESCRIPTION
## Summary

- make tmux the fifth full `ManagedRuntimeManager` manifest consumer, inheriting the shared install, archive acquisition/cache, guard, cleanup, extraction, persistence, and probe owners
- retain only tmux product adapters: released schema-1 compatibility, quarantine-only macOS binary preparation, and runtime compatibility/status projection
- add one default-off shared spec capability for manifests without `binary_sha256`, enabled only for tmux; verified installs persist a measured executable digest for later local-integrity checks
- preserve the old deterministic tmux force-repair contract by opting tmux into the shared canonical-target replacement transaction
- add one default-off shared spec capability for manifest-bound install fingerprints, enabled only for tmux, so metadata-only manifest updates publish to deterministic, pointerless-discoverable targets
- apply the runtime admission hook to every manifest-selected existing candidate and let only tmux replace a rejected canonical target after the staged replacement passes the complete shared verification pipeline
- normalize both sides of install-claim replay comparison while retaining manifest identity in tmux metadata, returned targets, and deterministic install paths
- add tmux to `vibe runtime clean` without adding another registry or shared policy seam
- make ancestor/descendant install-root protection a shared cleanup invariant and delete Show's identical override

## Exact Obsolete Symbol Set

The following 27 exact, qualified tmux-owned symbols were non-empty and verified with `rg` against definitions and call sites at base `0eb15bea2f573b207caaf6c4a3c6e891a3cc0d2d` before editing:

1. `core.tmux_runtime.TmuxArchive`
2. `core.tmux_runtime.TmuxManifest`
3. `core.tmux_runtime._TMUX_INSTALL_LOCK`
4. `core.tmux_runtime.TmuxRuntimeManager.ensure`
5. `core.tmux_runtime.TmuxRuntimeManager.probe_archive_reachability`
6. `core.tmux_runtime.TmuxRuntimeManager._load_manifest`
7. `core.tmux_runtime.TmuxRuntimeManager._manifest_archive_for_platform`
8. `core.tmux_runtime.TmuxRuntimeManager._resolve_manifest_archive`
9. `core.tmux_runtime.TmuxRuntimeManager._downloaded_archive_matches`
10. `core.tmux_runtime.TmuxRuntimeManager._manifest_install_dir`
11. `core.tmux_runtime.TmuxRuntimeManager._legacy_manifest_install_dir`
12. `core.tmux_runtime.TmuxRuntimeManager._manifest_metadata_path`
13. `core.tmux_runtime.TmuxRuntimeManager._verified_manifest_binary`
14. `core.tmux_runtime.TmuxRuntimeManager._manifest_install_matches`
15. `core.tmux_runtime.TmuxRuntimeManager._write_manifest_install_metadata`
16. `core.tmux_runtime.TmuxRuntimeManager._write_current_pointer`
17. `core.tmux_runtime.TmuxRuntimeManager._failure`
18. `core.tmux_runtime._runtime_platform_tag`
19. `core.tmux_runtime._safe_extract_tar`
20. `core.tmux_runtime._tar_archive_path_is_unsafe`
21. `core.tmux_runtime._file_sha256`
22. `core.tmux_runtime._make_executable`
23. `core.tmux_runtime._safe_path_part`
24. `core.tmux_runtime._env_flag_enabled`
25. `core.tmux_runtime._manifest_status_payload`
26. `core.tmux_runtime._archive_status_payload`
27. `core.tmux_runtime._reason_message`

The completion `rg` gate has zero definitions and zero exact-owner call-site hits for all 27 symbols across source and tests. Homonymous methods now resolve to `ManagedRuntimeManager`; the structural acceptance test verifies inherited method identity and the absence of the three deleted methods with no shared counterpart. The Step 6 frozen set of 33 exact `ShowRuntimeManager`/module-owned symbols also remains at zero definitions and exact-owner call sites; retained homonyms belong to `_ShowManifestRuntimeManager` or the shared owner.

## Released-State Compatibility

- froze the exact pre-change packaged manifest bytes at SHA-256 `ee2826f881c236718ff18b2d1f939afb9417c584df5f29b796129c80691d2e63`
- measured and fixture-bound the four released v3.6b archive digests, sizes, URLs, and extracted binary digests; the production released-state reader supplies those binary digests to the shared parser
- admits the old packaged fingerprint only for the frozen manifest digest plus a known released archive digest and exact old metadata; no generalized candidate inference was added
- preserves arbitrary pre-digest schema-1 custom manifests selected through either `manifest_path` or `manifest_url`; the publisher's archive size/SHA remains the acquisition anchor
- after verified extraction and non-mutating preparation, persists the measured executable digest in existing metadata and uses it for immediate, offline, and tamper-detecting installed-byte verification
- admits an existing custom old-fingerprint install without archive access only when its legacy provider, selected manifest digest, tmux version, platform, archive digest, bin path, confined executable layout, and runnable/version probe satisfy the previous contract; it does not derive or persist a digest from those legacy installed bytes
- proves an old packaged install with no pointer is adopted from the old fingerprint while archive resolution is unreachable, so adding `binary_sha256` cannot force a redownload; this `7f4312da` regression remains unchanged
- force repair replaces the deterministic canonical target only after shared staged validation; after checksum-damaging the old executable, the regression proves repair keeps the same install directory and pointerless recovery rediscovers it without archive access
- non-force reconciliation no longer reuses a digest-valid but non-runnable canonical tmux install; after the staged replacement passes archive, extraction, digest, preparation, and runtime admission, it replaces that same canonical leaf and remains pointerless-discoverable without archive access
- if both the existing candidate and staged bytes fail runtime admission, non-force ensure returns `tmux_binary_not_runnable` without changing the old target or pointer
- a metadata-only manifest update with unchanged tmux version, platform, archive bytes, and archive digest publishes to the exact `sha256(manifest.digest:archive.sha256)[:16]` target; the prior install remains for rollback, and pointerless recovery rediscovers the updated install without archive access
- exact returned tmux install targets replay successfully without archive access or pointer mutation; the changed-target negative contract remains intact
- separately proves a released legacy parent containing the current fingerprinted install is never recursively removed, while its stale sibling is reclaimed
- preserves the tmux user-facing checksum and non-runnable messages, applies runnable/version admission to pointer and released candidates, and reports the admitted install root for nested `bin_path` values

## macOS Release Evidence

- exact pinned arm64 binary SHA-256 `5f8b6a7eda2ccd5bc283368e93e0e5c45b78071b5f90df7e394cf9a7f7ed6373` already carries a valid linker ad-hoc signature
- exact pinned x86_64 binary SHA-256 `9adf4f75e12bce1e1a3b53696e38b60854761bb7945a7c09a806999f1995b870` is unsigned and executes successfully as `tmux 3.6b` after extraction
- installer-side ad-hoc signing and its dead validation helper are deleted; quarantine removal does not rewrite the pinned bytes, the manifest digest remains the installed-byte integrity anchor, and the existing runnable/version check rejects any artifact that still cannot execute
- no `source_binary_sha256`, mutable-preparation policy, or shared integrity data-model change was added

## Shared Ownership

- `TmuxRuntimeManager.ensure` and `probe_archive_reachability` are the shared production methods
- shared reuse checks the canonical base pointer resolver before publication, so a consumer legacy fallback cannot suppress the pointer needed by cleanup
- shared parsing requires `binary_sha256` for binary artifacts unless the consumer explicitly opts into the one default-off capability; a present malformed digest remains invalid, and every other consumer retains the strict requirement
- shared acquisition still verifies archive size and SHA before extraction; a present executable digest keeps its exact comparison, while an opted-in omission records the measured post-preparation executable digest without synthesizing it from the archive digest
- every manifest-selected existing candidate now passes provider, runtime id, target identity, platform, path, executable bit, binary digest, and the same `_binary_matches_manifest` hook already used by staged installation; hook rejection preserves the established `binary_not_runnable` classification
- shared candidate admission compares new metadata against its persisted executable digest; the narrowly admitted tmux legacy record remains read-only until a verified reinstall creates that fact
- shared force replacement remains default-off; only tmux and the already-established Show consumer opt into the existing confined canonical-leaf replacement transaction
- invalid-canonical non-force replacement is a separate default-off capability enabled only for tmux; deletion occurs only after the staged artifact passes the complete verification and runtime-admission pipeline, and a failed staged artifact leaves the old target intact
- shared manifest-bound install fingerprints remain default-off; only tmux includes the selected manifest digest, with the exact former tmux fingerprint, while other runtime path identities remain unchanged
- expected install claims and current targets pass through the same normalization before comparison; `manifest_sha256` remains persisted and returned, while the existing changed-target negative case and Model Hub claim/replay contracts remain unchanged
- shared cleanup protects equal, ancestor, and descendant install roots; Show's identical override was removed and tmux adds no cleanup predicate
- released schema-1 installation, archive verification/extraction, retry behavior, offline manifest/archive cache reuse, non-runnable rejection, and macOS preparation all execute through shared `ensure()`
- tmux status uses one read-only selected manifest snapshot for archive selection and shared installed-candidate admission; it does not persist a diagnostic fetch or call `super().status()` for a second snapshot
- when that diagnostic manifest is unavailable, status preserves an already-admitted canonical current install through the shared pointer resolver plus the tmux runnable/version check; the corrective regression covers a nested `bin_path` and leaves `manifest` as `None`
- `vibe runtime clean` invokes tmux in the existing explicit stable-order cleaner list and covers preview plus real reclamation of both current `install-*` and released `manifest-*` staging directories
- no random-sibling enumeration, tmux replacement/acquisition/parser/cleanup loop, dependency, plan edit, or public-doc edit

## Review Classification

- Initial convergence commit `e846843cffaf979be380f34c01812b1e18171312` introduced the five findings in Codex review `5038022302`, the pre-digest and repair/discoverability findings in threads `3869479999`, `3869825259`, and `3870019705`, and the runnable-admission class represented by sibling threads `3869406242` and `3870170182`
- pointer-only correction `7f4312da814887cefff485f3505aa3dc358b1751` adds no findings-bearing behavior class
- behavior closure `b98f4de94c0c7169f33d112517bc6c2a2b8ac0c5` and manifest-missing status correction `3b90e0ed2a9d76dda6144525f936bd4a7463b39b` form one pre-review closure round; `b98f4de94` was never pushed or reviewed separately
- additive pre-digest compatibility correction `8dd7990b17ae70a3889f27db7f808c1ce658d336` received the exact-head clean Codex pass in comment `5436282437` and introduced the distinct asymmetric claim-normalization finding in thread `3870170189`
- additive canonical force-repair correction `dfa168ca592cf780d3d0eb157fd462be4dcec637` closes the force-repair finding under the workspace hard-history contract
- additive manifest-identity correction `b0c46122e8bd130177798db6c6024d669498b31f` closes updated-manifest discoverability and introduced neither finding in its exact-head review
- additive runnable-admission and claim-replay correction `1681a869e91d3c64d39a46d6fbcf10fd9cf120fd` closes threads `3870170182` and `3870170189` under ruling `5436724689`
- the complete inventory has two findings-bearing behavior-introducing commits, `e846843c` and `8dd7990b`, with no root class repeated across two introducing commits; the same-class breaker and post-rewrite three-commit threshold have not tripped
- any finding behaviorally introduced by corrective head `1681a869e9` requires a full recount before another edit or push
- final exact head is `1681a869e91d3c64d39a46d6fbcf10fd9cf120fd`

## Evidence

- **tmux, released/preparation/status, custom pre-digest compatibility, canonical and non-force repair, manifest identity, claim replay, and runtime clean:** 47 passed, 181 deselected
- **shared manager, composite artifacts, negative claim replay, and force replacement:** 189 passed
- **unchanged Git:** 41 passed
- **unchanged Memory:** 62 passed
- **unchanged Model Hub including claim/replay:** 160 passed
- **unchanged Show manifest/cleanup and force-replacement consumer:** 72 passed
- **Show overlap/retention consumers of the shared cleanup invariant:** 6 passed, 488 deselected
- **lint:** full `ruff check .` passes
- **symbol gates:** exact Step 7 set of 27 and frozen Step 6 set of 33 both have zero qualified definitions/call sites; tmux `_codesign_valid` and `source_binary_sha256` also have zero hits
- **exact base:** `0eb15bea2f573b207caaf6c4a3c6e891a3cc0d2d`
- **merge base:** `0eb15bea2f573b207caaf6c4a3c6e891a3cc0d2d`
- **behavior closure commit:** `b98f4de94c0c7169f33d112517bc6c2a2b8ac0c5`
- **manifest-missing correction:** `3b90e0ed2a9d76dda6144525f936bd4a7463b39b`
- **pre-digest compatibility correction:** `8dd7990b17ae70a3889f27db7f808c1ce658d336`
- **canonical force-repair correction:** `dfa168ca592cf780d3d0eb157fd462be4dcec637`
- **manifest-identity correction:** `b0c46122e8bd130177798db6c6024d669498b31f`
- **runnable-admission and claim-replay correction / final review head:** `1681a869e91d3c64d39a46d6fbcf10fd9cf120fd`
- **merge-base diff:** 13 files, 1170 insertions, 763 deletions; source 337 insertions/578 deletions, tests and fixtures 833 insertions/185 deletions
- **scenario IDs:** none

## Deferred Validation

- no local `vibe` restart, remote Incus work, or final local Incus regression was run; the orchestrator owns the final post-merge local Incus regression
- this PR must not be merged by the lane
