### PR TITLE
fix(storage): bound migration tightening safety checks

### DIFF
--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -27,7 +27,7 @@ reason, and nothing needs an old Python environment -- ``env.py`` reads
                                   upgrades it
     releases_with_state_but_no   every release that wrote a database is inside the
     _graph()                      window the property above walks
-    migration_safety_problems()   each post-baseline revision has one finite, explicit
+    migration_safety_problems()   each post-latest-release revision has one finite, explicit
                                   migration-safety attestation
 
 Readiness is not this module's opinion. ``unrepairable_releases`` drives
@@ -74,7 +74,6 @@ if str(REPO_ROOT) not in sys.path:
 
 from alembic import command
 from alembic.config import Config
-from alembic.script import ScriptDirectory
 from alembic.script.base import _only_source_rev_file
 from alembic.util import to_tuple
 from packaging.version import InvalidVersion, Version
@@ -703,12 +702,6 @@ def table_names(db_path: Path) -> set[str]:
         connection.close()
 
 
-def _planned_revisions(config: Config, shipped_heads: set[str]) -> list[str]:
-    """Return Alembic's ordered upgrade revisions from a released graph to today's head."""
-    script = ScriptDirectory.from_config(config)
-    return [step.revision.revision for step in script._upgrade_revs("head", tuple(sorted(shipped_heads)))]
-
-
 def _migration_safety_declaration_error(
     revision: str, declaration: str | _ComputedMetadata | None
 ) -> str | None:
@@ -723,15 +716,15 @@ def _migration_safety_declaration_error(
     return None
 
 
-def migration_safety_problems(baseline: str | None = None) -> list[str]:
-    """Require one explicit attestation for every post-baseline revision.
+def migration_safety_problems() -> list[str]:
+    """Require one explicit attestation for every revision after the latest release.
 
-    The latest released graph is the grandfather boundary. The actual Alembic plan is still
-    executed from each released graph as independent behavioral evidence, but this gate does
-    not infer data guarantees from the resulting database or from migration source effects.
+    This is deliberately a metadata-only gate. ``unrepairable_releases`` owns real upgrade
+    execution and readiness evidence; duplicating that executor here would make the
+    attestation boundary both slow and a second source of migration behavior.
     """
-    baseline = baseline or latest_released_tag()
-    baseline_graph = revision_graph(released_sources(baseline))
+    latest_release = latest_released_tag()
+    baseline_graph = revision_graph(released_sources(latest_release))
     current_sources = working_tree_sources()
     current_graph = revision_graph(current_sources)
     new_revisions = set(current_graph) - set(baseline_graph)
@@ -747,41 +740,6 @@ def migration_safety_problems(baseline: str | None = None) -> list[str]:
         ))
     ]
 
-    planned: set[tuple[str, str]] = set()
-    analyzed: set[tuple[str, str]] = set()
-    for tag in released_graphs():
-        try:
-            with tempfile.TemporaryDirectory() as workspace:
-                root = Path(workspace)
-                db_path = root / "vibe.sqlite"
-                released = extract_released_versions(tag, root / "released")
-                shipped_heads = shipped_head_revisions(released_sources(tag))
-                released_config = _alembic_config(db_path, released)
-                command.upgrade(released_config, "head")
-                current_config = _alembic_config(db_path)
-                revisions = _planned_revisions(current_config, shipped_heads)
-                planned.update((tag, revision) for revision in revisions if revision in new_revisions)
-                for revision in revisions:
-                    try:
-                        command.upgrade(current_config, revision)
-                    except Exception as exc:  # noqa: BLE001 - an unanalyzable plan fails closed
-                        problems.append(
-                            f"{tag}: {revision} could not be executed from its released schema: "
-                            f"{type(exc).__name__}: {str(exc).splitlines()[0]}"
-                        )
-                        break
-                    if revision in new_revisions:
-                        analyzed.add((tag, revision))
-        except Exception as exc:  # noqa: BLE001 - plan/setup failure is a closed-gate result
-            problems.append(
-                f"{tag}: migration safety plan could not be executed: "
-                f"{type(exc).__name__}: {str(exc).splitlines()[0]}"
-            )
-
-    for tag, revision in sorted(planned - analyzed):
-        problems.append(f"{tag}: planned revision {revision} was not executed")
-    for tag, revision in sorted(analyzed - planned):
-        problems.append(f"{tag}: unplanned revision {revision} was executed")
     return problems
 
 
@@ -1625,8 +1583,9 @@ def collect_problems(
     problems.extend(edited_released_bodies(baseline))
     problems.extend(spent_body_edit_declarations(baseline))
 
+    problems.extend(migration_safety_problems())
+
     if include_upgrade:
-        problems.extend(migration_safety_problems(baseline))
         failures, refused = unrepairable_releases()
         for tag, reasons in sorted(failures.items(), key=lambda item: version_key(item[0])):
             problems.extend(f"{tag}: {reason}" for reason in reasons)
@@ -1643,7 +1602,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--skip-upgrade",
         action="store_true",
-        help="check only metadata, skipping per-release upgrades and migration-safety analysis",
+        help="skip per-release upgrade evidence while retaining metadata and attestation checks",
     )
     return parser
 

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -7,7 +7,7 @@ never back. So editing a released revision's parentage does not change what thos
 databases have already done -- it changes what they will do next, silently, with no error
 at the moment of the edit and no error at the moment of the upgrade.
 
-Seven properties, one primitive: the graph as a released tag actually shipped it, read
+Eight properties, one primitive: the graph as a released tag actually shipped it, read
 straight out of git. Nothing here is an allowlist of known-bad cases that outlives its
 reason, and nothing needs an old Python environment -- ``env.py`` reads
 ``target_metadata`` only during autogenerate, so today's runtime can drive an older
@@ -27,6 +27,8 @@ reason, and nothing needs an old Python environment -- ``env.py`` reads
                                   upgrades it
     releases_with_state_but_no   every release that wrote a database is inside the
     _graph()                      window the property above walks
+    migration_safety_problems()   each post-baseline tightening has one finite, explicit
+                                  safety declaration, checked against SQLite's observed delta
 
 Readiness is not this module's opinion. ``unrepairable_releases`` drives
 ``run_migrations`` and asks ``background_tables_ready``, so it covers the repair and
@@ -72,6 +74,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from alembic import command
 from alembic.config import Config
+from alembic.script import ScriptDirectory
 from alembic.script.base import _only_source_rev_file
 from alembic.util import to_tuple
 from packaging.version import InvalidVersion, Version
@@ -338,6 +341,13 @@ GRAPH_FIELDS = {
 
 GRAPH_EDGES = tuple(field for field in GRAPH_FIELDS if field != "revision")
 
+# A migration may acknowledge one bounded data-safety mechanism. The guard deliberately
+# does not inspect the mechanism: doing so would recreate the Python/SQL interpreter this
+# contract replaces. The observed SQLite delta is the obligation; this literal is the
+# migration author's explicit ownership of how its data establishes that obligation.
+MIGRATION_SAFETY_FIELD = "MIGRATION_SAFETY"
+MIGRATION_SAFETY_KINDS = frozenset({"deduplicate", "backfill", "copy"})
+
 
 def declared_graph_fields(source: str) -> dict[str, object]:
     """The graph declarations a migration module makes, in either form Python allows.
@@ -367,6 +377,43 @@ def declared_graph_fields(source: str) -> dict[str, object]:
             continue
         declared[target.id] = literal if target.id == "revision" else to_tuple(literal, default=())
     return declared
+
+
+def declared_migration_safety(source: str) -> tuple[str, ...] | _ComputedMetadata | None:
+    """Read one finite top-level safety declaration without evaluating migration code.
+
+    Only a literal string or tuple/list of strings is part of the contract. A call,
+    comprehension, import-derived value, duplicate assignment, or unsupported value is
+    ``COMPUTED`` and therefore fails closed. This is intentionally the same tiny AST
+    literal reader used for Alembic graph metadata, not a model of Python control flow.
+    """
+    values: list[object] = []
+    try:
+        nodes = ast.parse(source).body
+    except SyntaxError:
+        return COMPUTED
+    for node in nodes:
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target, value = node.targets[0], node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            target, value = node.target, node.value
+        else:
+            continue
+        if isinstance(target, ast.Name) and target.id == MIGRATION_SAFETY_FIELD:
+            try:
+                values.append(ast.literal_eval(value))
+            except (ValueError, TypeError, SyntaxError):
+                return COMPUTED
+    if not values:
+        return None
+    if len(values) != 1:
+        return COMPUTED
+    literal = values[0]
+    if isinstance(literal, str):
+        return (literal,)
+    if isinstance(literal, (tuple, list)) and all(isinstance(item, str) for item in literal):
+        return tuple(literal)
+    return COMPUTED
 
 
 def revision_claims(sources: dict[str, str]) -> dict[str, list[tuple[str, dict[str, object]]]]:
@@ -666,6 +713,285 @@ def table_names(db_path: Path) -> set[str]:
         return {str(row[0]) for row in connection.execute("select name from sqlite_master where type = 'table'")}
     finally:
         connection.close()
+
+
+@dataclass(frozen=True)
+class _ColumnShape:
+    name: str
+    declared_type: str
+    not_null: bool
+    default: str | None
+    primary_key: int
+
+
+@dataclass(frozen=True)
+class _TableShape:
+    columns: tuple[_ColumnShape, ...]
+    check_count: int
+    ddl: str = ""
+
+
+@dataclass(frozen=True)
+class _UniqueShape:
+    table: str
+    columns: tuple[str | None, ...]
+    partial: bool
+
+
+@dataclass(frozen=True)
+class _SchemaShape:
+    tables: dict[str, _TableShape]
+    unique_indexes: frozenset[_UniqueShape]
+
+
+@dataclass(frozen=True)
+class SchemaTightening:
+    """One structural obligation observed between two SQLite schema snapshots."""
+
+    kind: str
+    table: str
+    detail: str
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def sqlite_schema_shape(connection: sqlite3.Connection) -> _SchemaShape:
+    """Capture only SQLite's structural facts needed by the safety contract.
+
+    The DDL text is used for a count of newly present ``CHECK`` tokens, never evaluated.
+    Column and unique-index facts come from SQLite PRAGMAs, so this function carries no
+    SQL expression or migration-source semantics of its own.
+    """
+    rows = connection.execute(
+        "select name, sql from sqlite_master "
+        "where type = 'table' and name not like 'sqlite_%' and name != ?",
+        (ALEMBIC_BOOKKEEPING_TABLE,),
+    ).fetchall()
+    tables: dict[str, _TableShape] = {}
+    unique_indexes: set[_UniqueShape] = set()
+    for raw_name, raw_sql in rows:
+        table = str(raw_name)
+        table_sql = str(raw_sql or "")
+        columns = tuple(
+            _ColumnShape(
+                name=str(row[1]),
+                declared_type=str(row[2] or ""),
+                not_null=bool(row[3]),
+                default=None if row[4] is None else str(row[4]),
+                primary_key=int(row[5]),
+            )
+            for row in connection.execute(f"pragma table_info({_quote_identifier(table)})")
+        )
+        tables[table] = _TableShape(
+            columns=columns,
+            check_count=len(re.findall(r"\bcheck\b", table_sql, re.IGNORECASE)),
+            ddl=table_sql,
+        )
+        for index_row in connection.execute(f"pragma index_list({_quote_identifier(table)})"):
+            index_name = str(index_row[1])
+            if not bool(index_row[2]):
+                continue
+            columns_for_index = tuple(
+                None if info[2] is None else str(info[2])
+                for info in connection.execute(f"pragma index_info({_quote_identifier(index_name)})")
+            )
+            unique_indexes.add(
+                _UniqueShape(
+                    table=table,
+                    columns=columns_for_index,
+                    partial=bool(index_row[4]),
+                )
+            )
+    return _SchemaShape(tables=tables, unique_indexes=frozenset(unique_indexes))
+
+
+def _default_is_non_null(default: str | None) -> bool:
+    if default is None:
+        return False
+    value = default.strip()
+    while value.startswith("(") and value.endswith(")"):
+        value = value[1:-1].strip()
+    if value.upper() == "NULL":
+        return False
+    # SQLite's literal defaults and its three timestamp keywords are the only values
+    # whose non-NULL result is decidable here. An expression that merely looks unlike
+    # NULL may still evaluate to NULL, so it is deliberately refused.
+    return bool(
+        re.fullmatch(r"[-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)", value)
+        or re.fullmatch(r"(?:'(?:''|[^'])*'|\"(?:\"\"|[^\"])*\")", value)
+        or re.fullmatch(r"X'[0-9A-Fa-f]*'", value)
+        or value.upper() in {"CURRENT_TIMESTAMP", "CURRENT_DATE", "CURRENT_TIME"}
+    )
+
+
+def schema_tightenings(before: _SchemaShape, after: _SchemaShape) -> tuple[SchemaTightening, ...]:
+    """Classify only finite, structural tightenings; unknown semantics are not inferred."""
+    obligations: list[SchemaTightening] = []
+    before_tables = set(before.tables)
+    after_tables = set(after.tables)
+
+    for table in sorted(before_tables - after_tables):
+        obligations.append(SchemaTightening("copy", table, f"table {table} was removed"))
+
+    rebuilt_tables: set[str] = set()
+    for table in sorted(before_tables & after_tables):
+        old = {column.name: column for column in before.tables[table].columns}
+        new = {column.name: column for column in after.tables[table].columns}
+        removed = set(old) - set(new)
+        changed = {
+            name
+            for name in set(old) & set(new)
+            if old[name] != new[name]
+        }
+        check_added = after.tables[table].check_count > before.tables[table].check_count
+        added = set(new) - set(old)
+        added_only = bool(added) and not removed and not changed
+        ddl_changed = before.tables[table].ddl != after.tables[table].ddl
+        if removed or changed or check_added or (ddl_changed and not added_only):
+            rebuilt_tables.add(table)
+            reason = []
+            if removed:
+                reason.append(f"removed columns {', '.join(sorted(removed))}")
+            if changed:
+                reason.append(f"changed columns {', '.join(sorted(changed))}")
+            if check_added:
+                reason.append("added CHECK constraint")
+            if ddl_changed and not (removed or changed or check_added):
+                reason.append("changed table definition")
+            obligations.append(SchemaTightening("copy", table, "; ".join(reason)))
+            continue
+
+        for name in sorted(set(new) - set(old)):
+            column = new[name]
+            if column.not_null and not _default_is_non_null(column.default):
+                obligations.append(SchemaTightening("backfill", table, f"new NOT NULL column {table}.{name}"))
+
+    for index in sorted(after.unique_indexes - before.unique_indexes, key=repr):
+        if index.table not in before_tables or index.table in rebuilt_tables:
+            continue
+        columns = ", ".join(column or "<expression>" for column in index.columns)
+        predicate = " partial" if index.partial else ""
+        obligations.append(SchemaTightening("deduplicate", index.table, f"new{predicate} unique key ({columns})"))
+
+    return tuple(obligations)
+
+
+def _migration_safety_declaration_error(
+    revision: str, declaration: tuple[str, ...] | _ComputedMetadata | None, expected: set[str]
+) -> str | None:
+    if declaration is None:
+        return f"{revision} has {', '.join(sorted(expected))} obligations but no MIGRATION_SAFETY declaration"
+    if declaration is COMPUTED:
+        return f"{revision} MIGRATION_SAFETY is computed or malformed; only a literal is supported"
+    if not declaration or len(set(declaration)) != len(declaration):
+        return f"{revision} MIGRATION_SAFETY must contain each mechanism exactly once"
+    unsupported = set(declaration) - MIGRATION_SAFETY_KINDS
+    if unsupported:
+        return f"{revision} MIGRATION_SAFETY contains unsupported kinds: {', '.join(sorted(unsupported))}"
+    if set(declaration) != expected:
+        return (
+            f"{revision} MIGRATION_SAFETY names {', '.join(declaration)}, "
+            f"but observed obligations are {', '.join(sorted(expected))}"
+        )
+    return None
+
+
+def _planned_revisions(config: Config, shipped_heads: set[str]) -> list[str]:
+    """Return Alembic's ordered upgrade revisions from a released graph to today's head."""
+    script = ScriptDirectory.from_config(config)
+    return [step.revision.revision for step in script._upgrade_revs("head", tuple(sorted(shipped_heads)))]
+
+
+def migration_safety_problems(baseline: str | None = None) -> list[str]:
+    """Check new revisions using SQLite deltas and the finite declaration contract.
+
+    The latest released graph is the grandfather boundary. Each distinct released graph is
+    materialized once, then today's actual Alembic plan is applied one revision at a time so
+    the before/after facts come from the runtime database rather than a source interpreter.
+    """
+    baseline = baseline or latest_released_tag()
+    baseline_graph = revision_graph(released_sources(baseline))
+    current_sources = working_tree_sources()
+    current_graph = revision_graph(current_sources)
+    new_revisions = set(current_graph) - set(baseline_graph)
+    if not new_revisions:
+        return []
+
+    planned: set[tuple[str, str]] = set()
+    analyzed: set[tuple[str, str]] = set()
+    observed: dict[tuple[str, str], tuple[SchemaTightening, ...]] = {}
+    problems: list[str] = []
+
+    for tag in released_graphs():
+        try:
+            with tempfile.TemporaryDirectory() as workspace:
+                root = Path(workspace)
+                db_path = root / "vibe.sqlite"
+                released = extract_released_versions(tag, root / "released")
+                shipped_heads = shipped_head_revisions(released_sources(tag))
+                released_config = _alembic_config(db_path, released)
+                command.upgrade(released_config, "head")
+                current_config = _alembic_config(db_path)
+                revisions = _planned_revisions(current_config, shipped_heads)
+                tag_plan = [(tag, revision) for revision in revisions if revision in new_revisions]
+                planned.update(tag_plan)
+                with sqlite3.connect(db_path) as connection:
+                    # Apply every step in Alembic's plan so a snapshot for a new revision is
+                    # not polluted by earlier post-release steps. Only new revisions are
+                    # obligations; released steps are replayed to reach each one's boundary
+                    # and then discarded under the baseline grandfather rule.
+                    for revision in revisions:
+                        before = sqlite_schema_shape(connection)
+                        try:
+                            command.upgrade(current_config, revision)
+                        except Exception as exc:  # noqa: BLE001 - an unanalyzable plan fails closed
+                            problems.append(
+                                f"{tag}: {revision} could not be analyzed after its released schema: "
+                                f"{type(exc).__name__}: {str(exc).splitlines()[0]}"
+                            )
+                            break
+                        after = sqlite_schema_shape(connection)
+                        if revision not in new_revisions:
+                            continue
+                        pair = (tag, revision)
+                        analyzed.add(pair)
+                        observed[pair] = schema_tightenings(before, after)
+        except Exception as exc:  # noqa: BLE001 - plan/setup failure is a closed-gate result
+            problems.append(
+                f"{tag}: migration safety plan could not be analyzed: "
+                f"{type(exc).__name__}: {str(exc).splitlines()[0]}"
+            )
+
+    for tag, revision in sorted(planned - analyzed):
+        problems.append(f"{tag}: planned revision {revision} was not analyzed")
+    for tag, revision in sorted(analyzed - planned):
+        problems.append(f"{tag}: unplanned revision {revision} was analyzed")
+
+    declarations = {
+        revision: declared_migration_safety(current_sources[name])
+        for revision, (name, _) in current_graph.items()
+        if revision in new_revisions
+    }
+    for pair, obligations in sorted(observed.items()):
+        if not obligations:
+            continue
+        expected = {obligation.kind for obligation in obligations}
+        error = _migration_safety_declaration_error(pair[1], declarations.get(pair[1]), expected)
+        if error:
+            details = "; ".join(obligation.detail for obligation in obligations)
+            problems.append(f"{pair[0]}: {error} ({details})")
+
+    observed_revisions = {revision for _, revision in observed}
+    for revision, declaration in sorted(declarations.items()):
+        if revision in observed_revisions:
+            continue
+        if declaration is not None:
+            detail = "computed or malformed" if declaration is COMPUTED else ", ".join(declaration)
+            problems.append(f"{revision} declares MIGRATION_SAFETY ({detail}) but has no structural obligation")
+
+    return problems
 
 
 def fresh_install_tables() -> set[str]:
@@ -1509,6 +1835,7 @@ def collect_problems(
     problems.extend(spent_body_edit_declarations(baseline))
 
     if include_upgrade:
+        problems.extend(migration_safety_problems(baseline))
         failures, refused = unrepairable_releases()
         for tag, reasons in sorted(failures.items(), key=lambda item: version_key(item[0])):
             problems.extend(f"{tag}: {reason}" for reason in reasons)
@@ -1525,7 +1852,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--skip-upgrade",
         action="store_true",
-        help="check only the metadata properties, skipping the per-release upgrade",
+        help="check only metadata, skipping per-release upgrades and migration-safety analysis",
     )
     return parser
 

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -736,6 +736,7 @@ class _UniqueShape:
     table: str
     columns: tuple[str | None, ...]
     partial: bool
+    ddl: str | None = None
 
 
 @dataclass(frozen=True)
@@ -757,10 +758,165 @@ def _quote_identifier(identifier: str) -> str:
     return '"' + identifier.replace('"', '""') + '"'
 
 
+def _sql_words(sql: str) -> Iterable[tuple[str, int, int]]:
+    """Yield unquoted, uncommented word tokens without interpreting SQL expressions."""
+    index = 0
+    length = len(sql)
+    while index < length:
+        character = sql[index]
+        if character in {"'", '"', "`"}:
+            quote = character
+            index += 1
+            while index < length:
+                if sql[index] == quote:
+                    if index + 1 < length and sql[index + 1] == quote:
+                        index += 2
+                        continue
+                    index += 1
+                    break
+                index += 1
+            continue
+        if character == "[":
+            closing = sql.find("]", index + 1)
+            index = length if closing < 0 else closing + 1
+            continue
+        if sql.startswith("--", index):
+            newline = sql.find("\n", index + 2)
+            index = length if newline < 0 else newline + 1
+            continue
+        if sql.startswith("/*", index):
+            closing = sql.find("*/", index + 2)
+            index = length if closing < 0 else closing + 2
+            continue
+        if character.isalpha() or character == "_":
+            start = index
+            index += 1
+            while index < length and (sql[index].isalnum() or sql[index] in {"_", "$"}):
+                index += 1
+            yield sql[start:index], start, index
+            continue
+        index += 1
+
+
+def _sql_keyword_count(sql: str, keyword: str) -> int:
+    expected = keyword.casefold()
+    return sum(1 for word, _, _ in _sql_words(sql) if word.casefold() == expected)
+
+
+def _sql_top_level_parts(ddl: str) -> tuple[str, ...] | None:
+    """Split a CREATE TABLE body without inspecting expression semantics."""
+    quote: str | None = None
+    comment: str | None = None
+    depth = 0
+    body_start: int | None = None
+    parts: list[str] = []
+    part_start = 0
+    index = 0
+    while index < len(ddl):
+        character = ddl[index]
+        if comment == "line":
+            if character == "\n":
+                comment = None
+            index += 1
+            continue
+        if comment == "block":
+            if ddl.startswith("*/", index):
+                comment = None
+                index += 2
+            else:
+                index += 1
+            continue
+        if quote is not None:
+            if character == quote:
+                if index + 1 < len(ddl) and ddl[index + 1] == quote:
+                    index += 2
+                    continue
+                quote = None
+            index += 1
+            continue
+        if ddl.startswith("--", index):
+            comment = "line"
+            index += 2
+            continue
+        if ddl.startswith("/*", index):
+            comment = "block"
+            index += 2
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+            index += 1
+            continue
+        if character == "[":
+            closing = ddl.find("]", index + 1)
+            index = len(ddl) if closing < 0 else closing + 1
+            continue
+        if character == "(":
+            if depth == 0 and body_start is None:
+                body_start = index + 1
+                part_start = body_start
+            depth += 1
+        elif character == ")" and body_start is not None:
+            depth -= 1
+            if depth < 0:
+                return None
+            if depth == 0:
+                parts.append(ddl[part_start:index].strip())
+                return tuple(part for part in parts if part)
+        elif character == "," and body_start is not None and depth == 1:
+            parts.append(ddl[part_start:index].strip())
+            part_start = index + 1
+        index += 1
+    return None
+
+
+def _sql_identifier(part: str) -> str | None:
+    """Read only the first identifier of a top-level table declaration."""
+    part = part.lstrip()
+    if not part:
+        return None
+    if part[0] in {'"', "`"}:
+        quote = part[0]
+        end = 1
+        value: list[str] = []
+        while end < len(part):
+            if part[end] == quote:
+                if end + 1 < len(part) and part[end + 1] == quote:
+                    value.append(quote)
+                    end += 2
+                    continue
+                return "".join(value)
+            value.append(part[end])
+            end += 1
+        return None
+    if part[0] == "[":
+        end = part.find("]", 1)
+        return None if end < 0 else part[1:end]
+    match = re.match(r"[A-Za-z_][A-Za-z0-9_$]*", part)
+    return None if match is None else match.group(0)
+
+
+def _ddl_is_additive_column_change(before: str, after: str, added: set[str]) -> bool:
+    """Prove the raw DDL only appended the newly reported column definitions."""
+    if not added:
+        return False
+    old_parts = _sql_top_level_parts(before)
+    new_parts = _sql_top_level_parts(after)
+    if old_parts is None or new_parts is None or len(new_parts) != len(old_parts) + len(added):
+        return False
+    if new_parts[: len(old_parts)] != old_parts:
+        return False
+    return {
+        identifier
+        for identifier in (_sql_identifier(part) for part in new_parts[len(old_parts) :])
+        if identifier is not None
+    } == added
+
+
 def sqlite_schema_shape(connection: sqlite3.Connection) -> _SchemaShape:
     """Capture only SQLite's structural facts needed by the safety contract.
 
-    The DDL text is used for a count of newly present ``CHECK`` tokens, never evaluated.
+    The DDL text is lexed only for structural ``CHECK`` changes, never evaluated. Unique
+    index DDL is retained verbatim so predicate and expression identity cannot collapse.
     Column and unique-index facts come from SQLite PRAGMAs, so this function carries no
     SQL expression or migration-source semantics of its own.
     """
@@ -786,13 +942,17 @@ def sqlite_schema_shape(connection: sqlite3.Connection) -> _SchemaShape:
         )
         tables[table] = _TableShape(
             columns=columns,
-            check_count=len(re.findall(r"\bcheck\b", table_sql, re.IGNORECASE)),
+            check_count=_sql_keyword_count(table_sql, "check"),
             ddl=table_sql,
         )
         for index_row in connection.execute(f"pragma index_list({_quote_identifier(table)})"):
             index_name = str(index_row[1])
             if not bool(index_row[2]):
                 continue
+            index_sql_row = connection.execute(
+                "select sql from sqlite_master where type = 'index' and name = ?", (index_name,)
+            ).fetchone()
+            index_sql = None if index_sql_row is None else index_sql_row[0]
             columns_for_index = tuple(
                 None if info[2] is None else str(info[2])
                 for info in connection.execute(f"pragma index_info({_quote_identifier(index_name)})")
@@ -802,6 +962,7 @@ def sqlite_schema_shape(connection: sqlite3.Connection) -> _SchemaShape:
                     table=table,
                     columns=columns_for_index,
                     partial=bool(index_row[4]),
+                    ddl=None if index_sql is None else str(index_sql),
                 )
             )
     return _SchemaShape(tables=tables, unique_indexes=frozenset(unique_indexes))
@@ -822,7 +983,7 @@ def _default_is_non_null(default: str | None) -> bool:
         re.fullmatch(r"[-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)", value)
         or re.fullmatch(r"(?:'(?:''|[^'])*'|\"(?:\"\"|[^\"])*\")", value)
         or re.fullmatch(r"X'[0-9A-Fa-f]*'", value)
-        or value.upper() in {"CURRENT_TIMESTAMP", "CURRENT_DATE", "CURRENT_TIME"}
+        or value.upper() in {"CURRENT_TIMESTAMP", "CURRENT_DATE", "CURRENT_TIME", "TRUE", "FALSE"}
     )
 
 
@@ -847,9 +1008,11 @@ def schema_tightenings(before: _SchemaShape, after: _SchemaShape) -> tuple[Schem
         }
         check_added = after.tables[table].check_count > before.tables[table].check_count
         added = set(new) - set(old)
-        added_only = bool(added) and not removed and not changed
         ddl_changed = before.tables[table].ddl != after.tables[table].ddl
-        if removed or changed or check_added or (ddl_changed and not added_only):
+        ddl_added_only = _ddl_is_additive_column_change(
+            before.tables[table].ddl, after.tables[table].ddl, added
+        )
+        if removed or changed or check_added or (ddl_changed and not ddl_added_only):
             rebuilt_tables.add(table)
             reason = []
             if removed:
@@ -976,6 +1139,10 @@ def migration_safety_problems(baseline: str | None = None) -> list[str]:
     }
     for pair, obligations in sorted(observed.items()):
         if not obligations:
+            declaration = declarations.get(pair[1])
+            if declaration is not None:
+                detail = "computed or malformed" if declaration is COMPUTED else ", ".join(declaration)
+                problems.append(f"{pair[0]}: {pair[1]} declares MIGRATION_SAFETY ({detail}) but has no structural obligation")
             continue
         expected = {obligation.kind for obligation in obligations}
         error = _migration_safety_declaration_error(pair[1], declarations.get(pair[1]), expected)

--- a/scripts/migration_release_guard.py
+++ b/scripts/migration_release_guard.py
@@ -27,8 +27,8 @@ reason, and nothing needs an old Python environment -- ``env.py`` reads
                                   upgrades it
     releases_with_state_but_no   every release that wrote a database is inside the
     _graph()                      window the property above walks
-    migration_safety_problems()   each post-baseline tightening has one finite, explicit
-                                  safety declaration, checked against SQLite's observed delta
+    migration_safety_problems()   each post-baseline revision has one finite, explicit
+                                  migration-safety attestation
 
 Readiness is not this module's opinion. ``unrepairable_releases`` drives
 ``run_migrations`` and asks ``background_tables_ready``, so it covers the repair and
@@ -341,12 +341,10 @@ GRAPH_FIELDS = {
 
 GRAPH_EDGES = tuple(field for field in GRAPH_FIELDS if field != "revision")
 
-# A migration may acknowledge one bounded data-safety mechanism. The guard deliberately
-# does not inspect the mechanism: doing so would recreate the Python/SQL interpreter this
-# contract replaces. The observed SQLite delta is the obligation; this literal is the
-# migration author's explicit ownership of how its data establishes that obligation.
+# The guard deliberately does not infer a data-safety obligation from Python or SQL. Every
+# new migration owns one explicit attestation, and only this finite vocabulary is accepted.
 MIGRATION_SAFETY_FIELD = "MIGRATION_SAFETY"
-MIGRATION_SAFETY_KINDS = frozenset({"deduplicate", "backfill", "copy"})
+MIGRATION_SAFETY_KINDS = frozenset({"additive", "deduplicate", "backfill", "copy"})
 
 
 def declared_graph_fields(source: str) -> dict[str, object]:
@@ -379,14 +377,8 @@ def declared_graph_fields(source: str) -> dict[str, object]:
     return declared
 
 
-def declared_migration_safety(source: str) -> tuple[str, ...] | _ComputedMetadata | None:
-    """Read one finite top-level safety declaration without evaluating migration code.
-
-    Only a literal string or tuple/list of strings is part of the contract. A call,
-    comprehension, import-derived value, duplicate assignment, or unsupported value is
-    ``COMPUTED`` and therefore fails closed. This is intentionally the same tiny AST
-    literal reader used for Alembic graph metadata, not a model of Python control flow.
-    """
+def declared_migration_safety(source: str) -> str | _ComputedMetadata | None:
+    """Read exactly one top-level string literal without evaluating migration code."""
     values: list[object] = []
     try:
         nodes = ast.parse(source).body
@@ -409,11 +401,7 @@ def declared_migration_safety(source: str) -> tuple[str, ...] | _ComputedMetadat
     if len(values) != 1:
         return COMPUTED
     literal = values[0]
-    if isinstance(literal, str):
-        return (literal,)
-    if isinstance(literal, (tuple, list)) and all(isinstance(item, str) for item in literal):
-        return tuple(literal)
-    return COMPUTED
+    return literal if isinstance(literal, str) else COMPUTED
 
 
 def revision_claims(sources: dict[str, str]) -> dict[str, list[tuple[str, dict[str, object]]]]:
@@ -715,364 +703,32 @@ def table_names(db_path: Path) -> set[str]:
         connection.close()
 
 
-@dataclass(frozen=True)
-class _ColumnShape:
-    name: str
-    declared_type: str
-    not_null: bool
-    default: str | None
-    primary_key: int
-
-
-@dataclass(frozen=True)
-class _TableShape:
-    columns: tuple[_ColumnShape, ...]
-    check_count: int
-    ddl: str = ""
-
-
-@dataclass(frozen=True)
-class _UniqueShape:
-    table: str
-    columns: tuple[str | None, ...]
-    partial: bool
-    ddl: str | None = None
-
-
-@dataclass(frozen=True)
-class _SchemaShape:
-    tables: dict[str, _TableShape]
-    unique_indexes: frozenset[_UniqueShape]
-
-
-@dataclass(frozen=True)
-class SchemaTightening:
-    """One structural obligation observed between two SQLite schema snapshots."""
-
-    kind: str
-    table: str
-    detail: str
-
-
-def _quote_identifier(identifier: str) -> str:
-    return '"' + identifier.replace('"', '""') + '"'
-
-
-def _sql_words(sql: str) -> Iterable[tuple[str, int, int]]:
-    """Yield unquoted, uncommented word tokens without interpreting SQL expressions."""
-    index = 0
-    length = len(sql)
-    while index < length:
-        character = sql[index]
-        if character in {"'", '"', "`"}:
-            quote = character
-            index += 1
-            while index < length:
-                if sql[index] == quote:
-                    if index + 1 < length and sql[index + 1] == quote:
-                        index += 2
-                        continue
-                    index += 1
-                    break
-                index += 1
-            continue
-        if character == "[":
-            closing = sql.find("]", index + 1)
-            index = length if closing < 0 else closing + 1
-            continue
-        if sql.startswith("--", index):
-            newline = sql.find("\n", index + 2)
-            index = length if newline < 0 else newline + 1
-            continue
-        if sql.startswith("/*", index):
-            closing = sql.find("*/", index + 2)
-            index = length if closing < 0 else closing + 2
-            continue
-        if character.isalpha() or character == "_":
-            start = index
-            index += 1
-            while index < length and (sql[index].isalnum() or sql[index] in {"_", "$"}):
-                index += 1
-            yield sql[start:index], start, index
-            continue
-        index += 1
-
-
-def _sql_keyword_count(sql: str, keyword: str) -> int:
-    expected = keyword.casefold()
-    return sum(1 for word, _, _ in _sql_words(sql) if word.casefold() == expected)
-
-
-def _sql_top_level_parts(ddl: str) -> tuple[str, ...] | None:
-    """Split a CREATE TABLE body without inspecting expression semantics."""
-    quote: str | None = None
-    comment: str | None = None
-    depth = 0
-    body_start: int | None = None
-    parts: list[str] = []
-    part_start = 0
-    index = 0
-    while index < len(ddl):
-        character = ddl[index]
-        if comment == "line":
-            if character == "\n":
-                comment = None
-            index += 1
-            continue
-        if comment == "block":
-            if ddl.startswith("*/", index):
-                comment = None
-                index += 2
-            else:
-                index += 1
-            continue
-        if quote is not None:
-            if character == quote:
-                if index + 1 < len(ddl) and ddl[index + 1] == quote:
-                    index += 2
-                    continue
-                quote = None
-            index += 1
-            continue
-        if ddl.startswith("--", index):
-            comment = "line"
-            index += 2
-            continue
-        if ddl.startswith("/*", index):
-            comment = "block"
-            index += 2
-            continue
-        if character in {"'", '"', "`"}:
-            quote = character
-            index += 1
-            continue
-        if character == "[":
-            closing = ddl.find("]", index + 1)
-            index = len(ddl) if closing < 0 else closing + 1
-            continue
-        if character == "(":
-            if depth == 0 and body_start is None:
-                body_start = index + 1
-                part_start = body_start
-            depth += 1
-        elif character == ")" and body_start is not None:
-            depth -= 1
-            if depth < 0:
-                return None
-            if depth == 0:
-                parts.append(ddl[part_start:index].strip())
-                return tuple(part for part in parts if part)
-        elif character == "," and body_start is not None and depth == 1:
-            parts.append(ddl[part_start:index].strip())
-            part_start = index + 1
-        index += 1
-    return None
-
-
-def _sql_identifier(part: str) -> str | None:
-    """Read only the first identifier of a top-level table declaration."""
-    part = part.lstrip()
-    if not part:
-        return None
-    if part[0] in {'"', "`"}:
-        quote = part[0]
-        end = 1
-        value: list[str] = []
-        while end < len(part):
-            if part[end] == quote:
-                if end + 1 < len(part) and part[end + 1] == quote:
-                    value.append(quote)
-                    end += 2
-                    continue
-                return "".join(value)
-            value.append(part[end])
-            end += 1
-        return None
-    if part[0] == "[":
-        end = part.find("]", 1)
-        return None if end < 0 else part[1:end]
-    match = re.match(r"[A-Za-z_][A-Za-z0-9_$]*", part)
-    return None if match is None else match.group(0)
-
-
-def _ddl_is_additive_column_change(before: str, after: str, added: set[str]) -> bool:
-    """Prove the raw DDL only appended the newly reported column definitions."""
-    if not added:
-        return False
-    old_parts = _sql_top_level_parts(before)
-    new_parts = _sql_top_level_parts(after)
-    if old_parts is None or new_parts is None or len(new_parts) != len(old_parts) + len(added):
-        return False
-    if new_parts[: len(old_parts)] != old_parts:
-        return False
-    return {
-        identifier
-        for identifier in (_sql_identifier(part) for part in new_parts[len(old_parts) :])
-        if identifier is not None
-    } == added
-
-
-def sqlite_schema_shape(connection: sqlite3.Connection) -> _SchemaShape:
-    """Capture only SQLite's structural facts needed by the safety contract.
-
-    The DDL text is lexed only for structural ``CHECK`` changes, never evaluated. Unique
-    index DDL is retained verbatim so predicate and expression identity cannot collapse.
-    Column and unique-index facts come from SQLite PRAGMAs, so this function carries no
-    SQL expression or migration-source semantics of its own.
-    """
-    rows = connection.execute(
-        "select name, sql from sqlite_master "
-        "where type = 'table' and name not like 'sqlite_%' and name != ?",
-        (ALEMBIC_BOOKKEEPING_TABLE,),
-    ).fetchall()
-    tables: dict[str, _TableShape] = {}
-    unique_indexes: set[_UniqueShape] = set()
-    for raw_name, raw_sql in rows:
-        table = str(raw_name)
-        table_sql = str(raw_sql or "")
-        columns = tuple(
-            _ColumnShape(
-                name=str(row[1]),
-                declared_type=str(row[2] or ""),
-                not_null=bool(row[3]),
-                default=None if row[4] is None else str(row[4]),
-                primary_key=int(row[5]),
-            )
-            for row in connection.execute(f"pragma table_info({_quote_identifier(table)})")
-        )
-        tables[table] = _TableShape(
-            columns=columns,
-            check_count=_sql_keyword_count(table_sql, "check"),
-            ddl=table_sql,
-        )
-        for index_row in connection.execute(f"pragma index_list({_quote_identifier(table)})"):
-            index_name = str(index_row[1])
-            if not bool(index_row[2]):
-                continue
-            index_sql_row = connection.execute(
-                "select sql from sqlite_master where type = 'index' and name = ?", (index_name,)
-            ).fetchone()
-            index_sql = None if index_sql_row is None else index_sql_row[0]
-            columns_for_index = tuple(
-                None if info[2] is None else str(info[2])
-                for info in connection.execute(f"pragma index_info({_quote_identifier(index_name)})")
-            )
-            unique_indexes.add(
-                _UniqueShape(
-                    table=table,
-                    columns=columns_for_index,
-                    partial=bool(index_row[4]),
-                    ddl=None if index_sql is None else str(index_sql),
-                )
-            )
-    return _SchemaShape(tables=tables, unique_indexes=frozenset(unique_indexes))
-
-
-def _default_is_non_null(default: str | None) -> bool:
-    if default is None:
-        return False
-    value = default.strip()
-    while value.startswith("(") and value.endswith(")"):
-        value = value[1:-1].strip()
-    if value.upper() == "NULL":
-        return False
-    # SQLite's literal defaults and its three timestamp keywords are the only values
-    # whose non-NULL result is decidable here. An expression that merely looks unlike
-    # NULL may still evaluate to NULL, so it is deliberately refused.
-    return bool(
-        re.fullmatch(r"[-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)", value)
-        or re.fullmatch(r"(?:'(?:''|[^'])*'|\"(?:\"\"|[^\"])*\")", value)
-        or re.fullmatch(r"X'[0-9A-Fa-f]*'", value)
-        or value.upper() in {"CURRENT_TIMESTAMP", "CURRENT_DATE", "CURRENT_TIME", "TRUE", "FALSE"}
-    )
-
-
-def schema_tightenings(before: _SchemaShape, after: _SchemaShape) -> tuple[SchemaTightening, ...]:
-    """Classify only finite, structural tightenings; unknown semantics are not inferred."""
-    obligations: list[SchemaTightening] = []
-    before_tables = set(before.tables)
-    after_tables = set(after.tables)
-
-    for table in sorted(before_tables - after_tables):
-        obligations.append(SchemaTightening("copy", table, f"table {table} was removed"))
-
-    rebuilt_tables: set[str] = set()
-    for table in sorted(before_tables & after_tables):
-        old = {column.name: column for column in before.tables[table].columns}
-        new = {column.name: column for column in after.tables[table].columns}
-        removed = set(old) - set(new)
-        changed = {
-            name
-            for name in set(old) & set(new)
-            if old[name] != new[name]
-        }
-        check_added = after.tables[table].check_count > before.tables[table].check_count
-        added = set(new) - set(old)
-        ddl_changed = before.tables[table].ddl != after.tables[table].ddl
-        ddl_added_only = _ddl_is_additive_column_change(
-            before.tables[table].ddl, after.tables[table].ddl, added
-        )
-        if removed or changed or check_added or (ddl_changed and not ddl_added_only):
-            rebuilt_tables.add(table)
-            reason = []
-            if removed:
-                reason.append(f"removed columns {', '.join(sorted(removed))}")
-            if changed:
-                reason.append(f"changed columns {', '.join(sorted(changed))}")
-            if check_added:
-                reason.append("added CHECK constraint")
-            if ddl_changed and not (removed or changed or check_added):
-                reason.append("changed table definition")
-            obligations.append(SchemaTightening("copy", table, "; ".join(reason)))
-            continue
-
-        for name in sorted(set(new) - set(old)):
-            column = new[name]
-            if column.not_null and not _default_is_non_null(column.default):
-                obligations.append(SchemaTightening("backfill", table, f"new NOT NULL column {table}.{name}"))
-
-    for index in sorted(after.unique_indexes - before.unique_indexes, key=repr):
-        if index.table not in before_tables or index.table in rebuilt_tables:
-            continue
-        columns = ", ".join(column or "<expression>" for column in index.columns)
-        predicate = " partial" if index.partial else ""
-        obligations.append(SchemaTightening("deduplicate", index.table, f"new{predicate} unique key ({columns})"))
-
-    return tuple(obligations)
-
-
-def _migration_safety_declaration_error(
-    revision: str, declaration: tuple[str, ...] | _ComputedMetadata | None, expected: set[str]
-) -> str | None:
-    if declaration is None:
-        return f"{revision} has {', '.join(sorted(expected))} obligations but no MIGRATION_SAFETY declaration"
-    if declaration is COMPUTED:
-        return f"{revision} MIGRATION_SAFETY is computed or malformed; only a literal is supported"
-    if not declaration or len(set(declaration)) != len(declaration):
-        return f"{revision} MIGRATION_SAFETY must contain each mechanism exactly once"
-    unsupported = set(declaration) - MIGRATION_SAFETY_KINDS
-    if unsupported:
-        return f"{revision} MIGRATION_SAFETY contains unsupported kinds: {', '.join(sorted(unsupported))}"
-    if set(declaration) != expected:
-        return (
-            f"{revision} MIGRATION_SAFETY names {', '.join(declaration)}, "
-            f"but observed obligations are {', '.join(sorted(expected))}"
-        )
-    return None
-
-
 def _planned_revisions(config: Config, shipped_heads: set[str]) -> list[str]:
     """Return Alembic's ordered upgrade revisions from a released graph to today's head."""
     script = ScriptDirectory.from_config(config)
     return [step.revision.revision for step in script._upgrade_revs("head", tuple(sorted(shipped_heads)))]
 
 
-def migration_safety_problems(baseline: str | None = None) -> list[str]:
-    """Check new revisions using SQLite deltas and the finite declaration contract.
+def _migration_safety_declaration_error(
+    revision: str, declaration: str | _ComputedMetadata | None
+) -> str | None:
+    if declaration is None:
+        return f"{revision} has no MIGRATION_SAFETY declaration"
+    if declaration is COMPUTED:
+        return f"{revision} MIGRATION_SAFETY is computed or malformed; only one literal string is supported"
+    if not isinstance(declaration, str):
+        return f"{revision} MIGRATION_SAFETY is malformed; only one literal string is supported"
+    if declaration not in MIGRATION_SAFETY_KINDS:
+        return f"{revision} MIGRATION_SAFETY contains unsupported kind: {declaration}"
+    return None
 
-    The latest released graph is the grandfather boundary. Each distinct released graph is
-    materialized once, then today's actual Alembic plan is applied one revision at a time so
-    the before/after facts come from the runtime database rather than a source interpreter.
+
+def migration_safety_problems(baseline: str | None = None) -> list[str]:
+    """Require one explicit attestation for every post-baseline revision.
+
+    The latest released graph is the grandfather boundary. The actual Alembic plan is still
+    executed from each released graph as independent behavioral evidence, but this gate does
+    not infer data guarantees from the resulting database or from migration source effects.
     """
     baseline = baseline or latest_released_tag()
     baseline_graph = revision_graph(released_sources(baseline))
@@ -1082,11 +738,17 @@ def migration_safety_problems(baseline: str | None = None) -> list[str]:
     if not new_revisions:
         return []
 
+    problems = [
+        error
+        for revision in sorted(new_revisions)
+        if (error := _migration_safety_declaration_error(
+            revision,
+            declared_migration_safety(current_sources[current_graph[revision][0]]),
+        ))
+    ]
+
     planned: set[tuple[str, str]] = set()
     analyzed: set[tuple[str, str]] = set()
-    observed: dict[tuple[str, str], tuple[SchemaTightening, ...]] = {}
-    problems: list[str] = []
-
     for tag in released_graphs():
         try:
             with tempfile.TemporaryDirectory() as workspace:
@@ -1098,66 +760,28 @@ def migration_safety_problems(baseline: str | None = None) -> list[str]:
                 command.upgrade(released_config, "head")
                 current_config = _alembic_config(db_path)
                 revisions = _planned_revisions(current_config, shipped_heads)
-                tag_plan = [(tag, revision) for revision in revisions if revision in new_revisions]
-                planned.update(tag_plan)
-                with sqlite3.connect(db_path) as connection:
-                    # Apply every step in Alembic's plan so a snapshot for a new revision is
-                    # not polluted by earlier post-release steps. Only new revisions are
-                    # obligations; released steps are replayed to reach each one's boundary
-                    # and then discarded under the baseline grandfather rule.
-                    for revision in revisions:
-                        before = sqlite_schema_shape(connection)
-                        try:
-                            command.upgrade(current_config, revision)
-                        except Exception as exc:  # noqa: BLE001 - an unanalyzable plan fails closed
-                            problems.append(
-                                f"{tag}: {revision} could not be analyzed after its released schema: "
-                                f"{type(exc).__name__}: {str(exc).splitlines()[0]}"
-                            )
-                            break
-                        after = sqlite_schema_shape(connection)
-                        if revision not in new_revisions:
-                            continue
-                        pair = (tag, revision)
-                        analyzed.add(pair)
-                        observed[pair] = schema_tightenings(before, after)
+                planned.update((tag, revision) for revision in revisions if revision in new_revisions)
+                for revision in revisions:
+                    try:
+                        command.upgrade(current_config, revision)
+                    except Exception as exc:  # noqa: BLE001 - an unanalyzable plan fails closed
+                        problems.append(
+                            f"{tag}: {revision} could not be executed from its released schema: "
+                            f"{type(exc).__name__}: {str(exc).splitlines()[0]}"
+                        )
+                        break
+                    if revision in new_revisions:
+                        analyzed.add((tag, revision))
         except Exception as exc:  # noqa: BLE001 - plan/setup failure is a closed-gate result
             problems.append(
-                f"{tag}: migration safety plan could not be analyzed: "
+                f"{tag}: migration safety plan could not be executed: "
                 f"{type(exc).__name__}: {str(exc).splitlines()[0]}"
             )
 
     for tag, revision in sorted(planned - analyzed):
-        problems.append(f"{tag}: planned revision {revision} was not analyzed")
+        problems.append(f"{tag}: planned revision {revision} was not executed")
     for tag, revision in sorted(analyzed - planned):
-        problems.append(f"{tag}: unplanned revision {revision} was analyzed")
-
-    declarations = {
-        revision: declared_migration_safety(current_sources[name])
-        for revision, (name, _) in current_graph.items()
-        if revision in new_revisions
-    }
-    for pair, obligations in sorted(observed.items()):
-        if not obligations:
-            declaration = declarations.get(pair[1])
-            if declaration is not None:
-                detail = "computed or malformed" if declaration is COMPUTED else ", ".join(declaration)
-                problems.append(f"{pair[0]}: {pair[1]} declares MIGRATION_SAFETY ({detail}) but has no structural obligation")
-            continue
-        expected = {obligation.kind for obligation in obligations}
-        error = _migration_safety_declaration_error(pair[1], declarations.get(pair[1]), expected)
-        if error:
-            details = "; ".join(obligation.detail for obligation in obligations)
-            problems.append(f"{pair[0]}: {error} ({details})")
-
-    observed_revisions = {revision for _, revision in observed}
-    for revision, declaration in sorted(declarations.items()):
-        if revision in observed_revisions:
-            continue
-        if declaration is not None:
-            detail = "computed or malformed" if declaration is COMPUTED else ", ".join(declaration)
-            problems.append(f"{revision} declares MIGRATION_SAFETY ({detail}) but has no structural obligation")
-
+        problems.append(f"{tag}: unplanned revision {revision} was executed")
     return problems
 
 

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -611,6 +611,88 @@ def test_check_replacement_is_not_treated_as_a_relaxation(tmp_path):
     assert [(item.kind, item.table) for item in obligations] == [("copy", "checked")]
 
 
+def test_check_tokens_inside_literals_identifiers_and_comments_are_ignored(tmp_path):
+    db_path = tmp_path / "check_tokens.sqlite"
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute(
+            "create table quoted (label text default 'check', \"check\" text, note text /* check */)"
+        )
+        shape = guard.sqlite_schema_shape(connection)
+    finally:
+        connection.close()
+
+    assert shape.tables["quoted"].check_count == 0
+
+
+def test_added_column_plus_replaced_check_requires_copy(tmp_path):
+    db_path = tmp_path / "mixed_check.sqlite"
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute("create table mixed (id integer primary key, value text check (value != 'old'))")
+        before = guard.sqlite_schema_shape(connection)
+        connection.execute("alter table mixed rename to mixed_old")
+        connection.execute(
+            "create table mixed (id integer primary key, value text check (value != 'new'), added text)"
+        )
+        connection.execute("insert into mixed (id, value) select id, value from mixed_old")
+        connection.execute("drop table mixed_old")
+        after = guard.sqlite_schema_shape(connection)
+    finally:
+        connection.close()
+
+    obligations = guard.schema_tightenings(before, after)
+    assert [(item.kind, item.table) for item in obligations] == [("copy", "mixed")]
+
+
+def test_sqlite_boolean_defaults_are_known_non_null(tmp_path):
+    db_path = tmp_path / "boolean_default.sqlite"
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute("create table flags (id integer primary key)")
+        before = guard.sqlite_schema_shape(connection)
+        connection.execute("alter table flags add column enabled integer not null default TRUE")
+        after = guard.sqlite_schema_shape(connection)
+    finally:
+        connection.close()
+
+    assert guard.schema_tightenings(before, after) == ()
+
+
+def test_partial_unique_predicate_change_is_a_new_deduplication_obligation(tmp_path):
+    db_path = tmp_path / "partial_unique.sqlite"
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute("create table scoped (key text, active integer)")
+        connection.execute("create unique index ux_scoped_key on scoped (key) where active = 1")
+        before = guard.sqlite_schema_shape(connection)
+        connection.execute("drop index ux_scoped_key")
+        connection.execute("create unique index ux_scoped_key on scoped (key) where active = 0")
+        after = guard.sqlite_schema_shape(connection)
+    finally:
+        connection.close()
+
+    obligations = guard.schema_tightenings(before, after)
+    assert [(item.kind, item.table) for item in obligations] == [("deduplicate", "scoped")]
+
+
+def test_unique_expression_change_is_a_new_deduplication_obligation(tmp_path):
+    db_path = tmp_path / "expression_unique.sqlite"
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute("create table normalized (value text)")
+        connection.execute("create unique index ux_normalized_value on normalized (lower(value))")
+        before = guard.sqlite_schema_shape(connection)
+        connection.execute("drop index ux_normalized_value")
+        connection.execute("create unique index ux_normalized_value on normalized (upper(value))")
+        after = guard.sqlite_schema_shape(connection)
+    finally:
+        connection.close()
+
+    obligations = guard.schema_tightenings(before, after)
+    assert [(item.kind, item.table) for item in obligations] == [("deduplicate", "normalized")]
+
+
 @pytest.mark.parametrize("kind", sorted(guard.MIGRATION_SAFETY_KINDS))
 def test_each_safety_kind_requires_an_exact_positive_declaration(kind):
     """The finite contract accepts its matching kind and rejects a different mechanism."""
@@ -671,6 +753,36 @@ def test_new_planned_revision_is_audited_without_an_id_allowlist(monkeypatch, tm
         assert problems == []
     else:
         assert any(expected_fragment in problem and revision in problem for problem in problems)
+
+
+def test_safety_declaration_on_an_empty_obligation_is_rejected(monkeypatch):
+    revision = "20260105_0005"
+    shipped = dict(SHIPPED_GRAPH)
+    current = dict(shipped)
+    current[f"{revision}_new.py"] = _revision_file(revision, '"20260104_0004"') + 'MIGRATION_SAFETY = "copy"\n'
+    before = guard._SchemaShape(
+        tables={
+            "records": guard._TableShape(
+                (
+                    guard._ColumnShape("id", "INTEGER", False, None, 1),
+                    guard._ColumnShape("key", "TEXT", False, None, 0),
+                ),
+                0,
+            )
+        },
+        unique_indexes=frozenset(),
+    )
+    _graphs(monkeypatch, shipped, current)
+    monkeypatch.setattr(guard, "latest_released_tag", lambda: "v0.0.0")
+    monkeypatch.setattr(guard, "released_graphs", lambda: ["v0.0.0"])
+    monkeypatch.setattr(guard, "extract_released_versions", lambda tag, destination: destination)
+    monkeypatch.setattr(guard, "shipped_head_revisions", lambda sources: {"20260104_0004"})
+    monkeypatch.setattr(guard, "_planned_revisions", lambda config, heads: [revision])
+    monkeypatch.setattr(guard, "sqlite_schema_shape", lambda connection: before)
+    monkeypatch.setattr(guard.command, "upgrade", lambda *args, **kwargs: None)
+
+    problems = guard.migration_safety_problems("v0.0.0")
+    assert any("no structural obligation" in problem and revision in problem for problem in problems)
 
 
 @requires_release_history

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -536,6 +536,149 @@ def test_the_command_line_refuses_rather_than_passing_without_history(monkeypatc
     assert "could not run" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ('MIGRATION_SAFETY = "copy"\n', ("copy",)),
+        ('MIGRATION_SAFETY: tuple[str, ...] = ("deduplicate", "backfill")\n', ("deduplicate", "backfill")),
+        ('MIGRATION_SAFETY = ["backfill"]\n', ("backfill",)),
+        ('MIGRATION_SAFETY = make_safety()\n', guard.COMPUTED),
+        ('MIGRATION_SAFETY = ("unknown",)\n', ("unknown",)),
+        ('MIGRATION_SAFETY = ("copy",)\nMIGRATION_SAFETY = ("backfill",)\n', guard.COMPUTED),
+        ("", None),
+    ],
+    ids=["string", "annotated-tuple", "list", "computed", "unknown", "duplicate", "absent"],
+)
+def test_migration_safety_declaration_is_a_literal_only(source, expected):
+    """The declaration reader has no path to execute migration code or evaluate SQL."""
+    actual = guard.declared_migration_safety(source)
+    if expected is guard.COMPUTED:
+        assert actual is guard.COMPUTED
+    else:
+        assert actual == expected
+
+
+def test_schema_tightenings_only_reports_structural_obligations(tmp_path):
+    """SQLite PRAGMAs drive the finite kinds; ordinary indexes and safe defaults are quiet."""
+    db_path = tmp_path / "shapes.sqlite"
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute("create table unique_key (id integer primary key, key text)")
+        connection.execute("create table safe_default (id integer primary key)")
+        connection.execute("create index ix_safe_default_id on safe_default (id)")
+        connection.execute("create table missing_default (id integer primary key)")
+        connection.execute("create table copied (id integer primary key, legacy text, value text)")
+        before = guard.sqlite_schema_shape(connection)
+
+        connection.execute("create unique index ux_unique_key_key on unique_key (key)")
+        connection.execute("alter table safe_default add column filled text not null default 'x'")
+        connection.execute("alter table missing_default add column required text not null")
+        connection.execute(
+            "create table copied_new (id integer primary key, value text not null, "
+            "constraint ck_copied_value check (length(value) > 0))"
+        )
+        connection.execute("insert into copied_new (id, value) select id, coalesce(value, 'x') from copied")
+        connection.execute("drop table copied")
+        connection.execute("alter table copied_new rename to copied")
+        after = guard.sqlite_schema_shape(connection)
+    finally:
+        connection.close()
+
+    obligations = guard.schema_tightenings(before, after)
+    assert {(item.kind, item.table) for item in obligations} == {
+        ("deduplicate", "unique_key"),
+        ("backfill", "missing_default"),
+        ("copy", "copied"),
+    }
+    assert all(item.table != "safe_default" for item in obligations)
+
+
+def test_check_replacement_is_not_treated_as_a_relaxation(tmp_path):
+    db_path = tmp_path / "check.sqlite"
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute("create table checked (id integer primary key, value text check (value != 'old'))")
+        before = guard.sqlite_schema_shape(connection)
+        connection.execute("alter table checked rename to checked_old")
+        connection.execute("create table checked (id integer primary key, value text check (value != 'new'))")
+        connection.execute("insert into checked (id, value) select id, value from checked_old")
+        connection.execute("drop table checked_old")
+        after = guard.sqlite_schema_shape(connection)
+    finally:
+        connection.close()
+
+    obligations = guard.schema_tightenings(before, after)
+    assert [(item.kind, item.table) for item in obligations] == [("copy", "checked")]
+
+
+@pytest.mark.parametrize("kind", sorted(guard.MIGRATION_SAFETY_KINDS))
+def test_each_safety_kind_requires_an_exact_positive_declaration(kind):
+    """The finite contract accepts its matching kind and rejects a different mechanism."""
+    assert guard._migration_safety_declaration_error("r", (kind,), {kind}) is None
+    other = next(candidate for candidate in guard.MIGRATION_SAFETY_KINDS if candidate != kind)
+    error = guard._migration_safety_declaration_error("r", (other,), {kind})
+    assert error is not None
+    assert "observed obligations" in error
+
+
+def test_safety_declaration_errors_fail_closed():
+    assert "no MIGRATION_SAFETY" in guard._migration_safety_declaration_error("r", None, {"copy"})
+    assert "computed" in guard._migration_safety_declaration_error("r", guard.COMPUTED, {"copy"})
+    assert "unsupported" in guard._migration_safety_declaration_error("r", ("future",), {"copy"})
+    assert "exactly once" in guard._migration_safety_declaration_error("r", ("copy", "copy"), {"copy"})
+
+
+@pytest.mark.parametrize(
+    ("declaration", "expected_fragment"),
+    [
+        ("", "no MIGRATION_SAFETY"),
+        ('MIGRATION_SAFETY = "deduplicate"\n', None),
+    ],
+    ids=["missing-declaration", "matching-declaration"],
+)
+def test_new_planned_revision_is_audited_without_an_id_allowlist(monkeypatch, tmp_path, declaration, expected_fragment):
+    """A revision added after the baseline joins every released graph's real plan automatically."""
+    revision = "20260105_0005"
+    shipped = dict(SHIPPED_GRAPH)
+    current = dict(shipped)
+    current[f"{revision}_new.py"] = _revision_file(revision, '"20260104_0004"') + declaration
+    before = guard._SchemaShape(
+        tables={
+            "records": guard._TableShape(
+                (guard._ColumnShape("id", "INTEGER", False, None, 1), guard._ColumnShape("key", "TEXT", False, None, 0)),
+                0,
+            )
+        },
+        unique_indexes=frozenset(),
+    )
+    after = guard._SchemaShape(
+        tables=before.tables,
+        unique_indexes=frozenset({guard._UniqueShape("records", ("key",), False)}),
+    )
+    shapes = iter((before, after))
+    monkeypatch.setattr(guard, "latest_released_tag", lambda: "v0.0.0")
+    monkeypatch.setattr(guard, "released_sources", lambda tag: shipped)
+    monkeypatch.setattr(guard, "working_tree_sources", lambda: current)
+    monkeypatch.setattr(guard, "released_graphs", lambda: ["v0.0.0"])
+    monkeypatch.setattr(guard, "extract_released_versions", lambda tag, destination: destination)
+    monkeypatch.setattr(guard, "shipped_head_revisions", lambda sources: {"20260104_0004"})
+    monkeypatch.setattr(guard, "_planned_revisions", lambda config, heads: [revision])
+    monkeypatch.setattr(guard, "sqlite_schema_shape", lambda connection: next(shapes))
+    monkeypatch.setattr(guard.command, "upgrade", lambda *args, **kwargs: None)
+
+    problems = guard.migration_safety_problems("v0.0.0")
+    if expected_fragment is None:
+        assert problems == []
+    else:
+        assert any(expected_fragment in problem and revision in problem for problem in problems)
+
+
+@requires_release_history
+def test_real_release_baseline_has_no_new_migration_safety_obligations():
+    """Released migrations are grandfathered; only revisions after the latest baseline enter the contract."""
+    assert guard.migration_safety_problems() == []
+
+
 def test_head_tables_is_what_a_fresh_install_has():
     """The derivation source for the upgrade property must itself be measured, not maintained.
 

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -582,23 +582,58 @@ def test_safety_attestation_shape_fails_closed(declaration, expected_fragment):
         assert expected_fragment in error
 
 
-def test_new_revisions_are_enrolled_in_each_released_graph(monkeypatch):
-    """The graph, not a migration allowlist, supplies every attestation subject."""
+def test_attestation_is_metadata_only_and_does_not_execute_alembic(monkeypatch):
+    """The graph supplies every subject without a second migration executor."""
     revision = "20260105_0005"
     shipped = dict(SHIPPED_GRAPH)
     current = dict(shipped)
     current[f"{revision}_new.py"] = _revision_file(revision, '"20260104_0004"') + 'MIGRATION_SAFETY = "additive"\n'
     _graphs(monkeypatch, shipped, current)
     monkeypatch.setattr(guard, "latest_released_tag", lambda: "v0.0.0")
-    monkeypatch.setattr(guard, "released_graphs", lambda: ["v0.0.0", "v0.0.1"])
-    monkeypatch.setattr(guard, "extract_released_versions", lambda tag, destination: destination)
-    monkeypatch.setattr(guard, "shipped_head_revisions", lambda sources: {"20260104_0004"})
-    monkeypatch.setattr(guard, "_planned_revisions", lambda config, heads: [revision])
-    upgrade_calls = []
-    monkeypatch.setattr(guard.command, "upgrade", lambda *args, **kwargs: upgrade_calls.append((args, kwargs)))
+    monkeypatch.setattr(guard, "released_graphs", lambda: pytest.fail("attestation must not enumerate upgrade graphs"))
+    monkeypatch.setattr(guard.command, "upgrade", lambda *args, **kwargs: pytest.fail("attestation must not execute Alembic"))
 
-    assert guard.migration_safety_problems("v0.0.0") == []
-    assert len(upgrade_calls) == 4
+    assert guard.migration_safety_problems() == []
+
+
+def test_attestation_boundary_uses_latest_release_not_comparison_baseline(monkeypatch):
+    """An older metadata comparison cannot re-enroll revisions already released later."""
+    released_revision = "20260105_0005"
+    latest = dict(SHIPPED_GRAPH)
+    latest[f"{released_revision}_released.py"] = _revision_file(released_revision, '"20260104_0004"')
+    current = dict(latest)
+    monkeypatch.setattr(guard, "latest_released_tag", lambda: "v0.0.1")
+    monkeypatch.setattr(guard, "released_sources", lambda tag: SHIPPED_GRAPH if tag == "v0.0.0" else latest)
+    monkeypatch.setattr(guard, "working_tree_sources", lambda: current)
+    monkeypatch.setattr(guard, "releases_with_state_but_no_graph", lambda: [])
+    monkeypatch.setattr(guard, "fresh_install_tables", lambda: guard.HEAD_TABLES)
+    monkeypatch.setattr(guard, "new_slot_collisions", lambda baseline: {})
+    monkeypatch.setattr(guard, "rechained_revisions", lambda baseline: [])
+    monkeypatch.setattr(guard, "edited_released_bodies", lambda baseline: [])
+    monkeypatch.setattr(guard, "spent_body_edit_declarations", lambda baseline: [])
+    monkeypatch.setattr(guard, "unrepairable_releases", lambda: pytest.fail("--skip-upgrade must skip runtime upgrades"))
+
+    _, problems, refused = guard.collect_problems("v0.0.0", include_upgrade=False)
+
+    assert problems == []
+    assert refused == {}
+
+
+def test_only_revisions_after_latest_release_require_attestation(monkeypatch):
+    """A missing declaration is reported for a new revision, never for grandfathered history."""
+    released_revision = "20260105_0005"
+    new_revision = "20260106_0006"
+    latest = dict(SHIPPED_GRAPH)
+    latest[f"{released_revision}_released.py"] = _revision_file(released_revision, '"20260104_0004"')
+    current = dict(latest)
+    current[f"{new_revision}_new.py"] = _revision_file(new_revision, f'"{released_revision}"')
+    monkeypatch.setattr(guard, "latest_released_tag", lambda: "v0.0.1")
+    monkeypatch.setattr(guard, "released_sources", lambda tag: latest)
+    monkeypatch.setattr(guard, "working_tree_sources", lambda: current)
+
+    problems = guard.migration_safety_problems()
+
+    assert problems == [f"{new_revision} has no MIGRATION_SAFETY declaration"]
 
 
 @pytest.mark.parametrize(
@@ -618,13 +653,8 @@ def test_new_revision_requires_exact_attestation(monkeypatch, declaration, expec
     current[f"{revision}_new.py"] = _revision_file(revision, '"20260104_0004"') + declaration
     _graphs(monkeypatch, shipped, current)
     monkeypatch.setattr(guard, "latest_released_tag", lambda: "v0.0.0")
-    monkeypatch.setattr(guard, "released_graphs", lambda: ["v0.0.0"])
-    monkeypatch.setattr(guard, "extract_released_versions", lambda tag, destination: destination)
-    monkeypatch.setattr(guard, "shipped_head_revisions", lambda sources: {"20260104_0004"})
-    monkeypatch.setattr(guard, "_planned_revisions", lambda config, heads: [revision])
-    monkeypatch.setattr(guard.command, "upgrade", lambda *args, **kwargs: None)
 
-    problems = guard.migration_safety_problems("v0.0.0")
+    problems = guard.migration_safety_problems()
     if expected_fragment is None:
         assert problems == []
     else:

--- a/tests/test_migration_release_guard.py
+++ b/tests/test_migration_release_guard.py
@@ -1,10 +1,10 @@
-"""Cover the migration release guard's detection and the properties it asserts.
+"""Cover the migration release guard's graph and attestation properties.
 
-Two layers. The synthetic tests pin the detection itself, so the guard cannot decay into
-something that passes because it stopped looking. The repository tests are the guard
-running for real: three of them state the invariant the working tree must hold, and one
-runs the guard against the release that preceded the v3.0.11 splice, which is the known
-positive that keeps the other three honest.
+The synthetic tests pin the detection itself, so the guard cannot decay into something
+that passes because it stopped looking. The repository tests run the guard for real and
+exercise the release-history invariants it owns. Migration safety is intentionally an
+explicit, finite attestation contract; these tests do not infer data guarantees from
+Python or SQL source.
 
 Anything reading release history needs tags, which a shallow CI checkout does not have.
 Those tests skip there and the ``migration-release-guard`` workflow runs the same
@@ -539,18 +539,19 @@ def test_the_command_line_refuses_rather_than_passing_without_history(monkeypatc
 @pytest.mark.parametrize(
     ("source", "expected"),
     [
-        ('MIGRATION_SAFETY = "copy"\n', ("copy",)),
-        ('MIGRATION_SAFETY: tuple[str, ...] = ("deduplicate", "backfill")\n', ("deduplicate", "backfill")),
-        ('MIGRATION_SAFETY = ["backfill"]\n', ("backfill",)),
+        ('MIGRATION_SAFETY = "copy"\n', "copy"),
+        ('MIGRATION_SAFETY: str = "additive"\n', "additive"),
+        ('MIGRATION_SAFETY = ("copy",)\n', guard.COMPUTED),
+        ('MIGRATION_SAFETY = ["copy"]\n', guard.COMPUTED),
         ('MIGRATION_SAFETY = make_safety()\n', guard.COMPUTED),
-        ('MIGRATION_SAFETY = ("unknown",)\n', ("unknown",)),
-        ('MIGRATION_SAFETY = ("copy",)\nMIGRATION_SAFETY = ("backfill",)\n', guard.COMPUTED),
+        ('MIGRATION_SAFETY = "copy"\nMIGRATION_SAFETY = "backfill"\n', guard.COMPUTED),
+        ('if enabled:\n    MIGRATION_SAFETY = "copy"\n', None),
         ("", None),
     ],
-    ids=["string", "annotated-tuple", "list", "computed", "unknown", "duplicate", "absent"],
+    ids=["string", "annotated-string", "tuple", "list", "computed", "duplicate", "nested", "absent"],
 )
-def test_migration_safety_declaration_is_a_literal_only(source, expected):
-    """The declaration reader has no path to execute migration code or evaluate SQL."""
+def test_migration_safety_declaration_is_one_top_level_literal(source, expected):
+    """The declaration reader never executes migration code or evaluates SQL."""
     actual = guard.declared_migration_safety(source)
     if expected is guard.COMPUTED:
         assert actual is guard.COMPUTED
@@ -558,194 +559,69 @@ def test_migration_safety_declaration_is_a_literal_only(source, expected):
         assert actual == expected
 
 
-def test_schema_tightenings_only_reports_structural_obligations(tmp_path):
-    """SQLite PRAGMAs drive the finite kinds; ordinary indexes and safe defaults are quiet."""
-    db_path = tmp_path / "shapes.sqlite"
-    connection = sqlite3.connect(db_path)
-    try:
-        connection.execute("create table unique_key (id integer primary key, key text)")
-        connection.execute("create table safe_default (id integer primary key)")
-        connection.execute("create index ix_safe_default_id on safe_default (id)")
-        connection.execute("create table missing_default (id integer primary key)")
-        connection.execute("create table copied (id integer primary key, legacy text, value text)")
-        before = guard.sqlite_schema_shape(connection)
-
-        connection.execute("create unique index ux_unique_key_key on unique_key (key)")
-        connection.execute("alter table safe_default add column filled text not null default 'x'")
-        connection.execute("alter table missing_default add column required text not null")
-        connection.execute(
-            "create table copied_new (id integer primary key, value text not null, "
-            "constraint ck_copied_value check (length(value) > 0))"
-        )
-        connection.execute("insert into copied_new (id, value) select id, coalesce(value, 'x') from copied")
-        connection.execute("drop table copied")
-        connection.execute("alter table copied_new rename to copied")
-        after = guard.sqlite_schema_shape(connection)
-    finally:
-        connection.close()
-
-    obligations = guard.schema_tightenings(before, after)
-    assert {(item.kind, item.table) for item in obligations} == {
-        ("deduplicate", "unique_key"),
-        ("backfill", "missing_default"),
-        ("copy", "copied"),
-    }
-    assert all(item.table != "safe_default" for item in obligations)
-
-
-def test_check_replacement_is_not_treated_as_a_relaxation(tmp_path):
-    db_path = tmp_path / "check.sqlite"
-    connection = sqlite3.connect(db_path)
-    try:
-        connection.execute("create table checked (id integer primary key, value text check (value != 'old'))")
-        before = guard.sqlite_schema_shape(connection)
-        connection.execute("alter table checked rename to checked_old")
-        connection.execute("create table checked (id integer primary key, value text check (value != 'new'))")
-        connection.execute("insert into checked (id, value) select id, value from checked_old")
-        connection.execute("drop table checked_old")
-        after = guard.sqlite_schema_shape(connection)
-    finally:
-        connection.close()
-
-    obligations = guard.schema_tightenings(before, after)
-    assert [(item.kind, item.table) for item in obligations] == [("copy", "checked")]
-
-
-def test_check_tokens_inside_literals_identifiers_and_comments_are_ignored(tmp_path):
-    db_path = tmp_path / "check_tokens.sqlite"
-    connection = sqlite3.connect(db_path)
-    try:
-        connection.execute(
-            "create table quoted (label text default 'check', \"check\" text, note text /* check */)"
-        )
-        shape = guard.sqlite_schema_shape(connection)
-    finally:
-        connection.close()
-
-    assert shape.tables["quoted"].check_count == 0
-
-
-def test_added_column_plus_replaced_check_requires_copy(tmp_path):
-    db_path = tmp_path / "mixed_check.sqlite"
-    connection = sqlite3.connect(db_path)
-    try:
-        connection.execute("create table mixed (id integer primary key, value text check (value != 'old'))")
-        before = guard.sqlite_schema_shape(connection)
-        connection.execute("alter table mixed rename to mixed_old")
-        connection.execute(
-            "create table mixed (id integer primary key, value text check (value != 'new'), added text)"
-        )
-        connection.execute("insert into mixed (id, value) select id, value from mixed_old")
-        connection.execute("drop table mixed_old")
-        after = guard.sqlite_schema_shape(connection)
-    finally:
-        connection.close()
-
-    obligations = guard.schema_tightenings(before, after)
-    assert [(item.kind, item.table) for item in obligations] == [("copy", "mixed")]
-
-
-def test_sqlite_boolean_defaults_are_known_non_null(tmp_path):
-    db_path = tmp_path / "boolean_default.sqlite"
-    connection = sqlite3.connect(db_path)
-    try:
-        connection.execute("create table flags (id integer primary key)")
-        before = guard.sqlite_schema_shape(connection)
-        connection.execute("alter table flags add column enabled integer not null default TRUE")
-        after = guard.sqlite_schema_shape(connection)
-    finally:
-        connection.close()
-
-    assert guard.schema_tightenings(before, after) == ()
-
-
-def test_partial_unique_predicate_change_is_a_new_deduplication_obligation(tmp_path):
-    db_path = tmp_path / "partial_unique.sqlite"
-    connection = sqlite3.connect(db_path)
-    try:
-        connection.execute("create table scoped (key text, active integer)")
-        connection.execute("create unique index ux_scoped_key on scoped (key) where active = 1")
-        before = guard.sqlite_schema_shape(connection)
-        connection.execute("drop index ux_scoped_key")
-        connection.execute("create unique index ux_scoped_key on scoped (key) where active = 0")
-        after = guard.sqlite_schema_shape(connection)
-    finally:
-        connection.close()
-
-    obligations = guard.schema_tightenings(before, after)
-    assert [(item.kind, item.table) for item in obligations] == [("deduplicate", "scoped")]
-
-
-def test_unique_expression_change_is_a_new_deduplication_obligation(tmp_path):
-    db_path = tmp_path / "expression_unique.sqlite"
-    connection = sqlite3.connect(db_path)
-    try:
-        connection.execute("create table normalized (value text)")
-        connection.execute("create unique index ux_normalized_value on normalized (lower(value))")
-        before = guard.sqlite_schema_shape(connection)
-        connection.execute("drop index ux_normalized_value")
-        connection.execute("create unique index ux_normalized_value on normalized (upper(value))")
-        after = guard.sqlite_schema_shape(connection)
-    finally:
-        connection.close()
-
-    obligations = guard.schema_tightenings(before, after)
-    assert [(item.kind, item.table) for item in obligations] == [("deduplicate", "normalized")]
-
-
 @pytest.mark.parametrize("kind", sorted(guard.MIGRATION_SAFETY_KINDS))
-def test_each_safety_kind_requires_an_exact_positive_declaration(kind):
-    """The finite contract accepts its matching kind and rejects a different mechanism."""
-    assert guard._migration_safety_declaration_error("r", (kind,), {kind}) is None
-    other = next(candidate for candidate in guard.MIGRATION_SAFETY_KINDS if candidate != kind)
-    error = guard._migration_safety_declaration_error("r", (other,), {kind})
-    assert error is not None
-    assert "observed obligations" in error
+def test_each_safety_kind_is_an_accepted_attestation(kind):
+    assert guard._migration_safety_declaration_error("r", kind) is None
 
 
-def test_safety_declaration_errors_fail_closed():
-    assert "no MIGRATION_SAFETY" in guard._migration_safety_declaration_error("r", None, {"copy"})
-    assert "computed" in guard._migration_safety_declaration_error("r", guard.COMPUTED, {"copy"})
-    assert "unsupported" in guard._migration_safety_declaration_error("r", ("future",), {"copy"})
-    assert "exactly once" in guard._migration_safety_declaration_error("r", ("copy", "copy"), {"copy"})
+@pytest.mark.parametrize(
+    ("declaration", "expected_fragment"),
+    [
+        (None, "no MIGRATION_SAFETY"),
+        (guard.COMPUTED, "computed or malformed"),
+        ("future", "unsupported kind"),
+        ("copy", None),
+    ],
+    ids=["missing", "computed", "unsupported", "accepted"],
+)
+def test_safety_attestation_shape_fails_closed(declaration, expected_fragment):
+    error = guard._migration_safety_declaration_error("r", declaration)
+    if expected_fragment is None:
+        assert error is None
+    else:
+        assert expected_fragment in error
+
+
+def test_new_revisions_are_enrolled_in_each_released_graph(monkeypatch):
+    """The graph, not a migration allowlist, supplies every attestation subject."""
+    revision = "20260105_0005"
+    shipped = dict(SHIPPED_GRAPH)
+    current = dict(shipped)
+    current[f"{revision}_new.py"] = _revision_file(revision, '"20260104_0004"') + 'MIGRATION_SAFETY = "additive"\n'
+    _graphs(monkeypatch, shipped, current)
+    monkeypatch.setattr(guard, "latest_released_tag", lambda: "v0.0.0")
+    monkeypatch.setattr(guard, "released_graphs", lambda: ["v0.0.0", "v0.0.1"])
+    monkeypatch.setattr(guard, "extract_released_versions", lambda tag, destination: destination)
+    monkeypatch.setattr(guard, "shipped_head_revisions", lambda sources: {"20260104_0004"})
+    monkeypatch.setattr(guard, "_planned_revisions", lambda config, heads: [revision])
+    upgrade_calls = []
+    monkeypatch.setattr(guard.command, "upgrade", lambda *args, **kwargs: upgrade_calls.append((args, kwargs)))
+
+    assert guard.migration_safety_problems("v0.0.0") == []
+    assert len(upgrade_calls) == 4
 
 
 @pytest.mark.parametrize(
     ("declaration", "expected_fragment"),
     [
         ("", "no MIGRATION_SAFETY"),
-        ('MIGRATION_SAFETY = "deduplicate"\n', None),
+        ('MIGRATION_SAFETY = "additive"\n', None),
+        ('MIGRATION_SAFETY = "future"\n', "unsupported kind"),
+        ('MIGRATION_SAFETY = ("copy",)\n', "computed or malformed"),
     ],
-    ids=["missing-declaration", "matching-declaration"],
+    ids=["missing", "accepted", "unknown", "non-string"],
 )
-def test_new_planned_revision_is_audited_without_an_id_allowlist(monkeypatch, tmp_path, declaration, expected_fragment):
-    """A revision added after the baseline joins every released graph's real plan automatically."""
+def test_new_revision_requires_exact_attestation(monkeypatch, declaration, expected_fragment):
     revision = "20260105_0005"
     shipped = dict(SHIPPED_GRAPH)
     current = dict(shipped)
     current[f"{revision}_new.py"] = _revision_file(revision, '"20260104_0004"') + declaration
-    before = guard._SchemaShape(
-        tables={
-            "records": guard._TableShape(
-                (guard._ColumnShape("id", "INTEGER", False, None, 1), guard._ColumnShape("key", "TEXT", False, None, 0)),
-                0,
-            )
-        },
-        unique_indexes=frozenset(),
-    )
-    after = guard._SchemaShape(
-        tables=before.tables,
-        unique_indexes=frozenset({guard._UniqueShape("records", ("key",), False)}),
-    )
-    shapes = iter((before, after))
+    _graphs(monkeypatch, shipped, current)
     monkeypatch.setattr(guard, "latest_released_tag", lambda: "v0.0.0")
-    monkeypatch.setattr(guard, "released_sources", lambda tag: shipped)
-    monkeypatch.setattr(guard, "working_tree_sources", lambda: current)
     monkeypatch.setattr(guard, "released_graphs", lambda: ["v0.0.0"])
     monkeypatch.setattr(guard, "extract_released_versions", lambda tag, destination: destination)
     monkeypatch.setattr(guard, "shipped_head_revisions", lambda sources: {"20260104_0004"})
     monkeypatch.setattr(guard, "_planned_revisions", lambda config, heads: [revision])
-    monkeypatch.setattr(guard, "sqlite_schema_shape", lambda connection: next(shapes))
     monkeypatch.setattr(guard.command, "upgrade", lambda *args, **kwargs: None)
 
     problems = guard.migration_safety_problems("v0.0.0")
@@ -755,39 +631,9 @@ def test_new_planned_revision_is_audited_without_an_id_allowlist(monkeypatch, tm
         assert any(expected_fragment in problem and revision in problem for problem in problems)
 
 
-def test_safety_declaration_on_an_empty_obligation_is_rejected(monkeypatch):
-    revision = "20260105_0005"
-    shipped = dict(SHIPPED_GRAPH)
-    current = dict(shipped)
-    current[f"{revision}_new.py"] = _revision_file(revision, '"20260104_0004"') + 'MIGRATION_SAFETY = "copy"\n'
-    before = guard._SchemaShape(
-        tables={
-            "records": guard._TableShape(
-                (
-                    guard._ColumnShape("id", "INTEGER", False, None, 1),
-                    guard._ColumnShape("key", "TEXT", False, None, 0),
-                ),
-                0,
-            )
-        },
-        unique_indexes=frozenset(),
-    )
-    _graphs(monkeypatch, shipped, current)
-    monkeypatch.setattr(guard, "latest_released_tag", lambda: "v0.0.0")
-    monkeypatch.setattr(guard, "released_graphs", lambda: ["v0.0.0"])
-    monkeypatch.setattr(guard, "extract_released_versions", lambda tag, destination: destination)
-    monkeypatch.setattr(guard, "shipped_head_revisions", lambda sources: {"20260104_0004"})
-    monkeypatch.setattr(guard, "_planned_revisions", lambda config, heads: [revision])
-    monkeypatch.setattr(guard, "sqlite_schema_shape", lambda connection: before)
-    monkeypatch.setattr(guard.command, "upgrade", lambda *args, **kwargs: None)
-
-    problems = guard.migration_safety_problems("v0.0.0")
-    assert any("no structural obligation" in problem and revision in problem for problem in problems)
-
-
 @requires_release_history
 def test_real_release_baseline_has_no_new_migration_safety_obligations():
-    """Released migrations are grandfathered; only revisions after the latest baseline enter the contract."""
+    """A current graph with no post-release revisions needs no new attestation run."""
     assert guard.migration_safety_problems() == []
 
 


### PR DESCRIPTION
## What changed

Adds an explicit migration-safety attestation gate for revisions introduced after the
latest released Alembic graph. The graph diff against the latest released graph enrolls every
new revision automatically; there is no migration ID allowlist. The existing release-history
checks and real Alembic execution remain separate evidence for graph identity, reachability,
and upgrade behavior.

## Bounded contract

- Every revision introduced after the latest release must contain exactly one top-level literal
  string named `MIGRATION_SAFETY`.
- The value must be exactly one of `additive`, `deduplicate`, `backfill`, or `copy`.
- Missing, computed, non-string, duplicate, or unknown declarations fail closed.
- The values are author-owned strategy attestations. The guard does not parse Python control
  flow, interpret SQL, infer guarantees from identifiers, or claim to prove every stored row.
- Extra declarations are not rejected as mismatches: without obligation inference there is no
  second semantic claim for the guard to compare.
- Revisions already in the latest release baseline are grandfathered and are not reinterpreted.

This replaces the interpreter direction from PR #1720. The four second-round counterexamples
(new-table population, unique-index identity, table DDL options, and foreign keys) are handled
by removing unsupported schema/DDL inference rather than adding another partial SQL interpreter.
If this finite attestation contract is insufficient for Issue #1577's universal acceptance
property, the issue must be narrowed instead of expanding this guard.

## Evidence

- **Unit**: exact top-level literal parsing, duplicate/computed/non-string rejection, and the
  finite vocabulary.
- **Contract**: the graph diff against the latest released graph enrolls every new revision;
  `unrepairable_releases` separately owns real Alembic upgrade evidence. No hand-maintained
  migration list or duplicate executor is used.
- **Repository**: 221 migration guard, SQLite state migration, and migration lock tests pass;
  Ruff and bytecode compilation are clean; the full release guard passes against the latest
  released baseline.
- **Scenario**: no migration scenario catalog applies.
- **Residual manual**: attestation values are author-owned declarations of the migration
  mechanism; the guard does not validate arbitrary data transformation semantics.

Relates to #1577.
