### PR TITLE
fix(model-hub): distinguish unconfigured routes and unblock OpenCode

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -452,14 +452,26 @@ class Controller:
             ]
 
         cli_presence: dict[str, bool] = {}
+        cli_presence_lock = threading.Lock()
+        cli_presence_generation: dict[str, int] = {}
+        next_cli_presence_generation = 0
 
         def cli_present(backend: str) -> bool:
             # Payload assembly runs on the controller loop. Read only the last
             # complete worker-produced snapshot here.
             return cli_presence.get(backend, False)
 
-        def refresh_cli_presence(include_npm_global: bool) -> None:
-            nonlocal cli_presence
+        def refresh_cli_presence(
+            include_npm_global: bool,
+            backends: tuple[str, ...] | None = None,
+        ) -> None:
+            nonlocal cli_presence, next_cli_presence_generation
+            selected_backends = backends or ("claude", "codex", "opencode")
+            with cli_presence_lock:
+                next_cli_presence_generation += 1
+                generation = next_cli_presence_generation
+                for backend in selected_backends:
+                    cli_presence_generation[backend] = generation
             try:
                 v2_config = V2Config.load()
             except FileNotFoundError:
@@ -468,7 +480,7 @@ class Controller:
                 logger.warning("Model Hub CLI config probe failed", exc_info=True)
                 v2_config = None
             configured_paths: dict[str, str] = {}
-            for backend in ("claude", "codex", "opencode"):
+            for backend in selected_backends:
                 backend_config = getattr(getattr(v2_config, "agents", None), backend, None)
                 configured_paths[backend] = str(
                     getattr(backend_config, "cli_path", None) or backend
@@ -485,12 +497,20 @@ class Controller:
                 backend: resolved_paths.get(configured_path) is not None
                 for backend, configured_path in configured_paths.items()
             }
-            cli_presence = refreshed
+            with cli_presence_lock:
+                cli_presence = {
+                    **cli_presence,
+                    **{
+                        backend: present
+                        for backend, present in refreshed.items()
+                        if cli_presence_generation.get(backend) == generation
+                    },
+                }
 
         # Seed only filesystem and PATH facts before the internal RPC surface
         # exists. The page publishes npm-only installs through an explicit
         # post-paint refresh, so controller readiness never waits on npm.
-        refresh_cli_presence(False)
+        refresh_cli_presence(False, None)
 
         self.model_hub_service = create_default_service(
             requested_model_override=default_vibe_agent_model,

--- a/core/handlers/model_hub/rpc.py
+++ b/core/handlers/model_hub/rpc.py
@@ -6,46 +6,68 @@ import asyncio
 from typing import Any
 from weakref import WeakKeyDictionary
 
-from .service import ModelHubError, ModelHubService
+from .service import BackendName, ModelHubError, ModelHubService
 from .usage import USAGE_DEFAULT_WINDOW_DAYS
 
 _cli_presence_refresh_tasks: WeakKeyDictionary[
     ModelHubService,
-    asyncio.Task[None],
+    dict[tuple[BackendName, ...] | None, asyncio.Task[None]],
 ] = WeakKeyDictionary()
 
 
-async def _refresh_agent_presence(service: ModelHubService) -> None:
+async def _refresh_agent_presence(
+    service: ModelHubService,
+    backends: tuple[BackendName, ...] | None = None,
+) -> None:
     """Refresh host CLI facts without blocking the controller event loop."""
 
-    current = _cli_presence_refresh_tasks.get(service)
+    tasks = _cli_presence_refresh_tasks.setdefault(service, {})
+    current = tasks.get(backends)
     if current is not None and not current.done():
         await asyncio.shield(current)
         return
 
-    task = _start_agent_presence_refresh(service)
+    task = _start_agent_presence_refresh(service, backends)
     await asyncio.shield(task)
 
 
-async def _run_agent_presence_refresh(service: ModelHubService) -> None:
+async def _run_agent_presence_refresh(
+    service: ModelHubService,
+    backends: tuple[BackendName, ...] | None,
+) -> None:
     try:
         await asyncio.to_thread(
             service.refresh_cli_presence,
             include_npm_global=True,
+            backends=backends,
         )
     finally:
         current = asyncio.current_task()
-        if _cli_presence_refresh_tasks.get(service) is current:
-            _cli_presence_refresh_tasks.pop(service, None)
+        tasks = _cli_presence_refresh_tasks.get(service)
+        if tasks is not None and tasks.get(backends) is current:
+            tasks.pop(backends, None)
+            if not tasks:
+                _cli_presence_refresh_tasks.pop(service, None)
 
 
-def _start_agent_presence_refresh(service: ModelHubService) -> asyncio.Task[None]:
+def _start_agent_presence_refresh(
+    service: ModelHubService,
+    backends: tuple[BackendName, ...] | None,
+) -> asyncio.Task[None]:
     task = asyncio.create_task(
-        _run_agent_presence_refresh(service),
+        _run_agent_presence_refresh(service, backends),
         name="model-hub-cli-presence-refresh",
     )
-    _cli_presence_refresh_tasks[service] = task
+    _cli_presence_refresh_tasks.setdefault(service, {})[backends] = task
     return task
+
+
+async def _refresh_payload_backend(
+    service: ModelHubService,
+    backend: object,
+) -> None:
+    if backend in ("claude", "codex", "opencode"):
+        await _refresh_agent_presence(service, (backend,))
 
 
 async def dispatch_model_hub_rpc(
@@ -95,13 +117,13 @@ async def dispatch_model_hub_rpc(
             payload.get("backend"),
         )
     if operation == "set_agent_sources":
-        await _refresh_agent_presence(service)
+        await _refresh_payload_backend(service, payload.get("backend"))
         return await service.set_agent_sources(
             payload.get("backend"),
             payload.get("sources"),
         )
     if operation == "reorder_agent_chains":
-        await _refresh_agent_presence(service)
+        await _refresh_payload_backend(service, payload.get("backend"))
         if "order" in payload:
             return await service.reorder_agent_chains(
                 payload.get("backend"),
@@ -109,7 +131,7 @@ async def dispatch_model_hub_rpc(
             )
         return await service.reorder_agent_chains(payload.get("backend"))
     if operation == "set_agent_mode":
-        await _refresh_agent_presence(service)
+        await _refresh_payload_backend(service, payload.get("backend"))
         return await service.set_agent_mode(payload.get("backend"), payload.get("mode"))
     if operation == "set_agent_chain":
         return await service.set_agent_chain(
@@ -118,7 +140,7 @@ async def dispatch_model_hub_rpc(
             payload.get("chain"),
         )
     if operation == "set_opencode_menu":
-        await _refresh_agent_presence(service)
+        await _refresh_agent_presence(service, ("opencode",))
         return await service.set_opencode_menu(payload.get("menu"))
     if operation == "add_custom_model":
         return await service.add_custom_model(payload.get("source_id"), payload.get("model"))

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -654,7 +654,9 @@ class ModelHubService:
             Callable[[BackendName], list[tuple[str, Optional[str]]]]
         ] = None,
         cli_present_override: Optional[Callable[[BackendName], bool]] = None,
-        cli_presence_refresh: Optional[Callable[[bool], None]] = None,
+        cli_presence_refresh: Optional[
+            Callable[[bool, tuple[BackendName, ...] | None], None]
+        ] = None,
         now: Callable[[], datetime] = _utc_now,
     ):
         self.store = store
@@ -3476,6 +3478,11 @@ class ModelHubService:
                             if agent.mode == "hub" and named_resolution.requested_model
                             else None
                         ),
+                        "route_reason": (
+                            named_resolution.route_reason
+                            if agent.mode == "hub" and named_resolution.requested_model
+                            else None
+                        ),
                     }
                 )
         agent_payload = agent.to_payload()
@@ -3506,11 +3513,16 @@ class ModelHubService:
         config = self.store.load()
         return [self._agent_payload(config, config.agents[backend]) for backend in ("claude", "codex", "opencode")]
 
-    def refresh_cli_presence(self, *, include_npm_global: bool = False) -> None:
+    def refresh_cli_presence(
+        self,
+        *,
+        include_npm_global: bool = False,
+        backends: tuple[BackendName, ...] | None = None,
+    ) -> None:
         if self.cli_presence_refresh is None:
             return
         try:
-            self.cli_presence_refresh(include_npm_global)
+            self.cli_presence_refresh(include_npm_global, backends)
         except Exception:
             logger.warning("Model Hub CLI presence refresh failed", exc_info=True)
 
@@ -5584,7 +5596,9 @@ def create_default_service(
         Callable[[BackendName], list[tuple[str, Optional[str]]]]
     ] = None,
     cli_present_override: Optional[Callable[[BackendName], bool]] = None,
-    cli_presence_refresh: Optional[Callable[[bool], None]] = None,
+    cli_presence_refresh: Optional[
+        Callable[[bool, tuple[BackendName, ...] | None], None]
+    ] = None,
 ) -> ModelHubService:
     if adapter is None:
         from vibe.model_hub_runtime import get_model_hub_engine_adapter

--- a/docs/plans/model-hub-contracts/agent-supply.schema.json
+++ b/docs/plans/model-hub-contracts/agent-supply.schema.json
@@ -186,7 +186,7 @@
       "description": "Read-only projection of every enabled named Vibe Agent on this backend, derived live from each Agent's explicit model. The distinct name avoids collision with SupplyGap.agents, whose items are bare names inside a mutation-refusal payload.",
       "items": {
         "type": "object",
-        "required": ["name", "effective_model_id", "supply_status"],
+        "required": ["name", "effective_model_id", "supply_status", "route_reason"],
         "additionalProperties": false,
         "properties": {
           "name": { "type": "string", "minLength": 1 },
@@ -197,6 +197,10 @@
           "supply_status": {
             "enum": ["ok", "degraded", "waiting", "interrupted", null],
             "description": "This named Agent's own live rollup for effective_model_id. null in Direct mode or when effective_model_id is null."
+          },
+          "route_reason": {
+            "enum": ["route_unconfigured", null],
+            "description": "Why this Agent has no usable route before Source health is considered. route_unconfigured means the selected model has no configured hops; null covers configured routes, Direct mode, and Agents without an explicit model."
           }
         },
         "allOf": [
@@ -230,8 +234,11 @@
           "model_supply": { "type": "null" },
           "named_agents": {
             "items": {
-              "required": ["supply_status"],
-              "properties": { "supply_status": { "type": "null" } }
+              "required": ["supply_status", "route_reason"],
+              "properties": {
+                "supply_status": { "type": "null" },
+                "route_reason": { "type": "null" }
+              }
             }
           }
         }

--- a/docs/plans/model-hub-contracts/api.md
+++ b/docs/plans/model-hub-contracts/api.md
@@ -275,12 +275,14 @@ Each backend entry on `GET /api/models/agents` carries the v5 API-boundary keys:
     {
       "name": "pm",
       "effective_model_id": "claude-opus-4-6",
-      "supply_status": "degraded"
+      "supply_status": "degraded",
+      "route_reason": null
     },
     {
       "name": "reviewer",
       "effective_model_id": "claude-haiku-4-5",
-      "supply_status": "interrupted"
+      "supply_status": "interrupted",
+      "route_reason": "route_unconfigured"
     }
   ]
 }
@@ -288,7 +290,8 @@ Each backend entry on `GET /api/models/agents` carries the v5 API-boundary keys:
 
 `named_agents` lists every enabled named Vibe Agent whose backend matches this
 record. `effective_model_id` is the Agent's explicit model. `supply_status` is
-derived independently for that effective model. The
+derived independently for that effective model. `route_reason` distinguishes a
+missing route from a configured route whose Sources are unavailable. The
 list name and object shape are intentionally distinct from `SupplyGap.agents`,
 which is a list of bare names inside a mutation result.
 
@@ -1151,7 +1154,7 @@ contract harness and API-boundary tests enforce:
 | probe `source_id` names an existing source | probe assembler |
 | non-null event endpoints name existing sources at emission time | event emitter |
 | `channel_switch.from_source == channel_switch.to_source` | event emitter |
-| API AgentSupply includes `cli_present`, `selected_by_agent`, `selected_model_id`, `selected_model_explicit`, policy-free `sources.order`, `supply_status`, `model_supply[].has_runnable_hop`, and `named_agents`; every Source includes persisted `last_discovered_at`, optional persisted `client_nonce`, derived `adopted_by`, and model retirement tombstones; source creation returns `added_to` and top-level `adopted_by` equal to `source.adopted_by`; saved refresh and discovered-model retirement use the guarded Source envelope | API payload test |
+| API AgentSupply includes `cli_present`, `selected_by_agent`, `selected_model_id`, `selected_model_explicit`, policy-free `sources.order`, `supply_status`, `model_supply[].has_runnable_hop`, and `named_agents[].route_reason`; every Source includes persisted `last_discovered_at`, optional persisted `client_nonce`, derived `adopted_by`, and model retirement tombstones; source creation returns `added_to` and top-level `adopted_by` equal to `source.adopted_by`; saved refresh and discovered-model retirement use the guarded Source envelope | API payload test |
 | every OAuthFlow response includes `intent` | API payload test |
 | Hub OAuth and native CLI `POST /sources/<id>/reauth` requests with missing or false `acknowledge_irreversible` return `reauth_confirmation_required` before the OAuth adapter is called; true acknowledgement is the only start path, while transactional API-key PUT is unaffected | API route negative/positive fixtures |
 | OAuth start claims `(client_nonce, vendor, channel)` before provider work; a blocked first call plus concurrent same-tuple retry coalesces to one pending result and exactly one provider start; pending-start failure/task cancellation releases after cleanup; success atomically exposes one echoed-nonce flow; explicit cancellation retains that nonce-bearing flow as `cancelled` so a same-tuple retry starts no provider, while existing expiry releases it for exactly one fresh start; no-nonce cancellation forgets | OAuth registry totality, clocked expiry, API payload, and auth-setup closed-loop tests |

--- a/docs/plans/model-hub-ui-spec.md
+++ b/docs/plans/model-hub-ui-spec.md
@@ -817,12 +817,12 @@ state exit; held intent never bypasses the evidence column.
 | §1.1 | Group waiting | The enabled-Agent aggregate reads `waiting`: no `named_agents[]` member reads `ok` / `degraded`, and at least one reads `waiting` `[derived]` | F5 — no request of this state's can fail, and no elapsed time resolves it either | `gateway.group.status.waiting` — 供给暂不可用 / Supply unavailable for now | A later payload reports a usable Agent → Ready or Takeover active. Every underlying `retry_at` can pass with the group still waiting, so the exit is the next payload's reading and never the elapsed time. F5 says this state issues nothing, not that waiting is the cure |
 | §1.1 | Group interrupted — CLI unavailable | The enabled-Agent aggregate reads `interrupted`, no Agent is usable or waiting, and at least one member is blocked because the native CLI its chain depends on is unreachable **in this process** `[derived]` | F2 — the group keeps its last rendering | `gateway.group.status.interrupted` | The CLI becomes reachable → the next enabled-Agent aggregate. Waiting does not resolve this one, which is why it remains distinct from the self-healing `waiting` umbrella |
 | §1.1 | Group interrupted — a source needs action | The enabled-Agent aggregate reads `interrupted`, no Agent is usable or waiting, and at least one member is blocked by a source in `needs_action` or `error` `[derived]` | F2 — the group keeps its last rendering | `gateway.group.status.interrupted` | The source leaves `needs_action` / `error` → whichever aggregate the named Agents then produce. Frame 12 owns the credential repair controls; 06 keeps 重新拉取 for a source whose stored credential still works `[contract]` |
-| §1.1 | Group interrupted — empty chain | The enabled-Agent aggregate reads `interrupted`, no Agent is usable or waiting, and at least one member's effective model has an empty capability chain `[derived]` | F2 — the group keeps its last rendering | `gateway.group.status.interrupted` | A source is placed into that model's chain → whichever aggregate the named Agents then produce. Distinct from *No enabled Agent uses this backend*, where there is no Agent member and therefore no chain to be empty |
+| §1.1 | Group unconfigured | `named_agents` is nonempty and every member either has no `effective_model_id` or reads `route_reason: route_unconfigured` `[derived from contract]` | F5 — a rendered configuration statement, not a request or a Source-health failure | `gateway.group.status.unconfigured` — 未配置型号路由 / No model route configured | Any member gains both an effective model and a configured Route → whichever aggregate the named Agents then produce. Distinct from *No enabled Agent uses this backend*, where there is no Agent member, and from *Group interrupted*, where at least one configured Route exists but cannot currently supply |
 | §1.1 | Group interrupted — a hop's source is gone | The enabled-Agent aggregate reads `interrupted`, no Agent is usable or waiting, and at least one member's chain names a source that no longer exists `[derived]` | F2 — the group keeps its last rendering | `gateway.group.status.interrupted` | The payload stops reporting the blocker → whichever aggregate the named Agents then produce. Adding the source again produces a different source and does not re-satisfy the stored hop, so the exit is §1.2's explicit remove/change of that exact stale pair |
 | §1.1 | Group interrupted — a hop's model is no longer callable | The enabled-Agent aggregate reads `interrupted`, no Agent is usable or waiting, and at least one member's chain pins a model its source no longer advertises `[derived]` | F2 — the group keeps its last rendering | `gateway.group.status.interrupted` | 重新拉取 on 06 puts the model back into that source's inventory → whichever aggregate the named Agents then produce. The contract keeps the hop visible and non-runnable until an explicit refresh or edit and never re-points it `[contract]`; §1.2 owns the explicit remove/change while allowing the unchanged stale pair to remain |
 | §1.1 | Backend has no usable source | Every candidate filtered out | F5 | `gateway.supply.none` | Any source becomes eligible; 来源顺序 → 03 |
 | §1.1 | Backend has no models | The group resolves to zero model rows `[derived]` | F5 | `gateway.group.emptyModels` | A model becomes available to that backend |
-| §1.1 | No enabled Agent uses this backend | `mode` reads `hub` and `named_agents` is empty `[contract]` | F5 — a rendered report, not a request | `gateway.group.subtitle.gateway`, `gateway.group.mode.gateway`, `gateway.group.status.unused` | An enabled Agent begins using this backend; its live rollup enters the aggregate and selects Ready, waiting, degraded or interrupted |
+| §1.1 | No enabled Agent uses this backend | `mode` reads `hub` and `named_agents` is empty `[contract]` | F5 — a rendered report, not a request | `gateway.group.subtitle.gateway`, `gateway.group.mode.gateway`, `gateway.group.status.unused` | An enabled Agent begins using this backend; its model, Route and live rollup enter the aggregate and select Ready, unconfigured, waiting, degraded or interrupted |
 | §1.1 | Per-model route unconfigured | The page-grain `model_supply` row reads `chain_length: 0`; this structural branch is evaluated before the forced `has_runnable_hop: false` reading `[contract]` | F5 for the page-grain statement; an outstanding or failed chain detail read remains F2 only for its other derived columns | server-owned `models.launch.route_unconfigured`, consumed verbatim | Render the existing route-unconfigured family in the current-text slot; never gold 供给已暂停 / Supply paused. A later page-grain payload with `chain_length > 0` leaves this structural state and is dispatched by `has_runnable_hop` |
 | §1.1 | Per-model supply paused | The page-grain `model_supply` row reads `chain_length > 0` and `has_runnable_hop: false` `[contract]` | F5 for the page-grain marker; an outstanding or failed chain-collection member remains F2 only for its other derived columns | `legend.unavailable` in the existing current-text slot | Render 供给已暂停 / Supply paused immediately in `$--gold`; do not wait for the backend chain collection. A later page-grain payload with `has_runnable_hop: true` removes the marker; `chain_length: 0` instead enters Per-model route unconfigured. The collection member may still fill its other derived columns, but a pending or failed detail read cannot erase or replace this page-owned marker |
 | §1.1 | Takeover active | A member of `GET /api/models/agents/<backend>/chains` returns non-null `current` different from `chain[0]`, while the head is unavailable for a recoverable quota/cooldown or live connection-backoff reason `[contract]` | F5 | `gateway.group.takenOver`, `gateway.row.currentTakeover`, `gateway.group.status.degraded` | Re-evaluate the complete predicate on every later chain payload. `current` back at the head → Ready. A head that is runnable / no longer recoverably unavailable also retires Takeover immediately under the derived-state predicate rule: if `current` still names the later hop, render the ordinary serving/current-hop projection without violet takeover ink or copy until a later payload changes `current`. A local clock alone changes no payload. This is frame 08 (§1.7) |
@@ -973,7 +973,7 @@ a different key.
 | `{{delay}}` | A rough interval, looking forward — how long until the automatic retry. Same shape as `{{time}}` and the opposite direction, which is why it is its own slot: one string says a fetch happened 3 分钟前, the other says a retry comes 3 分钟后, and a single "relative timestamp" covers both while meaning neither. | Always present in the one key that carries it, because a `retry_at` still ahead is what selects that key. **A `retry_at` that has passed cannot fill it** — the interval renders zero or negative — and that is an ordinary reading, not an edge: no row in this document promotes a source on a clock, so `cooldown` can be reported with its retry time behind it for as long as the next payload takes. That reading renders `upstream.state.unavailableDue`, which is the absence rule's 「a state that cannot fill it uses a different key」 applied to a slot that may not be dropped. | `upstream.state.unavailableRetry` |
 | `{{request}}` | The request that failed, as `METHOD path`. | Always present in the remaining consumer, which is selected only for a request-backed §1.9 step. Source observation exposes no request member. | `adopt.fail.detail` |
 | `{{status}}` | The HTTP status that request returned. | **Absent when the §1.9 request had no HTTP response.** The separator drops with it. Source observation exposes no status member. | `adopt.fail.detail` |
-| `{{health}}` | One of exactly five words — `gateway.group.status.ok`, `gateway.group.status.degraded`, `gateway.group.status.waiting`, `gateway.group.status.interrupted`, `gateway.group.status.unused`. The first four are the closed aggregate over `named_agents[].supply_status`; the fifth means no enabled Agent uses this backend. Supply health, not an HTTP status: nothing here is a code, and the group renders it whether or not any request was made. | Always present | `gateway.group.subtitle.gateway` |
+| `{{health}}` | One of exactly six words — `gateway.group.status.ok`, `gateway.group.status.degraded`, `gateway.group.status.waiting`, `gateway.group.status.interrupted`, `gateway.group.status.unconfigured`, `gateway.group.status.unused`. The first four roll up `named_agents[].supply_status`; the fifth means every enabled Agent lacks either an effective model or a configured Route, from `effective_model_id` plus `route_reason`; the sixth means no enabled Agent uses this backend. Supply/configuration state, not an HTTP status: nothing here is a code, and the group renders it whether or not any request was made. | Always present | `gateway.group.subtitle.gateway` |
 | `{{reason}}` | The §1.9 classified cause, from that state's closed and total copy set. No consumer interpolates an upstream string here. Source observation exposes no reason member. | Always present | `adopt.fail.detail` |
 | `{{mode}}` | One of exactly two words — `gateway.group.mode.direct` or `gateway.group.mode.gateway`. The subtitle interpolates the word rather than carrying two whole strings, because the health half varies independently of it. | Always present | `gateway.group.subtitle.direct`, `gateway.group.subtitle.gateway` |
 | `{{backends}}` | The backends in Hub mode that have this source configured into a route, by product name, joined by `、` / `,` — `adopted_by`'s projection, grouped and de-duplicated, never a computation over live chains (§1.0). | Always present — `upstream.state.supplying` is entered only when the list is non-empty; a source no Hub-mode backend has configured is 可用 · 当前未供给 instead | `upstream.state.supplying` |
@@ -1469,6 +1469,7 @@ unable to outlive its surface, which is the cheaper answer wherever it is availa
 | `gateway.group.status.degraded` `[contract]` | 降级 | Degraded |
 | `gateway.group.status.waiting` `[contract]` | 供给暂不可用 | Supply unavailable for now |
 | `gateway.group.status.interrupted` `[contract]` | 无可用来源 | No source is available |
+| `gateway.group.status.unconfigured` `[derived]` | 未配置型号路由 | No model route configured |
 | `gateway.group.status.unused` `[derived]` | 暂无 Agent 使用 | No Agent uses this backend |
 | `gateway.group.takenOver` | 接管中 | Taken over |
 | `gateway.supply.none` `[derived]` | 没有可用来源 | No usable source |
@@ -1496,14 +1497,15 @@ backend and therefore cannot truthfully describe this group. The header never re
 field. Direct mode renders the mode alone. Gateway mode evaluates every enabled named
 Agent on this backend:
 
-| `AgentSupply.mode` `[contract]` | `named_agents[].supply_status` `[contract]` | Subtitle | Key |
+| `AgentSupply.mode` `[contract]` | `named_agents[]` projection `[contract]` | Subtitle | Key |
 | --- | --- | --- | --- |
 | `direct` | not read — Direct arbitrates nothing, so it rolls nothing up | 直连 | `gateway.group.subtitle.direct` + `gateway.group.mode.direct` |
 | `hub` | empty `named_agents` | 网关 · 暂无 Agent 使用 | `gateway.group.subtitle.gateway` + `gateway.group.status.unused` |
+| `hub` | every member has `effective_model_id: null` or `route_reason: route_unconfigured` | 网关 · 未配置型号路由 | `gateway.group.subtitle.gateway` + `gateway.group.status.unconfigured` |
 | `hub` | every member is `ok` | 网关 · 正常 | `gateway.group.subtitle.gateway` + `gateway.group.status.ok` |
 | `hub` | at least one member is `ok` / `degraded`, but not every member is `ok` | 网关 · 降级 | `gateway.group.subtitle.gateway` + `gateway.group.status.degraded` |
 | `hub` | no member is `ok` / `degraded`, and at least one is `waiting` | 网关 · 供给暂不可用 | `gateway.group.subtitle.gateway` + `gateway.group.status.waiting` |
-| `hub` | every remaining member is `interrupted` / `null` | 网关 · 无可用来源 | `gateway.group.subtitle.gateway` + `gateway.group.status.interrupted` |
+| `hub` | the configuration-gap predicate above did not match, and every remaining `supply_status` is `interrupted` / `null` | 网关 · 无可用来源 | `gateway.group.subtitle.gateway` + `gateway.group.status.interrupted` |
 
 **All four `[contract]` words are transcribed** `[contract]`.
 正常 / 降级 / 无可用来源 remain `model-hub.md` §4.5's verbatim labels. The frozen
@@ -1511,8 +1513,8 @@ Agent on this backend:
 connection-backoff chains, while per-Source rows retain their distinct causes. It states
 only present availability and promises neither a recovery time nor a recovery outcome.
 
-`gateway.supply.none` is not a sixth word, because it is not the same grain `[derived]`.
-The five above are the enabled-Agent aggregate rendered into the group head's status line.
+`gateway.supply.none` is not a seventh word, because it is not the same grain `[derived]`.
+The six above are the enabled-Agent aggregate rendered into the group head's status line.
 `gateway.supply.none` is a body line under a group that has no source at all — a statement
 about that backend's inventory, not a reading of enabled-Agent supply, which
 is why it appears in neither the `{{health}}` slot's closed set (§0.9) nor the table
@@ -1533,7 +1535,8 @@ those two rows are mirrors rather than one row with two moods.
 
 **This document renders one group aggregate and no named-Agent row** `[frame]`.
 `AgentSupply.named_agents[].supply_status` remains each named Agent's own rollup for its
-own explicit model. The group consumes every member through the table above, but it does
+own explicit model, while `effective_model_id` and `route_reason` expose a missing model
+or Route before Source health is considered. The group consumes every member through the table above, but it does
 not print an individual Agent name or assign the aggregate back to one Agent. Per-Agent
 detail remains a separate surface that needs its own frame. The top-level
 `selected_model_id` / `supply_status` pair remains useful for describing the next default
@@ -5509,7 +5512,7 @@ are not the same claim. §1.0's ink table is the single place both are written d
 **D-22 — A group head's status line is `<mode> · <status>` on the gateway and the mode
 word alone in Direct; mode comes from `mode`, while status comes from the closed
 `named_agents` aggregate.** 网关 · 正常, 网关 · 降级, 网关 · 供给暂不可用,
-网关 · 无可用来源, 网关 · 暂无 Agent 使用 — and bare 直连, because a
+网关 · 无可用来源, 网关 · 未配置型号路由, 网关 · 暂无 Agent 使用 — and bare 直连, because a
 direct backend arbitrates nothing and so has no supply whose health could be reported.
 §1.0's C-6 is the total mapping, and no other surface derives a status line of its own.
 *Why:* mode and health are independently variable and users confuse them constantly —

--- a/docs/plans/model-hub-ui-spec.md
+++ b/docs/plans/model-hub-ui-spec.md
@@ -5497,13 +5497,15 @@ is cyan there.
 means different things in each.** Wires: cyan = 原生, mint = 网关供给, violet =
 接管, `#FFFFFF26` = 已启用 · 当前未被使用, gold = 供给已暂停. State text:
 mint = 使用中 / 正常, gold = 降级 / 暂不可用 / 冷却 / 供给暂不可用, rose = 需处理 /
-异常 / 无可用来源, muted = 可用 · 当前未供给 / 暂无 Agent 使用, cyan = 原生 provenance only, violet-tint
+异常 / 无可用来源, muted = 可用 · 当前未供给 / 未配置型号路由 / 暂无 Agent 使用,
+cyan = 原生 provenance only, violet-tint
 `#7C5BFFCC` = a takeover hop label. The group-status vocabulary (§1.1) is assigned here
 in full — 正常 mint, 降级 gold, 供给暂不可用 gold, 无可用来源 rose,
-暂无 Agent 使用 muted — and
+未配置型号路由 muted, 暂无 Agent 使用 muted — and
 the split worth stating is §4.5's: a wait that heals itself takes the same gold as every
-other wait, one that does not takes rose, and the fifth is not a fault at all, because
-no enabled Agent uses this backend.
+other wait, one that does not takes rose, and the last two are not Source faults at all:
+the fifth means enabled Agents lack a selected model or configured Route, while the sixth
+means no enabled Agent uses this backend.
 *Why:* a wire describes a *relation between two things*; state text describes *one
 thing's condition*. Collapsing them into one legend forces both to be wrong somewhere —
 gold as a relation means supply stopped, gold as a condition means degraded, and those

--- a/tests/test_controller_model_hub_gate.py
+++ b/tests/test_controller_model_hub_gate.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -66,15 +67,25 @@ def test_controller_builds_one_model_hub_aggregate_after_explicit_opt_in(monkeyp
     monkeypatch.setattr(agent_model_hub, "ModelHubRuntimeRouter", Router)
     presence_probes = []
     probe_failure = [False]
+    block_full_probe = [False]
+    opencode_present = [False]
+    full_probe_started = threading.Event()
+    full_probe_release = threading.Event()
 
     def resolve_cli_paths(binaries, *, include_npm_global=True):
         presence_probes.append((binaries, include_npm_global))
         if probe_failure[0]:
             raise OSError("CLI inventory unavailable")
-        return {
+        result = {
             binary: f"/usr/bin/{binary}" if binary == "codex" else None
             for binary in binaries
         }
+        if "opencode" in result and opencode_present[0]:
+            result["opencode"] = "/usr/bin/opencode"
+        if block_full_probe[0] and len(binaries) > 1:
+            full_probe_started.set()
+            full_probe_release.wait(timeout=2)
+        return result
 
     monkeypatch.setattr(api, "resolve_cli_paths", resolve_cli_paths)
     controller = Controller.__new__(Controller)
@@ -98,9 +109,24 @@ def test_controller_builds_one_model_hub_aggregate_after_explicit_opt_in(monkeyp
     assert captured["cli_present_override"]("claude") is False
     assert presence_probes == [(["claude", "codex", "opencode"], False)]
     probe_failure[0] = True
-    captured["cli_presence_refresh"](True)
+    captured["cli_presence_refresh"](True, ("opencode",))
     assert captured["cli_present_override"]("codex") is True
-    assert presence_probes[-1] == (["claude", "codex", "opencode"], True)
+    assert presence_probes[-1] == (["opencode"], True)
+
+    probe_failure[0] = False
+    block_full_probe[0] = True
+    full_refresh = threading.Thread(
+        target=captured["cli_presence_refresh"],
+        args=(True, None),
+    )
+    full_refresh.start()
+    assert full_probe_started.wait(timeout=0.5)
+    opencode_present[0] = True
+    captured["cli_presence_refresh"](True, ("opencode",))
+    full_probe_release.set()
+    full_refresh.join(timeout=0.5)
+    assert not full_refresh.is_alive()
+    assert captured["cli_present_override"]("opencode") is True
     assert controller.model_hub_turn_gateway.language_provider() == "zh"
     assert calls == [
         ("gateway", service, controller.model_hub_turn_gateway.language_provider),

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -1894,8 +1894,8 @@ def test_agents_endpoint_projects_cli_presence_from_runtime(tmp_path):
 def test_agents_collection_reads_cli_presence_without_running_discovery(tmp_path):
     service, _store, _adapter = _service(tmp_path)
     calls = []
-    service.cli_presence_refresh = lambda include_npm_global: calls.append(
-        include_npm_global
+    service.cli_presence_refresh = lambda include_npm_global, backends: calls.append(
+        (include_npm_global, backends)
     )
     service.cli_present_override = lambda backend: backend == "codex"
 
@@ -2007,8 +2007,8 @@ def test_agent_supply_mutation_rpc_refreshes_cli_presence_before_writing(tmp_pat
 
     service, store, _adapter = _service(tmp_path)
     calls = []
-    service.cli_presence_refresh = lambda include_npm_global: calls.append(
-        include_npm_global
+    service.cli_presence_refresh = lambda include_npm_global, backends: calls.append(
+        (include_npm_global, backends)
     )
     service.cli_present_override = lambda backend: backend == "claude"
 
@@ -2026,7 +2026,7 @@ def test_agent_supply_mutation_rpc_refreshes_cli_presence_before_writing(tmp_pat
     )
 
     assert payload["cli_present"] is True
-    assert calls == [True]
+    assert calls == [(True, ("claude",))]
 
 
 def test_agent_supply_rpc_publishes_explicit_deep_discovery_after_fast_reads(
@@ -2035,13 +2035,16 @@ def test_agent_supply_rpc_publishes_explicit_deep_discovery_after_fast_reads(
     from core.handlers.model_hub import rpc as model_hub_rpc
 
     service, _store, _adapter = _service(tmp_path)
-    calls: list[bool] = []
+    calls: list[tuple[bool, tuple[str, ...] | None]] = []
     present = {"codex": False}
     deep_started = threading.Event()
     deep_release = threading.Event()
 
-    def refresh(include_npm_global: bool) -> None:
-        calls.append(include_npm_global)
+    def refresh(
+        include_npm_global: bool,
+        backends: tuple[str, ...] | None,
+    ) -> None:
+        calls.append((include_npm_global, backends))
         deep_started.set()
         deep_release.wait(timeout=2)
         present["codex"] = True
@@ -2108,7 +2111,46 @@ def test_agent_supply_rpc_publishes_explicit_deep_discovery_after_fast_reads(
         next(agent for agent in joined if agent["backend"] == "codex")["cli_present"]
         is True
     )
-    assert calls == [True]
+    assert calls == [(True, None)]
+
+
+def test_targeted_cli_refresh_does_not_wait_for_unrelated_full_inventory(tmp_path):
+    from core.handlers.model_hub import rpc as model_hub_rpc
+
+    service, _store, _adapter = _service(tmp_path)
+    calls: list[tuple[bool, tuple[str, ...] | None]] = []
+    full_started = threading.Event()
+    full_release = threading.Event()
+
+    def refresh(
+        include_npm_global: bool,
+        backends: tuple[str, ...] | None,
+    ) -> None:
+        calls.append((include_npm_global, backends))
+        if backends is None:
+            full_started.set()
+            full_release.wait(timeout=2)
+
+    service.cli_presence_refresh = refresh
+
+    async def exercise() -> None:
+        full = asyncio.create_task(
+            model_hub_rpc._refresh_agent_presence(service)
+        )
+        assert await asyncio.to_thread(full_started.wait, 0.5)
+        await asyncio.wait_for(
+            model_hub_rpc._refresh_agent_presence(service, ("opencode",)),
+            timeout=0.5,
+        )
+        full_release.set()
+        await full
+
+    try:
+        asyncio.run(exercise())
+    finally:
+        full_release.set()
+
+    assert calls == [(True, None), (True, ("opencode",))]
 
 
 def test_agent_presence_refresh_crosses_the_controller_rpc_boundary(monkeypatch):
@@ -2206,6 +2248,14 @@ def test_agents_endpoint_projects_each_enabled_named_agent_live(tmp_path):
         "codex": [("codex", "gpt-5.3-codex")],
         "opencode": [],
     }[backend]
+    store.config.agents["claude"].routes["claude-sonnet-4-6"] = ModelHubRouteConfig(
+        hops=[
+            ModelHubRouteHopConfig(
+                source_id="src_missing01",
+                model_id="claude-sonnet-4-6",
+            )
+        ]
+    )
 
     agents = {agent["backend"]: agent for agent in service.list_agents()}
 
@@ -2214,11 +2264,13 @@ def test_agents_endpoint_projects_each_enabled_named_agent_live(tmp_path):
             "name": "pm",
             "effective_model_id": "claude-sonnet-4-6",
             "supply_status": "interrupted",
+            "route_reason": None,
         },
         {
             "name": "reviewer",
             "effective_model_id": "claude-opus-4-6",
             "supply_status": "interrupted",
+            "route_reason": "route_unconfigured",
         },
     ]
     assert agents["codex"]["named_agents"] == [
@@ -2226,6 +2278,7 @@ def test_agents_endpoint_projects_each_enabled_named_agent_live(tmp_path):
             "name": "codex",
             "effective_model_id": "gpt-5.3-codex",
             "supply_status": "interrupted",
+            "route_reason": "route_unconfigured",
         }
     ]
     assert agents["opencode"]["named_agents"] == []
@@ -2236,6 +2289,7 @@ def test_agents_endpoint_projects_each_enabled_named_agent_live(tmp_path):
         "name": "pm",
         "effective_model_id": "claude-sonnet-4-6",
         "supply_status": None,
+        "route_reason": None,
     }
 
 

--- a/tests/test_model_hub_resolution.py
+++ b/tests/test_model_hub_resolution.py
@@ -1103,6 +1103,7 @@ def test_explicit_opencode_selection_outside_menu_remains_visible(tmp_path):
             "name": "researcher",
             "effective_model_id": "custom/hidden-model",
             "supply_status": "interrupted",
+            "route_reason": "route_unconfigured",
         }
     ]
     assert resolution.requested_model == "custom/hidden-model"

--- a/ui/eslint-baseline.json
+++ b/ui/eslint-baseline.json
@@ -45,14 +45,14 @@
       "react-hooks/preserve-manual-memoization": 1
     },
     "src/components/shared/RoutingConfigPanel.tsx": {
-      "@typescript-eslint/no-explicit-any": 3,
+      "@typescript-eslint/no-explicit-any": 2,
       "react-hooks/set-state-in-effect": 1
     },
     "src/components/steps/AgentDetection.tsx": {
       "@typescript-eslint/no-explicit-any": 3
     },
     "src/components/steps/ChannelList.tsx": {
-      "@typescript-eslint/no-explicit-any": 29
+      "@typescript-eslint/no-explicit-any": 28
     },
     "src/components/steps/DiscordConfig.tsx": {
       "@typescript-eslint/no-explicit-any": 6
@@ -79,7 +79,7 @@
       "@typescript-eslint/no-explicit-any": 4
     },
     "src/components/steps/UserList.tsx": {
-      "@typescript-eslint/no-explicit-any": 6
+      "@typescript-eslint/no-explicit-any": 3
     },
     "src/components/steps/WeChatConfig.tsx": {
       "@typescript-eslint/no-explicit-any": 4

--- a/ui/src/components/settings/models/supply.test.ts
+++ b/ui/src/components/settings/models/supply.test.ts
@@ -98,6 +98,29 @@ describe('agentGroupStatus', () => {
     expect(agentGroupStatus([])).toBe('unused');
   });
 
+  it('reports a configuration gap separately from unavailable configured sources', () => {
+    expect(agentGroupStatus([
+      {
+        name: 'opencode',
+        effective_model_id: 'openai/gpt-5.6-terra',
+        supply_status: 'interrupted',
+        route_reason: 'route_unconfigured',
+      },
+    ])).toBe('unconfigured');
+    expect(agentGroupStatus([
+      {
+        name: 'opencode',
+        effective_model_id: 'openai/gpt-5.6-terra',
+        supply_status: 'interrupted',
+        route_reason: null,
+      },
+    ])).toBe('interrupted');
+  });
+
+  it('reports an Agent without a model as unconfigured', () => {
+    expect(agentGroupStatus(statuses(null))).toBe('unconfigured');
+  });
+
   it('reports healthy only when every enabled Agent is healthy', () => {
     expect(agentGroupStatus(statuses('ok', 'ok'))).toBe('ok');
   });

--- a/ui/src/components/settings/models/supply.ts
+++ b/ui/src/components/settings/models/supply.ts
@@ -69,11 +69,14 @@ export const needsAttention = (state: SourceState): boolean =>
 export const healthyButUnrunnable = (agent: Pick<AgentSupply, 'sources'>, source: Source): boolean =>
   !isUnhealthy(source.state) && !processAvailabilityOf(agent, source.id).runnable;
 
-export type AgentGroupStatus = SupplyStatus | 'unused';
+export type AgentGroupStatus = SupplyStatus | 'unconfigured' | 'unused';
 
 /** Summarize the enabled Agents using one backend without inventing a backend selection. */
 export const agentGroupStatus = (agents: NamedAgentSupply[]): AgentGroupStatus => {
   if (agents.length === 0) return 'unused';
+  if (agents.every((agent) =>
+    agent.effective_model_id === null || agent.route_reason === 'route_unconfigured'
+  )) return 'unconfigured';
 
   const statuses = agents.map((agent) => agent.supply_status);
   if (statuses.every((status) => status === 'ok')) return 'ok';

--- a/ui/src/components/settings/models/types.ts
+++ b/ui/src/components/settings/models/types.ts
@@ -210,6 +210,9 @@ export type NamedAgentSupply = {
   /** null exactly when `effective_model_id` is null — no model, no capability
    *  to report. */
   supply_status: SupplyStatus | null;
+  /** A configuration gap is distinct from a configured Route whose Sources
+   *  are unavailable. */
+  route_reason?: 'route_unconfigured' | null;
 };
 
 /** How many sources can currently serve a selectable model. `chain_length: 0`

--- a/ui/src/components/shared/RoutingConfigPanel.tsx
+++ b/ui/src/components/shared/RoutingConfigPanel.tsx
@@ -50,16 +50,6 @@ export interface RoutingConfigPanelProps {
   vibeAgents?: VibeAgentBrief[];
   defaultAgentName?: string | null;
   availableMessageTypes?: string[];
-  // Legacy backend-model props: no longer read here (AgentRoutePicker self-loads
-  // models + effort options). Kept on the interface so existing callers still
-  // type-check; a follow-up can drop them and the parents' model preloading.
-  opencodeOptions?: any;
-  claudeAgents?: { id: string; name: string }[];
-  claudeModels?: string[];
-  claudeModelLabels?: Record<string, string>;
-  claudeReasoningOptions?: Record<string, { value: string; label: string }[]>;
-  codexAgents?: { id: string; name: string }[];
-  codexModels?: string[];
   /** Custom footer slot — e.g., admin/remove actions on the users page. */
   footerActions?: React.ReactNode;
   /** Wrapper class — controls outer padding/border. Default: 'border-t border-border/60 px-5 py-4'. */

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -126,13 +126,6 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
   const [threadConfigs, setThreadConfigs] = useState<Record<string, Record<string, ChannelConfig>>>({});
   const [config, setConfig] = useState<any>(data);
   const [pagePlatform, setPagePlatform] = useState<string>(forcedPlatform || data.platform || 'slack');
-  const [opencodeOptionsByCwd, setOpencodeOptionsByCwd] = useState<Record<string, any>>({});
-  const [claudeAgentsByCwd, setClaudeAgentsByCwd] = useState<Record<string, { id: string; name: string; path: string; source?: string }[]>>({});
-  const [codexAgentsByCwd, setCodexAgentsByCwd] = useState<Record<string, { id: string; name: string; path: string; source?: string; description?: string }[]>>({});
-  const [claudeModels, setClaudeModels] = useState<string[]>([]);
-  const [claudeModelLabels, setClaudeModelLabels] = useState<Record<string, string>>({});
-  const [claudeReasoningOptions, setClaudeReasoningOptions] = useState<Record<string, { value: string; label: string }[]>>({});
-  const [codexModels, setCodexModels] = useState<string[]>([]);
   const [guilds, setGuilds] = useState<any[]>([]);
   const [selectedGuildIds, setSelectedGuildIds] = useState<string[]>(getDiscordGuildAllowlist(data));
   const [selectedGuild, setSelectedGuild] = useState<string>(getDiscordGuildAllowlist(data)[0] || '');
@@ -556,63 +549,6 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
     }
   };
 
-  const loadOpenCodeOptions = async (cwd: string) => {
-    try {
-      const result = await api.opencodeOptions(cwd);
-      if (result.ok) {
-        setOpencodeOptionsByCwd((prev) => ({ ...prev, [cwd]: result.data }));
-      }
-    } catch (e) {
-      console.error('Failed to load OpenCode options:', e);
-    }
-  };
-
-  const loadClaudeAgents = async (cwd: string) => {
-    try {
-      const result = await api.claudeAgents(cwd);
-      if (result.ok) {
-        setClaudeAgentsByCwd((prev) => ({ ...prev, [cwd]: result.agents || [] }));
-      }
-    } catch (e) {
-      console.error('Failed to load Claude agents:', e);
-    }
-  };
-
-  const loadClaudeModels = async () => {
-    try {
-      const result = await api.claudeModels();
-      if (result.ok) {
-        setClaudeModels(result.models || []);
-        setClaudeModelLabels(result.model_labels || {});
-        setClaudeReasoningOptions(result.reasoning_options || {});
-      }
-    } catch (e) {
-      console.error('Failed to load Claude models:', e);
-    }
-  };
-
-  const loadCodexModels = async () => {
-    try {
-      const result = await api.codexModels();
-      if (result.ok) {
-        setCodexModels(result.models || []);
-      }
-    } catch (e) {
-      console.error('Failed to load Codex models:', e);
-    }
-  };
-
-  const loadCodexAgents = async (cwd: string) => {
-    try {
-      const result = await api.codexAgents(cwd);
-      if (result.ok) {
-        setCodexAgentsByCwd((prev) => ({ ...prev, [cwd]: result.agents || [] }));
-      }
-    } catch (e) {
-      console.error('Failed to load Codex agents:', e);
-    }
-  };
-
   useEffect(() => {
     if (platform === 'lark') {
       if (larkAppId && hasChannelCredentials('lark')) {
@@ -697,71 +633,6 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
       setRemovingChannelId(null);
     }
   };
-
-  useEffect(() => {
-    if (config.agents?.claude?.enabled) {
-      loadClaudeModels();
-    }
-  }, [config.agents?.claude?.enabled]);
-
-  useEffect(() => {
-    if (config.agents?.codex?.enabled) {
-      loadCodexModels();
-    }
-  }, [config.agents?.codex?.enabled]);
-
-  useEffect(() => {
-    if (!channels.length) return;
-    const defaultCwd = config.runtime?.default_cwd || '~/work';
-    const defaultAgent = agentByName[defaultAgentName || ''] || null;
-
-    const neededOpenCodeCwds = new Set<string>();
-    const neededClaudeCwds = new Set<string>();
-    const neededCodexCwds = new Set<string>();
-
-    const collectBackendCwd = (raw: ChannelConfig | undefined) => {
-      if (!raw || raw.enabled === false) return;
-      const effectiveCwd = (raw.custom_cwd ?? '') || defaultCwd;
-      const routing = raw.routing || {};
-      const selectedAgent = routing.agent_name ? agentByName[routing.agent_name] : null;
-      const backend = selectedAgent?.backend || defaultAgent?.backend || 'opencode';
-
-      if (backend === 'opencode' && config.agents?.opencode?.enabled) {
-        neededOpenCodeCwds.add(effectiveCwd);
-      }
-      if (backend === 'claude' && config.agents?.claude?.enabled) {
-        neededClaudeCwds.add(effectiveCwd);
-      }
-      if (backend === 'codex' && config.agents?.codex?.enabled) {
-        neededCodexCwds.add(effectiveCwd);
-      }
-    };
-
-    channels.forEach((channel) => {
-      collectBackendCwd(configs[channel.id]);
-    });
-    Object.values(threadConfigs).forEach((topics) => {
-      Object.values(topics).forEach(collectBackendCwd);
-    });
-
-    neededOpenCodeCwds.forEach((cwd) => {
-      if (!opencodeOptionsByCwd[cwd]) {
-        void loadOpenCodeOptions(cwd);
-      }
-    });
-
-    neededClaudeCwds.forEach((cwd) => {
-      if (!claudeAgentsByCwd[cwd]) {
-        void loadClaudeAgents(cwd);
-      }
-    });
-
-    neededCodexCwds.forEach((cwd) => {
-      if (!codexAgentsByCwd[cwd]) {
-        void loadCodexAgents(cwd);
-      }
-    });
-  }, [channels, configs, threadConfigs, config.runtime?.default_cwd, config.agents?.opencode?.enabled, config.agents?.claude?.enabled, config.agents?.codex?.enabled, agentByName, defaultAgentName]);
 
   const isChannelEnabled = (channelId: string) => {
     const channel = configs[channelId];
@@ -1562,10 +1433,6 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
               const expanded = expandedChannelId === rowKey;
               const selectedAgent = agentByName[channelConfig.routing.agent_name || ''] || agentByName[defaultAgentName || ''];
               const effectiveBackend = selectedAgent?.backend || defaultAgent?.backend || 'opencode';
-              const effectiveCwd = channelConfig.custom_cwd || config.runtime?.default_cwd || '~/work';
-              const opencodeOptions = opencodeOptionsByCwd[effectiveCwd];
-              const claudeAgents = claudeAgentsByCwd[effectiveCwd] || [];
-              const codexAgents = codexAgentsByCwd[effectiveCwd] || [];
 
               const updateRow = (patch: Partial<ChannelConfig>) => {
                 void updateConfigForPlatform(channelPlatform, channel.id, patch);
@@ -1721,13 +1588,6 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                         availableMessageTypes={availableMessageTypes(channelPlatform)}
                         showRequireMention={true}
                         inheritsFromKey={channelPlatform}
-                        opencodeOptions={opencodeOptions}
-                        claudeAgents={claudeAgents}
-                        claudeModels={claudeModels}
-                        claudeModelLabels={claudeModelLabels}
-                        claudeReasoningOptions={claudeReasoningOptions}
-                        codexAgents={codexAgents}
-                        codexModels={codexModels}
                       />
                       {channelPlatform === 'telegram' && channel.supports_topics && (
                         <TelegramTopicList<ChannelConfig>
@@ -1757,7 +1617,6 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                             if (topicConfig) void saveTelegramTopicConfig(channel.id, topicId, { ...topicConfig, enabled });
                           }}
                           renderEditor={(topicId, topicConfig) => {
-                            const topicCwd = topicConfig.custom_cwd || config.runtime?.default_cwd || '~/work';
                             return (
                               <RoutingConfigPanel
                                 value={topicConfig}
@@ -1769,13 +1628,6 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                                 availableMessageTypes={availableMessageTypes('telegram')}
                                 showRequireMention={true}
                                 inheritsFromKey="telegram"
-                                opencodeOptions={opencodeOptionsByCwd[topicCwd]}
-                                claudeAgents={claudeAgentsByCwd[topicCwd] || []}
-                                claudeModels={claudeModels}
-                                claudeModelLabels={claudeModelLabels}
-                                claudeReasoningOptions={claudeReasoningOptions}
-                                codexAgents={codexAgentsByCwd[topicCwd] || []}
-                                codexModels={codexModels}
                                 containerClass="border-t border-cyan/20 bg-background/35"
                               />
                             );
@@ -2033,10 +1885,6 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
             require_mention: rawConfig.require_mention !== undefined ? rawConfig.require_mention : def.require_mention,
             require_bind: rawConfig.require_bind !== undefined ? rawConfig.require_bind : def.require_bind,
           };
-          const effectiveCwd = channelConfig.custom_cwd || config.runtime?.default_cwd || '~/work';
-          const opencodeOptions = opencodeOptionsByCwd[effectiveCwd];
-          const claudeAgents = claudeAgentsByCwd[effectiveCwd] || [];
-          const codexAgents = codexAgentsByCwd[effectiveCwd] || [];
           return (
             <div key={channel.id} className="rounded-xl border border-border bg-surface-3/60 p-4 transition-colors hover:border-border-strong hover:bg-surface-2/70">
               <div className="flex items-center justify-between gap-2">
@@ -2123,13 +1971,6 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                   availableMessageTypes={availableMessageTypes(platform)}
                   showRequireMention={true}
                   inheritsFromKey={platform}
-                  opencodeOptions={opencodeOptions}
-                  claudeAgents={claudeAgents}
-                  claudeModels={claudeModels}
-                  claudeModelLabels={claudeModelLabels}
-                  claudeReasoningOptions={claudeReasoningOptions}
-                  codexAgents={codexAgents}
-                  codexModels={codexModels}
                   containerClass="mt-4 pl-8"
                 />
               )}

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -450,13 +450,6 @@ export const UserList: React.FC = () => {
   const [, setLoading] = useState(false);
   const [usersByPlatform, setUsersByPlatform] = useState<Record<string, Record<string, UserConfig>>>({});
   const [config, setConfig] = useState<any>({});
-  const [opencodeOptionsByCwd, setOpencodeOptionsByCwd] = useState<Record<string, any>>({});
-  const [claudeAgentsByCwd, setClaudeAgentsByCwd] = useState<Record<string, any[]>>({});
-  const [codexAgentsByCwd, setCodexAgentsByCwd] = useState<Record<string, any[]>>({});
-  const [claudeModels, setClaudeModels] = useState<string[]>([]);
-  const [claudeModelLabels, setClaudeModelLabels] = useState<Record<string, string>>({});
-  const [claudeReasoningOptions, setClaudeReasoningOptions] = useState<Record<string, { value: string; label: string }[]>>({});
-  const [codexModels, setCodexModels] = useState<string[]>([]);
   const [browsingCwdFor, setBrowsingCwdFor] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [showDisabled, setShowDisabled] = useState(false);
@@ -501,43 +494,6 @@ export const UserList: React.FC = () => {
 
   useEffect(() => { loadAllUsers(); }, [enabledPlatforms.join(','), refreshTrigger]);
 
-  const loadOpenCodeOptions = async (cwd: string) => {
-    try {
-      const result = await api.opencodeOptions(cwd);
-      if (result.ok) setOpencodeOptionsByCwd((prev) => ({ ...prev, [cwd]: result.data }));
-    } catch (e) { console.error('Failed to load OpenCode options:', e); }
-  };
-
-  const loadClaudeAgents = async (cwd: string) => {
-    try {
-      const result = await api.claudeAgents(cwd);
-      if (result.ok) setClaudeAgentsByCwd((prev) => ({ ...prev, [cwd]: result.agents || [] }));
-    } catch (e) { console.error('Failed to load Claude agents:', e); }
-  };
-
-  const loadCodexAgents = async (cwd: string) => {
-    try {
-      const result = await api.codexAgents(cwd);
-      if (result.ok) setCodexAgentsByCwd((prev) => ({ ...prev, [cwd]: result.agents || [] }));
-    } catch (e) { console.error('Failed to load Codex agents:', e); }
-  };
-
-  useEffect(() => {
-    if (config.agents?.claude?.enabled) {
-      api.claudeModels().then((r) => {
-        if (r.ok) {
-          setClaudeModels(r.models || []);
-          setClaudeModelLabels(r.model_labels || {});
-          setClaudeReasoningOptions(r.reasoning_options || {});
-        }
-      });
-    }
-  }, [config.agents?.claude?.enabled]);
-
-  useEffect(() => {
-    if (config.agents?.codex?.enabled) api.codexModels().then(r => r.ok && setCodexModels(r.models || []));
-  }, [config.agents?.codex?.enabled]);
-
   // Aggregate users
   const aggregated = useMemo<AggregatedUser[]>(() => {
     const flat: AggregatedUser[] = [];
@@ -565,22 +521,6 @@ export const UserList: React.FC = () => {
       return name.includes(q) || id.includes(q);
     });
   }, [aggregated, searchQuery, showDisabled]);
-
-  // Load agent options for visible enabled users
-  useEffect(() => {
-    const defaultCwd = config.runtime?.default_cwd || '~/work';
-    const defaultAgent = agentByName[defaultAgentName || ''] || null;
-    aggregated.forEach((u) => {
-      if (!u.config.enabled) return;
-      const cwd = u.config.custom_cwd || defaultCwd;
-      const routing = u.config.routing || {};
-      const selectedAgent = routing.agent_name ? agentByName[routing.agent_name] : null;
-      const backend = selectedAgent?.backend || defaultAgent?.backend || 'opencode';
-      if (backend === 'opencode' && config.agents?.opencode?.enabled && !opencodeOptionsByCwd[cwd]) loadOpenCodeOptions(cwd);
-      if (backend === 'claude' && config.agents?.claude?.enabled && !claudeAgentsByCwd[cwd]) loadClaudeAgents(cwd);
-      if (backend === 'codex' && config.agents?.codex?.enabled && !codexAgentsByCwd[cwd]) loadCodexAgents(cwd);
-    });
-  }, [aggregated, config, agentByName, defaultAgentName]);
 
   const persistUsers = async (platform: string, next: Record<string, UserConfig>) => {
     setLoading(true);
@@ -747,10 +687,6 @@ export const UserList: React.FC = () => {
               const defaultAgent = agentByName[defaultAgentName || ''] || null;
               const selectedAgent = agentByName[userConfig.routing?.agent_name || ''] || agentByName[defaultAgentName || ''];
               const effectiveBackend = selectedAgent?.backend || defaultAgent?.backend || 'opencode';
-              const effectiveCwd = userConfig.custom_cwd || config.runtime?.default_cwd || '~/work';
-              const opencodeOptions = opencodeOptionsByCwd[effectiveCwd];
-              const claudeAgents = claudeAgentsByCwd[effectiveCwd] || [];
-              const codexAgents = codexAgentsByCwd[effectiveCwd] || [];
               const isBot = !userConfig.is_admin && (userConfig.display_name || u.userId).toLowerCase().includes('bot');
               const tone = AVATAR_TONES[hashCode(u.userId) % AVATAR_TONES.length];
               const initials = getInitials(userConfig.display_name, u.userId);
@@ -888,13 +824,6 @@ export const UserList: React.FC = () => {
                       defaultAgentName={defaultAgentName}
                       availableMessageTypes={availableMessageTypes(u.platform)}
                       showRequireMention={false}
-                      opencodeOptions={opencodeOptions}
-                      claudeAgents={claudeAgents}
-                      claudeModels={claudeModels}
-                      claudeModelLabels={claudeModelLabels}
-                      claudeReasoningOptions={claudeReasoningOptions}
-                      codexAgents={codexAgents}
-                      codexModels={codexModels}
                       footerActions={
                         <Button
                           type="button"

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -925,6 +925,7 @@
             "degraded": "Degraded",
             "waiting": "Supply unavailable for now",
             "interrupted": "No source is available",
+            "unconfigured": "No model route configured",
             "unused": "No Agent uses this backend"
           },
           "emptyModels": "This backend has no models"

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -925,6 +925,7 @@
             "degraded": "降级",
             "waiting": "供给暂不可用",
             "interrupted": "无可用来源",
+            "unconfigured": "未配置型号路由",
             "unused": "暂无 Agent 使用"
           },
           "emptyModels": "这个后端没有可用型号"


### PR DESCRIPTION
## Summary

- distinguish an unconfigured Model Hub route from a configured route whose sources are unavailable
- limit gateway mutations to refreshing the CLI presence of the backend being changed
- remove obsolete group/user option preloads that started OpenCode even though the shared route picker no longer consumed their results

## Root Cause

The Agent card collapsed every non-runnable named Agent into `interrupted`, so an absent route was rendered as a source outage. Gateway mutations also joined the same all-backend deep CLI scan used by the page refresh, and the group/user settings pages still ran legacy per-directory catalog discovery after those values stopped being consumed.

## Validation

- `533 passed` across Model Hub API, resolution, contract, and controller tests
- `3319 passed` across the full UI test suite
- Ruff passed on every changed Python file
- UI lint passed with all 738 TypeScript sources measured
- production UI build passed

## Regression

- Isolated local Incus deployment verified commit `3ab666647aa0f3a93549d0a2cc2ed1bb5eb3d71b`: `avibe-regression.service` active, `/health` healthy, `/status` running, and the prepared Show Runtime installed for Linux arm64.
- The live fixture started with OpenCode in Direct mode, temporarily enabled Model Hub, switched OpenCode to Hub, and selected the existing `openai/gpt-5.6-sol` menu entry with an empty route. `GET /api/models/agents` projected that named Agent with `route_reason: route_unconfigured`.
- Cleanup restored the exact original product configuration byte-for-byte, removed the temporary feature override, and re-established service health. Master was only health-checked and was not mutated.
- Focused backend coverage passed (`7 passed`) for explicit opt-in, fast reads, targeted CLI refresh, and unrelated discovery concurrency. Focused UI coverage passed (`26 passed`) for unconfigured status rendering and gateway adoption behavior.
