### PR TITLE
feat(memory): add package lifecycle reservation foundation

### DIFF
--- a/tests/test_package_lifecycle_reservation.py
+++ b/tests/test_package_lifecycle_reservation.py
@@ -13,7 +13,6 @@ import pytest
 from vibe import package_lifecycle_reservation as reservation_module
 from vibe.package_lifecycle_reservation import (
     BusyClassification,
-    HolderCorrelationEvidence,
     HolderType,
     PackageLifecycleReservationManager,
     ReservationLiveness,
@@ -49,18 +48,14 @@ def _hold_before_publication(runtime_dir: str, ready, proceed) -> None:
         reservation.release()
 
 
-def _hold_inherited_descriptor(descriptor: int, ready, release) -> None:
+def _hold_runner_duplicate(descriptor: int, ready, release) -> None:
     ready.set()
     release.wait(10)
     os.close(descriptor)
 
 
-def _correlation(reservation) -> HolderCorrelationEvidence:
-    return HolderCorrelationEvidence(reservation.holder.acquisition_id, reservation.holder.holder_type)
-
-
 @pytest.mark.parametrize("holder_type", list(HolderType))
-def test_memory_indep_020_holder_publication_names_each_owner(tmp_path, holder_type) -> None:
+def test_memory_indep_020_publication_records_diagnostic_holder_types(tmp_path, holder_type) -> None:
     manager = PackageLifecycleReservationManager(tmp_path / holder_type.value)
 
     reservation = manager.acquire(holder_type)
@@ -95,36 +90,29 @@ def test_memory_indep_020_acquire_overwrites_metadata_and_release_is_reusable(tm
     assert manager.probe().liveness is ReservationLiveness.FREE
 
 
-def test_memory_indep_020_late_contender_uses_consistency_not_id_change(tmp_path) -> None:
-    manager = PackageLifecycleReservationManager(tmp_path)
-    package = manager.acquire(HolderType.PACKAGE)
-    assert package is not None
+@pytest.mark.parametrize("holder_type", list(HolderType))
+def test_memory_indep_020_publication_never_drives_owner_classification(
+    tmp_path,
+    holder_type,
+) -> None:
+    manager = PackageLifecycleReservationManager(tmp_path / holder_type.value)
+    reservation = manager.acquire(holder_type)
+    assert reservation is not None
     publication_before_attempt = json.loads(manager.lock_path.read_text(encoding="utf-8"))
 
-    classified = manager.classify_busy(
-        correlation=_correlation(package),
-    )
+    probe = manager.probe()
+    classified = manager.classify_busy(rereads=0)
 
-    assert classified.classification is BusyClassification.PACKAGE_TRANSACTION
-    assert classified.holder == package.holder
+    assert set(BusyClassification) == {
+        BusyClassification.PENDING_PUBLICATION,
+        BusyClassification.BUSY,
+    }
+    assert probe.liveness is ReservationLiveness.HELD
+    assert probe.publication == reservation.holder
+    assert classified.classification is BusyClassification.BUSY
     assert classified.observations == 1
     assert json.loads(manager.lock_path.read_text(encoding="utf-8")) == publication_before_attempt
-    mismatched = manager.classify_busy(
-        correlation=HolderCorrelationEvidence("different-live-acquisition", HolderType.PACKAGE),
-        rereads=0,
-    )
-    assert mismatched.classification is BusyClassification.BUSY
-    assert mismatched.holder is None
-    package.release()
-
-    ordinary = manager.acquire(HolderType.ORDINARY_RESTART)
-    assert ordinary is not None
-    uncorrelated = manager.classify_busy()
-    assert uncorrelated.classification is BusyClassification.BUSY
-    restart_busy = manager.classify_busy(correlation=_correlation(ordinary))
-    assert restart_busy.classification is BusyClassification.ORDINARY_RESTART
-    assert restart_busy.holder == ordinary.holder
-    ordinary.release()
+    reservation.release()
 
 
 @pytest.mark.parametrize("publication", [b"", b"{unreadable", b'{"acquisition_id":"stale"}'])
@@ -136,23 +124,13 @@ def test_memory_indep_020_inconsistent_live_publication_stays_retry_neutral(
     reservation = manager.acquire(HolderType.PACKAGE)
     assert reservation is not None
     manager.lock_path.write_bytes(publication)
-    correlation = _correlation(reservation)
 
-    immediate = manager.classify_busy(
-        correlation=correlation,
-        rereads=0,
-    )
-    exhausted = manager.classify_busy(
-        correlation=correlation,
-        rereads=2,
-        retry_delay=0,
-    )
+    immediate = manager.classify_busy(rereads=0)
+    exhausted = manager.classify_busy(rereads=2, retry_delay=0)
 
-    assert immediate.classification is BusyClassification.RESERVATION_PUBLICATION
-    assert immediate.holder is None
+    assert immediate.classification is BusyClassification.PENDING_PUBLICATION
     assert immediate.observations == 1
     assert exhausted.classification is BusyClassification.BUSY
-    assert exhausted.holder is None
     assert exhausted.observations == 3
     reservation.release()
 
@@ -166,17 +144,18 @@ def test_memory_indep_020_stale_free_bytes_are_not_a_live_holder(tmp_path) -> No
     )
 
     probe = manager.probe()
+    classified = manager.classify_busy(rereads=0)
 
     assert probe.liveness is ReservationLiveness.FREE
-    assert probe.holder is None
-    assert probe.publication_consistent is False
+    assert probe.publication is None
+    assert probe.publication_observed is False
+    assert classified.classification is BusyClassification.BUSY
 
 
-def test_memory_indep_020_holder_turnover_never_guesses_from_stale_bytes(tmp_path) -> None:
+def test_memory_indep_020_recovery_turnover_never_names_stale_package_owner(tmp_path) -> None:
     manager = PackageLifecycleReservationManager(tmp_path)
     manager.lock_path.write_text(
-        '{"acquisition_id":"previous-restart","holder_type":"ordinary_restart",'
-        '"pid":999999,"acquired_at":"2026-01-01T00:00:00Z"}',
+        '{"acquisition_id":"dead-package-a","holder_type":"package","pid":999999,"acquired_at":"2026-01-01T00:00:00Z"}',
         encoding="utf-8",
     )
     context = multiprocessing.get_context("spawn")
@@ -188,9 +167,11 @@ def test_memory_indep_020_holder_turnover_never_guesses_from_stale_bytes(tmp_pat
     process.start()
     try:
         assert ready.wait(10)
+        observed = manager.probe()
         busy = manager.classify_busy(rereads=2, retry_delay=0)
+        assert observed.publication is not None
+        assert observed.publication.acquisition_id == "dead-package-a"
         assert busy.classification is BusyClassification.BUSY
-        assert busy.holder is None
         assert busy.observations == 3
     finally:
         proceed.set()
@@ -202,27 +183,23 @@ def test_memory_indep_020_holder_turnover_never_guesses_from_stale_bytes(tmp_pat
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX open-file-description evidence")
-def test_memory_indep_020_parent_handoff_closes_without_unlock(tmp_path, monkeypatch) -> None:
+def test_memory_indep_020_supervisor_retains_primary_with_runner_ofd_duplicate(tmp_path) -> None:
     manager = PackageLifecycleReservationManager(tmp_path)
     reservation = manager.acquire(HolderType.ORDINARY_RESTART)
     assert reservation is not None
+    runner_descriptor = reservation.duplicate_for_runner()
+    assert os.get_inheritable(runner_descriptor) is True
     context = multiprocessing.get_context("fork")
     ready, release = context.Event(), context.Event()
     process = context.Process(
-        target=_hold_inherited_descriptor,
-        args=(reservation.fileno(), ready, release),
+        target=_hold_runner_duplicate,
+        args=(runner_descriptor, ready, release),
     )
     process.start()
+    os.close(runner_descriptor)
     try:
         assert ready.wait(10)
-        with monkeypatch.context() as patch:
-            patch.setattr(
-                reservation_module,
-                "_unlock_os_lock",
-                lambda _descriptor: (_ for _ in ()).throw(AssertionError("unexpected unlock")),
-            )
-            reservation.close_parent_duplicate()
-            assert manager.acquire(HolderType.PACKAGE) is None
+        assert manager.acquire(HolderType.PACKAGE) is None
     finally:
         release.set()
         process.join(10)
@@ -230,6 +207,7 @@ def test_memory_indep_020_parent_handoff_closes_without_unlock(tmp_path, monkeyp
             process.terminate()
             process.join(5)
     assert process.exitcode == 0
+    reservation.release()
     recovered = manager.acquire(HolderType.PACKAGE)
     assert recovered is not None
     recovered.release()
@@ -255,7 +233,9 @@ def test_memory_indep_020_windows_lock_byte_does_not_cover_publication(tmp_path,
     publication = manager.lock_path.read_bytes()
     assert len(publication) < reservation_module._LOCK_BYTE_OFFSET
     assert json.loads(publication)["acquisition_id"] == reservation.holder.acquisition_id
-    assert PackageLifecycleReservationManager(tmp_path).probe().holder == reservation.holder
+    assert PackageLifecycleReservationManager(tmp_path).probe().publication == reservation.holder
+    with pytest.raises(OSError, match="Windows runners do not inherit"):
+        reservation.duplicate_for_runner()
     reservation.release()
     assert FakeMsvcrt.calls == [
         (reservation_module._LOCK_BYTE_OFFSET, FakeMsvcrt.LK_NBLCK, 1),
@@ -299,13 +279,11 @@ def test_memory_indep_020_true_multiprocess_contention_and_release(tmp_path) -> 
 
         assert manager.acquire(HolderType.ORDINARY_RESTART) is None
         probe = manager.probe()
-        busy = manager.classify_busy(
-            correlation=HolderCorrelationEvidence(child_holder["acquisition_id"], HolderType.PACKAGE),
-        )
+        busy = manager.classify_busy()
         assert probe.liveness is ReservationLiveness.HELD
-        assert probe.holder is not None
-        assert probe.holder.pid == child_holder["pid"]
-        assert busy.classification is BusyClassification.PACKAGE_TRANSACTION
+        assert probe.publication is not None
+        assert probe.publication.pid == child_holder["pid"]
+        assert busy.classification is BusyClassification.BUSY
     finally:
         release.set()
         process.join(10)

--- a/tests/test_package_lifecycle_reservation.py
+++ b/tests/test_package_lifecycle_reservation.py
@@ -55,26 +55,42 @@ def _hold_runner_duplicate(descriptor: int, ready, release) -> None:
     os.close(descriptor)
 
 
+def _finish_process(process, signal) -> None:
+    signal.set()
+    process.join(10)
+    if process.is_alive():
+        process.terminate()
+        process.join(5)
+
+
 @pytest.mark.parametrize("holder_type", list(HolderType))
-def test_memory_indep_020_publication_records_diagnostic_holder_types(tmp_path, holder_type) -> None:
+def test_memory_indep_020_publication_is_observational_only(tmp_path, holder_type) -> None:
     manager = PackageLifecycleReservationManager(tmp_path / holder_type.value)
-
     reservation = manager.acquire(holder_type)
-
     assert reservation is not None
-    assert json.loads(manager.lock_path.read_text(encoding="utf-8")) == {
+    publication = json.loads(manager.lock_path.read_text(encoding="utf-8"))
+    assert publication == {
         "acquired_at": reservation.holder.acquired_at,
         "acquisition_id": reservation.holder.acquisition_id,
         "holder_type": holder_type.value,
         "pid": os.getpid(),
     }
+    probe = manager.probe()
+    classified = manager.classify_busy(rereads=0)
+    assert set(BusyClassification) == {
+        BusyClassification.PENDING_PUBLICATION,
+        BusyClassification.BUSY,
+    }
+    assert probe.liveness is ReservationLiveness.HELD
+    assert probe.publication == reservation.holder
+    assert classified.classification is BusyClassification.BUSY and classified.observations == 1
+    assert json.loads(manager.lock_path.read_text(encoding="utf-8")) == publication
     reservation.release()
 
 
 def test_memory_indep_020_acquire_overwrites_metadata_and_release_is_reusable(tmp_path) -> None:
     manager = PackageLifecycleReservationManager(tmp_path)
     manager.lock_path.write_text('{"acquisition_id":"stale"}' + ("x" * 200), encoding="utf-8")
-
     first = manager.acquire(HolderType.PACKAGE)
     assert first is not None
     first_id = first.holder.acquisition_id
@@ -82,7 +98,6 @@ def test_memory_indep_020_acquire_overwrites_metadata_and_release_is_reusable(tm
     assert "stale" not in manager.lock_path.read_text(encoding="utf-8")
     first.release()
     first.release()
-
     second = manager.acquire(HolderType.ORDINARY_RESTART)
     assert second is not None
     assert second.holder.acquisition_id != first_id
@@ -91,48 +106,33 @@ def test_memory_indep_020_acquire_overwrites_metadata_and_release_is_reusable(tm
     assert manager.probe().liveness is ReservationLiveness.FREE
 
 
-@pytest.mark.parametrize("holder_type", list(HolderType))
-def test_memory_indep_020_publication_never_drives_owner_classification(
-    tmp_path,
-    holder_type,
-) -> None:
-    manager = PackageLifecycleReservationManager(tmp_path / holder_type.value)
-    reservation = manager.acquire(holder_type)
-    assert reservation is not None
-    publication_before_attempt = json.loads(manager.lock_path.read_text(encoding="utf-8"))
-
-    probe = manager.probe()
-    classified = manager.classify_busy(rereads=0)
-
-    assert set(BusyClassification) == {
-        BusyClassification.PENDING_PUBLICATION,
-        BusyClassification.BUSY,
-    }
-    assert probe.liveness is ReservationLiveness.HELD
-    assert probe.publication == reservation.holder
-    assert classified.classification is BusyClassification.BUSY
-    assert classified.observations == 1
-    assert json.loads(manager.lock_path.read_text(encoding="utf-8")) == publication_before_attempt
-    reservation.release()
-
-
-@pytest.mark.parametrize("publication", [b"", b"{unreadable", b'{"acquisition_id":"stale"}'])
+@pytest.mark.parametrize(
+    "publication",
+    [
+        b"",
+        b"{unreadable",
+        b'{"acquisition_id":"stale"}',
+        b"x" * (reservation_module._LOCK_BYTE_OFFSET + 1),
+    ],
+)
 def test_memory_indep_020_inconsistent_live_publication_stays_retry_neutral(
     tmp_path,
     publication,
+    monkeypatch,
 ) -> None:
     manager = PackageLifecycleReservationManager(tmp_path)
     reservation = manager.acquire(HolderType.PACKAGE)
     assert reservation is not None
     manager.lock_path.write_bytes(publication)
-
+    if len(publication) > reservation_module._LOCK_BYTE_OFFSET:
+        monkeypatch.setattr(Path, "read_text", lambda *_args, **_kwargs: pytest.fail("unbounded read"))
+    probe = manager.probe()
     immediate = manager.classify_busy(rereads=0)
     exhausted = manager.classify_busy(rereads=2, retry_delay=0)
-
-    assert immediate.classification is BusyClassification.PENDING_PUBLICATION
-    assert immediate.observations == 1
-    assert exhausted.classification is BusyClassification.BUSY
-    assert exhausted.observations == 3
+    assert probe.liveness is ReservationLiveness.HELD
+    assert probe.publication is None
+    assert immediate.classification is BusyClassification.PENDING_PUBLICATION and immediate.observations == 1
+    assert exhausted.classification is BusyClassification.BUSY and exhausted.observations == 3
     reservation.release()
 
 
@@ -143,13 +143,10 @@ def test_memory_indep_020_stale_free_bytes_are_not_a_live_holder(tmp_path) -> No
         '"pid":999999,"acquired_at":"2026-01-01T00:00:00Z"}',
         encoding="utf-8",
     )
-
     probe = manager.probe()
     classified = manager.classify_busy(rereads=0)
-
     assert probe.liveness is ReservationLiveness.FREE
-    assert probe.publication is None
-    assert probe.publication_observed is False
+    assert probe.publication is None and probe.publication_observed is False
     assert classified.classification is BusyClassification.BUSY
 
 
@@ -181,11 +178,60 @@ def test_memory_indep_020_probe_ignores_pre_lock_acquisition_attempt(tmp_path, m
     finally:
         allow_lock.set()
         thread.join(10)
-
     assert not thread.is_alive()
     assert len(acquired) == 1 and acquired[0] is not None
     assert manager.probe().liveness is ReservationLiveness.HELD
     acquired[0].release()
+
+
+def test_memory_indep_020_release_turnover_obeys_os_lock_and_token(tmp_path, monkeypatch) -> None:
+    manager = PackageLifecycleReservationManager(tmp_path)
+    predecessor = manager.acquire(HolderType.PACKAGE)
+    assert predecessor is not None
+    predecessor_token = predecessor._registration_token
+    real_unlock = reservation_module._unlock_os_lock
+    before_unlock, allow_unlock = threading.Event(), threading.Event()
+    unlocked, finish_release = threading.Event(), threading.Event()
+    errors = []
+
+    def staged_unlock(descriptor: int) -> None:
+        with reservation_module._PROCESS_RESERVATIONS_LOCK:
+            assert manager._key not in reservation_module._PROCESS_RESERVATIONS
+        before_unlock.set()
+        assert allow_unlock.wait(10)
+        real_unlock(descriptor)
+        unlocked.set()
+        assert finish_release.wait(10)
+
+    def release() -> None:
+        try:
+            predecessor.release()
+        except BaseException as error:
+            errors.append(error)
+
+    monkeypatch.setattr(reservation_module, "_unlock_os_lock", staged_unlock)
+    thread = threading.Thread(target=release)
+    thread.start()
+    successor = None
+    try:
+        assert before_unlock.wait(10)
+        assert manager.probe().liveness is ReservationLiveness.HELD
+        assert manager.acquire(HolderType.ORDINARY_RESTART) is None
+        allow_unlock.set()
+        assert unlocked.wait(10)
+        successor = manager.acquire(HolderType.ORDINARY_RESTART)
+        assert successor is not None
+        reservation_module._forget_process_reservation(manager._key, predecessor_token)
+    finally:
+        allow_unlock.set()
+        finish_release.set()
+        thread.join(10)
+    assert not thread.is_alive() and not errors
+    assert successor is not None
+    assert manager.probe().liveness is ReservationLiveness.HELD
+    assert manager.acquire(HolderType.PACKAGE) is None
+    monkeypatch.setattr(reservation_module, "_unlock_os_lock", real_unlock)
+    successor.release()
 
 
 def test_memory_indep_020_recovery_turnover_never_names_stale_package_owner(tmp_path) -> None:
@@ -210,11 +256,7 @@ def test_memory_indep_020_recovery_turnover_never_names_stale_package_owner(tmp_
         assert busy.classification is BusyClassification.BUSY
         assert busy.observations == 3
     finally:
-        proceed.set()
-        process.join(10)
-        if process.is_alive():
-            process.terminate()
-            process.join(5)
+        _finish_process(process, proceed)
     assert process.exitcode == 0
 
 
@@ -237,11 +279,7 @@ def test_memory_indep_020_supervisor_retains_primary_with_runner_ofd_duplicate(t
         assert ready.wait(10)
         assert manager.acquire(HolderType.PACKAGE) is None
     finally:
-        release.set()
-        process.join(10)
-        if process.is_alive():
-            process.terminate()
-            process.join(5)
+        _finish_process(process, release)
     assert process.exitcode == 0
     reservation.release()
     recovered = manager.acquire(HolderType.PACKAGE)
@@ -262,9 +300,7 @@ def test_memory_indep_020_windows_lock_byte_does_not_cover_publication(tmp_path,
     monkeypatch.setattr(reservation_module, "_IS_WINDOWS", True)
     monkeypatch.setitem(sys.modules, "msvcrt", FakeMsvcrt)
     manager = PackageLifecycleReservationManager(tmp_path)
-
     reservation = manager.acquire(HolderType.PACKAGE)
-
     assert reservation is not None
     publication = manager.lock_path.read_bytes()
     assert len(publication) < reservation_module._LOCK_BYTE_OFFSET
@@ -284,7 +320,6 @@ def test_memory_indep_020_publication_failure_releases_every_reservation_claim(
     monkeypatch,
 ) -> None:
     manager = PackageLifecycleReservationManager(tmp_path)
-
     with monkeypatch.context() as patch:
         patch.setattr(
             reservation_module.os,
@@ -293,7 +328,6 @@ def test_memory_indep_020_publication_failure_releases_every_reservation_claim(
         )
         with pytest.raises(OSError, match="disk unavailable"):
             manager.acquire(HolderType.PACKAGE)
-
     recovered = manager.acquire(HolderType.PACKAGE)
     assert recovered is not None
     recovered.release()
@@ -312,7 +346,6 @@ def test_memory_indep_020_true_multiprocess_contention_and_release(tmp_path) -> 
         child_holder = result.get(timeout=10)
         assert "error" not in child_holder
         manager = PackageLifecycleReservationManager(tmp_path)
-
         assert manager.acquire(HolderType.ORDINARY_RESTART) is None
         probe = manager.probe()
         busy = manager.classify_busy()
@@ -321,12 +354,7 @@ def test_memory_indep_020_true_multiprocess_contention_and_release(tmp_path) -> 
         assert probe.publication.pid == child_holder["pid"]
         assert busy.classification is BusyClassification.BUSY
     finally:
-        release.set()
-        process.join(10)
-        if process.is_alive():
-            process.terminate()
-            process.join(5)
-
+        _finish_process(process, release)
     assert process.exitcode == 0
     after_release = PackageLifecycleReservationManager(tmp_path).acquire(HolderType.ORDINARY_RESTART)
     assert after_release is not None

--- a/tests/test_package_lifecycle_reservation.py
+++ b/tests/test_package_lifecycle_reservation.py
@@ -1,0 +1,216 @@
+"""MEMORY-INDEP-020 reservation/publication foundation evidence."""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+from pathlib import Path
+
+import pytest
+
+from vibe import package_lifecycle_reservation as reservation_module
+from vibe.package_lifecycle_reservation import (
+    BusyClassification,
+    HolderType,
+    PackageLifecycleReservationManager,
+    ReservationLiveness,
+)
+
+
+def _hold_reservation(runtime_dir: str, ready, release, result) -> None:
+    manager = PackageLifecycleReservationManager(Path(runtime_dir))
+    reservation = manager.acquire(HolderType.PACKAGE)
+    if reservation is None:
+        result.put({"error": "acquire_failed"})
+        return
+    try:
+        result.put(
+            {
+                "acquisition_id": reservation.holder.acquisition_id,
+                "pid": reservation.holder.pid,
+            }
+        )
+        ready.set()
+        release.wait(10)
+    finally:
+        reservation.release()
+
+
+@pytest.mark.parametrize("holder_type", list(HolderType))
+def test_memory_indep_020_holder_publication_names_each_owner(tmp_path, holder_type) -> None:
+    manager = PackageLifecycleReservationManager(tmp_path / holder_type.value)
+
+    reservation = manager.acquire(holder_type)
+
+    assert reservation is not None
+    assert json.loads(manager.lock_path.read_text(encoding="utf-8")) == {
+        "acquired_at": reservation.holder.acquired_at,
+        "acquisition_id": reservation.holder.acquisition_id,
+        "holder_type": holder_type.value,
+        "pid": os.getpid(),
+    }
+    reservation.release()
+
+
+def test_memory_indep_020_acquire_overwrites_metadata_and_release_is_reusable(tmp_path) -> None:
+    manager = PackageLifecycleReservationManager(tmp_path)
+    manager.lock_path.write_text(
+        '{"acquisition_id":"stale"}' + ("x" * 200),
+        encoding="utf-8",
+    )
+
+    first = manager.acquire(HolderType.PACKAGE)
+    assert first is not None
+    first_id = first.holder.acquisition_id
+    assert manager.acquire(HolderType.ORDINARY_RESTART) is None
+    assert "stale" not in manager.lock_path.read_text(encoding="utf-8")
+    first.release()
+    first.release()
+
+    second = manager.acquire(HolderType.ORDINARY_RESTART)
+    assert second is not None
+    assert second.holder.acquisition_id != first_id
+    assert json.loads(manager.lock_path.read_text(encoding="utf-8"))["holder_type"] == "ordinary_restart"
+    second.release()
+    assert manager.probe().liveness is ReservationLiveness.FREE
+
+
+def test_memory_indep_020_late_contender_uses_consistency_not_id_change(tmp_path) -> None:
+    manager = PackageLifecycleReservationManager(tmp_path)
+    package = manager.acquire(HolderType.PACKAGE)
+    assert package is not None
+    publication_before_attempt = json.loads(manager.lock_path.read_text(encoding="utf-8"))
+
+    classified = manager.classify_busy(
+        expected_package_acquisition_id=publication_before_attempt["acquisition_id"],
+    )
+
+    assert classified.classification is BusyClassification.PACKAGE_TRANSACTION
+    assert classified.holder == package.holder
+    assert classified.observations == 1
+    assert json.loads(manager.lock_path.read_text(encoding="utf-8")) == publication_before_attempt
+    mismatched = manager.classify_busy(
+        expected_package_acquisition_id="different-live-acquisition",
+        rereads=0,
+    )
+    assert mismatched.classification is BusyClassification.RESERVATION_PUBLICATION
+    assert mismatched.holder is None
+    package.release()
+
+    ordinary = manager.acquire(HolderType.ORDINARY_RESTART)
+    assert ordinary is not None
+    restart_busy = manager.classify_busy(expected_package_acquisition_id=None)
+    assert restart_busy.classification is BusyClassification.ORDINARY_RESTART
+    assert restart_busy.holder == ordinary.holder
+    ordinary.release()
+
+
+@pytest.mark.parametrize("publication", [b"", b"{unreadable", b'{"acquisition_id":"stale"}'])
+def test_memory_indep_020_inconsistent_live_publication_stays_retry_neutral(
+    tmp_path,
+    publication,
+) -> None:
+    manager = PackageLifecycleReservationManager(tmp_path)
+    reservation = manager.acquire(HolderType.PACKAGE)
+    assert reservation is not None
+    manager.lock_path.write_bytes(publication)
+
+    immediate = manager.classify_busy(
+        expected_package_acquisition_id=reservation.holder.acquisition_id,
+        rereads=0,
+    )
+    exhausted = manager.classify_busy(
+        expected_package_acquisition_id=reservation.holder.acquisition_id,
+        rereads=2,
+        retry_delay=0,
+    )
+
+    assert immediate.classification is BusyClassification.RESERVATION_PUBLICATION
+    assert immediate.holder is None
+    assert immediate.observations == 1
+    assert exhausted.classification is BusyClassification.BUSY
+    assert exhausted.holder is None
+    assert exhausted.observations == 3
+    reservation.release()
+
+
+def test_memory_indep_020_stale_free_bytes_are_not_a_live_holder(tmp_path) -> None:
+    manager = PackageLifecycleReservationManager(tmp_path)
+    manager.lock_path.write_text(
+        json.dumps(
+            {
+                "acquisition_id": "released-acquisition",
+                "holder_type": "package",
+                "pid": 999999,
+                "acquired_at": "2026-01-01T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    probe = manager.probe()
+
+    assert probe.liveness is ReservationLiveness.FREE
+    assert probe.holder is None
+    assert probe.publication_consistent is False
+
+
+def test_memory_indep_020_publication_failure_releases_every_reservation_claim(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    manager = PackageLifecycleReservationManager(tmp_path)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            reservation_module.os,
+            "fsync",
+            lambda _descriptor: (_ for _ in ()).throw(OSError("disk unavailable")),
+        )
+        with pytest.raises(OSError, match="disk unavailable"):
+            manager.acquire(HolderType.PACKAGE)
+
+    recovered = manager.acquire(HolderType.PACKAGE)
+    assert recovered is not None
+    recovered.release()
+
+
+def test_memory_indep_020_true_multiprocess_contention_and_release(tmp_path) -> None:
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    release = context.Event()
+    result = context.Queue()
+    process = context.Process(
+        target=_hold_reservation,
+        args=(str(tmp_path), ready, release, result),
+    )
+    process.start()
+    try:
+        assert ready.wait(10)
+        child_holder = result.get(timeout=10)
+        assert "error" not in child_holder
+        manager = PackageLifecycleReservationManager(tmp_path)
+
+        assert manager.acquire(HolderType.ORDINARY_RESTART) is None
+        probe = manager.probe()
+        busy = manager.classify_busy(
+            expected_package_acquisition_id=child_holder["acquisition_id"],
+        )
+        assert probe.liveness is ReservationLiveness.HELD
+        assert probe.holder is not None
+        assert probe.holder.pid == child_holder["pid"]
+        assert busy.classification is BusyClassification.PACKAGE_TRANSACTION
+    finally:
+        release.set()
+        process.join(10)
+        if process.is_alive():
+            process.terminate()
+            process.join(5)
+
+    assert process.exitcode == 0
+    after_release = PackageLifecycleReservationManager(tmp_path).acquire(
+        HolderType.ORDINARY_RESTART
+    )
+    assert after_release is not None
+    after_release.release()

--- a/tests/test_package_lifecycle_reservation.py
+++ b/tests/test_package_lifecycle_reservation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import multiprocessing
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,7 @@ import pytest
 from vibe import package_lifecycle_reservation as reservation_module
 from vibe.package_lifecycle_reservation import (
     BusyClassification,
+    HolderCorrelationEvidence,
     HolderType,
     PackageLifecycleReservationManager,
     ReservationLiveness,
@@ -25,16 +27,36 @@ def _hold_reservation(runtime_dir: str, ready, release, result) -> None:
         result.put({"error": "acquire_failed"})
         return
     try:
-        result.put(
-            {
-                "acquisition_id": reservation.holder.acquisition_id,
-                "pid": reservation.holder.pid,
-            }
-        )
+        result.put({"acquisition_id": reservation.holder.acquisition_id, "pid": reservation.holder.pid})
         ready.set()
         release.wait(10)
     finally:
         reservation.release()
+
+
+def _hold_before_publication(runtime_dir: str, ready, proceed) -> None:
+    manager = PackageLifecycleReservationManager(Path(runtime_dir))
+    publish = manager._publish_holder
+
+    def pause(descriptor, holder) -> None:
+        ready.set()
+        assert proceed.wait(10)
+        publish(descriptor, holder)
+
+    manager._publish_holder = pause
+    reservation = manager.acquire(HolderType.PACKAGE)
+    if reservation is not None:
+        reservation.release()
+
+
+def _hold_inherited_descriptor(descriptor: int, ready, release) -> None:
+    ready.set()
+    release.wait(10)
+    os.close(descriptor)
+
+
+def _correlation(reservation) -> HolderCorrelationEvidence:
+    return HolderCorrelationEvidence(reservation.holder.acquisition_id, reservation.holder.holder_type)
 
 
 @pytest.mark.parametrize("holder_type", list(HolderType))
@@ -55,10 +77,7 @@ def test_memory_indep_020_holder_publication_names_each_owner(tmp_path, holder_t
 
 def test_memory_indep_020_acquire_overwrites_metadata_and_release_is_reusable(tmp_path) -> None:
     manager = PackageLifecycleReservationManager(tmp_path)
-    manager.lock_path.write_text(
-        '{"acquisition_id":"stale"}' + ("x" * 200),
-        encoding="utf-8",
-    )
+    manager.lock_path.write_text('{"acquisition_id":"stale"}' + ("x" * 200), encoding="utf-8")
 
     first = manager.acquire(HolderType.PACKAGE)
     assert first is not None
@@ -83,7 +102,7 @@ def test_memory_indep_020_late_contender_uses_consistency_not_id_change(tmp_path
     publication_before_attempt = json.loads(manager.lock_path.read_text(encoding="utf-8"))
 
     classified = manager.classify_busy(
-        expected_package_acquisition_id=publication_before_attempt["acquisition_id"],
+        correlation=_correlation(package),
     )
 
     assert classified.classification is BusyClassification.PACKAGE_TRANSACTION
@@ -91,16 +110,18 @@ def test_memory_indep_020_late_contender_uses_consistency_not_id_change(tmp_path
     assert classified.observations == 1
     assert json.loads(manager.lock_path.read_text(encoding="utf-8")) == publication_before_attempt
     mismatched = manager.classify_busy(
-        expected_package_acquisition_id="different-live-acquisition",
+        correlation=HolderCorrelationEvidence("different-live-acquisition", HolderType.PACKAGE),
         rereads=0,
     )
-    assert mismatched.classification is BusyClassification.RESERVATION_PUBLICATION
+    assert mismatched.classification is BusyClassification.BUSY
     assert mismatched.holder is None
     package.release()
 
     ordinary = manager.acquire(HolderType.ORDINARY_RESTART)
     assert ordinary is not None
-    restart_busy = manager.classify_busy(expected_package_acquisition_id=None)
+    uncorrelated = manager.classify_busy()
+    assert uncorrelated.classification is BusyClassification.BUSY
+    restart_busy = manager.classify_busy(correlation=_correlation(ordinary))
     assert restart_busy.classification is BusyClassification.ORDINARY_RESTART
     assert restart_busy.holder == ordinary.holder
     ordinary.release()
@@ -115,13 +136,14 @@ def test_memory_indep_020_inconsistent_live_publication_stays_retry_neutral(
     reservation = manager.acquire(HolderType.PACKAGE)
     assert reservation is not None
     manager.lock_path.write_bytes(publication)
+    correlation = _correlation(reservation)
 
     immediate = manager.classify_busy(
-        expected_package_acquisition_id=reservation.holder.acquisition_id,
+        correlation=correlation,
         rereads=0,
     )
     exhausted = manager.classify_busy(
-        expected_package_acquisition_id=reservation.holder.acquisition_id,
+        correlation=correlation,
         rereads=2,
         retry_delay=0,
     )
@@ -138,14 +160,8 @@ def test_memory_indep_020_inconsistent_live_publication_stays_retry_neutral(
 def test_memory_indep_020_stale_free_bytes_are_not_a_live_holder(tmp_path) -> None:
     manager = PackageLifecycleReservationManager(tmp_path)
     manager.lock_path.write_text(
-        json.dumps(
-            {
-                "acquisition_id": "released-acquisition",
-                "holder_type": "package",
-                "pid": 999999,
-                "acquired_at": "2026-01-01T00:00:00Z",
-            }
-        ),
+        '{"acquisition_id":"released-acquisition","holder_type":"package",'
+        '"pid":999999,"acquired_at":"2026-01-01T00:00:00Z"}',
         encoding="utf-8",
     )
 
@@ -154,6 +170,97 @@ def test_memory_indep_020_stale_free_bytes_are_not_a_live_holder(tmp_path) -> No
     assert probe.liveness is ReservationLiveness.FREE
     assert probe.holder is None
     assert probe.publication_consistent is False
+
+
+def test_memory_indep_020_holder_turnover_never_guesses_from_stale_bytes(tmp_path) -> None:
+    manager = PackageLifecycleReservationManager(tmp_path)
+    manager.lock_path.write_text(
+        '{"acquisition_id":"previous-restart","holder_type":"ordinary_restart",'
+        '"pid":999999,"acquired_at":"2026-01-01T00:00:00Z"}',
+        encoding="utf-8",
+    )
+    context = multiprocessing.get_context("spawn")
+    ready, proceed = context.Event(), context.Event()
+    process = context.Process(
+        target=_hold_before_publication,
+        args=(str(tmp_path), ready, proceed),
+    )
+    process.start()
+    try:
+        assert ready.wait(10)
+        busy = manager.classify_busy(rereads=2, retry_delay=0)
+        assert busy.classification is BusyClassification.BUSY
+        assert busy.holder is None
+        assert busy.observations == 3
+    finally:
+        proceed.set()
+        process.join(10)
+        if process.is_alive():
+            process.terminate()
+            process.join(5)
+    assert process.exitcode == 0
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX open-file-description evidence")
+def test_memory_indep_020_parent_handoff_closes_without_unlock(tmp_path, monkeypatch) -> None:
+    manager = PackageLifecycleReservationManager(tmp_path)
+    reservation = manager.acquire(HolderType.ORDINARY_RESTART)
+    assert reservation is not None
+    context = multiprocessing.get_context("fork")
+    ready, release = context.Event(), context.Event()
+    process = context.Process(
+        target=_hold_inherited_descriptor,
+        args=(reservation.fileno(), ready, release),
+    )
+    process.start()
+    try:
+        assert ready.wait(10)
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                reservation_module,
+                "_unlock_os_lock",
+                lambda _descriptor: (_ for _ in ()).throw(AssertionError("unexpected unlock")),
+            )
+            reservation.close_parent_duplicate()
+            assert manager.acquire(HolderType.PACKAGE) is None
+    finally:
+        release.set()
+        process.join(10)
+        if process.is_alive():
+            process.terminate()
+            process.join(5)
+    assert process.exitcode == 0
+    recovered = manager.acquire(HolderType.PACKAGE)
+    assert recovered is not None
+    recovered.release()
+
+
+def test_memory_indep_020_windows_lock_byte_does_not_cover_publication(tmp_path, monkeypatch) -> None:
+    class FakeMsvcrt:
+        LK_NBLCK = 1
+        LK_UNLCK = 2
+        calls: list[tuple[int, int, int]] = []
+
+        @classmethod
+        def locking(cls, descriptor, mode, length) -> None:
+            cls.calls.append((os.lseek(descriptor, 0, os.SEEK_CUR), mode, length))
+
+    monkeypatch.setattr(reservation_module, "_IS_WINDOWS", True)
+    monkeypatch.setitem(sys.modules, "msvcrt", FakeMsvcrt)
+    manager = PackageLifecycleReservationManager(tmp_path)
+
+    reservation = manager.acquire(HolderType.PACKAGE)
+
+    assert reservation is not None
+    publication = manager.lock_path.read_bytes()
+    assert len(publication) < reservation_module._LOCK_BYTE_OFFSET
+    assert json.loads(publication)["acquisition_id"] == reservation.holder.acquisition_id
+    assert PackageLifecycleReservationManager(tmp_path).probe().holder == reservation.holder
+    reservation.release()
+    assert FakeMsvcrt.calls == [
+        (reservation_module._LOCK_BYTE_OFFSET, FakeMsvcrt.LK_NBLCK, 1),
+        (reservation_module._LOCK_BYTE_OFFSET, FakeMsvcrt.LK_UNLCK, 1),
+    ]
 
 
 def test_memory_indep_020_publication_failure_releases_every_reservation_claim(
@@ -178,9 +285,7 @@ def test_memory_indep_020_publication_failure_releases_every_reservation_claim(
 
 def test_memory_indep_020_true_multiprocess_contention_and_release(tmp_path) -> None:
     context = multiprocessing.get_context("spawn")
-    ready = context.Event()
-    release = context.Event()
-    result = context.Queue()
+    ready, release, result = context.Event(), context.Event(), context.Queue()
     process = context.Process(
         target=_hold_reservation,
         args=(str(tmp_path), ready, release, result),
@@ -195,7 +300,7 @@ def test_memory_indep_020_true_multiprocess_contention_and_release(tmp_path) -> 
         assert manager.acquire(HolderType.ORDINARY_RESTART) is None
         probe = manager.probe()
         busy = manager.classify_busy(
-            expected_package_acquisition_id=child_holder["acquisition_id"],
+            correlation=HolderCorrelationEvidence(child_holder["acquisition_id"], HolderType.PACKAGE),
         )
         assert probe.liveness is ReservationLiveness.HELD
         assert probe.holder is not None
@@ -209,8 +314,6 @@ def test_memory_indep_020_true_multiprocess_contention_and_release(tmp_path) -> 
             process.join(5)
 
     assert process.exitcode == 0
-    after_release = PackageLifecycleReservationManager(tmp_path).acquire(
-        HolderType.ORDINARY_RESTART
-    )
+    after_release = PackageLifecycleReservationManager(tmp_path).acquire(HolderType.ORDINARY_RESTART)
     assert after_release is not None
     after_release.release()

--- a/tests/test_package_lifecycle_reservation.py
+++ b/tests/test_package_lifecycle_reservation.py
@@ -6,6 +6,7 @@ import json
 import multiprocessing
 import os
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -150,6 +151,41 @@ def test_memory_indep_020_stale_free_bytes_are_not_a_live_holder(tmp_path) -> No
     assert probe.publication is None
     assert probe.publication_observed is False
     assert classified.classification is BusyClassification.BUSY
+
+
+def test_memory_indep_020_probe_ignores_pre_lock_acquisition_attempt(tmp_path, monkeypatch) -> None:
+    manager = PackageLifecycleReservationManager(tmp_path)
+    real_try_os_lock = reservation_module._try_os_lock
+    before_lock = threading.Event()
+    allow_lock = threading.Event()
+    acquirer_ident: int | None = None
+    acquired = []
+
+    def block_acquirer(descriptor: int) -> bool:
+        if threading.get_ident() == acquirer_ident:
+            before_lock.set()
+            assert allow_lock.wait(10)
+        return real_try_os_lock(descriptor)
+
+    def acquire() -> None:
+        nonlocal acquirer_ident
+        acquirer_ident = threading.get_ident()
+        acquired.append(manager.acquire(HolderType.PACKAGE))
+
+    monkeypatch.setattr(reservation_module, "_try_os_lock", block_acquirer)
+    thread = threading.Thread(target=acquire)
+    thread.start()
+    try:
+        assert before_lock.wait(10)
+        assert manager.probe().liveness is ReservationLiveness.FREE
+    finally:
+        allow_lock.set()
+        thread.join(10)
+
+    assert not thread.is_alive()
+    assert len(acquired) == 1 and acquired[0] is not None
+    assert manager.probe().liveness is ReservationLiveness.HELD
+    acquired[0].release()
 
 
 def test_memory_indep_020_recovery_turnover_never_names_stale_package_owner(tmp_path) -> None:

--- a/vibe/package_lifecycle_reservation.py
+++ b/vibe/package_lifecycle_reservation.py
@@ -198,10 +198,10 @@ class PackageLifecycleReservationManager:
             _refresh_process_reservations()
             if self._key in _PROCESS_RESERVATIONS:
                 return None
-            _PROCESS_RESERVATIONS.add(self._key)
 
         descriptor: int | None = None
         locked = False
+        registered = False
         try:
             flags = os.O_RDWR | os.O_CREAT
             flags |= getattr(os, "O_CLOEXEC", 0)
@@ -211,9 +211,12 @@ class PackageLifecycleReservationManager:
             if not _try_os_lock(descriptor):
                 os.close(descriptor)
                 descriptor = None
-                self._forget_process_reservation()
                 return None
             locked = True
+            with _PROCESS_RESERVATIONS_LOCK:
+                _refresh_process_reservations()
+                _PROCESS_RESERVATIONS.add(self._key)
+                registered = True
 
             holder = HolderInformation(
                 acquisition_id=uuid.uuid4().hex,
@@ -235,7 +238,8 @@ class PackageLifecycleReservationManager:
                 if locked:
                     _unlock_os_lock(descriptor)
                 os.close(descriptor)
-            self._forget_process_reservation()
+            if registered:
+                self._forget_process_reservation()
             raise
 
     def probe(self) -> LivenessProbeResult:

--- a/vibe/package_lifecycle_reservation.py
+++ b/vibe/package_lifecycle_reservation.py
@@ -1,0 +1,349 @@
+"""The one OS reservation for package lifecycle and ordinary restart work."""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+
+LOCK_FILENAME = "package-lifecycle.lock"
+
+
+class _StringEnum(str, Enum):
+    def __str__(self) -> str:
+        return self.value
+
+
+class HolderType(_StringEnum):
+    PACKAGE = "package"
+    ORDINARY_RESTART = "ordinary_restart"
+
+
+class ReservationLiveness(_StringEnum):
+    FREE = "free"
+    HELD = "held"
+
+
+class BusyClassification(_StringEnum):
+    PACKAGE_TRANSACTION = "busy_package_transaction"
+    ORDINARY_RESTART = "busy_restart"
+    RESERVATION_PUBLICATION = "busy_reservation_publication"
+    BUSY = "busy"
+
+
+@dataclass(frozen=True)
+class HolderInformation:
+    acquisition_id: str
+    holder_type: HolderType
+    pid: int
+    acquired_at: str
+
+
+@dataclass(frozen=True)
+class LivenessProbeResult:
+    liveness: ReservationLiveness
+    holder: HolderInformation | None
+
+    @property
+    def publication_consistent(self) -> bool:
+        return self.liveness is ReservationLiveness.HELD and self.holder is not None
+
+
+@dataclass(frozen=True)
+class BusyResult:
+    classification: BusyClassification
+    holder: HolderInformation | None
+    observations: int
+
+    @property
+    def retryable(self) -> bool:
+        return True
+
+
+_PROCESS_RESERVATIONS: set[Path] = set()
+_PROCESS_RESERVATIONS_LOCK = threading.Lock()
+_PROCESS_RESERVATIONS_PID = os.getpid()
+
+
+def _refresh_process_reservations() -> None:
+    global _PROCESS_RESERVATIONS_PID
+
+    pid = os.getpid()
+    if pid != _PROCESS_RESERVATIONS_PID:
+        _PROCESS_RESERVATIONS.clear()
+        _PROCESS_RESERVATIONS_PID = pid
+
+
+def _try_os_lock(descriptor: int) -> bool:
+    if os.name == "nt":
+        import msvcrt
+
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        try:
+            msvcrt.locking(descriptor, msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError as error:
+            if error.errno in {errno.EACCES, errno.EAGAIN, errno.EDEADLK}:
+                return False
+            raise
+
+    import fcntl
+
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except OSError as error:
+        if error.errno in {errno.EACCES, errno.EAGAIN}:
+            return False
+        raise
+
+
+def _unlock_os_lock(descriptor: int) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(descriptor, fcntl.LOCK_UN)
+
+
+def _write_all(descriptor: int, payload: bytes) -> None:
+    remaining = memoryview(payload)
+    while remaining:
+        written = os.write(descriptor, remaining)
+        if written <= 0:
+            raise OSError("failed to publish package lifecycle reservation")
+        remaining = remaining[written:]
+
+
+class PackageLifecycleReservation:
+    """A live descriptor plus the holder identity published for that acquisition."""
+
+    def __init__(
+        self,
+        *,
+        descriptor: int,
+        key: Path,
+        path: Path,
+        holder: HolderInformation,
+    ) -> None:
+        self._descriptor: int | None = descriptor
+        self._key = key
+        self.path = path
+        self.holder = holder
+
+    def fileno(self) -> int:
+        if self._descriptor is None:
+            raise ValueError("package lifecycle reservation is closed")
+        return self._descriptor
+
+    def release(self) -> None:
+        descriptor = self._descriptor
+        if descriptor is None:
+            return
+        self._descriptor = None
+        try:
+            _unlock_os_lock(descriptor)
+        finally:
+            os.close(descriptor)
+            with _PROCESS_RESERVATIONS_LOCK:
+                _refresh_process_reservations()
+                _PROCESS_RESERVATIONS.discard(self._key)
+
+    close = release
+
+    def __enter__(self) -> PackageLifecycleReservation:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.release()
+
+
+class PackageLifecycleReservationManager:
+    """Acquire, probe, and classify the one runtime-scoped reservation."""
+
+    def __init__(self, runtime_dir: Path) -> None:
+        self.runtime_dir = Path(runtime_dir)
+        self.lock_path = self.runtime_dir / LOCK_FILENAME
+        self._key = Path(os.path.abspath(self.lock_path))
+
+    def acquire(self, holder_type: HolderType) -> PackageLifecycleReservation | None:
+        """Try once; publish the new holder before doing any other owner work."""
+
+        self.runtime_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        with _PROCESS_RESERVATIONS_LOCK:
+            _refresh_process_reservations()
+            if self._key in _PROCESS_RESERVATIONS:
+                return None
+            _PROCESS_RESERVATIONS.add(self._key)
+
+        descriptor: int | None = None
+        locked = False
+        try:
+            flags = os.O_RDWR | os.O_CREAT
+            flags |= getattr(os, "O_CLOEXEC", 0)
+            flags |= getattr(os, "O_NOFOLLOW", 0)
+            descriptor = os.open(self.lock_path, flags, 0o600)
+            os.set_inheritable(descriptor, False)
+            if os.name == "nt" and os.fstat(descriptor).st_size == 0:
+                _write_all(descriptor, b"\0")
+            if not _try_os_lock(descriptor):
+                os.close(descriptor)
+                descriptor = None
+                self._forget_process_reservation()
+                return None
+            locked = True
+
+            holder = HolderInformation(
+                acquisition_id=uuid.uuid4().hex,
+                holder_type=holder_type,
+                pid=os.getpid(),
+                acquired_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            )
+            self._publish_holder(descriptor, holder)
+            reservation = PackageLifecycleReservation(
+                descriptor=descriptor,
+                key=self._key,
+                path=self.lock_path,
+                holder=holder,
+            )
+            descriptor = None
+            return reservation
+        except BaseException:
+            if descriptor is not None:
+                if locked:
+                    _unlock_os_lock(descriptor)
+                os.close(descriptor)
+            self._forget_process_reservation()
+            raise
+
+    def probe(self) -> LivenessProbeResult:
+        """Classify current lock liveness without trusting stale file bytes."""
+
+        first = self._read_holder()
+        with _PROCESS_RESERVATIONS_LOCK:
+            _refresh_process_reservations()
+            held_here = self._key in _PROCESS_RESERVATIONS
+        if held_here:
+            second = self._read_holder()
+            return LivenessProbeResult(
+                ReservationLiveness.HELD,
+                first if first is not None and first == second else None,
+            )
+        if not self.lock_path.exists():
+            return LivenessProbeResult(ReservationLiveness.FREE, None)
+
+        descriptor = os.open(self.lock_path, os.O_RDWR)
+        try:
+            if _try_os_lock(descriptor):
+                _unlock_os_lock(descriptor)
+                return LivenessProbeResult(ReservationLiveness.FREE, None)
+            second = self._read_holder()
+            return LivenessProbeResult(
+                ReservationLiveness.HELD,
+                first if first is not None and first == second else None,
+            )
+        finally:
+            os.close(descriptor)
+
+    def classify_busy(
+        self,
+        *,
+        expected_package_acquisition_id: str | None,
+        rereads: int = 2,
+        retry_delay: float = 0.01,
+    ) -> BusyResult:
+        """Return an owner-specific result only for a live consistent holder.
+
+        The caller supplies the package acquisition identity from its own state;
+        ``None`` means it established that no package identity exists. This module
+        deliberately knows nothing about the source of that consistency fact.
+        """
+
+        observations = max(0, rereads) + 1
+        for index in range(observations):
+            probe = self.probe()
+            holder = probe.holder
+            if probe.publication_consistent and holder is not None:
+                if (
+                    holder.holder_type is HolderType.PACKAGE
+                    and holder.acquisition_id == expected_package_acquisition_id
+                ):
+                    return BusyResult(BusyClassification.PACKAGE_TRANSACTION, holder, index + 1)
+                if (
+                    holder.holder_type is HolderType.ORDINARY_RESTART
+                    and expected_package_acquisition_id is None
+                ):
+                    return BusyResult(BusyClassification.ORDINARY_RESTART, holder, index + 1)
+            if index + 1 < observations:
+                time.sleep(max(0.0, retry_delay))
+
+        classification = (
+            BusyClassification.RESERVATION_PUBLICATION
+            if rereads <= 0
+            else BusyClassification.BUSY
+        )
+        return BusyResult(classification, None, observations)
+
+    def _publish_holder(self, descriptor: int, holder: HolderInformation) -> None:
+        payload = {
+            "acquisition_id": holder.acquisition_id,
+            "holder_type": holder.holder_type.value,
+            "pid": holder.pid,
+            "acquired_at": holder.acquired_at,
+        }
+        encoded = (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode()
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        os.ftruncate(descriptor, 0)
+        _write_all(descriptor, encoded)
+        os.fsync(descriptor)
+
+    def _read_holder(self) -> HolderInformation | None:
+        try:
+            payload = json.loads(self.lock_path.read_text(encoding="utf-8"))
+            acquisition_id = payload["acquisition_id"]
+            pid = payload["pid"]
+            acquired_at = payload["acquired_at"]
+            if not isinstance(acquisition_id, str) or not acquisition_id:
+                return None
+            if not isinstance(pid, int) or pid <= 0:
+                return None
+            if not isinstance(acquired_at, str) or not acquired_at:
+                return None
+            return HolderInformation(
+                acquisition_id=acquisition_id,
+                holder_type=HolderType(payload["holder_type"]),
+                pid=pid,
+                acquired_at=acquired_at,
+            )
+        except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+            return None
+
+    def _forget_process_reservation(self) -> None:
+        with _PROCESS_RESERVATIONS_LOCK:
+            _refresh_process_reservations()
+            _PROCESS_RESERVATIONS.discard(self._key)
+
+
+__all__ = [
+    "BusyClassification",
+    "BusyResult",
+    "HolderInformation",
+    "HolderType",
+    "LivenessProbeResult",
+    "LOCK_FILENAME",
+    "PackageLifecycleReservation",
+    "PackageLifecycleReservationManager",
+    "ReservationLiveness",
+]

--- a/vibe/package_lifecycle_reservation.py
+++ b/vibe/package_lifecycle_reservation.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 
 LOCK_FILENAME = "package-lifecycle.lock"
+_LOCK_BYTE_OFFSET = 4096
+_IS_WINDOWS = os.name == "nt"
 
 
 class _StringEnum(str, Enum):
@@ -44,6 +46,14 @@ class HolderInformation:
     holder_type: HolderType
     pid: int
     acquired_at: str
+
+
+@dataclass(frozen=True)
+class HolderCorrelationEvidence:
+    """Caller-owned proof that a publication names an authoritative owner."""
+
+    acquisition_id: str
+    holder_type: HolderType
 
 
 @dataclass(frozen=True)
@@ -82,10 +92,10 @@ def _refresh_process_reservations() -> None:
 
 
 def _try_os_lock(descriptor: int) -> bool:
-    if os.name == "nt":
+    if _IS_WINDOWS:
         import msvcrt
 
-        os.lseek(descriptor, 0, os.SEEK_SET)
+        os.lseek(descriptor, _LOCK_BYTE_OFFSET, os.SEEK_SET)
         try:
             msvcrt.locking(descriptor, msvcrt.LK_NBLCK, 1)
             return True
@@ -106,10 +116,10 @@ def _try_os_lock(descriptor: int) -> bool:
 
 
 def _unlock_os_lock(descriptor: int) -> None:
-    if os.name == "nt":
+    if _IS_WINDOWS:
         import msvcrt
 
-        os.lseek(descriptor, 0, os.SEEK_SET)
+        os.lseek(descriptor, _LOCK_BYTE_OFFSET, os.SEEK_SET)
         msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
         return
 
@@ -149,12 +159,21 @@ class PackageLifecycleReservation:
         return self._descriptor
 
     def release(self) -> None:
+        self._close(unlock=True)
+
+    def close_parent_duplicate(self) -> None:
+        """Close a post-spawn parent duplicate without releasing the shared lock."""
+
+        self._close(unlock=False)
+
+    def _close(self, *, unlock: bool) -> None:
         descriptor = self._descriptor
         if descriptor is None:
             return
         self._descriptor = None
         try:
-            _unlock_os_lock(descriptor)
+            if unlock:
+                _unlock_os_lock(descriptor)
         finally:
             os.close(descriptor)
             with _PROCESS_RESERVATIONS_LOCK:
@@ -196,8 +215,6 @@ class PackageLifecycleReservationManager:
             flags |= getattr(os, "O_NOFOLLOW", 0)
             descriptor = os.open(self.lock_path, flags, 0o600)
             os.set_inheritable(descriptor, False)
-            if os.name == "nt" and os.fstat(descriptor).st_size == 0:
-                _write_all(descriptor, b"\0")
             if not _try_os_lock(descriptor):
                 os.close(descriptor)
                 descriptor = None
@@ -260,38 +277,40 @@ class PackageLifecycleReservationManager:
     def classify_busy(
         self,
         *,
-        expected_package_acquisition_id: str | None,
+        correlation: HolderCorrelationEvidence | None = None,
         rereads: int = 2,
         retry_delay: float = 0.01,
     ) -> BusyResult:
         """Return an owner-specific result only for a live consistent holder.
 
-        The caller supplies the package acquisition identity from its own state;
-        ``None`` means it established that no package identity exists. This module
-        deliberately knows nothing about the source of that consistency fact.
+        This record-free layer never infers authority from stable publication bytes.
+        The caller supplies correlation only after proving it against authoritative
+        state owned outside this module.
         """
 
         observations = max(0, rereads) + 1
+        saw_stable_publication = False
         for index in range(observations):
             probe = self.probe()
             holder = probe.holder
-            if probe.publication_consistent and holder is not None:
-                if (
-                    holder.holder_type is HolderType.PACKAGE
-                    and holder.acquisition_id == expected_package_acquisition_id
-                ):
+            saw_stable_publication |= probe.publication_consistent
+            if (
+                probe.publication_consistent
+                and holder is not None
+                and correlation is not None
+                and holder.acquisition_id == correlation.acquisition_id
+                and holder.holder_type is correlation.holder_type
+            ):
+                if holder.holder_type is HolderType.PACKAGE:
                     return BusyResult(BusyClassification.PACKAGE_TRANSACTION, holder, index + 1)
-                if (
-                    holder.holder_type is HolderType.ORDINARY_RESTART
-                    and expected_package_acquisition_id is None
-                ):
+                if holder.holder_type is HolderType.ORDINARY_RESTART:
                     return BusyResult(BusyClassification.ORDINARY_RESTART, holder, index + 1)
             if index + 1 < observations:
                 time.sleep(max(0.0, retry_delay))
 
         classification = (
             BusyClassification.RESERVATION_PUBLICATION
-            if rereads <= 0
+            if rereads <= 0 and not saw_stable_publication
             else BusyClassification.BUSY
         )
         return BusyResult(classification, None, observations)
@@ -339,6 +358,7 @@ class PackageLifecycleReservationManager:
 __all__ = [
     "BusyClassification",
     "BusyResult",
+    "HolderCorrelationEvidence",
     "HolderInformation",
     "HolderType",
     "LivenessProbeResult",

--- a/vibe/package_lifecycle_reservation.py
+++ b/vibe/package_lifecycle_reservation.py
@@ -34,14 +34,14 @@ class ReservationLiveness(_StringEnum):
 
 
 class BusyClassification(_StringEnum):
-    PACKAGE_TRANSACTION = "busy_package_transaction"
-    ORDINARY_RESTART = "busy_restart"
-    RESERVATION_PUBLICATION = "busy_reservation_publication"
+    PENDING_PUBLICATION = "busy_pending_publication"
     BUSY = "busy"
 
 
 @dataclass(frozen=True)
 class HolderInformation:
+    """Diagnostic publication fields that never prove reservation ownership."""
+
     acquisition_id: str
     holder_type: HolderType
     pid: int
@@ -49,27 +49,18 @@ class HolderInformation:
 
 
 @dataclass(frozen=True)
-class HolderCorrelationEvidence:
-    """Caller-owned proof that a publication names an authoritative owner."""
-
-    acquisition_id: str
-    holder_type: HolderType
-
-
-@dataclass(frozen=True)
 class LivenessProbeResult:
     liveness: ReservationLiveness
-    holder: HolderInformation | None
+    publication: HolderInformation | None
 
     @property
-    def publication_consistent(self) -> bool:
-        return self.liveness is ReservationLiveness.HELD and self.holder is not None
+    def publication_observed(self) -> bool:
+        return self.publication is not None
 
 
 @dataclass(frozen=True)
 class BusyResult:
     classification: BusyClassification
-    holder: HolderInformation | None
     observations: int
 
     @property
@@ -138,7 +129,7 @@ def _write_all(descriptor: int, payload: bytes) -> None:
 
 
 class PackageLifecycleReservation:
-    """A live descriptor plus the holder identity published for that acquisition."""
+    """The supervisor's live reservation and diagnostic publication."""
 
     def __init__(
         self,
@@ -153,27 +144,29 @@ class PackageLifecycleReservation:
         self.path = path
         self.holder = holder
 
-    def fileno(self) -> int:
-        if self._descriptor is None:
+    def duplicate_for_runner(self) -> int:
+        """Return an inheritable POSIX OFD duplicate without transferring ownership."""
+
+        if _IS_WINDOWS:
+            raise OSError(errno.ENOTSUP, "Windows runners do not inherit reservation locks")
+        descriptor = self._descriptor
+        if descriptor is None:
             raise ValueError("package lifecycle reservation is closed")
-        return self._descriptor
+        duplicate = os.dup(descriptor)
+        try:
+            os.set_inheritable(duplicate, True)
+        except BaseException:
+            os.close(duplicate)
+            raise
+        return duplicate
 
     def release(self) -> None:
-        self._close(unlock=True)
-
-    def close_parent_duplicate(self) -> None:
-        """Close a post-spawn parent duplicate without releasing the shared lock."""
-
-        self._close(unlock=False)
-
-    def _close(self, *, unlock: bool) -> None:
         descriptor = self._descriptor
         if descriptor is None:
             return
         self._descriptor = None
         try:
-            if unlock:
-                _unlock_os_lock(descriptor)
+            _unlock_os_lock(descriptor)
         finally:
             os.close(descriptor)
             with _PROCESS_RESERVATIONS_LOCK:
@@ -190,7 +183,7 @@ class PackageLifecycleReservation:
 
 
 class PackageLifecycleReservationManager:
-    """Acquire, probe, and classify the one runtime-scoped reservation."""
+    """Acquire and observe the one runtime-scoped reservation without naming its owner."""
 
     def __init__(self, runtime_dir: Path) -> None:
         self.runtime_dir = Path(runtime_dir)
@@ -277,43 +270,25 @@ class PackageLifecycleReservationManager:
     def classify_busy(
         self,
         *,
-        correlation: HolderCorrelationEvidence | None = None,
         rereads: int = 2,
         retry_delay: float = 0.01,
     ) -> BusyResult:
-        """Return an owner-specific result only for a live consistent holder.
-
-        This record-free layer never infers authority from stable publication bytes.
-        The caller supplies correlation only after proving it against authoritative
-        state owned outside this module.
-        """
+        """Bound publication rereads, then return owner-neutral contention."""
 
         observations = max(0, rereads) + 1
-        saw_stable_publication = False
+        saw_pending_publication = False
         for index in range(observations):
             probe = self.probe()
-            holder = probe.holder
-            saw_stable_publication |= probe.publication_consistent
-            if (
-                probe.publication_consistent
-                and holder is not None
-                and correlation is not None
-                and holder.acquisition_id == correlation.acquisition_id
-                and holder.holder_type is correlation.holder_type
-            ):
-                if holder.holder_type is HolderType.PACKAGE:
-                    return BusyResult(BusyClassification.PACKAGE_TRANSACTION, holder, index + 1)
-                if holder.holder_type is HolderType.ORDINARY_RESTART:
-                    return BusyResult(BusyClassification.ORDINARY_RESTART, holder, index + 1)
+            saw_pending_publication |= probe.liveness is ReservationLiveness.HELD and not probe.publication_observed
             if index + 1 < observations:
                 time.sleep(max(0.0, retry_delay))
 
         classification = (
-            BusyClassification.RESERVATION_PUBLICATION
-            if rereads <= 0 and not saw_stable_publication
+            BusyClassification.PENDING_PUBLICATION
+            if rereads <= 0 and saw_pending_publication
             else BusyClassification.BUSY
         )
-        return BusyResult(classification, None, observations)
+        return BusyResult(classification, observations)
 
     def _publish_holder(self, descriptor: int, holder: HolderInformation) -> None:
         payload = {
@@ -358,7 +333,6 @@ class PackageLifecycleReservationManager:
 __all__ = [
     "BusyClassification",
     "BusyResult",
-    "HolderCorrelationEvidence",
     "HolderInformation",
     "HolderType",
     "LivenessProbeResult",

--- a/vibe/package_lifecycle_reservation.py
+++ b/vibe/package_lifecycle_reservation.py
@@ -1,4 +1,10 @@
-"""The one OS reservation for package lifecycle and ordinary restart work."""
+"""The one OS reservation for package lifecycle and ordinary restart work.
+
+The process registry is a narrowing cache for an already-held OS lock: its
+token-owned membership starts after acquisition and ends before unlock. During
+either boundary window, the OS lock remains authoritative for probe/acquire;
+only matching-token cleanup may remove an entry, preserving any successor.
+"""
 
 from __future__ import annotations
 
@@ -68,18 +74,25 @@ class BusyResult:
         return True
 
 
-_PROCESS_RESERVATIONS: set[Path] = set()
+_PROCESS_RESERVATIONS: dict[Path, object] = {}
 _PROCESS_RESERVATIONS_LOCK = threading.Lock()
 _PROCESS_RESERVATIONS_PID = os.getpid()
 
 
 def _refresh_process_reservations() -> None:
     global _PROCESS_RESERVATIONS_PID
-
     pid = os.getpid()
     if pid != _PROCESS_RESERVATIONS_PID:
         _PROCESS_RESERVATIONS.clear()
         _PROCESS_RESERVATIONS_PID = pid
+
+
+def _forget_process_reservation(key: Path, registration_token: object) -> None:
+    with _PROCESS_RESERVATIONS_LOCK:
+        _refresh_process_reservations()
+        if _PROCESS_RESERVATIONS.get(key) is registration_token:
+            del _PROCESS_RESERVATIONS[key]
+        assert _PROCESS_RESERVATIONS.get(key) is not registration_token
 
 
 def _try_os_lock(descriptor: int) -> bool:
@@ -138,15 +151,16 @@ class PackageLifecycleReservation:
         key: Path,
         path: Path,
         holder: HolderInformation,
+        registration_token: object,
     ) -> None:
         self._descriptor: int | None = descriptor
         self._key = key
+        self._registration_token = registration_token
         self.path = path
         self.holder = holder
 
     def duplicate_for_runner(self) -> int:
         """Return an inheritable POSIX OFD duplicate without transferring ownership."""
-
         if _IS_WINDOWS:
             raise OSError(errno.ENOTSUP, "Windows runners do not inherit reservation locks")
         descriptor = self._descriptor
@@ -165,13 +179,11 @@ class PackageLifecycleReservation:
         if descriptor is None:
             return
         self._descriptor = None
+        _forget_process_reservation(self._key, self._registration_token)
         try:
             _unlock_os_lock(descriptor)
         finally:
             os.close(descriptor)
-            with _PROCESS_RESERVATIONS_LOCK:
-                _refresh_process_reservations()
-                _PROCESS_RESERVATIONS.discard(self._key)
 
     close = release
 
@@ -192,7 +204,6 @@ class PackageLifecycleReservationManager:
 
     def acquire(self, holder_type: HolderType) -> PackageLifecycleReservation | None:
         """Try once; publish the new holder before doing any other owner work."""
-
         self.runtime_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
         with _PROCESS_RESERVATIONS_LOCK:
             _refresh_process_reservations()
@@ -202,10 +213,9 @@ class PackageLifecycleReservationManager:
         descriptor: int | None = None
         locked = False
         registered = False
+        registration_token = object()
         try:
-            flags = os.O_RDWR | os.O_CREAT
-            flags |= getattr(os, "O_CLOEXEC", 0)
-            flags |= getattr(os, "O_NOFOLLOW", 0)
+            flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
             descriptor = os.open(self.lock_path, flags, 0o600)
             os.set_inheritable(descriptor, False)
             if not _try_os_lock(descriptor):
@@ -215,8 +225,10 @@ class PackageLifecycleReservationManager:
             locked = True
             with _PROCESS_RESERVATIONS_LOCK:
                 _refresh_process_reservations()
-                _PROCESS_RESERVATIONS.add(self._key)
+                assert self._key not in _PROCESS_RESERVATIONS
+                _PROCESS_RESERVATIONS[self._key] = registration_token
                 registered = True
+                assert _PROCESS_RESERVATIONS[self._key] is registration_token
 
             holder = HolderInformation(
                 acquisition_id=uuid.uuid4().hex,
@@ -230,21 +242,25 @@ class PackageLifecycleReservationManager:
                 key=self._key,
                 path=self.lock_path,
                 holder=holder,
+                registration_token=registration_token,
             )
             descriptor = None
             return reservation
         except BaseException:
-            if descriptor is not None:
-                if locked:
-                    _unlock_os_lock(descriptor)
-                os.close(descriptor)
-            if registered:
-                self._forget_process_reservation()
+            try:
+                if registered:
+                    _forget_process_reservation(self._key, registration_token)
+            finally:
+                if descriptor is not None:
+                    try:
+                        if locked:
+                            _unlock_os_lock(descriptor)
+                    finally:
+                        os.close(descriptor)
             raise
 
     def probe(self) -> LivenessProbeResult:
         """Classify current lock liveness without trusting stale file bytes."""
-
         first = self._read_holder()
         with _PROCESS_RESERVATIONS_LOCK:
             _refresh_process_reservations()
@@ -278,7 +294,6 @@ class PackageLifecycleReservationManager:
         retry_delay: float = 0.01,
     ) -> BusyResult:
         """Bound publication rereads, then return owner-neutral contention."""
-
         observations = max(0, rereads) + 1
         saw_pending_publication = False
         for index in range(observations):
@@ -302,20 +317,28 @@ class PackageLifecycleReservationManager:
             "acquired_at": holder.acquired_at,
         }
         encoded = (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode()
+        assert len(encoded) < _LOCK_BYTE_OFFSET
         os.lseek(descriptor, 0, os.SEEK_SET)
         os.ftruncate(descriptor, 0)
         _write_all(descriptor, encoded)
         os.fsync(descriptor)
 
     def _read_holder(self) -> HolderInformation | None:
+        descriptor: int | None = None
         try:
-            payload = json.loads(self.lock_path.read_text(encoding="utf-8"))
+            flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+            descriptor = os.open(self.lock_path, flags)
+            expected_size = os.fstat(descriptor).st_size
+            if expected_size <= 0 or expected_size >= _LOCK_BYTE_OFFSET:
+                return None
+            encoded = os.read(descriptor, _LOCK_BYTE_OFFSET)
+            if len(encoded) != expected_size or os.fstat(descriptor).st_size != expected_size:
+                return None
+            payload = json.loads(encoded.decode("utf-8"))
             acquisition_id = payload["acquisition_id"]
             pid = payload["pid"]
             acquired_at = payload["acquired_at"]
-            if not isinstance(acquisition_id, str) or not acquisition_id:
-                return None
-            if not isinstance(pid, int) or pid <= 0:
+            if not isinstance(acquisition_id, str) or not acquisition_id or not isinstance(pid, int) or pid <= 0:
                 return None
             if not isinstance(acquired_at, str) or not acquired_at:
                 return None
@@ -327,11 +350,9 @@ class PackageLifecycleReservationManager:
             )
         except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError, ValueError):
             return None
-
-    def _forget_process_reservation(self) -> None:
-        with _PROCESS_RESERVATIONS_LOCK:
-            _refresh_process_reservations()
-            _PROCESS_RESERVATIONS.discard(self._key)
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
 
 
 __all__ = [


### PR DESCRIPTION
## Capability

Adds the record-free G3-1A package-lifecycle reservation foundation under the final owner-neutral contract from Doc A PR #1755, merged to `dev` at `95621a89c77de94059bb8d450fd5b9d4cf3e6060`.

## Root Cause And Invariants

- `MEMORY-INDEP-020`: the single OS reservation proves liveness; lock-file publication is diagnostic observability only.
- The process registry is a narrowing cache for an already-held OS lock: token-owned membership begins only after OS acquisition and ends before OS unlock.
- Only matching-token cleanup may remove a registry entry, so delayed predecessor cleanup cannot erase a successor. In either boundary window, the OS lock is authoritative for probe and acquire.
- Every detached package or ordinary-restart supervisor acquires the reservation itself. There is no entrypoint-to-supervisor lock handoff.
- Every acquisition publishes a new collision-resistant acquisition ID, diagnostic holder type, PID, and timestamp by overwriting the lock file as the first post-acquire action.
- Publication bytes never authorize owner identity, correlation, `busy_package_transaction`, or `busy_restart`.
- Diagnostic reads are descriptor-based and bounded strictly below the high-offset lock byte; empty, invalid, changing, or oversized bytes remain unpublished and retry-neutral.
- Held liveness with missing or unreadable publication may return owner-neutral `busy_pending_publication`; bounded reread exhaustion returns generic retryable `busy`.
- POSIX supervisors retain the primary OFD reservation and may create an inheritable duplicate only for bounded runners.
- Windows supervisors retain their non-inherited byte-range lock; the fixed high-offset lock byte never overlaps diagnostic JSON.

## Scope

- `vibe/package_lifecycle_reservation.py`
- `tests/test_package_lifecycle_reservation.py`

No API, CLI, controller, UI, upgrade planner, restart supervisor, schedule/restart entrypoint, pending-restart flow, release workflow, scenario catalog, transaction record, nonce, state machine, recovery, executor, or product-entrypoint change.

Final diff: 729 added lines across the two whitelisted files.

## Evidence

- Unit: 15 focused tests covering diagnostic package and ordinary-restart publication, metadata overwrite and new acquisition identity, owner-neutral classification for every published holder type, bounded empty/unreadable/stale/oversized publication, stale free bytes, paused recovery-holder turnover over dead package-owner bytes, publication-failure cleanup, and reusable release.
- Threaded boundaries: pre-lock acquisition attempts remain free; release pauses after token removal but before unlock and same-process probe/acquire defer to the held OS lock; successor acquisition survives delayed predecessor-token cleanup.
- Multiprocess: a true spawned-process reservation holder excludes a contender and release permits a later acquisition.
- POSIX: the supervisor retains its primary hold while a real forked bounded runner receives an inheritable OFD duplicate.
- Windows: simulated platform calls lock/unlock only byte 4096, JSON remains outside that range and readable while held, and runner lock inheritance is explicitly rejected.
- Static: focused Pytest `15 passed`; Ruff format/check, `py_compile`, and `git diff --check` pass.
- CI/review: the existing forever combined exact-head Codex + `lint` Watch `74af173283a3` remains armed and unchanged.

## Known By Design

- G3-1A owns reservation acquire/release, owner-neutral liveness, diagnostic publication observability, `busy_pending_publication`, generic `busy`, and POSIX bounded-runner duplication only.
- G3-1B derives `busy_package_transaction` from a durable active-track record. It never identifies the current OS holder from publication.
- G3-2 owns package execution, the supervisor primary hold, POSIX runner/process-group containment, Windows Job Object containment, and recovery execution.
- G3-3 owns product entrypoints, attempt-keyed ordinary-restart state, and platform-symmetric detached-supervisor launch.
- The five mandatory G3-2/G3-3 obligations are tracked in issue #1760 and are outside this PR.
- Product entrypoints remain uncollected until their owning later gates.

## Contract Alignment

This revision removes `HolderCorrelationEvidence`, all owner-specific busy outcomes, and the entrypoint-to-supervisor close-without-unlock transfer API. It implements the final merged Doc A rule that publication can be inspected but cannot create an owner claim.