### PR TITLE
feat(memory): add exact rollback package shapes

### DIFF
--- a/tests/scenarios/memory_independence/catalog.yaml
+++ b/tests/scenarios/memory_independence/catalog.yaml
@@ -14,6 +14,7 @@ capability:
     - tests/test_core_services_dispatch.py
     - tests/test_admin_notifications.py
     - tests/test_memory_disabled_isolation.py
+    - tests/scenarios/memory_independence/test_memory_rollback_types.py
 contract:
   dispatch: capture_must_not_fence_turn_start
   destructive_ops: new_and_archive_fail_open_on_capture_timeout
@@ -129,3 +130,9 @@ scenarios:
     kind: guardrail
     layer: scenario
     test: tests/test_memory_disabled_isolation.py::test_memory_indep_017_core_workflows_run_without_avibe_memory
+  - id: MEMORY-INDEP-019
+    name: Every captured release family resolves only to an exact staged rollback shape
+    status: covered
+    kind: guardrail
+    layer: scenario
+    test: tests/scenarios/memory_independence/test_memory_rollback_types.py::test_memory_indep_019_release_family_property_table

--- a/tests/scenarios/memory_independence/test_memory_rollback_types.py
+++ b/tests/scenarios/memory_independence/test_memory_rollback_types.py
@@ -265,14 +265,43 @@ def test_memory_indep_019_duplicate_canonical_providers_fail_before_shape() -> N
         )
 
 
-def test_memory_indep_019_alternate_core_providers_fail_before_shape() -> None:
+@pytest.mark.parametrize(
+    ("core_version", "expected_provider", "expected_family"),
+    [
+        ("3.0.13", "vibe-remote", ReleaseFamily.PRE_SPLIT),
+        ("3.0.14", "avibe-os", ReleaseFamily.OPTIONAL_SPLIT),
+    ],
+)
+def test_memory_indep_019_alternate_core_providers_select_running_version(
+    core_version: str,
+    expected_provider: str,
+    expected_family: ReleaseFamily,
+) -> None:
     providers = (
-        _provider("avibe-os", "3.0.14"),
         _provider("vibe-remote", "3.0.13"),
+        _provider(
+            "avibe-os",
+            "3.0.14",
+            requires_dist=(OPTIONAL_MEMORY_REQUIREMENT,),
+        ),
     )
-    with pytest.raises(DuplicateDistributionProviderError):
+    shape = capture_package_shape(
+        core_version=core_version,
+        launcher=LAUNCHER,
+        providers=providers,
+    )
+    assert shape.core_distribution == expected_provider
+    assert shape.release_family is expected_family
+
+
+def test_memory_indep_019_alternate_core_providers_reject_ambiguous_version() -> None:
+    providers = (
+        _provider("vibe-remote", "3.0.13"),
+        _provider("avibe-os", "3.0.13"),
+    )
+    with pytest.raises(PackageShapeError, match="exactly one"):
         capture_package_shape(
-            core_version="3.0.14",
+            core_version="3.0.13",
             launcher=LAUNCHER,
             providers=providers,
         )
@@ -436,14 +465,16 @@ def test_memory_indep_019_no_resolved_target_has_presence_without_version(tmp_pa
     assert plan.captured.memory_version is None
 
 
-def test_memory_indep_019_legacy_target_rejects_presence_without_version() -> None:
+def test_memory_indep_019_legacy_target_marks_presence_without_version_unavailable() -> None:
     from vibe.upgrade import RollbackTarget
 
-    with pytest.raises(PackageShapeError, match="requires one exact version"):
-        RollbackTarget(
-            version="3.0.14",
-            package="avibe-os",
-            launcher=LAUNCHER,
-            memory_package=True,
-            memory_version=None,
-        )
+    target = RollbackTarget(
+        version="3.0.14",
+        package="avibe-os",
+        launcher=LAUNCHER,
+        memory_package=True,
+        memory_version=None,
+    )
+    assert not target
+    assert target.memory_package is False
+    assert target.memory_version is None

--- a/tests/scenarios/memory_independence/test_memory_rollback_types.py
+++ b/tests/scenarios/memory_independence/test_memory_rollback_types.py
@@ -11,6 +11,7 @@ import subprocess
 import zipfile
 from dataclasses import FrozenInstanceError, dataclass
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -38,6 +39,7 @@ LAUNCHER = ServiceLauncher(
     main="/opt/avibe/lib/python/site-packages/vibe/service_main.py",
 )
 OPTIONAL_MEMORY_REQUIREMENT = 'avibe-memory>=3.0.14.dev0,<3.1; extra == "memory"'
+MEMORY_FORWARD_CORE_REQUIREMENT = "avibe-os>=3.0.14.dev0,<3.1"
 
 
 def _provider(
@@ -60,8 +62,9 @@ def _shape(
     *,
     memory_version: str | None,
     core_requires: tuple[str, ...] = (OPTIONAL_MEMORY_REQUIREMENT,),
+    core_distribution: str = "avibe-os",
 ) -> CapturedPackageShape:
-    providers = [_provider("avibe-os", core_version, requires_dist=core_requires)]
+    providers = [_provider(core_distribution, core_version, requires_dist=core_requires)]
     if memory_version is not None:
         providers.append(_provider("avibe-memory", memory_version))
     return capture_package_shape(
@@ -119,6 +122,7 @@ class FamilyCase:
     expected_family: ReleaseFamily
     expected_requirements: tuple[str, ...] | None
     residual_memory: bool = False
+    core_distribution: str = "avibe-os"
 
 
 FAMILY_CASES = (
@@ -176,16 +180,18 @@ FAMILY_CASES = (
         None,
         (),
         ReleaseFamily.PRE_SPLIT,
-        ("avibe-os==3.0.13",),
+        ("vibe-remote==3.0.13",),
+        core_distribution="vibe-remote",
     ),
     FamilyCase(
         "bundled_residual",
         "3.0.13",
-        "3.0.12",
+        "3.0.14",
         (),
         ReleaseFamily.PRE_SPLIT,
-        ("avibe-os==3.0.13", "avibe-memory==3.0.12"),
+        ("vibe-remote==3.0.13", "avibe-memory==3.0.14"),
         residual_memory=True,
+        core_distribution="vibe-remote",
     ),
 )
 
@@ -201,6 +207,7 @@ def test_memory_indep_019_release_family_property_table(
         case.core_version,
         memory_version=case.memory_version,
         core_requires=case.core_requires,
+        core_distribution=case.core_distribution,
     )
     assert shape.release_family is case.expected_family
     assert shape.memory_present is (case.memory_version is not None)
@@ -212,12 +219,26 @@ def test_memory_indep_019_release_family_property_table(
     wheelhouse.mkdir()
     _wheel(
         wheelhouse,
-        "avibe-os",
+        case.core_distribution,
         case.core_version,
         requires_dist=case.core_requires,
     )
+    if case.residual_memory:
+        _wheel(
+            wheelhouse,
+            "avibe-os",
+            "3.0.14",
+            requires_dist=(OPTIONAL_MEMORY_REQUIREMENT,),
+        )
     if case.memory_version is not None:
-        _wheel(wheelhouse, "avibe-memory", case.memory_version)
+        _wheel(
+            wheelhouse,
+            "avibe-memory",
+            case.memory_version,
+            requires_dist=(MEMORY_FORWARD_CORE_REQUIREMENT,)
+            if case.residual_memory
+            else (),
+        )
     staging = tmp_path / "staging"
     if case.expected_requirements is None:
         with pytest.raises(RollbackResolutionError):
@@ -232,10 +253,18 @@ def test_memory_indep_019_release_family_property_table(
     assert plan.verification.memory_provider_cardinality == int(case.memory_version is not None)
     assert plan.verification.memory_version == case.memory_version
     assert plan.verification.residual_memory is case.residual_memory
-    assert plan.verification.absent_core_distributions == ("vibe-remote",)
+    expected_absent_core = (
+        "avibe-os" if case.core_distribution == "vibe-remote" else "vibe-remote"
+    )
+    assert plan.verification.absent_core_distributions == (expected_absent_core,)
     assert plan.staging_dir == staging
     assert all(artifact.path.parent == staging for artifact in plan.artifacts)
     assert all(len(artifact.sha256) == 64 for artifact in plan.artifacts)
+    assert [
+        (artifact.distribution, artifact.version)
+        for artifact in plan.artifacts
+        if artifact.distribution in ("avibe-os", "vibe-remote")
+    ] == [(case.core_distribution, case.core_version)]
 
 
 def test_memory_indep_019_capture_normalizes_versions_and_is_immutable() -> None:
@@ -251,11 +280,18 @@ def test_memory_indep_019_unknown_post_split_family_fails_closed() -> None:
         _shape("3.1.1", memory_version=None, core_requires=())
 
 
-def test_memory_indep_019_duplicate_canonical_providers_fail_before_shape() -> None:
-    providers = (
-        _provider("avibe-os", "3.0.14"),
-        _provider("avibe-memory", "3.0.14", suffix="one"),
-        _provider("avibe_memory", "3.0.14", suffix="two"),
+@pytest.mark.parametrize("duplicate_name", ["avibe-os", "vibe-remote", "avibe-memory"])
+def test_memory_indep_019_duplicate_canonical_providers_fail_before_shape(
+    duplicate_name: str,
+) -> None:
+    providers = [_provider("avibe-os", "3.0.14")]
+    if duplicate_name == "avibe-os":
+        providers = []
+    providers.extend(
+        (
+            _provider(duplicate_name, "3.0.14", suffix="one"),
+            _provider(duplicate_name.replace("-", "_"), "3.0.14", suffix="two"),
+        )
     )
     with pytest.raises(DuplicateDistributionProviderError):
         capture_package_shape(
@@ -311,6 +347,76 @@ class _UnreadableDistribution:
     @property
     def metadata(self) -> Any:
         raise OSError("unreadable metadata")
+
+
+def test_memory_indep_019_repeated_metadata_paths_count_as_one_provider(
+    tmp_path: Path,
+) -> None:
+    site_packages = tmp_path / "site-packages"
+    core_path = site_packages / "avibe_os-3.0.14.dist-info"
+    memory_path = site_packages / "avibe_memory-3.0.14.dist-info"
+    repeated_core_path = site_packages / ".." / "site-packages" / core_path.name
+    repeated_memory_path = site_packages / "." / memory_path.name
+    core = SimpleNamespace(
+        metadata={"Name": "avibe-os"},
+        version="3.0.14",
+        _path=core_path,
+        requires=(OPTIONAL_MEMORY_REQUIREMENT,),
+    )
+    repeated_core = SimpleNamespace(
+        metadata={"Name": "avibe-os"},
+        version="3.0.14",
+        _path=repeated_core_path,
+        requires=(OPTIONAL_MEMORY_REQUIREMENT,),
+    )
+    memory = SimpleNamespace(
+        metadata={"Name": "avibe-memory"},
+        version="3.0.14",
+        _path=memory_path,
+        requires=(),
+    )
+    repeated_memory = SimpleNamespace(
+        metadata={"Name": "avibe-memory"},
+        version="3.0.14",
+        _path=repeated_memory_path,
+        requires=(),
+    )
+
+    shape = capture_package_shape(
+        core_version="3.0.14",
+        launcher=LAUNCHER,
+        providers=inspect_installed_distribution_providers(
+            [core, repeated_core, memory, repeated_memory]
+        ),
+    )
+
+    assert shape.core_provider.provider_id == str(core_path.resolve())
+    assert shape.memory_provider_cardinality == 1
+    assert shape.memory_providers[0].provider_id == str(memory_path.resolve())
+
+
+def test_memory_indep_019_same_provider_identity_with_conflicting_metadata_fails() -> None:
+    provider_id = "/site-packages/avibe_os.dist-info"
+    providers = (
+        DistributionProvider(
+            name="avibe-os",
+            version="3.0.14",
+            provider_id=provider_id,
+            requires_dist=(OPTIONAL_MEMORY_REQUIREMENT,),
+        ),
+        DistributionProvider(
+            name="avibe-os",
+            version="3.0.15",
+            provider_id=provider_id,
+            requires_dist=(OPTIONAL_MEMORY_REQUIREMENT,),
+        ),
+    )
+    with pytest.raises(PackageShapeError, match="conflicting metadata"):
+        capture_package_shape(
+            core_version="3.0.14",
+            launcher=LAUNCHER,
+            providers=providers,
+        )
 
 
 def test_memory_indep_019_unreadable_metadata_fails_before_shape() -> None:

--- a/tests/scenarios/memory_independence/test_memory_rollback_types.py
+++ b/tests/scenarios/memory_independence/test_memory_rollback_types.py
@@ -1,0 +1,449 @@
+"""MEMORY-INDEP-019 exact capture and resolver-satisfiable rollback evidence."""
+
+from __future__ import annotations
+
+import ast
+import base64
+import csv
+import hashlib
+import io
+import subprocess
+import zipfile
+from dataclasses import FrozenInstanceError, dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from vibe.package_shape import (
+    CapturedPackageShape,
+    DistributionProvider,
+    DuplicateDistributionProviderError,
+    PackageShapeError,
+    ReleaseFamily,
+    ResolvedRollbackPlan,
+    RollbackResolutionError,
+    capture_package_shape,
+    inspect_installed_distribution_providers,
+    resolve_rollback_plan,
+)
+from vibe.runtime import ServiceLauncher
+from vibe.upgrade import build_upgrade_plan
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SHIPPED_SOURCE_ROOTS = ("main.py", "config", "core", "modules", "storage", "vibe")
+LAUNCHER = ServiceLauncher(
+    python="/opt/avibe/bin/python",
+    main="/opt/avibe/lib/python/site-packages/vibe/service_main.py",
+)
+OPTIONAL_MEMORY_REQUIREMENT = 'avibe-memory>=3.0.14.dev0,<3.1; extra == "memory"'
+
+
+def _provider(
+    name: str,
+    version: str,
+    *,
+    requires_dist: tuple[str, ...] = (),
+    suffix: str = "1",
+) -> DistributionProvider:
+    return DistributionProvider(
+        name=name,
+        version=version,
+        provider_id=f"/{name}-{version}-{suffix}.dist-info",
+        requires_dist=requires_dist,
+    )
+
+
+def _shape(
+    core_version: str,
+    *,
+    memory_version: str | None,
+    core_requires: tuple[str, ...] = (OPTIONAL_MEMORY_REQUIREMENT,),
+) -> CapturedPackageShape:
+    providers = [_provider("avibe-os", core_version, requires_dist=core_requires)]
+    if memory_version is not None:
+        providers.append(_provider("avibe-memory", memory_version))
+    return capture_package_shape(
+        core_version=core_version,
+        launcher=LAUNCHER,
+        providers=providers,
+    )
+
+
+def _wheel(
+    wheelhouse: Path,
+    name: str,
+    version: str,
+    *,
+    requires_dist: tuple[str, ...] = (),
+) -> Path:
+    wheel_name = name.replace("-", "_")
+    dist_info = f"{wheel_name}-{version}.dist-info"
+    path = wheelhouse / f"{wheel_name}-{version}-py3-none-any.whl"
+    metadata = "\n".join(
+        [
+            "Metadata-Version: 2.1",
+            f"Name: {name}",
+            f"Version: {version}",
+            *(f"Requires-Dist: {requirement}" for requirement in requires_dist),
+            "",
+        ]
+    ).encode()
+    wheel = b"Wheel-Version: 1.0\nGenerator: memory-indep-019\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+    entries = {
+        f"{dist_info}/METADATA": metadata,
+        f"{dist_info}/WHEEL": wheel,
+    }
+    rows: list[list[str]] = []
+    for entry, payload in entries.items():
+        digest = base64.urlsafe_b64encode(hashlib.sha256(payload).digest()).rstrip(b"=").decode()
+        rows.append([entry, f"sha256={digest}", str(len(payload))])
+    record_name = f"{dist_info}/RECORD"
+    rows.append([record_name, "", ""])
+    record = io.StringIO()
+    csv.writer(record, lineterminator="\n").writerows(rows)
+    entries[record_name] = record.getvalue().encode()
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for entry, payload in entries.items():
+            archive.writestr(entry, payload)
+    return path
+
+
+@dataclass(frozen=True)
+class FamilyCase:
+    name: str
+    core_version: str
+    memory_version: str | None
+    core_requires: tuple[str, ...]
+    expected_family: ReleaseFamily
+    expected_requirements: tuple[str, ...] | None
+    residual_memory: bool = False
+
+
+FAMILY_CASES = (
+    FamilyCase(
+        "core_only",
+        "3.0.14",
+        None,
+        (OPTIONAL_MEMORY_REQUIREMENT,),
+        ReleaseFamily.OPTIONAL_SPLIT,
+        ("avibe-os==3.0.14",),
+    ),
+    FamilyCase(
+        "matching_split",
+        "3.0.14",
+        "3.0.14",
+        (OPTIONAL_MEMORY_REQUIREMENT,),
+        ReleaseFamily.OPTIONAL_SPLIT,
+        ("avibe-os==3.0.14", "avibe-memory==3.0.14"),
+    ),
+    FamilyCase(
+        "optional_mismatch",
+        "3.0.14",
+        "3.0.15",
+        (OPTIONAL_MEMORY_REQUIREMENT,),
+        ReleaseFamily.OPTIONAL_SPLIT,
+        ("avibe-os==3.0.14", "avibe-memory==3.0.15"),
+    ),
+    FamilyCase(
+        "healthy_transition",
+        "3.1.0",
+        "3.1.0",
+        ("avibe-memory==3.1.0",),
+        ReleaseFamily.TRANSITION,
+        ("avibe-os==3.1.0", "avibe-memory==3.1.0"),
+    ),
+    FamilyCase(
+        "transition_missing",
+        "3.1.0",
+        None,
+        ("avibe-memory==3.1.0",),
+        ReleaseFamily.TRANSITION,
+        None,
+    ),
+    FamilyCase(
+        "transition_mismatch",
+        "3.1.0",
+        "3.1.1",
+        ("avibe-memory==3.1.0",),
+        ReleaseFamily.TRANSITION,
+        None,
+    ),
+    FamilyCase(
+        "pre_split",
+        "3.0.13",
+        None,
+        (),
+        ReleaseFamily.PRE_SPLIT,
+        ("avibe-os==3.0.13",),
+    ),
+    FamilyCase(
+        "bundled_residual",
+        "3.0.13",
+        "3.0.12",
+        (),
+        ReleaseFamily.PRE_SPLIT,
+        ("avibe-os==3.0.13", "avibe-memory==3.0.12"),
+        residual_memory=True,
+    ),
+)
+
+
+@pytest.mark.parametrize("case", FAMILY_CASES, ids=lambda case: case.name)
+def test_memory_indep_019_release_family_property_table(
+    case: FamilyCase,
+    tmp_path: Path,
+) -> None:
+    """Every specified family either resolves exactly or has no plan."""
+
+    shape = _shape(
+        case.core_version,
+        memory_version=case.memory_version,
+        core_requires=case.core_requires,
+    )
+    assert shape.release_family is case.expected_family
+    assert shape.memory_present is (case.memory_version is not None)
+    assert shape.memory_version == case.memory_version
+    assert shape.memory_provider_cardinality == int(case.memory_version is not None)
+    assert shape.residual_memory is case.residual_memory
+
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    _wheel(
+        wheelhouse,
+        "avibe-os",
+        case.core_version,
+        requires_dist=case.core_requires,
+    )
+    if case.memory_version is not None:
+        _wheel(wheelhouse, "avibe-memory", case.memory_version)
+    staging = tmp_path / "staging"
+    if case.expected_requirements is None:
+        with pytest.raises(RollbackResolutionError):
+            resolve_rollback_plan(shape, wheelhouse=wheelhouse, staging_dir=staging)
+        assert not staging.exists()
+        return
+
+    plan = resolve_rollback_plan(shape, wheelhouse=wheelhouse, staging_dir=staging)
+    assert tuple(requirement.specifier for requirement in plan.requirements) == (
+        case.expected_requirements
+    )
+    assert plan.verification.memory_provider_cardinality == int(case.memory_version is not None)
+    assert plan.verification.memory_version == case.memory_version
+    assert plan.verification.residual_memory is case.residual_memory
+    assert plan.verification.absent_core_distributions == ("vibe-remote",)
+    assert plan.staging_dir == staging
+    assert all(artifact.path.parent == staging for artifact in plan.artifacts)
+    assert all(len(artifact.sha256) == 64 for artifact in plan.artifacts)
+
+
+def test_memory_indep_019_capture_normalizes_versions_and_is_immutable() -> None:
+    shape = _shape("3.0.14RC1", memory_version="3.0.14RC1")
+    assert shape.core_version == "3.0.14rc1"
+    assert shape.memory_version == "3.0.14rc1"
+    with pytest.raises(FrozenInstanceError):
+        shape.residual_memory = True  # type: ignore[misc]
+
+
+def test_memory_indep_019_unknown_post_split_family_fails_closed() -> None:
+    with pytest.raises(PackageShapeError, match="known Memory release family"):
+        _shape("3.1.1", memory_version=None, core_requires=())
+
+
+def test_memory_indep_019_duplicate_canonical_providers_fail_before_shape() -> None:
+    providers = (
+        _provider("avibe-os", "3.0.14"),
+        _provider("avibe-memory", "3.0.14", suffix="one"),
+        _provider("avibe_memory", "3.0.14", suffix="two"),
+    )
+    with pytest.raises(DuplicateDistributionProviderError):
+        capture_package_shape(
+            core_version="3.0.14",
+            launcher=LAUNCHER,
+            providers=providers,
+        )
+
+
+def test_memory_indep_019_alternate_core_providers_fail_before_shape() -> None:
+    providers = (
+        _provider("avibe-os", "3.0.14"),
+        _provider("vibe-remote", "3.0.13"),
+    )
+    with pytest.raises(DuplicateDistributionProviderError):
+        capture_package_shape(
+            core_version="3.0.14",
+            launcher=LAUNCHER,
+            providers=providers,
+        )
+
+
+class _UnreadableDistribution:
+    @property
+    def metadata(self) -> Any:
+        raise OSError("unreadable metadata")
+
+
+def test_memory_indep_019_unreadable_metadata_fails_before_shape() -> None:
+    with pytest.raises(PackageShapeError, match="unreadable"):
+        inspect_installed_distribution_providers([_UnreadableDistribution()])
+
+
+def test_memory_indep_019_resolver_failure_leaves_no_plan_or_staging(tmp_path: Path) -> None:
+    shape = _shape("3.0.14", memory_version=None)
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    staging = tmp_path / "staging"
+    with pytest.raises(RollbackResolutionError, match="did not resolve"):
+        resolve_rollback_plan(shape, wheelhouse=wheelhouse, staging_dir=staging)
+    assert not staging.exists()
+
+
+def test_memory_indep_019_core_only_rejects_transitive_memory_artifact(tmp_path: Path) -> None:
+    core_requires = (
+        "shape-helper==1.0",
+        OPTIONAL_MEMORY_REQUIREMENT,
+    )
+    shape = _shape("3.0.14", memory_version=None, core_requires=core_requires)
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    _wheel(wheelhouse, "avibe-os", "3.0.14", requires_dist=core_requires)
+    _wheel(
+        wheelhouse,
+        "shape-helper",
+        "1.0",
+        requires_dist=("avibe-memory==3.0.14",),
+    )
+    _wheel(wheelhouse, "avibe-memory", "3.0.14")
+    staging = tmp_path / "staging"
+    with pytest.raises(RollbackResolutionError, match="exact captured Memory shape"):
+        resolve_rollback_plan(shape, wheelhouse=wheelhouse, staging_dir=staging)
+    assert not staging.exists()
+
+
+def test_memory_indep_019_local_resolution_only_downloads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shape = _shape("3.0.14", memory_version="3.0.15")
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    _wheel(
+        wheelhouse,
+        "avibe-os",
+        "3.0.14",
+        requires_dist=(OPTIONAL_MEMORY_REQUIREMENT,),
+    )
+    _wheel(wheelhouse, "avibe-memory", "3.0.15")
+    commands: list[tuple[str, ...]] = []
+    real_run = subprocess.run
+
+    def record_run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        commands.append(tuple(command))
+        return real_run(command, **kwargs)
+
+    monkeypatch.setattr("vibe.package_shape.subprocess.run", record_run)
+    resolve_rollback_plan(
+        shape,
+        wheelhouse=wheelhouse,
+        staging_dir=tmp_path / "staging",
+    )
+    assert len(commands) == 1
+    assert commands[0][1:4] == ("-m", "pip", "download")
+    assert "install" not in commands[0]
+
+
+def test_memory_indep_019_resolved_plan_constructor_cannot_be_bypassed() -> None:
+    with pytest.raises(TypeError, match="constructed only by rollback resolution"):
+        ResolvedRollbackPlan(
+            captured=_shape("3.0.14", memory_version=None),
+            requirements=(),
+            artifacts=(),
+            staging_dir=Path("/not/staged"),
+            uninstall_distributions=(),
+            verification=None,  # type: ignore[arg-type]
+        )
+
+
+def test_memory_indep_019_unknown_hybrid_family_fails_closed() -> None:
+    with pytest.raises(PackageShapeError, match="one exact Memory dependency"):
+        _shape(
+            "3.1.0",
+            memory_version="3.1.0",
+            core_requires=(
+                "avibe-memory==3.1.0",
+                'avibe-memory>=3.0.14.dev0,<3.1; extra == "memory"',
+            ),
+        )
+
+
+def _call_inventory(function_name: str) -> dict[str, int]:
+    callers: dict[str, int] = {}
+    for root in SHIPPED_SOURCE_ROOTS:
+        target = ROOT / root
+        for source in [target] if target.is_file() else sorted(target.rglob("*.py")):
+            tree = ast.parse(source.read_text(encoding="utf-8"))
+            calls = sum(
+                1
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call)
+                and (getattr(node.func, "id", None) or getattr(node.func, "attr", None))
+                == function_name
+            )
+            if calls:
+                callers[source.relative_to(ROOT).as_posix()] = calls
+    return callers
+
+
+def test_memory_indep_019_full_tree_caller_inventory_keeps_ownership_private() -> None:
+    assert _call_inventory("capture_installed_package_shape") == {"vibe/upgrade.py": 1}
+    assert _call_inventory("resolve_rollback_plan") == {}
+    assert _call_inventory("ResolvedRollbackPlan") == {}
+
+
+def test_memory_indep_019_pinned_core_and_memory_requirements_are_independent(monkeypatch) -> None:
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
+    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: True)
+    plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        base_env={"PATH": "/usr/bin"},
+        version="3.0.14",
+        package_name="avibe-os",
+        memory_package=True,
+        memory_version="3.0.15",
+    )
+    assert "avibe-os==3.0.14" in plan.command
+    assert "avibe-os[memory]" not in " ".join(plan.command)
+    assert "avibe-memory==3.0.15" in plan.command
+
+
+def test_memory_indep_019_no_resolved_target_has_presence_without_version(tmp_path: Path) -> None:
+    shape = _shape("3.0.14", memory_version=None)
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    _wheel(
+        wheelhouse,
+        "avibe-os",
+        "3.0.14",
+        requires_dist=(OPTIONAL_MEMORY_REQUIREMENT,),
+    )
+    plan = resolve_rollback_plan(
+        shape,
+        wheelhouse=wheelhouse,
+        staging_dir=tmp_path / "staging",
+    )
+    assert plan.captured.memory_package is False
+    assert plan.captured.memory_version is None
+
+
+def test_memory_indep_019_legacy_target_rejects_presence_without_version() -> None:
+    from vibe.upgrade import RollbackTarget
+
+    with pytest.raises(PackageShapeError, match="requires one exact version"):
+        RollbackTarget(
+            version="3.0.14",
+            package="avibe-os",
+            launcher=LAUNCHER,
+            memory_package=True,
+            memory_version=None,
+        )

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -586,6 +586,41 @@ def test_the_argv_the_job_builds_is_the_argv_the_entry_point_accepts(monkeypatch
     assert ran["prepare_show_runtime"] is True
 
 
+def test_incomplete_legacy_memory_argv_stays_restartable(monkeypatch):
+    ran = {}
+
+    def fake_run_restart_job(**kwargs):
+        ran.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(restart_supervisor, "_run_restart_job", fake_run_restart_job)
+
+    result = restart_supervisor.main(
+        [
+            "--job-id",
+            "legacy-incomplete-memory",
+            "--trigger",
+            "upgrade",
+            "--rollback-to",
+            "3.0.14",
+            "--rollback-package",
+            "avibe-os",
+            "--rollback-python",
+            "/opt/avibe/bin/python",
+            "--rollback-main",
+            "/opt/avibe/lib/python/site-packages/vibe/service_main.py",
+            "--rollback-memory-package",
+        ]
+    )
+
+    assert result == 0
+    target = ran["rollback_to"]
+    assert target is not None
+    assert not target
+    assert target.memory_package is False
+    assert target.memory_version is None
+
+
 def test_schedule_restart_marks_status_failed_when_spawn_fails(monkeypatch, tmp_path):
     # The "scheduled" status is seeded before spawning; if the spawn fails, no
     # child will overwrite it, so schedule_restart must mark it failed (otherwise

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -12,6 +12,11 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from vibe import api, cli
+from vibe.package_shape import (
+    CapturedPackageShape,
+    DistributionProvider,
+    ReleaseFamily,
+)
 from vibe.runtime import ServiceLauncher
 from vibe.upgrade import (
     UpgradePlan,
@@ -55,6 +60,30 @@ def _tree_is_not_an_installed_distribution(monkeypatch):
 
     monkeypatch.setattr("vibe.upgrade._distributions_providing_this_package", lambda: [])
     monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: False)
+    # Installer-command tests describe synthetic machines. Exact package capture
+    # has its own provider-backed tests below and in MEMORY-INDEP-019; opting out
+    # here prevents the developer or CI environment from becoming test evidence.
+    monkeypatch.setattr("vibe.upgrade.rollback_target", lambda: None)
+
+
+def _captured_shape(
+    version: str,
+    *,
+    package: str,
+    launcher: ServiceLauncher,
+) -> CapturedPackageShape:
+    return CapturedPackageShape(
+        core_provider=DistributionProvider(
+            name=package,
+            version=version,
+            provider_id=f"/{package}-{version}.dist-info",
+        ),
+        launcher=launcher,
+        release_family=ReleaseFamily.PRE_SPLIT,
+        memory_providers=(),
+        transition_memory_version=None,
+        residual_memory=False,
+    )
 
 
 def test_build_upgrade_plan_uses_uv_and_preserves_tool_bin_dir(monkeypatch):
@@ -386,6 +415,10 @@ def test_the_rename_pair_still_names_the_distribution_that_describes_the_code(mo
     # failed upgrade rolls back to names a release that exists.
     launcher = ServiceLauncher(python="/uv/tools/vibe-remote/bin/python", main="/uv/tools/vibe-remote/service_main.py")
     monkeypatch.setattr("vibe.runtime.current_service_launcher", lambda: launcher)
+    monkeypatch.setattr(
+        "vibe.upgrade.capture_installed_package_shape",
+        lambda **kwargs: _captured_shape("2.9.0", package="vibe-remote", launcher=launcher),
+    )
     target = rollback_target()
     assert target is not None and target.package == "vibe-remote"
     assert pinned_package_spec(target.version, package_name=target.package) == "vibe-remote==2.9.0"
@@ -459,9 +492,13 @@ def test_a_tree_with_no_published_release_has_no_rollback_target(monkeypatch):
     # restored correctly and then started from the wrong generation.
     launcher = ServiceLauncher(python="/uv/tools/vibe-remote/bin/python", main="/uv/tools/vibe-remote/service_main.py")
     monkeypatch.setattr("vibe.__version__", "3.0.10", raising=False)
-    monkeypatch.setattr("vibe.upgrade.installed_package_name", lambda *args, **kwargs: "vibe-remote")
     monkeypatch.setattr("vibe.runtime.current_service_launcher", lambda: launcher)
-    assert rollback_target() == RollbackTarget(version="3.0.10", package="vibe-remote", launcher=launcher)
+    captured = _captured_shape("3.0.10", package="vibe-remote", launcher=launcher)
+    monkeypatch.setattr(
+        "vibe.upgrade.capture_installed_package_shape",
+        lambda **kwargs: captured,
+    )
+    assert rollback_target() == captured
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -510,11 +547,12 @@ def test_the_plan_that_installs_carries_what_it_is_replacing(monkeypatch):
     # target, which is the shape of every way this has gone wrong so far.
     launcher = ServiceLauncher(python="/uv/tools/vibe-remote/bin/python", main="/uv/tools/vibe-remote/service_main.py")
     monkeypatch.setattr("vibe.__version__", "3.0.10", raising=False)
-    monkeypatch.setattr("vibe.upgrade.installed_package_name", lambda *args, **kwargs: "vibe-remote")
     monkeypatch.setattr("vibe.runtime.current_service_launcher", lambda: launcher)
+    captured = _captured_shape("3.0.10", package="vibe-remote", launcher=launcher)
+    monkeypatch.setattr("vibe.upgrade.rollback_target", lambda: captured)
 
     forward = build_upgrade_plan(python_executable="/usr/bin/python3", uv_path=None, base_env={"PATH": "/usr/bin"})
-    assert forward.rollback_to == RollbackTarget(version="3.0.10", package="vibe-remote", launcher=launcher)
+    assert forward.rollback_to == captured
 
     pinned = build_upgrade_plan(
         python_executable="/usr/bin/python3", uv_path=None, base_env={"PATH": "/usr/bin"}, version="3.0.9"
@@ -1750,7 +1788,8 @@ def test_pinned_rollback_keeps_exact_memory_version(monkeypatch):
         memory_version="3.0.14",
     )
 
-    assert "avibe-os[memory]==3.0.14" in plan.command
+    assert "avibe-os==3.0.14" in plan.command
+    assert "avibe-os[memory]" not in " ".join(plan.command)
     assert "avibe-memory==3.0.14" in plan.command
     assert plan.preflight_command is not None
     assert "avibe-memory==3.0.14" in plan.preflight_command

--- a/vibe/package_shape.py
+++ b/vibe/package_shape.py
@@ -290,13 +290,11 @@ def capture_package_shape(
     installed_core_providers = tuple(
         provider for provider in relevant if provider.name in CORE_DISTRIBUTION_NAMES
     )
-    if len(installed_core_providers) > 1:
-        raise DuplicateDistributionProviderError(
-            "multiple canonical core distribution providers are installed"
-        )
     if not installed_core_providers:
         raise PackageShapeError("running core has no canonical distribution provider")
 
+    # A rename or rollback can leave one provider for each published core name.
+    # The running version still has to identify exactly one of those providers.
     core_candidates = tuple(
         provider
         for provider in installed_core_providers

--- a/vibe/package_shape.py
+++ b/vibe/package_shape.py
@@ -57,6 +57,16 @@ def _normalized_version(value: object, *, field: str) -> str:
         raise PackageShapeError(f"{field} is not a valid package version") from exc
 
 
+def _normalized_provider_id(value: object) -> str:
+    try:
+        provider_id = os.fsdecode(os.fspath(value)).strip()
+    except TypeError as exc:
+        raise PackageShapeError("distribution provider identity is missing") from exc
+    if not provider_id:
+        raise PackageShapeError("distribution provider identity is missing")
+    return os.path.normcase(os.path.realpath(os.path.abspath(provider_id)))
+
+
 @dataclass(frozen=True, order=True)
 class DistributionProvider:
     """One exact installed dist-info provider."""
@@ -70,15 +80,13 @@ class DistributionProvider:
         canonical_name = canonicalize_name(self.name)
         if not canonical_name:
             raise PackageShapeError("distribution provider name is missing")
-        if not isinstance(self.provider_id, str) or not self.provider_id.strip():
-            raise PackageShapeError("distribution provider identity is missing")
         object.__setattr__(self, "name", canonical_name)
         object.__setattr__(
             self,
             "version",
             _normalized_version(self.version, field=f"{canonical_name} version"),
         )
-        object.__setattr__(self, "provider_id", self.provider_id.strip())
+        object.__setattr__(self, "provider_id", _normalized_provider_id(self.provider_id))
         object.__setattr__(self, "requires_dist", tuple(self.requires_dist))
 
 
@@ -273,11 +281,21 @@ def capture_package_shape(
     """Validate an exact provider inventory into one immutable captured shape."""
 
     normalized_core_version = _normalized_version(core_version, field="running core version")
-    relevant = tuple(
+    observed = tuple(
         provider
         for provider in providers
         if provider.name in CORE_DISTRIBUTION_NAMES or provider.name == MEMORY_PACKAGE_NAME
     )
+    by_identity: dict[str, DistributionProvider] = {}
+    for provider in observed:
+        existing = by_identity.get(provider.provider_id)
+        if existing is not None and existing != provider:
+            raise PackageShapeError(
+                "canonical distribution provider identity has conflicting metadata"
+            )
+        by_identity[provider.provider_id] = provider
+    relevant = tuple(by_identity.values())
+
     by_name: dict[str, list[DistributionProvider]] = {}
     for provider in relevant:
         by_name.setdefault(provider.name, []).append(provider)
@@ -529,7 +547,7 @@ def resolve_rollback_plan(
         raise RollbackResolutionError("rollback staging destination already exists")
     staging_dir.parent.mkdir(parents=True, exist_ok=True)
     temporary = Path(tempfile.mkdtemp(prefix=f".{staging_dir.name}-", dir=staging_dir.parent))
-    command = [
+    command_prefix = [
         resolver_python or sys.executable,
         "-m",
         "pip",
@@ -543,8 +561,26 @@ def resolve_rollback_plan(
         "--only-binary=:all:",
         "--dest",
         str(temporary),
-        *(requirement.specifier for requirement in requirements),
     ]
+    resolver_requests = ((False, requirements),)
+    if captured.residual_memory:
+        # Residual Memory metadata points at the replacement avibe-os family.
+        # Resolve the legacy core closure normally, then stage that exact
+        # residual wheel without following its forward-core dependency.
+        core_requirements = tuple(
+            requirement
+            for requirement in requirements
+            if requirement.distribution != MEMORY_PACKAGE_NAME
+        )
+        memory_requirements = tuple(
+            requirement
+            for requirement in requirements
+            if requirement.distribution == MEMORY_PACKAGE_NAME
+        )
+        resolver_requests = (
+            (False, core_requirements),
+            (True, memory_requirements),
+        )
     env = {
         **{
             key: value
@@ -560,18 +596,24 @@ def resolve_rollback_plan(
     moved_to_staging = False
     resolved = False
     try:
-        result = subprocess.run(
-            command,
-            env=env,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=300,
-        )
-        if result.returncode != 0:
-            raise RollbackResolutionError(
-                "exact rollback requirements did not resolve from the local wheelhouse"
+        for without_dependencies, requested in resolver_requests:
+            command = [
+                *command_prefix,
+                *(["--no-deps"] if without_dependencies else []),
+                *(requirement.specifier for requirement in requested),
+            ]
+            result = subprocess.run(
+                command,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=300,
             )
+            if result.returncode != 0:
+                raise RollbackResolutionError(
+                    "exact rollback requirements did not resolve from the local wheelhouse"
+                )
         temporary_artifacts = _staged_artifacts(temporary)
         _verify_staged_shape(captured, temporary_artifacts)
         staged_versions = {

--- a/vibe/package_shape.py
+++ b/vibe/package_shape.py
@@ -1,0 +1,649 @@
+"""Exact pre-mutation package capture and staged rollback resolution."""
+
+from __future__ import annotations
+
+import email.parser
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import InvalidWheelFilename, canonicalize_name, parse_wheel_filename
+from packaging.version import InvalidVersion, Version
+
+from vibe.runtime import ServiceLauncher
+
+
+CORE_PACKAGE_NAME = "avibe-os"
+LEGACY_CORE_PACKAGE_NAME = "vibe-remote"
+MEMORY_PACKAGE_NAME = "avibe-memory"
+CORE_DISTRIBUTION_NAMES = frozenset({CORE_PACKAGE_NAME, LEGACY_CORE_PACKAGE_NAME})
+MEMORY_SPLIT_MIN_VERSION = Version("3.0.14.dev0")
+
+
+class PackageShapeError(ValueError):
+    """The installed package shape cannot be represented safely."""
+
+
+class DuplicateDistributionProviderError(PackageShapeError):
+    """More than one dist-info provider claims one canonical distribution."""
+
+
+class RollbackResolutionError(PackageShapeError):
+    """An exact rollback target could not be resolved entirely into staging."""
+
+
+class ReleaseFamily(str, Enum):
+    PRE_SPLIT = "pre_split"
+    OPTIONAL_SPLIT = "optional_split"
+    TRANSITION = "transition"
+
+
+def _normalized_version(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise PackageShapeError(f"{field} is missing")
+    try:
+        return str(Version(value.strip()))
+    except InvalidVersion as exc:
+        raise PackageShapeError(f"{field} is not a valid package version") from exc
+
+
+@dataclass(frozen=True, order=True)
+class DistributionProvider:
+    """One exact installed dist-info provider."""
+
+    name: str
+    version: str
+    provider_id: str
+    requires_dist: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        canonical_name = canonicalize_name(self.name)
+        if not canonical_name:
+            raise PackageShapeError("distribution provider name is missing")
+        if not isinstance(self.provider_id, str) or not self.provider_id.strip():
+            raise PackageShapeError("distribution provider identity is missing")
+        object.__setattr__(self, "name", canonical_name)
+        object.__setattr__(
+            self,
+            "version",
+            _normalized_version(self.version, field=f"{canonical_name} version"),
+        )
+        object.__setattr__(self, "provider_id", self.provider_id.strip())
+        object.__setattr__(self, "requires_dist", tuple(self.requires_dist))
+
+
+@dataclass(frozen=True)
+class CapturedPackageShape:
+    """Immutable package evidence captured before any mutation can start."""
+
+    core_provider: DistributionProvider
+    launcher: ServiceLauncher
+    release_family: ReleaseFamily
+    memory_providers: tuple[DistributionProvider, ...]
+    transition_memory_version: str | None
+    residual_memory: bool
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.release_family, ReleaseFamily):
+            raise PackageShapeError("captured release family is unknown")
+        if self.core_provider.name not in CORE_DISTRIBUTION_NAMES:
+            raise PackageShapeError("captured core provider is not an Avibe distribution")
+        if not isinstance(self.launcher, ServiceLauncher):
+            raise PackageShapeError("captured service launcher is invalid")
+        if len(self.memory_providers) > 1:
+            raise DuplicateDistributionProviderError(
+                "multiple canonical avibe-memory providers are not representable"
+            )
+        if any(provider.name != MEMORY_PACKAGE_NAME for provider in self.memory_providers):
+            raise PackageShapeError("captured Memory provider has the wrong canonical name")
+
+        transition_memory_version = self.transition_memory_version
+        if transition_memory_version is not None:
+            transition_memory_version = _normalized_version(
+                transition_memory_version,
+                field="transition Memory requirement",
+            )
+        object.__setattr__(self, "memory_providers", tuple(self.memory_providers))
+        object.__setattr__(self, "transition_memory_version", transition_memory_version)
+
+        if self.release_family is ReleaseFamily.TRANSITION:
+            if transition_memory_version is None:
+                raise PackageShapeError("transition family is missing its exact Memory requirement")
+        elif transition_memory_version is not None:
+            raise PackageShapeError("only the transition family may carry a hard Memory requirement")
+
+        expected_residual = self.release_family is ReleaseFamily.PRE_SPLIT and self.memory_present
+        if self.residual_memory != expected_residual:
+            raise PackageShapeError("residual Memory marker does not match the captured family")
+
+    @property
+    def core_version(self) -> str:
+        return self.core_provider.version
+
+    @property
+    def core_distribution(self) -> str:
+        return self.core_provider.name
+
+    @property
+    def memory_present(self) -> bool:
+        return bool(self.memory_providers)
+
+    @property
+    def memory_version(self) -> str | None:
+        return self.memory_providers[0].version if self.memory_providers else None
+
+    @property
+    def memory_provider_cardinality(self) -> int:
+        return len(self.memory_providers)
+
+    # Compatibility projections for the pre-Gate-3 restart supervisor. New code
+    # consumes the exact fields above and never reconstructs package presence from
+    # a separate boolean/version pair.
+    @property
+    def version(self) -> str:
+        return self.core_version
+
+    @property
+    def package(self) -> str:
+        return self.core_distribution
+
+    @property
+    def memory_package(self) -> bool:
+        return self.memory_present
+
+
+@dataclass(frozen=True, order=True)
+class ExactRequirement:
+    distribution: str
+    version: str
+
+    def __post_init__(self) -> None:
+        canonical_name = canonicalize_name(self.distribution)
+        if not canonical_name:
+            raise PackageShapeError("rollback requirement distribution is missing")
+        object.__setattr__(self, "distribution", canonical_name)
+        object.__setattr__(
+            self,
+            "version",
+            _normalized_version(self.version, field=f"{canonical_name} rollback version"),
+        )
+
+    @property
+    def specifier(self) -> str:
+        return f"{self.distribution}=={self.version}"
+
+
+@dataclass(frozen=True, order=True)
+class StagedArtifact:
+    distribution: str
+    version: str
+    path: Path
+    sha256: str
+    requires_dist: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PackageShapeVerification:
+    core_distribution: str
+    core_version: str
+    absent_core_distributions: tuple[str, ...]
+    memory_provider_cardinality: int
+    memory_version: str | None
+    residual_memory: bool
+
+
+@dataclass(frozen=True, init=False)
+class ResolvedRollbackPlan:
+    """A rollback whose complete exact closure already exists in staging."""
+
+    captured: CapturedPackageShape
+    requirements: tuple[ExactRequirement, ...]
+    artifacts: tuple[StagedArtifact, ...]
+    staging_dir: Path
+    uninstall_distributions: tuple[str, ...]
+    verification: PackageShapeVerification
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        raise TypeError("ResolvedRollbackPlan is constructed only by rollback resolution")
+
+
+def _parsed_memory_requirements(provider: DistributionProvider) -> tuple[Requirement, ...]:
+    parsed: list[Requirement] = []
+    for value in provider.requires_dist:
+        try:
+            requirement = Requirement(value)
+        except (InvalidRequirement, TypeError) as exc:
+            raise PackageShapeError("core distribution contains unreadable dependency metadata") from exc
+        if canonicalize_name(requirement.name) == MEMORY_PACKAGE_NAME:
+            parsed.append(requirement)
+    return tuple(parsed)
+
+
+def _release_family(provider: DistributionProvider) -> tuple[ReleaseFamily, str | None]:
+    memory_requirements = _parsed_memory_requirements(provider)
+    hard: list[Requirement] = []
+    for requirement in memory_requirements:
+        if requirement.marker is None:
+            hard.append(requirement)
+            continue
+        if str(requirement.marker) != 'extra == "memory"':
+            raise PackageShapeError("conditional Memory dependency does not name the optional release family")
+
+    version = Version(provider.version)
+    if version < MEMORY_SPLIT_MIN_VERSION:
+        if memory_requirements:
+            raise PackageShapeError("pre-split core declares a split Memory dependency")
+        return ReleaseFamily.PRE_SPLIT, None
+
+    if not memory_requirements:
+        raise PackageShapeError("split core does not declare a known Memory release family")
+    if not hard:
+        return ReleaseFamily.OPTIONAL_SPLIT, None
+    if len(hard) != 1 or len(memory_requirements) != 1:
+        raise PackageShapeError("transition core must declare one exact Memory dependency")
+
+    specifiers = list(hard[0].specifier)
+    if len(specifiers) != 1 or specifiers[0].operator != "==" or "*" in specifiers[0].version:
+        raise PackageShapeError("transition core Memory dependency is not an exact pin")
+    required_version = _normalized_version(
+        specifiers[0].version,
+        field="transition Memory requirement",
+    )
+    if required_version != provider.version:
+        raise PackageShapeError("transition core does not require its matching Memory release")
+    return ReleaseFamily.TRANSITION, required_version
+
+
+def capture_package_shape(
+    *,
+    core_version: str,
+    launcher: ServiceLauncher,
+    providers: Iterable[DistributionProvider],
+) -> CapturedPackageShape:
+    """Validate an exact provider inventory into one immutable captured shape."""
+
+    normalized_core_version = _normalized_version(core_version, field="running core version")
+    relevant = tuple(
+        provider
+        for provider in providers
+        if provider.name in CORE_DISTRIBUTION_NAMES or provider.name == MEMORY_PACKAGE_NAME
+    )
+    by_name: dict[str, list[DistributionProvider]] = {}
+    for provider in relevant:
+        by_name.setdefault(provider.name, []).append(provider)
+    duplicate = next((name for name, values in by_name.items() if len(values) > 1), None)
+    if duplicate is not None:
+        raise DuplicateDistributionProviderError(
+            f"multiple canonical {duplicate} dist-info providers are installed"
+        )
+
+    installed_core_providers = tuple(
+        provider for provider in relevant if provider.name in CORE_DISTRIBUTION_NAMES
+    )
+    if len(installed_core_providers) > 1:
+        raise DuplicateDistributionProviderError(
+            "multiple canonical core distribution providers are installed"
+        )
+    if not installed_core_providers:
+        raise PackageShapeError("running core has no canonical distribution provider")
+
+    core_candidates = tuple(
+        provider
+        for provider in installed_core_providers
+        if provider.name in CORE_DISTRIBUTION_NAMES and provider.version == normalized_core_version
+    )
+    if len(core_candidates) != 1:
+        raise PackageShapeError("running core does not have exactly one canonical distribution provider")
+    memory_providers = tuple(
+        provider for provider in relevant if provider.name == MEMORY_PACKAGE_NAME
+    )
+    family, transition_memory_version = _release_family(core_candidates[0])
+    return CapturedPackageShape(
+        core_provider=core_candidates[0],
+        launcher=launcher,
+        release_family=family,
+        memory_providers=memory_providers,
+        transition_memory_version=transition_memory_version,
+        residual_memory=family is ReleaseFamily.PRE_SPLIT and bool(memory_providers),
+    )
+
+
+def _distribution_provider_id(distribution: Any) -> str:
+    metadata_path = getattr(distribution, "_path", None)
+    if metadata_path is not None:
+        return os.fspath(metadata_path)
+    files = distribution.files
+    if files is not None:
+        for entry in files:
+            if str(entry).endswith((".dist-info/METADATA", ".egg-info/PKG-INFO")):
+                return os.fspath(distribution.locate_file(entry))
+    raise PackageShapeError("installed distribution provider identity is unreadable")
+
+
+def inspect_installed_distribution_providers(
+    distributions: Iterable[Any] | None = None,
+) -> tuple[DistributionProvider, ...]:
+    """Read relevant installed metadata without importing optional implementation."""
+
+    if distributions is None:
+        from importlib.metadata import distributions as installed_distributions
+
+        distributions = installed_distributions()
+
+    providers: list[DistributionProvider] = []
+    try:
+        for distribution in distributions:
+            name = distribution.metadata["Name"]
+            if not isinstance(name, str) or not name.strip():
+                raise PackageShapeError("installed distribution name is unreadable")
+            canonical_name = canonicalize_name(name)
+            if canonical_name not in CORE_DISTRIBUTION_NAMES and canonical_name != MEMORY_PACKAGE_NAME:
+                continue
+            providers.append(
+                DistributionProvider(
+                    name=canonical_name,
+                    version=distribution.version,
+                    provider_id=_distribution_provider_id(distribution),
+                    requires_dist=tuple(distribution.requires or ()),
+                )
+            )
+    except PackageShapeError:
+        raise
+    except Exception as exc:
+        raise PackageShapeError("installed distribution metadata is unreadable") from exc
+    return tuple(providers)
+
+
+def capture_installed_package_shape(
+    *,
+    core_version: str,
+    launcher: ServiceLauncher,
+    distributions: Iterable[Any] | None = None,
+) -> CapturedPackageShape:
+    return capture_package_shape(
+        core_version=core_version,
+        launcher=launcher,
+        providers=inspect_installed_distribution_providers(distributions),
+    )
+
+
+def _rollback_requirements(captured: CapturedPackageShape) -> tuple[ExactRequirement, ...]:
+    if captured.release_family is ReleaseFamily.TRANSITION:
+        if not captured.memory_present:
+            raise RollbackResolutionError(
+                "transition package shape is missing its exact Memory distribution"
+            )
+        if captured.memory_version != captured.transition_memory_version:
+            raise RollbackResolutionError(
+                "transition package shape does not match its exact Memory dependency"
+            )
+
+    requirements = [
+        ExactRequirement(captured.core_distribution, captured.core_version),
+    ]
+    if captured.memory_present:
+        # Presence implies a normalized exact version by construction. Keeping the
+        # pin independent is essential: an optional extra cannot express a captured
+        # optional-era mismatch or a bundled core's residual split distribution.
+        assert captured.memory_version is not None
+        requirements.append(ExactRequirement(MEMORY_PACKAGE_NAME, captured.memory_version))
+    return tuple(requirements)
+
+
+def _wheel_provider(path: Path) -> DistributionProvider:
+    try:
+        filename_name, filename_version, _, _ = parse_wheel_filename(path.name)
+    except InvalidWheelFilename as exc:
+        raise RollbackResolutionError("staging contains a non-wheel package artifact") from exc
+    try:
+        with zipfile.ZipFile(path) as archive:
+            metadata_names = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+            if len(metadata_names) != 1:
+                raise RollbackResolutionError("staged wheel metadata is missing or ambiguous")
+            metadata = email.parser.Parser().parsestr(archive.read(metadata_names[0]).decode("utf-8"))
+    except (OSError, UnicodeError, zipfile.BadZipFile) as exc:
+        raise RollbackResolutionError("staged wheel metadata is unreadable") from exc
+
+    provider = DistributionProvider(
+        name=metadata.get("Name"),
+        version=metadata.get("Version"),
+        provider_id=str(path),
+        requires_dist=tuple(metadata.get_all("Requires-Dist", [])),
+    )
+    if provider.name != canonicalize_name(str(filename_name)) or provider.version != str(filename_version):
+        raise RollbackResolutionError("staged wheel filename and metadata disagree")
+    return provider
+
+
+def _staged_artifacts(staging_dir: Path) -> tuple[StagedArtifact, ...]:
+    artifacts: list[StagedArtifact] = []
+    for path in sorted(staging_dir.iterdir()):
+        if not path.is_file():
+            raise RollbackResolutionError("staging contains a non-artifact entry")
+        provider = _wheel_provider(path)
+        artifacts.append(
+            StagedArtifact(
+                distribution=provider.name,
+                version=provider.version,
+                path=path,
+                sha256=hashlib.sha256(path.read_bytes()).hexdigest(),
+                requires_dist=provider.requires_dist,
+            )
+        )
+    if not artifacts:
+        raise RollbackResolutionError("rollback resolution produced no staged artifacts")
+    return tuple(artifacts)
+
+
+def _verify_staged_shape(
+    captured: CapturedPackageShape,
+    artifacts: tuple[StagedArtifact, ...],
+) -> None:
+    by_distribution: dict[str, list[StagedArtifact]] = {}
+    for artifact in artifacts:
+        by_distribution.setdefault(artifact.distribution, []).append(artifact)
+    if any(len(values) != 1 for values in by_distribution.values()):
+        raise RollbackResolutionError("staging contains duplicate distribution artifacts")
+
+    core_artifacts = tuple(
+        artifact
+        for artifact in artifacts
+        if artifact.distribution in CORE_DISTRIBUTION_NAMES
+    )
+    if len(core_artifacts) != 1 or (
+        core_artifacts[0].distribution,
+        core_artifacts[0].version,
+    ) != (captured.core_distribution, captured.core_version):
+        raise RollbackResolutionError("staging does not contain the exact captured core shape")
+
+    memory_artifacts = tuple(
+        artifact
+        for artifact in artifacts
+        if artifact.distribution == MEMORY_PACKAGE_NAME
+    )
+    staged_memory_version = memory_artifacts[0].version if len(memory_artifacts) == 1 else None
+    if (
+        len(memory_artifacts) != captured.memory_provider_cardinality
+        or staged_memory_version != captured.memory_version
+    ):
+        raise RollbackResolutionError("staging does not contain the exact captured Memory shape")
+
+
+def _construct_resolved_plan(
+    *,
+    captured: CapturedPackageShape,
+    requirements: tuple[ExactRequirement, ...],
+    artifacts: tuple[StagedArtifact, ...],
+    staging_dir: Path,
+) -> ResolvedRollbackPlan:
+    plan = object.__new__(ResolvedRollbackPlan)
+    object.__setattr__(plan, "captured", captured)
+    object.__setattr__(plan, "requirements", requirements)
+    object.__setattr__(plan, "artifacts", artifacts)
+    object.__setattr__(plan, "staging_dir", staging_dir)
+    object.__setattr__(
+        plan,
+        "uninstall_distributions",
+        tuple(sorted((*CORE_DISTRIBUTION_NAMES, MEMORY_PACKAGE_NAME))),
+    )
+    object.__setattr__(
+        plan,
+        "verification",
+        PackageShapeVerification(
+            core_distribution=captured.core_distribution,
+            core_version=captured.core_version,
+            absent_core_distributions=tuple(
+                sorted(CORE_DISTRIBUTION_NAMES - {captured.core_distribution})
+            ),
+            memory_provider_cardinality=captured.memory_provider_cardinality,
+            memory_version=captured.memory_version,
+            residual_memory=captured.residual_memory,
+        ),
+    )
+    return plan
+
+
+def resolve_rollback_plan(
+    captured: CapturedPackageShape,
+    *,
+    wheelhouse: Path,
+    staging_dir: Path,
+    resolver_python: str | None = None,
+) -> ResolvedRollbackPlan:
+    """Resolve exact requirements from one local wheelhouse without installing."""
+
+    requirements = _rollback_requirements(captured)
+    wheelhouse = Path(wheelhouse).resolve()
+    staging_dir = Path(staging_dir).resolve()
+    if not wheelhouse.is_dir():
+        raise RollbackResolutionError("rollback wheelhouse does not exist")
+    if staging_dir.exists():
+        raise RollbackResolutionError("rollback staging destination already exists")
+    staging_dir.parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{staging_dir.name}-", dir=staging_dir.parent))
+    command = [
+        resolver_python or sys.executable,
+        "-m",
+        "pip",
+        "download",
+        "--disable-pip-version-check",
+        "--no-input",
+        "--no-cache-dir",
+        "--no-index",
+        "--find-links",
+        str(wheelhouse),
+        "--only-binary=:all:",
+        "--dest",
+        str(temporary),
+        *(requirement.specifier for requirement in requirements),
+    ]
+    env = {
+        **{
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith("PIP_") and key != "PYTHONPATH"
+        },
+        "PIP_CONFIG_FILE": os.devnull,
+        "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+        "PIP_NO_INDEX": "1",
+        "PIP_FIND_LINKS": str(wheelhouse),
+        "PYTHONNOUSERSITE": "1",
+    }
+    moved_to_staging = False
+    resolved = False
+    try:
+        result = subprocess.run(
+            command,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=300,
+        )
+        if result.returncode != 0:
+            raise RollbackResolutionError(
+                "exact rollback requirements did not resolve from the local wheelhouse"
+            )
+        temporary_artifacts = _staged_artifacts(temporary)
+        _verify_staged_shape(captured, temporary_artifacts)
+        staged_versions = {
+            (artifact.distribution, artifact.version) for artifact in temporary_artifacts
+        }
+        missing = [
+            requirement.specifier
+            for requirement in requirements
+            if (requirement.distribution, requirement.version) not in staged_versions
+        ]
+        if missing:
+            raise RollbackResolutionError("resolved staging is missing an exact rollback artifact")
+
+        staged_core = next(
+            artifact
+            for artifact in temporary_artifacts
+            if artifact.distribution == captured.core_distribution
+            and artifact.version == captured.core_version
+        )
+        staged_family, staged_transition_version = _release_family(
+            DistributionProvider(
+                name=staged_core.distribution,
+                version=staged_core.version,
+                provider_id=str(staged_core.path),
+                requires_dist=staged_core.requires_dist,
+            )
+        )
+        if (
+            staged_family is not captured.release_family
+            or staged_transition_version != captured.transition_memory_version
+        ):
+            raise RollbackResolutionError(
+                "staged core artifact does not match the captured release family"
+            )
+
+        if staging_dir.exists():
+            raise RollbackResolutionError("rollback staging destination appeared during resolution")
+        os.replace(temporary, staging_dir)
+        moved_to_staging = True
+        artifacts = _staged_artifacts(staging_dir)
+        plan = _construct_resolved_plan(
+            captured=captured,
+            requirements=requirements,
+            artifacts=artifacts,
+            staging_dir=staging_dir,
+        )
+        resolved = True
+        return plan
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RollbackResolutionError("rollback artifact staging failed") from exc
+    finally:
+        if temporary.exists():
+            shutil.rmtree(temporary, ignore_errors=True)
+        if moved_to_staging and not resolved and staging_dir.exists():
+            shutil.rmtree(staging_dir, ignore_errors=True)
+
+
+__all__ = [
+    "CapturedPackageShape",
+    "DistributionProvider",
+    "DuplicateDistributionProviderError",
+    "ExactRequirement",
+    "PackageShapeError",
+    "PackageShapeVerification",
+    "ReleaseFamily",
+    "ResolvedRollbackPlan",
+    "RollbackResolutionError",
+    "StagedArtifact",
+    "capture_installed_package_shape",
+    "capture_package_shape",
+    "inspect_installed_distribution_providers",
+    "resolve_rollback_plan",
+]

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -14,7 +14,7 @@ import urllib.request
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import NamedTuple, cast
+from typing import cast
 
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import (
@@ -26,15 +26,32 @@ from packaging.utils import (
 from packaging.version import InvalidVersion, Version
 
 from vibe import runtime as runtime_mod
+from vibe.package_shape import (
+    CORE_PACKAGE_NAME,
+    LEGACY_CORE_PACKAGE_NAME,
+    MEMORY_PACKAGE_NAME as SHAPE_MEMORY_PACKAGE_NAME,
+    MEMORY_SPLIT_MIN_VERSION,
+    CapturedPackageShape,
+    DistributionProvider,
+    DuplicateDistributionProviderError,
+    PackageShapeError,
+    ReleaseFamily,
+    ResolvedRollbackPlan,
+    RollbackResolutionError,
+    capture_installed_package_shape,
+    capture_package_shape,
+    inspect_installed_distribution_providers,
+    resolve_rollback_plan,
+)
 
 
 logger = logging.getLogger(__name__)
 
-PACKAGE_NAME = "avibe-os"
-LEGACY_PACKAGE_NAME = "vibe-remote"
-MEMORY_PACKAGE_NAME = "avibe-memory"
+PACKAGE_NAME = CORE_PACKAGE_NAME
+LEGACY_PACKAGE_NAME = LEGACY_CORE_PACKAGE_NAME
+MEMORY_PACKAGE_NAME = SHAPE_MEMORY_PACKAGE_NAME
 MEMORY_EXTRA_NAME = "memory"
-_MEMORY_SPLIT_MIN_VERSION = Version("3.0.14.dev0")
+_MEMORY_SPLIT_MIN_VERSION = MEMORY_SPLIT_MIN_VERSION
 PIP_DOWNLOAD_DEST_PLACEHOLDER = "{avibe-pip-download-destination}"
 DEFAULT_UPDATE_METADATA_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
 CURRENT_VIBE_EXECUTABLE_ENV = "VIBE_CURRENT_EXECUTABLE"
@@ -98,7 +115,7 @@ class UpgradePlan:
     command: list[str]
     env: dict[str, str] | None
     method: str
-    rollback_to: RollbackTarget | None = None
+    rollback_to: CapturedPackageShape | RollbackTarget | None = None
     preflight_command: list[str] | None = None
     preflight_fallback_command: list[str] | None = None
     cleanup_command: list[str] | None = None
@@ -781,7 +798,8 @@ def get_current_vibe_bin_dir(vibe_path: str | None = None) -> str | None:
     return get_launcher_bin_dir(current_vibe)
 
 
-class RollbackTarget(NamedTuple):
+@dataclass(frozen=True)
+class RollbackTarget:
     """The install being replaced, described completely enough to restore it.
 
     Every field travels with the others because they are one measurement, and
@@ -805,6 +823,19 @@ class RollbackTarget(NamedTuple):
     launcher: runtime_mod.ServiceLauncher
     memory_package: bool = False
     memory_version: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.memory_package != (self.memory_version is not None):
+            raise PackageShapeError(
+                "legacy rollback target Memory presence requires one exact version"
+            )
+        if self.memory_version is not None:
+            try:
+                object.__setattr__(self, "memory_version", str(Version(self.memory_version)))
+            except InvalidVersion as exc:
+                raise PackageShapeError(
+                    "legacy rollback target Memory version is invalid"
+                ) from exc
 
 
 def _names_a_published_release(version: str) -> bool:
@@ -830,7 +861,7 @@ def _names_a_published_release(version: str) -> bool:
     return not (match.group("dev") or match.group("local"))
 
 
-def rollback_target() -> RollbackTarget | None:
+def rollback_target() -> CapturedPackageShape | None:
     """The install a failed restart of THIS process could be put back on.
 
     Everything here is measured from the running process, and that is the whole
@@ -863,13 +894,9 @@ def rollback_target() -> RollbackTarget | None:
 
     if not _names_a_published_release(__version__):
         return None
-    memory_package = memory_package_installed()
-    return RollbackTarget(
-        version=__version__,
-        package=installed_package_name(),
+    return capture_installed_package_shape(
+        core_version=__version__,
         launcher=runtime_mod.current_service_launcher(),
-        memory_package=memory_package,
-        memory_version=installed_memory_package_version() if memory_package else None,
     )
 
 
@@ -973,13 +1000,20 @@ def pinned_package_spec(
 
     The message never quotes the spec. An operator-supplied spec can be an index
     URL carrying credentials, and this error is written to a restart log.
+
+    `memory_package` remains a compatibility argument for existing callers. It
+    never changes the core requirement: rollback Memory is always a separate
+    exact pin.
     """
 
     spec = package_name or installed_package_name(python_executable) or get_upgrade_package_spec()
     if _BARE_PACKAGE_NAME_RE.fullmatch(spec) is None:
         raise ValueError("The configured upgrade package spec cannot carry a version pin")
-    pinned = f"{spec}=={version}"
-    return _with_memory_extra(pinned) if memory_package else pinned
+    # Rollback requirements are independent exact pins. An extra couples the
+    # core pin back to whichever Memory constraint that historical core happens
+    # to declare, which cannot express optional-era mismatches or residual
+    # Memory next to a bundled pre-split core.
+    return f"{spec}=={version}"
 
 
 def build_upgrade_plan(

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -12,7 +12,7 @@ import tempfile
 import urllib.parse
 import urllib.request
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import cast
 
@@ -34,7 +34,6 @@ from vibe.package_shape import (
     CapturedPackageShape,
     DistributionProvider,
     DuplicateDistributionProviderError,
-    PackageShapeError,
     ReleaseFamily,
     ResolvedRollbackPlan,
     RollbackResolutionError,
@@ -815,7 +814,9 @@ class RollbackTarget:
     So the rule is that nothing about the replaced install is looked up again
     later. Anything a rollback needs to know about it is measured here, once, in
     the only process that can still see it, and carried. There is no constructor
-    that reads one field.
+    that reads one field. The one compatibility exception is argv emitted by a
+    released scheduler before it carried an exact Memory version: that form is
+    normalized to a falsey, rollback-unavailable target so restart still runs.
     """
 
     version: str
@@ -823,19 +824,28 @@ class RollbackTarget:
     launcher: runtime_mod.ServiceLauncher
     memory_package: bool = False
     memory_version: str | None = None
+    _rollback_available: bool = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
-        if self.memory_package != (self.memory_version is not None):
-            raise PackageShapeError(
-                "legacy rollback target Memory presence requires one exact version"
-            )
-        if self.memory_version is not None:
+        rollback_available = self.memory_package == (self.memory_version is not None)
+        normalized_memory_version = self.memory_version
+        if rollback_available and normalized_memory_version is not None:
             try:
-                object.__setattr__(self, "memory_version", str(Version(self.memory_version)))
-            except InvalidVersion as exc:
-                raise PackageShapeError(
-                    "legacy rollback target Memory version is invalid"
-                ) from exc
+                normalized_memory_version = str(Version(normalized_memory_version))
+            except InvalidVersion:
+                rollback_available = False
+
+        # Released schedulers could emit Memory presence without its version.
+        # Keep their restart job runnable, but make the incomplete target falsey
+        # so no rollback path can consume or persist it as restorable evidence.
+        if not rollback_available:
+            object.__setattr__(self, "memory_package", False)
+            normalized_memory_version = None
+        object.__setattr__(self, "memory_version", normalized_memory_version)
+        object.__setattr__(self, "_rollback_available", rollback_available)
+
+    def __bool__(self) -> bool:
+        return self._rollback_available
 
 
 def _names_a_published_release(version: str) -> bool:


### PR DESCRIPTION
## Capability

Implement Wave 3c Gate 2b rollback types from exact `origin/dev` base `1f175e42ef9e90c2b2366b13f50be8d664b9cb5f`.

- capture one immutable, exact pre-mutation `CapturedPackageShape`;
- derive pre-split, optional-split, and transition release families from installed core metadata;
- resolve independent exact core/Memory pins and their complete local wheel closure into staging;
- construct `ResolvedRollbackPlan` only through the private post-verification factory; and
- fail closed for ambiguous providers, unreadable metadata, unknown families, inconsistent transition shapes, and resolver/staging failures.

Affected scenario: `MEMORY-INDEP-019`.

## Root Cause

The Wave 3b rollback target represented Memory presence and version as separable fields and let pinned core rollback reuse the optional `[memory]` extra. That shape could encode `memory_package=True` without an exact version, could not reproduce an optional-era version mismatch or bundled-plus-residual shape, and did not prove that exact artifacts were available before package mutation.

## Invariants

- Core identity records exact normalized version, canonical distribution provider, launcher, and release family.
- Canonical core and Memory provider sets are cardinality 0/1; duplicates fail before plan construction.
- Memory presence is derived from an exact provider, never from a standalone boolean.
- Optional-era core and Memory requirements are independent exact pins; core pins never include `[memory]`.
- Transition missing/mismatched Memory and unknown later family metadata have no rollback plan.
- A resolved plan implies exact requirements and the complete matching wheel closure exist in staging with verified metadata and hashes.
- Core-only verification actively requires zero Memory providers and absence of the alternate core distribution.

## Scope

Product changes are limited to `vibe/package_shape.py` and `vibe/upgrade.py`. Tests add the focused `MEMORY-INDEP-019` family/property matrix and adapt existing synthetic upgrade fixtures. The catalog change adds only `MEMORY-INDEP-019` and its canonical test.

No loader, supervisor, restart, lock, admission, IPC, pending-restart, UI, adapter, release, finalizer, or workflow ownership changes are included. No code was cherry-picked from closed PR #1739.

## Layered Evidence

- Unit: immutable/normalized capture, duplicate canonical providers, unreadable metadata, unknown-family rejection, non-callable resolved constructor, compatibility target consistency, independent pins, and failed staging cleanup.
- Contract: full shipped-tree caller inventory proves capture remains owned by `vibe/upgrade.py`, resolved construction remains private, and Gate 3 has not gained an early execution caller.
- Scenario: `MEMORY-INDEP-019` covers core-only, matching split, optional mismatch, healthy transition, transition missing/mismatch, pre-split, bundled-plus-residual, unexpected transitive Memory, and resolver failure using local synthetic wheels and `pip download` only.
- Packaged: existing synchronous upgrade/supervisor real-wheel matrix passes 3/3 after generating test-owned build prerequisites.
- Compatibility: existing upgrade/supervisor focused suites pass; legacy supervisor serialization remains field-compatible while invalid Memory presence/version pairs now reject.

Local validation:

- `ruff check vibe/package_shape.py vibe/upgrade.py tests/test_upgrade_flow.py tests/scenarios/memory_independence/test_memory_rollback_types.py`
- `pytest -q tests/test_upgrade_flow.py tests/test_restart_supervisor.py tests/scenarios/memory_independence/test_memory_independence_catalog.py tests/scenarios/memory_independence/test_memory_rollback_types.py` (159 passed)
- `pytest -q tests/test_memory_upgrade_packaged.py` (3 passed)
- `python -m compileall -q vibe/package_shape.py vibe/upgrade.py tests/scenarios/memory_independence/test_memory_rollback_types.py`
- `git diff --check`

## Known By Design / Deferred

- Gate 3 owns mutation execution, transaction records, uninstall/install commands, activation, health, runtime rollback, locking/admission, and packaged activation evidence.
- This gate describes cleanup and verification data but does not retire KBD-5/KBD-6 runtime evidence ahead of Gate 3.
- PR #1746 future adapter/UI, ordinary lineage reset, stale lock replay, and quarantine baseline invariants remain compatibility-only here.
- Gate 2a may update the same scenario catalog concurrently; the later merger must mechanically preserve both scenario IDs when updating from `dev`.
