### PR TITLE
fix(codex): isolate app-server host surface

### DIFF
--- a/modules/agents/codex/transport.py
+++ b/modules/agents/codex/transport.py
@@ -24,7 +24,6 @@ STREAM_BUFFER_LIMIT = 128 * 1024 * 1024  # 128 MB
 # user's global config. These overrides are appended last so backend extra args
 # cannot re-enable a competing host surface for this process.
 AVIBE_APP_SERVER_CONFIG_OVERRIDES = (
-    "agents.enabled=false",
     "analytics.enabled=false",
     "check_for_update_on_startup=false",
     "feedback.enabled=false",

--- a/modules/agents/codex/transport.py
+++ b/modules/agents/codex/transport.py
@@ -33,7 +33,6 @@ AVIBE_APP_SERVER_CONFIG_OVERRIDES = (
     "features.browser_use_external=false",
     "features.browser_use_full_cdp_access=false",
     "features.computer_use=false",
-    "features.fast_mode=false",
     "features.goals=false",
     "features.guardian_approval=false",
     "features.hooks=false",

--- a/modules/agents/codex/transport.py
+++ b/modules/agents/codex/transport.py
@@ -18,6 +18,52 @@ logger = logging.getLogger(__name__)
 STREAM_BUFFER_LIMIT = 128 * 1024 * 1024  # 128 MB
 
 
+# Avibe owns the user-facing surface, durable automation, memory, and agent
+# delegation. Keep Codex app-server focused on the execution capabilities that
+# Avibe deliberately exposes instead of inheriting Codex client features from a
+# user's global config. These overrides are appended last so backend extra args
+# cannot re-enable a competing host surface for this process.
+AVIBE_APP_SERVER_CONFIG_OVERRIDES = (
+    "agents.enabled=false",
+    "analytics.enabled=false",
+    "check_for_update_on_startup=false",
+    "feedback.enabled=false",
+    "features.apps=false",
+    "features.auth_elicitation=false",
+    "features.browser_use=false",
+    "features.browser_use_external=false",
+    "features.browser_use_full_cdp_access=false",
+    "features.computer_use=false",
+    "features.fast_mode=false",
+    "features.goals=false",
+    "features.guardian_approval=false",
+    "features.hooks=false",
+    "features.in_app_browser=false",
+    "features.in_app_updates=false",
+    "features.memories=false",
+    "features.mentions_v2=false",
+    "features.multi_agent=false",
+    "features.personality=false",
+    "features.plugin_sharing=false",
+    "features.plugins=false",
+    "features.recommended_plugins=false",
+    "features.remote_plugin=false",
+    "features.skill_mcp_dependency_install=false",
+    "features.terminal_visualization_instructions=false",
+    "features.tool_call_mcp_elicitation=false",
+    "features.tool_suggest=false",
+    "features.workspace_dependencies=false",
+)
+
+
+def _avibe_app_server_config_args() -> list[str]:
+    return [
+        arg
+        for override in AVIBE_APP_SERVER_CONFIG_OVERRIDES
+        for arg in ("-c", override)
+    ]
+
+
 class CodexTransport:
     """Manages a persistent ``codex app-server`` subprocess.
 
@@ -74,10 +120,7 @@ class CodexTransport:
             + ["app-server"]
             + self._runtime_args
             + self._extra_args
-            # Keep this process-local policy last so user args cannot re-enable
-            # memory. Older Codex builds ignore unknown config keys, while an
-            # unknown ``--disable`` feature would abort startup.
-            + ["-c", "features.memories=false"]
+            + _avibe_app_server_config_args()
         )
         logger.info("Launching Codex app-server: %s (cwd=%s)", " ".join(cmd), self._cwd)
 
@@ -117,8 +160,12 @@ class CodexTransport:
                 {
                     "clientInfo": {
                         "name": "avibe",
+                        "title": "Avibe",
                         "version": "1.0.0",
                     },
+                    # Avibe intentionally consumes only the stable app-server
+                    # contract. Omitted server-request capabilities stay off.
+                    "capabilities": {"experimentalApi": False},
                 },
             )
             logger.info("Codex app-server initialized: %s", resp)

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -3712,7 +3712,17 @@ class CodexTransportCommandTests(unittest.IsolatedAsyncioTestCase):
             await transport.stop()
             initialize_request = json.loads(writes[0])
             self.assertEqual(initialize_request["method"], "initialize")
-            self.assertEqual(initialize_request["params"]["clientInfo"]["name"], "avibe")
+            self.assertEqual(
+                initialize_request["params"],
+                {
+                    "clientInfo": {
+                        "name": "avibe",
+                        "title": "Avibe",
+                        "version": "1.0.0",
+                    },
+                    "capabilities": {"experimentalApi": False},
+                },
+            )
             transport = Transport(
                 binary="codex",
                 cwd="/tmp/work",
@@ -3721,6 +3731,11 @@ class CodexTransportCommandTests(unittest.IsolatedAsyncioTestCase):
             await transport.start()
             await transport.stop()
 
+        forced_args = [
+            arg
+            for override in transport_module.AVIBE_APP_SERVER_CONFIG_OVERRIDES
+            for arg in ("-c", override)
+        ]
         self.assertEqual(
             created_cmds,
             [
@@ -3728,8 +3743,7 @@ class CodexTransportCommandTests(unittest.IsolatedAsyncioTestCase):
                     "codex",
                     "--dangerously-bypass-approvals-and-sandbox",
                     "app-server",
-                    "-c",
-                    "features.memories=false",
+                    *forced_args,
                 ],
                 [
                     "codex",
@@ -3737,8 +3751,7 @@ class CodexTransportCommandTests(unittest.IsolatedAsyncioTestCase):
                     "app-server",
                     "-c",
                     'model_provider="avibe_model_hub"',
-                    "-c",
-                    "features.memories=false",
+                    *forced_args,
                 ],
             ],
         )

--- a/tests/test_codex_transport.py
+++ b/tests/test_codex_transport.py
@@ -125,6 +125,7 @@ class CodexTransportHealthTests(unittest.IsolatedAsyncioTestCase):
         # ``agents`` is a role-definition table in older supported Codex
         # releases; native delegation is disabled through the feature gate.
         self.assertNotIn("agents.enabled=false", disabled)
+        self.assertNotIn("features.fast_mode=false", disabled)
         self.assertNotIn("features.image_generation=false", disabled)
         self.assertNotIn("features.shell_tool=false", disabled)
         self.assertNotIn("web_search=disabled", disabled)

--- a/tests/test_codex_transport.py
+++ b/tests/test_codex_transport.py
@@ -7,7 +7,19 @@ from unittest.mock import AsyncMock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from modules.agents.codex.transport import CodexTransport, STREAM_BUFFER_LIMIT
+from modules.agents.codex.transport import (
+    AVIBE_APP_SERVER_CONFIG_OVERRIDES,
+    CodexTransport,
+    STREAM_BUFFER_LIMIT,
+)
+
+
+def _forced_config_args() -> tuple[str, ...]:
+    return tuple(
+        arg
+        for override in AVIBE_APP_SERVER_CONFIG_OVERRIDES
+        for arg in ("-c", override)
+    )
 
 
 class CodexTransportHealthTests(unittest.IsolatedAsyncioTestCase):
@@ -29,7 +41,14 @@ class CodexTransportHealthTests(unittest.IsolatedAsyncioTestCase):
             binary="codex",
             cwd="/tmp",
             runtime_args=["-c", 'model_provider="avibe"'],
-            extra_args=["-c", "features.memories=true"],
+            extra_args=[
+                "-c",
+                "features.memories=true",
+                "-c",
+                "features.plugins=true",
+                "-c",
+                "features.multi_agent=true",
+            ],
         )
 
         async def wait_for_initialize(_method, _params):
@@ -69,9 +88,44 @@ class CodexTransportHealthTests(unittest.IsolatedAsyncioTestCase):
                 "-c",
                 "features.memories=true",
                 "-c",
-                "features.memories=false",
+                "features.plugins=true",
+                "-c",
+                "features.multi_agent=true",
+                *_forced_config_args(),
             ),
         )
+
+        initialize_params = transport.send_request.await_args.args[1]
+        self.assertEqual(
+            initialize_params,
+            {
+                "clientInfo": {
+                    "name": "avibe",
+                    "title": "Avibe",
+                    "version": "1.0.0",
+                },
+                "capabilities": {"experimentalApi": False},
+            },
+        )
+
+    def test_app_server_policy_disables_competing_host_surfaces(self):
+        disabled = set(AVIBE_APP_SERVER_CONFIG_OVERRIDES)
+
+        self.assertTrue(
+            {
+                "agents.enabled=false",
+                "features.apps=false",
+                "features.goals=false",
+                "features.hooks=false",
+                "features.memories=false",
+                "features.multi_agent=false",
+                "features.plugins=false",
+                "features.terminal_visualization_instructions=false",
+            }.issubset(disabled)
+        )
+        self.assertNotIn("features.image_generation=false", disabled)
+        self.assertNotIn("features.shell_tool=false", disabled)
+        self.assertNotIn("web_search=disabled", disabled)
 
     async def test_reader_task_failure_marks_transport_not_alive(self):
         transport = CodexTransport(binary="codex", cwd="/tmp")

--- a/tests/test_codex_transport.py
+++ b/tests/test_codex_transport.py
@@ -113,7 +113,6 @@ class CodexTransportHealthTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(
             {
-                "agents.enabled=false",
                 "features.apps=false",
                 "features.goals=false",
                 "features.hooks=false",
@@ -123,6 +122,9 @@ class CodexTransportHealthTests(unittest.IsolatedAsyncioTestCase):
                 "features.terminal_visualization_instructions=false",
             }.issubset(disabled)
         )
+        # ``agents`` is a role-definition table in older supported Codex
+        # releases; native delegation is disabled through the feature gate.
+        self.assertNotIn("agents.enabled=false", disabled)
         self.assertNotIn("features.image_generation=false", disabled)
         self.assertNotIn("features.shell_tool=false", disabled)
         self.assertNotIn("web_search=disabled", disabled)


### PR DESCRIPTION
## Summary

- force Codex app-server into an Avibe-owned host profile so Codex client surfaces cannot leak into Web or IM replies
- disable Codex Apps, Plugins, native goals/hooks/memory/multi-agent, desktop/browser UI controls, and related discovery or elicitation features at process scope
- explicitly stay on the stable app-server protocol while retaining Avibe prompts and core execution capabilities

## Verification

- `118 passed` across `tests/test_codex_transport.py` and `tests/test_codex_agent.py`
- pinned pre-commit ruff hook passed on all files
- real Codex 0.147.0 app-server request capture confirmed Avibe Show Pages, file delivery, and quick-reply instructions remain while the visualize skill, native multi-agent tools, and native goal tools are absent

The local Avibe service was not restarted.
