### PR TITLE
fix(memory): repair optional package from settings

### DIFF
--- a/core/memory_loader.py
+++ b/core/memory_loader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+from collections.abc import Callable
 from typing import Any
 
 from vibe.memory_contract import (
@@ -20,21 +21,9 @@ MEMORY_LIST_CURSOR_MAX_BYTES = 8192
 _PROTOCOL_ATTR = "MEMORY_RUNTIME_PROTOCOL_VERSION"
 
 
-def load_memory_runtime(
-    config: Any,
-    *,
-    allow_disabled: bool = False,
-    **runtime_kwargs: Any,
-) -> Any:
-    """Load and construct the fixed Memory runtime for an enabled snapshot.
+def _resolve_memory_runtime_factory() -> Callable[..., Any]:
+    """Import the fixed entrypoint and return its compatible factory."""
 
-    This module intentionally imports no implementation module at import time.
-    The entrypoint, protocol comparison, and constructor are deliberately fixed
-    so a missing/broken optional implementation cannot affect core startup.
-    """
-
-    if not bool(getattr(config, "enabled", False)) and not allow_disabled:
-        return None
     try:
         implementation = importlib.import_module(MEMORY_RUNTIME_ENTRYPOINT)
     except Exception as exc:
@@ -56,6 +45,31 @@ def load_memory_runtime(
         raise MemoryPluginUnavailableError(
             "Memory implementation constructor is unavailable"
         )
+    return factory
+
+
+def probe_memory_runtime_entrypoint() -> None:
+    """Validate the runtime entrypoint contract without constructing it."""
+
+    _resolve_memory_runtime_factory()
+
+
+def load_memory_runtime(
+    config: Any,
+    *,
+    allow_disabled: bool = False,
+    **runtime_kwargs: Any,
+) -> Any:
+    """Load and construct the fixed Memory runtime for an enabled snapshot.
+
+    This module intentionally imports no implementation module at import time.
+    The entrypoint, protocol comparison, and constructor are deliberately fixed
+    so a missing/broken optional implementation cannot affect core startup.
+    """
+
+    if not bool(getattr(config, "enabled", False)) and not allow_disabled:
+        return None
+    factory = _resolve_memory_runtime_factory()
     try:
         runtime = factory(config, **runtime_kwargs)
     except Exception as exc:

--- a/tests/scenarios/memory_independence/catalog.yaml
+++ b/tests/scenarios/memory_independence/catalog.yaml
@@ -14,6 +14,7 @@ capability:
     - tests/test_core_services_dispatch.py
     - tests/test_admin_notifications.py
     - tests/test_memory_disabled_isolation.py
+    - tests/test_memory_upgrade_packaged.py
 contract:
   dispatch: capture_must_not_fence_turn_start
   destructive_ops: new_and_archive_fail_open_on_capture_timeout
@@ -129,3 +130,9 @@ scenarios:
     kind: guardrail
     layer: scenario
     test: tests/test_memory_disabled_isolation.py::test_memory_indep_017_core_workflows_run_without_avibe_memory
+  - id: MEMORY-INDEP-018
+    name: Settings repair installs the exact optional Memory package without changing the core release
+    status: covered
+    kind: correctness
+    layer: scenario
+    test: tests/test_memory_upgrade_packaged.py::test_memory_indep_018_packaged_settings_repair_adds_memory_without_changing_core

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -1237,6 +1237,109 @@ def test_dependencies_status_shape(monkeypatch):
     assert by["node"]["installed"] and by["node"]["version"] == "20.11"
 
 
+@pytest.mark.parametrize(
+    ("installed", "installed_version", "current_version", "expected"),
+    (
+        pytest.param(
+            True,
+            "3.0.14",
+            "3.0.14",
+            {"status": "ready", "reason": None, "latest_version": None, "has_update": False},
+            id="exact-match",
+        ),
+        pytest.param(
+            True,
+            "3.0.14.0",
+            "3.0.14",
+            {"status": "ready", "reason": None, "latest_version": None, "has_update": False},
+            id="normalized-equivalent",
+        ),
+        pytest.param(
+            True,
+            "3.0.13",
+            "3.0.14",
+            {
+                "status": "error",
+                "reason": "memory_package_version_mismatch",
+                "latest_version": "3.0.14",
+                "has_update": True,
+            },
+            id="version-mismatch",
+        ),
+        pytest.param(
+            True,
+            "not-a-version",
+            "3.0.14",
+            {
+                "status": "error",
+                "reason": "memory_package_version_mismatch",
+                "latest_version": "3.0.14",
+                "has_update": True,
+            },
+            id="invalid-installed-version",
+        ),
+        pytest.param(
+            True,
+            None,
+            "3.0.14",
+            {
+                "status": "error",
+                "reason": "memory_package_metadata_unreadable",
+                "latest_version": None,
+                "has_update": False,
+            },
+            id="unreadable-metadata",
+        ),
+        pytest.param(
+            False,
+            None,
+            "3.0.14",
+            {
+                "status": "missing",
+                "reason": "memory_package_missing",
+                "latest_version": None,
+                "has_update": False,
+            },
+            id="absent-distribution",
+        ),
+    ),
+)
+def test_memory_package_dependency_requires_the_running_release(
+    monkeypatch,
+    installed,
+    installed_version,
+    current_version,
+    expected,
+):
+    monkeypatch.setattr(api, "memory_package_installed", lambda: installed)
+    if installed:
+        monkeypatch.setattr(
+            api,
+            "installed_memory_package_version",
+            lambda: installed_version,
+        )
+    else:
+        monkeypatch.setattr(
+            api,
+            "installed_memory_package_version",
+            lambda: pytest.fail("an absent distribution has no version metadata"),
+        )
+
+    dependency = api._memory_package_dependency(
+        required=True,
+        current_version=current_version,
+    )
+
+    assert dependency == {
+        "id": "memory-package",
+        "kind": "runtime",
+        "required": True,
+        "installed": installed,
+        "version": installed_version,
+        **expected,
+    }
+
+
 def test_source_version_does_not_advertise_python_package_repair(monkeypatch):
     monkeypatch.setattr(api, "memory_package_repair_supported", lambda: False)
     monkeypatch.setattr(

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -1715,6 +1715,43 @@ def test_memory_package_dependency_job_fails_before_install_without_rollback_tar
     }
 
 
+def test_memory_package_dependency_job_fails_before_install_for_unreadable_rollback_shape(
+    monkeypatch,
+):
+    from vibe.upgrade import MemoryRollbackTargetUnavailableError
+
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/bin/vibe")
+    monkeypatch.setattr(
+        api,
+        "rollback_target",
+        Mock(
+            side_effect=MemoryRollbackTargetUnavailableError(
+                "The installed avibe-memory version cannot be determined for safe rollback"
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        api,
+        "build_memory_package_repair_plan",
+        lambda **_: pytest.fail("an incomplete rollback shape must not build an install plan"),
+    )
+    monkeypatch.setattr(
+        api,
+        "execute_upgrade_plan",
+        lambda *_args, **_kwargs: pytest.fail("an incomplete rollback shape must not install"),
+    )
+
+    result = api._prepare_memory_package_job()
+
+    assert result == {
+        "ok": False,
+        "message": "memory_package_metadata_unreadable",
+        "output": "The installed avibe-memory version cannot be determined for safe rollback",
+        "reason": "memory_package_metadata_unreadable",
+        "restarting": False,
+    }
+
+
 def test_dependencies_status_node_unsupported_not_ready(monkeypatch):
     # Node present but below the runtime minimum (node_supported False) -> not ready.
     monkeypatch.setattr(

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -1238,12 +1238,19 @@ def test_dependencies_status_shape(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ("installed", "installed_version", "current_version", "expected"),
+    (
+        "installed",
+        "installed_version",
+        "current_version",
+        "importable",
+        "expected",
+    ),
     (
         pytest.param(
             True,
             "3.0.14",
             "3.0.14",
+            True,
             {"status": "ready", "reason": None, "latest_version": None, "has_update": False},
             id="exact-match",
         ),
@@ -1251,6 +1258,7 @@ def test_dependencies_status_shape(monkeypatch):
             True,
             "3.0.14.0",
             "3.0.14",
+            True,
             {"status": "ready", "reason": None, "latest_version": None, "has_update": False},
             id="normalized-equivalent",
         ),
@@ -1258,6 +1266,7 @@ def test_dependencies_status_shape(monkeypatch):
             True,
             "3.0.13",
             "3.0.14",
+            False,
             {
                 "status": "error",
                 "reason": "memory_package_version_mismatch",
@@ -1270,6 +1279,7 @@ def test_dependencies_status_shape(monkeypatch):
             True,
             "not-a-version",
             "3.0.14",
+            True,
             {
                 "status": "error",
                 "reason": "memory_package_version_mismatch",
@@ -1282,6 +1292,7 @@ def test_dependencies_status_shape(monkeypatch):
             True,
             None,
             "3.0.14",
+            True,
             {
                 "status": "error",
                 "reason": "memory_package_metadata_unreadable",
@@ -1294,6 +1305,7 @@ def test_dependencies_status_shape(monkeypatch):
             False,
             None,
             "3.0.14",
+            False,
             {
                 "status": "missing",
                 "reason": "memory_package_missing",
@@ -1302,6 +1314,19 @@ def test_dependencies_status_shape(monkeypatch):
             },
             id="absent-distribution",
         ),
+        pytest.param(
+            True,
+            "3.0.14",
+            "3.0.14",
+            False,
+            {
+                "status": "error",
+                "reason": "memory_package_import_unavailable",
+                "latest_version": "3.0.14",
+                "has_update": True,
+            },
+            id="matching-version-import-unavailable",
+        ),
     ),
 )
 def test_memory_package_dependency_requires_the_running_release(
@@ -1309,6 +1334,7 @@ def test_memory_package_dependency_requires_the_running_release(
     installed,
     installed_version,
     current_version,
+    importable,
     expected,
 ):
     monkeypatch.setattr(api, "memory_package_installed", lambda: installed)
@@ -1328,6 +1354,7 @@ def test_memory_package_dependency_requires_the_running_release(
     dependency = api._memory_package_dependency(
         required=True,
         current_version=current_version,
+        importable=importable,
     )
 
     assert dependency == {
@@ -1338,6 +1365,114 @@ def test_memory_package_dependency_requires_the_running_release(
         "version": installed_version,
         **expected,
     }
+
+
+def _patch_memory_dependency_status_shell(monkeypatch) -> None:
+    import core.show_runtime as show_runtime
+    import core.tmux_runtime as tmux_runtime
+    import vibe
+
+    monkeypatch.setattr(
+        api,
+        "askill_update_status",
+        lambda **_: {
+            "installed": True,
+            "version": "0.1.14",
+            "latest_version": None,
+            "has_update": False,
+            "status": "ready",
+        },
+    )
+    monkeypatch.setattr(
+        api,
+        "avault_status",
+        lambda: {"installed": True, "version": "0.0.1", "status": "ready"},
+    )
+    monkeypatch.setattr(
+        api.V2Config,
+        "load",
+        classmethod(lambda _cls: SimpleNamespace(memory=SimpleNamespace(enabled=True))),
+    )
+    monkeypatch.setattr(
+        api,
+        "get_build_identity",
+        lambda: SimpleNamespace(kind="package"),
+    )
+    monkeypatch.setattr(api, "memory_package_repair_supported", lambda: True)
+    monkeypatch.setattr(api, "memory_package_installed", lambda: True)
+    monkeypatch.setattr(api, "installed_memory_package_version", lambda: "3.0.14")
+    monkeypatch.setattr(vibe, "__version__", "3.0.14")
+
+    show_manager = Mock()
+    show_manager.status.return_value = {
+        "install": {"state": "installed", "runtime_version": "1.4.0", "matches_manifest": True},
+        "manifest": {"runtime_version": "1.4.0"},
+        "node_available": True,
+        "node_supported": True,
+        "node_version": "22.12.0",
+    }
+    monkeypatch.setattr(show_runtime, "get_show_runtime_manager", lambda: show_manager)
+    monkeypatch.setattr(
+        tmux_runtime,
+        "tmux_status",
+        lambda: {"installed": False, "version": None, "status": "missing"},
+    )
+
+
+def test_dependencies_status_marks_matching_package_import_failure_repairable(
+    monkeypatch,
+):
+    import builtins
+
+    _patch_memory_dependency_status_shell(monkeypatch)
+    real_import = builtins.__import__
+
+    def block_memory_artifact(name, *args, **kwargs):
+        if name == "avibe_memory.artifact":
+            raise ImportError("broken optional package")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", block_memory_artifact)
+
+    by_id = {
+        item["id"]: item
+        for item in api.dependencies_status()["deps"]
+    }
+
+    assert by_id["memory-package"] == {
+        "id": "memory-package",
+        "kind": "runtime",
+        "required": True,
+        "installed": True,
+        "version": "3.0.14",
+        "latest_version": "3.0.14",
+        "has_update": True,
+        "status": "error",
+        "reason": "memory_package_import_unavailable",
+    }
+
+
+def test_dependencies_status_keeps_importable_package_ready_when_runtime_probe_fails(
+    monkeypatch,
+):
+    import avibe_memory.artifact as memory_artifact
+
+    _patch_memory_dependency_status_shell(monkeypatch)
+    monkeypatch.setattr(
+        memory_artifact,
+        "get_memory_artifact_manager",
+        lambda: (_ for _ in ()).throw(RuntimeError("EverOS status failed")),
+    )
+
+    by_id = {
+        item["id"]: item
+        for item in api.dependencies_status()["deps"]
+    }
+
+    assert by_id["memory-package"]["status"] == "ready"
+    assert by_id["memory-package"]["reason"] is None
+    assert by_id["memory-runtime"]["status"] == "error"
+    assert by_id["memory-runtime"]["reason"] == "memory_runtime_install_failed"
 
 
 def test_source_version_does_not_advertise_python_package_repair(monkeypatch):
@@ -1475,21 +1610,39 @@ def test_memory_runtime_dependency_job_preserves_controller_closed_error(monkeyp
 
 def test_memory_package_dependency_job_uses_current_release_plan(monkeypatch):
     plan = SimpleNamespace(command=["repair"], rollback_to=None)
+    repair_rollback_to = object()
     calls: dict[str, object] = {}
+    order: list[str] = []
 
     monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/bin/vibe")
+
+    def capture_rollback_target():
+        order.append("rollback_target")
+        return repair_rollback_to
+
+    def build_plan(**kwargs):
+        order.append("plan")
+        calls["plan"] = kwargs
+        return plan
+
+    def execute_plan(actual, **kwargs):
+        order.append("execute")
+        calls["execute"] = (actual, kwargs)
+        return subprocess.CompletedProcess(
+            ["repair"],
+            0,
+            stdout="installed",
+            stderr="",
+        )
+
+    monkeypatch.setattr(api, "rollback_target", capture_rollback_target)
     monkeypatch.setattr(
         api,
         "build_memory_package_repair_plan",
-        lambda **kwargs: calls.setdefault("plan", kwargs) and plan,
+        build_plan,
     )
     monkeypatch.setattr(api, "get_safe_cwd", lambda: "/safe")
-    monkeypatch.setattr(
-        api,
-        "execute_upgrade_plan",
-        lambda actual, **kwargs: calls.setdefault("execute", (actual, kwargs))
-        and subprocess.CompletedProcess(["repair"], 0, stdout="installed", stderr=""),
-    )
+    monkeypatch.setattr(api, "execute_upgrade_plan", execute_plan)
     monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
     monkeypatch.setattr(
         api,
@@ -1502,12 +1655,41 @@ def test_memory_package_dependency_job_uses_current_release_plan(monkeypatch):
     assert result["ok"] is True
     assert result["message"] == "memory_package_ready"
     assert result["restarting"] is True
+    assert order == ["rollback_target", "plan", "execute"]
     assert calls["plan"] == {"vibe_path": "/bin/vibe"}
     assert calls["restart"] == {
         "delay_seconds": 2.0,
         "vibe_path": "/bin/vibe",
         "trigger": "memory_package_repair",
         "prepare_show_runtime": False,
+        "rollback_to": repair_rollback_to,
+    }
+
+
+def test_memory_package_dependency_job_fails_before_install_without_rollback_target(
+    monkeypatch,
+):
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/bin/vibe")
+    monkeypatch.setattr(api, "rollback_target", lambda: None)
+    monkeypatch.setattr(
+        api,
+        "build_memory_package_repair_plan",
+        lambda **_: pytest.fail("a repair without rollback must not build an install plan"),
+    )
+    monkeypatch.setattr(
+        api,
+        "execute_upgrade_plan",
+        lambda *_args, **_kwargs: pytest.fail("a repair without rollback must not install"),
+    )
+
+    result = api._prepare_memory_package_job()
+
+    assert result == {
+        "ok": False,
+        "message": "memory_package_repair_unavailable",
+        "output": "The running installation has no published rollback target",
+        "reason": "memory_package_repair_unavailable",
+        "restarting": False,
     }
 
 
@@ -1690,6 +1872,82 @@ def test_startup_show_page_prewarm_limit_env(monkeypatch):
 
 def test_start_dependency_install_job_rejects_unknown():
     assert api.start_dependency_install_job("bogus")["ok"] is False
+
+
+def test_dependency_install_job_returns_live_state_unchanged(monkeypatch):
+    live = {
+        "ok": True,
+        "job_id": "job-live",
+        "backend": "memory-package",
+        "status": "running",
+    }
+    monkeypatch.setattr(api, "get_agent_install_job", lambda *_args, **_kwargs: live)
+    monkeypatch.setattr(
+        api,
+        "dependencies_status",
+        lambda **_: pytest.fail("a live job must not be reconstructed from state"),
+    )
+
+    assert api.get_dependency_install_job("memory-package", "job-live") is live
+
+
+def test_dependency_install_job_recovers_ready_memory_package(monkeypatch):
+    monkeypatch.setattr(
+        api,
+        "get_agent_install_job",
+        lambda *_args, **_kwargs: {"ok": False, "error": "job_not_found"},
+    )
+    monkeypatch.setattr(
+        api,
+        "dependencies_status",
+        lambda **kwargs: {
+            "ok": True,
+            "offline": kwargs["offline"],
+            "deps": [{"id": "memory-package", "status": "ready"}],
+        },
+    )
+
+    assert api.get_dependency_install_job("memory-package", "job-restarted") == {
+        "ok": True,
+        "job_id": "job-restarted",
+        "backend": "memory-package",
+        "status": "succeeded",
+        "message": "memory_package_ready",
+        "recovered": True,
+    }
+
+
+def test_dependency_install_job_keeps_missing_memory_repair_not_found(monkeypatch):
+    missing = {"ok": False, "error": "job_not_found"}
+    monkeypatch.setattr(api, "get_agent_install_job", lambda *_args, **_kwargs: missing)
+    monkeypatch.setattr(
+        api,
+        "dependencies_status",
+        lambda **_: {
+            "ok": True,
+            "deps": [
+                {
+                    "id": "memory-package",
+                    "status": "error",
+                    "reason": "memory_package_import_unavailable",
+                }
+            ],
+        },
+    )
+
+    assert api.get_dependency_install_job("memory-package", "job-failed") is missing
+
+
+def test_dependency_install_job_does_not_recover_unrelated_dependency(monkeypatch):
+    missing = {"ok": False, "error": "job_not_found"}
+    monkeypatch.setattr(api, "get_agent_install_job", lambda *_args, **_kwargs: missing)
+    monkeypatch.setattr(
+        api,
+        "dependencies_status",
+        lambda **_: pytest.fail("unrelated dependency polling stays unchanged"),
+    )
+
+    assert api.get_dependency_install_job("askill", "job-gone") is missing
 
 
 def test_prepare_show_runtime_job_surfaces_retry_diagnostics(monkeypatch):

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -1452,12 +1452,33 @@ def test_dependencies_status_marks_matching_package_import_failure_repairable(
     }
 
 
-def test_dependencies_status_keeps_importable_package_ready_when_runtime_probe_fails(
+def test_dependencies_status_marks_broken_memory_runtime_contract_repairable(
+    monkeypatch,
+):
+    _patch_memory_dependency_status_shell(monkeypatch)
+    monkeypatch.setattr(
+        api,
+        "probe_memory_runtime_entrypoint",
+        Mock(side_effect=RuntimeError("broken Memory runtime entrypoint")),
+    )
+
+    by_id = {
+        item["id"]: item
+        for item in api.dependencies_status()["deps"]
+    }
+
+    assert by_id["memory-package"]["status"] == "error"
+    assert by_id["memory-package"]["reason"] == "memory_package_import_unavailable"
+
+
+def test_dependencies_status_keeps_valid_package_ready_when_everos_status_fails(
     monkeypatch,
 ):
     import avibe_memory.artifact as memory_artifact
 
     _patch_memory_dependency_status_shell(monkeypatch)
+    runtime_probe = Mock()
+    monkeypatch.setattr(api, "probe_memory_runtime_entrypoint", runtime_probe)
     monkeypatch.setattr(
         memory_artifact,
         "get_memory_artifact_manager",
@@ -1473,6 +1494,7 @@ def test_dependencies_status_keeps_importable_package_ready_when_runtime_probe_f
     assert by_id["memory-package"]["reason"] is None
     assert by_id["memory-runtime"]["status"] == "error"
     assert by_id["memory-runtime"]["reason"] == "memory_runtime_install_failed"
+    runtime_probe.assert_called_once_with()
 
 
 def test_source_version_does_not_advertise_python_package_repair(monkeypatch):

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -1168,6 +1168,9 @@ def test_dependencies_status_shape(monkeypatch):
         "avault_status",
         lambda: {"id": "avault", "installed": True, "version": "0.0.1", "status": "ready", "path": "/x/avault"},
     )
+    monkeypatch.setattr(api, "memory_package_installed", lambda: False)
+    monkeypatch.setattr(api, "installed_memory_package_version", lambda: None)
+    monkeypatch.setattr(api, "memory_package_repair_supported", lambda: True)
     import core.show_runtime as srt_mod
 
     class _Mgr:
@@ -1198,7 +1201,7 @@ def test_dependencies_status_shape(monkeypatch):
     out = api.dependencies_status()
     assert out["ok"]
     by = {d["id"]: d for d in out["deps"]}
-    assert list(by) == ["askill", "avault", "show-runtime", "memory-runtime", "tmux", "node"]
+    assert list(by) == ["askill", "avault", "show-runtime", "memory-package", "memory-runtime", "tmux", "node"]
     assert "tmux" in by and by["tmux"]["required"] is False  # tmux is the optional terminal backend
     assert by["askill"]["status"] == "ready" and by["askill"]["version"] == "0.1.13" and by["askill"]["required"]
     assert by["askill"]["latest_version"] is None and by["askill"]["has_update"] is False
@@ -1207,6 +1210,17 @@ def test_dependencies_status_shape(monkeypatch):
     assert by["show-runtime"]["installed"] and by["show-runtime"]["version"] == "1.4.0"
     assert by["show-runtime"]["latest_version"] == "1.4.0"
     assert by["show-runtime"]["has_update"] is False
+    assert by["memory-package"] == {
+        "id": "memory-package",
+        "kind": "runtime",
+        "required": True,
+        "installed": False,
+        "version": None,
+        "latest_version": None,
+        "has_update": False,
+        "status": "missing",
+        "reason": "memory_package_missing",
+    }
     assert by["memory-runtime"] == {
         "id": "memory-runtime",
         "kind": "runtime",
@@ -1221,6 +1235,19 @@ def test_dependencies_status_shape(monkeypatch):
         "download_error": None,
     }
     assert by["node"]["installed"] and by["node"]["version"] == "20.11"
+
+
+def test_source_version_does_not_advertise_python_package_repair(monkeypatch):
+    monkeypatch.setattr(api, "memory_package_repair_supported", lambda: False)
+    monkeypatch.setattr(
+        api,
+        "memory_package_installed",
+        lambda: pytest.fail("an unsupported source build must not inspect package repair state"),
+    )
+
+    deps = api.dependencies_status(offline=True)["deps"]
+
+    assert all(dependency["id"] != "memory-package" for dependency in deps)
 
 
 @pytest.mark.parametrize(
@@ -1340,6 +1367,44 @@ def test_memory_runtime_dependency_job_preserves_controller_closed_error(monkeyp
         "output": None,
         "reason": "memory_runtime_missing",
         "download_error": None,
+    }
+
+
+def test_memory_package_dependency_job_uses_current_release_plan(monkeypatch):
+    plan = SimpleNamespace(command=["repair"], rollback_to=None)
+    calls: dict[str, object] = {}
+
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/bin/vibe")
+    monkeypatch.setattr(
+        api,
+        "build_memory_package_repair_plan",
+        lambda **kwargs: calls.setdefault("plan", kwargs) and plan,
+    )
+    monkeypatch.setattr(api, "get_safe_cwd", lambda: "/safe")
+    monkeypatch.setattr(
+        api,
+        "execute_upgrade_plan",
+        lambda actual, **kwargs: calls.setdefault("execute", (actual, kwargs))
+        and subprocess.CompletedProcess(["repair"], 0, stdout="installed", stderr=""),
+    )
+    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
+    monkeypatch.setattr(
+        api,
+        "schedule_restart",
+        lambda **kwargs: calls.setdefault("restart", kwargs) or {"ok": True},
+    )
+
+    result = api._prepare_memory_package_job()
+
+    assert result["ok"] is True
+    assert result["message"] == "memory_package_ready"
+    assert result["restarting"] is True
+    assert calls["plan"] == {"vibe_path": "/bin/vibe"}
+    assert calls["restart"] == {
+        "delay_seconds": 2.0,
+        "vibe_path": "/bin/vibe",
+        "trigger": "memory_package_repair",
+        "prepare_show_runtime": False,
     }
 
 

--- a/tests/test_memory_loader.py
+++ b/tests/test_memory_loader.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from core.memory_loader import load_memory_runtime
+from core.memory_loader import load_memory_runtime, probe_memory_runtime_entrypoint
 from vibe.memory_contract import (
     MemoryPluginIncompatibleError,
     MemoryPluginUnavailableError,
@@ -39,6 +39,21 @@ def test_loader_maps_missing_implementation_to_unavailable(monkeypatch: pytest.M
         load_memory_runtime(_config())
 
 
+def test_entrypoint_probe_maps_missing_implementation_to_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import core.memory_loader
+
+    monkeypatch.setattr(
+        core.memory_loader.importlib,
+        "import_module",
+        Mock(side_effect=ModuleNotFoundError("optional package missing")),
+    )
+
+    with pytest.raises(MemoryPluginUnavailableError):
+        probe_memory_runtime_entrypoint()
+
+
 def test_loader_rejects_protocol_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
     import core.memory_loader
 
@@ -50,6 +65,67 @@ def test_loader_rejects_protocol_mismatch(monkeypatch: pytest.MonkeyPatch) -> No
 
     with pytest.raises(MemoryPluginIncompatibleError):
         load_memory_runtime(_config())
+
+
+def test_entrypoint_probe_rejects_protocol_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    import core.memory_loader
+
+    monkeypatch.setattr(
+        core.memory_loader.importlib,
+        "import_module",
+        Mock(
+            return_value=SimpleNamespace(
+                MEMORY_RUNTIME_PROTOCOL_VERSION=99,
+                create_memory_runtime=Mock(),
+            )
+        ),
+    )
+
+    with pytest.raises(MemoryPluginIncompatibleError):
+        probe_memory_runtime_entrypoint()
+
+
+@pytest.mark.parametrize("factory", (None, object()))
+def test_entrypoint_probe_rejects_missing_or_noncallable_factory(
+    monkeypatch: pytest.MonkeyPatch,
+    factory: object,
+) -> None:
+    import core.memory_loader
+
+    monkeypatch.setattr(
+        core.memory_loader.importlib,
+        "import_module",
+        Mock(
+            return_value=SimpleNamespace(
+                MEMORY_RUNTIME_PROTOCOL_VERSION=1,
+                create_memory_runtime=factory,
+            )
+        ),
+    )
+
+    with pytest.raises(MemoryPluginUnavailableError):
+        probe_memory_runtime_entrypoint()
+
+
+def test_entrypoint_probe_validates_contract_without_constructing_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import core.memory_loader
+
+    factory = Mock(side_effect=AssertionError("the contract probe constructed Memory"))
+    monkeypatch.setattr(
+        core.memory_loader.importlib,
+        "import_module",
+        Mock(
+            return_value=SimpleNamespace(
+                MEMORY_RUNTIME_PROTOCOL_VERSION=1,
+                create_memory_runtime=factory,
+            )
+        ),
+    )
+
+    assert probe_memory_runtime_entrypoint() is None
+    factory.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_memory_upgrade_packaged.py
+++ b/tests/test_memory_upgrade_packaged.py
@@ -15,7 +15,12 @@ from pathlib import Path
 import pytest
 
 from vibe import restart_supervisor, runtime
-from vibe.upgrade import RollbackTarget, build_upgrade_plan, execute_upgrade_plan
+from vibe.upgrade import (
+    RollbackTarget,
+    build_memory_package_repair_plan,
+    build_upgrade_plan,
+    execute_upgrade_plan,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -258,6 +263,38 @@ def test_packaged_core_only_upgrade_preserves_core_only_shape(
     versions = _installed_versions(python)
     assert versions["avibe-os"] == "3.0.15"
     assert "avibe-memory" not in versions
+
+
+@pytest.mark.integration
+def test_packaged_settings_repair_adds_memory_without_changing_core(
+    tmp_path: Path, packaged_dependency_seed: Path
+) -> None:
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    _build_release_wheels("3.0.14", wheelhouse)
+    python = _venv(tmp_path / "core-only-repair-venv")
+    _install_initial(python, wheelhouse, memory=False, dependency_seed=packaged_dependency_seed)
+    assert _installed_versions(python)["avibe-os"] == "3.0.14"
+    assert "avibe-memory" not in _installed_versions(python)
+
+    plan = build_memory_package_repair_plan(
+        current_version="3.0.14",
+        python_executable=str(python),
+        base_env=_plan_env(wheelhouse),
+    )
+    result = execute_upgrade_plan(
+        plan,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=600,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    repaired = _installed_versions(python)
+    assert repaired["avibe-os"] == "3.0.14"
+    assert repaired["avibe-memory"] == "3.0.14"
 
 
 @pytest.mark.integration

--- a/tests/test_memory_upgrade_packaged.py
+++ b/tests/test_memory_upgrade_packaged.py
@@ -266,7 +266,7 @@ def test_packaged_core_only_upgrade_preserves_core_only_shape(
 
 
 @pytest.mark.integration
-def test_packaged_settings_repair_adds_memory_without_changing_core(
+def test_memory_indep_018_packaged_settings_repair_adds_memory_without_changing_core(
     tmp_path: Path, packaged_dependency_seed: Path
 ) -> None:
     wheelhouse = tmp_path / "wheelhouse"

--- a/tests/test_ui_server_install.py
+++ b/tests/test_ui_server_install.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import threading
 import time
 
+import pytest
+
 from config.v2_config import AgentsConfig, RuntimeConfig, SlackConfig, UiConfig, V2Config
 from vibe import api
 from vibe.ui_server import app
@@ -170,6 +172,63 @@ def test_dependency_install_route_allows_memory_package(monkeypatch, tmp_path):
 
     assert response.status_code == 200
     assert response.get_json()["backend"] == "memory-package"
+
+
+@pytest.mark.parametrize(
+    ("dep", "result", "expected_status"),
+    (
+        pytest.param(
+            "memory-package",
+            {
+                "ok": True,
+                "job_id": "job-restarted",
+                "backend": "memory-package",
+                "status": "succeeded",
+                "message": "memory_package_ready",
+                "recovered": True,
+            },
+            200,
+            id="recovered-memory-package",
+        ),
+        pytest.param(
+            "memory-package",
+            {"ok": False, "error": "job_not_found"},
+            404,
+            id="non-ready-memory-package",
+        ),
+        pytest.param(
+            "askill",
+            {"ok": False, "error": "job_not_found"},
+            404,
+            id="unrelated-dependency",
+        ),
+    ),
+)
+def test_dependency_install_status_uses_state_aware_poller(
+    monkeypatch,
+    tmp_path,
+    dep,
+    result,
+    expected_status,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        api,
+        "get_dependency_install_job",
+        lambda actual_dep, job_id: calls.append((actual_dep, job_id)) or result,
+    )
+
+    client = app.test_client()
+    response = client.get(
+        f"/api/dependencies/{dep}/install/job-restarted",
+        headers=csrf_headers(client, "http://127.0.0.1:15131"),
+        base_url="http://127.0.0.1:15131",
+    )
+
+    assert response.status_code == expected_status
+    assert response.get_json() == result
+    assert calls == [(dep, "job-restarted")]
 
 
 def test_install_job_fails_when_runtime_refresh_fails(monkeypatch):

--- a/tests/test_ui_server_install.py
+++ b/tests/test_ui_server_install.py
@@ -153,6 +153,25 @@ def test_dependency_install_route_allows_memory_runtime(monkeypatch, tmp_path):
     assert response.get_json()["backend"] == "memory-runtime"
 
 
+def test_dependency_install_route_allows_memory_package(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        api,
+        "start_dependency_install_job",
+        lambda dep: {"ok": True, "job_id": "job-memory-package", "backend": dep, "status": "running"},
+    )
+
+    client = app.test_client()
+    response = client.post(
+        "/api/dependencies/memory-package/install",
+        headers=csrf_headers(client, "http://127.0.0.1:15131"),
+        base_url="http://127.0.0.1:15131",
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["backend"] == "memory-package"
+
+
 def test_install_job_fails_when_runtime_refresh_fails(monkeypatch):
     monkeypatch.setattr(api, "is_agent_backend", lambda name: name == "codex")
     monkeypatch.setattr(api, "supports_runtime_refresh", lambda name: name == "codex")

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -545,8 +545,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SHIPPED_SOURCE_ROOTS = ("main.py", "config", "core", "modules", "storage", "vibe")
 
 
-def test_only_the_plan_builder_can_ask_what_this_install_is():
-    """One caller, found by looking rather than by remembering.
+def test_only_pre_mutation_owners_can_ask_what_this_install_is():
+    """Two exact callers, found by looking rather than by remembering.
 
     The measurement has always been documented as something to take before the
     install and never after, and both upgrade paths took it after anyway --
@@ -554,11 +554,12 @@ def test_only_the_plan_builder_can_ask_what_this_install_is():
     already been overwritten. A rule that lives in a docstring is enforced by
     whoever happens to have read it.
 
-    Moving it into `UpgradePlan` removes the ordering from every caller: a plan
-    is what produces the command, so the measurement cannot happen later than the
-    install unless someone reaches past the plan. This counts over the whole
-    shipped tree so that reaching past it fails here, when it is written, rather
-    than on a machine that predates the rename months later.
+    The general forward-upgrade owner remains `build_upgrade_plan`, which captures
+    the target before it produces the mutating command. The explicit Settings
+    package-repair owner is `_prepare_memory_package_job`, which must capture its
+    repair-local rollback target before it executes the pinned repair plan. This
+    counts both exact owners over the whole shipped tree so any third caller or
+    count drift fails here, when it is written, rather than on a user's machine.
     """
 
     callers = {}
@@ -575,7 +576,7 @@ def test_only_the_plan_builder_can_ask_what_this_install_is():
             if calls:
                 callers[source.relative_to(REPO_ROOT).as_posix()] = calls
 
-    assert callers == {"vibe/upgrade.py": 1}
+    assert callers == {"vibe/api.py": 1, "vibe/upgrade.py": 1}
 
 
 def test_the_plan_that_installs_carries_what_it_is_replacing(monkeypatch):

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -29,6 +29,7 @@ from vibe.upgrade import (
     get_safe_cwd,
     installed_package_name,
     memory_package_repair_supported,
+    MemoryRollbackTargetUnavailableError,
     pinned_package_spec,
     RollbackTarget,
     rollback_target,
@@ -538,6 +539,45 @@ def test_a_tree_with_no_published_release_has_no_rollback_target(monkeypatch):
     monkeypatch.setattr("vibe.upgrade.installed_package_name", lambda *args, **kwargs: "vibe-remote")
     monkeypatch.setattr("vibe.runtime.current_service_launcher", lambda: launcher)
     assert rollback_target() == RollbackTarget(version="3.0.10", package="vibe-remote", launcher=launcher)
+
+
+@pytest.mark.parametrize("memory_version", (None, "not-a-version"))
+def test_rollback_target_rejects_memory_without_a_publishable_version(
+    monkeypatch,
+    memory_version,
+):
+    monkeypatch.setattr("vibe.__version__", "3.0.10", raising=False)
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: True)
+    monkeypatch.setattr(
+        "vibe.upgrade.installed_memory_package_version",
+        lambda: memory_version,
+    )
+
+    with pytest.raises(MemoryRollbackTargetUnavailableError):
+        rollback_target()
+
+
+def test_rollback_target_carries_an_exact_memory_package_shape(monkeypatch):
+    launcher = ServiceLauncher(
+        python="/uv/tools/avibe-os/bin/python",
+        main="/uv/tools/avibe-os/service_main.py",
+    )
+    monkeypatch.setattr("vibe.__version__", "3.0.10", raising=False)
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: True)
+    monkeypatch.setattr(
+        "vibe.upgrade.installed_memory_package_version",
+        lambda: "3.0.10",
+    )
+    monkeypatch.setattr("vibe.upgrade.installed_package_name", lambda: "avibe-os")
+    monkeypatch.setattr("vibe.runtime.current_service_launcher", lambda: launcher)
+
+    assert rollback_target() == RollbackTarget(
+        version="3.0.10",
+        package="avibe-os",
+        launcher=launcher,
+        memory_package=True,
+        memory_version="3.0.10",
+    )
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -1797,7 +1797,12 @@ def test_pip_preflight_does_not_fallback_on_resolver_failure():
 @pytest.mark.parametrize("memory_installed", [False, True])
 def test_unreadable_memory_config_preserves_only_an_installed_package(monkeypatch, memory_installed):
     monkeypatch.setattr("config.v2_config.V2Config.load", lambda: (_ for _ in ()).throw(ValueError("bad config")))
+    monkeypatch.setattr("vibe.__version__", "3.0.14", raising=False)
     monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: memory_installed)
+    monkeypatch.setattr(
+        "vibe.upgrade.installed_memory_package_version",
+        lambda: "3.0.14" if memory_installed else None,
+    )
     monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
     monkeypatch.setattr("vibe.upgrade.installed_metadata_describes_running_code", lambda: True)
 

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -1021,6 +1021,30 @@ def test_do_upgrade_uses_upgrade_plan_env_and_restarts(monkeypatch):
     }
 
 
+def test_do_upgrade_blocks_when_memory_rollback_metadata_is_unreadable(monkeypatch):
+    message = "The installed avibe-memory version cannot be determined for safe rollback"
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(api, "get_version_info", lambda: {"latest": "3.0.15"})
+    monkeypatch.setattr(
+        api,
+        "build_upgrade_plan",
+        lambda **kwargs: (_ for _ in ()).throw(MemoryRollbackTargetUnavailableError(message)),
+    )
+    monkeypatch.setattr(
+        api,
+        "execute_upgrade_plan",
+        lambda *args, **kwargs: pytest.fail("upgrade must not mutate without an exact rollback target"),
+    )
+
+    assert api.do_upgrade(auto_restart=True) == {
+        "ok": False,
+        "message": "memory_package_metadata_unreadable",
+        "output": message,
+        "reason": "memory_package_metadata_unreadable",
+        "restarting": False,
+    }
+
+
 def test_do_upgrade_auto_restart_does_not_block_on_runtime_prepare(monkeypatch):
     plan = UpgradePlan(
         command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
@@ -1276,6 +1300,27 @@ def test_cmd_upgrade_uses_upgrade_plan_env(monkeypatch):
         # See the do_upgrade case: the restart is handed the install to fall back to.
         "rollback_to": LEGACY_INSTALL,
     }
+
+
+def test_cmd_upgrade_blocks_when_memory_rollback_metadata_is_unreadable(monkeypatch, capsys):
+    message = "The installed avibe-memory version cannot be determined for safe rollback"
+    monkeypatch.setattr(cli, "get_latest_version", lambda: {"error": None, "has_update": True, "latest": "3.0.15"})
+    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(
+        cli,
+        "build_upgrade_plan",
+        lambda **kwargs: (_ for _ in ()).throw(MemoryRollbackTargetUnavailableError(message)),
+    )
+    monkeypatch.setattr(
+        cli,
+        "execute_upgrade_plan",
+        lambda *args, **kwargs: pytest.fail("upgrade must not mutate without an exact rollback target"),
+    )
+
+    assert cli.cmd_upgrade() == 1
+    output = capsys.readouterr().out
+    assert f"Upgrade failed: {message}" in output
+    assert "Traceback" not in output
 
 
 def test_cmd_upgrade_running_runtime_honors_show_runtime_skip_for_restart(monkeypatch):

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -15,6 +15,7 @@ from vibe import api, cli
 from vibe.runtime import ServiceLauncher
 from vibe.upgrade import (
     UpgradePlan,
+    build_memory_package_repair_plan,
     build_upgrade_plan,
     configured_memory_enabled,
     has_newer_version,
@@ -27,6 +28,7 @@ from vibe.upgrade import (
     get_running_vibe_path,
     get_safe_cwd,
     installed_package_name,
+    memory_package_repair_supported,
     pinned_package_spec,
     RollbackTarget,
     rollback_target,
@@ -101,6 +103,80 @@ def test_build_upgrade_plan_uses_pip_for_non_uv_install():
     assert plan.method == "pip"
     assert plan.command == ["/usr/bin/python3", "-m", "pip", "install", "--upgrade", "avibe-os"]
     assert plan.env == {"PATH": "/usr/bin"}
+
+
+def test_memory_package_repair_plan_pins_the_running_release_for_pip(monkeypatch):
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
+
+    plan = build_memory_package_repair_plan(
+        current_version="3.0.14",
+        python_executable="/usr/bin/python3",
+        base_env={"PATH": "/usr/bin"},
+    )
+
+    assert plan.command == [
+        "/usr/bin/python3",
+        "-m",
+        "pip",
+        "install",
+        "--force-reinstall",
+        "avibe-os[memory]==3.0.14",
+        "avibe-memory==3.0.14",
+    ]
+    assert plan.preflight_command == [
+        "/usr/bin/python3",
+        "-m",
+        "pip",
+        "download",
+        "--dest",
+        "{avibe-pip-download-destination}",
+        "--no-deps",
+        "avibe-os[memory]==3.0.14",
+        "avibe-memory==3.0.14",
+    ]
+    assert plan.rollback_to is None
+
+
+def test_memory_package_repair_plan_pins_the_running_release_for_uv(monkeypatch):
+    monkeypatch.setattr("vibe.upgrade.is_uv_tool_install", lambda executable: True)
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: "/usr/bin/uv")
+    monkeypatch.setattr("vibe.upgrade.get_current_vibe_bin_dir", lambda vibe_path: "/custom/bin")
+
+    plan = build_memory_package_repair_plan(
+        current_version="3.0.14",
+        python_executable="/tools/avibe-os/bin/python",
+        vibe_path="/custom/bin/vibe",
+        base_env={"PATH": "/usr/bin"},
+    )
+
+    assert plan.command == [
+        "/usr/bin/uv",
+        "tool",
+        "install",
+        "avibe-os[memory]==3.0.14",
+        "--with",
+        "avibe-memory==3.0.14",
+        "--force",
+    ]
+    assert plan.env is not None
+    assert plan.env["UV_TOOL_BIN_DIR"] == "/custom/bin"
+    assert plan.rollback_to is None
+
+
+@pytest.mark.parametrize("current_version", ["0.0.0.dev0", "3.0.14.dev1", "not-a-version"])
+def test_memory_package_repair_plan_rejects_unpublished_source_versions(current_version):
+    with pytest.raises(ValueError, match="published split-package release"):
+        build_memory_package_repair_plan(current_version=current_version)
+
+
+@pytest.mark.parametrize(
+    ("current_version", "expected"),
+    [("3.0.13", False), ("3.0.14.dev1", False), ("3.0.14", True)],
+)
+def test_memory_package_repair_support_starts_at_the_first_split_release(
+    current_version, expected
+):
+    assert memory_package_repair_supported(current_version) is expected
 
 
 def test_build_upgrade_plan_uses_env_package_spec(monkeypatch):

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -1871,6 +1871,13 @@ def test_managed_dependencies_doctor_uses_one_status_contract(monkeypatch):
                 {"id": "askill", "required": True, "installed": False, "status": "missing"},
                 {"id": "avault", "required": True, "installed": True, "status": "ready", "version": "0.1.6"},
                 {"id": "show-runtime", "required": True, "installed": False, "status": "missing"},
+                {
+                    "id": "memory-package",
+                    "required": True,
+                    "installed": True,
+                    "status": "ready",
+                    "version": "3.2.8",
+                },
                 {"id": "tmux", "required": False, "installed": False, "status": "missing"},
                 {"id": "git-runtime", "required": False, "installed": True, "status": "ready"},
                 {"id": "node", "required": True, "installed": False, "status": "missing"},
@@ -1886,8 +1893,75 @@ def test_managed_dependencies_doctor_uses_one_status_contract(monkeypatch):
     assert next(item for item in items if item.get("code") == "dependencies.askill.not_ready")["repair"]["target"] == "askill"
     assert next(item for item in items if item.get("code") == "dependencies.avault.ready")["status"] == "pass"
     assert next(item for item in items if item.get("code") == "dependencies.git-runtime.ready")["status"] == "pass"
+    memory_package = next(
+        item for item in items if item.get("code") == "dependencies.memory-package.ready"
+    )
+    assert memory_package["status"] == "pass"
+    assert "avibe-memory 3.2.8" in memory_package["message"]
     assert next(item for item in items if item.get("code") == "dependencies.tmux.not_ready")["status"] == "warn"
     assert next(item for item in items if item.get("code") == "dependencies.node.not_ready")["status"] == "fail"
+
+
+def test_managed_dependencies_doctor_directs_memory_package_repair_to_settings(monkeypatch):
+    monkeypatch.setattr(
+        cli.api,
+        "dependencies_status",
+        lambda **_kwargs: {
+            "deps": [
+                {
+                    "id": "memory-package",
+                    "required": True,
+                    "installed": True,
+                    "status": "error",
+                    "reason": "memory_package_version_mismatch",
+                },
+                {"id": "git-runtime", "required": False, "installed": True, "status": "ready"},
+            ]
+        },
+    )
+    monkeypatch.setattr(cli, "_configured_cli_language", lambda: "en")
+
+    items = cli._managed_dependencies_doctor_items(deep=False)
+
+    failure = next(
+        item for item in items if item.get("code") == "dependencies.memory-package.not_ready"
+    )
+    assert failure["status"] == "fail"
+    assert failure["action"] == cli.i18n_t("runtime.doctor.memoryPackageSettingsAction", "en")
+    assert "repair" not in failure
+
+
+def test_managed_dependencies_doctor_deep_does_not_probe_memory_package(monkeypatch):
+    monkeypatch.setattr(
+        cli.api,
+        "dependencies_status",
+        lambda **_kwargs: {
+            "deps": [
+                {
+                    "id": "memory-package",
+                    "required": False,
+                    "installed": False,
+                    "status": "missing",
+                },
+                {"id": "git-runtime", "required": False, "installed": True, "status": "ready"},
+            ]
+        },
+    )
+    monkeypatch.setattr(cli, "_configured_cli_language", lambda: "en")
+    monkeypatch.setattr(
+        "core.dependency_network.probe_url",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("memory-package must not use a network probe")
+        ),
+    )
+
+    items = cli._managed_dependencies_doctor_items(deep=True)
+
+    failure = next(
+        item for item in items if item.get("code") == "dependencies.memory-package.not_ready"
+    )
+    assert failure["status"] == "warn"
+    assert "repair" not in failure
 
 
 def test_managed_dependencies_doctor_suppresses_unsupported_askill_repair(monkeypatch):

--- a/ui/src/components/settings/SettingsDependenciesPage.logic.ts
+++ b/ui/src/components/settings/SettingsDependenciesPage.logic.ts
@@ -1,10 +1,21 @@
 import type { DependencyItem, MemoryStatusResult } from '@/context/ApiContext';
 
-const INSTALLABLE_DEPENDENCIES = new Set(['askill', 'avault', 'show-runtime', 'memory-runtime', 'tmux']);
+const INSTALLABLE_DEPENDENCIES = new Set([
+  'askill',
+  'avault',
+  'show-runtime',
+  'memory-package',
+  'memory-runtime',
+  'tmux',
+]);
 
 export const dependencyHasInstallAction = (
   dependency: Pick<DependencyItem, 'id' | 'status'>,
-): boolean => dependency.status !== 'unsupported' && INSTALLABLE_DEPENDENCIES.has(dependency.id);
+): boolean => (
+  dependency.status !== 'unsupported'
+  && !(dependency.id === 'memory-package' && dependency.status === 'ready')
+  && INSTALLABLE_DEPENDENCIES.has(dependency.id)
+);
 
 /** Treat any active or uncertain runtime as unsafe for dependency replacement. */
 export const memoryRuntimeSidecarRunning = (

--- a/ui/src/components/settings/SettingsDependenciesPage.test.ts
+++ b/ui/src/components/settings/SettingsDependenciesPage.test.ts
@@ -8,9 +8,14 @@ describe('dependencyHasInstallAction', () => {
   });
 
   it('keeps supported dependency actions unchanged', () => {
+    expect(dependencyHasInstallAction({ id: 'memory-package', status: 'missing' })).toBe(true);
     expect(dependencyHasInstallAction({ id: 'memory-runtime', status: 'missing' })).toBe(true);
     expect(dependencyHasInstallAction({ id: 'show-runtime', status: 'ready' })).toBe(true);
     expect(dependencyHasInstallAction({ id: 'node', status: 'missing' })).toBe(false);
+  });
+
+  it('does not offer a healthy Memory Python package reinstall', () => {
+    expect(dependencyHasInstallAction({ id: 'memory-package', status: 'ready' })).toBe(false);
   });
 });
 

--- a/ui/src/components/settings/SettingsDependenciesPage.test.ts
+++ b/ui/src/components/settings/SettingsDependenciesPage.test.ts
@@ -17,6 +17,10 @@ describe('dependencyHasInstallAction', () => {
   it('does not offer a healthy Memory Python package reinstall', () => {
     expect(dependencyHasInstallAction({ id: 'memory-package', status: 'ready' })).toBe(false);
   });
+
+  it('offers repair for a mismatched Memory Python package', () => {
+    expect(dependencyHasInstallAction({ id: 'memory-package', status: 'error' })).toBe(true);
+  });
 });
 
 describe('memoryRuntimeSidecarRunning', () => {

--- a/ui/src/components/settings/SettingsDependenciesPage.test.tsx
+++ b/ui/src/components/settings/SettingsDependenciesPage.test.tsx
@@ -67,6 +67,23 @@ afterEach(() => {
 });
 
 describe('SettingsDependenciesPage Memory runtime', () => {
+  it('keeps Python distribution recovery separate from EverOS runtime repair', async () => {
+    api.listDependencies.mockResolvedValue({
+      ok: true,
+      deps: [
+        dependency({ id: 'memory-package', installed: false, status: 'missing', version: null }),
+        dependency(),
+      ],
+    });
+    renderPage();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'settings.dependencies.install' }));
+
+    await waitFor(() => expect(api.installDependency).toHaveBeenCalledWith('memory-package'));
+    expect(api.installDependency).not.toHaveBeenCalledWith('memory-runtime');
+    expect(screen.getByRole('button', { name: 'settings.dependencies.repair' })).toBeTruthy();
+  });
+
   it('shows only dependency repair and the Memory settings link', async () => {
     renderPage();
     expect(await screen.findByRole('button', { name: 'settings.dependencies.repair' })).toBeTruthy();

--- a/ui/src/components/settings/SettingsDependenciesPage.tsx
+++ b/ui/src/components/settings/SettingsDependenciesPage.tsx
@@ -40,6 +40,7 @@ const DEP_META: Record<string, DepMeta> = {
   askill: { icon: WandSparkles, tileCls: 'bg-mint-soft', iconCls: 'text-mint-ink' },
   avault: { icon: KeyRound, tileCls: 'bg-gold-soft', iconCls: 'text-gold-ink' },
   'show-runtime': { icon: LayoutDashboard, tileCls: 'bg-cyan-soft', iconCls: 'text-cyan-ink' },
+  'memory-package': { icon: Brain, tileCls: 'bg-gold-soft', iconCls: 'text-gold-ink' },
   'memory-runtime': { icon: Brain, tileCls: 'bg-violet-soft', iconCls: 'text-violet-ink' },
   tmux: { icon: SquareTerminal, tileCls: 'bg-surface-3', iconCls: 'text-foreground' },
   node: { icon: Hexagon, tileCls: 'bg-violet-soft', iconCls: 'text-violet-ink' },
@@ -156,8 +157,9 @@ export const SettingsDependenciesPage: React.FC = () => {
             const installing = busy === d.id;
             const showAction = dependencyHasInstallAction(d);
             const isMemoryRuntime = d.id === 'memory-runtime';
-            const sidecarRunning = isMemoryRuntime && memoryRuntimeSidecarRunning(memoryStatus);
-            const repairBlockedBySidecar = isMemoryRuntime && (!memoryStatusLoaded || sidecarRunning);
+            const isMemoryDependency = d.id === 'memory-package' || isMemoryRuntime;
+            const sidecarRunning = isMemoryDependency && memoryRuntimeSidecarRunning(memoryStatus);
+            const repairBlockedBySidecar = isMemoryDependency && (!memoryStatusLoaded || sidecarRunning);
             const dependencyOperationBusy = busy !== null;
             return (
               <SettingsResourceRow

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1772,7 +1772,7 @@
     "memory_plugin_unavailable": "The Memory implementation is unavailable.",
     "memory_plugin_incompatible": "The Memory implementation is incompatible with this Avibe version.",
     "memory_package_install_failed": "The Memory Python package failed to install.",
-    "memory_package_metadata_unreadable": "The Memory Python package metadata is unreadable.",
+    "memory_package_metadata_unreadable": "The Memory Python package version cannot be read, so repair is blocked because a safe rollback target cannot be determined.",
     "memory_package_missing": "The Memory Python package isn't installed yet.",
     "memory_package_repair_unavailable": "Memory package repair requires an installed Avibe release.",
     "memory_package_restart_required": "The Memory Python package was installed, but Avibe must be restarted manually.",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -363,6 +363,10 @@
           "label": "Node.js",
           "detail": "Shared prerequisite for the runtimes above."
         },
+        "memory-package": {
+          "label": "Memory Python package",
+          "detail": "Adds the optional Memory implementation matched to this Avibe release."
+        },
         "memory-runtime": {
           "label": "Memory runtime",
           "detail": "Runs local memory distillation and search on your machine."
@@ -1767,6 +1771,11 @@
     "memory_disabled": "Memory is disabled, or this connection can't reach it.",
     "memory_plugin_unavailable": "The Memory implementation is unavailable.",
     "memory_plugin_incompatible": "The Memory implementation is incompatible with this Avibe version.",
+    "memory_package_install_failed": "The Memory Python package failed to install.",
+    "memory_package_metadata_unreadable": "The Memory Python package metadata is unreadable.",
+    "memory_package_missing": "The Memory Python package isn't installed yet.",
+    "memory_package_repair_unavailable": "Memory package repair requires an installed Avibe release.",
+    "memory_package_restart_required": "The Memory Python package was installed, but Avibe must be restarted manually.",
     "memory_invalid_input": "That Memory request wasn't valid.",
     "memory_processing_record_entry_not_found": "That Memory processing entry is no longer available.",
     "memory_failure_history_unavailable": "Detailed Memory failure history is unavailable.",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -363,6 +363,10 @@
           "label": "Node.js",
           "detail": "上述运行时的共同前置依赖。"
         },
+        "memory-package": {
+          "label": "记忆 Python 包",
+          "detail": "安装与当前 Avibe 版本匹配的可选记忆实现。"
+        },
         "memory-runtime": {
           "label": "记忆运行时",
           "detail": "在本机运行记忆提炼与搜索。"
@@ -1767,6 +1771,11 @@
     "memory_disabled": "记忆功能已禁用，或当前连接无法访问它。",
     "memory_plugin_unavailable": "记忆实现当前不可用。",
     "memory_plugin_incompatible": "记忆实现与此 Avibe 版本不兼容。",
+    "memory_package_install_failed": "记忆 Python 包安装失败。",
+    "memory_package_metadata_unreadable": "无法读取记忆 Python 包元数据。",
+    "memory_package_missing": "记忆 Python 包尚未安装。",
+    "memory_package_repair_unavailable": "记忆包修复仅适用于已安装的 Avibe 正式版本。",
+    "memory_package_restart_required": "记忆 Python 包已安装，但需要手动重启 Avibe。",
     "memory_invalid_input": "该记忆请求无效。",
     "memory_processing_record_entry_not_found": "该记忆处理条目已不可用。",
     "memory_failure_history_unavailable": "详细的记忆失败历史记录不可用。",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1772,7 +1772,7 @@
     "memory_plugin_unavailable": "记忆实现当前不可用。",
     "memory_plugin_incompatible": "记忆实现与此 Avibe 版本不兼容。",
     "memory_package_install_failed": "记忆 Python 包安装失败。",
-    "memory_package_metadata_unreadable": "无法读取记忆 Python 包元数据。",
+    "memory_package_metadata_unreadable": "无法读取记忆 Python 包版本，因此无法确定安全回滚目标，修复操作已阻止。",
     "memory_package_missing": "记忆 Python 包尚未安装。",
     "memory_package_repair_unavailable": "记忆包修复仅适用于已安装的 Avibe 正式版本。",
     "memory_package_restart_required": "记忆 Python 包已安装，但需要手动重启 Avibe。",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -52,6 +52,7 @@ from config.v2_settings import (
 from config.v2_sessions import SessionsStore
 from config.platform_registry import get_platform_descriptor
 from core import latest_version_cache
+from core.memory_loader import probe_memory_runtime_entrypoint
 from config.memory_operation_lock import MemoryOperationBusy, MemoryOperationLease
 from vibe.opencode_config import (
     get_opencode_config_paths,
@@ -8624,11 +8625,20 @@ def dependencies_status(*, offline: bool = False) -> dict:
     ):
         from vibe import __version__
 
+        try:
+            probe_memory_runtime_entrypoint()
+            memory_runtime_contract_ready = True
+        except Exception:  # noqa: BLE001
+            memory_runtime_contract_ready = False
+
         deps.append(
             _memory_package_dependency(
                 required=memory_required,
                 current_version=__version__,
-                importable=memory_package_importable,
+                importable=(
+                    memory_package_importable
+                    and memory_runtime_contract_ready
+                ),
             )
         )
     deps.append(

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -70,6 +70,7 @@ from vibe.upgrade import (
     installed_memory_package_version,
     memory_package_installed,
     memory_package_repair_supported,
+    rollback_target,
     should_skip_show_runtime_prepare,
 )
 from vibe.restart_supervisor import schedule_restart
@@ -6894,6 +6895,40 @@ def get_agent_install_job(job_id: str | None = None, *, backend: str | None = No
         return dict(job)
 
 
+def get_dependency_install_job(dep: str, job_id: str | None) -> dict:
+    """Recover Memory repair completion from installed state after a restart."""
+
+    result = get_agent_install_job(job_id, backend=dep)
+    if result.get("error") != "job_not_found" or dep != "memory-package":
+        return result
+
+    try:
+        status = dependencies_status(offline=True)
+    except Exception:  # noqa: BLE001
+        return result
+    dependencies = status.get("deps") if isinstance(status, dict) else None
+    if not isinstance(dependencies, list):
+        return result
+    package = next(
+        (
+            item
+            for item in dependencies
+            if isinstance(item, dict) and item.get("id") == "memory-package"
+        ),
+        None,
+    )
+    if not isinstance(package, dict) or package.get("status") != "ready":
+        return result
+    return {
+        "ok": True,
+        "job_id": job_id,
+        "backend": dep,
+        "status": "succeeded",
+        "message": "memory_package_ready",
+        "recovered": True,
+    }
+
+
 def install_agent(name: str) -> dict:
     """Install (or upgrade) an agent CLI tool.
 
@@ -8417,7 +8452,43 @@ _DEFAULT_STARTUP_SHOW_PAGE_PREWARM_LIMIT = 3
 _MAX_STARTUP_SHOW_PAGE_PREWARM_LIMIT = 10
 
 
-def _memory_package_dependency(*, required: bool, current_version: str) -> dict:
+def _memory_artifact_status(*, offline: bool) -> tuple[bool, dict]:
+    """Inspect the optional package separately from its managed EverOS runtime."""
+
+    failed = {
+        "installed": False,
+        "status": "missing",
+        "manifest": None,
+        "reason": "memory_runtime_install_failed",
+    }
+    try:
+        from avibe_memory.artifact import (
+            MemoryArtifactManager,
+            get_memory_artifact_manager,
+        )
+    except Exception:  # noqa: BLE001
+        return False, failed
+
+    try:
+        manager = (
+            MemoryArtifactManager(offline=True)
+            if offline
+            else get_memory_artifact_manager()
+        )
+        status = manager.status()
+        if not isinstance(status, dict):
+            raise TypeError("Memory artifact status must be a mapping")
+        return True, status
+    except Exception:  # noqa: BLE001
+        return True, failed
+
+
+def _memory_package_dependency(
+    *,
+    required: bool,
+    current_version: str,
+    importable: bool,
+) -> dict:
     """Describe whether the optional distribution matches this Avibe release."""
 
     installed = memory_package_installed()
@@ -8450,15 +8521,23 @@ def _memory_package_dependency(*, required: bool, current_version: str) -> dict:
         matches_running_release = Version(installed_version) == Version(current_version)
     except InvalidVersion:
         matches_running_release = False
-    if matches_running_release:
-        return {**dependency, "status": "ready", "reason": None}
-    return {
-        **dependency,
-        "latest_version": current_version,
-        "has_update": True,
-        "status": "error",
-        "reason": "memory_package_version_mismatch",
-    }
+    if not matches_running_release:
+        return {
+            **dependency,
+            "latest_version": current_version,
+            "has_update": True,
+            "status": "error",
+            "reason": "memory_package_version_mismatch",
+        }
+    if not importable:
+        return {
+            **dependency,
+            "latest_version": current_version,
+            "has_update": True,
+            "status": "error",
+            "reason": "memory_package_import_unavailable",
+        }
+    return {**dependency, "status": "ready", "reason": None}
 
 
 def dependencies_status(*, offline: bool = False) -> dict:
@@ -8530,18 +8609,9 @@ def dependencies_status(*, offline: bool = False) -> dict:
         }
     )
 
-    try:
-        from avibe_memory.artifact import MemoryArtifactManager, get_memory_artifact_manager
-
-        memory_manager = MemoryArtifactManager(offline=True) if offline else get_memory_artifact_manager()
-        memory_runtime = memory_manager.status()
-    except Exception:  # noqa: BLE001
-        memory_runtime = {
-            "installed": False,
-            "status": "missing",
-            "manifest": None,
-            "reason": "memory_runtime_install_failed",
-        }
+    memory_package_importable, memory_runtime = _memory_artifact_status(
+        offline=offline
+    )
     memory_manifest = memory_runtime.get("manifest") if isinstance(memory_runtime.get("manifest"), dict) else {}
     release_state = memory_manifest.get("release_state")
     try:
@@ -8558,6 +8628,7 @@ def dependencies_status(*, offline: bool = False) -> dict:
             _memory_package_dependency(
                 required=memory_required,
                 current_version=__version__,
+                importable=memory_package_importable,
             )
         )
     deps.append(
@@ -8710,6 +8781,24 @@ def _prepare_memory_package_job() -> dict:
 
     current_vibe_path = get_running_vibe_path()
     try:
+        repair_rollback_to = rollback_target()
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "ok": False,
+            "message": "memory_package_repair_unavailable",
+            "output": str(exc),
+            "reason": "memory_package_repair_unavailable",
+            "restarting": False,
+        }
+    if repair_rollback_to is None:
+        return {
+            "ok": False,
+            "message": "memory_package_repair_unavailable",
+            "output": "The running installation has no published rollback target",
+            "reason": "memory_package_repair_unavailable",
+            "restarting": False,
+        }
+    try:
         plan = build_memory_package_repair_plan(vibe_path=current_vibe_path)
     except ValueError as exc:
         return {
@@ -8753,6 +8842,7 @@ def _prepare_memory_package_job() -> dict:
                 vibe_path=current_vibe_path,
                 trigger="memory_package_repair",
                 prepare_show_runtime=False,
+                rollback_to=repair_rollback_to,
             )
             restarting = True
         except Exception as exc:  # noqa: BLE001

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -71,6 +71,7 @@ from vibe.upgrade import (
     installed_memory_package_version,
     memory_package_installed,
     memory_package_repair_supported,
+    MemoryRollbackTargetUnavailableError,
     rollback_target,
     should_skip_show_runtime_prepare,
 )
@@ -8792,6 +8793,14 @@ def _prepare_memory_package_job() -> dict:
     current_vibe_path = get_running_vibe_path()
     try:
         repair_rollback_to = rollback_target()
+    except MemoryRollbackTargetUnavailableError as exc:
+        return {
+            "ok": False,
+            "message": "memory_package_metadata_unreadable",
+            "output": str(exc),
+            "reason": "memory_package_metadata_unreadable",
+            "restarting": False,
+        }
     except Exception as exc:  # noqa: BLE001
         return {
             "ok": False,

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -60,12 +60,16 @@ from vibe.opencode_config import (
 )
 from vibe.build_identity import get_build_identity
 from vibe.upgrade import (
+    build_memory_package_repair_plan,
     build_upgrade_plan,
     configured_memory_enabled,
     execute_upgrade_plan,
     get_latest_version_info,
     get_running_vibe_path,
     get_safe_cwd,
+    installed_memory_package_version,
+    memory_package_installed,
+    memory_package_repair_supported,
     should_skip_show_runtime_prepare,
 )
 from vibe.restart_supervisor import schedule_restart
@@ -8397,10 +8401,17 @@ def reconcile_askill_auto_update() -> dict:
 
 
 # =============================================================================
-# Dependencies aggregate + manual install jobs (askill / show runtime)
+# Dependencies aggregate + explicit manual install jobs
 # =============================================================================
 
-_ALLOWED_DEP_INSTALLS = {"askill", "avault", "show-runtime", "memory-runtime", "tmux"}
+_ALLOWED_DEP_INSTALLS = {
+    "askill",
+    "avault",
+    "show-runtime",
+    "memory-package",
+    "memory-runtime",
+    "tmux",
+}
 _STARTUP_DEPENDENCY_RECONCILE_LOCK = threading.Lock()
 _DEFAULT_STARTUP_SHOW_PAGE_PREWARM_LIMIT = 3
 _MAX_STARTUP_SHOW_PAGE_PREWARM_LIMIT = 10
@@ -8493,6 +8504,39 @@ def dependencies_status(*, offline: bool = False) -> dict:
         memory_required = bool(V2Config.load().memory.enabled)
     except Exception:  # noqa: BLE001
         memory_required = False
+    if (
+        get_build_identity().kind != "source"
+        and memory_package_repair_supported()
+    ):
+        memory_package = memory_package_installed()
+        memory_package_version = (
+            installed_memory_package_version() if memory_package else None
+        )
+        deps.append(
+            {
+                "id": "memory-package",
+                "kind": "runtime",
+                "required": memory_required,
+                "installed": memory_package,
+                "version": memory_package_version,
+                "latest_version": None,
+                "has_update": False,
+                "status": (
+                    "ready"
+                    if memory_package_version is not None
+                    else ("error" if memory_package else "missing")
+                ),
+                "reason": (
+                    None
+                    if memory_package_version is not None
+                    else (
+                        "memory_package_metadata_unreadable"
+                        if memory_package
+                        else "memory_package_missing"
+                    )
+                ),
+            }
+        )
     deps.append(
         {
             "id": "memory-runtime",
@@ -8635,6 +8679,73 @@ def _prepare_memory_runtime_job() -> dict:
         "output": None,
         "reason": None if ok else (reason or "memory_runtime_install_failed"),
         "download_error": payload.get("download_error"),
+    }
+
+
+def _prepare_memory_package_job() -> dict:
+    """Reinstall the running release with its matching Python Memory package."""
+
+    current_vibe_path = get_running_vibe_path()
+    try:
+        plan = build_memory_package_repair_plan(vibe_path=current_vibe_path)
+    except ValueError as exc:
+        return {
+            "ok": False,
+            "message": "memory_package_repair_unavailable",
+            "output": str(exc),
+            "reason": "memory_package_repair_unavailable",
+            "restarting": False,
+        }
+    try:
+        result = execute_upgrade_plan(
+            plan,
+            run=subprocess.run,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            cwd=get_safe_cwd(),
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {
+            "ok": False,
+            "message": "memory_package_install_failed",
+            "output": str(exc),
+            "reason": "memory_package_install_failed",
+            "restarting": False,
+        }
+    if result.returncode != 0:
+        return {
+            "ok": False,
+            "message": "memory_package_install_failed",
+            "output": result.stderr or result.stdout,
+            "reason": "memory_package_install_failed",
+            "restarting": False,
+        }
+
+    restarting = False
+    if _runtime_process_was_running():
+        try:
+            schedule_restart(
+                delay_seconds=2.0,
+                vibe_path=current_vibe_path,
+                trigger="memory_package_repair",
+                prepare_show_runtime=False,
+            )
+            restarting = True
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "ok": False,
+                "message": "memory_package_restart_required",
+                "output": str(exc),
+                "reason": "memory_package_restart_required",
+                "restarting": False,
+            }
+    return {
+        "ok": True,
+        "message": "memory_package_ready",
+        "output": result.stdout,
+        "reason": None,
+        "restarting": restarting,
     }
 
 
@@ -8863,6 +8974,8 @@ def start_dependency_install_job(dep: str) -> dict:
                 result = ensure_avault_installed(force=True)
             elif dep == "show-runtime":
                 result = _prepare_show_runtime_job()
+            elif dep == "memory-package":
+                result = _prepare_memory_package_job()
             elif dep == "memory-runtime":
                 result = _prepare_memory_runtime_job()
             elif dep == "tmux":

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -6141,6 +6141,14 @@ def do_upgrade(auto_restart: bool = True) -> dict:
             memory_enabled=configured_memory_enabled(),
             target_version=get_version_info().get("latest"),
         )
+    except MemoryRollbackTargetUnavailableError as exc:
+        return {
+            "ok": False,
+            "message": "memory_package_metadata_unreadable",
+            "output": str(exc),
+            "reason": "memory_package_metadata_unreadable",
+            "restarting": False,
+        }
     except ValueError as exc:
         return {"ok": False, "message": "Upgrade failed.", "output": str(exc), "restarting": False}
     runtime_was_running = _runtime_process_was_running()

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -8417,6 +8417,50 @@ _DEFAULT_STARTUP_SHOW_PAGE_PREWARM_LIMIT = 3
 _MAX_STARTUP_SHOW_PAGE_PREWARM_LIMIT = 10
 
 
+def _memory_package_dependency(*, required: bool, current_version: str) -> dict:
+    """Describe whether the optional distribution matches this Avibe release."""
+
+    installed = memory_package_installed()
+    installed_version = installed_memory_package_version() if installed else None
+    dependency = {
+        "id": "memory-package",
+        "kind": "runtime",
+        "required": required,
+        "installed": installed,
+        "version": installed_version,
+        "latest_version": None,
+        "has_update": False,
+    }
+    if not installed:
+        return {
+            **dependency,
+            "status": "missing",
+            "reason": "memory_package_missing",
+        }
+    if installed_version is None:
+        return {
+            **dependency,
+            "status": "error",
+            "reason": "memory_package_metadata_unreadable",
+        }
+
+    from packaging.version import InvalidVersion, Version
+
+    try:
+        matches_running_release = Version(installed_version) == Version(current_version)
+    except InvalidVersion:
+        matches_running_release = False
+    if matches_running_release:
+        return {**dependency, "status": "ready", "reason": None}
+    return {
+        **dependency,
+        "latest_version": current_version,
+        "has_update": True,
+        "status": "error",
+        "reason": "memory_package_version_mismatch",
+    }
+
+
 def dependencies_status(*, offline: bool = False) -> dict:
     """Status of the required local runtime dependencies for the Dependencies
     settings page: askill, local managed runtimes, and the shared Node.js
@@ -8508,34 +8552,13 @@ def dependencies_status(*, offline: bool = False) -> dict:
         get_build_identity().kind != "source"
         and memory_package_repair_supported()
     ):
-        memory_package = memory_package_installed()
-        memory_package_version = (
-            installed_memory_package_version() if memory_package else None
-        )
+        from vibe import __version__
+
         deps.append(
-            {
-                "id": "memory-package",
-                "kind": "runtime",
-                "required": memory_required,
-                "installed": memory_package,
-                "version": memory_package_version,
-                "latest_version": None,
-                "has_update": False,
-                "status": (
-                    "ready"
-                    if memory_package_version is not None
-                    else ("error" if memory_package else "missing")
-                ),
-                "reason": (
-                    None
-                    if memory_package_version is not None
-                    else (
-                        "memory_package_metadata_unreadable"
-                        if memory_package
-                        else "memory_package_missing"
-                    )
-                ),
-            }
+            _memory_package_dependency(
+                required=memory_required,
+                current_version=__version__,
+            )
         )
     deps.append(
         {

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -10863,6 +10863,7 @@ def _managed_dependencies_doctor_items(*, deep: bool = False) -> list[dict]:
     labels = {
         "askill": "askill",
         "avault": "avault",
+        "memory-package": "avibe-memory",
         "tmux": "tmux runtime",
         "git-runtime": "Git Runtime",
         "node": "Node.js",
@@ -10950,6 +10951,19 @@ def _managed_dependencies_doctor_items(*, deep: bool = False) -> list[dict]:
                 f"{label} is not published for this platform",
                 "Use a system dependency where supported, or run Avibe on a platform with a published runtime.",
                 code=f"dependencies.{dependency_id}.platform_unsupported",
+            )
+            continue
+
+        if dependency_id == "memory-package":
+            _add_doctor_item(
+                items,
+                severity,
+                f"{label} is not ready ({status})",
+                i18n_t(
+                    "runtime.doctor.memoryPackageSettingsAction",
+                    _configured_cli_language(),
+                ),
+                code="dependencies.memory-package.not_ready",
             )
             continue
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -74,6 +74,7 @@ from vibe.upgrade import (
     execute_upgrade_plan,
     get_latest_version_info,
     get_safe_cwd,
+    MemoryRollbackTargetUnavailableError,
     should_skip_show_runtime_prepare,
 )
 from storage.db import create_sqlite_engine
@@ -14415,6 +14416,9 @@ def cmd_upgrade():
             memory_enabled=configured_memory_enabled(),
             target_version=info.get("latest"),
         )
+    except MemoryRollbackTargetUnavailableError as exc:
+        print(f"\033[31mUpgrade failed: {exc}\033[0m")
+        return 1
     except ValueError as exc:
         print(f"\033[31mUpgrade failed: {exc}\033[0m")
         return 1

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -994,6 +994,7 @@
       "archiveCacheSkipped": "Show Runtime archive cache was not inspected ({reason}); it may still hold reclaimable archives.",
       "archiveCacheSkippedAction": "Wait for the running install or clean to finish, then rerun Doctor.",
       "archiveCacheSkippedInspectionAction": "Check runtime directory permissions and the Avibe log; retry Doctor once fixed.",
+      "memoryPackageSettingsAction": "Open Settings > Dependencies and reinstall the Memory Python package.",
       "providerUnsupportedAction": "Remove VIBE_SHOW_RUNTIME_SOURCE to use the packaged runtime, or set VIBE_SHOW_RUNTIME_BIN to a runtime you built.",
       "repairHealthy": "Show Runtime starts successfully; no repair is needed.",
       "repairInstalled": "Installed and started Show Runtime.",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -994,6 +994,7 @@
       "archiveCacheSkipped": "未能检查 Show Runtime 归档缓存（{reason}）；其中可能仍有可回收归档。",
       "archiveCacheSkippedAction": "等待正在进行的安装或清理结束后，重新运行 Doctor。",
       "archiveCacheSkippedInspectionAction": "\u8bf7\u68c0\u67e5\u8fd0\u884c\u76ee\u5f55\u6743\u9650\u548c Avibe \u65e5\u5fd7\uff0c\u4fee\u590d\u540e\u91cd\u8bd5 Doctor\u3002",
+      "memoryPackageSettingsAction": "\u6253\u5f00\u8bbe\u7f6e > \u4f9d\u8d56\uff0c\u7136\u540e\u91cd\u65b0\u5b89\u88c5 Memory Python \u8f6f\u4ef6\u5305\u3002",
       "providerUnsupportedAction": "请移除 VIBE_SHOW_RUNTIME_SOURCE 以使用随 Avibe 发布的运行时，或将 VIBE_SHOW_RUNTIME_BIN 指向你自行构建的运行时。",
       "repairHealthy": "Show Runtime \u53ef\u4ee5\u6b63\u5e38\u542f\u52a8\uff0c\u65e0\u9700\u4fee\u590d\u3002",
       "repairExplicitCommandFailed": "VIBE_SHOW_RUNTIME_BIN \u6307\u5b9a\u7684 Show Runtime \u547d\u4ee4\u65e0\u6cd5\u542f\u52a8\uff1a{reason}\u3002\u8bf7\u4fee\u590d\u6216\u79fb\u9664\u8be5\u8986\u76d6\u540e\u91cd\u65b0\u8fd0\u884c Doctor\u3002",

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7940,7 +7940,7 @@ def dependency_install_status(dep, job_id):
 
     from vibe import api
 
-    result = api.get_agent_install_job(job_id, backend=dep)
+    result = api.get_dependency_install_job(dep, job_id)
     status = 404 if not result.get("ok") and result.get("error") == "job_not_found" else 200
     return jsonify(result), status
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7903,12 +7903,19 @@ def backend_restart(name):
     return jsonify(api.restart_backend(name, metadata=metadata))
 
 
-_ALLOWED_DEPENDENCIES = {"askill", "avault", "show-runtime", "memory-runtime", "tmux"}
+_ALLOWED_DEPENDENCIES = {
+    "askill",
+    "avault",
+    "show-runtime",
+    "memory-package",
+    "memory-runtime",
+    "tmux",
+}
 
 
 @app.route("/api/dependencies")
 def get_dependencies():
-    """Status of required local runtime dependencies (askill, Show runtime, Node)."""
+    """Status of the local tool, package, and managed-runtime dependencies."""
     from vibe import api
 
     return jsonify(api.dependencies_status())

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -807,6 +807,10 @@ class RollbackTarget(NamedTuple):
     memory_version: str | None = None
 
 
+class MemoryRollbackTargetUnavailableError(RuntimeError):
+    """The installed Memory package cannot be pinned for a safe rollback."""
+
+
 def _names_a_published_release(version: str) -> bool:
     """Whether an index could serve `version`, as opposed to it naming this tree.
 
@@ -839,10 +843,10 @@ def rollback_target() -> RollbackTarget | None:
     left on the machine to measure. Calling this from the detached restart job
     would answer for the install that did the replacing, which is not a rollback.
 
-    Which is why the only caller is :func:`build_upgrade_plan`, and why the
-    answer reaches everyone else as `UpgradePlan.rollback_to`. As a function
-    anyone could reach, it was reached at the wrong time -- both upgrade paths
-    called it after the install they were describing had already been overwritten.
+    The general upgrade planner and the Settings Memory-package repair owner are
+    the only callers. Both capture this target before the install they are about
+    to run, and every later phase receives the complete value rather than
+    measuring any field again.
 
     So: the version from this process's already-bound `__version__`, which the
     install on disk cannot change underneath it; the distribution from this
@@ -864,12 +868,19 @@ def rollback_target() -> RollbackTarget | None:
     if not _names_a_published_release(__version__):
         return None
     memory_package = memory_package_installed()
+    memory_version = None
+    if memory_package:
+        memory_version = _published_version(installed_memory_package_version())
+        if memory_version is None:
+            raise MemoryRollbackTargetUnavailableError(
+                "The installed avibe-memory version cannot be determined for safe rollback"
+            )
     return RollbackTarget(
         version=__version__,
         package=installed_package_name(),
         launcher=runtime_mod.current_service_launcher(),
         memory_package=memory_package,
-        memory_version=installed_memory_package_version() if memory_package else None,
+        memory_version=memory_version,
     )
 
 

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -1152,6 +1152,55 @@ def build_upgrade_plan(
         cleanup_after_command=cleanup_after_command,
     )
 
+
+def build_memory_package_repair_plan(
+    *,
+    current_version: str | None = None,
+    python_executable: str | None = None,
+    uv_path: str | None = None,
+    vibe_path: str | None = None,
+    base_env: dict[str, str] | None = None,
+) -> UpgradePlan:
+    """Reinstall this released Avibe version with its matching Memory extra."""
+
+    if current_version is None:
+        from vibe import __version__
+
+        current_version = __version__
+    if not memory_package_repair_supported(current_version):
+        raise ValueError(
+            "Memory package repair requires a published split-package release"
+        )
+    version = Version(current_version)
+    normalized_version = str(version)
+    return build_upgrade_plan(
+        python_executable=python_executable,
+        uv_path=uv_path,
+        vibe_path=vibe_path,
+        base_env=base_env,
+        version=normalized_version,
+        package_name=PACKAGE_NAME,
+        memory_package=True,
+        memory_version=normalized_version,
+    )
+
+
+def memory_package_repair_supported(current_version: str | None = None) -> bool:
+    """Return whether the running version names a published split release."""
+
+    if current_version is None:
+        from vibe import __version__
+
+        current_version = __version__
+    try:
+        version = Version(current_version)
+    except InvalidVersion:
+        return False
+    return (
+        _names_a_published_release(str(version))
+        and version >= _MEMORY_SPLIT_MIN_VERSION
+    )
+
 def get_safe_cwd() -> str:
     """Return a stable, existing absolute directory for subprocess cwd.
 

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -808,7 +808,12 @@ class RollbackTarget(NamedTuple):
 
 
 class MemoryRollbackTargetUnavailableError(RuntimeError):
-    """The installed Memory package cannot be pinned for a safe rollback."""
+    """The installed Memory package cannot be pinned for a safe rollback.
+
+    Raised before mutation when the current package shape cannot be represented
+    by an exact rollback target. Upgrade and repair entrypoints must map this to
+    their normal structured failure instead of letting it escape to the user.
+    """
 
 
 def _names_a_published_release(version: str) -> bool:


### PR DESCRIPTION
## Capability

Add the explicit Settings recovery path for the optional `avibe-memory` Python distribution required before Memory Wave 3c.

- expose `memory-package` separately from the existing `memory-runtime` / EverOS artifact dependency
- reinstall the current published Avibe version as `avibe-os[memory]` with an exact matching `avibe-memory` pin
- preflight both artifacts before mutation and reuse the existing installer/restart supervisor
- keep source deployments and pre-split releases out of the package-index repair path
- do not add any startup package installation

## Affected scenarios

- `MEMORY-INDEP-018`: explicit package-shape recovery from core-only to core-plus-Memory at the same release.
- Existing Memory runtime repair and disabled-isolation scenarios remain unchanged.

## Evidence layers

- **Unit:** planner command contracts for pip and uv, published-release admission, loader-owned non-constructing runtime-entrypoint validation, complete package-readiness truth table, exact repair rollback handoff, fail-closed unreadable rollback metadata with structured Web/CLI failure propagation, state-derived post-restart job recovery, HTTP route, Settings action separation, and Doctor ready/non-ready/deep-mode projection.
- **Contract:** real core and optional wheels install into a test-owned venv; a core-only `3.0.14` installation remains on `3.0.14` and gains `avibe-memory==3.0.14`.
- **Scenario:** full packaged upgrade/rollback matrix passes 4/4 without skips; focused loader/upgrade/dependency/catalog suite passes 247/247; full CLI suite passes 183/183; supervisor rollback slice passes 7/7; locked-environment disabled-isolation subprocess cases pass 3/3.
- **UI:** targeted dependency/i18n Vitest passes 15/15 and production `npm run build`.
- **Static:** backend i18n parity passes 97/97, UI locale key parity passes 3917/3917, Ruff on changed Python files, JSON/YAML parsing, and `git diff --check`.
- **Residual manual:** no local service restart, Incus, account connection, or production-state operation; packaged user activation remains for the orchestrator's integration pass.

## Dependency and scope

Depends on merged Wave 3b PR #1736 and must merge before Wave 3c begins. This PR does not change release workflows, manifests, publish ordering, global lifecycle/UI/QR/doctor locking, pending-restart protocols, PluginHost/UDS/RPC, or process topology.

Rollback invariant: every forward upgrade and Settings package repair captures the complete currently installed package shape before mutation. If an installed Memory distribution cannot supply an exact version pin, rollback is unavailable and mutation is blocked; API and CLI entrypoints must translate that domain outcome into their normal structured failure rather than returning a server error or traceback.

## Known-by-design ledger

- Source and unpublished builds omit `memory-package`; package repair is meaningful only for a published split-package release.
- A successful explicit repair uses the existing all-process restart supervisor to activate the newly installed optional package; it introduces no new restart protocol or lock.
- The existing `memory-runtime` action remains the controller-owned EverOS artifact install/repair path and is not changed or conflated with Python distribution recovery.
- Controller startup never installs or downloads Python packages.
- `MEMORY-INDEP-018-KBD-10`: explicit Settings Python-package repair is not serialized with concurrent controller, Web, or CLI product upgrades or with active Memory work (Codex thread `PRRT_kwDOPbFPYs6c0fTr`, comment `3871851372`). A one-shot controller status predicate is TOCTOU and is not accepted as a server-side guarantee; complete enforcement requires controller-owned admission/reservation spanning package mutation through restart ownership as part of a separately scoped cross-process package lifecycle transaction, and is not owned by Wave 3c. Operators must not trigger repair while Memory or an upgrade is active; after that work and its restart settle, rerun Settings repair to restore the exact running-release package shape.

Do not merge automatically; Codex review and exact-head CI are the delivery gates.

## Owner disposition

Close this PR unmerged. Five review rounds across four correction heads and 15 total review threads invalidated the narrow Settings-repair framework: readiness/probing, UI restart recovery, rollback-plan satisfiability, and server-owned lifecycle admission are one coupled contract rather than independent local patches.

The branch `fix/memory-settings-python-distribution` remains at `b6793eae46127aa251b82a372d43904d1e5680ea` for recovery and design evidence; it is not an approved merge source. Wave 3c must begin with an owner-approved Phase 0 specification before any further code:

- `MEMORY-INDEP-021` - readiness/probe isolation: disabled or not-required packaged Memory imports no optional runtime code.
- `MEMORY-INDEP-018` - UI recovery: polling survives transient restart errors and converges on state-derived recovery, with no naked awaited poll request.
- `MEMORY-INDEP-019` - rollback-plan semantics: every constructed rollback is resolver-satisfiable; explicitly choose fail-closed inconsistent shape or core-without-extra plus independently pinned Memory.
- `MEMORY-INDEP-020` - server admission: source deployments reject package mutation, and KBD-10 becomes a formal cross-process admission/reservation design spanning mutation through restart ownership.

Wave 3c implementation is gated on explicit owner approval of those Phase 0 sections. No code from this terminally parked PR may be merged or carried forward without reconciliation against that contract.
