### PR TITLE
fix(model-hub): unify settings page scrolling

### DIFF
--- a/docs/plans/model-hub-ui-spec.md
+++ b/docs/plans/model-hub-ui-spec.md
@@ -1057,8 +1057,8 @@ sections. §1.8 states the direct-only body condition.
 | `tabs` | 1120×39, `gap: 4`, `border-bottom: 1 $--border` |
 | tab | `padding: [10,14]`, `gap: 7`; label 13 / 600 |
 | active tab | `border-bottom: 2 $--mint` |
-| `body` | 1120×854, `layout: none` (children positioned absolutely) |
-| `cols` | 1120×806, `gap: 16` → upstream 384 + rail 72 + gateway 632 |
+| `body` | 1120 wide, height follows its content; the enclosing settings route pane is the sole page scroll owner |
+| `cols` | 1120 wide, natural height, `gap: 16` → upstream 384 + rail 72 + gateway 632 |
 | Module card | `$--surface`, `border 1 $--border`, `radius 14` |
 | Legend row | 1120×34, `gap: 18`, `space_between`, swatch 20×2, label 11 / 500 `$--muted` |
 
@@ -1795,11 +1795,12 @@ Claude Code's head has no order button, because a direct backend consults no sou
 order and an editor there would edit a list nothing reads. D-9a states the rule, and it
 is a set equality over the three groups.
 
-**Track metrics** `[frame]`: `cols` 1120×806, `gap 16`; upstream module 384 wide,
-rail 72, gateway module takes the rest. Everything inside those tracks is
-`fill_container`, so this file records the three track widths and the fixed heights
-and never a derived row width — a literal there is a number that goes stale the first
-time a track moves.
+**Track metrics** `[frame]` `[derived]`: `cols` is 1120 wide with `gap 16`; upstream
+module is 384 wide, rail is 72, and the gateway module takes the rest. The frame's
+806px column is an instance, not a height cap: both modules grow with their content,
+the legend follows the taller module, and the enclosing settings route pane owns the
+only page scroll. This file records the three track widths and never a derived row
+width — a literal there is a number that goes stale the first time a track moves.
 
 **Card and row metrics** `[frame]`: upstream card `fill_container`×96 minimum, auto height,
 `padding [8,12]`, `gap 10`, `radius 10`; tile 34×34 `radius 9`; name 12.5/700 Inter
@@ -1900,10 +1901,10 @@ Other limits `[derived]`:
 | Long source name | Single line, ellipsis at the card's inner width — `upstream module 384 − border 2 − upContent padding 24 − card padding 24 − tile 34 − gap 10 = 290` at the frame's track width, and derived from the live track everywhere else. `title` attribute carries the full value. |
 | Long base URL / masked key | Mono line truncates **from the middle**, keeping scheme+host and the last 4 key chars — the two ends are what identifies it. |
 | Long model id | Mono, ellipsis at the `a` column; full value in `title`. |
-| Many sources (> 6) | Upstream module grows to the `cols` track height (806) and then `upContent` scrolls; the head and footer stay pinned. Group labels scroll with the content. |
-| Many backends (> 3) | `gwContent` scrolls; the rail line keeps spanning the visible track. |
+| Many sources (> 6) | The upstream module grows with every source; the enclosing settings route pane scrolls, so the head, groups and footer remain in one reading flow. |
+| Many backends (> 3) | The gateway module grows with every backend; the enclosing settings route pane scrolls and no nested gateway scrollbar appears. |
 | Zero supply relations | The wire layer renders nothing — no placeholder path. |
-| Wires | Generated from the supply-relation set, never hand-placed; the frame's four paths are an instance of that generator, not a fixed asset. The SVG is clipped to the 806px `cols` track and cannot paint into the legend or following page sections. |
+| Wires | Generated from the supply-relation set, never hand-placed; the frame's four paths are an instance of that generator, not a fixed asset. The SVG follows the natural-height `cols` track and remains clipped before the legend and following page sections. |
 
 ---
 

--- a/ui/src/components/settings/models/GatewayModule.test.tsx
+++ b/ui/src/components/settings/models/GatewayModule.test.tsx
@@ -50,6 +50,8 @@ describe('GatewayModule region failure treatment', () => {
     const panel = screen.getByRole('heading', { name: /Gateway routes|网关路由/i }).closest('section');
     expect(panel?.className).toContain('w-full');
     expect(panel?.className).toContain('min-w-0');
+    expect(panel?.className).not.toContain('max-h-full');
+    expect(panel?.children.item(1)?.className).not.toContain('overflow-y-auto');
   });
 
   it('keeps the last good Agent rows visible with an F2 retry after a later read fails', async () => {

--- a/ui/src/components/settings/models/GatewayModule.tsx
+++ b/ui/src/components/settings/models/GatewayModule.tsx
@@ -27,7 +27,7 @@ export const GatewayModule: React.FC<GatewayModuleProps> = ({ runtime, runtimeSn
   });
   const listening = runtimeSnapshot?.status.listening;
   return (
-    <section className="relative z-20 flex max-h-full min-h-[420px] w-full min-w-0 flex-col self-start overflow-hidden rounded-[14px] border border-border bg-surface">
+    <section className="relative z-20 flex min-h-[420px] w-full min-w-0 flex-col self-start overflow-hidden rounded-[14px] border border-border bg-surface">
       <header className="flex h-14 shrink-0 items-center justify-between border-b border-border px-3.5">
         <span className="flex items-center gap-[7px]">
           <h2 className="text-[16px] font-bold leading-[23px] text-foreground">{t('settings.models.gateway.heading')}</h2>
@@ -35,7 +35,7 @@ export const GatewayModule: React.FC<GatewayModuleProps> = ({ runtime, runtimeSn
         </span>
         {listening && <span className="model-hub-pill model-hub-fill-0a border border-border text-muted">{listening.host}:{listening.port}</span>}
       </header>
-      <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2 pt-3">
+      <div className="flex-1 px-2 pb-2 pt-3">
         {supply.kind === 'loading' && agents === undefined
           ? <div className="flex h-full min-h-36 items-center justify-center"><LoaderCircle className="size-4 animate-spin text-muted" /></div>
           : supply.kind === 'unread'

--- a/ui/src/components/settings/models/SourcesCard.test.tsx
+++ b/ui/src/components/settings/models/SourcesCard.test.tsx
@@ -35,6 +35,8 @@ describe('SourcesCard footer', () => {
     const panel = screen.getByRole('heading', { name: /Upstream sources|上游来源/i }).closest('section');
     expect(panel?.className).toContain('w-full');
     expect(panel?.className).toContain('min-w-0');
+    expect(panel?.className).not.toContain('max-h-full');
+    expect(panel?.children.item(1)?.className).not.toContain('overflow-y-auto');
   });
 
   it('keeps the source title on its own line above the interface and kind tags', () => {

--- a/ui/src/components/settings/models/SourcesCard.tsx
+++ b/ui/src/components/settings/models/SourcesCard.tsx
@@ -30,12 +30,10 @@ export const SourcesCard: React.FC<{
     { id: 'native', sources: (sources ?? []).filter((source) => source.supply_channel === 'native_cli') },
     { id: 'hub', sources: (sources ?? []).filter((source) => source.supply_channel === 'hub') },
   ].filter((group) => group.sources.length > 0);
-  // No height floor: the frame sizes this panel to its cards, so a fixture with
-  // fewer sources than the design draws should end below the footer rather than
-  // leave ~100px of void above it. `max-h-full` still hands overflow to the
-  // scroll region when there are more.
+  // The settings route pane owns vertical scrolling. This card grows with its
+  // sources so users never have to coordinate a second scroll area here.
   return (
-    <section className="relative z-20 flex max-h-full w-full min-w-0 flex-col self-start overflow-hidden rounded-[14px] border border-border bg-surface">
+    <section className="relative z-20 flex w-full min-w-0 flex-col self-start overflow-hidden rounded-[14px] border border-border bg-surface">
       <div className="flex h-14 shrink-0 items-center justify-between border-b border-border px-3.5">
         <span className="flex items-center gap-[7px]">
           <h2 className="text-[16px] font-bold leading-[23px] text-foreground">{t('settings.models.upstream.heading')}</h2>
@@ -47,7 +45,7 @@ export const SourcesCard: React.FC<{
         </span>
         {sources !== undefined && <span className="model-hub-pill model-hub-upstream-count border">{t('settings.models.upstream.count', { count: sources.length })}</span>}
       </div>
-      <div className="min-h-0 flex-1 space-y-2.5 overflow-y-auto p-3">
+      <div className="flex-1 space-y-2.5 p-3">
         {read.kind === 'loading' && sources === undefined
           ? <div className="flex h-full min-h-36 items-center justify-center"><LoaderCircle className="size-4 animate-spin text-muted" /></div>
           : read.kind === 'unread'

--- a/ui/src/components/settings/models/modelHubStylePolicy.test.ts
+++ b/ui/src/components/settings/models/modelHubStylePolicy.test.ts
@@ -36,6 +36,18 @@ describe('Model Hub theme token policy', () => {
 });
 
 describe('Model Hub visual token policy', () => {
+  it('lets the settings route pane own overview scrolling', () => {
+    const overviewGrid = surfaceCss.match(/\.model-hub-overview-grid\s*\{([^}]*)\}/)?.[1] ?? '';
+    const overviewBody = surfaceCss.match(/\.model-hub-overview-body\s*\{([^}]*)\}/)?.[1] ?? '';
+    const legendBlocks = [...surfaceCss.matchAll(/\.model-hub-legend\s*\{([^}]*)\}/g)]
+      .map((match) => match[1]);
+
+    expect(overviewGrid).not.toMatch(/(?:^|;)\s*height\s*:/);
+    expect(overviewBody).not.toMatch(/(?:^|;)\s*height\s*:/);
+    expect(legendBlocks).not.toEqual([]);
+    for (const legend of legendBlocks) expect(legend).not.toContain('position: absolute');
+  });
+
   it('keeps approximate utility colors out of product surfaces', () => {
     const forbidden = /(?:text-(?:foreground|muted)\/\d+|bg-foreground\/\[[^\]]+\]|border-foreground\/\d+|\btext-(?:gold|violet|mint)\b)/g;
     const violations = productFiles(__dirname).flatMap((path) => (

--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -341,7 +341,6 @@
   --model-hub-upstream-track: 384px;
   --model-hub-rail-track: 72px;
   --model-hub-track-gap: 16px;
-  --model-hub-track-height: 806px;
   --model-hub-legend-height: 34px;
   --model-hub-wire-active-width: 1.75px;
   --model-hub-wire-muted-width: 1px;
@@ -1741,21 +1740,11 @@
 
 @media (min-width: 1024px) {
   .model-hub-shell { padding-top: 4px; }
-  .model-hub-overview-body { height: 854px; }
   .model-hub-overview-grid {
     display: grid;
     grid-template-columns: var(--model-hub-upstream-track) var(--model-hub-rail-track) minmax(0, 1fr);
     gap: var(--model-hub-track-gap);
-    height: var(--model-hub-track-height);
     align-items: start;
-  }
-  .model-hub-legend {
-    position: absolute;
-    top: 820px;
-    left: 0;
-    width: 100%;
-    height: var(--model-hub-legend-height);
-    padding-block: 0;
   }
 }
 


### PR DESCRIPTION
## Summary

- make the settings route pane the only vertical scroll owner on the Model Hub overview
- let upstream and gateway cards grow with their content instead of clipping them to the former 806px track
- keep the supply graph and legend aligned to the overview's natural height, and update the normative UI spec

## Validation

- `npm test -- --run` for SettingsLayout, SourcesCard, GatewayModule, SupplyGraph, Model Hub style policy, and SettingsModelsPage rendering: 81 tests passed
- `npm run build`, `npm run lint`, and `npm run validate:theme` passed
- `uv run python scripts/check_model_hub_authorities.py` passed
- local Incus master regression backend with its persisted two upstream sources at 1470x797 and 390x844: scrolling over gateway content moved only the settings route pane; the settings rail stayed viewport-bound; source detail/back and the priority drawer remained usable

## Evidence layers

- Unit: updated component and style-policy coverage
- Contract: normative Model Hub UI spec updated; authority closure passed
- Scenario IDs: N/A, this changes layout ownership without changing a scenario contract
- Manual: real regression data and interactive browser checks completed

## Risk

Large source or backend inventories now make the route pane taller by design. They no longer create nested scroll regions inside the overview cards.
