### PR TITLE
feat(model-hub): edit individual route hops

### DIFF
--- a/tests/scenarios/INDEX.yaml
+++ b/tests/scenarios/INDEX.yaml
@@ -122,6 +122,7 @@ capabilities:
       - tests/test_opencode_server.py
       - ui/src/components/settings/models/UsageTab.test.tsx
       - ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
+      - ui/src/components/settings/models/RouteChainDialog.test.tsx
       - ui/scripts/scenarioCatalog.test.mjs
   - id: harness_failure_recovery
     name: Harness per-Session failure recovery

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -15,6 +15,7 @@ capability:
     # properties can be observed, so the catalog checker resolves both shapes.
     - ui/src/components/settings/models/UsageTab.test.tsx
     - ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
+    - ui/src/components/settings/models/RouteChainDialog.test.tsx
     # The gate that resolves those rows against vitest's own collection, and
     # its own evidence.
     - ui/scripts/scenarioCatalog.test.mjs

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -65,6 +65,12 @@ scenarios:
     kind: persistence
     layer: scenario
     test: tests/scenarios/model_hub/test_model_hub_configured_route_scenarios.py::test_mh_config_001_chain_is_the_persisted_artifact_until_explicit_edit
+  - id: MH-ROUTE-EDIT-001
+    name: Replacing one route hop preserves its position and every untouched hop
+    status: covered
+    kind: mutation
+    layer: unit
+    test: ui/src/components/settings/models/RouteChainDialog.test.tsx::MH-ROUTE-EDIT-001
   - id: MH-MATCH-001
     name: Add-time matching persists each exact hop and returns its visible position
     status: covered

--- a/ui/src/components/settings/models/RouteCandidatePopover.tsx
+++ b/ui/src/components/settings/models/RouteCandidatePopover.tsx
@@ -1,0 +1,202 @@
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import type { RouteCandidate } from "./routeChainDraft";
+import type { RouteHop, Source } from "./types";
+
+const candidateKey = (hop: RouteHop): string =>
+  JSON.stringify([hop.source_id, hop.model_id]);
+
+export const RouteCandidatePopover: React.FC<{
+  candidates: RouteCandidate[];
+  confirmLabel: string;
+  initialHop?: RouteHop;
+  label: string;
+  onApply: (candidate: RouteCandidate) => void;
+  trigger: React.ReactElement;
+  width: "route" | "trigger";
+}> = ({
+  candidates,
+  confirmLabel,
+  initialHop,
+  label,
+  onApply,
+  trigger,
+  width,
+}) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState("");
+  const [candidate, setCandidate] = React.useState<RouteCandidate | null>(null);
+  const searchRef = React.useRef<HTMLInputElement | null>(null);
+  const term = query.trim().toLowerCase();
+  const matched = term
+    ? candidates.filter((item) =>
+        `${item.source.display_name}\n${item.hop.model_id}`
+          .toLowerCase()
+          .includes(term),
+      )
+    : candidates;
+  const groups = matched.reduce<
+    Array<{ source: Source; items: RouteCandidate[] }>
+  >((result, item) => {
+    const previous = result.at(-1);
+    if (previous?.source.id === item.source.id) previous.items.push(item);
+    else result.push({ source: item.source, items: [item] });
+    return result;
+  }, []);
+  const matchedRef = React.useRef(matched);
+  matchedRef.current = matched;
+  const matchedKeys = matched.map((item) => candidateKey(item.hop)).join("\n");
+  const unchanged =
+    candidate !== null &&
+    initialHop !== undefined &&
+    candidateKey(candidate.hop) === candidateKey(initialHop);
+
+  React.useEffect(() => {
+    if (!open) return;
+    setCandidate((current) => {
+      const keys = matchedKeys ? matchedKeys.split("\n") : [];
+      if (current && keys.includes(candidateKey(current.hop))) return current;
+      return matchedRef.current[0] ?? null;
+    });
+  }, [matchedKeys, open]);
+
+  const chooseCandidate = (next: string) => {
+    setCandidate(
+      matchedRef.current.find((item) => candidateKey(item.hop) === next) ??
+        null,
+    );
+  };
+
+  return (
+    <Popover
+      modal
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) {
+          setQuery("");
+          setCandidate(
+            (initialHop
+              ? candidates.find(
+                  (item) => candidateKey(item.hop) === candidateKey(initialHop),
+                )
+              : null) ??
+              candidates[0] ??
+              null,
+          );
+        } else {
+          setQuery("");
+          setCandidate(null);
+        }
+        setOpen(nextOpen);
+      }}
+    >
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      {/* This picker is body-portalled inside a scroll-locked dialog. A modal
+          popover owns the nested scroll lock, while a bounded downward panel
+          stays attached to either the full-width Add trigger or a row action. */}
+      <PopoverContent
+        side="bottom"
+        avoidCollisions={false}
+        align={width === "route" ? "end" : "start"}
+        sideOffset={6}
+        collisionPadding={16}
+        className={cn(
+          "model-hub-route-selector flex max-w-[calc(100vw-64px)] flex-col p-0",
+          width === "trigger"
+            ? "w-[var(--radix-popover-trigger-width)]"
+            : "w-[420px]",
+        )}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          searchRef.current?.focus();
+        }}
+      >
+        <Command
+          shouldFilter={false}
+          disablePointerSelection
+          label={label}
+          value={candidate ? candidateKey(candidate.hop) : ""}
+          onValueChange={chooseCandidate}
+          className="model-hub-route-selector-command min-h-0 bg-transparent"
+        >
+          <CommandInput
+            ref={searchRef}
+            value={query}
+            onValueChange={setQuery}
+            placeholder={t("settings.models.routeDialog.add.search") as string}
+          />
+          <p
+            className="model-hub-route-selector-head model-hub-route-selector-row"
+            aria-hidden="true"
+          >
+            <span>{t("settings.models.routeDialog.add.source")}</span>
+            <span>{t("settings.models.routeDialog.add.model")}</span>
+          </p>
+          <CommandList className="model-hub-route-selector-list">
+            {matched.length === 0 && (
+              <CommandEmpty>
+                {t("settings.models.routeDialog.add.noMatch")}
+              </CommandEmpty>
+            )}
+            {groups.map((group) => (
+              <CommandGroup
+                key={group.source.id}
+                heading={group.source.display_name}
+                className="model-hub-route-selector-group [&_[cmdk-group-heading]]:sr-only"
+              >
+                {group.items.map((item, itemIndex) => (
+                  <CommandItem
+                    key={candidateKey(item.hop)}
+                    value={candidateKey(item.hop)}
+                    onSelect={() => setCandidate(item)}
+                    className="model-hub-route-candidate model-hub-route-selector-row text-foreground"
+                  >
+                    <span className="model-hub-route-candidate-source truncate">
+                      {itemIndex === 0 ? group.source.display_name : ""}
+                    </span>
+                    <span className="model-hub-route-candidate-model truncate font-mono">
+                      {item.hop.model_id}
+                    </span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ))}
+          </CommandList>
+          <div className="model-hub-route-selector-foot flex shrink-0 items-center justify-end border-t border-border">
+            <Button
+              type="button"
+              className="model-hub-route-selector-confirm px-4"
+              disabled={!candidate || unchanged}
+              onClick={() => {
+                if (!candidate || unchanged) return;
+                onApply(candidate);
+                setOpen(false);
+                setQuery("");
+                setCandidate(null);
+              }}
+            >
+              {confirmLabel}
+            </Button>
+          </div>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/ui/src/components/settings/models/RouteCandidatePopover.tsx
+++ b/ui/src/components/settings/models/RouteCandidatePopover.tsx
@@ -28,6 +28,7 @@ export const RouteCandidatePopover: React.FC<{
   initialHop?: RouteHop;
   label: string;
   onApply: (candidate: RouteCandidate) => void;
+  onReturnFocus?: () => void;
   trigger: React.ReactElement;
   width: "route" | "trigger";
 }> = ({
@@ -36,6 +37,7 @@ export const RouteCandidatePopover: React.FC<{
   initialHop,
   label,
   onApply,
+  onReturnFocus,
   trigger,
   width,
 }) => {
@@ -44,14 +46,19 @@ export const RouteCandidatePopover: React.FC<{
   const [query, setQuery] = React.useState("");
   const [candidate, setCandidate] = React.useState<RouteCandidate | null>(null);
   const searchRef = React.useRef<HTMLInputElement | null>(null);
+  const pendingCandidateRef = React.useRef<RouteCandidate | null>(null);
   const term = query.trim().toLowerCase();
-  const matched = term
-    ? candidates.filter((item) =>
-        `${item.source.display_name}\n${item.hop.model_id}`
-          .toLowerCase()
-          .includes(term),
-      )
-    : candidates;
+  const matched = React.useMemo(
+    () =>
+      term
+        ? candidates.filter((item) =>
+            `${item.source.display_name}\n${item.hop.model_id}`
+              .toLowerCase()
+              .includes(term),
+          )
+        : candidates,
+    [candidates, term],
+  );
   const groups = matched.reduce<
     Array<{ source: Source; items: RouteCandidate[] }>
   >((result, item) => {
@@ -60,9 +67,6 @@ export const RouteCandidatePopover: React.FC<{
     else result.push({ source: item.source, items: [item] });
     return result;
   }, []);
-  const matchedRef = React.useRef(matched);
-  matchedRef.current = matched;
-  const matchedKeys = matched.map((item) => candidateKey(item.hop)).join("\n");
   const unchanged =
     candidate !== null &&
     initialHop !== undefined &&
@@ -71,16 +75,21 @@ export const RouteCandidatePopover: React.FC<{
   React.useEffect(() => {
     if (!open) return;
     setCandidate((current) => {
-      const keys = matchedKeys ? matchedKeys.split("\n") : [];
-      if (current && keys.includes(candidateKey(current.hop))) return current;
-      return matchedRef.current[0] ?? null;
+      if (
+        current &&
+        matched.some(
+          (item) => candidateKey(item.hop) === candidateKey(current.hop),
+        )
+      ) {
+        return current;
+      }
+      return matched[0] ?? null;
     });
-  }, [matchedKeys, open]);
+  }, [matched, open]);
 
   const chooseCandidate = (next: string) => {
     setCandidate(
-      matchedRef.current.find((item) => candidateKey(item.hop) === next) ??
-        null,
+      matched.find((item) => candidateKey(item.hop) === next) ?? null,
     );
   };
 
@@ -101,6 +110,7 @@ export const RouteCandidatePopover: React.FC<{
               null,
           );
         } else {
+          pendingCandidateRef.current = null;
           setQuery("");
           setCandidate(null);
         }
@@ -126,6 +136,13 @@ export const RouteCandidatePopover: React.FC<{
         onOpenAutoFocus={(event) => {
           event.preventDefault();
           searchRef.current?.focus();
+        }}
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+          const pendingCandidate = pendingCandidateRef.current;
+          pendingCandidateRef.current = null;
+          if (pendingCandidate) onApply(pendingCandidate);
+          else onReturnFocus?.();
         }}
       >
         <Command
@@ -186,7 +203,7 @@ export const RouteCandidatePopover: React.FC<{
               disabled={!candidate || unchanged}
               onClick={() => {
                 if (!candidate || unchanged) return;
-                onApply(candidate);
+                pendingCandidateRef.current = candidate;
                 setOpen(false);
                 setQuery("");
                 setCandidate(null);

--- a/ui/src/components/settings/models/RouteChainDialog.test.tsx
+++ b/ui/src/components/settings/models/RouteChainDialog.test.tsx
@@ -252,6 +252,49 @@ describe("RouteChainDialog", () => {
     expect(screen.getByText("Done").closest("button")).toBeTruthy();
   });
 
+  it("MH-ROUTE-EDIT-001 replaces one hop in place and saves the exact order", async () => {
+    const user = userEvent.setup();
+    const put = vi
+      .spyOn(modelsApi, "putAgentChain")
+      .mockResolvedValue(mutation());
+    renderStockedDialog();
+    const editButtons = await screen.findAllByRole("button", {
+      name: "Edit hop",
+    });
+
+    await user.click(editButtons[0]);
+    expect(
+      [...document.querySelectorAll(".model-hub-route-candidate-model")].map(
+        (element) => element.textContent,
+      ),
+    ).toEqual([
+      "claude-haiku-5",
+      "claude-opus-5",
+      "claude-sonnet-5",
+      "sonnet-5",
+    ]);
+    await user.type(
+      screen.getByPlaceholderText("Search sources or models"),
+      "claude-sonnet-5",
+    );
+    await user.click(screen.getByRole("button", { name: "Replace" }));
+
+    expect(
+      [...document.querySelectorAll(".model-hub-route-hop-model")].map(
+        (element) => element.textContent,
+      ),
+    ).toEqual(["claude-sonnet-5", "opus-5"]);
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() =>
+      expect(put).toHaveBeenCalledWith("claude", "opus-5", {
+        hops: [
+          { source_id: "src_a", model_id: "claude-sonnet-5" },
+          { source_id: "src_b", model_id: "opus-5" },
+        ],
+      }),
+    );
+  });
+
   it("renders the complete removed-hop impact after a successful save", async () => {
     const user = userEvent.setup();
     const removed = {
@@ -572,7 +615,7 @@ describe("RouteChainDialog", () => {
 
     expect(
       await screen.findAllByText(
-        "This edited hop is unavailable after the refresh. Remove it before saving.",
+        "This edited hop is unavailable after the refresh. Replace or remove it before saving.",
       ),
     ).toHaveLength(2);
     expect(screen.getAllByRole("button", { name: "Remove hop" })).toHaveLength(3);

--- a/ui/src/components/settings/models/RouteChainDialog.test.tsx
+++ b/ui/src/components/settings/models/RouteChainDialog.test.tsx
@@ -279,11 +279,13 @@ describe("RouteChainDialog", () => {
     );
     await user.click(screen.getByRole("button", { name: "Replace" }));
 
-    expect(
-      [...document.querySelectorAll(".model-hub-route-hop-model")].map(
-        (element) => element.textContent,
-      ),
-    ).toEqual(["claude-sonnet-5", "opus-5"]);
+    await waitFor(() =>
+      expect(
+        [...document.querySelectorAll(".model-hub-route-hop-model")].map(
+          (element) => element.textContent,
+        ),
+      ).toEqual(["claude-sonnet-5", "opus-5"]),
+    );
     await user.click(screen.getByRole("button", { name: "Save" }));
     await waitFor(() =>
       expect(put).toHaveBeenCalledWith("claude", "opus-5", {

--- a/ui/src/components/settings/models/RouteChainDialog.tsx
+++ b/ui/src/components/settings/models/RouteChainDialog.tsx
@@ -5,27 +5,16 @@ import {
   Info,
   ListOrdered,
   LoaderCircle,
+  Pencil,
   Plus,
   X,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { GuardGapList } from "./GuardGapList";
+import { RouteCandidatePopover } from "./RouteCandidatePopover";
 import { equalHopIdentity, hopBelongsToSource } from "./hopIdentity";
 import { apiFailure, modelsApi, type GuardConfirmation } from "./modelsApi";
 import type { ModelChainRead } from "./modelRows";
@@ -51,10 +40,6 @@ import type {
 
 const sourceName = (sources: Source[], sourceId: string): string =>
   sources.find((source) => source.id === sourceId)?.display_name ?? sourceId;
-
-/** Stable list-item identity for one candidate pair. Nothing parses it back. */
-const candidateKey = (hop: RouteHop): string =>
-  JSON.stringify([hop.source_id, hop.model_id]);
 
 type GuardState = {
   hops: RouteHopRef[];
@@ -146,16 +131,13 @@ export const RouteChainDialog: React.FC<{
   const [unknownObservation, setUnknownObservation] =
     React.useState<UnknownObservation>("none");
   const [unknownSourceCurrent, setUnknownSourceCurrent] = React.useState(false);
-  const [selectorOpen, setSelectorOpen] = React.useState(false);
-  const [query, setQuery] = React.useState("");
-  const [candidate, setCandidate] = React.useState<RouteCandidate | null>(null);
+  const [selectorEpoch, setSelectorEpoch] = React.useState(0);
   const [announcement, setAnnouncement] = React.useState<{
     key: string;
     params?: Record<string, unknown>;
   } | null>(null);
   const gripRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
   const removeRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
-  const searchRef = React.useRef<HTMLInputElement | null>(null);
   const addButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const reseedButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const cancelButtonRef = React.useRef<HTMLButtonElement | null>(null);
@@ -182,29 +164,7 @@ export const RouteChainDialog: React.FC<{
     },
     [],
   );
-  const candidates = agent ? routeCandidates(agent, sources, draft) : [];
-  // The filter narrows the same grouped projection V5 exposes, so an empty
-  // result means "nothing matches what you typed", never "nothing is available"
-  // — that second sentence stays `route.add.none` on the disabled trigger.
-  const term = query.trim().toLowerCase();
-  const matched = term
-    ? candidates.filter((item) =>
-        `${item.source.display_name}\n${item.hop.model_id}`
-          .toLowerCase()
-          .includes(term),
-      )
-    : candidates;
-  const candidateGroups = matched.reduce<
-    Array<{ source: Source; items: RouteCandidate[] }>
-  >((groups, item) => {
-    const previous = groups.at(-1);
-    if (previous?.source.id === item.source.id) previous.items.push(item);
-    else groups.push({ source: item.source, items: [item] });
-    return groups;
-  }, []);
-  const matchedRef = React.useRef(matched);
-  matchedRef.current = matched;
-  const matchedKeys = matched.map((item) => candidateKey(item.hop)).join("\n");
+  const addCandidates = agent ? routeCandidates(agent, sources, draft) : [];
   const backend = agent
     ? (t(`settings.models.backends.${agent.backend}`, {
         defaultValue: agent.backend,
@@ -264,9 +224,6 @@ export const RouteChainDialog: React.FC<{
     setFailedMembers(new Set());
     setUnknownObservation("none");
     setUnknownSourceCurrent(false);
-    setSelectorOpen(false);
-    setQuery("");
-    setCandidate(null);
     advanceInteraction({ type: "reset", draft: [], focusIndex: 0 });
     if (selection) void readChain();
   }, [advanceInteraction, readChain, selection]);
@@ -284,19 +241,6 @@ export const RouteChainDialog: React.FC<{
     onClose();
   }, [onClose, phase, selection]);
 
-  // ET-5a plus its invariant: while the selector is open exactly one candidate is
-  // active, and it is always one of the candidates currently listed. Filtering or
-  // a draft change that drops the active pair re-elects the first listed one
-  // rather than leaving the confirmation pointing at a row nobody can see.
-  React.useEffect(() => {
-    if (!selectorOpen) return;
-    setCandidate((current) => {
-      const keys = matchedKeys ? matchedKeys.split("\n") : [];
-      if (current && keys.includes(candidateKey(current.hop))) return current;
-      return matchedRef.current[0] ?? null;
-    });
-  }, [matchedKeys, selectorOpen]);
-
   React.useEffect(() => {
     const signature = valid.invalidIndexes.join(",");
     if (!signature) {
@@ -307,9 +251,7 @@ export const RouteChainDialog: React.FC<{
     if (signature === invalidSignature.current) return;
     invalidSignature.current = signature;
     if (phase === "rejected") setPhase("ready");
-    setSelectorOpen(false);
-    setQuery("");
-    setCandidate(null);
+    setSelectorEpoch((current) => current + 1);
     advanceInteraction({ type: "drop-grab" });
     focusAfterRender({
       current: removeRefs.current[valid.invalidIndexes[0]] ?? null,
@@ -322,10 +264,6 @@ export const RouteChainDialog: React.FC<{
     setPhase(commitReconciliation.pending ? "refreshing" : "impact");
     if (commitReconciliation.failed) focusAfterRender(retryButtonRef);
   }, [commitReconciliation, report]);
-
-  const focusAfterSelectorClose = () => {
-    requestAnimationFrame(() => addButtonRef.current?.focus());
-  };
 
   const close = () => {
     if (phase === "guard") {
@@ -350,7 +288,7 @@ export const RouteChainDialog: React.FC<{
     requestAnimationFrame(() => {
       if (nextDraft.length > 0) {
         gripRefs.current[focusedIndex]?.focus();
-      } else if (candidates.length > 0) {
+      } else if (addCandidates.length > 0) {
         addButtonRef.current?.focus();
       } else if (reseedButtonRef.current && !reseedButtonRef.current.disabled) {
         reseedButtonRef.current.focus();
@@ -671,22 +609,8 @@ export const RouteChainDialog: React.FC<{
     doneButtonRef.current?.focus();
     commitReconciliation.retry();
   };
-  // Every ET-5d move — arrow keys, Home/End, pointer activation — arrives here as
-  // the list's single active key, so activeness and selection cannot diverge.
-  const chooseCandidate = (next: string) => {
-    setCandidate(
-      matchedRef.current.find((item) => candidateKey(item.hop) === next) ?? null,
-    );
-  };
-  const closeSelector = () => {
-    setSelectorOpen(false);
-    setQuery("");
-    setCandidate(null);
-  };
-  const addCandidate = () => {
-    if (!candidate) return;
+  const addCandidate = (candidate: RouteCandidate) => {
     const next = advanceInteraction({ type: "append", hop: candidate.hop });
-    closeSelector();
     requestAnimationFrame(() => gripRefs.current[next.focusIndex]?.focus());
   };
   const renderHop = (hop: RouteHop, index: number) => {
@@ -702,6 +626,13 @@ export const RouteChainDialog: React.FC<{
         : hop.source_id;
     const chainCurrent = chain ? chain.current : null;
     const current = equalHopIdentity(chainCurrent, hop);
+    const replacementCandidates = agent
+      ? routeCandidates(
+          agent,
+          sources,
+          draft.filter((_, draftIndex) => draftIndex !== index),
+        )
+      : [];
     return (
       <div
         key={`${hop.source_id}:${hop.model_id}:${index}`}
@@ -787,21 +718,60 @@ export const RouteChainDialog: React.FC<{
             </span>
           )}
         </span>
-        <button
-          ref={(node) => {
-            removeRefs.current[index] = node;
-          }}
-          type="button"
-          aria-label={t("settings.models.routeDialog.removeHop") as string}
-          tabIndex={grabbed === null && rovingIndex === index ? 0 : -1}
-          disabled={
-            phase === "saving" || phase === "impact" || phase === "refreshing"
-          }
-          onClick={() => remove(index)}
-          className="model-hub-route-remove model-hub-fill-0a grid shrink-0 place-items-center border border-border text-muted"
-        >
-          <X aria-hidden="true" />
-        </button>
+        <span className="model-hub-route-actions flex shrink-0 items-center">
+          <RouteCandidatePopover
+            key={`edit:${selectorEpoch}:${index}`}
+            candidates={replacementCandidates}
+            confirmLabel={t("settings.models.routeDialog.edit.confirm") as string}
+            initialHop={hop}
+            label={t("settings.models.routeDialog.editHop") as string}
+            width="route"
+            onApply={(nextCandidate) => {
+              const next = advanceInteraction({
+                type: "replace",
+                index,
+                hop: nextCandidate.hop,
+              });
+              announce("settings.models.routeDialog.edit.replaced", {
+                position: index + 1,
+              });
+              requestAnimationFrame(() =>
+                gripRefs.current[next.focusIndex]?.focus(),
+              );
+            }}
+            trigger={
+              <button
+                type="button"
+                aria-label={t("settings.models.routeDialog.editHop") as string}
+                title={t("settings.models.routeDialog.editHop") as string}
+                tabIndex={grabbed === null && rovingIndex === index ? 0 : -1}
+                disabled={
+                  phase === "saving" ||
+                  phase === "impact" ||
+                  phase === "refreshing"
+                }
+                className="model-hub-route-action model-hub-route-edit model-hub-fill-0a grid shrink-0 place-items-center border border-border text-muted"
+              >
+                <Pencil aria-hidden="true" />
+              </button>
+            }
+          />
+          <button
+            ref={(node) => {
+              removeRefs.current[index] = node;
+            }}
+            type="button"
+            aria-label={t("settings.models.routeDialog.removeHop") as string}
+            tabIndex={grabbed === null && rovingIndex === index ? 0 : -1}
+            disabled={
+              phase === "saving" || phase === "impact" || phase === "refreshing"
+            }
+            onClick={() => remove(index)}
+            className="model-hub-route-action model-hub-route-remove model-hub-fill-0a grid shrink-0 place-items-center border border-border text-muted"
+          >
+            <X aria-hidden="true" />
+          </button>
+        </span>
       </div>
     );
   };
@@ -971,29 +941,20 @@ export const RouteChainDialog: React.FC<{
               {t("settings.models.routeDialog.empty")}
             </div>
           )}
-          {/* `modal` is what makes the panel scrollable: the Dialog's overlay owns a
-              `react-remove-scroll` lock whose shards cover the dialog only, so a
-              body-portalled non-modal popover has its wheel events cancelled. A
-              modal popover pushes its own lock, which the dialog's defers to. */}
-          <Popover
-            modal
-            open={selectorOpen}
-            onOpenChange={(open) => {
-              if (open) {
-                setSelectorOpen(true);
-                return;
-              }
-              closeSelector();
-              focusAfterSelectorClose();
-            }}
-          >
-            <PopoverTrigger asChild>
+          <RouteCandidatePopover
+            key={`add:${selectorEpoch}`}
+            candidates={addCandidates}
+            confirmLabel={t("settings.models.routeDialog.add.confirm") as string}
+            label={t("settings.models.routeDialog.addHop") as string}
+            width="trigger"
+            onApply={addCandidate}
+            trigger={
               <button
                 ref={addButtonRef}
                 type="button"
-                disabled={candidates.length === 0}
+                disabled={addCandidates.length === 0}
                 aria-describedby={
-                  candidates.length === 0
+                  addCandidates.length === 0
                     ? "model-hub-route-add-none"
                     : undefined
                 }
@@ -1002,103 +963,8 @@ export const RouteChainDialog: React.FC<{
                 <Plus aria-hidden="true" />
                 {t("settings.models.routeDialog.addHop")}
               </button>
-            </PopoverTrigger>
-            {/* Placement is deterministic and the height adapts, rather than the
-                other way round. Two variants were measured and rejected: bounding
-                collisions to the dialog gives a 131px panel over an 18px list,
-                because an empty chain — the case where this picker matters most —
-                makes the dialog short; letting it flip gives a full 300px panel
-                that jumps 150px above the dialog's own top, covering the page
-                title, since the room below happens to fall a few px short of the
-                300px preference. Dropping down always and taking `min(300px,
-                available-height)` keeps the panel attached to its trigger and on
-                screen. It stays scrollable when a long chain leaves little room
-                below; the dialog body scrolls, so the trigger can be moved up. */}
-            <PopoverContent
-              side="bottom"
-              avoidCollisions={false}
-              align="start"
-              sideOffset={6}
-              collisionPadding={16}
-              className="model-hub-route-selector flex w-[var(--radix-popover-trigger-width)] max-w-[calc(100vw-64px)] flex-col p-0"
-              onOpenAutoFocus={(event) => {
-                event.preventDefault();
-                searchRef.current?.focus();
-              }}
-              onCloseAutoFocus={(event) => {
-                event.preventDefault();
-                addButtonRef.current?.focus();
-              }}
-            >
-              <Command
-                shouldFilter={false}
-                disablePointerSelection
-                label={t("settings.models.routeDialog.addHop") as string}
-                value={candidate ? candidateKey(candidate.hop) : ""}
-                onValueChange={chooseCandidate}
-                className="model-hub-route-selector-command min-h-0 bg-transparent"
-              >
-                <CommandInput
-                  ref={searchRef}
-                  value={query}
-                  onValueChange={setQuery}
-                  placeholder={
-                    t("settings.models.routeDialog.add.search") as string
-                  }
-                />
-                <p
-                  className="model-hub-route-selector-head model-hub-route-selector-row"
-                  aria-hidden="true"
-                >
-                  <span>{t("settings.models.routeDialog.add.source")}</span>
-                  <span>{t("settings.models.routeDialog.add.model")}</span>
-                </p>
-                <CommandList className="model-hub-route-selector-list">
-                  {matched.length === 0 && (
-                    <CommandEmpty>
-                      {t("settings.models.routeDialog.add.noMatch")}
-                    </CommandEmpty>
-                  )}
-                  {candidateGroups.map((group) => (
-                    <CommandGroup
-                      key={group.source.id}
-                      heading={group.source.display_name}
-                      className="model-hub-route-selector-group [&_[cmdk-group-heading]]:sr-only"
-                    >
-                      {group.items.map((item, itemIndex) => (
-                        <CommandItem
-                          key={candidateKey(item.hop)}
-                          value={candidateKey(item.hop)}
-                          onSelect={() => setCandidate(item)}
-                          className="model-hub-route-candidate model-hub-route-selector-row text-foreground"
-                        >
-                          {/* The frame prints the source once per group and leaves
-                              the rest of the column blank; the group's own heading
-                              carries it for assistive tech. */}
-                          <span className="model-hub-route-candidate-source truncate">
-                            {itemIndex === 0 ? group.source.display_name : ""}
-                          </span>
-                          <span className="model-hub-route-candidate-model truncate font-mono">
-                            {item.hop.model_id}
-                          </span>
-                        </CommandItem>
-                      ))}
-                    </CommandGroup>
-                  ))}
-                </CommandList>
-                <div className="model-hub-route-selector-foot flex shrink-0 items-center justify-end border-t border-border">
-                  <Button
-                    type="button"
-                    className="model-hub-route-selector-confirm px-4"
-                    disabled={!candidate}
-                    onClick={addCandidate}
-                  >
-                    {t("settings.models.routeDialog.add.confirm")}
-                  </Button>
-                </div>
-              </Command>
-            </PopoverContent>
-          </Popover>
+            }
+          />
         </div>
         <button
           ref={reseedButtonRef}
@@ -1117,7 +983,7 @@ export const RouteChainDialog: React.FC<{
           <ListOrdered aria-hidden="true" />
           {t("settings.models.routeDialog.reorder.label")}
         </button>
-        {candidates.length === 0 && (
+        {addCandidates.length === 0 && (
           <span className="sr-only" id="model-hub-route-add-none">
             {t("settings.models.routeDialog.add.none")}
           </span>

--- a/ui/src/components/settings/models/RouteChainDialog.tsx
+++ b/ui/src/components/settings/models/RouteChainDialog.tsx
@@ -137,6 +137,7 @@ export const RouteChainDialog: React.FC<{
     params?: Record<string, unknown>;
   } | null>(null);
   const gripRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
+  const editRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
   const removeRefs = React.useRef<Array<HTMLButtonElement | null>>([]);
   const addButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const reseedButtonRef = React.useRef<HTMLButtonElement | null>(null);
@@ -726,6 +727,7 @@ export const RouteChainDialog: React.FC<{
             initialHop={hop}
             label={t("settings.models.routeDialog.editHop") as string}
             width="route"
+            onReturnFocus={() => editRefs.current[index]?.focus()}
             onApply={(nextCandidate) => {
               const next = advanceInteraction({
                 type: "replace",
@@ -741,6 +743,9 @@ export const RouteChainDialog: React.FC<{
             }}
             trigger={
               <button
+                ref={(node) => {
+                  editRefs.current[index] = node;
+                }}
                 type="button"
                 aria-label={t("settings.models.routeDialog.editHop") as string}
                 title={t("settings.models.routeDialog.editHop") as string}
@@ -948,6 +953,7 @@ export const RouteChainDialog: React.FC<{
             label={t("settings.models.routeDialog.addHop") as string}
             width="trigger"
             onApply={addCandidate}
+            onReturnFocus={() => addButtonRef.current?.focus()}
             trigger={
               <button
                 ref={addButtonRef}

--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -858,8 +858,9 @@
   border-radius: var(--model-hub-dialog-action-radius);
   font-size: var(--model-hub-route-selector-confirm-size);
 }
-.model-hub-route-remove { width: 26px; height: 26px; border-radius: 6px; color: var(--foreground); }
-.model-hub-route-remove > svg { width: 13px; height: 13px; }
+.model-hub-route-actions { gap: 4px; }
+.model-hub-route-action { width: 26px; height: 26px; border-radius: 6px; color: var(--foreground); }
+.model-hub-route-action > svg { width: 13px; height: 13px; }
 .model-hub-route-add { height: var(--model-hub-route-add-height); border-radius: var(--model-hub-route-hop-radius); border-color: var(--model-hub-wash-14); font-size: var(--model-hub-route-add-size); }
 .model-hub-route-add > svg { width: 13px; height: 13px; }
 .model-hub-route-reseed { font-size: 12px; }

--- a/ui/src/components/settings/models/routeChainInteraction.test.ts
+++ b/ui/src/components/settings/models/routeChainInteraction.test.ts
@@ -49,4 +49,16 @@ describe("route chain interaction owner", () => {
     expect(appended.focusIndex).toBe(2);
     expect(appended.draft).toEqual([hops[0], hops[2], hops[1]]);
   });
+
+  it("replaces one hop without changing its position", () => {
+    const replacement = { source_id: "src_d", model_id: "model_d" };
+    const replaced = advanceRouteChainInteraction(
+      createRouteChainInteraction(hops),
+      { type: "replace", index: 1, hop: replacement },
+    );
+
+    expect(replaced.focusIndex).toBe(1);
+    expect(replaced.grab).toBeNull();
+    expect(replaced.draft).toEqual([hops[0], replacement, hops[2]]);
+  });
 });

--- a/ui/src/components/settings/models/routeChainInteraction.ts
+++ b/ui/src/components/settings/models/routeChainInteraction.ts
@@ -16,6 +16,7 @@ export type RouteChainInteractionAction =
   | { type: "reset"; draft: RouteHop[]; focusIndex?: number }
   | { type: "focus"; index: number }
   | { type: "append"; hop: RouteHop }
+  | { type: "replace"; index: number; hop: RouteHop }
   | { type: "remove"; index: number }
   | { type: "begin-grab"; index: number }
   | { type: "move-grab"; direction: -1 | 1 }
@@ -78,6 +79,15 @@ export function advanceRouteChainInteraction(
       return {
         draft: [...state.draft, { ...action.hop }],
         focusIndex: state.draft.length,
+        grab: null,
+      };
+    case "replace":
+      if (action.index < 0 || action.index >= state.draft.length) return state;
+      return {
+        draft: state.draft.map((hop, index) =>
+          index === action.index ? { ...action.hop } : hop,
+        ),
+        focusIndex: action.index,
         grab: null,
       };
     case "remove": {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1194,6 +1194,7 @@
         "label": "Route chain for this model",
         "section": "Route chain for this model",
         "removeHop": "Remove hop",
+        "editHop": "Edit hop",
         "addHop": "Add a hop",
         "add": {
           "source": "Source",
@@ -1203,8 +1204,12 @@
           "noMatch": "No source or model matches that",
           "none": "No source/model pair is available to add"
         },
+        "edit": {
+          "confirm": "Replace",
+          "replaced": "Hop {{position}} replaced."
+        },
         "sourceMissing": "Source missing",
-        "invalidAfterRefresh": "This edited hop is unavailable after the refresh. Remove it before saving.",
+        "invalidAfterRefresh": "This edited hop is unavailable after the refresh. Replace or remove it before saving.",
         "reorder": {
           "label": "Reorder by Source order",
           "grabbed": "Hop {{position}} grabbed. Use arrow keys to move.",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1194,6 +1194,7 @@
         "label": "这个型号的路由链",
         "section": "这个型号的路由链",
         "removeHop": "移除这一跳",
+        "editHop": "修改这一跳",
         "addHop": "添加一跳",
         "add": {
           "source": "来源",
@@ -1203,8 +1204,12 @@
           "noMatch": "没有匹配的来源型号",
           "none": "没有可添加的来源型号"
         },
+        "edit": {
+          "confirm": "替换",
+          "replaced": "已替换第 {{position}} 跳。"
+        },
         "sourceMissing": "来源不存在",
-        "invalidAfterRefresh": "这个已编辑的跳在刷新后的来源中不可用。移除它后再保存。",
+        "invalidAfterRefresh": "这个已编辑的跳在刷新后的来源中不可用。替换或移除它后再保存。",
         "reorder": {
           "label": "按来源顺序重排",
           "grabbed": "已抓取第 {{position}} 跳。使用方向键移动。",


### PR DESCRIPTION
## Summary

- add an edit action to every Model Hub route hop
- reuse the existing source/model picker to replace a hop without changing its position
- keep duplicate-pair exclusion, stale-hop recovery, and exact whole-chain persistence intact

## Scenario

- `MH-ROUTE-EDIT-001`: replacing one route hop preserves its position and every untouched hop

## Verification

- `npx vitest run src/components/settings/models/routeChainInteraction.test.ts src/components/settings/models/routeChainDraft.test.ts src/components/settings/models/RouteChainDialog.test.tsx`
- `npm run validate:catalog`
- `npm run lint`
- `npm run build`

## Evidence layers

- Unit/UI interaction: covered by `MH-ROUTE-EDIT-001`
- Production bundle: TypeScript and Vite build passed
- Local Incus/browser: pending exact-head deployment
