### PR TITLE
fix(ui): finish voice input on repeated shortcut

### DIFF
--- a/ui/src/components/workbench/Composer.shortcut.test.tsx
+++ b/ui/src/components/workbench/Composer.shortcut.test.tsx
@@ -5,10 +5,16 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { I18nextProvider, initReactI18next } from 'react-i18next';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+type VoiceStopped = (
+  reason: 'finish' | 'abort' | 'error',
+  metadata: { pendingSegmentCount: number },
+) => void;
+
 const voiceMocks = vi.hoisted(() => ({
   abort: vi.fn(),
   finish: vi.fn(),
   getUserMedia: vi.fn(),
+  onStopped: undefined as VoiceStopped | undefined,
   pipelineStart: vi.fn(),
   realtimeAbort: vi.fn(),
   realtimeStart: vi.fn(),
@@ -29,6 +35,10 @@ vi.mock('../../lib/avibeFetch', async (importOriginal) => ({
 vi.mock('../../lib/voiceRecording', async (importOriginal) => ({
   ...await importOriginal<typeof import('../../lib/voiceRecording')>(),
   VoiceRecordingPipeline: class {
+    constructor(options: { onStopped: VoiceStopped }) {
+      voiceMocks.onStopped = options.onStopped;
+    }
+
     start = voiceMocks.pipelineStart;
     finish = voiceMocks.finish;
     abort = voiceMocks.abort;
@@ -82,6 +92,7 @@ beforeEach(() => {
   voiceMocks.abort.mockReset();
   voiceMocks.finish.mockReset();
   voiceMocks.getUserMedia.mockReset();
+  voiceMocks.onStopped = undefined;
   voiceMocks.pipelineStart.mockReset().mockResolvedValue(true);
   voiceMocks.realtimeAbort.mockReset();
   voiceMocks.realtimeStart.mockReset().mockReturnValue(new Promise(() => undefined));
@@ -154,6 +165,7 @@ describe('Composer voice shortcut', () => {
     const textbox = screen.getByRole('textbox');
     await waitFor(() => expect(textbox.textContent).toBe('Keep this draft'));
     await act(async () => undefined);
+    textbox.focus();
 
     fireEvent.keyDown(textbox, { code: 'KeyZ', key: 'z', ctrlKey: true });
     await waitFor(() => expect(voiceMocks.getUserMedia).toHaveBeenCalledOnce());
@@ -163,6 +175,8 @@ describe('Composer voice shortcut', () => {
     await waitFor(() => expect(document.activeElement).toBe(finish));
     fireEvent.keyDown(finish, { code: 'KeyZ', key: 'z', ctrlKey: true });
     expect(voiceMocks.finish).toHaveBeenCalledOnce();
+    act(() => voiceMocks.onStopped?.('finish', { pendingSegmentCount: 0 }));
+    await waitFor(() => expect(document.activeElement).toBe(textbox));
   });
 
   it('yields the voice shortcut while the mention picker is open', async () => {

--- a/ui/src/components/workbench/Composer.shortcut.test.tsx
+++ b/ui/src/components/workbench/Composer.shortcut.test.tsx
@@ -139,7 +139,7 @@ describe('Composer voice shortcut', () => {
     await waitFor(() => expect(voiceMocks.getUserMedia).toHaveBeenCalledOnce());
   });
 
-  it('owns a configured editor chord before Lexical handles it', async () => {
+  it('keeps a configured editor chord through the complete voice flow', async () => {
     const shortcuts = defaultActionShortcuts();
     shortcuts.voiceInput = {
       code: 'KeyZ',
@@ -158,6 +158,11 @@ describe('Composer voice shortcut', () => {
     fireEvent.keyDown(textbox, { code: 'KeyZ', key: 'z', ctrlKey: true });
     await waitFor(() => expect(voiceMocks.getUserMedia).toHaveBeenCalledOnce());
     expect(textbox.textContent).toBe('Keep this draft');
+
+    const finish = await screen.findByRole('button', { name: en.chat.compose.stopRecording });
+    await waitFor(() => expect(document.activeElement).toBe(finish));
+    fireEvent.keyDown(finish, { code: 'KeyZ', key: 'z', ctrlKey: true });
+    expect(voiceMocks.finish).toHaveBeenCalledOnce();
   });
 
   it('yields the voice shortcut while the mention picker is open', async () => {

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -428,6 +428,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   const recordingStartRef = useRef(false);
   const pendingVoiceInsertionRef = useRef<VoiceInsertionSnapshot | null>(null);
   const focusNextVoiceControlRef = useRef(false);
+  const voiceEditorFocusReturnRef = useRef<HTMLElement | null>(null);
   const finishVoiceControlRef = useRef<HTMLButtonElement | null>(null);
   const recordingTickerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const unmountedRef = useRef(false);
@@ -1234,6 +1235,19 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
     }
   }, [voiceControlMode]);
 
+  useLayoutEffect(() => {
+    if (voiceDraftReadOnly || voiceEditorFocusReturnRef.current === null) return;
+    const target = voiceEditorFocusReturnRef.current;
+    voiceEditorFocusReturnRef.current = null;
+    const activeElement = document.activeElement;
+    if (
+      target.isConnected
+      && (activeElement === null || activeElement === document.body || !activeElement.isConnected)
+    ) {
+      target.focus({ preventScroll: true });
+    }
+  }, [voiceDraftReadOnly]);
+
   const handleVoiceShortcut = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
     if (
       !voiceShortcutAvailable
@@ -1247,6 +1261,15 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
     event.preventDefault();
     if (voiceControlMode === 'finish') stopRecording();
     else {
+      const activeElement = document.activeElement;
+      voiceEditorFocusReturnRef.current = (
+        activeElement === textareaRef.current
+        || (
+          activeElement instanceof HTMLElement
+          && activeElement.getAttribute('contenteditable') === 'true'
+          && event.currentTarget.contains(activeElement)
+        )
+      ) ? activeElement as HTMLElement : null;
       focusNextVoiceControlRef.current = true;
       void startRecording(captureVoiceInsertion());
     }

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -1246,7 +1246,10 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
     }
     event.preventDefault();
     if (voiceControlMode === 'finish') stopRecording();
-    else void startRecording(captureVoiceInsertion());
+    else {
+      focusNextVoiceControlRef.current = true;
+      void startRecording(captureVoiceInsertion());
+    }
   }, [
     captureVoiceInsertion,
     startRecording,


### PR DESCRIPTION
## Summary

- keep keyboard ownership after starting voice input from the configured shortcut
- let the repeated shortcut activate the same finish action as the recording control
- cover the complete Lexical start/finish shortcut flow with a regression test

## Validation

- `npm exec vitest run src/components/workbench/Composer.shortcut.test.tsx src/components/workbench/MentionEditor.voicePreview.test.tsx`
- `npm run lint`
- `npm run build`
- `uv sync`

## Dependencies

- None

## Scenario Catalog

- No scenario catalog changes; this is a focused UI regression fix.
