### PR TITLE
feat(memory): add Gate5a verifier core

### DIFF
--- a/.github/workflows/memory-runtime-release-guard.yml
+++ b/.github/workflows/memory-runtime-release-guard.yml
@@ -54,38 +54,32 @@ jobs:
                 '{release_tag: $release_tag, reason: $reason}' >> "$excluded_file"
               continue
             fi
-            set +e
-            CANDIDATE_TAG="$candidate_tag" CANDIDATE_DIR="$candidate_dir" \
-              python3 - <<'PY'
-          import json
-          import os
-          import zipfile
-          from pathlib import Path
-
-          wheels = sorted(Path(os.environ["CANDIDATE_DIR"]).glob("avibe_os-*.whl"))
-          if len(wheels) != 1:
-              raise SystemExit(1)
-          with zipfile.ZipFile(wheels[0]) as wheel:
-              try:
-                  manifest = wheel.read("vibe/memory_runtime_manifest.json")
-              except KeyError:
-                  raise SystemExit(4) from None
-          payload = json.loads(manifest)
-          if payload.get("release_state") != "published" or payload.get("release_tag") != os.environ["CANDIDATE_TAG"]:
-              raise SystemExit(1)
-          (Path(os.environ["CANDIDATE_DIR"]) / "memory-runtime-manifest.json").write_bytes(manifest)
-          PY
-            manifest_status=$?
-            set -e
-            # Wheels without a manifest predate Memory Runtime and are not scope exclusions.
-            if [ "$manifest_status" -eq 4 ]; then
-              continue
-            elif [ "$manifest_status" -ne 0 ]; then
-              jq -nc --arg release_tag "$candidate_tag" \
-                --arg reason "wheel does not contain a self-pinned published manifest" \
-                '{release_tag: $release_tag, reason: $reason}' >> "$excluded_file"
-              continue
+            asset_names="$(
+              gh release view "$candidate_tag" --repo "$GITHUB_REPOSITORY" \
+                --json assets --jq '.assets[].name'
+            )"
+            if grep -Eq '^avibe_memory-.*\.whl$' <<<"$asset_names"; then
+              gh release download "$candidate_tag" --repo "$GITHUB_REPOSITORY" \
+                --pattern 'avibe_memory-*.whl' --dir "$candidate_dir" >/dev/null
             fi
+            set +e
+            discovery_output="$(
+              python3 scripts/memory_runtime_release_guard.py \
+                discover-manifest --asset-dir "$candidate_dir" \
+                --output-manifest "$candidate_dir/memory-runtime-manifest.json" \
+                --release-tag "$candidate_tag" 2>&1
+            )"
+            discovery_status=$?
+            set -e
+            # Explicitly retain releases that predate the managed runtime as
+            # manifest-free legacy releases. Transition package failures are fatal.
+            if [ "$discovery_status" -eq 4 ]; then
+              continue
+            elif [ "$discovery_status" -ne 0 ]; then
+              echo "$discovery_output" >&2
+              exit "$discovery_status"
+            fi
+            manifest_owner="$(jq -r '.manifest_owner' <<<"$discovery_output")"
             manifest="$candidate_dir/memory-runtime-manifest.json"
             manifest_sha="$(sha256sum "$manifest" | cut -d' ' -f1)"
             set +e
@@ -97,7 +91,8 @@ jobs:
             set -e
             if [ "$policy_status" -eq 0 ]; then
               jq -nc --arg release_tag "$candidate_tag" --arg sha256 "$manifest_sha" \
-                '{release_tag: $release_tag, sha256: $sha256}' >> "$records_file"
+                --arg owner "$manifest_owner" \
+                '{release_tag: $release_tag, sha256: $sha256, owner: $owner}' >> "$records_file"
             elif [ "$policy_status" -eq 2 ]; then
               policy_reason="$(jq -r '.error // "manifest excluded by policy"' <<<"$policy_output")"
               jq -nc --arg release_tag "$candidate_tag" --arg reason "$policy_reason" \
@@ -172,33 +167,36 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ matrix.manifest.release_tag }}
           EXPECTED_SHA256: ${{ matrix.manifest.sha256 }}
+          EXPECTED_OWNER: ${{ matrix.manifest.owner }}
         shell: bash
         run: |
           set -euo pipefail
-          manifest_dir="$RUNNER_TEMP/memory-runtime-manifest"
-          rm -rf "$manifest_dir"
-          mkdir -p "$manifest_dir"
+          package_dir="$RUNNER_TEMP/memory-runtime-packages"
+          rm -rf "$package_dir"
+          mkdir -p "$package_dir"
           gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
-            --pattern 'avibe_os-*.whl' --dir "$manifest_dir" >/dev/null
-          CANDIDATE_TAG="$RELEASE_TAG" CANDIDATE_DIR="$manifest_dir" \
-            python3 - <<'PY'
-          import json
-          import os
-          import zipfile
-          from pathlib import Path
-
-          wheels = sorted(Path(os.environ["CANDIDATE_DIR"]).glob("avibe_os-*.whl"))
-          if len(wheels) != 1:
-              raise SystemExit("expected exactly one avibe_os wheel")
-          with zipfile.ZipFile(wheels[0]) as wheel:
-              manifest = wheel.read("vibe/memory_runtime_manifest.json")
-          payload = json.loads(manifest)
-          if payload.get("release_state") != "published" or payload.get("release_tag") != os.environ["CANDIDATE_TAG"]:
-              raise SystemExit("wheel does not contain the selected published manifest")
-          (Path(os.environ["CANDIDATE_DIR"]) / "memory-runtime-manifest.json").write_bytes(manifest)
-          PY
-          manifest="$manifest_dir/memory-runtime-manifest.json"
+            --pattern 'avibe_os-*' --dir "$package_dir" >/dev/null
+          if [ "$EXPECTED_OWNER" = "memory" ]; then
+            gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+              --pattern 'avibe_memory-*' --dir "$package_dir" >/dev/null
+          fi
+          discovery_output="$(
+            python3 scripts/memory_runtime_release_guard.py \
+              discover-manifest --asset-dir "$package_dir" \
+              --output-manifest "$package_dir/memory-runtime-manifest.json" \
+              --release-tag "$RELEASE_TAG"
+          )"
+          test "$(jq -r '.manifest_owner' <<<"$discovery_output")" = "$EXPECTED_OWNER"
+          manifest="$package_dir/memory-runtime-manifest.json"
           test "$(sha256sum "$manifest" | cut -d' ' -f1)" = "$EXPECTED_SHA256"
+
+      - name: Verify Memory distribution ownership and isolated sdist rebuilds
+        if: matrix.manifest.owner == 'memory'
+        run: |
+          python3 -m pip install build
+          python3 scripts/memory_runtime_release_guard.py \
+            --manifest "$RUNNER_TEMP/memory-runtime-packages/memory-runtime-manifest.json" \
+            verify-packages --asset-dir "$RUNNER_TEMP/memory-runtime-packages"
 
       - name: Fetch and verify published assets
         id: probe
@@ -210,7 +208,7 @@ jobs:
           set +e
           probe_output="$(
             python3 scripts/memory_runtime_release_guard.py \
-              --manifest "$RUNNER_TEMP/memory-runtime-manifest/memory-runtime-manifest.json" \
+              --manifest "$RUNNER_TEMP/memory-runtime-packages/memory-runtime-manifest.json" \
               fetch --output-dir "$RUNNER_TEMP/memory-runtime-release" 2>&1
           )"
           probe_status=$?
@@ -264,7 +262,7 @@ jobs:
             exit 1
           fi
           python3 scripts/memory_runtime_release_guard.py \
-            --manifest "$RUNNER_TEMP/memory-runtime-manifest/memory-runtime-manifest.json" \
+            --manifest "$RUNNER_TEMP/memory-runtime-packages/memory-runtime-manifest.json" \
             verify --asset-dir "$restore_dir"
 
           existing="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')"
@@ -285,7 +283,7 @@ jobs:
         if: steps.probe.outputs.result == 'bytes_failure'
         run: |
           python3 scripts/memory_runtime_release_guard.py \
-            --manifest "$RUNNER_TEMP/memory-runtime-manifest/memory-runtime-manifest.json" \
+            --manifest "$RUNNER_TEMP/memory-runtime-packages/memory-runtime-manifest.json" \
             fetch --output-dir "$RUNNER_TEMP/memory-runtime-release"
 
       - name: Check whether this manifest already has a backup

--- a/.github/workflows/memory-runtime-release-guard.yml
+++ b/.github/workflows/memory-runtime-release-guard.yml
@@ -31,9 +31,6 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
-      - name: Install release metadata parser
-        run: python3 -m pip install packaging
-
       - name: Resolve every published Memory Runtime manifest
         id: manifests
         env:
@@ -57,37 +54,38 @@ jobs:
                 '{release_tag: $release_tag, reason: $reason}' >> "$excluded_file"
               continue
             fi
-            asset_names="$(
-              gh release view "$candidate_tag" --repo "$GITHUB_REPOSITORY" \
-                --json assets --jq '.assets[].name'
-            )"
-            if grep -Eq '^avibe_memory-.*\.whl$' <<<"$asset_names"; then
-              gh release download "$candidate_tag" --repo "$GITHUB_REPOSITORY" \
-                --pattern 'avibe_memory-*.whl' --dir "$candidate_dir" >/dev/null
-            fi
             set +e
-            discovery_output="$(
-              python3 scripts/memory_runtime_release_guard.py \
-                discover-manifest --asset-dir "$candidate_dir" \
-                --output-manifest "$candidate_dir/memory-runtime-manifest.json" \
-                --release-tag "$candidate_tag" 2>&1
-            )"
-            discovery_status=$?
+            CANDIDATE_TAG="$candidate_tag" CANDIDATE_DIR="$candidate_dir" \
+              python3 - <<'PY'
+          import json
+          import os
+          import zipfile
+          from pathlib import Path
+
+          wheels = sorted(Path(os.environ["CANDIDATE_DIR"]).glob("avibe_os-*.whl"))
+          if len(wheels) != 1:
+              raise SystemExit(1)
+          with zipfile.ZipFile(wheels[0]) as wheel:
+              try:
+                  manifest = wheel.read("vibe/memory_runtime_manifest.json")
+              except KeyError:
+                  raise SystemExit(4) from None
+          payload = json.loads(manifest)
+          if payload.get("release_state") != "published" or payload.get("release_tag") != os.environ["CANDIDATE_TAG"]:
+              raise SystemExit(1)
+          (Path(os.environ["CANDIDATE_DIR"]) / "memory-runtime-manifest.json").write_bytes(manifest)
+          PY
+            manifest_status=$?
             set -e
-            # Explicitly retain releases that predate the managed runtime as
-            # manifest-free legacy releases. Transition package failures are fatal.
-            if [ "$discovery_status" -eq 4 ]; then
+            # Wheels without a manifest predate Memory Runtime and are not scope exclusions.
+            if [ "$manifest_status" -eq 4 ]; then
               continue
-            elif [ "$discovery_status" -eq 2 ]; then
-              policy_reason="$(jq -r '.error // "manifest excluded by policy"' <<<"$discovery_output")"
-              jq -nc --arg release_tag "$candidate_tag" --arg reason "$policy_reason" \
+            elif [ "$manifest_status" -ne 0 ]; then
+              jq -nc --arg release_tag "$candidate_tag" \
+                --arg reason "wheel does not contain a self-pinned published manifest" \
                 '{release_tag: $release_tag, reason: $reason}' >> "$excluded_file"
               continue
-            elif [ "$discovery_status" -ne 0 ]; then
-              echo "$discovery_output" >&2
-              exit "$discovery_status"
             fi
-            manifest_owner="$(jq -r '.manifest_owner' <<<"$discovery_output")"
             manifest="$candidate_dir/memory-runtime-manifest.json"
             manifest_sha="$(sha256sum "$manifest" | cut -d' ' -f1)"
             set +e
@@ -99,8 +97,7 @@ jobs:
             set -e
             if [ "$policy_status" -eq 0 ]; then
               jq -nc --arg release_tag "$candidate_tag" --arg sha256 "$manifest_sha" \
-                --arg owner "$manifest_owner" \
-                '{release_tag: $release_tag, sha256: $sha256, owner: $owner}' >> "$records_file"
+                '{release_tag: $release_tag, sha256: $sha256}' >> "$records_file"
             elif [ "$policy_status" -eq 2 ]; then
               policy_reason="$(jq -r '.error // "manifest excluded by policy"' <<<"$policy_output")"
               jq -nc --arg release_tag "$candidate_tag" --arg reason "$policy_reason" \
@@ -170,44 +167,38 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
-      - name: Install release metadata parser
-        run: python3 -m pip install packaging
-
       - name: Resolve selected published Memory Runtime manifest
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ matrix.manifest.release_tag }}
           EXPECTED_SHA256: ${{ matrix.manifest.sha256 }}
-          EXPECTED_OWNER: ${{ matrix.manifest.owner }}
         shell: bash
         run: |
           set -euo pipefail
-          package_dir="$RUNNER_TEMP/memory-runtime-packages"
-          rm -rf "$package_dir"
-          mkdir -p "$package_dir"
+          manifest_dir="$RUNNER_TEMP/memory-runtime-manifest"
+          rm -rf "$manifest_dir"
+          mkdir -p "$manifest_dir"
           gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
-            --pattern 'avibe_os-*' --dir "$package_dir" >/dev/null
-          if [ "$EXPECTED_OWNER" = "memory" ]; then
-            gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
-              --pattern 'avibe_memory-*' --dir "$package_dir" >/dev/null
-          fi
-          discovery_output="$(
-            python3 scripts/memory_runtime_release_guard.py \
-              discover-manifest --asset-dir "$package_dir" \
-              --output-manifest "$package_dir/memory-runtime-manifest.json" \
-              --release-tag "$RELEASE_TAG"
-          )"
-          test "$(jq -r '.manifest_owner' <<<"$discovery_output")" = "$EXPECTED_OWNER"
-          manifest="$package_dir/memory-runtime-manifest.json"
-          test "$(sha256sum "$manifest" | cut -d' ' -f1)" = "$EXPECTED_SHA256"
+            --pattern 'avibe_os-*.whl' --dir "$manifest_dir" >/dev/null
+          CANDIDATE_TAG="$RELEASE_TAG" CANDIDATE_DIR="$manifest_dir" \
+            python3 - <<'PY'
+          import json
+          import os
+          import zipfile
+          from pathlib import Path
 
-      - name: Verify Memory distribution ownership and isolated sdist rebuilds
-        if: matrix.manifest.owner == 'memory'
-        run: |
-          python3 -m pip install build
-          python3 scripts/memory_runtime_release_guard.py \
-            --manifest "$RUNNER_TEMP/memory-runtime-packages/memory-runtime-manifest.json" \
-            verify-packages --asset-dir "$RUNNER_TEMP/memory-runtime-packages"
+          wheels = sorted(Path(os.environ["CANDIDATE_DIR"]).glob("avibe_os-*.whl"))
+          if len(wheels) != 1:
+              raise SystemExit("expected exactly one avibe_os wheel")
+          with zipfile.ZipFile(wheels[0]) as wheel:
+              manifest = wheel.read("vibe/memory_runtime_manifest.json")
+          payload = json.loads(manifest)
+          if payload.get("release_state") != "published" or payload.get("release_tag") != os.environ["CANDIDATE_TAG"]:
+              raise SystemExit("wheel does not contain the selected published manifest")
+          (Path(os.environ["CANDIDATE_DIR"]) / "memory-runtime-manifest.json").write_bytes(manifest)
+          PY
+          manifest="$manifest_dir/memory-runtime-manifest.json"
+          test "$(sha256sum "$manifest" | cut -d' ' -f1)" = "$EXPECTED_SHA256"
 
       - name: Fetch and verify published assets
         id: probe
@@ -219,7 +210,7 @@ jobs:
           set +e
           probe_output="$(
             python3 scripts/memory_runtime_release_guard.py \
-              --manifest "$RUNNER_TEMP/memory-runtime-packages/memory-runtime-manifest.json" \
+              --manifest "$RUNNER_TEMP/memory-runtime-manifest/memory-runtime-manifest.json" \
               fetch --output-dir "$RUNNER_TEMP/memory-runtime-release" 2>&1
           )"
           probe_status=$?
@@ -273,7 +264,7 @@ jobs:
             exit 1
           fi
           python3 scripts/memory_runtime_release_guard.py \
-            --manifest "$RUNNER_TEMP/memory-runtime-packages/memory-runtime-manifest.json" \
+            --manifest "$RUNNER_TEMP/memory-runtime-manifest/memory-runtime-manifest.json" \
             verify --asset-dir "$restore_dir"
 
           existing="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')"
@@ -294,7 +285,7 @@ jobs:
         if: steps.probe.outputs.result == 'bytes_failure'
         run: |
           python3 scripts/memory_runtime_release_guard.py \
-            --manifest "$RUNNER_TEMP/memory-runtime-packages/memory-runtime-manifest.json" \
+            --manifest "$RUNNER_TEMP/memory-runtime-manifest/memory-runtime-manifest.json" \
             fetch --output-dir "$RUNNER_TEMP/memory-runtime-release"
 
       - name: Check whether this manifest already has a backup

--- a/.github/workflows/memory-runtime-release-guard.yml
+++ b/.github/workflows/memory-runtime-release-guard.yml
@@ -31,6 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
 
+      - name: Install release metadata parser
+        run: python3 -m pip install packaging
+
       - name: Resolve every published Memory Runtime manifest
         id: manifests
         env:
@@ -74,6 +77,11 @@ jobs:
             # Explicitly retain releases that predate the managed runtime as
             # manifest-free legacy releases. Transition package failures are fatal.
             if [ "$discovery_status" -eq 4 ]; then
+              continue
+            elif [ "$discovery_status" -eq 2 ]; then
+              policy_reason="$(jq -r '.error // "manifest excluded by policy"' <<<"$discovery_output")"
+              jq -nc --arg release_tag "$candidate_tag" --arg reason "$policy_reason" \
+                '{release_tag: $release_tag, reason: $reason}' >> "$excluded_file"
               continue
             elif [ "$discovery_status" -ne 0 ]; then
               echo "$discovery_output" >&2
@@ -161,6 +169,9 @@ jobs:
         manifest: ${{ fromJSON(needs.resolve_manifests.outputs.manifests) }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+
+      - name: Install release metadata parser
+        run: python3 -m pip install packaging
 
       - name: Resolve selected published Memory Runtime manifest
         env:

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -4,11 +4,11 @@
 from __future__ import annotations
 
 import argparse
-from email.parser import Parser
+from contextlib import nullcontext
 import hashlib
+from importlib.metadata import PathDistribution
 import json
 import os
-from pathlib import PurePosixPath
 import shutil
 import subprocess
 import sys
@@ -17,10 +17,8 @@ import tempfile
 import time
 import urllib.error
 import urllib.request
-import zipfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
 
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
@@ -132,10 +130,10 @@ class PackageMetadata:
 
 
 @dataclass(frozen=True)
-class PackageArchive:
-    path: Path
+class InstalledDistribution:
     metadata: PackageMetadata
-    files: dict[str, bytes]
+    dist_info: str
+    files: dict[tuple[str, str], bytes]
 
 
 @dataclass(frozen=True)
@@ -151,40 +149,55 @@ class ManifestDiscovery:
     manifest_bytes: bytes
 
 
-SdistBuilder = Callable[[Path, Path], Path]
-
+INSTALL_SCHEMES = ("purelib", "platlib", "scripts", "headers", "data")
+PIP_OFFLINE_FLAGS = ("--disable-pip-version-check", "--no-input", "--no-index", "--no-cache-dir")
+_EMPTY_SCHEMES = dict.fromkeys(INSTALL_SCHEMES, frozenset())
+_CORE_LIBRARIES = frozenset({"config/", "core/", "modules/", "storage/", "vibe/"})
+_MEMORY_LIBRARIES = frozenset({"avibe_memory/", MEMORY_MANIFEST_PATH})
 NAMESPACE_POLICIES = {
     1: {
-        "avibe-os": frozenset({"config", "core", "modules", "storage", "vibe"}),
-        "avibe-memory": frozenset({"avibe_memory"}),
+        "avibe-os": {
+            **_EMPTY_SCHEMES,
+            "purelib": _CORE_LIBRARIES,
+            "platlib": _CORE_LIBRARIES,
+            "scripts": frozenset({"vibe"}),
+        },
+        "avibe-memory": {
+            **_EMPTY_SCHEMES,
+            "purelib": _MEMORY_LIBRARIES,
+            "platlib": _MEMORY_LIBRARIES,
+        },
     }
 }
-PIP_FLAGS = (
-    "install",
-    "--dry-run",
-    "--ignore-installed",
-    "--disable-pip-version-check",
-    "--no-input",
-    "--no-index",
-    "--only-binary=:all:",
-)
 
 
-def _run_pip(arguments: list[str], failure: str) -> None:
-    pip = shutil.which("pip") or shutil.which("pip3")
-    if pip is None:
-        raise ReleaseAssetError("offline pip tooling is unavailable")
+def _run_interpreter(
+    python_executable: Path,
+    arguments: list[str],
+    failure: str,
+) -> subprocess.CompletedProcess[str]:
     environment = {key: value for key, value in os.environ.items() if not key.startswith("PIP_")}
-    environment.update(PIP_CONFIG_FILE=os.devnull, PIP_NO_CACHE_DIR="1", PYTHONPATH="")
-    result = subprocess.run(
-        [pip, *arguments],
-        env=environment,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    environment.update(PIP_CONFIG_FILE=os.devnull, PIP_NO_CACHE_DIR="1", PYTHONNOUSERSITE="1", PYTHONPATH="")
+    try:
+        executable = python_executable.expanduser().resolve(strict=True)
+        if not executable.is_file() or not os.access(executable, os.X_OK):
+            raise OSError("path is not executable")
+        result = subprocess.run(
+            [str(executable), *arguments],
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        raise ReleaseAssetError(f"requested Python interpreter is unavailable: {python_executable}: {exc}") from exc
     if result.returncode:
         raise ReleaseAssetError(f"{failure}: {result.stdout}{result.stderr}")
+    return result
+
+
+def _run_pip(python_executable: Path, arguments: list[str], failure: str) -> None:
+    _run_interpreter(python_executable, ["-m", "pip", "--isolated", *arguments], failure)
 
 
 def _sha256(path: Path) -> str:
@@ -220,96 +233,133 @@ def _assert_filename_identity(path: Path, metadata: PackageMetadata) -> None:
         raise ReleaseAssetError(f"distribution filename identity differs from metadata: {path.name}")
 
 
-def _metadata(message_bytes: bytes, context: str) -> PackageMetadata:
-    try:
-        message = Parser().parsestr(message_bytes.decode("utf-8"))
-    except UnicodeDecodeError as exc:
-        raise ReleaseAssetError(f"{context} metadata is not UTF-8") from exc
-    required: dict[str, str] = {}
-    for key in ("Name", "Version", "Requires-Python"):
-        values = message.get_all(key) or []
-        if len(values) != 1 or not values[0]:
-            raise ReleaseAssetError(f"{context} metadata must contain exactly one {key}")
-        required[key] = values[0]
+def _metadata(message, context: str) -> PackageMetadata:
+    values = [message.get_all(key) or [] for key in ("Name", "Version", "Requires-Python")]
+    if any(len(field) != 1 or not field[0] for field in values):
+        raise ReleaseAssetError(f"{context} metadata has invalid identity fields")
+    name, version, requires_python = (field[0] for field in values)
     return PackageMetadata(
-        name=str(canonicalize_name(required["Name"])),
-        version=required["Version"],
-        requires_python=required["Requires-Python"],
+        name=str(canonicalize_name(name)),
+        version=version,
+        requires_python=requires_python,
         requires_dist=tuple(sorted(message.get_all("Requires-Dist") or [])),
     )
 
 
-def _validate_wheel_structure(path: Path) -> None:
-    _run_pip(
-        [*PIP_FLAGS, "--no-deps", "--ignore-requires-python", str(path.resolve())],
-        f"wheel structure validation failed for {path.name}",
+def _interpreter_version(python_executable: Path) -> str:
+    result = _run_interpreter(
+        python_executable,
+        ["-I", "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"],
+        "cannot identify requested Python interpreter",
     )
+    version = result.stdout.strip()
+    if len(version.split(".")) != 2 or not version.replace(".", "").isdigit():
+        raise ReleaseAssetError("requested Python interpreter reported an invalid version")
+    return version
 
 
-def _wheel_archive(path: Path) -> PackageArchive:
-    _validate_wheel_structure(path)
+def _pip_scheme(python_executable: Path, prefix: Path, distribution: str) -> dict[str, Path]:
+    script = (
+        "import json,sys; from pip._internal.locations import get_scheme; "
+        "s=get_scheme(sys.argv[1],prefix=sys.argv[2]); "
+        "print(json.dumps({k:getattr(s,k) for k in "
+        "('purelib','platlib','scripts','headers','data')}))"
+    )
+    result = _run_interpreter(
+        python_executable,
+        ["-I", "-c", script, distribution, str(prefix.resolve())],
+        f"cannot determine pip install scheme for {distribution}",
+    )
     try:
-        with zipfile.ZipFile(path) as archive:
-            names = archive.namelist()
-            if len(names) != len(set(names)):
-                raise ReleaseAssetError(f"wheel contains duplicate paths: {path.name}")
-            if any(
-                "\\" in name or PurePosixPath(name).is_absolute() or ".." in PurePosixPath(name).parts for name in names
-            ):
-                raise ReleaseAssetError(f"wheel contains an unsafe path: {path.name}")
-            files = {name: archive.read(name) for name in names if not name.endswith("/")}
-    except (OSError, zipfile.BadZipFile) as exc:
-        raise ReleaseAssetError(f"cannot read wheel {path.name}: {exc}") from exc
-    metadata_paths = [name for name in files if name.endswith(".dist-info/METADATA")]
+        raw = json.loads(result.stdout)
+        if (
+            not isinstance(raw, dict)
+            or set(raw) != set(INSTALL_SCHEMES)
+            or not all(map(lambda value: isinstance(value, str), raw.values()))
+        ):
+            raise ValueError
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise ReleaseAssetError(f"pip install scheme is invalid for {distribution}") from exc
+    return {key: Path(value).resolve() for key, value in raw.items()}
+
+
+def _pip_install(
+    python_executable: Path,
+    wheels: tuple[Path, ...],
+    find_links: tuple[Path, ...],
+    prefix: Path,
+    *,
+    no_deps: bool,
+) -> None:
+    prefix.mkdir(parents=True)
+    links = [item for directory in find_links for item in ("--find-links", str(directory.resolve()))]
+    arguments = [
+        "install",
+        *PIP_OFFLINE_FLAGS,
+        "--no-compile",
+        "--ignore-installed",
+        "--only-binary=:all:",
+        "--prefix",
+        str(prefix.resolve()),
+        *links,
+    ]
+    if no_deps:
+        arguments.append("--no-deps")
+    arguments.extend(str(wheel.resolve()) for wheel in wheels)
+    _run_pip(python_executable, arguments, "offline pip install failed")
+
+
+def _installed_distribution(
+    wheel: Path,
+    distribution: str,
+    prefix: Path,
+    python_executable: Path,
+) -> InstalledDistribution:
+    _pip_install(python_executable, (wheel,), (wheel.parent,), prefix, no_deps=True)
+    metadata_paths = sorted(prefix.rglob("*.dist-info/METADATA"))
     if len(metadata_paths) != 1:
-        raise ReleaseAssetError(f"wheel must contain exactly one METADATA file: {path.name}")
-    package = PackageArchive(path, _metadata(files[metadata_paths[0]], path.name), files)
-    _assert_filename_identity(path, package.metadata)
-    return package
-
-
-def _sdist_archive(path: Path) -> PackageArchive:
-    files: dict[str, bytes] = {}
-    roots: set[str] = set()
-    try:
-        with tarfile.open(path, "r:gz") as archive:
-            for member in archive.getmembers():
-                member_path = PurePosixPath(member.name)
-                if member_path.is_absolute() or ".." in member_path.parts or not member_path.parts:
-                    raise ReleaseAssetError(f"sdist contains an unsafe path: {path.name}")
-                roots.add(member_path.parts[0])
-                if member.isdir():
-                    continue
-                if not member.isfile():
-                    raise ReleaseAssetError(f"sdist contains a non-regular entry: {path.name}")
-                stream = archive.extractfile(member)
-                if stream is None:
-                    raise ReleaseAssetError(f"sdist member is unreadable: {member.name}")
-                relative = PurePosixPath(*member_path.parts[1:]).as_posix()
-                if not relative or relative in files:
-                    raise ReleaseAssetError(f"sdist contains duplicate or root-level content: {path.name}")
-                files[relative] = stream.read()
-    except (OSError, tarfile.TarError) as exc:
-        raise ReleaseAssetError(f"cannot read sdist {path.name}: {exc}") from exc
-    if len(roots) != 1 or "PKG-INFO" not in files:
-        raise ReleaseAssetError(f"sdist must have one root and one PKG-INFO: {path.name}")
-    package = PackageArchive(path, _metadata(files["PKG-INFO"], path.name), files)
-    _assert_filename_identity(path, package.metadata)
-    return package
-
-
-def _installed_files(package: PackageArchive) -> dict[str, bytes]:
-    if package.path.suffix != ".whl":
-        return package.files
-    installed: dict[str, bytes] = {}
-    for name, content in package.files.items():
-        parts = PurePosixPath(name).parts
-        if len(parts) >= 3 and parts[0].endswith(".data") and parts[1] in {"purelib", "platlib"}:
-            name = PurePosixPath(*parts[2:]).as_posix()
-        if name in installed:
-            raise ReleaseAssetError(f"wheel has colliding install paths: {package.path.name}")
-        installed[name] = content
-    return installed
+        raise ReleaseAssetError(f"pip install produced {len(metadata_paths)} METADATA files for {wheel.name}")
+    metadata_path = metadata_paths[0]
+    installed = PathDistribution(metadata_path.parent)
+    metadata = _metadata(installed.metadata, wheel.name)
+    if metadata.name != canonicalize_name(distribution):
+        raise ReleaseAssetError(f"installed distribution identity differs from expected {distribution}")
+    _assert_filename_identity(wheel, metadata)
+    scheme = _pip_scheme(python_executable, prefix, distribution)
+    scheme_roots = sorted(
+        scheme.items(),
+        key=lambda item: (-len(item[1].parts), INSTALL_SCHEMES.index(item[0])),
+    )
+    entries = installed.files
+    if entries is None:
+        raise ReleaseAssetError(f"installed RECORD is invalid: {wheel.name}")
+    files: dict[tuple[str, str], bytes] = {}
+    recorded: set[Path] = set()
+    for entry in entries:
+        target = Path(entry.locate()).resolve()
+        try:
+            target.relative_to(prefix.resolve())
+        except ValueError as exc:
+            raise ReleaseAssetError(f"installed RECORD escapes its disposable prefix: {entry}") from exc
+        if target in recorded or not target.is_file() or target.is_symlink():
+            raise ReleaseAssetError(f"installed RECORD path is invalid: {entry}")
+        recorded.add(target)
+        for scheme_name, root in scheme_roots:
+            try:
+                relative = target.relative_to(root)
+            except ValueError:
+                continue
+            key = (scheme_name, relative.as_posix())
+            if not relative.parts or key in files:
+                raise ReleaseAssetError(f"installed RECORD has a colliding path: {entry}")
+            files[key] = target.read_bytes()
+            break
+        else:
+            raise ReleaseAssetError(f"installed path is outside pip's install scheme: {entry}")
+    actual = {path.resolve() for path in prefix.rglob("*") if path.is_file()}
+    if actual != recorded:
+        raise ReleaseAssetError(f"installed inventory differs from RECORD: {wheel.name}")
+    return InstalledDistribution(metadata, metadata_path.parent.name, files)
 
 
 def _requirements_for(metadata: PackageMetadata, name: str) -> tuple[Requirement, ...]:
@@ -333,9 +383,13 @@ def _exact_memory_pin(metadata: PackageMetadata) -> str | None:
         or requirement.marker is not None
         or len(specifiers) != 1
         or specifiers[0].operator != "=="
+        or "*" in specifiers[0].version
     ):
         return None
-    return str(Version(specifiers[0].version))
+    try:
+        return str(Version(specifiers[0].version))
+    except InvalidVersion as exc:
+        raise ReleaseAssetError("avibe-memory exact dependency has an invalid version") from exc
 
 
 def _package_files(asset_dir: Path, distribution: str, suffix: str) -> list[Path]:
@@ -397,6 +451,7 @@ def _package_release_policy(payload: dict, release_tag: str) -> PackageReleasePo
 def discover_release_manifest(
     asset_dir: Path,
     *,
+    python_executable: Path,
     release_tag: str | None = None,
 ) -> ManifestDiscovery:
     if not asset_dir.is_dir():
@@ -405,10 +460,16 @@ def discover_release_manifest(
     memory_paths = _package_files(asset_dir, "avibe-memory", ".whl")
     if len(core_paths) != 1 or len(memory_paths) > 1:
         raise ReleaseAssetError("release must contain one core wheel and at most one Memory wheel")
-    core = _wheel_archive(core_paths[0])
-    core_manifest = _installed_files(core).get(MEMORY_MANIFEST_PATH)
-    memory = _wheel_archive(memory_paths[0]) if memory_paths else None
-    memory_manifest = _installed_files(memory).get(MEMORY_MANIFEST_PATH) if memory else None
+    with tempfile.TemporaryDirectory(prefix="memory-manifest-discovery-") as temporary:
+        root = Path(temporary)
+        core = _installed_distribution(core_paths[0], "avibe-os", root / "core", python_executable)
+        memory = (
+            _installed_distribution(memory_paths[0], "avibe-memory", root / "memory", python_executable)
+            if memory_paths
+            else None
+        )
+        core_manifest = _package_file(core, MEMORY_MANIFEST_PATH)
+        memory_manifest = _package_file(memory, MEMORY_MANIFEST_PATH) if memory else None
     if core_manifest and memory_manifest:
         raise ReleaseAssetError("Memory Runtime manifest ownership is ambiguous")
     if memory_manifest:
@@ -426,48 +487,53 @@ def discover_release_manifest(
     raise LegacyManifestAbsent("legacy release predates the Memory Runtime manifest")
 
 
-def _assert_metadata_parity(wheel: PackageArchive, sdist: PackageArchive, name: str) -> None:
-    if wheel.metadata.name != name or wheel.metadata != sdist.metadata:
-        raise ReleaseAssetError(f"{name} wheel and sdist metadata differ")
+def _package_file(package: InstalledDistribution, path: str) -> bytes | None:
+    matches = [
+        content
+        for (scheme, name), content in package.files.items()
+        if scheme in {"purelib", "platlib"} and name == path
+    ]
+    if len(matches) > 1:
+        raise ReleaseAssetError(f"installed distribution has duplicate library paths: {path}")
+    return matches[0] if matches else None
 
 
-def _owned_content(package: PackageArchive, prefix: str) -> dict[str, bytes]:
-    return {name: value for name, value in _installed_files(package).items() if name.startswith(prefix)}
+def _owned_files(package: InstalledDistribution) -> dict[tuple[str, str], bytes]:
+    return {
+        key: value
+        for key, value in package.files.items()
+        if not (
+            key[0] in {"purelib", "platlib"}
+            and (key[1] == package.dist_info or key[1].startswith(f"{package.dist_info}/"))
+        )
+    }
 
 
-def _assert_namespace_policy(package: PackageArchive, distribution: str, policy_version: int) -> None:
-    policies = NAMESPACE_POLICIES[policy_version]
-    allowed_top_levels = policies[distribution]
-    known_namespaces = set().union(*policies.values())
-    for name in _installed_files(package):
-        if name == MEMORY_MANIFEST_PATH:
-            if distribution == "avibe-memory":
-                continue
-            raise ReleaseAssetError(f"{distribution} artifact violates namespace policy: {name}")
-        top_level = PurePosixPath(name).parts[0]
-        if top_level.endswith((".dist-info", ".data")):
-            continue
-        if package.path.suffix == ".whl":
-            allowed = top_level in allowed_top_levels
-        else:
-            allowed = top_level not in known_namespaces or top_level in allowed_top_levels
-        if not allowed:
-            raise ReleaseAssetError(f"{distribution} artifact violates namespace policy: {name}")
+def _assert_namespace_policy(
+    package: InstalledDistribution,
+    distribution: str,
+    policy_version: int,
+) -> None:
+    policy = NAMESPACE_POLICIES[policy_version][distribution]
+    for key in _owned_files(package):
+        scheme, path = key
+        allowed = policy[scheme]
+        if not any(path == entry or (entry.endswith("/") and path.startswith(entry)) for entry in allowed):
+            raise ReleaseAssetError(f"{distribution} artifact violates namespace policy: {scheme}/{path}")
 
 
-def _assert_transition_packages(
-    packages: tuple[PackageArchive, PackageArchive, PackageArchive, PackageArchive],
+def _assert_transition_pair(
+    core: InstalledDistribution,
+    memory: InstalledDistribution,
     policy: PackageReleasePolicy,
 ) -> str:
-    core_wheel, memory_wheel, core_sdist, memory_sdist = packages
-    _assert_metadata_parity(core_wheel, core_sdist, "avibe-os")
-    _assert_metadata_parity(memory_wheel, memory_sdist, "avibe-memory")
-    version = core_wheel.metadata.version
-    if memory_wheel.metadata.version != version:
+    version = core.metadata.version
+    normalized_version = str(Version(version))
+    if memory.metadata.version != version:
         raise ReleaseAssetError("core and Memory distribution versions differ")
-    if _exact_memory_pin(core_wheel.metadata) != version:
+    if _exact_memory_pin(core.metadata) != normalized_version:
         raise ReleaseAssetError("transition core must hard-depend on the exact Memory version")
-    reverse_requirements = _requirements_for(memory_wheel.metadata, "avibe-os")
+    reverse_requirements = _requirements_for(memory.metadata, "avibe-os")
     if len(reverse_requirements) != 1:
         raise ReleaseAssetError("Memory metadata must contain exactly one avibe-os dependency")
     reverse_requirement = reverse_requirements[0]
@@ -475,36 +541,31 @@ def _assert_transition_packages(
         reverse_requirement.url is not None
         or reverse_requirement.marker is not None
         or not reverse_requirement.specifier
-        or Version(version) not in reverse_requirement.specifier
+        or Version(normalized_version) not in reverse_requirement.specifier
     ):
         raise ReleaseAssetError("Memory avibe-os dependency must accept the exact core version")
-    requires_python = {core_wheel.metadata.requires_python, memory_wheel.metadata.requires_python}
+    requires_python = {core.metadata.requires_python, memory.metadata.requires_python}
     if requires_python != {policy.requires_python}:
         raise ReleaseAssetError(f"core and Memory Requires-Python must match release policy {policy.requires_python}")
-
-    for package, distribution in (
-        (core_wheel, "avibe-os"),
-        (core_sdist, "avibe-os"),
-        (memory_wheel, "avibe-memory"),
-        (memory_sdist, "avibe-memory"),
-    ):
-        _assert_namespace_policy(package, distribution, policy.namespace_policy_version)
-    wheel_implementation = _owned_content(memory_wheel, "avibe_memory/")
-    sdist_implementation = _owned_content(memory_sdist, "avibe_memory/")
-    if not REQUIRED_MEMORY_IMPLEMENTATION.issubset(wheel_implementation):
+    _assert_namespace_policy(core, "avibe-os", policy.namespace_policy_version)
+    _assert_namespace_policy(memory, "avibe-memory", policy.namespace_policy_version)
+    if _package_file(core, MEMORY_MANIFEST_PATH) is not None:
+        raise ReleaseAssetError("core artifact must not own the Memory Runtime manifest")
+    implementation = {
+        path for scheme, path in memory.files if scheme in {"purelib", "platlib"} and path.startswith("avibe_memory/")
+    }
+    if not REQUIRED_MEMORY_IMPLEMENTATION.issubset(implementation):
         raise ReleaseAssetError("Memory artifact is missing required implementation files")
-    if wheel_implementation != sdist_implementation:
-        raise ReleaseAssetError("Memory wheel and sdist implementation content differ")
-    wheel_manifest = _installed_files(memory_wheel).get(MEMORY_MANIFEST_PATH)
-    sdist_manifest = _installed_files(memory_sdist).get(MEMORY_MANIFEST_PATH)
-    if wheel_manifest is None or wheel_manifest != sdist_manifest:
-        raise ReleaseAssetError("Memory wheel and sdist manifest content differ")
+    if _package_file(memory, MEMORY_MANIFEST_PATH) is None:
+        raise ReleaseAssetError("Memory artifact is missing its owned manifest")
+    collisions = set(_owned_files(core)) & set(_owned_files(memory))
+    if collisions:
+        scheme, path = sorted(collisions)[0]
+        raise ReleaseAssetError(f"core and Memory install paths collide: {scheme}/{path}")
     return version
 
 
-def _transition_artifacts(
-    asset_dir: Path,
-) -> tuple[PackageArchive, PackageArchive, PackageArchive, PackageArchive]:
+def _transition_artifacts(asset_dir: Path) -> tuple[Path, Path, Path, Path]:
     if not asset_dir.is_dir():
         raise ReleaseAssetError("release package directory is missing")
 
@@ -515,57 +576,53 @@ def _transition_artifacts(
         return matches[0]
 
     return (
-        _wheel_archive(one("avibe-os", ".whl")),
-        _wheel_archive(one("avibe-memory", ".whl")),
-        _sdist_archive(one("avibe-os", ".tar.gz")),
-        _sdist_archive(one("avibe-memory", ".tar.gz")),
+        one("avibe-os", ".whl"),
+        one("avibe-memory", ".whl"),
+        one("avibe-os", ".tar.gz"),
+        one("avibe-memory", ".tar.gz"),
     )
 
 
-def _extract_sdist(sdist: Path, destination: Path) -> Path:
-    archive = _sdist_archive(sdist)
-    project_root = destination / sdist.name.removesuffix(".tar.gz")
-    project_root.mkdir(parents=True)
-    for name, content in archive.files.items():
-        target = project_root.joinpath(*PurePosixPath(name).parts)
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(content)
-    return project_root
-
-
-def rebuild_sdist_wheel(sdist: Path, output_dir: Path) -> Path:
+def rebuild_sdist_wheel(
+    sdist: Path,
+    output_dir: Path,
+    *,
+    python_executable: Path,
+    find_links: tuple[Path, ...],
+) -> Path:
+    distribution, _ = _filename_identity(sdist)
     output_dir.mkdir(parents=True, exist_ok=True)
-    attempt_dir = Path(tempfile.mkdtemp(prefix="attempt-", dir=output_dir))
-    extract_dir = attempt_dir / "source"
-    project_root = _extract_sdist(sdist, extract_dir)
-    wheel_dir = attempt_dir / "wheel"
+    wheel_dir = Path(tempfile.mkdtemp(prefix="attempt-", dir=output_dir)) / "wheel"
     wheel_dir.mkdir(parents=True)
-    environment = {**os.environ, "PYTHONPATH": ""}
-    result = subprocess.run(
-        [sys.executable, "-m", "build", "--wheel", "--outdir", str(wheel_dir), str(project_root)],
-        env=environment,
-        capture_output=True,
-        text=True,
-        check=False,
+    links = [item for directory in find_links for item in ("--find-links", str(directory.resolve()))]
+    _run_pip(
+        python_executable,
+        [
+            "wheel",
+            *PIP_OFFLINE_FLAGS,
+            "--no-deps",
+            "--wheel-dir",
+            str(wheel_dir.resolve()),
+            *links,
+            str(sdist.resolve()),
+        ],
+        f"isolated pip sdist rebuild failed for {sdist.name}",
     )
-    if result.returncode != 0:
-        raise ReleaseAssetError(f"isolated sdist rebuild failed for {sdist.name}: {result.stdout}{result.stderr}")
-    wheels = sorted(wheel_dir.glob("*.whl"))
+    wheels = _package_files(wheel_dir, distribution, ".whl")
     if len(wheels) != 1:
         raise ReleaseAssetError(f"isolated sdist rebuild produced {len(wheels)} wheels for {sdist.name}")
     return wheels[0]
 
 
-def _resolve_wheelhouse(
+def _install_pair(
     wheels: tuple[Path, Path],
-    find_links: tuple[Path, ...],
-    python_versions: tuple[str, ...],
-) -> None:
-    for python_version in python_versions:
-        links = [item for directory in find_links for item in ("--find-links", str(directory.resolve()))]
-        command = [*PIP_FLAGS, "--python-version", python_version, *links]
-        command.extend(str(wheel.resolve()) for wheel in wheels)
-        _run_pip(command, f"offline pip resolution failed for Python {python_version}")
+    root: Path,
+    python_executable: Path,
+) -> tuple[InstalledDistribution, InstalledDistribution]:
+    return (
+        _installed_distribution(wheels[0], "avibe-os", root / "core", python_executable),
+        _installed_distribution(wheels[1], "avibe-memory", root / "memory", python_executable),
+    )
 
 
 def verify_transition_distributions(
@@ -573,11 +630,15 @@ def verify_transition_distributions(
     rebuild_root: Path,
     *,
     release_tag: str,
-    builder: SdistBuilder = rebuild_sdist_wheel,
+    python_executable: Path,
+    expected_manifest: bytes | None = None,
 ) -> str:
-    staged = _transition_artifacts(asset_dir)
-    core_wheel, memory_wheel, core_sdist, memory_sdist = staged
-    manifest_bytes = _installed_files(memory_wheel).get(MEMORY_MANIFEST_PATH)
+    python_version = _interpreter_version(python_executable)
+    core_wheel, memory_wheel, core_sdist, memory_sdist = _transition_artifacts(asset_dir)
+    rebuild_root.mkdir(parents=True, exist_ok=True)
+    attempt = Path(tempfile.mkdtemp(prefix="attempt-", dir=rebuild_root))
+    staged = _install_pair((core_wheel, memory_wheel), attempt / "staged", python_executable)
+    manifest_bytes = _package_file(staged[1], MEMORY_MANIFEST_PATH)
     try:
         manifest_payload = json.loads(manifest_bytes) if manifest_bytes is not None else None
     except (TypeError, json.JSONDecodeError) as exc:
@@ -587,23 +648,47 @@ def verify_transition_distributions(
     policy = _package_release_policy(manifest_payload, release_tag)
     if policy is None:
         raise ReleaseAssetError("Memory artifact manifest is missing frozen package_policy")
-    version = _assert_transition_packages(staged, policy)
+    if python_version not in policy.supported_python_versions:
+        raise ReleaseAssetError(f"requested Python {python_version} is not in the release policy interpreter matrix")
+    if expected_manifest is not None and manifest_bytes != expected_manifest:
+        raise ReleaseAssetError("transition package manifest does not match the selected manifest")
+    version = _assert_transition_pair(*staged, policy)
     if Version(version) != _release_version(release_tag):
         raise ReleaseAssetError("distribution version does not match the release tag")
-    _resolve_wheelhouse(
-        (core_wheel.path, memory_wheel.path),
+    _pip_install(
+        python_executable,
+        (core_wheel, memory_wheel),
         (asset_dir,),
-        policy.supported_python_versions,
+        attempt / "staged-combined",
+        no_deps=False,
     )
-    rebuilt_core = _wheel_archive(builder(core_sdist.path, rebuild_root / "core"))
-    rebuilt_memory = _wheel_archive(builder(memory_sdist.path, rebuild_root / "memory"))
-    rebuilt_version = _assert_transition_packages((rebuilt_core, rebuilt_memory, core_sdist, memory_sdist), policy)
+    rebuilt_wheels = (
+        rebuild_sdist_wheel(
+            core_sdist, attempt / "core-build", python_executable=python_executable, find_links=(asset_dir,)
+        ),
+        rebuild_sdist_wheel(
+            memory_sdist, attempt / "memory-build", python_executable=python_executable, find_links=(asset_dir,)
+        ),
+    )
+    rebuilt = _install_pair(rebuilt_wheels, attempt / "rebuilt", python_executable)
+    _assert_filename_identity(core_sdist, rebuilt[0].metadata)
+    _assert_filename_identity(memory_sdist, rebuilt[1].metadata)
+    rebuilt_version = _assert_transition_pair(*rebuilt, policy)
     if rebuilt_version != version:
         raise ReleaseAssetError("rebuilt distribution version differs from staged artifacts")
-    _resolve_wheelhouse(
-        (rebuilt_core.path, rebuilt_memory.path),
-        (asset_dir, rebuilt_core.path.parent, rebuilt_memory.path.parent),
-        policy.supported_python_versions,
+    for distribution, staged_package, rebuilt_package in zip(
+        ("avibe-os", "avibe-memory"), staged, rebuilt, strict=True
+    ):
+        if staged_package.metadata != rebuilt_package.metadata:
+            raise ReleaseAssetError(f"{distribution} wheel and sdist metadata differ")
+        if _owned_files(staged_package) != _owned_files(rebuilt_package):
+            raise ReleaseAssetError(f"{distribution} wheel and sdist installed content differ")
+    _pip_install(
+        python_executable,
+        rebuilt_wheels,
+        (asset_dir, rebuilt_wheels[0].parent, rebuilt_wheels[1].parent),
+        attempt / "rebuilt-combined",
+        no_deps=False,
     )
     return version
 
@@ -818,9 +903,11 @@ def main(argv: list[str] | None = None) -> int:
     discover.add_argument("--asset-dir", type=Path, required=True)
     discover.add_argument("--output-manifest", type=Path, required=True)
     discover.add_argument("--release-tag")
+    discover.add_argument("--python-executable", type=Path, required=True)
     packages = subparsers.add_parser("verify-packages")
     packages.add_argument("--asset-dir", type=Path, required=True)
     packages.add_argument("--work-dir", type=Path)
+    packages.add_argument("--python-executable", type=Path, required=True)
     subparsers.add_parser("verify-public")
     subparsers.add_parser("check-policy")
     args = parser.parse_args(argv)
@@ -833,7 +920,11 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "verify":
             spec = verify_release_assets(args.manifest, args.asset_dir)
         elif args.command == "discover-manifest":
-            discovery = discover_release_manifest(args.asset_dir, release_tag=args.release_tag)
+            discovery = discover_release_manifest(
+                args.asset_dir,
+                python_executable=args.python_executable,
+                release_tag=args.release_tag,
+            )
             args.output_manifest.parent.mkdir(parents=True, exist_ok=True)
             args.output_manifest.write_bytes(discovery.manifest_bytes)
             spec = load_release_spec(args.output_manifest)
@@ -842,17 +933,19 @@ def main(argv: list[str] | None = None) -> int:
             result["manifest_owner"] = discovery.owner
         elif args.command == "verify-packages":
             spec = load_release_spec(args.manifest)
-            if args.work_dir is None:
-                with tempfile.TemporaryDirectory(prefix="memory-distribution-rebuild-") as temporary:
-                    version = verify_transition_distributions(
-                        args.asset_dir, Path(temporary), release_tag=spec.release_tag
-                    )
-            else:
-                args.work_dir.mkdir(parents=True, exist_ok=True)
-                version = verify_transition_distributions(args.asset_dir, args.work_dir, release_tag=spec.release_tag)
-            discovery = discover_release_manifest(args.asset_dir, release_tag=spec.release_tag)
-            if discovery.owner != "memory" or discovery.manifest_bytes != spec.manifest_bytes:
-                raise ReleaseAssetError("transition package manifest does not match the selected manifest")
+            workspace = (
+                tempfile.TemporaryDirectory(prefix="memory-distribution-rebuild-")
+                if args.work_dir is None
+                else nullcontext(args.work_dir)
+            )
+            with workspace as work_dir:
+                version = verify_transition_distributions(
+                    args.asset_dir,
+                    Path(work_dir),
+                    release_tag=spec.release_tag,
+                    python_executable=args.python_executable,
+                    expected_manifest=spec.manifest_bytes,
+                )
             result["package_version"] = version
         elif args.command == "verify-public":
             spec = verify_public_release_assets(args.manifest)

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -4,17 +4,25 @@
 from __future__ import annotations
 
 import argparse
+from email.message import Message
+from email.parser import Parser
 import hashlib
 import json
+import os
+from pathlib import PurePosixPath
+import re
 import shutil
+import subprocess
 import sys
 import tarfile
 import tempfile
 import time
 import urllib.error
 import urllib.request
+import zipfile
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable
 
 RELEASE_DOWNLOAD_ROOT = "https://github.com/avibe-bot/avibe/releases/download"
 EXPECTED_EVEROS_VERSION = "1.2.3"
@@ -28,6 +36,11 @@ MAX_ARCHIVE_BYTES = 1024 * 1024 * 1024
 ASSET_FAILURE_EXIT = 1
 POLICY_EXCLUSION_EXIT = 2
 INTERNAL_GUARD_FAILURE_EXIT = 3
+LEGACY_MANIFEST_ABSENT_EXIT = 4
+MEMORY_MANIFEST_PATH = "vibe/memory_runtime_manifest.json"
+REQUIRED_MEMORY_IMPLEMENTATION = frozenset(
+    {"avibe_memory/__init__.py", "avibe_memory/runtime.py"}
+)
 
 
 class ReleaseGuardError(RuntimeError):
@@ -40,6 +53,10 @@ class ManifestPolicyError(ReleaseGuardError):
 
 class ReleaseAssetError(ReleaseGuardError):
     """Raised when guarded release bytes are unavailable or fail verification."""
+
+
+class LegacyManifestAbsent(ReleaseGuardError):
+    """Raised when a pre-transition release predates the managed runtime manifest."""
 
 
 @dataclass(frozen=True)
@@ -93,6 +110,30 @@ class ReleaseSpec:
         return {"memory-runtime-manifest.json", *(archive.name for archive in self.archives)}
 
 
+@dataclass(frozen=True)
+class PackageMetadata:
+    name: str
+    version: str
+    requires_python: str
+    requires_dist: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PackageArchive:
+    path: Path
+    metadata: PackageMetadata
+    files: dict[str, bytes]
+
+
+@dataclass(frozen=True)
+class ManifestDiscovery:
+    owner: str
+    manifest_bytes: bytes
+
+
+SdistBuilder = Callable[[Path, Path], Path]
+
+
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as stream:
@@ -106,6 +147,263 @@ def _required_string(payload: dict, key: str, context: str) -> str:
     if not isinstance(value, str) or not value:
         raise ManifestPolicyError(f"{context}.{key} must be a non-empty string")
     return value
+
+
+def _canonical_name(value: str) -> str:
+    return re.sub(r"[-_.]+", "-", value).lower()
+
+
+def _metadata(message_bytes: bytes, context: str) -> PackageMetadata:
+    try:
+        message: Message = Parser().parsestr(message_bytes.decode("utf-8"))
+    except UnicodeDecodeError as exc:
+        raise ReleaseAssetError(f"{context} metadata is not UTF-8") from exc
+    required: dict[str, str] = {}
+    for key in ("Name", "Version", "Requires-Python"):
+        values = message.get_all(key) or []
+        if len(values) != 1 or not values[0]:
+            raise ReleaseAssetError(f"{context} metadata must contain exactly one {key}")
+        required[key] = values[0]
+    return PackageMetadata(
+        name=_canonical_name(required["Name"]),
+        version=required["Version"],
+        requires_python=required["Requires-Python"],
+        requires_dist=tuple(sorted(message.get_all("Requires-Dist") or [])),
+    )
+
+
+def _wheel_archive(path: Path) -> PackageArchive:
+    try:
+        with zipfile.ZipFile(path) as archive:
+            names = archive.namelist()
+            if len(names) != len(set(names)):
+                raise ReleaseAssetError(f"wheel contains duplicate paths: {path.name}")
+            if any(
+                "\\" in name
+                or PurePosixPath(name).is_absolute()
+                or ".." in PurePosixPath(name).parts
+                for name in names
+            ):
+                raise ReleaseAssetError(f"wheel contains an unsafe path: {path.name}")
+            files = {
+                name: archive.read(name)
+                for name in names
+                if not name.endswith("/")
+            }
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise ReleaseAssetError(f"cannot read wheel {path.name}: {exc}") from exc
+    metadata_paths = [name for name in files if name.endswith(".dist-info/METADATA")]
+    if len(metadata_paths) != 1:
+        raise ReleaseAssetError(f"wheel must contain exactly one METADATA file: {path.name}")
+    return PackageArchive(path, _metadata(files[metadata_paths[0]], path.name), files)
+
+
+def _sdist_archive(path: Path) -> PackageArchive:
+    files: dict[str, bytes] = {}
+    roots: set[str] = set()
+    try:
+        with tarfile.open(path, "r:gz") as archive:
+            for member in archive.getmembers():
+                member_path = PurePosixPath(member.name)
+                if member_path.is_absolute() or ".." in member_path.parts or not member_path.parts:
+                    raise ReleaseAssetError(f"sdist contains an unsafe path: {path.name}")
+                roots.add(member_path.parts[0])
+                if member.isdir():
+                    continue
+                if not member.isfile():
+                    raise ReleaseAssetError(f"sdist contains a non-regular entry: {path.name}")
+                stream = archive.extractfile(member)
+                if stream is None:
+                    raise ReleaseAssetError(f"sdist member is unreadable: {member.name}")
+                relative = PurePosixPath(*member_path.parts[1:]).as_posix()
+                if not relative or relative in files:
+                    raise ReleaseAssetError(f"sdist contains duplicate or root-level content: {path.name}")
+                files[relative] = stream.read()
+    except ReleaseAssetError:
+        raise
+    except (OSError, tarfile.TarError) as exc:
+        raise ReleaseAssetError(f"cannot read sdist {path.name}: {exc}") from exc
+    if len(roots) != 1 or "PKG-INFO" not in files:
+        raise ReleaseAssetError(f"sdist must have one root and one PKG-INFO: {path.name}")
+    return PackageArchive(path, _metadata(files["PKG-INFO"], path.name), files)
+
+
+def _requirements_for(metadata: PackageMetadata, name: str) -> tuple[str, ...]:
+    expected = _canonical_name(name)
+    matches = []
+    for requirement in metadata.requires_dist:
+        match = re.match(r"\s*([A-Za-z0-9_.-]+)", requirement)
+        if match and _canonical_name(match.group(1)) == expected:
+            matches.append(requirement)
+    return tuple(matches)
+
+
+def _exact_memory_pin(metadata: PackageMetadata) -> str | None:
+    requirements = _requirements_for(metadata, "avibe-memory")
+    if len(requirements) != 1:
+        return None
+    match = re.fullmatch(r"\s*avibe[-_.]memory\s*==\s*([^\s;]+)\s*", requirements[0], re.IGNORECASE)
+    return match.group(1) if match else None
+
+
+def _package_files(asset_dir: Path, distribution: str, suffix: str) -> list[Path]:
+    prefix = distribution.replace("-", "_") + "-"
+    matches = [
+        path
+        for path in asset_dir.iterdir()
+        if path.name.startswith(prefix) and path.name.endswith(suffix)
+    ]
+    if any(path.is_symlink() or not path.is_file() for path in matches):
+        raise ReleaseAssetError(f"{distribution} release artifacts contain an unsafe entry")
+    return sorted(matches)
+
+
+def discover_release_manifest(asset_dir: Path) -> ManifestDiscovery:
+    if not asset_dir.is_dir():
+        raise ReleaseAssetError("release package directory is missing")
+    core_paths = _package_files(asset_dir, "avibe-os", ".whl")
+    memory_paths = _package_files(asset_dir, "avibe-memory", ".whl")
+    if len(core_paths) != 1 or len(memory_paths) > 1:
+        raise ReleaseAssetError("release must contain one core wheel and at most one Memory wheel")
+    core = _wheel_archive(core_paths[0])
+    if core.metadata.name != "avibe-os":
+        raise ReleaseAssetError("core wheel metadata Name must be avibe-os")
+    core_manifest = core.files.get(MEMORY_MANIFEST_PATH)
+    memory = _wheel_archive(memory_paths[0]) if memory_paths else None
+    memory_manifest = memory.files.get(MEMORY_MANIFEST_PATH) if memory else None
+    if memory and memory.metadata.name != "avibe-memory":
+        raise ReleaseAssetError("Memory wheel metadata Name must be avibe-memory")
+    if core_manifest and memory_manifest:
+        raise ReleaseAssetError("Memory Runtime manifest ownership is ambiguous")
+    if memory_manifest:
+        return ManifestDiscovery("memory", memory_manifest)
+    transition_pin = _exact_memory_pin(core.metadata)
+    if transition_pin is not None:
+        detail = "artifact is missing" if memory is None else "artifact has no owned manifest"
+        raise ReleaseAssetError(f"transition avibe-memory {detail}")
+    if memory is not None:
+        raise ReleaseAssetError("legacy release unexpectedly contains an unowned Memory wheel")
+    if core_manifest:
+        return ManifestDiscovery("core", core_manifest)
+    raise LegacyManifestAbsent("legacy release predates the Memory Runtime manifest")
+
+
+def _assert_metadata_parity(wheel: PackageArchive, sdist: PackageArchive, name: str) -> None:
+    if wheel.metadata.name != name or sdist.metadata.name != name:
+        raise ReleaseAssetError(f"{name} distribution metadata has the wrong Name")
+    if wheel.metadata != sdist.metadata:
+        raise ReleaseAssetError(f"{name} wheel and sdist metadata differ")
+
+
+def _owned_content(package: PackageArchive, prefix: str) -> dict[str, bytes]:
+    return {name: value for name, value in package.files.items() if name.startswith(prefix)}
+
+
+def _assert_transition_packages(
+    core_wheel: PackageArchive,
+    memory_wheel: PackageArchive,
+    core_sdist: PackageArchive,
+    memory_sdist: PackageArchive,
+) -> str:
+    _assert_metadata_parity(core_wheel, core_sdist, "avibe-os")
+    _assert_metadata_parity(memory_wheel, memory_sdist, "avibe-memory")
+    version = core_wheel.metadata.version
+    if memory_wheel.metadata.version != version:
+        raise ReleaseAssetError("core and Memory distribution versions differ")
+    if _exact_memory_pin(core_wheel.metadata) != version:
+        raise ReleaseAssetError("transition core must hard-depend on the exact Memory version")
+    if len(_requirements_for(memory_wheel.metadata, "avibe-os")) != 1:
+        raise ReleaseAssetError("Memory metadata must contain exactly one avibe-os dependency")
+    if core_wheel.metadata.requires_python != memory_wheel.metadata.requires_python:
+        raise ReleaseAssetError("core and Memory Requires-Python metadata differ")
+
+    for package in (core_wheel, core_sdist):
+        if _owned_content(package, "avibe_memory/") or MEMORY_MANIFEST_PATH in package.files:
+            raise ReleaseAssetError(f"core artifact owns Memory content: {package.path.name}")
+    wheel_implementation = _owned_content(memory_wheel, "avibe_memory/")
+    sdist_implementation = _owned_content(memory_sdist, "avibe_memory/")
+    if not REQUIRED_MEMORY_IMPLEMENTATION.issubset(wheel_implementation):
+        raise ReleaseAssetError("Memory artifact is missing required implementation files")
+    if wheel_implementation != sdist_implementation:
+        raise ReleaseAssetError("Memory wheel and sdist implementation content differ")
+    wheel_manifest = memory_wheel.files.get(MEMORY_MANIFEST_PATH)
+    sdist_manifest = memory_sdist.files.get(MEMORY_MANIFEST_PATH)
+    if wheel_manifest is None or wheel_manifest != sdist_manifest:
+        raise ReleaseAssetError("Memory wheel and sdist manifest content differ")
+    return version
+
+
+def _transition_artifacts(asset_dir: Path) -> tuple[PackageArchive, PackageArchive, PackageArchive, PackageArchive]:
+    if not asset_dir.is_dir():
+        raise ReleaseAssetError("release package directory is missing")
+    paths: list[Path] = []
+    for distribution in ("avibe-os", "avibe-memory"):
+        for suffix in (".whl", ".tar.gz"):
+            matches = _package_files(asset_dir, distribution, suffix)
+            if len(matches) != 1:
+                raise ReleaseAssetError(
+                    f"transition release must contain exactly one {distribution} {suffix} artifact"
+                )
+            paths.append(matches[0])
+    return (
+        _wheel_archive(paths[0]),
+        _wheel_archive(paths[2]),
+        _sdist_archive(paths[1]),
+        _sdist_archive(paths[3]),
+    )
+
+
+def _extract_sdist(sdist: Path, destination: Path) -> Path:
+    archive = _sdist_archive(sdist)
+    project_root = destination / sdist.name.removesuffix(".tar.gz")
+    project_root.mkdir(parents=True)
+    for name, content in archive.files.items():
+        target = project_root.joinpath(*PurePosixPath(name).parts)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+    return project_root
+
+
+def rebuild_sdist_wheel(sdist: Path, output_dir: Path) -> Path:
+    extract_dir = output_dir / f"source-{sdist.stem}"
+    project_root = _extract_sdist(sdist, extract_dir)
+    wheel_dir = output_dir / f"wheel-{sdist.stem}"
+    wheel_dir.mkdir(parents=True)
+    environment = {**os.environ, "PYTHONPATH": ""}
+    result = subprocess.run(
+        [sys.executable, "-m", "build", "--wheel", "--outdir", str(wheel_dir), str(project_root)],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ReleaseAssetError(f"isolated sdist rebuild failed for {sdist.name}: {result.stdout}{result.stderr}")
+    wheels = sorted(wheel_dir.glob("*.whl"))
+    if len(wheels) != 1:
+        raise ReleaseAssetError(f"isolated sdist rebuild produced {len(wheels)} wheels for {sdist.name}")
+    return wheels[0]
+
+
+def verify_transition_distributions(
+    asset_dir: Path,
+    rebuild_root: Path,
+    *,
+    builder: SdistBuilder = rebuild_sdist_wheel,
+) -> str:
+    core_wheel, memory_wheel, core_sdist, memory_sdist = _transition_artifacts(asset_dir)
+    version = _assert_transition_packages(core_wheel, memory_wheel, core_sdist, memory_sdist)
+    rebuilt_core = _wheel_archive(builder(core_sdist.path, rebuild_root / "core"))
+    rebuilt_memory = _wheel_archive(builder(memory_sdist.path, rebuild_root / "memory"))
+    rebuilt_version = _assert_transition_packages(
+        rebuilt_core,
+        rebuilt_memory,
+        core_sdist,
+        memory_sdist,
+    )
+    if rebuilt_version != version:
+        raise ReleaseAssetError("rebuilt distribution version differs from staged artifacts")
+    return version
 
 
 def load_release_spec(manifest_path: Path) -> ReleaseSpec:
@@ -308,23 +606,67 @@ def fetch_release_assets(manifest_path: Path, output_dir: Path) -> ReleaseSpec:
     return spec
 
 
+def verify_public_release_assets(manifest_path: Path) -> ReleaseSpec:
+    with tempfile.TemporaryDirectory(prefix="memory-runtime-public-verify-") as temporary:
+        return fetch_release_assets(manifest_path, Path(temporary) / "assets")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path)
     subparsers = parser.add_subparsers(dest="command", required=True)
     fetch = subparsers.add_parser("fetch")
     fetch.add_argument("--output-dir", type=Path, required=True)
     verify = subparsers.add_parser("verify")
     verify.add_argument("--asset-dir", type=Path, required=True)
+    discover = subparsers.add_parser("discover-manifest")
+    discover.add_argument("--asset-dir", type=Path, required=True)
+    discover.add_argument("--output-manifest", type=Path, required=True)
+    discover.add_argument("--release-tag")
+    packages = subparsers.add_parser("verify-packages")
+    packages.add_argument("--asset-dir", type=Path, required=True)
+    packages.add_argument("--work-dir", type=Path)
+    subparsers.add_parser("verify-public")
     subparsers.add_parser("check-policy")
     args = parser.parse_args(argv)
+    if args.command != "discover-manifest" and args.manifest is None:
+        parser.error("--manifest is required for this command")
+    result: dict[str, object] = {}
     try:
         if args.command == "fetch":
             spec = fetch_release_assets(args.manifest, args.output_dir)
         elif args.command == "verify":
             spec = verify_release_assets(args.manifest, args.asset_dir)
+        elif args.command == "discover-manifest":
+            discovery = discover_release_manifest(args.asset_dir)
+            args.output_manifest.parent.mkdir(parents=True, exist_ok=True)
+            args.output_manifest.write_bytes(discovery.manifest_bytes)
+            spec = load_release_spec(args.output_manifest)
+            if args.release_tag and spec.release_tag != args.release_tag:
+                raise ReleaseAssetError("owned manifest release identity does not match the selected release")
+            result["manifest_owner"] = discovery.owner
+        elif args.command == "verify-packages":
+            spec = load_release_spec(args.manifest)
+            if args.work_dir is None:
+                with tempfile.TemporaryDirectory(prefix="memory-distribution-rebuild-") as temporary:
+                    version = verify_transition_distributions(args.asset_dir, Path(temporary))
+            else:
+                args.work_dir.mkdir(parents=True, exist_ok=True)
+                version = verify_transition_distributions(args.asset_dir, args.work_dir)
+            discovery = discover_release_manifest(args.asset_dir)
+            if discovery.owner != "memory" or discovery.manifest_bytes != spec.manifest_bytes:
+                raise ReleaseAssetError("transition package manifest does not match the selected manifest")
+            result["package_version"] = version
+        elif args.command == "verify-public":
+            spec = verify_public_release_assets(args.manifest)
         else:
             spec = load_release_spec(args.manifest)
+    except LegacyManifestAbsent as exc:
+        print(
+            json.dumps({"ok": False, "failure_kind": "legacy_absent", "error": str(exc)}),
+            file=sys.stderr,
+        )
+        return LEGACY_MANIFEST_ABSENT_EXIT
     except ManifestPolicyError as exc:
         print(
             json.dumps({"ok": False, "failure_kind": "policy", "error": str(exc)}),
@@ -343,7 +685,12 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return INTERNAL_GUARD_FAILURE_EXIT
-    print(json.dumps({"ok": True, "release_tag": spec.release_tag, "asset_count": len(spec.expected_asset_names)}))
+    result.update(
+        ok=True,
+        release_tag=spec.release_tag,
+        asset_count=len(spec.expected_asset_names),
+    )
+    print(json.dumps(result))
     return 0
 
 

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -24,7 +24,16 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.version import InvalidVersion, Version
+
+try:
+    from scripts.release_package_version import package_version_from_release_tag
+except ModuleNotFoundError:  # Direct execution adds scripts/, not the repository root.
+    from release_package_version import package_version_from_release_tag
+
 RELEASE_DOWNLOAD_ROOT = "https://github.com/avibe-bot/avibe/releases/download"
+TRANSITION_RELEASE_VERSION = Version("3.0.14")
 EXPECTED_EVEROS_VERSION = "1.2.3"
 EXPECTED_PYTHON_VERSION = "3.12.12"
 EXPECTED_LOCK_SHA256 = "e6acc17e4c0969563d380326e90134965af0822259bb4a9adb4d54433e9737fe"
@@ -258,7 +267,18 @@ def _package_files(asset_dir: Path, distribution: str, suffix: str) -> list[Path
     return sorted(matches)
 
 
-def discover_release_manifest(asset_dir: Path) -> ManifestDiscovery:
+def _release_version(release_tag: str) -> Version:
+    try:
+        return Version(package_version_from_release_tag(release_tag))
+    except (ValueError, InvalidVersion) as exc:
+        raise ReleaseAssetError(f"invalid release tag: {release_tag!r}") from exc
+
+
+def discover_release_manifest(
+    asset_dir: Path,
+    *,
+    release_tag: str | None = None,
+) -> ManifestDiscovery:
     if not asset_dir.is_dir():
         raise ReleaseAssetError("release package directory is missing")
     core_paths = _package_files(asset_dir, "avibe-os", ".whl")
@@ -285,6 +305,8 @@ def discover_release_manifest(asset_dir: Path) -> ManifestDiscovery:
         raise ReleaseAssetError("legacy release unexpectedly contains an unowned Memory wheel")
     if core_manifest:
         return ManifestDiscovery("core", core_manifest)
+    if release_tag is not None and _release_version(release_tag) >= TRANSITION_RELEASE_VERSION:
+        raise ReleaseAssetError("transition-and-later release is missing its Memory manifest")
     raise LegacyManifestAbsent("legacy release predates the Memory Runtime manifest")
 
 
@@ -312,8 +334,21 @@ def _assert_transition_packages(
         raise ReleaseAssetError("core and Memory distribution versions differ")
     if _exact_memory_pin(core_wheel.metadata) != version:
         raise ReleaseAssetError("transition core must hard-depend on the exact Memory version")
-    if len(_requirements_for(memory_wheel.metadata, "avibe-os")) != 1:
+    reverse_requirements = _requirements_for(memory_wheel.metadata, "avibe-os")
+    if len(reverse_requirements) != 1:
         raise ReleaseAssetError("Memory metadata must contain exactly one avibe-os dependency")
+    try:
+        reverse_requirement = Requirement(reverse_requirements[0])
+        core_version = Version(version)
+    except (InvalidRequirement, InvalidVersion) as exc:
+        raise ReleaseAssetError("Memory avibe-os dependency metadata is invalid") from exc
+    if (
+        reverse_requirement.url is not None
+        or reverse_requirement.marker is not None
+        or not reverse_requirement.specifier
+        or core_version not in reverse_requirement.specifier
+    ):
+        raise ReleaseAssetError("Memory avibe-os dependency must accept the exact core version")
     if core_wheel.metadata.requires_python != memory_wheel.metadata.requires_python:
         raise ReleaseAssetError("core and Memory Requires-Python metadata differ")
 
@@ -389,10 +424,13 @@ def verify_transition_distributions(
     asset_dir: Path,
     rebuild_root: Path,
     *,
+    release_tag: str,
     builder: SdistBuilder = rebuild_sdist_wheel,
 ) -> str:
     core_wheel, memory_wheel, core_sdist, memory_sdist = _transition_artifacts(asset_dir)
     version = _assert_transition_packages(core_wheel, memory_wheel, core_sdist, memory_sdist)
+    if Version(version) != _release_version(release_tag):
+        raise ReleaseAssetError("distribution version does not match the release tag")
     rebuilt_core = _wheel_archive(builder(core_sdist.path, rebuild_root / "core"))
     rebuilt_memory = _wheel_archive(builder(memory_sdist.path, rebuild_root / "memory"))
     rebuilt_version = _assert_transition_packages(
@@ -638,7 +676,7 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "verify":
             spec = verify_release_assets(args.manifest, args.asset_dir)
         elif args.command == "discover-manifest":
-            discovery = discover_release_manifest(args.asset_dir)
+            discovery = discover_release_manifest(args.asset_dir, release_tag=args.release_tag)
             args.output_manifest.parent.mkdir(parents=True, exist_ok=True)
             args.output_manifest.write_bytes(discovery.manifest_bytes)
             spec = load_release_spec(args.output_manifest)
@@ -649,11 +687,15 @@ def main(argv: list[str] | None = None) -> int:
             spec = load_release_spec(args.manifest)
             if args.work_dir is None:
                 with tempfile.TemporaryDirectory(prefix="memory-distribution-rebuild-") as temporary:
-                    version = verify_transition_distributions(args.asset_dir, Path(temporary))
+                    version = verify_transition_distributions(
+                        args.asset_dir, Path(temporary), release_tag=spec.release_tag
+                    )
             else:
                 args.work_dir.mkdir(parents=True, exist_ok=True)
-                version = verify_transition_distributions(args.asset_dir, args.work_dir)
-            discovery = discover_release_manifest(args.asset_dir)
+                version = verify_transition_distributions(
+                    args.asset_dir, args.work_dir, release_tag=spec.release_tag
+                )
+            discovery = discover_release_manifest(args.asset_dir, release_tag=spec.release_tag)
             if discovery.owner != "memory" or discovery.manifest_bytes != spec.manifest_bytes:
                 raise ReleaseAssetError("transition package manifest does not match the selected manifest")
             result["package_version"] = version

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -50,7 +50,6 @@ POLICY_EXCLUSION_EXIT = 2
 INTERNAL_GUARD_FAILURE_EXIT = 3
 LEGACY_MANIFEST_ABSENT_EXIT = 4
 MEMORY_MANIFEST_PATH = "vibe/memory_runtime_manifest.json"
-REQUIRED_MEMORY_IMPLEMENTATION = frozenset({"avibe_memory/__init__.py", "avibe_memory/runtime.py"})
 
 
 class ReleaseGuardError(RuntimeError):
@@ -151,24 +150,35 @@ class ManifestDiscovery:
 
 INSTALL_SCHEMES = ("purelib", "platlib", "scripts", "headers", "data")
 PIP_OFFLINE_FLAGS = ("--disable-pip-version-check", "--no-input", "--no-index", "--no-cache-dir")
-_EMPTY_SCHEMES = dict.fromkeys(INSTALL_SCHEMES, frozenset())
-_CORE_LIBRARIES = frozenset({"config/", "core/", "modules/", "storage/", "vibe/"})
-_MEMORY_LIBRARIES = frozenset({"avibe_memory/", MEMORY_MANIFEST_PATH})
-NAMESPACE_POLICIES = {
+_CORE_FORBIDDEN = frozenset({"avibe_memory/", MEMORY_MANIFEST_PATH})
+_MEMORY_FORBIDDEN = frozenset({"config/", "core/", "modules/", "storage/", "vibe/"})
+FORBIDDEN_PATH_POLICIES = {
     1: {
-        "avibe-os": {
-            **_EMPTY_SCHEMES,
-            "purelib": _CORE_LIBRARIES,
-            "platlib": _CORE_LIBRARIES,
-            "scripts": frozenset({"vibe"}),
-        },
+        "avibe-os": {scheme: _CORE_FORBIDDEN for scheme in INSTALL_SCHEMES},
         "avibe-memory": {
-            **_EMPTY_SCHEMES,
-            "purelib": _MEMORY_LIBRARIES,
-            "platlib": _MEMORY_LIBRARIES,
+            **{scheme: _MEMORY_FORBIDDEN for scheme in INSTALL_SCHEMES},
+            "scripts": _MEMORY_FORBIDDEN | {"vibe"},
         },
     }
 }
+_RUNTIME_PROBE = (
+    "import hashlib, importlib.resources as resources, sys\n"
+    "from importlib.metadata import distribution, packages_distributions\n"
+    "from pathlib import Path\n"
+    "expected_version, expected_digest, source = sys.argv[1:]\n"
+    "source = Path(source).resolve()\n"
+    "assert all(source != (path := Path(item).resolve()) and source not in path.parents for item in sys.path)\n"
+    "import avibe_memory\n"
+    "provider = distribution('avibe-memory')\n"
+    "normalize = lambda value: value.lower().replace('_', '-')\n"
+    "assert normalize(provider.metadata['Name']) == 'avibe-memory'\n"
+    "assert provider.version == expected_version\n"
+    "assert {normalize(name) for name in packages_distributions().get('avibe_memory', ())} == {'avibe-memory'}\n"
+    "assert Path(sys.prefix).resolve() in Path(avibe_memory.__file__).resolve().parents\n"
+    "manifest = resources.files('vibe').joinpath('memory_runtime_manifest.json')\n"
+    "assert manifest.is_file()\n"
+    "assert hashlib.sha256(manifest.read_bytes()).hexdigest() == expected_digest\n"
+)
 
 
 def _run_interpreter(
@@ -179,7 +189,7 @@ def _run_interpreter(
     environment = {key: value for key, value in os.environ.items() if not key.startswith("PIP_")}
     environment.update(PIP_CONFIG_FILE=os.devnull, PIP_NO_CACHE_DIR="1", PYTHONNOUSERSITE="1", PYTHONPATH="")
     try:
-        executable = python_executable.expanduser().resolve(strict=True)
+        executable = python_executable.expanduser().absolute()
         result = subprocess.run(
             [str(executable), *arguments],
             env=environment,
@@ -419,7 +429,7 @@ def _package_release_policy(payload: dict, release_tag: str) -> PackageReleasePo
         or not versions
         or any(not isinstance(version, str) for version in versions)
         or len(versions) != len(set(versions))
-        or namespace_policy_version not in NAMESPACE_POLICIES
+        or namespace_policy_version not in FORBIDDEN_PATH_POLICIES
     ):
         raise ManifestPolicyError("manifest package_policy identity is invalid")
     try:
@@ -452,12 +462,12 @@ def discover_release_manifest(
             if memory_paths
             else None
         )
-        core_manifest = _package_file(core, MEMORY_MANIFEST_PATH)
-        memory_manifest = _package_file(memory, MEMORY_MANIFEST_PATH) if memory else None
+        core_manifest = _distribution_resource(core, MEMORY_MANIFEST_PATH)
+        memory_manifest = _distribution_resource(memory, MEMORY_MANIFEST_PATH) if memory else None
     if core_manifest and memory_manifest:
         raise ReleaseAssetError("Memory Runtime manifest ownership is ambiguous")
     if memory_manifest:
-        return ManifestDiscovery("memory", memory_manifest)
+        return ManifestDiscovery("memory", memory_manifest[1])
     transition_pin = _exact_memory_pin(core.metadata)
     if transition_pin is not None:
         detail = "artifact is missing" if memory is None else "artifact has no owned manifest"
@@ -465,18 +475,17 @@ def discover_release_manifest(
     if memory is not None:
         raise ReleaseAssetError("legacy release unexpectedly contains an unowned Memory wheel")
     if core_manifest:
-        return ManifestDiscovery("core", core_manifest)
+        return ManifestDiscovery("core", core_manifest[1])
     if release_tag is not None and _release_version(release_tag) > LAST_LEGACY_RELEASE_VERSION:
         raise ReleaseAssetError("transition-and-later release is missing its Memory manifest")
     raise LegacyManifestAbsent("legacy release predates the Memory Runtime manifest")
 
 
-def _package_file(package: InstalledDistribution, path: str) -> bytes | None:
-    for scheme in ("purelib", "platlib"):
-        key = (scheme, path)
-        if key in package.files:
-            return package.files[key]
-    return None
+def _distribution_resource(package: InstalledDistribution, path: str) -> tuple[str, bytes] | None:
+    matches = [(scheme, content) for (scheme, name), content in package.files.items() if name == path]
+    if len(matches) > 1:
+        raise ReleaseAssetError(f"distribution resource has multiple installed locations: {path}")
+    return matches[0] if matches else None
 
 
 def _owned_files(package: InstalledDistribution) -> dict[tuple[str, str], bytes]:
@@ -490,17 +499,18 @@ def _owned_files(package: InstalledDistribution) -> dict[tuple[str, str], bytes]
     }
 
 
-def _assert_namespace_policy(
+def _assert_forbidden_paths(
     package: InstalledDistribution,
     distribution: str,
     policy_version: int,
 ) -> None:
-    policy = NAMESPACE_POLICIES[policy_version][distribution]
+    policy = FORBIDDEN_PATH_POLICIES[policy_version][distribution]
     for key in _owned_files(package):
         scheme, path = key
-        allowed = policy[scheme]
-        if not any(path == entry or (entry.endswith("/") and path.startswith(entry)) for entry in allowed):
-            raise ReleaseAssetError(f"{distribution} artifact violates namespace policy: {scheme}/{path}")
+        if distribution == "avibe-memory" and path == MEMORY_MANIFEST_PATH:
+            continue
+        if any(path == entry or (entry.endswith("/") and path.startswith(entry)) for entry in policy.get(scheme, ())):
+            raise ReleaseAssetError(f"{distribution} artifact violates forbidden path policy: {scheme}/{path}")
 
 
 def _assert_transition_pair(
@@ -528,21 +538,8 @@ def _assert_transition_pair(
     requires_python = {core.metadata.requires_python, memory.metadata.requires_python}
     if requires_python != {policy.requires_python}:
         raise ReleaseAssetError(f"core and Memory Requires-Python must match release policy {policy.requires_python}")
-    _assert_namespace_policy(core, "avibe-os", policy.namespace_policy_version)
-    _assert_namespace_policy(memory, "avibe-memory", policy.namespace_policy_version)
-    if _package_file(core, MEMORY_MANIFEST_PATH) is not None:
-        raise ReleaseAssetError("core artifact must not own the Memory Runtime manifest")
-    implementation = {
-        path for scheme, path in memory.files if scheme in {"purelib", "platlib"} and path.startswith("avibe_memory/")
-    }
-    if not REQUIRED_MEMORY_IMPLEMENTATION.issubset(implementation):
-        raise ReleaseAssetError("Memory artifact is missing required implementation files")
-    if _package_file(memory, MEMORY_MANIFEST_PATH) is None:
-        raise ReleaseAssetError("Memory artifact is missing its owned manifest")
-    collisions = set(_owned_files(core)) & set(_owned_files(memory))
-    if collisions:
-        scheme, path = sorted(collisions)[0]
-        raise ReleaseAssetError(f"core and Memory install paths collide: {scheme}/{path}")
+    _assert_forbidden_paths(core, "avibe-os", policy.namespace_policy_version)
+    _assert_forbidden_paths(memory, "avibe-memory", policy.namespace_policy_version)
     return version
 
 
@@ -606,6 +603,48 @@ def _install_pair(
     )
 
 
+def _runtime_probe(
+    wheels: tuple[Path, Path],
+    find_links: tuple[Path, ...],
+    root: Path,
+    python_executable: Path,
+    version: str,
+    manifest_bytes: bytes,
+) -> None:
+    environment = root / "environment"
+    _run_interpreter(
+        python_executable,
+        ["-I", "-m", "venv", str(environment)],
+        "cannot create isolated Memory runtime probe environment",
+    )
+    environment_python = environment / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    links = [item for directory in find_links for item in ("--find-links", str(directory.resolve()))]
+    _run_pip(
+        environment_python,
+        [
+            "install",
+            *PIP_OFFLINE_FLAGS,
+            "--no-compile",
+            "--only-binary=:all:",
+            *links,
+            *(str(w.resolve()) for w in wheels),
+        ],
+        "offline pip install failed",
+    )
+    _run_interpreter(
+        environment_python,
+        [
+            "-I",
+            "-c",
+            _RUNTIME_PROBE,
+            version,
+            hashlib.sha256(manifest_bytes).hexdigest(),
+            str(Path(__file__).resolve().parents[1]),
+        ],
+        "installed Memory runtime probe failed",
+    )
+
+
 def verify_transition_distributions(
     asset_dir: Path,
     rebuild_root: Path,
@@ -618,7 +657,8 @@ def verify_transition_distributions(
     rebuild_root.mkdir(parents=True, exist_ok=True)
     attempt = Path(tempfile.mkdtemp(prefix="attempt-", dir=rebuild_root))
     staged = _install_pair((core_wheel, memory_wheel), attempt / "staged", python_executable)
-    manifest_bytes = _package_file(staged[1], MEMORY_MANIFEST_PATH)
+    manifest_resource = _distribution_resource(staged[1], MEMORY_MANIFEST_PATH)
+    manifest_bytes = manifest_resource[1] if manifest_resource else None
     try:
         manifest_payload = json.loads(manifest_bytes) if manifest_bytes is not None else None
     except (TypeError, json.JSONDecodeError) as exc:
@@ -637,13 +677,6 @@ def verify_transition_distributions(
     version = _assert_transition_pair(*staged, policy)
     if Version(version) != _release_version(release_tag):
         raise ReleaseAssetError("distribution version does not match the release tag")
-    _pip_install(
-        python_executable,
-        (core_wheel, memory_wheel),
-        (asset_dir,),
-        attempt / "staged-combined",
-        no_deps=False,
-    )
     rebuilt_wheels = (
         rebuild_sdist_wheel(
             core_sdist, attempt / "core-build", python_executable=python_executable, find_links=(asset_dir,)
@@ -665,12 +698,21 @@ def verify_transition_distributions(
             raise ReleaseAssetError(f"{distribution} wheel and sdist metadata differ")
         if _owned_files(staged_package) != _owned_files(rebuilt_package):
             raise ReleaseAssetError(f"{distribution} wheel and sdist installed content differ")
-    _pip_install(
+    _runtime_probe(
+        (core_wheel, memory_wheel),
+        (asset_dir,),
+        attempt / "staged-runtime",
         python_executable,
+        version,
+        manifest_bytes,
+    )
+    _runtime_probe(
         rebuilt_wheels,
         (asset_dir, rebuilt_wheels[0].parent, rebuilt_wheels[1].parent),
-        attempt / "rebuilt-combined",
-        no_deps=False,
+        attempt / "rebuilt-runtime",
+        python_executable,
+        version,
+        manifest_bytes,
     )
     return version
 

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -28,12 +28,20 @@ from packaging.requirements import InvalidRequirement, Requirement
 from packaging.version import InvalidVersion, Version
 
 try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 project support.
+    import tomli as tomllib
+
+try:
     from scripts.release_package_version import package_version_from_release_tag
 except ModuleNotFoundError:  # Direct execution adds scripts/, not the repository root.
     from release_package_version import package_version_from_release_tag
 
 RELEASE_DOWNLOAD_ROOT = "https://github.com/avibe-bot/avibe/releases/download"
 LAST_LEGACY_RELEASE_VERSION = Version("3.0.14rc2")
+PROJECT_REQUIRES_PYTHON = tomllib.loads(
+    (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(encoding="utf-8")
+)["project"]["requires-python"]
 EXPECTED_EVEROS_VERSION = "1.2.3"
 EXPECTED_PYTHON_VERSION = "3.12.12"
 EXPECTED_LOCK_SHA256 = "e6acc17e4c0969563d380326e90134965af0822259bb4a9adb4d54433e9737fe"
@@ -237,6 +245,20 @@ def _sdist_archive(path: Path) -> PackageArchive:
     return PackageArchive(path, _metadata(files["PKG-INFO"], path.name), files)
 
 
+def _installed_files(package: PackageArchive) -> dict[str, bytes]:
+    if package.path.suffix != ".whl":
+        return package.files
+    installed: dict[str, bytes] = {}
+    for name, content in package.files.items():
+        parts = PurePosixPath(name).parts
+        if len(parts) >= 3 and parts[0].endswith(".data") and parts[1] in {"purelib", "platlib"}:
+            name = PurePosixPath(*parts[2:]).as_posix()
+        if name in installed:
+            raise ReleaseAssetError(f"wheel has colliding install paths: {package.path.name}")
+        installed[name] = content
+    return installed
+
+
 def _requirements_for(metadata: PackageMetadata, name: str) -> tuple[str, ...]:
     expected = _canonical_name(name)
     matches = []
@@ -288,9 +310,9 @@ def discover_release_manifest(
     core = _wheel_archive(core_paths[0])
     if core.metadata.name != "avibe-os":
         raise ReleaseAssetError("core wheel metadata Name must be avibe-os")
-    core_manifest = core.files.get(MEMORY_MANIFEST_PATH)
+    core_manifest = _installed_files(core).get(MEMORY_MANIFEST_PATH)
     memory = _wheel_archive(memory_paths[0]) if memory_paths else None
-    memory_manifest = memory.files.get(MEMORY_MANIFEST_PATH) if memory else None
+    memory_manifest = _installed_files(memory).get(MEMORY_MANIFEST_PATH) if memory else None
     if memory and memory.metadata.name != "avibe-memory":
         raise ReleaseAssetError("Memory wheel metadata Name must be avibe-memory")
     if core_manifest and memory_manifest:
@@ -318,7 +340,7 @@ def _assert_metadata_parity(wheel: PackageArchive, sdist: PackageArchive, name: 
 
 
 def _owned_content(package: PackageArchive, prefix: str) -> dict[str, bytes]:
-    return {name: value for name, value in package.files.items() if name.startswith(prefix)}
+    return {name: value for name, value in _installed_files(package).items() if name.startswith(prefix)}
 
 
 def _assert_transition_packages(
@@ -349,11 +371,16 @@ def _assert_transition_packages(
         or core_version not in reverse_requirement.specifier
     ):
         raise ReleaseAssetError("Memory avibe-os dependency must accept the exact core version")
-    if core_wheel.metadata.requires_python != memory_wheel.metadata.requires_python:
-        raise ReleaseAssetError("core and Memory Requires-Python metadata differ")
+    if (
+        core_wheel.metadata.requires_python != PROJECT_REQUIRES_PYTHON
+        or memory_wheel.metadata.requires_python != PROJECT_REQUIRES_PYTHON
+    ):
+        raise ReleaseAssetError(
+            f"core and Memory Requires-Python must match the project range {PROJECT_REQUIRES_PYTHON}"
+        )
 
     for package in (core_wheel, core_sdist):
-        if _owned_content(package, "avibe_memory/") or MEMORY_MANIFEST_PATH in package.files:
+        if _owned_content(package, "avibe_memory/") or MEMORY_MANIFEST_PATH in _installed_files(package):
             raise ReleaseAssetError(f"core artifact owns Memory content: {package.path.name}")
     wheel_implementation = _owned_content(memory_wheel, "avibe_memory/")
     sdist_implementation = _owned_content(memory_sdist, "avibe_memory/")
@@ -361,8 +388,8 @@ def _assert_transition_packages(
         raise ReleaseAssetError("Memory artifact is missing required implementation files")
     if wheel_implementation != sdist_implementation:
         raise ReleaseAssetError("Memory wheel and sdist implementation content differ")
-    wheel_manifest = memory_wheel.files.get(MEMORY_MANIFEST_PATH)
-    sdist_manifest = memory_sdist.files.get(MEMORY_MANIFEST_PATH)
+    wheel_manifest = _installed_files(memory_wheel).get(MEMORY_MANIFEST_PATH)
+    sdist_manifest = _installed_files(memory_sdist).get(MEMORY_MANIFEST_PATH)
     if wheel_manifest is None or wheel_manifest != sdist_manifest:
         raise ReleaseAssetError("Memory wheel and sdist manifest content differ")
     return version
@@ -400,9 +427,11 @@ def _extract_sdist(sdist: Path, destination: Path) -> Path:
 
 
 def rebuild_sdist_wheel(sdist: Path, output_dir: Path) -> Path:
-    extract_dir = output_dir / f"source-{sdist.stem}"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    attempt_dir = Path(tempfile.mkdtemp(prefix="attempt-", dir=output_dir))
+    extract_dir = attempt_dir / "source"
     project_root = _extract_sdist(sdist, extract_dir)
-    wheel_dir = output_dir / f"wheel-{sdist.stem}"
+    wheel_dir = attempt_dir / "wheel"
     wheel_dir.mkdir(parents=True)
     environment = {**os.environ, "PYTHONPATH": ""}
     result = subprocess.run(

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-from contextlib import nullcontext
 import hashlib
 from importlib.metadata import PathDistribution
 import json
@@ -134,6 +133,7 @@ class InstalledDistribution:
     metadata: PackageMetadata
     dist_info: str
     files: dict[tuple[str, str], bytes]
+    python_version: str
 
 
 @dataclass(frozen=True)
@@ -180,8 +180,6 @@ def _run_interpreter(
     environment.update(PIP_CONFIG_FILE=os.devnull, PIP_NO_CACHE_DIR="1", PYTHONNOUSERSITE="1", PYTHONPATH="")
     try:
         executable = python_executable.expanduser().resolve(strict=True)
-        if not executable.is_file() or not os.access(executable, os.X_OK):
-            raise OSError("path is not executable")
         result = subprocess.run(
             [str(executable), *arguments],
             env=environment,
@@ -246,24 +244,13 @@ def _metadata(message, context: str) -> PackageMetadata:
     )
 
 
-def _interpreter_version(python_executable: Path) -> str:
-    result = _run_interpreter(
-        python_executable,
-        ["-I", "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"],
-        "cannot identify requested Python interpreter",
-    )
-    version = result.stdout.strip()
-    if len(version.split(".")) != 2 or not version.replace(".", "").isdigit():
-        raise ReleaseAssetError("requested Python interpreter reported an invalid version")
-    return version
-
-
-def _pip_scheme(python_executable: Path, prefix: Path, distribution: str) -> dict[str, Path]:
+def _pip_scheme(python_executable: Path, prefix: Path, distribution: str) -> tuple[dict[str, Path], str]:
     script = (
         "import json,sys; from pip._internal.locations import get_scheme; "
         "s=get_scheme(sys.argv[1],prefix=sys.argv[2]); "
         "print(json.dumps({k:getattr(s,k) for k in "
-        "('purelib','platlib','scripts','headers','data')}))"
+        "('purelib','platlib','scripts','headers','data')} | "
+        "{'python':f'{sys.version_info.major}.{sys.version_info.minor}'}))"
     )
     result = _run_interpreter(
         python_executable,
@@ -272,15 +259,12 @@ def _pip_scheme(python_executable: Path, prefix: Path, distribution: str) -> dic
     )
     try:
         raw = json.loads(result.stdout)
-        if (
-            not isinstance(raw, dict)
-            or set(raw) != set(INSTALL_SCHEMES)
-            or not all(map(lambda value: isinstance(value, str), raw.values()))
-        ):
+        keys = {*INSTALL_SCHEMES, "python"}
+        if not isinstance(raw, dict) or set(raw) != keys or not all(isinstance(value, str) for value in raw.values()):
             raise ValueError
     except (json.JSONDecodeError, ValueError) as exc:
         raise ReleaseAssetError(f"pip install scheme is invalid for {distribution}") from exc
-    return {key: Path(value).resolve() for key, value in raw.items()}
+    return ({key: Path(raw[key]).resolve() for key in INSTALL_SCHEMES}, raw["python"])
 
 
 def _pip_install(
@@ -325,7 +309,7 @@ def _installed_distribution(
     if metadata.name != canonicalize_name(distribution):
         raise ReleaseAssetError(f"installed distribution identity differs from expected {distribution}")
     _assert_filename_identity(wheel, metadata)
-    scheme = _pip_scheme(python_executable, prefix, distribution)
+    scheme, python_version = _pip_scheme(python_executable, prefix, distribution)
     scheme_roots = sorted(
         scheme.items(),
         key=lambda item: (-len(item[1].parts), INSTALL_SCHEMES.index(item[0])),
@@ -359,7 +343,7 @@ def _installed_distribution(
     actual = {path.resolve() for path in prefix.rglob("*") if path.is_file()}
     if actual != recorded:
         raise ReleaseAssetError(f"installed inventory differs from RECORD: {wheel.name}")
-    return InstalledDistribution(metadata, metadata_path.parent.name, files)
+    return InstalledDistribution(metadata, metadata_path.parent.name, files, python_version)
 
 
 def _requirements_for(metadata: PackageMetadata, name: str) -> tuple[Requirement, ...]:
@@ -488,14 +472,11 @@ def discover_release_manifest(
 
 
 def _package_file(package: InstalledDistribution, path: str) -> bytes | None:
-    matches = [
-        content
-        for (scheme, name), content in package.files.items()
-        if scheme in {"purelib", "platlib"} and name == path
-    ]
-    if len(matches) > 1:
-        raise ReleaseAssetError(f"installed distribution has duplicate library paths: {path}")
-    return matches[0] if matches else None
+    for scheme in ("purelib", "platlib"):
+        key = (scheme, path)
+        if key in package.files:
+            return package.files[key]
+    return None
 
 
 def _owned_files(package: InstalledDistribution) -> dict[tuple[str, str], bytes]:
@@ -633,7 +614,6 @@ def verify_transition_distributions(
     python_executable: Path,
     expected_manifest: bytes | None = None,
 ) -> str:
-    python_version = _interpreter_version(python_executable)
     core_wheel, memory_wheel, core_sdist, memory_sdist = _transition_artifacts(asset_dir)
     rebuild_root.mkdir(parents=True, exist_ok=True)
     attempt = Path(tempfile.mkdtemp(prefix="attempt-", dir=rebuild_root))
@@ -648,8 +628,10 @@ def verify_transition_distributions(
     policy = _package_release_policy(manifest_payload, release_tag)
     if policy is None:
         raise ReleaseAssetError("Memory artifact manifest is missing frozen package_policy")
-    if python_version not in policy.supported_python_versions:
-        raise ReleaseAssetError(f"requested Python {python_version} is not in the release policy interpreter matrix")
+    if staged[0].python_version not in policy.supported_python_versions:
+        raise ReleaseAssetError(
+            f"requested Python {staged[0].python_version} is not in the release policy interpreter matrix"
+        )
     if expected_manifest is not None and manifest_bytes != expected_manifest:
         raise ReleaseAssetError("transition package manifest does not match the selected manifest")
     version = _assert_transition_pair(*staged, policy)
@@ -933,15 +915,10 @@ def main(argv: list[str] | None = None) -> int:
             result["manifest_owner"] = discovery.owner
         elif args.command == "verify-packages":
             spec = load_release_spec(args.manifest)
-            workspace = (
-                tempfile.TemporaryDirectory(prefix="memory-distribution-rebuild-")
-                if args.work_dir is None
-                else nullcontext(args.work_dir)
-            )
-            with workspace as work_dir:
+            with tempfile.TemporaryDirectory(prefix="memory-distribution-rebuild-") as temporary:
                 version = verify_transition_distributions(
                     args.asset_dir,
-                    Path(work_dir),
+                    args.work_dir or Path(temporary),
                     release_tag=spec.release_tag,
                     python_executable=args.python_executable,
                     expected_manifest=spec.manifest_bytes,

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -33,7 +33,7 @@ except ModuleNotFoundError:  # Direct execution adds scripts/, not the repositor
     from release_package_version import package_version_from_release_tag
 
 RELEASE_DOWNLOAD_ROOT = "https://github.com/avibe-bot/avibe/releases/download"
-TRANSITION_RELEASE_VERSION = Version("3.0.14")
+LAST_LEGACY_RELEASE_VERSION = Version("3.0.14rc2")
 EXPECTED_EVEROS_VERSION = "1.2.3"
 EXPECTED_PYTHON_VERSION = "3.12.12"
 EXPECTED_LOCK_SHA256 = "e6acc17e4c0969563d380326e90134965af0822259bb4a9adb4d54433e9737fe"
@@ -305,7 +305,7 @@ def discover_release_manifest(
         raise ReleaseAssetError("legacy release unexpectedly contains an unowned Memory wheel")
     if core_manifest:
         return ManifestDiscovery("core", core_manifest)
-    if release_tag is not None and _release_version(release_tag) >= TRANSITION_RELEASE_VERSION:
+    if release_tag is not None and _release_version(release_tag) > LAST_LEGACY_RELEASE_VERSION:
         raise ReleaseAssetError("transition-and-later release is missing its Memory manifest")
     raise LegacyManifestAbsent("legacy release predates the Memory Runtime manifest")
 

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Verify and materialize manifest-pinned Memory Runtime release assets."""
+"""Verify and materialize manifest-pinned Memory Runtime release assets.
+
+Identity and byte-level checks precede semantic parsing. Semantic policy parsers
+never receive bytes that failed an available identity or exact-byte check.
+"""
 
 from __future__ import annotations
 
@@ -161,24 +165,6 @@ FORBIDDEN_PATH_POLICIES = {
         },
     }
 }
-_RUNTIME_PROBE = (
-    "import hashlib, importlib.resources as resources, sys\n"
-    "from importlib.metadata import distribution, packages_distributions\n"
-    "from pathlib import Path\n"
-    "expected_version, expected_digest, source = sys.argv[1:]\n"
-    "source = Path(source).resolve()\n"
-    "assert all(source != (path := Path(item).resolve()) and source not in path.parents for item in sys.path)\n"
-    "import avibe_memory\n"
-    "provider = distribution('avibe-memory')\n"
-    "normalize = lambda value: value.lower().replace('_', '-')\n"
-    "assert normalize(provider.metadata['Name']) == 'avibe-memory'\n"
-    "assert provider.version == expected_version\n"
-    "assert {normalize(name) for name in packages_distributions().get('avibe_memory', ())} == {'avibe-memory'}\n"
-    "assert Path(sys.prefix).resolve() in Path(avibe_memory.__file__).resolve().parents\n"
-    "manifest = resources.files('vibe').joinpath('memory_runtime_manifest.json')\n"
-    "assert manifest.is_file()\n"
-    "assert hashlib.sha256(manifest.read_bytes()).hexdigest() == expected_digest\n"
-)
 
 
 def _run_interpreter(
@@ -189,7 +175,7 @@ def _run_interpreter(
     environment = {key: value for key, value in os.environ.items() if not key.startswith("PIP_")}
     environment.update(PIP_CONFIG_FILE=os.devnull, PIP_NO_CACHE_DIR="1", PYTHONNOUSERSITE="1", PYTHONPATH="")
     try:
-        executable = python_executable.expanduser().absolute()
+        executable = python_executable.expanduser().resolve(strict=True)
         result = subprocess.run(
             [str(executable), *arguments],
             env=environment,
@@ -603,48 +589,6 @@ def _install_pair(
     )
 
 
-def _runtime_probe(
-    wheels: tuple[Path, Path],
-    find_links: tuple[Path, ...],
-    root: Path,
-    python_executable: Path,
-    version: str,
-    manifest_bytes: bytes,
-) -> None:
-    environment = root / "environment"
-    _run_interpreter(
-        python_executable,
-        ["-I", "-m", "venv", str(environment)],
-        "cannot create isolated Memory runtime probe environment",
-    )
-    environment_python = environment / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
-    links = [item for directory in find_links for item in ("--find-links", str(directory.resolve()))]
-    _run_pip(
-        environment_python,
-        [
-            "install",
-            *PIP_OFFLINE_FLAGS,
-            "--no-compile",
-            "--only-binary=:all:",
-            *links,
-            *(str(w.resolve()) for w in wheels),
-        ],
-        "offline pip install failed",
-    )
-    _run_interpreter(
-        environment_python,
-        [
-            "-I",
-            "-c",
-            _RUNTIME_PROBE,
-            version,
-            hashlib.sha256(manifest_bytes).hexdigest(),
-            str(Path(__file__).resolve().parents[1]),
-        ],
-        "installed Memory runtime probe failed",
-    )
-
-
 def verify_transition_distributions(
     asset_dir: Path,
     rebuild_root: Path,
@@ -659,6 +603,8 @@ def verify_transition_distributions(
     staged = _install_pair((core_wheel, memory_wheel), attempt / "staged", python_executable)
     manifest_resource = _distribution_resource(staged[1], MEMORY_MANIFEST_PATH)
     manifest_bytes = manifest_resource[1] if manifest_resource else None
+    if expected_manifest is not None and manifest_bytes != expected_manifest:
+        raise ReleaseAssetError("transition package manifest does not match the selected manifest")
     try:
         manifest_payload = json.loads(manifest_bytes) if manifest_bytes is not None else None
     except (TypeError, json.JSONDecodeError) as exc:
@@ -672,8 +618,6 @@ def verify_transition_distributions(
         raise ReleaseAssetError(
             f"requested Python {staged[0].python_version} is not in the release policy interpreter matrix"
         )
-    if expected_manifest is not None and manifest_bytes != expected_manifest:
-        raise ReleaseAssetError("transition package manifest does not match the selected manifest")
     version = _assert_transition_pair(*staged, policy)
     if Version(version) != _release_version(release_tag):
         raise ReleaseAssetError("distribution version does not match the release tag")
@@ -698,22 +642,6 @@ def verify_transition_distributions(
             raise ReleaseAssetError(f"{distribution} wheel and sdist metadata differ")
         if _owned_files(staged_package) != _owned_files(rebuilt_package):
             raise ReleaseAssetError(f"{distribution} wheel and sdist installed content differ")
-    _runtime_probe(
-        (core_wheel, memory_wheel),
-        (asset_dir,),
-        attempt / "staged-runtime",
-        python_executable,
-        version,
-        manifest_bytes,
-    )
-    _runtime_probe(
-        rebuilt_wheels,
-        (asset_dir, rebuilt_wheels[0].parent, rebuilt_wheels[1].parent),
-        attempt / "rebuilt-runtime",
-        python_executable,
-        version,
-        manifest_bytes,
-    )
     return version
 
 

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -4,13 +4,11 @@
 from __future__ import annotations
 
 import argparse
-from email.message import Message
 from email.parser import Parser
 import hashlib
 import json
 import os
 from pathlib import PurePosixPath
-import re
 import shutil
 import subprocess
 import sys
@@ -25,12 +23,15 @@ from pathlib import Path
 from typing import Callable
 
 from packaging.requirements import InvalidRequirement, Requirement
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.utils import (
+    InvalidSdistFilename,
+    InvalidWheelFilename,
+    canonicalize_name,
+    parse_sdist_filename,
+    parse_wheel_filename,
+)
 from packaging.version import InvalidVersion, Version
-
-try:
-    import tomllib
-except ModuleNotFoundError:  # Python 3.10 project support.
-    import tomli as tomllib
 
 try:
     from scripts.release_package_version import package_version_from_release_tag
@@ -39,9 +40,6 @@ except ModuleNotFoundError:  # Direct execution adds scripts/, not the repositor
 
 RELEASE_DOWNLOAD_ROOT = "https://github.com/avibe-bot/avibe/releases/download"
 LAST_LEGACY_RELEASE_VERSION = Version("3.0.14rc2")
-PROJECT_REQUIRES_PYTHON = tomllib.loads(
-    (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(encoding="utf-8")
-)["project"]["requires-python"]
 EXPECTED_EVEROS_VERSION = "1.2.3"
 EXPECTED_PYTHON_VERSION = "3.12.12"
 EXPECTED_LOCK_SHA256 = "e6acc17e4c0969563d380326e90134965af0822259bb4a9adb4d54433e9737fe"
@@ -55,9 +53,7 @@ POLICY_EXCLUSION_EXIT = 2
 INTERNAL_GUARD_FAILURE_EXIT = 3
 LEGACY_MANIFEST_ABSENT_EXIT = 4
 MEMORY_MANIFEST_PATH = "vibe/memory_runtime_manifest.json"
-REQUIRED_MEMORY_IMPLEMENTATION = frozenset(
-    {"avibe_memory/__init__.py", "avibe_memory/runtime.py"}
-)
+REQUIRED_MEMORY_IMPLEMENTATION = frozenset({"avibe_memory/__init__.py", "avibe_memory/runtime.py"})
 
 
 class ReleaseGuardError(RuntimeError):
@@ -143,12 +139,52 @@ class PackageArchive:
 
 
 @dataclass(frozen=True)
+class PackageReleasePolicy:
+    requires_python: str
+    supported_python_versions: tuple[str, ...]
+    namespace_policy_version: int
+
+
+@dataclass(frozen=True)
 class ManifestDiscovery:
     owner: str
     manifest_bytes: bytes
 
 
 SdistBuilder = Callable[[Path, Path], Path]
+
+NAMESPACE_POLICIES = {
+    1: {
+        "avibe-os": frozenset({"config", "core", "modules", "storage", "vibe"}),
+        "avibe-memory": frozenset({"avibe_memory"}),
+    }
+}
+PIP_FLAGS = (
+    "install",
+    "--dry-run",
+    "--ignore-installed",
+    "--disable-pip-version-check",
+    "--no-input",
+    "--no-index",
+    "--only-binary=:all:",
+)
+
+
+def _run_pip(arguments: list[str], failure: str) -> None:
+    pip = shutil.which("pip") or shutil.which("pip3")
+    if pip is None:
+        raise ReleaseAssetError("offline pip tooling is unavailable")
+    environment = {key: value for key, value in os.environ.items() if not key.startswith("PIP_")}
+    environment.update(PIP_CONFIG_FILE=os.devnull, PIP_NO_CACHE_DIR="1", PYTHONPATH="")
+    result = subprocess.run(
+        [pip, *arguments],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode:
+        raise ReleaseAssetError(f"{failure}: {result.stdout}{result.stderr}")
 
 
 def _sha256(path: Path) -> str:
@@ -166,13 +202,27 @@ def _required_string(payload: dict, key: str, context: str) -> str:
     return value
 
 
-def _canonical_name(value: str) -> str:
-    return re.sub(r"[-_.]+", "-", value).lower()
+def _filename_identity(path: Path) -> tuple[str, Version]:
+    try:
+        parsed = parse_wheel_filename(path.name)[:2] if path.name.endswith(".whl") else parse_sdist_filename(path.name)
+    except (InvalidWheelFilename, InvalidSdistFilename) as exc:
+        raise ReleaseAssetError(f"invalid distribution filename: {path.name}") from exc
+    return str(parsed[0]), parsed[1]
+
+
+def _assert_filename_identity(path: Path, metadata: PackageMetadata) -> None:
+    filename_name, filename_version = _filename_identity(path)
+    try:
+        metadata_version = Version(metadata.version)
+    except InvalidVersion as exc:
+        raise ReleaseAssetError(f"invalid distribution metadata Version: {path.name}") from exc
+    if filename_name != metadata.name or filename_version != metadata_version:
+        raise ReleaseAssetError(f"distribution filename identity differs from metadata: {path.name}")
 
 
 def _metadata(message_bytes: bytes, context: str) -> PackageMetadata:
     try:
-        message: Message = Parser().parsestr(message_bytes.decode("utf-8"))
+        message = Parser().parsestr(message_bytes.decode("utf-8"))
     except UnicodeDecodeError as exc:
         raise ReleaseAssetError(f"{context} metadata is not UTF-8") from exc
     required: dict[str, str] = {}
@@ -182,37 +232,40 @@ def _metadata(message_bytes: bytes, context: str) -> PackageMetadata:
             raise ReleaseAssetError(f"{context} metadata must contain exactly one {key}")
         required[key] = values[0]
     return PackageMetadata(
-        name=_canonical_name(required["Name"]),
+        name=str(canonicalize_name(required["Name"])),
         version=required["Version"],
         requires_python=required["Requires-Python"],
         requires_dist=tuple(sorted(message.get_all("Requires-Dist") or [])),
     )
 
 
+def _validate_wheel_structure(path: Path) -> None:
+    _run_pip(
+        [*PIP_FLAGS, "--no-deps", "--ignore-requires-python", str(path.resolve())],
+        f"wheel structure validation failed for {path.name}",
+    )
+
+
 def _wheel_archive(path: Path) -> PackageArchive:
+    _validate_wheel_structure(path)
     try:
         with zipfile.ZipFile(path) as archive:
             names = archive.namelist()
             if len(names) != len(set(names)):
                 raise ReleaseAssetError(f"wheel contains duplicate paths: {path.name}")
             if any(
-                "\\" in name
-                or PurePosixPath(name).is_absolute()
-                or ".." in PurePosixPath(name).parts
-                for name in names
+                "\\" in name or PurePosixPath(name).is_absolute() or ".." in PurePosixPath(name).parts for name in names
             ):
                 raise ReleaseAssetError(f"wheel contains an unsafe path: {path.name}")
-            files = {
-                name: archive.read(name)
-                for name in names
-                if not name.endswith("/")
-            }
+            files = {name: archive.read(name) for name in names if not name.endswith("/")}
     except (OSError, zipfile.BadZipFile) as exc:
         raise ReleaseAssetError(f"cannot read wheel {path.name}: {exc}") from exc
     metadata_paths = [name for name in files if name.endswith(".dist-info/METADATA")]
     if len(metadata_paths) != 1:
         raise ReleaseAssetError(f"wheel must contain exactly one METADATA file: {path.name}")
-    return PackageArchive(path, _metadata(files[metadata_paths[0]], path.name), files)
+    package = PackageArchive(path, _metadata(files[metadata_paths[0]], path.name), files)
+    _assert_filename_identity(path, package.metadata)
+    return package
 
 
 def _sdist_archive(path: Path) -> PackageArchive:
@@ -236,13 +289,13 @@ def _sdist_archive(path: Path) -> PackageArchive:
                 if not relative or relative in files:
                     raise ReleaseAssetError(f"sdist contains duplicate or root-level content: {path.name}")
                 files[relative] = stream.read()
-    except ReleaseAssetError:
-        raise
     except (OSError, tarfile.TarError) as exc:
         raise ReleaseAssetError(f"cannot read sdist {path.name}: {exc}") from exc
     if len(roots) != 1 or "PKG-INFO" not in files:
         raise ReleaseAssetError(f"sdist must have one root and one PKG-INFO: {path.name}")
-    return PackageArchive(path, _metadata(files["PKG-INFO"], path.name), files)
+    package = PackageArchive(path, _metadata(files["PKG-INFO"], path.name), files)
+    _assert_filename_identity(path, package.metadata)
+    return package
 
 
 def _installed_files(package: PackageArchive) -> dict[str, bytes]:
@@ -259,31 +312,36 @@ def _installed_files(package: PackageArchive) -> dict[str, bytes]:
     return installed
 
 
-def _requirements_for(metadata: PackageMetadata, name: str) -> tuple[str, ...]:
-    expected = _canonical_name(name)
-    matches = []
-    for requirement in metadata.requires_dist:
-        match = re.match(r"\s*([A-Za-z0-9_.-]+)", requirement)
-        if match and _canonical_name(match.group(1)) == expected:
-            matches.append(requirement)
-    return tuple(matches)
+def _requirements_for(metadata: PackageMetadata, name: str) -> tuple[Requirement, ...]:
+    expected = canonicalize_name(name)
+    try:
+        requirements = tuple(Requirement(raw) for raw in metadata.requires_dist)
+    except InvalidRequirement as exc:
+        raise ReleaseAssetError(f"{metadata.name} has invalid Requires-Dist metadata") from exc
+    return tuple(item for item in requirements if canonicalize_name(item.name) == expected)
 
 
 def _exact_memory_pin(metadata: PackageMetadata) -> str | None:
     requirements = _requirements_for(metadata, "avibe-memory")
     if len(requirements) != 1:
         return None
-    match = re.fullmatch(r"\s*avibe[-_.]memory\s*==\s*([^\s;]+)\s*", requirements[0], re.IGNORECASE)
-    return match.group(1) if match else None
+    requirement = requirements[0]
+    specifiers = tuple(requirement.specifier)
+    if (
+        requirement.extras
+        or requirement.url is not None
+        or requirement.marker is not None
+        or len(specifiers) != 1
+        or specifiers[0].operator != "=="
+    ):
+        return None
+    return str(Version(specifiers[0].version))
 
 
 def _package_files(asset_dir: Path, distribution: str, suffix: str) -> list[Path]:
-    prefix = distribution.replace("-", "_") + "-"
-    matches = [
-        path
-        for path in asset_dir.iterdir()
-        if path.name.startswith(prefix) and path.name.endswith(suffix)
-    ]
+    expected = canonicalize_name(distribution)
+    candidates = [path for path in asset_dir.iterdir() if path.name.endswith(suffix)]
+    matches = [path for path in candidates if _filename_identity(path)[0] == expected]
     if any(path.is_symlink() or not path.is_file() for path in matches):
         raise ReleaseAssetError(f"{distribution} release artifacts contain an unsafe entry")
     return sorted(matches)
@@ -294,6 +352,46 @@ def _release_version(release_tag: str) -> Version:
         return Version(package_version_from_release_tag(release_tag))
     except (ValueError, InvalidVersion) as exc:
         raise ReleaseAssetError(f"invalid release tag: {release_tag!r}") from exc
+
+
+def _package_release_policy(payload: dict, release_tag: str) -> PackageReleasePolicy | None:
+    raw = payload.get("package_policy")
+    if raw is None:
+        return None
+    keys = {
+        "schema_version",
+        "release_tag",
+        "release_family",
+        "requires_python",
+        "supported_python_versions",
+        "namespace_policy_version",
+    }
+    if not isinstance(raw, dict) or set(raw) != keys or raw.get("schema_version") != 1:
+        raise ManifestPolicyError("manifest package_policy schema is invalid")
+    release_version = _release_version(release_tag)
+    release_family = f"{release_version.major}.{release_version.minor}"
+    requires_python = raw.get("requires_python")
+    versions = raw.get("supported_python_versions")
+    namespace_policy_version = raw.get("namespace_policy_version")
+    if (
+        raw.get("release_tag") != release_tag
+        or raw.get("release_family") != release_family
+        or not isinstance(requires_python, str)
+        or not isinstance(versions, list)
+        or not versions
+        or any(not isinstance(version, str) for version in versions)
+        or len(versions) != len(set(versions))
+        or namespace_policy_version not in NAMESPACE_POLICIES
+    ):
+        raise ManifestPolicyError("manifest package_policy identity is invalid")
+    try:
+        specifier = SpecifierSet(requires_python)
+        parsed_versions = tuple(Version(version) for version in versions)
+    except (InvalidSpecifier, InvalidVersion) as exc:
+        raise ManifestPolicyError("manifest package_policy Python contract is invalid") from exc
+    if any(version not in specifier for version in parsed_versions):
+        raise ManifestPolicyError("manifest package_policy excludes a supported Python version")
+    return PackageReleasePolicy(requires_python, tuple(versions), namespace_policy_version)
 
 
 def discover_release_manifest(
@@ -308,13 +406,9 @@ def discover_release_manifest(
     if len(core_paths) != 1 or len(memory_paths) > 1:
         raise ReleaseAssetError("release must contain one core wheel and at most one Memory wheel")
     core = _wheel_archive(core_paths[0])
-    if core.metadata.name != "avibe-os":
-        raise ReleaseAssetError("core wheel metadata Name must be avibe-os")
     core_manifest = _installed_files(core).get(MEMORY_MANIFEST_PATH)
     memory = _wheel_archive(memory_paths[0]) if memory_paths else None
     memory_manifest = _installed_files(memory).get(MEMORY_MANIFEST_PATH) if memory else None
-    if memory and memory.metadata.name != "avibe-memory":
-        raise ReleaseAssetError("Memory wheel metadata Name must be avibe-memory")
     if core_manifest and memory_manifest:
         raise ReleaseAssetError("Memory Runtime manifest ownership is ambiguous")
     if memory_manifest:
@@ -333,9 +427,7 @@ def discover_release_manifest(
 
 
 def _assert_metadata_parity(wheel: PackageArchive, sdist: PackageArchive, name: str) -> None:
-    if wheel.metadata.name != name or sdist.metadata.name != name:
-        raise ReleaseAssetError(f"{name} distribution metadata has the wrong Name")
-    if wheel.metadata != sdist.metadata:
+    if wheel.metadata.name != name or wheel.metadata != sdist.metadata:
         raise ReleaseAssetError(f"{name} wheel and sdist metadata differ")
 
 
@@ -343,12 +435,31 @@ def _owned_content(package: PackageArchive, prefix: str) -> dict[str, bytes]:
     return {name: value for name, value in _installed_files(package).items() if name.startswith(prefix)}
 
 
+def _assert_namespace_policy(package: PackageArchive, distribution: str, policy_version: int) -> None:
+    policies = NAMESPACE_POLICIES[policy_version]
+    allowed_top_levels = policies[distribution]
+    known_namespaces = set().union(*policies.values())
+    for name in _installed_files(package):
+        if name == MEMORY_MANIFEST_PATH:
+            if distribution == "avibe-memory":
+                continue
+            raise ReleaseAssetError(f"{distribution} artifact violates namespace policy: {name}")
+        top_level = PurePosixPath(name).parts[0]
+        if top_level.endswith((".dist-info", ".data")):
+            continue
+        if package.path.suffix == ".whl":
+            allowed = top_level in allowed_top_levels
+        else:
+            allowed = top_level not in known_namespaces or top_level in allowed_top_levels
+        if not allowed:
+            raise ReleaseAssetError(f"{distribution} artifact violates namespace policy: {name}")
+
+
 def _assert_transition_packages(
-    core_wheel: PackageArchive,
-    memory_wheel: PackageArchive,
-    core_sdist: PackageArchive,
-    memory_sdist: PackageArchive,
+    packages: tuple[PackageArchive, PackageArchive, PackageArchive, PackageArchive],
+    policy: PackageReleasePolicy,
 ) -> str:
+    core_wheel, memory_wheel, core_sdist, memory_sdist = packages
     _assert_metadata_parity(core_wheel, core_sdist, "avibe-os")
     _assert_metadata_parity(memory_wheel, memory_sdist, "avibe-memory")
     version = core_wheel.metadata.version
@@ -359,29 +470,25 @@ def _assert_transition_packages(
     reverse_requirements = _requirements_for(memory_wheel.metadata, "avibe-os")
     if len(reverse_requirements) != 1:
         raise ReleaseAssetError("Memory metadata must contain exactly one avibe-os dependency")
-    try:
-        reverse_requirement = Requirement(reverse_requirements[0])
-        core_version = Version(version)
-    except (InvalidRequirement, InvalidVersion) as exc:
-        raise ReleaseAssetError("Memory avibe-os dependency metadata is invalid") from exc
+    reverse_requirement = reverse_requirements[0]
     if (
         reverse_requirement.url is not None
         or reverse_requirement.marker is not None
         or not reverse_requirement.specifier
-        or core_version not in reverse_requirement.specifier
+        or Version(version) not in reverse_requirement.specifier
     ):
         raise ReleaseAssetError("Memory avibe-os dependency must accept the exact core version")
-    if (
-        core_wheel.metadata.requires_python != PROJECT_REQUIRES_PYTHON
-        or memory_wheel.metadata.requires_python != PROJECT_REQUIRES_PYTHON
-    ):
-        raise ReleaseAssetError(
-            f"core and Memory Requires-Python must match the project range {PROJECT_REQUIRES_PYTHON}"
-        )
+    requires_python = {core_wheel.metadata.requires_python, memory_wheel.metadata.requires_python}
+    if requires_python != {policy.requires_python}:
+        raise ReleaseAssetError(f"core and Memory Requires-Python must match release policy {policy.requires_python}")
 
-    for package in (core_wheel, core_sdist):
-        if _owned_content(package, "avibe_memory/") or MEMORY_MANIFEST_PATH in _installed_files(package):
-            raise ReleaseAssetError(f"core artifact owns Memory content: {package.path.name}")
+    for package, distribution in (
+        (core_wheel, "avibe-os"),
+        (core_sdist, "avibe-os"),
+        (memory_wheel, "avibe-memory"),
+        (memory_sdist, "avibe-memory"),
+    ):
+        _assert_namespace_policy(package, distribution, policy.namespace_policy_version)
     wheel_implementation = _owned_content(memory_wheel, "avibe_memory/")
     sdist_implementation = _owned_content(memory_sdist, "avibe_memory/")
     if not REQUIRED_MEMORY_IMPLEMENTATION.issubset(wheel_implementation):
@@ -395,23 +502,23 @@ def _assert_transition_packages(
     return version
 
 
-def _transition_artifacts(asset_dir: Path) -> tuple[PackageArchive, PackageArchive, PackageArchive, PackageArchive]:
+def _transition_artifacts(
+    asset_dir: Path,
+) -> tuple[PackageArchive, PackageArchive, PackageArchive, PackageArchive]:
     if not asset_dir.is_dir():
         raise ReleaseAssetError("release package directory is missing")
-    paths: list[Path] = []
-    for distribution in ("avibe-os", "avibe-memory"):
-        for suffix in (".whl", ".tar.gz"):
-            matches = _package_files(asset_dir, distribution, suffix)
-            if len(matches) != 1:
-                raise ReleaseAssetError(
-                    f"transition release must contain exactly one {distribution} {suffix} artifact"
-                )
-            paths.append(matches[0])
+
+    def one(distribution: str, suffix: str) -> Path:
+        matches = _package_files(asset_dir, distribution, suffix)
+        if len(matches) != 1:
+            raise ReleaseAssetError(f"release must contain one {distribution} {suffix}")
+        return matches[0]
+
     return (
-        _wheel_archive(paths[0]),
-        _wheel_archive(paths[2]),
-        _sdist_archive(paths[1]),
-        _sdist_archive(paths[3]),
+        _wheel_archive(one("avibe-os", ".whl")),
+        _wheel_archive(one("avibe-memory", ".whl")),
+        _sdist_archive(one("avibe-os", ".tar.gz")),
+        _sdist_archive(one("avibe-memory", ".tar.gz")),
     )
 
 
@@ -449,6 +556,18 @@ def rebuild_sdist_wheel(sdist: Path, output_dir: Path) -> Path:
     return wheels[0]
 
 
+def _resolve_wheelhouse(
+    wheels: tuple[Path, Path],
+    find_links: tuple[Path, ...],
+    python_versions: tuple[str, ...],
+) -> None:
+    for python_version in python_versions:
+        links = [item for directory in find_links for item in ("--find-links", str(directory.resolve()))]
+        command = [*PIP_FLAGS, "--python-version", python_version, *links]
+        command.extend(str(wheel.resolve()) for wheel in wheels)
+        _run_pip(command, f"offline pip resolution failed for Python {python_version}")
+
+
 def verify_transition_distributions(
     asset_dir: Path,
     rebuild_root: Path,
@@ -456,20 +575,36 @@ def verify_transition_distributions(
     release_tag: str,
     builder: SdistBuilder = rebuild_sdist_wheel,
 ) -> str:
-    core_wheel, memory_wheel, core_sdist, memory_sdist = _transition_artifacts(asset_dir)
-    version = _assert_transition_packages(core_wheel, memory_wheel, core_sdist, memory_sdist)
+    staged = _transition_artifacts(asset_dir)
+    core_wheel, memory_wheel, core_sdist, memory_sdist = staged
+    manifest_bytes = _installed_files(memory_wheel).get(MEMORY_MANIFEST_PATH)
+    try:
+        manifest_payload = json.loads(manifest_bytes) if manifest_bytes is not None else None
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ReleaseAssetError("Memory artifact package policy manifest is invalid") from exc
+    if not isinstance(manifest_payload, dict):
+        raise ReleaseAssetError("Memory artifact is missing its package policy manifest")
+    policy = _package_release_policy(manifest_payload, release_tag)
+    if policy is None:
+        raise ReleaseAssetError("Memory artifact manifest is missing frozen package_policy")
+    version = _assert_transition_packages(staged, policy)
     if Version(version) != _release_version(release_tag):
         raise ReleaseAssetError("distribution version does not match the release tag")
+    _resolve_wheelhouse(
+        (core_wheel.path, memory_wheel.path),
+        (asset_dir,),
+        policy.supported_python_versions,
+    )
     rebuilt_core = _wheel_archive(builder(core_sdist.path, rebuild_root / "core"))
     rebuilt_memory = _wheel_archive(builder(memory_sdist.path, rebuild_root / "memory"))
-    rebuilt_version = _assert_transition_packages(
-        rebuilt_core,
-        rebuilt_memory,
-        core_sdist,
-        memory_sdist,
-    )
+    rebuilt_version = _assert_transition_packages((rebuilt_core, rebuilt_memory, core_sdist, memory_sdist), policy)
     if rebuilt_version != version:
         raise ReleaseAssetError("rebuilt distribution version differs from staged artifacts")
+    _resolve_wheelhouse(
+        (rebuilt_core.path, rebuilt_memory.path),
+        (asset_dir, rebuilt_core.path.parent, rebuilt_memory.path.parent),
+        policy.supported_python_versions,
+    )
     return version
 
 
@@ -482,11 +617,7 @@ def load_release_spec(manifest_path: Path) -> ReleaseSpec:
     if not isinstance(payload, dict) or payload.get("schema_version") != 1:
         raise ManifestPolicyError("Memory Runtime manifest schema_version must be 1")
     everos_version = payload.get("everos_version")
-    provenance = (
-        PUBLISHED_RUNTIME_PROVENANCE.get(everos_version)
-        if isinstance(everos_version, str)
-        else None
-    )
+    provenance = PUBLISHED_RUNTIME_PROVENANCE.get(everos_version) if isinstance(everos_version, str) else None
     if payload.get("release_state") != "published" or provenance is None:
         raise ManifestPolicyError("Memory Runtime manifest must describe a published supported EverOS version")
     if (
@@ -519,6 +650,7 @@ def load_release_spec(manifest_path: Path) -> ReleaseSpec:
             raise ManifestPolicyError("Memory Runtime sync bootstrap contract is invalid")
 
     release_tag = _required_string(payload, "release_tag", "manifest")
+    _package_release_policy(payload, release_tag)
     release_root = f"{RELEASE_DOWNLOAD_ROOT}/{release_tag}"
     raw_archives = payload.get("archives")
     if not isinstance(raw_archives, dict) or set(raw_archives) != EXPECTED_PLATFORMS:
@@ -590,9 +722,7 @@ def verify_release_assets(manifest_path: Path, asset_dir: Path) -> ReleaseSpec:
                         "lib/python3.12/site-packages/avibe_memory_sync_scrubbers.py",
                     )
                     marker = bundle.extractfile(
-                        bundle.getmember(
-                            "lib/python3.12/site-packages/avibe_memory_sync_bootstrap.pth"
-                        )
+                        bundle.getmember("lib/python3.12/site-packages/avibe_memory_sync_bootstrap.pth")
                     )
                     if (
                         bootstrap_digest != spec.sync_bootstrap_sha256
@@ -600,9 +730,7 @@ def verify_release_assets(manifest_path: Path, asset_dir: Path) -> ReleaseSpec:
                         or marker is None
                         or marker.read() != b"import avibe_memory_sync_bootstrap\n"
                     ):
-                        raise ReleaseAssetError(
-                            f"Memory Runtime sync contract mismatch: {archive.name}"
-                        )
+                        raise ReleaseAssetError(f"Memory Runtime sync contract mismatch: {archive.name}")
         except (KeyError, OSError, tarfile.TarError) as exc:
             raise ReleaseAssetError(f"invalid Memory Runtime archive: {archive.name}") from exc
         if digest != archive.binary_sha256:
@@ -721,9 +849,7 @@ def main(argv: list[str] | None = None) -> int:
                     )
             else:
                 args.work_dir.mkdir(parents=True, exist_ok=True)
-                version = verify_transition_distributions(
-                    args.asset_dir, args.work_dir, release_tag=spec.release_tag
-                )
+                version = verify_transition_distributions(args.asset_dir, args.work_dir, release_tag=spec.release_tag)
             discovery = discover_release_manifest(args.asset_dir, release_tag=spec.release_tag)
             if discovery.owner != "memory" or discovery.manifest_bytes != spec.manifest_bytes:
                 raise ReleaseAssetError("transition package manifest does not match the selected manifest")

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -4,8 +4,10 @@ import gzip
 import hashlib
 import io
 import json
+import shutil
 import tarfile
 from pathlib import Path
+import zipfile
 
 import pytest
 
@@ -77,6 +79,111 @@ def _manifest(
     return manifest, remote
 
 
+def _package_metadata(name: str, version: str, requirements: tuple[str, ...]) -> bytes:
+    fields = [
+        "Metadata-Version: 2.4",
+        f"Name: {name}",
+        f"Version: {version}",
+        "Requires-Python: >=3.10",
+        *(f"Requires-Dist: {requirement}" for requirement in requirements),
+    ]
+    return ("\n".join(fields) + "\n\n").encode()
+
+
+def _wheel(
+    path: Path,
+    *,
+    name: str,
+    version: str,
+    requirements: tuple[str, ...],
+    files: dict[str, bytes],
+) -> Path:
+    dist_info = name.replace("-", "_") + f"-{version}.dist-info"
+    with zipfile.ZipFile(path, "w") as archive:
+        for member_name, content in {
+            **files,
+            f"{dist_info}/METADATA": _package_metadata(name, version, requirements),
+        }.items():
+            archive.writestr(member_name, content)
+    return path
+
+
+def _sdist(
+    path: Path,
+    *,
+    name: str,
+    version: str,
+    requirements: tuple[str, ...],
+    files: dict[str, bytes],
+) -> Path:
+    root = f"{name.replace('-', '_')}-{version}"
+    with tarfile.open(path, "w:gz") as archive:
+        for member_name, content in {
+            "PKG-INFO": _package_metadata(name, version, requirements),
+            **files,
+        }.items():
+            member = tarfile.TarInfo(f"{root}/{member_name}")
+            member.size = len(content)
+            archive.addfile(member, io.BytesIO(content))
+    return path
+
+
+def _transition_packages(tmp_path: Path, manifest: Path) -> tuple[Path, dict[str, Path]]:
+    package_dir = tmp_path / "packages"
+    package_dir.mkdir(parents=True)
+    version = "3.1.0"
+    core_files = {"core/memory_loader.py": b"MEMORY_ENTRYPOINT = 'avibe_memory.runtime'\n"}
+    memory_files = {
+        "avibe_memory/__init__.py": b"from .runtime import start\n",
+        "avibe_memory/runtime.py": b"def start(): return None\n",
+        guard.MEMORY_MANIFEST_PATH: manifest.read_bytes(),
+    }
+    artifacts = {
+        "core_wheel": _wheel(
+            package_dir / f"avibe_os-{version}-py3-none-any.whl",
+            name="avibe-os",
+            version=version,
+            requirements=(f"avibe-memory=={version}",),
+            files=core_files,
+        ),
+        "core_sdist": _sdist(
+            package_dir / f"avibe_os-{version}.tar.gz",
+            name="avibe-os",
+            version=version,
+            requirements=(f"avibe-memory=={version}",),
+            files=core_files,
+        ),
+        "memory_wheel": _wheel(
+            package_dir / f"avibe_memory-{version}-py3-none-any.whl",
+            name="avibe-memory",
+            version=version,
+            requirements=("avibe-os>=3.0.14.dev0,<3.2",),
+            files=memory_files,
+        ),
+        "memory_sdist": _sdist(
+            package_dir / f"avibe_memory-{version}.tar.gz",
+            name="avibe-memory",
+            version=version,
+            requirements=("avibe-os>=3.0.14.dev0,<3.2",),
+            files=memory_files,
+        ),
+    }
+    return package_dir, artifacts
+
+
+def _copy_builder(artifacts: dict[str, Path], built: list[str]):
+    def build(sdist: Path, output_dir: Path) -> Path:
+        kind = "memory" if sdist.name.startswith("avibe_memory-") else "core"
+        built.append(kind)
+        output_dir.mkdir(parents=True)
+        source = artifacts[f"{kind}_wheel"]
+        target = output_dir / source.name
+        shutil.copyfile(source, target)
+        return target
+
+    return build
+
+
 @pytest.mark.parametrize("everos_version", sorted(guard.PUBLISHED_RUNTIME_PROVENANCE))
 def test_guard_accepts_every_published_runtime_provenance(
     tmp_path: Path,
@@ -100,6 +207,196 @@ def test_guard_keeps_gh_v3_0_9rc3_runtime_in_coverage() -> None:
         lock_sha256="62b00f1a9ca04cc4ea4c5af51f389ba49acdea8786e5f7044d52823244502c57",
         uv_version="0.9.18",
     )
+
+
+def test_memory_indep_022_dual_form_discovery_reads_legacy_core_and_transition_memory(
+    tmp_path: Path,
+) -> None:
+    manifest, _ = _manifest(tmp_path)
+    package_dir, artifacts = _transition_packages(tmp_path, manifest)
+
+    transition = guard.discover_release_manifest(package_dir)
+    assert transition == guard.ManifestDiscovery("memory", manifest.read_bytes())
+
+    legacy_dir = tmp_path / "legacy"
+    legacy_dir.mkdir()
+    _wheel(
+        legacy_dir / "avibe_os-3.0.13-py3-none-any.whl",
+        name="avibe-os",
+        version="3.0.13",
+        requirements=(),
+        files={guard.MEMORY_MANIFEST_PATH: manifest.read_bytes()},
+    )
+    legacy = guard.discover_release_manifest(legacy_dir)
+    assert legacy == guard.ManifestDiscovery("core", manifest.read_bytes())
+
+    artifacts["memory_wheel"].unlink()
+    with pytest.raises(guard.ReleaseAssetError, match="transition avibe-memory artifact is missing"):
+        guard.discover_release_manifest(package_dir)
+
+
+def test_memory_indep_022_023_discovery_distinguishes_legacy_and_ambiguous_transition(
+    tmp_path: Path,
+) -> None:
+    manifest, _ = _manifest(tmp_path)
+    legacy_dir = tmp_path / "manifest-free"
+    legacy_dir.mkdir()
+    _wheel(
+        legacy_dir / "avibe_os-3.0.8-py3-none-any.whl",
+        name="avibe-os",
+        version="3.0.8",
+        requirements=(),
+        files={"core/memory_loader.py": b"legacy\n"},
+    )
+    with pytest.raises(guard.LegacyManifestAbsent):
+        guard.discover_release_manifest(legacy_dir)
+
+    package_dir, artifacts = _transition_packages(tmp_path / "ambiguous", manifest)
+    _wheel(
+        artifacts["core_wheel"],
+        name="avibe-os",
+        version="3.1.0",
+        requirements=("avibe-memory==3.1.0",),
+        files={
+            "core/memory_loader.py": b"loader\n",
+            guard.MEMORY_MANIFEST_PATH: manifest.read_bytes(),
+        },
+    )
+    with pytest.raises(guard.ReleaseAssetError, match="ownership is ambiguous"):
+        guard.discover_release_manifest(package_dir)
+
+
+def test_memory_indep_023_package_guard_reuses_assertions_for_both_rebuilt_wheels(
+    tmp_path: Path,
+) -> None:
+    manifest, _ = _manifest(tmp_path)
+    package_dir, artifacts = _transition_packages(tmp_path, manifest)
+    built: list[str] = []
+
+    version = guard.verify_transition_distributions(
+        package_dir,
+        tmp_path / "rebuild",
+        builder=_copy_builder(artifacts, built),
+    )
+
+    assert version == "3.1.0"
+    assert built == ["core", "memory"]
+
+
+def test_default_sdist_builder_uses_pep517_isolation_without_importing_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest, _ = _manifest(tmp_path)
+    _, artifacts = _transition_packages(tmp_path, manifest)
+    calls: list[list[str]] = []
+
+    def run(argv: list[str], **kwargs):
+        calls.append(argv)
+        assert "--no-isolation" not in argv
+        assert kwargs["env"]["PYTHONPATH"] == ""
+        project_root = Path(argv[-1])
+        assert (project_root / "PKG-INFO").is_file()
+        wheel_dir = Path(argv[argv.index("--outdir") + 1])
+        shutil.copyfile(artifacts["core_wheel"], wheel_dir / artifacts["core_wheel"].name)
+        return guard.subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(guard.subprocess, "run", run)
+    rebuilt = guard.rebuild_sdist_wheel(artifacts["core_sdist"], tmp_path / "isolated")
+
+    assert rebuilt.name == artifacts["core_wheel"].name
+    assert calls[0][1:4] == ["-m", "build", "--wheel"]
+
+
+def test_transition_package_guard_rejects_staged_and_rebuilt_ownership_drift(
+    tmp_path: Path,
+) -> None:
+    manifest, _ = _manifest(tmp_path)
+    package_dir, artifacts = _transition_packages(tmp_path, manifest)
+    _sdist(
+        artifacts["core_sdist"],
+        name="avibe-os",
+        version="3.1.0",
+        requirements=("avibe-memory==3.1.0",),
+        files={
+            "core/memory_loader.py": b"loader\n",
+            guard.MEMORY_MANIFEST_PATH: manifest.read_bytes(),
+        },
+    )
+    with pytest.raises(guard.ReleaseAssetError, match="core artifact owns Memory content"):
+        guard.verify_transition_distributions(
+            package_dir,
+            tmp_path / "staged-rebuild",
+            builder=_copy_builder(artifacts, []),
+        )
+
+    package_dir, artifacts = _transition_packages(tmp_path / "rebuilt", manifest)
+    bad_core = _wheel(
+        tmp_path / "bad-core.whl",
+        name="avibe-os",
+        version="3.1.0",
+        requirements=("avibe-memory==3.1.0",),
+        files={guard.MEMORY_MANIFEST_PATH: manifest.read_bytes()},
+    )
+
+    def bad_builder(sdist: Path, output_dir: Path) -> Path:
+        if sdist.name.startswith("avibe_os-"):
+            return bad_core
+        return _copy_builder(artifacts, [])(sdist, output_dir)
+
+    with pytest.raises(guard.ReleaseAssetError, match="core artifact owns Memory content"):
+        guard.verify_transition_distributions(
+            package_dir,
+            tmp_path / "bad-rebuild",
+            builder=bad_builder,
+        )
+
+
+def test_memory_indep_023_package_guard_rejects_dependency_and_metadata_drift(
+    tmp_path: Path,
+) -> None:
+    manifest, _ = _manifest(tmp_path)
+    package_dir, artifacts = _transition_packages(tmp_path, manifest)
+    _wheel(
+        artifacts["core_wheel"],
+        name="avibe-os",
+        version="3.1.0",
+        requirements=("avibe-memory==3.1.1",),
+        files={"core/memory_loader.py": b"MEMORY_ENTRYPOINT = 'avibe_memory.runtime'\n"},
+    )
+    _sdist(
+        artifacts["core_sdist"],
+        name="avibe-os",
+        version="3.1.0",
+        requirements=("avibe-memory==3.1.1",),
+        files={"core/memory_loader.py": b"MEMORY_ENTRYPOINT = 'avibe_memory.runtime'\n"},
+    )
+
+    with pytest.raises(guard.ReleaseAssetError, match="hard-depend on the exact Memory version"):
+        guard.verify_transition_distributions(
+            package_dir,
+            tmp_path / "metadata-rebuild",
+            builder=_copy_builder(artifacts, []),
+        )
+
+    package_dir, artifacts = _transition_packages(tmp_path / "metadata", manifest)
+    _sdist(
+        artifacts["memory_sdist"],
+        name="avibe-memory",
+        version="3.1.0",
+        requirements=("avibe-os>=3.1,<3.2",),
+        files={
+            "avibe_memory/__init__.py": b"from .runtime import start\n",
+            "avibe_memory/runtime.py": b"def start(): return None\n",
+            guard.MEMORY_MANIFEST_PATH: manifest.read_bytes(),
+        },
+    )
+    with pytest.raises(guard.ReleaseAssetError, match="wheel and sdist metadata differ"):
+        guard.verify_transition_distributions(
+            package_dir,
+            tmp_path / "parity-rebuild",
+            builder=_copy_builder(artifacts, []),
+        )
 
 
 def test_guard_rejects_unknown_runtime_provenance(tmp_path: Path) -> None:
@@ -162,6 +459,30 @@ def test_fetch_and_verify_exact_memory_runtime_release(
 
     assert spec.release_tag == "v3.1.0"
     assert verified.expected_asset_names == {path.name for path in (tmp_path / "backup").iterdir()}
+
+
+def test_memory_indep_022_023_public_verifier_redownloads_every_manifest_asset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest, remote = _manifest(tmp_path)
+    downloaded: list[str] = []
+    fake_download = _fake_download(remote)
+
+    def tracked_download(url: str, destination: Path, expected_size: int, attempts: int = 3) -> None:
+        downloaded.append(url)
+        fake_download(url, destination, expected_size, attempts)
+
+    monkeypatch.setattr(guard, "_download", tracked_download)
+    spec = guard.verify_public_release_assets(manifest)
+
+    assert spec.release_tag == "v3.1.0"
+    assert set(downloaded) == set(remote)
+
+    archive_url = next(url for url in remote if url.endswith(".tar.gz"))
+    remote[archive_url] = b"x" * len(remote[archive_url])
+    with pytest.raises(guard.ReleaseAssetError, match="integrity mismatch"):
+        guard.verify_public_release_assets(manifest)
 
 
 def test_verify_rejects_changed_archive(tmp_path: Path) -> None:
@@ -271,5 +592,10 @@ def test_guard_workflow_reports_and_verifies_supported_published_manifests() -> 
     assert "check-policy" in resolution
     assert "Guarded Memory Runtime manifests" in resolution
     assert "Excluded Memory Runtime manifests" in resolution
+    assert "discover-manifest" in resolution
+    assert "avibe_memory-*.whl" in resolution
     assert "fromJSON(needs.resolve_manifests.outputs.manifests)" in workflow
     assert "matrix.manifest.release_tag" in workflow
+    assert "matrix.manifest.owner == 'memory'" in workflow
+    assert "verify-packages --asset-dir" in workflow
+    assert "python3 -m pip install build" in workflow

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -42,6 +42,8 @@ def _manifest(
     *,
     everos_version: str = "1.2.3",
     lock_sha256: str = guard.EXPECTED_LOCK_SHA256,
+    package_requires_python: str = ">=3.10",
+    supported_python_versions: tuple[str, ...] = ("3.10", "3.11", "3.12"),
 ) -> tuple[Path, dict[str, bytes]]:
     tag = "v3.1.0"
     base_url = f"{guard.RELEASE_DOWNLOAD_ROOT}/{tag}"
@@ -70,6 +72,14 @@ def _manifest(
         "uv_version": guard.EXPECTED_UV_VERSION,
         "release_state": "published",
         "release_tag": tag,
+        "package_policy": {
+            "schema_version": 1,
+            "release_tag": tag,
+            "release_family": "3.1",
+            "requires_python": package_requires_python,
+            "supported_python_versions": list(supported_python_versions),
+            "namespace_policy_version": 1,
+        },
         "archives": archives,
     }
     manifest = tmp_path / "memory-runtime-manifest.json"
@@ -79,111 +89,85 @@ def _manifest(
     return manifest, remote
 
 
-def _package_metadata(
-    name: str, version: str, requirements: tuple[str, ...], requires_python: str = ">=3.10"
-) -> bytes:
-    fields = [
-        "Metadata-Version: 2.4",
-        f"Name: {name}",
-        f"Version: {version}",
-        f"Requires-Python: {requires_python}",
-        *(f"Requires-Dist: {requirement}" for requirement in requirements),
-    ]
-    return ("\n".join(fields) + "\n\n").encode()
+VERSION = "3.1.0"
+CORE_FILES = {"core/memory_loader.py": b"MEMORY_ENTRYPOINT = 'avibe_memory.runtime'\n"}
 
 
-def _wheel(
+def _package(
     path: Path,
-    *,
     name: str,
-    version: str,
-    requirements: tuple[str, ...],
-    files: dict[str, bytes],
-    requires_python: str = ">=3.10",
-) -> Path:
-    dist_info = name.replace("-", "_") + f"-{version}.dist-info"
-    with zipfile.ZipFile(path, "w") as archive:
-        for member_name, content in {
-            **files,
-            f"{dist_info}/METADATA": _package_metadata(name, version, requirements, requires_python),
-        }.items():
-            archive.writestr(member_name, content)
-    return path
-
-
-def _sdist(
-    path: Path,
+    requirements: tuple[str, ...] = (),
+    files: dict[str, bytes] | None = None,
     *,
-    name: str,
-    version: str,
-    requirements: tuple[str, ...],
-    files: dict[str, bytes],
+    version: str = VERSION,
     requires_python: str = ">=3.10",
+    wheel_version: str | None = "1.0",
+    dist_info_prefix: str = "",
 ) -> Path:
-    root = f"{name.replace('-', '_')}-{version}"
-    with tarfile.open(path, "w:gz") as archive:
-        for member_name, content in {
-            "PKG-INFO": _package_metadata(name, version, requirements, requires_python),
-            **files,
-        }.items():
-            member = tarfile.TarInfo(f"{root}/{member_name}")
-            member.size = len(content)
-            archive.addfile(member, io.BytesIO(content))
+    metadata = "\n".join(
+        [
+            "Metadata-Version: 2.4",
+            f"Name: {name}",
+            f"Version: {version}",
+            f"Requires-Python: {requires_python}",
+            *(f"Requires-Dist: {item}" for item in requirements),
+            "",
+            "",
+        ]
+    ).encode()
+    members = dict(files or {})
+    if path.suffix == ".whl":
+        dist_info = f"{dist_info_prefix}{name.replace('-', '_')}-{version}.dist-info"
+        members |= {f"{dist_info}/METADATA": metadata, f"{dist_info}/RECORD": b""}
+        if wheel_version is not None:
+            members[f"{dist_info}/WHEEL"] = (
+                f"Wheel-Version: {wheel_version}\nRoot-Is-Purelib: true\nTag: py3-none-any\n\n"
+            ).encode()
+        with zipfile.ZipFile(path, "w") as archive:
+            for member_name, content in members.items():
+                archive.writestr(member_name, content)
+    else:
+        members = {"PKG-INFO": metadata, **members}
+        with tarfile.open(path, "w:gz") as archive:
+            for member_name, content in members.items():
+                member = tarfile.TarInfo(f"{name.replace('-', '_')}-{version}/{member_name}")
+                member.size = len(content)
+                archive.addfile(member, io.BytesIO(content))
     return path
 
 
 def _transition_packages(
-    tmp_path: Path,
+    root: Path,
     manifest: Path,
     *,
     requires_python: str = ">=3.10",
     core_files: dict[str, bytes] | None = None,
+    core_requirements: tuple[str, ...] = (f"avibe-memory=={VERSION}",),
+    memory_extra_files: dict[str, bytes] | None = None,
     memory_requirements: tuple[str, ...] = ("avibe-os>=3.0.14.dev0,<3.2",),
 ) -> tuple[Path, dict[str, Path]]:
-    package_dir = tmp_path / "packages"
+    package_dir = root / "packages"
     package_dir.mkdir(parents=True)
-    version = "3.1.0"
-    if core_files is None:
-        core_files = {"core/memory_loader.py": b"MEMORY_ENTRYPOINT = 'avibe_memory.runtime'\n"}
     memory_files = {
         "avibe_memory/__init__.py": b"from .runtime import start\n",
         "avibe_memory/runtime.py": b"def start(): return None\n",
         guard.MEMORY_MANIFEST_PATH: manifest.read_bytes(),
+        **(memory_extra_files or {}),
     }
-    artifacts = {
-        "core_wheel": _wheel(
-            package_dir / f"avibe_os-{version}-py3-none-any.whl",
-            name="avibe-os",
-            version=version,
-            requirements=(f"avibe-memory=={version}",),
-            files=core_files,
-            requires_python=requires_python,
-        ),
-        "core_sdist": _sdist(
-            package_dir / f"avibe_os-{version}.tar.gz",
-            name="avibe-os",
-            version=version,
-            requirements=(f"avibe-memory=={version}",),
-            files=core_files,
-            requires_python=requires_python,
-        ),
-        "memory_wheel": _wheel(
-            package_dir / f"avibe_memory-{version}-py3-none-any.whl",
-            name="avibe-memory",
-            version=version,
-            requirements=memory_requirements,
-            files=memory_files,
-            requires_python=requires_python,
-        ),
-        "memory_sdist": _sdist(
-            package_dir / f"avibe_memory-{version}.tar.gz",
-            name="avibe-memory",
-            version=version,
-            requirements=memory_requirements,
-            files=memory_files,
-            requires_python=requires_python,
-        ),
-    }
+    artifacts: dict[str, Path] = {}
+    for key, name, requirements, files in (
+        ("core", "avibe-os", core_requirements, core_files or CORE_FILES),
+        ("memory", "avibe-memory", memory_requirements, memory_files),
+    ):
+        stem = name.replace("-", "_") + f"-{VERSION}"
+        for form, suffix in (("wheel", "-py3-none-any.whl"), ("sdist", ".tar.gz")):
+            artifacts[f"{key}_{form}"] = _package(
+                package_dir / f"{stem}{suffix}",
+                name,
+                requirements,
+                files,
+                requires_python=requires_python,
+            )
     return package_dir, artifacts
 
 
@@ -200,14 +184,9 @@ def _copy_builder(artifacts: dict[str, Path], built: list[str]):
     return build
 
 
-def _verify(
-    package_dir: Path,
-    rebuild_dir: Path,
-    artifacts: dict[str, Path],
-    release_tag: str = "v3.1.0",
-) -> str:
+def _verify(package_dir: Path, rebuild_dir: Path, artifacts: dict[str, Path], tag: str = "v3.1.0") -> str:
     return guard.verify_transition_distributions(
-        package_dir, rebuild_dir, release_tag=release_tag, builder=_copy_builder(artifacts, [])
+        package_dir, rebuild_dir, release_tag=tag, builder=_copy_builder(artifacts, [])
     )
 
 
@@ -236,87 +215,110 @@ def test_guard_keeps_gh_v3_0_9rc3_runtime_in_coverage() -> None:
     )
 
 
-def test_memory_indep_022_dual_form_discovery_reads_legacy_core_and_transition_memory(
-    tmp_path: Path,
-) -> None:
+def test_memory_indep_022_dual_form_discovery_reads_legacy_core_and_transition_memory(tmp_path: Path) -> None:
     manifest, _ = _manifest(tmp_path)
     package_dir, artifacts = _transition_packages(tmp_path, manifest)
-
-    transition = guard.discover_release_manifest(package_dir)
-    assert transition == guard.ManifestDiscovery("memory", manifest.read_bytes())
-
+    assert guard.discover_release_manifest(package_dir) == guard.ManifestDiscovery("memory", manifest.read_bytes())
     legacy_dir = tmp_path / "legacy"
     legacy_dir.mkdir()
-    _wheel(
+    _package(
         legacy_dir / "avibe_os-3.0.13-py3-none-any.whl",
-        name="avibe-os",
-        version="3.0.13",
-        requirements=(),
+        "avibe-os",
         files={guard.MEMORY_MANIFEST_PATH: manifest.read_bytes()},
+        version="3.0.13",
     )
-    legacy = guard.discover_release_manifest(legacy_dir)
-    assert legacy == guard.ManifestDiscovery("core", manifest.read_bytes())
-
+    assert guard.discover_release_manifest(legacy_dir).owner == "core"
+    _package(next(legacy_dir.iterdir()), "avibe-os", files=CORE_FILES, version="3.0.13")
+    with pytest.raises(guard.LegacyManifestAbsent):
+        guard.discover_release_manifest(legacy_dir, release_tag="gh-v3.0.14rc2")
+    with pytest.raises(guard.ReleaseAssetError, match="transition-and-later"):
+        guard.discover_release_manifest(legacy_dir, release_tag="gh-v3.0.14rc3")
     artifacts["memory_wheel"].unlink()
     with pytest.raises(guard.ReleaseAssetError, match="transition avibe-memory artifact is missing"):
         guard.discover_release_manifest(package_dir)
 
 
-def test_memory_indep_022_023_discovery_distinguishes_legacy_and_ambiguous_transition(
-    tmp_path: Path,
-) -> None:
-    manifest, _ = _manifest(tmp_path)
-    legacy_dir = tmp_path / "manifest-free"
-    legacy_dir.mkdir()
-    _wheel(
-        legacy_dir / "avibe_os-3.0.8-py3-none-any.whl",
-        name="avibe-os",
-        version="3.0.8",
-        requirements=(),
-        files={"core/memory_loader.py": b"legacy\n"},
-    )
-    with pytest.raises(guard.LegacyManifestAbsent):
-        guard.discover_release_manifest(legacy_dir, release_tag="gh-v3.0.14rc2")
-    for release_tag in ("gh-v3.0.14rc3", "v3.0.14"):
-        with pytest.raises(guard.ReleaseAssetError, match="transition-and-later"):
-            guard.discover_release_manifest(legacy_dir, release_tag=release_tag)
-
-    package_dir, artifacts = _transition_packages(tmp_path / "ambiguous", manifest)
-    _wheel(
-        artifacts["core_wheel"],
-        name="avibe-os",
-        version="3.1.0",
-        requirements=("avibe-memory==3.1.0",),
-        files={
-            "core/memory_loader.py": b"loader\n",
-            guard.MEMORY_MANIFEST_PATH: manifest.read_bytes(),
-        },
-    )
-    with pytest.raises(guard.ReleaseAssetError, match="ownership is ambiguous"):
-        guard.discover_release_manifest(package_dir)
-
-
-def test_memory_indep_023_package_guard_reuses_assertions_for_both_rebuilt_wheels(
-    tmp_path: Path,
+@pytest.mark.parametrize(
+    ("artifact_key", "wrong_name"),
+    [("core_wheel", "avibe_os-3.1.1-py3-none-any.whl"), ("memory_sdist", "avibe_memory-3.1.1.tar.gz")],
+)
+def test_package_guard_binds_parsed_filenames_to_metadata_and_release(
+    tmp_path: Path, artifact_key: str, wrong_name: str
 ) -> None:
     manifest, _ = _manifest(tmp_path)
     package_dir, artifacts = _transition_packages(tmp_path, manifest)
-    built: list[str] = []
+    artifacts[artifact_key] = artifacts[artifact_key].rename(package_dir / wrong_name)
+    with pytest.raises(guard.ReleaseAssetError, match="filename identity"):
+        _verify(package_dir, tmp_path / "rebuild", artifacts)
 
+
+def test_package_guard_uses_offline_pip_for_complete_dependency_resolution(tmp_path: Path) -> None:
+    manifest, _ = _manifest(tmp_path)
+    package_dir, artifacts = _transition_packages(
+        tmp_path,
+        manifest,
+        core_requirements=("avibe-memory==3.1.0", "shared==1"),
+        memory_requirements=("avibe-os>=3.1,<3.2", "shared==2"),
+    )
+    for version in ("1", "2"):
+        _package(
+            package_dir / f"shared-{version}-py3-none-any.whl",
+            "shared",
+            files={"shared/__init__.py": b""},
+            version=version,
+        )
+    with pytest.raises(guard.ReleaseAssetError, match="offline pip resolution"):
+        _verify(package_dir, tmp_path / "rebuild", artifacts)
+
+
+@pytest.mark.parametrize("forbidden_path", ["core/controller.py", "vibe/__init__.py"])
+def test_package_guard_enforces_memory_namespace_policy_in_both_artifact_forms(
+    tmp_path: Path, forbidden_path: str
+) -> None:
+    manifest, _ = _manifest(tmp_path)
+    package_dir, artifacts = _transition_packages(tmp_path, manifest, memory_extra_files={forbidden_path: b"shadow\n"})
+    with pytest.raises(guard.ReleaseAssetError, match="namespace policy"):
+        _verify(package_dir, tmp_path / "rebuild", artifacts)
+
+
+def test_package_guard_uses_manifest_frozen_python_policy(tmp_path: Path) -> None:
+    manifest, _ = _manifest(
+        tmp_path,
+        package_requires_python=">=3.11",
+        supported_python_versions=("3.11", "3.12"),
+    )
+    package_dir, artifacts = _transition_packages(tmp_path, manifest, requires_python=">=3.11")
+    built: list[str] = []
     version = guard.verify_transition_distributions(
-        package_dir,
-        tmp_path / "rebuild",
-        release_tag="v3.1.0",
-        builder=_copy_builder(artifacts, built),
+        package_dir, tmp_path / "rebuild", release_tag="v3.1.0", builder=_copy_builder(artifacts, built)
+    )
+    assert (version, built) == (VERSION, ["core", "memory"])
+
+
+@pytest.mark.parametrize(
+    ("wheel_version", "dist_info_prefix"),
+    [(None, ""), ("2.0", ""), ("1.0", "nested/")],
+)
+def test_package_guard_uses_pip_wheel_structure_validation(
+    tmp_path: Path, wheel_version: str | None, dist_info_prefix: str
+) -> None:
+    manifest, _ = _manifest(tmp_path)
+    package_dir, artifacts = _transition_packages(tmp_path, manifest)
+    _package(
+        artifacts["core_wheel"],
+        "avibe-os",
+        (f"avibe-memory=={VERSION}",),
+        CORE_FILES,
+        wheel_version=wheel_version,
+        dist_info_prefix=dist_info_prefix,
     )
 
-    assert version == "3.1.0"
-    assert built == ["core", "memory"]
+    with pytest.raises(guard.ReleaseAssetError, match="wheel structure validation"):
+        _verify(package_dir, tmp_path / "rebuild", artifacts)
 
 
 def test_default_sdist_builder_uses_pep517_isolation_without_importing_source(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     manifest, _ = _manifest(tmp_path)
     _, artifacts = _transition_packages(tmp_path, manifest)
@@ -326,49 +328,40 @@ def test_default_sdist_builder_uses_pep517_isolation_without_importing_source(
         calls.append(argv)
         assert "--no-isolation" not in argv
         assert kwargs["env"]["PYTHONPATH"] == ""
-        project_root = Path(argv[-1])
-        assert (project_root / "PKG-INFO").is_file()
+        assert (Path(argv[-1]) / "PKG-INFO").is_file()
         wheel_dir = Path(argv[argv.index("--outdir") + 1])
         shutil.copyfile(artifacts["core_wheel"], wheel_dir / artifacts["core_wheel"].name)
         return guard.subprocess.CompletedProcess(argv, 0, "", "")
 
     monkeypatch.setattr(guard.subprocess, "run", run)
-    rebuilt = guard.rebuild_sdist_wheel(artifacts["core_sdist"], tmp_path / "isolated")
-    rebuilt_again = guard.rebuild_sdist_wheel(artifacts["core_sdist"], tmp_path / "isolated")
-
-    assert rebuilt.name == artifacts["core_wheel"].name
-    assert rebuilt_again.name == artifacts["core_wheel"].name
-    assert rebuilt.parent != rebuilt_again.parent
+    rebuilt = [guard.rebuild_sdist_wheel(artifacts["core_sdist"], tmp_path / "isolated") for _ in range(2)]
+    assert {path.name for path in rebuilt} == {artifacts["core_wheel"].name}
+    assert rebuilt[0].parent != rebuilt[1].parent
     assert len(calls) == 2
     assert calls[0][1:4] == ["-m", "build", "--wheel"]
 
 
 @pytest.mark.parametrize("wheel_scheme", ["purelib", "platlib"])
-def test_transition_package_guard_rejects_staged_and_rebuilt_ownership_drift(
-    tmp_path: Path,
-    wheel_scheme: str,
-) -> None:
+def test_transition_package_guard_rejects_staged_and_rebuilt_ownership_drift(tmp_path: Path, wheel_scheme: str) -> None:
     manifest, _ = _manifest(tmp_path)
     package_dir, artifacts = _transition_packages(tmp_path, manifest)
-    _sdist(
+    _package(
         artifacts["core_sdist"],
-        name="avibe-os",
-        version="3.1.0",
-        requirements=("avibe-memory==3.1.0",),
+        "avibe-os",
+        (f"avibe-memory=={VERSION}",),
         files={
             "core/memory_loader.py": b"loader\n",
             guard.MEMORY_MANIFEST_PATH: manifest.read_bytes(),
         },
     )
-    with pytest.raises(guard.ReleaseAssetError, match="core artifact owns Memory content"):
+    with pytest.raises(guard.ReleaseAssetError, match="namespace policy"):
         _verify(package_dir, tmp_path / "staged-rebuild", artifacts)
 
     package_dir, artifacts = _transition_packages(tmp_path / "rebuilt", manifest)
-    bad_core = _wheel(
-        tmp_path / "bad-core.whl",
-        name="avibe-os",
-        version="3.1.0",
-        requirements=("avibe-memory==3.1.0",),
+    bad_core = _package(
+        tmp_path / "avibe_os-3.1.0-py3-none-any.whl",
+        "avibe-os",
+        (f"avibe-memory=={VERSION}",),
         files={guard.MEMORY_MANIFEST_PATH: manifest.read_bytes()},
     )
 
@@ -377,12 +370,9 @@ def test_transition_package_guard_rejects_staged_and_rebuilt_ownership_drift(
             return bad_core
         return _copy_builder(artifacts, [])(sdist, output_dir)
 
-    with pytest.raises(guard.ReleaseAssetError, match="core artifact owns Memory content"):
+    with pytest.raises(guard.ReleaseAssetError, match="namespace policy"):
         guard.verify_transition_distributions(
-            package_dir,
-            tmp_path / "bad-rebuild",
-            release_tag="v3.1.0",
-            builder=bad_builder,
+            package_dir, tmp_path / "bad-rebuild", release_tag="v3.1.0", builder=bad_builder
         )
 
     package_dir, artifacts = _transition_packages(
@@ -393,43 +383,27 @@ def test_transition_package_guard_rejects_staged_and_rebuilt_ownership_drift(
             f"avibe_os-3.1.0.data/{wheel_scheme}/avibe_memory/runtime.py": b"shadow\n",
         },
     )
-    with pytest.raises(guard.ReleaseAssetError, match="core artifact owns Memory content"):
+    with pytest.raises(guard.ReleaseAssetError, match="namespace policy"):
         _verify(package_dir, tmp_path / f"{wheel_scheme}-rebuild", artifacts)
 
 
-def test_memory_indep_023_package_guard_rejects_dependency_and_metadata_drift(
-    tmp_path: Path,
-) -> None:
+def test_memory_indep_023_package_guard_rejects_dependency_and_metadata_drift(tmp_path: Path) -> None:
     manifest, _ = _manifest(tmp_path)
     package_dir, artifacts = _transition_packages(tmp_path, manifest, requires_python=">=99")
-    with pytest.raises(guard.ReleaseAssetError, match="must match the project range >=3.10"):
+    with pytest.raises(guard.ReleaseAssetError, match="must match release policy >=3.10"):
         _verify(package_dir, tmp_path / "python-range-rebuild", artifacts)
 
-    package_dir, artifacts = _transition_packages(tmp_path / "pin", manifest)
-    _wheel(
-        artifacts["core_wheel"],
-        name="avibe-os",
-        version="3.1.0",
-        requirements=("avibe-memory==3.1.1",),
-        files={"core/memory_loader.py": b"MEMORY_ENTRYPOINT = 'avibe_memory.runtime'\n"},
+    package_dir, artifacts = _transition_packages(
+        tmp_path / "pin", manifest, core_requirements=("avibe-memory==3.1.1",)
     )
-    _sdist(
-        artifacts["core_sdist"],
-        name="avibe-os",
-        version="3.1.0",
-        requirements=("avibe-memory==3.1.1",),
-        files={"core/memory_loader.py": b"MEMORY_ENTRYPOINT = 'avibe_memory.runtime'\n"},
-    )
-
     with pytest.raises(guard.ReleaseAssetError, match="hard-depend on the exact Memory version"):
         _verify(package_dir, tmp_path / "metadata-rebuild", artifacts)
 
     package_dir, artifacts = _transition_packages(tmp_path / "metadata", manifest)
-    _sdist(
+    _package(
         artifacts["memory_sdist"],
-        name="avibe-memory",
-        version="3.1.0",
-        requirements=("avibe-os>=3.1,<3.2",),
+        "avibe-memory",
+        ("avibe-os>=3.1,<3.2",),
         files={
             "avibe_memory/__init__.py": b"from .runtime import start\n",
             "avibe_memory/runtime.py": b"def start(): return None\n",
@@ -439,15 +413,13 @@ def test_memory_indep_023_package_guard_rejects_dependency_and_metadata_drift(
     with pytest.raises(guard.ReleaseAssetError, match="wheel and sdist metadata differ"):
         _verify(package_dir, tmp_path / "parity-rebuild", artifacts)
 
-    package_dir, artifacts = _transition_packages(
-        tmp_path / "reverse", manifest, memory_requirements=("avibe-os>=4",)
-    )
+    package_dir, artifacts = _transition_packages(tmp_path / "reverse", manifest, memory_requirements=("avibe-os>=4",))
     with pytest.raises(guard.ReleaseAssetError, match="must accept the exact core version"):
         _verify(package_dir, tmp_path / "reverse-rebuild", artifacts)
 
     package_dir, artifacts = _transition_packages(tmp_path / "tag", manifest)
-    with pytest.raises(guard.ReleaseAssetError, match="does not match the release tag"):
-        _verify(package_dir, tmp_path / "tag-rebuild", artifacts, release_tag="v3.1.1")
+    with pytest.raises(guard.ManifestPolicyError, match="package_policy identity"):
+        _verify(package_dir, tmp_path / "tag-rebuild", artifacts, tag="v3.1.1")
 
 
 def test_guard_rejects_unknown_runtime_provenance(tmp_path: Path) -> None:

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -249,7 +249,9 @@ def test_memory_indep_022_023_discovery_distinguishes_legacy_and_ambiguous_trans
         files={"core/memory_loader.py": b"legacy\n"},
     )
     with pytest.raises(guard.LegacyManifestAbsent):
-        guard.discover_release_manifest(legacy_dir)
+        guard.discover_release_manifest(legacy_dir, release_tag="gh-v3.0.14rc2")
+    with pytest.raises(guard.ReleaseAssetError, match="transition-and-later"):
+        guard.discover_release_manifest(legacy_dir, release_tag="v3.0.14")
 
     package_dir, artifacts = _transition_packages(tmp_path / "ambiguous", manifest)
     _wheel(
@@ -276,6 +278,7 @@ def test_memory_indep_023_package_guard_reuses_assertions_for_both_rebuilt_wheel
     version = guard.verify_transition_distributions(
         package_dir,
         tmp_path / "rebuild",
+        release_tag="v3.1.0",
         builder=_copy_builder(artifacts, built),
     )
 
@@ -327,6 +330,7 @@ def test_transition_package_guard_rejects_staged_and_rebuilt_ownership_drift(
         guard.verify_transition_distributions(
             package_dir,
             tmp_path / "staged-rebuild",
+            release_tag="v3.1.0",
             builder=_copy_builder(artifacts, []),
         )
 
@@ -348,6 +352,7 @@ def test_transition_package_guard_rejects_staged_and_rebuilt_ownership_drift(
         guard.verify_transition_distributions(
             package_dir,
             tmp_path / "bad-rebuild",
+            release_tag="v3.1.0",
             builder=bad_builder,
         )
 
@@ -376,6 +381,7 @@ def test_memory_indep_023_package_guard_rejects_dependency_and_metadata_drift(
         guard.verify_transition_distributions(
             package_dir,
             tmp_path / "metadata-rebuild",
+            release_tag="v3.1.0",
             builder=_copy_builder(artifacts, []),
         )
 
@@ -395,6 +401,42 @@ def test_memory_indep_023_package_guard_rejects_dependency_and_metadata_drift(
         guard.verify_transition_distributions(
             package_dir,
             tmp_path / "parity-rebuild",
+            release_tag="v3.1.0",
+            builder=_copy_builder(artifacts, []),
+        )
+
+    package_dir, artifacts = _transition_packages(tmp_path / "reverse", manifest)
+    for key in ("memory_wheel", "memory_sdist"):
+        factory = _wheel if key.endswith("wheel") else _sdist
+        factory(
+            artifacts[key],
+            name="avibe-memory",
+            version="3.1.0",
+            requirements=("avibe-os>=4",),
+            files={
+                "avibe_memory/__init__.py": b"from .runtime import start\n",
+                "avibe_memory/runtime.py": b"def start(): return None\n",
+                guard.MEMORY_MANIFEST_PATH: manifest.read_bytes(),
+            },
+        )
+    with pytest.raises(guard.ReleaseAssetError, match="must accept the exact core version"):
+        guard.verify_transition_distributions(
+            package_dir,
+            tmp_path / "reverse-rebuild",
+            release_tag="v3.1.0",
+            builder=_copy_builder(artifacts, []),
+        )
+
+
+def test_transition_package_guard_binds_distribution_version_to_release_tag(tmp_path: Path) -> None:
+    manifest, _ = _manifest(tmp_path)
+    package_dir, artifacts = _transition_packages(tmp_path, manifest)
+
+    with pytest.raises(guard.ReleaseAssetError, match="does not match the release tag"):
+        guard.verify_transition_distributions(
+            package_dir,
+            tmp_path / "tag-rebuild",
+            release_tag="v3.1.1",
             builder=_copy_builder(artifacts, []),
         )
 
@@ -593,9 +635,11 @@ def test_guard_workflow_reports_and_verifies_supported_published_manifests() -> 
     assert "Guarded Memory Runtime manifests" in resolution
     assert "Excluded Memory Runtime manifests" in resolution
     assert "discover-manifest" in resolution
+    assert 'elif [ "$discovery_status" -eq 2 ]' in resolution
     assert "avibe_memory-*.whl" in resolution
     assert "fromJSON(needs.resolve_manifests.outputs.manifests)" in workflow
     assert "matrix.manifest.release_tag" in workflow
     assert "matrix.manifest.owner == 'memory'" in workflow
     assert "verify-packages --asset-dir" in workflow
+    assert workflow.count("python3 -m pip install packaging") == 2
     assert "python3 -m pip install build" in workflow

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -100,15 +100,11 @@ from pathlib import Path
 import zipfile
 def get_requires_for_build_wheel(config_settings=None): return []
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
-    metadata = Path("PKG-INFO").read_bytes(); message = Parser().parsestr(metadata.decode())
-    name, version = message["Name"].replace("-", "_"), message["Version"]
+    metadata=Path("PKG-INFO").read_bytes(); message=Parser().parsestr(metadata.decode()); name=message["Name"].replace("-", "_"); version=message["Version"]
     dist_info, wheel_name = f"{name}-{version}.dist-info", f"{name}-{version}-py3-none-any.whl"
-    excluded = {"PKG-INFO", "pyproject.toml", "_backend.py"}
-    files = {p.as_posix(): p.read_bytes() for p in Path().rglob("*") if p.is_file()
-             and p.as_posix() not in excluded and "__pycache__" not in p.parts}
+    files={p.as_posix():p.read_bytes() for p in Path().rglob("*") if p.is_file() and p.name not in {"PKG-INFO","pyproject.toml","_backend.py"} and "__pycache__" not in p.parts}
     files[f"{dist_info}/METADATA"] = metadata; files[f"{dist_info}/WHEEL"] = b"Wheel-Version: 1.0\\nRoot-Is-Purelib: true\\nTag: py3-none-any\\n\\n"
-    record = f"{dist_info}/RECORD"
-    files[record] = ("".join(f"{path},,\\n" for path in sorted(files)) + f"{record},,\\n").encode()
+    record=f"{dist_info}/RECORD"; files[record]=("".join(f"{path},,\\n" for path in sorted(files))+f"{record},,\\n").encode()
     with zipfile.ZipFile(Path(wheel_directory) / wheel_name, "w") as archive:
         for path, content in files.items():
             archive.writestr(path, content)
@@ -125,16 +121,10 @@ def _package(
     version: str = VERSION,
     requires_python: str = ">=3.10",
 ) -> Path:
-    metadata = "\n".join(
-        [
-            "Metadata-Version: 2.4",
-            f"Name: {name}",
-            f"Version: {version}",
-            f"Requires-Python: {requires_python}",
-            *(f"Requires-Dist: {item}" for item in requirements),
-            "",
-            "",
-        ]
+    metadata = (
+        f"Metadata-Version: 2.4\nName: {name}\nVersion: {version}\nRequires-Python: {requires_python}\n"
+        + "".join(f"Requires-Dist: {item}\n" for item in requirements)
+        + "\n"
     ).encode()
     members = dict(files or {})
     if path.suffix == ".whl":
@@ -261,16 +251,6 @@ def test_memory_indep_022_dual_form_discovery_reads_legacy_core_and_transition_m
         guard.discover_release_manifest(package_dir, python_executable=PYTHON)
 
 
-@pytest.mark.parametrize(
-    "filename",
-    ["avibe_os-3.1.1-py3-none-any.whl", "avibe_os-3.1.1.tar.gz"],
-)
-def test_package_guard_binds_parsed_filenames_to_metadata(filename: str) -> None:
-    metadata = guard.PackageMetadata("avibe-os", VERSION, ">=3.10", ())
-    with pytest.raises(guard.ReleaseAssetError, match="filename identity"):
-        guard._assert_filename_identity(Path(filename), metadata)
-
-
 def test_package_guard_uses_offline_pip_for_complete_dependency_resolution(tmp_path: Path) -> None:
     manifest, _ = _manifest(tmp_path)
     package_dir, artifacts = _transition_packages(
@@ -303,18 +283,22 @@ def test_package_guard_evaluates_markers_with_the_bound_interpreter(tmp_path: Pa
 
 
 @pytest.mark.parametrize(
-    "package_options",
+    ("package_options", "error"),
     [
-        {"memory_extra_files": {"core/controller.py": b"shadow\n"}},
-        {"memory_extra_files": {f"avibe_memory-{VERSION}.data/scripts/vibe": b"shadow\n"}},
-        {"core_files": {**CORE_FILES, "avibe_os-3.1.0.data/purelib/avibe_memory/runtime.py": b"shadow\n"}},
+        ({"memory_extra_files": {"core/controller.py": b"shadow\n"}}, "namespace policy"),
+        ({"memory_extra_files": {f"avibe_memory-{VERSION}.data/scripts/vibe": b"shadow\n"}}, "namespace policy"),
+        (
+            {"core_files": {**CORE_FILES, "avibe_os-3.1.0.data/purelib/avibe_memory/runtime.py": b"shadow\n"}},
+            "namespace policy",
+        ),
+        ({"core_files": {**CORE_FILES, guard.MEMORY_MANIFEST_PATH: b"owned\n"}}, "must not own"),
     ],
 )
 def test_package_guard_enforces_memory_namespace_policy_in_both_artifact_forms(
-    tmp_path: Path, package_options: dict
+    tmp_path: Path, package_options: dict, error: str
 ) -> None:
     manifest, _ = _manifest(tmp_path)
-    _reject(tmp_path, manifest, "namespace policy", **package_options)
+    _reject(tmp_path, manifest, error, **package_options)
 
 
 def test_package_guard_uses_manifest_frozen_python_policy(tmp_path: Path) -> None:
@@ -326,7 +310,7 @@ def test_package_guard_uses_manifest_frozen_python_policy(tmp_path: Path) -> Non
     package_dir, _ = _transition_packages(tmp_path, manifest, requires_python=">=3.11")
     assert _verify(package_dir, tmp_path / "rebuild") == _verify(package_dir, tmp_path / "rebuild") == VERSION
     with pytest.raises(guard.ReleaseAssetError, match="interpreter is unavailable"):
-        guard._interpreter_version(tmp_path / "missing-python")
+        guard._run_interpreter(tmp_path / "missing-python", [], "probe")
 
 
 def test_sdist_rebuild_delegates_the_archive_directly_to_isolated_pip(
@@ -351,24 +335,12 @@ def test_sdist_rebuild_delegates_the_archive_directly_to_isolated_pip(
     assert rebuilt.name == artifacts["core_wheel"].name
 
 
-def test_transition_package_guard_rejects_staged_and_rebuilt_ownership_drift(tmp_path: Path) -> None:
-    manifest, _ = _manifest(tmp_path)
-    package_dir, artifacts = _transition_packages(tmp_path, manifest)
-    _package(
-        artifacts["core_sdist"],
-        "avibe-os",
-        (f"avibe-memory=={VERSION}",),
-        files={
-            "core/memory_loader.py": b"loader\n",
-            guard.MEMORY_MANIFEST_PATH: manifest.read_bytes(),
-        },
-    )
-    with pytest.raises(guard.ReleaseAssetError, match="must not own the Memory Runtime manifest"):
-        _verify(package_dir, tmp_path / "staged-rebuild")
-
-
 def test_memory_indep_023_package_guard_rejects_dependency_and_metadata_drift(tmp_path: Path) -> None:
     manifest, _ = _manifest(tmp_path)
+    metadata = guard.PackageMetadata("avibe-os", VERSION, ">=3.10", ())
+    for filename in ("avibe_os-3.1.1-py3-none-any.whl", "avibe_os-3.1.1.tar.gz"):
+        with pytest.raises(guard.ReleaseAssetError, match="filename identity"):
+            guard._assert_filename_identity(Path(filename), metadata)
     _reject(tmp_path / "python", manifest, "must match release policy >=3.10", requires_python=">=3.9")
     _reject(
         tmp_path / "wildcard",

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -5,6 +5,7 @@ import hashlib
 import io
 import json
 import shutil
+import sys
 import tarfile
 from pathlib import Path
 import zipfile
@@ -13,6 +14,9 @@ import pytest
 
 from scripts import memory_runtime_release_guard as guard
 from scripts.build_memory_runtime import LOCK_SHA256 as RUNTIME_LOCK_SHA256
+
+PYTHON = Path(sys.executable)
+PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 
 def test_guard_platform_contract_keeps_no_follow_capable_shipped_targets_enabled() -> None:
@@ -43,7 +47,7 @@ def _manifest(
     everos_version: str = "1.2.3",
     lock_sha256: str = guard.EXPECTED_LOCK_SHA256,
     package_requires_python: str = ">=3.10",
-    supported_python_versions: tuple[str, ...] = ("3.10", "3.11", "3.12"),
+    supported_python_versions: tuple[str, ...] = (PYTHON_VERSION,),
 ) -> tuple[Path, dict[str, bytes]]:
     tag = "v3.1.0"
     base_url = f"{guard.RELEASE_DOWNLOAD_ROOT}/{tag}"
@@ -91,6 +95,25 @@ def _manifest(
 
 VERSION = "3.1.0"
 CORE_FILES = {"core/memory_loader.py": b"MEMORY_ENTRYPOINT = 'avibe_memory.runtime'\n"}
+BUILD_BACKEND = b"""from email.parser import Parser
+from pathlib import Path
+import zipfile
+def get_requires_for_build_wheel(config_settings=None): return []
+def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
+    metadata = Path("PKG-INFO").read_bytes(); message = Parser().parsestr(metadata.decode())
+    name, version = message["Name"].replace("-", "_"), message["Version"]
+    dist_info, wheel_name = f"{name}-{version}.dist-info", f"{name}-{version}-py3-none-any.whl"
+    excluded = {"PKG-INFO", "pyproject.toml", "_backend.py"}
+    files = {p.as_posix(): p.read_bytes() for p in Path().rglob("*") if p.is_file()
+             and p.as_posix() not in excluded and "__pycache__" not in p.parts}
+    files[f"{dist_info}/METADATA"] = metadata; files[f"{dist_info}/WHEEL"] = b"Wheel-Version: 1.0\\nRoot-Is-Purelib: true\\nTag: py3-none-any\\n\\n"
+    record = f"{dist_info}/RECORD"
+    files[record] = ("".join(f"{path},,\\n" for path in sorted(files)) + f"{record},,\\n").encode()
+    with zipfile.ZipFile(Path(wheel_directory) / wheel_name, "w") as archive:
+        for path, content in files.items():
+            archive.writestr(path, content)
+    return wheel_name
+"""
 
 
 def _package(
@@ -101,8 +124,6 @@ def _package(
     *,
     version: str = VERSION,
     requires_python: str = ">=3.10",
-    wheel_version: str | None = "1.0",
-    dist_info_prefix: str = "",
 ) -> Path:
     metadata = "\n".join(
         [
@@ -117,17 +138,21 @@ def _package(
     ).encode()
     members = dict(files or {})
     if path.suffix == ".whl":
-        dist_info = f"{dist_info_prefix}{name.replace('-', '_')}-{version}.dist-info"
-        members |= {f"{dist_info}/METADATA": metadata, f"{dist_info}/RECORD": b""}
-        if wheel_version is not None:
-            members[f"{dist_info}/WHEEL"] = (
-                f"Wheel-Version: {wheel_version}\nRoot-Is-Purelib: true\nTag: py3-none-any\n\n"
-            ).encode()
+        dist_info = f"{name.replace('-', '_')}-{version}.dist-info"
+        members[f"{dist_info}/METADATA"] = metadata
+        members[f"{dist_info}/WHEEL"] = b"Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n\n"
+        record = f"{dist_info}/RECORD"
+        members[record] = ("".join(f"{item},,\n" for item in sorted(members)) + f"{record},,\n").encode()
         with zipfile.ZipFile(path, "w") as archive:
             for member_name, content in members.items():
                 archive.writestr(member_name, content)
     else:
-        members = {"PKG-INFO": metadata, **members}
+        members = {
+            "PKG-INFO": metadata,
+            "pyproject.toml": b'[build-system]\nrequires = []\nbuild-backend = "_backend"\nbackend-path = ["."]\n',
+            "_backend.py": BUILD_BACKEND,
+            **members,
+        }
         with tarfile.open(path, "w:gz") as archive:
             for member_name, content in members.items():
                 member = tarfile.TarInfo(f"{name.replace('-', '_')}-{version}/{member_name}")
@@ -171,23 +196,19 @@ def _transition_packages(
     return package_dir, artifacts
 
 
-def _copy_builder(artifacts: dict[str, Path], built: list[str]):
-    def build(sdist: Path, output_dir: Path) -> Path:
-        kind = "memory" if sdist.name.startswith("avibe_memory-") else "core"
-        built.append(kind)
-        output_dir.mkdir(parents=True)
-        source = artifacts[f"{kind}_wheel"]
-        target = output_dir / source.name
-        shutil.copyfile(source, target)
-        return target
-
-    return build
-
-
-def _verify(package_dir: Path, rebuild_dir: Path, artifacts: dict[str, Path], tag: str = "v3.1.0") -> str:
+def _verify(package_dir: Path, rebuild_dir: Path) -> str:
     return guard.verify_transition_distributions(
-        package_dir, rebuild_dir, release_tag=tag, builder=_copy_builder(artifacts, [])
+        package_dir,
+        rebuild_dir,
+        release_tag="v3.1.0",
+        python_executable=PYTHON,
     )
+
+
+def _reject(root: Path, manifest: Path, error: str, **package_options) -> None:
+    package_dir, _ = _transition_packages(root, manifest, **package_options)
+    with pytest.raises(guard.ReleaseAssetError, match=error):
+        _verify(package_dir, root / "rebuild")
 
 
 @pytest.mark.parametrize("everos_version", sorted(guard.PUBLISHED_RUNTIME_PROVENANCE))
@@ -218,7 +239,9 @@ def test_guard_keeps_gh_v3_0_9rc3_runtime_in_coverage() -> None:
 def test_memory_indep_022_dual_form_discovery_reads_legacy_core_and_transition_memory(tmp_path: Path) -> None:
     manifest, _ = _manifest(tmp_path)
     package_dir, artifacts = _transition_packages(tmp_path, manifest)
-    assert guard.discover_release_manifest(package_dir) == guard.ManifestDiscovery("memory", manifest.read_bytes())
+    assert guard.discover_release_manifest(package_dir, python_executable=PYTHON) == guard.ManifestDiscovery(
+        "memory", manifest.read_bytes()
+    )
     legacy_dir = tmp_path / "legacy"
     legacy_dir.mkdir()
     _package(
@@ -227,29 +250,25 @@ def test_memory_indep_022_dual_form_discovery_reads_legacy_core_and_transition_m
         files={guard.MEMORY_MANIFEST_PATH: manifest.read_bytes()},
         version="3.0.13",
     )
-    assert guard.discover_release_manifest(legacy_dir).owner == "core"
+    assert guard.discover_release_manifest(legacy_dir, python_executable=PYTHON).owner == "core"
     _package(next(legacy_dir.iterdir()), "avibe-os", files=CORE_FILES, version="3.0.13")
     with pytest.raises(guard.LegacyManifestAbsent):
-        guard.discover_release_manifest(legacy_dir, release_tag="gh-v3.0.14rc2")
+        guard.discover_release_manifest(legacy_dir, python_executable=PYTHON, release_tag="gh-v3.0.14rc2")
     with pytest.raises(guard.ReleaseAssetError, match="transition-and-later"):
-        guard.discover_release_manifest(legacy_dir, release_tag="gh-v3.0.14rc3")
+        guard.discover_release_manifest(legacy_dir, python_executable=PYTHON, release_tag="gh-v3.0.14rc3")
     artifacts["memory_wheel"].unlink()
     with pytest.raises(guard.ReleaseAssetError, match="transition avibe-memory artifact is missing"):
-        guard.discover_release_manifest(package_dir)
+        guard.discover_release_manifest(package_dir, python_executable=PYTHON)
 
 
 @pytest.mark.parametrize(
-    ("artifact_key", "wrong_name"),
-    [("core_wheel", "avibe_os-3.1.1-py3-none-any.whl"), ("memory_sdist", "avibe_memory-3.1.1.tar.gz")],
+    "filename",
+    ["avibe_os-3.1.1-py3-none-any.whl", "avibe_os-3.1.1.tar.gz"],
 )
-def test_package_guard_binds_parsed_filenames_to_metadata_and_release(
-    tmp_path: Path, artifact_key: str, wrong_name: str
-) -> None:
-    manifest, _ = _manifest(tmp_path)
-    package_dir, artifacts = _transition_packages(tmp_path, manifest)
-    artifacts[artifact_key] = artifacts[artifact_key].rename(package_dir / wrong_name)
+def test_package_guard_binds_parsed_filenames_to_metadata(filename: str) -> None:
+    metadata = guard.PackageMetadata("avibe-os", VERSION, ">=3.10", ())
     with pytest.raises(guard.ReleaseAssetError, match="filename identity"):
-        _verify(package_dir, tmp_path / "rebuild", artifacts)
+        guard._assert_filename_identity(Path(filename), metadata)
 
 
 def test_package_guard_uses_offline_pip_for_complete_dependency_resolution(tmp_path: Path) -> None:
@@ -260,89 +279,79 @@ def test_package_guard_uses_offline_pip_for_complete_dependency_resolution(tmp_p
         core_requirements=("avibe-memory==3.1.0", "shared==1"),
         memory_requirements=("avibe-os>=3.1,<3.2", "shared==2"),
     )
-    for version in ("1", "2"):
-        _package(
-            package_dir / f"shared-{version}-py3-none-any.whl",
-            "shared",
-            files={"shared/__init__.py": b""},
-            version=version,
-        )
-    with pytest.raises(guard.ReleaseAssetError, match="offline pip resolution"):
-        _verify(package_dir, tmp_path / "rebuild", artifacts)
+    _package(
+        package_dir / "shared-1-py3-none-any.whl",
+        "shared",
+        files={"shared/__init__.py": b""},
+        version="1",
+    )
+    with pytest.raises(guard.ReleaseAssetError, match="offline pip install"):
+        _verify(package_dir, tmp_path / "rebuild")
 
 
-@pytest.mark.parametrize("forbidden_path", ["core/controller.py", "vibe/__init__.py"])
+def test_package_guard_evaluates_markers_with_the_bound_interpreter(tmp_path: Path) -> None:
+    manifest, _ = _manifest(tmp_path)
+    _reject(
+        tmp_path,
+        manifest,
+        "offline pip install",
+        core_requirements=(
+            f"avibe-memory=={VERSION}",
+            f"target-only==1; python_version == '{PYTHON_VERSION}'",
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "package_options",
+    [
+        {"memory_extra_files": {"core/controller.py": b"shadow\n"}},
+        {"memory_extra_files": {f"avibe_memory-{VERSION}.data/scripts/vibe": b"shadow\n"}},
+        {"core_files": {**CORE_FILES, "avibe_os-3.1.0.data/purelib/avibe_memory/runtime.py": b"shadow\n"}},
+    ],
+)
 def test_package_guard_enforces_memory_namespace_policy_in_both_artifact_forms(
-    tmp_path: Path, forbidden_path: str
+    tmp_path: Path, package_options: dict
 ) -> None:
     manifest, _ = _manifest(tmp_path)
-    package_dir, artifacts = _transition_packages(tmp_path, manifest, memory_extra_files={forbidden_path: b"shadow\n"})
-    with pytest.raises(guard.ReleaseAssetError, match="namespace policy"):
-        _verify(package_dir, tmp_path / "rebuild", artifacts)
+    _reject(tmp_path, manifest, "namespace policy", **package_options)
 
 
 def test_package_guard_uses_manifest_frozen_python_policy(tmp_path: Path) -> None:
     manifest, _ = _manifest(
         tmp_path,
         package_requires_python=">=3.11",
-        supported_python_versions=("3.11", "3.12"),
+        supported_python_versions=(PYTHON_VERSION,),
     )
-    package_dir, artifacts = _transition_packages(tmp_path, manifest, requires_python=">=3.11")
-    built: list[str] = []
-    version = guard.verify_transition_distributions(
-        package_dir, tmp_path / "rebuild", release_tag="v3.1.0", builder=_copy_builder(artifacts, built)
-    )
-    assert (version, built) == (VERSION, ["core", "memory"])
+    package_dir, _ = _transition_packages(tmp_path, manifest, requires_python=">=3.11")
+    assert _verify(package_dir, tmp_path / "rebuild") == _verify(package_dir, tmp_path / "rebuild") == VERSION
+    with pytest.raises(guard.ReleaseAssetError, match="interpreter is unavailable"):
+        guard._interpreter_version(tmp_path / "missing-python")
 
 
-@pytest.mark.parametrize(
-    ("wheel_version", "dist_info_prefix"),
-    [(None, ""), ("2.0", ""), ("1.0", "nested/")],
-)
-def test_package_guard_uses_pip_wheel_structure_validation(
-    tmp_path: Path, wheel_version: str | None, dist_info_prefix: str
-) -> None:
-    manifest, _ = _manifest(tmp_path)
-    package_dir, artifacts = _transition_packages(tmp_path, manifest)
-    _package(
-        artifacts["core_wheel"],
-        "avibe-os",
-        (f"avibe-memory=={VERSION}",),
-        CORE_FILES,
-        wheel_version=wheel_version,
-        dist_info_prefix=dist_info_prefix,
-    )
-
-    with pytest.raises(guard.ReleaseAssetError, match="wheel structure validation"):
-        _verify(package_dir, tmp_path / "rebuild", artifacts)
-
-
-def test_default_sdist_builder_uses_pep517_isolation_without_importing_source(
+def test_sdist_rebuild_delegates_the_archive_directly_to_isolated_pip(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     manifest, _ = _manifest(tmp_path)
     _, artifacts = _transition_packages(tmp_path, manifest)
-    calls: list[list[str]] = []
 
-    def run(argv: list[str], **kwargs):
-        calls.append(argv)
-        assert "--no-isolation" not in argv
-        assert kwargs["env"]["PYTHONPATH"] == ""
-        assert (Path(argv[-1]) / "PKG-INFO").is_file()
-        wheel_dir = Path(argv[argv.index("--outdir") + 1])
+    def run(_python: Path, argv: list[str], _failure: str):
+        assert argv[0] == "wheel"
+        assert argv[-1] == str(artifacts["core_sdist"].resolve())
+        wheel_dir = Path(argv[argv.index("--wheel-dir") + 1])
         shutil.copyfile(artifacts["core_wheel"], wheel_dir / artifacts["core_wheel"].name)
-        return guard.subprocess.CompletedProcess(argv, 0, "", "")
 
-    monkeypatch.setattr(guard.subprocess, "run", run)
-    rebuilt = [guard.rebuild_sdist_wheel(artifacts["core_sdist"], tmp_path / "isolated") for _ in range(2)]
-    assert {path.name for path in rebuilt} == {artifacts["core_wheel"].name}
-    assert rebuilt[0].parent != rebuilt[1].parent
-    assert len(calls) == 2
-    assert calls[0][1:4] == ["-m", "build", "--wheel"]
+    monkeypatch.setattr(guard, "_run_pip", run)
+    rebuilt = guard.rebuild_sdist_wheel(
+        artifacts["core_sdist"],
+        tmp_path / "isolated",
+        python_executable=PYTHON,
+        find_links=(artifacts["core_sdist"].parent,),
+    )
+    assert rebuilt.name == artifacts["core_wheel"].name
 
 
-@pytest.mark.parametrize("wheel_scheme", ["purelib", "platlib"])
-def test_transition_package_guard_rejects_staged_and_rebuilt_ownership_drift(tmp_path: Path, wheel_scheme: str) -> None:
+def test_transition_package_guard_rejects_staged_and_rebuilt_ownership_drift(tmp_path: Path) -> None:
     manifest, _ = _manifest(tmp_path)
     package_dir, artifacts = _transition_packages(tmp_path, manifest)
     _package(
@@ -354,50 +363,19 @@ def test_transition_package_guard_rejects_staged_and_rebuilt_ownership_drift(tmp
             guard.MEMORY_MANIFEST_PATH: manifest.read_bytes(),
         },
     )
-    with pytest.raises(guard.ReleaseAssetError, match="namespace policy"):
-        _verify(package_dir, tmp_path / "staged-rebuild", artifacts)
-
-    package_dir, artifacts = _transition_packages(tmp_path / "rebuilt", manifest)
-    bad_core = _package(
-        tmp_path / "avibe_os-3.1.0-py3-none-any.whl",
-        "avibe-os",
-        (f"avibe-memory=={VERSION}",),
-        files={guard.MEMORY_MANIFEST_PATH: manifest.read_bytes()},
-    )
-
-    def bad_builder(sdist: Path, output_dir: Path) -> Path:
-        if sdist.name.startswith("avibe_os-"):
-            return bad_core
-        return _copy_builder(artifacts, [])(sdist, output_dir)
-
-    with pytest.raises(guard.ReleaseAssetError, match="namespace policy"):
-        guard.verify_transition_distributions(
-            package_dir, tmp_path / "bad-rebuild", release_tag="v3.1.0", builder=bad_builder
-        )
-
-    package_dir, artifacts = _transition_packages(
-        tmp_path / wheel_scheme,
-        manifest,
-        core_files={
-            "core/memory_loader.py": b"loader\n",
-            f"avibe_os-3.1.0.data/{wheel_scheme}/avibe_memory/runtime.py": b"shadow\n",
-        },
-    )
-    with pytest.raises(guard.ReleaseAssetError, match="namespace policy"):
-        _verify(package_dir, tmp_path / f"{wheel_scheme}-rebuild", artifacts)
+    with pytest.raises(guard.ReleaseAssetError, match="must not own the Memory Runtime manifest"):
+        _verify(package_dir, tmp_path / "staged-rebuild")
 
 
 def test_memory_indep_023_package_guard_rejects_dependency_and_metadata_drift(tmp_path: Path) -> None:
     manifest, _ = _manifest(tmp_path)
-    package_dir, artifacts = _transition_packages(tmp_path, manifest, requires_python=">=99")
-    with pytest.raises(guard.ReleaseAssetError, match="must match release policy >=3.10"):
-        _verify(package_dir, tmp_path / "python-range-rebuild", artifacts)
-
-    package_dir, artifacts = _transition_packages(
-        tmp_path / "pin", manifest, core_requirements=("avibe-memory==3.1.1",)
+    _reject(tmp_path / "python", manifest, "must match release policy >=3.10", requires_python=">=3.9")
+    _reject(
+        tmp_path / "wildcard",
+        manifest,
+        "hard-depend on the exact Memory version",
+        core_requirements=("avibe-memory==3.1.*",),
     )
-    with pytest.raises(guard.ReleaseAssetError, match="hard-depend on the exact Memory version"):
-        _verify(package_dir, tmp_path / "metadata-rebuild", artifacts)
 
     package_dir, artifacts = _transition_packages(tmp_path / "metadata", manifest)
     _package(
@@ -411,15 +389,7 @@ def test_memory_indep_023_package_guard_rejects_dependency_and_metadata_drift(tm
         },
     )
     with pytest.raises(guard.ReleaseAssetError, match="wheel and sdist metadata differ"):
-        _verify(package_dir, tmp_path / "parity-rebuild", artifacts)
-
-    package_dir, artifacts = _transition_packages(tmp_path / "reverse", manifest, memory_requirements=("avibe-os>=4",))
-    with pytest.raises(guard.ReleaseAssetError, match="must accept the exact core version"):
-        _verify(package_dir, tmp_path / "reverse-rebuild", artifacts)
-
-    package_dir, artifacts = _transition_packages(tmp_path / "tag", manifest)
-    with pytest.raises(guard.ManifestPolicyError, match="package_policy identity"):
-        _verify(package_dir, tmp_path / "tag-rebuild", artifacts, tag="v3.1.1")
+        _verify(package_dir, tmp_path / "parity-rebuild")
 
 
 def test_guard_rejects_unknown_runtime_provenance(tmp_path: Path) -> None:

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -250,8 +250,9 @@ def test_memory_indep_022_023_discovery_distinguishes_legacy_and_ambiguous_trans
     )
     with pytest.raises(guard.LegacyManifestAbsent):
         guard.discover_release_manifest(legacy_dir, release_tag="gh-v3.0.14rc2")
-    with pytest.raises(guard.ReleaseAssetError, match="transition-and-later"):
-        guard.discover_release_manifest(legacy_dir, release_tag="v3.0.14")
+    for release_tag in ("gh-v3.0.14rc3", "v3.0.14"):
+        with pytest.raises(guard.ReleaseAssetError, match="transition-and-later"):
+            guard.discover_release_manifest(legacy_dir, release_tag=release_tag)
 
     package_dir, artifacts = _transition_packages(tmp_path / "ambiguous", manifest)
     _wheel(

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -159,16 +159,18 @@ def _transition_packages(
     core_files: dict[str, bytes] | None = None,
     core_requirements: tuple[str, ...] = (f"avibe-memory=={VERSION}",),
     memory_extra_files: dict[str, bytes] | None = None,
+    memory_files: dict[str, bytes] | None = None,
     memory_requirements: tuple[str, ...] = ("avibe-os>=3.0.14.dev0,<3.2",),
 ) -> tuple[Path, dict[str, Path]]:
     package_dir = root / "packages"
     package_dir.mkdir(parents=True)
-    memory_files = {
-        "avibe_memory/__init__.py": b"from .runtime import start\n",
-        "avibe_memory/runtime.py": b"def start(): return None\n",
-        guard.MEMORY_MANIFEST_PATH: manifest.read_bytes(),
-        **(memory_extra_files or {}),
-    }
+    if memory_files is None:
+        memory_files = {
+            "avibe_memory/__init__.py": b"from .runtime import start\n",
+            "avibe_memory/runtime.py": b"def start(): return None\n",
+            guard.MEMORY_MANIFEST_PATH: manifest.read_bytes(),
+        }
+    memory_files.update(memory_extra_files or {})
     artifacts: dict[str, Path] = {}
     for key, name, requirements, files in (
         ("core", "avibe-os", core_requirements, core_files or CORE_FILES),
@@ -285,13 +287,13 @@ def test_package_guard_evaluates_markers_with_the_bound_interpreter(tmp_path: Pa
 @pytest.mark.parametrize(
     ("package_options", "error"),
     [
-        ({"memory_extra_files": {"core/controller.py": b"shadow\n"}}, "namespace policy"),
-        ({"memory_extra_files": {f"avibe_memory-{VERSION}.data/scripts/vibe": b"shadow\n"}}, "namespace policy"),
+        ({"memory_extra_files": {"core/controller.py": b"shadow\n"}}, "forbidden path policy"),
+        ({"memory_extra_files": {f"avibe_memory-{VERSION}.data/scripts/vibe": b"shadow\n"}}, "forbidden path policy"),
         (
             {"core_files": {**CORE_FILES, "avibe_os-3.1.0.data/purelib/avibe_memory/runtime.py": b"shadow\n"}},
-            "namespace policy",
+            "forbidden path policy",
         ),
-        ({"core_files": {**CORE_FILES, guard.MEMORY_MANIFEST_PATH: b"owned\n"}}, "must not own"),
+        ({"core_files": {**CORE_FILES, guard.MEMORY_MANIFEST_PATH: b"owned\n"}}, "forbidden path policy"),
     ],
 )
 def test_package_guard_enforces_memory_namespace_policy_in_both_artifact_forms(
@@ -299,6 +301,12 @@ def test_package_guard_enforces_memory_namespace_policy_in_both_artifact_forms(
 ) -> None:
     manifest, _ = _manifest(tmp_path)
     _reject(tmp_path, manifest, error, **package_options)
+
+
+def test_package_guard_proves_runtime_without_source_tree_leakage(tmp_path: Path) -> None:
+    manifest, _ = _manifest(tmp_path)
+    files = {guard.MEMORY_MANIFEST_PATH: manifest.read_bytes()}
+    _reject(tmp_path, manifest, "installed Memory runtime probe failed", memory_files=files)
 
 
 def test_package_guard_uses_manifest_frozen_python_policy(tmp_path: Path) -> None:

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -159,18 +159,16 @@ def _transition_packages(
     core_files: dict[str, bytes] | None = None,
     core_requirements: tuple[str, ...] = (f"avibe-memory=={VERSION}",),
     memory_extra_files: dict[str, bytes] | None = None,
-    memory_files: dict[str, bytes] | None = None,
     memory_requirements: tuple[str, ...] = ("avibe-os>=3.0.14.dev0,<3.2",),
 ) -> tuple[Path, dict[str, Path]]:
     package_dir = root / "packages"
     package_dir.mkdir(parents=True)
-    if memory_files is None:
-        memory_files = {
-            "avibe_memory/__init__.py": b"from .runtime import start\n",
-            "avibe_memory/runtime.py": b"def start(): return None\n",
-            guard.MEMORY_MANIFEST_PATH: manifest.read_bytes(),
-        }
-    memory_files.update(memory_extra_files or {})
+    memory_files = {
+        "avibe_memory/__init__.py": b"from .runtime import start\n",
+        "avibe_memory/runtime.py": b"def start(): return None\n",
+        guard.MEMORY_MANIFEST_PATH: manifest.read_bytes(),
+        **(memory_extra_files or {}),
+    }
     artifacts: dict[str, Path] = {}
     for key, name, requirements, files in (
         ("core", "avibe-os", core_requirements, core_files or CORE_FILES),
@@ -253,37 +251,6 @@ def test_memory_indep_022_dual_form_discovery_reads_legacy_core_and_transition_m
         guard.discover_release_manifest(package_dir, python_executable=PYTHON)
 
 
-def test_package_guard_uses_offline_pip_for_complete_dependency_resolution(tmp_path: Path) -> None:
-    manifest, _ = _manifest(tmp_path)
-    package_dir, artifacts = _transition_packages(
-        tmp_path,
-        manifest,
-        core_requirements=("avibe-memory==3.1.0", "shared==1"),
-        memory_requirements=("avibe-os>=3.1,<3.2", "shared==2"),
-    )
-    _package(
-        package_dir / "shared-1-py3-none-any.whl",
-        "shared",
-        files={"shared/__init__.py": b""},
-        version="1",
-    )
-    with pytest.raises(guard.ReleaseAssetError, match="offline pip install"):
-        _verify(package_dir, tmp_path / "rebuild")
-
-
-def test_package_guard_evaluates_markers_with_the_bound_interpreter(tmp_path: Path) -> None:
-    manifest, _ = _manifest(tmp_path)
-    _reject(
-        tmp_path,
-        manifest,
-        "offline pip install",
-        core_requirements=(
-            f"avibe-memory=={VERSION}",
-            f"target-only==1; python_version == '{PYTHON_VERSION}'",
-        ),
-    )
-
-
 @pytest.mark.parametrize(
     ("package_options", "error"),
     [
@@ -303,12 +270,6 @@ def test_package_guard_enforces_memory_namespace_policy_in_both_artifact_forms(
     _reject(tmp_path, manifest, error, **package_options)
 
 
-def test_package_guard_proves_runtime_without_source_tree_leakage(tmp_path: Path) -> None:
-    manifest, _ = _manifest(tmp_path)
-    files = {guard.MEMORY_MANIFEST_PATH: manifest.read_bytes()}
-    _reject(tmp_path, manifest, "installed Memory runtime probe failed", memory_files=files)
-
-
 def test_package_guard_uses_manifest_frozen_python_policy(tmp_path: Path) -> None:
     manifest, _ = _manifest(
         tmp_path,
@@ -319,6 +280,23 @@ def test_package_guard_uses_manifest_frozen_python_policy(tmp_path: Path) -> Non
     assert _verify(package_dir, tmp_path / "rebuild") == _verify(package_dir, tmp_path / "rebuild") == VERSION
     with pytest.raises(guard.ReleaseAssetError, match="interpreter is unavailable"):
         guard._run_interpreter(tmp_path / "missing-python", [], "probe")
+
+
+def test_package_guard_rejects_manifest_byte_mismatch_before_policy_parsing(tmp_path: Path) -> None:
+    selected, _ = _manifest(tmp_path)
+    payload = json.loads(selected.read_bytes())
+    payload["package_policy"]["schema_version"] = 2
+    embedded = tmp_path / "embedded.json"
+    embedded.write_text(json.dumps(payload))
+    package_dir, _ = _transition_packages(tmp_path / "release", embedded)
+    with pytest.raises(guard.ReleaseAssetError, match="does not match the selected manifest"):
+        guard.verify_transition_distributions(
+            package_dir,
+            tmp_path / "rebuild",
+            release_tag="v3.1.0",
+            python_executable=PYTHON,
+            expected_manifest=selected.read_bytes(),
+        )
 
 
 def test_sdist_rebuild_delegates_the_archive_directly_to_isolated_pip(

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -79,12 +79,14 @@ def _manifest(
     return manifest, remote
 
 
-def _package_metadata(name: str, version: str, requirements: tuple[str, ...]) -> bytes:
+def _package_metadata(
+    name: str, version: str, requirements: tuple[str, ...], requires_python: str = ">=3.10"
+) -> bytes:
     fields = [
         "Metadata-Version: 2.4",
         f"Name: {name}",
         f"Version: {version}",
-        "Requires-Python: >=3.10",
+        f"Requires-Python: {requires_python}",
         *(f"Requires-Dist: {requirement}" for requirement in requirements),
     ]
     return ("\n".join(fields) + "\n\n").encode()
@@ -97,12 +99,13 @@ def _wheel(
     version: str,
     requirements: tuple[str, ...],
     files: dict[str, bytes],
+    requires_python: str = ">=3.10",
 ) -> Path:
     dist_info = name.replace("-", "_") + f"-{version}.dist-info"
     with zipfile.ZipFile(path, "w") as archive:
         for member_name, content in {
             **files,
-            f"{dist_info}/METADATA": _package_metadata(name, version, requirements),
+            f"{dist_info}/METADATA": _package_metadata(name, version, requirements, requires_python),
         }.items():
             archive.writestr(member_name, content)
     return path
@@ -115,11 +118,12 @@ def _sdist(
     version: str,
     requirements: tuple[str, ...],
     files: dict[str, bytes],
+    requires_python: str = ">=3.10",
 ) -> Path:
     root = f"{name.replace('-', '_')}-{version}"
     with tarfile.open(path, "w:gz") as archive:
         for member_name, content in {
-            "PKG-INFO": _package_metadata(name, version, requirements),
+            "PKG-INFO": _package_metadata(name, version, requirements, requires_python),
             **files,
         }.items():
             member = tarfile.TarInfo(f"{root}/{member_name}")
@@ -128,11 +132,19 @@ def _sdist(
     return path
 
 
-def _transition_packages(tmp_path: Path, manifest: Path) -> tuple[Path, dict[str, Path]]:
+def _transition_packages(
+    tmp_path: Path,
+    manifest: Path,
+    *,
+    requires_python: str = ">=3.10",
+    core_files: dict[str, bytes] | None = None,
+    memory_requirements: tuple[str, ...] = ("avibe-os>=3.0.14.dev0,<3.2",),
+) -> tuple[Path, dict[str, Path]]:
     package_dir = tmp_path / "packages"
     package_dir.mkdir(parents=True)
     version = "3.1.0"
-    core_files = {"core/memory_loader.py": b"MEMORY_ENTRYPOINT = 'avibe_memory.runtime'\n"}
+    if core_files is None:
+        core_files = {"core/memory_loader.py": b"MEMORY_ENTRYPOINT = 'avibe_memory.runtime'\n"}
     memory_files = {
         "avibe_memory/__init__.py": b"from .runtime import start\n",
         "avibe_memory/runtime.py": b"def start(): return None\n",
@@ -145,6 +157,7 @@ def _transition_packages(tmp_path: Path, manifest: Path) -> tuple[Path, dict[str
             version=version,
             requirements=(f"avibe-memory=={version}",),
             files=core_files,
+            requires_python=requires_python,
         ),
         "core_sdist": _sdist(
             package_dir / f"avibe_os-{version}.tar.gz",
@@ -152,20 +165,23 @@ def _transition_packages(tmp_path: Path, manifest: Path) -> tuple[Path, dict[str
             version=version,
             requirements=(f"avibe-memory=={version}",),
             files=core_files,
+            requires_python=requires_python,
         ),
         "memory_wheel": _wheel(
             package_dir / f"avibe_memory-{version}-py3-none-any.whl",
             name="avibe-memory",
             version=version,
-            requirements=("avibe-os>=3.0.14.dev0,<3.2",),
+            requirements=memory_requirements,
             files=memory_files,
+            requires_python=requires_python,
         ),
         "memory_sdist": _sdist(
             package_dir / f"avibe_memory-{version}.tar.gz",
             name="avibe-memory",
             version=version,
-            requirements=("avibe-os>=3.0.14.dev0,<3.2",),
+            requirements=memory_requirements,
             files=memory_files,
+            requires_python=requires_python,
         ),
     }
     return package_dir, artifacts
@@ -182,6 +198,17 @@ def _copy_builder(artifacts: dict[str, Path], built: list[str]):
         return target
 
     return build
+
+
+def _verify(
+    package_dir: Path,
+    rebuild_dir: Path,
+    artifacts: dict[str, Path],
+    release_tag: str = "v3.1.0",
+) -> str:
+    return guard.verify_transition_distributions(
+        package_dir, rebuild_dir, release_tag=release_tag, builder=_copy_builder(artifacts, [])
+    )
 
 
 @pytest.mark.parametrize("everos_version", sorted(guard.PUBLISHED_RUNTIME_PROVENANCE))
@@ -307,13 +334,19 @@ def test_default_sdist_builder_uses_pep517_isolation_without_importing_source(
 
     monkeypatch.setattr(guard.subprocess, "run", run)
     rebuilt = guard.rebuild_sdist_wheel(artifacts["core_sdist"], tmp_path / "isolated")
+    rebuilt_again = guard.rebuild_sdist_wheel(artifacts["core_sdist"], tmp_path / "isolated")
 
     assert rebuilt.name == artifacts["core_wheel"].name
+    assert rebuilt_again.name == artifacts["core_wheel"].name
+    assert rebuilt.parent != rebuilt_again.parent
+    assert len(calls) == 2
     assert calls[0][1:4] == ["-m", "build", "--wheel"]
 
 
+@pytest.mark.parametrize("wheel_scheme", ["purelib", "platlib"])
 def test_transition_package_guard_rejects_staged_and_rebuilt_ownership_drift(
     tmp_path: Path,
+    wheel_scheme: str,
 ) -> None:
     manifest, _ = _manifest(tmp_path)
     package_dir, artifacts = _transition_packages(tmp_path, manifest)
@@ -328,12 +361,7 @@ def test_transition_package_guard_rejects_staged_and_rebuilt_ownership_drift(
         },
     )
     with pytest.raises(guard.ReleaseAssetError, match="core artifact owns Memory content"):
-        guard.verify_transition_distributions(
-            package_dir,
-            tmp_path / "staged-rebuild",
-            release_tag="v3.1.0",
-            builder=_copy_builder(artifacts, []),
-        )
+        _verify(package_dir, tmp_path / "staged-rebuild", artifacts)
 
     package_dir, artifacts = _transition_packages(tmp_path / "rebuilt", manifest)
     bad_core = _wheel(
@@ -357,12 +385,27 @@ def test_transition_package_guard_rejects_staged_and_rebuilt_ownership_drift(
             builder=bad_builder,
         )
 
+    package_dir, artifacts = _transition_packages(
+        tmp_path / wheel_scheme,
+        manifest,
+        core_files={
+            "core/memory_loader.py": b"loader\n",
+            f"avibe_os-3.1.0.data/{wheel_scheme}/avibe_memory/runtime.py": b"shadow\n",
+        },
+    )
+    with pytest.raises(guard.ReleaseAssetError, match="core artifact owns Memory content"):
+        _verify(package_dir, tmp_path / f"{wheel_scheme}-rebuild", artifacts)
+
 
 def test_memory_indep_023_package_guard_rejects_dependency_and_metadata_drift(
     tmp_path: Path,
 ) -> None:
     manifest, _ = _manifest(tmp_path)
-    package_dir, artifacts = _transition_packages(tmp_path, manifest)
+    package_dir, artifacts = _transition_packages(tmp_path, manifest, requires_python=">=99")
+    with pytest.raises(guard.ReleaseAssetError, match="must match the project range >=3.10"):
+        _verify(package_dir, tmp_path / "python-range-rebuild", artifacts)
+
+    package_dir, artifacts = _transition_packages(tmp_path / "pin", manifest)
     _wheel(
         artifacts["core_wheel"],
         name="avibe-os",
@@ -379,12 +422,7 @@ def test_memory_indep_023_package_guard_rejects_dependency_and_metadata_drift(
     )
 
     with pytest.raises(guard.ReleaseAssetError, match="hard-depend on the exact Memory version"):
-        guard.verify_transition_distributions(
-            package_dir,
-            tmp_path / "metadata-rebuild",
-            release_tag="v3.1.0",
-            builder=_copy_builder(artifacts, []),
-        )
+        _verify(package_dir, tmp_path / "metadata-rebuild", artifacts)
 
     package_dir, artifacts = _transition_packages(tmp_path / "metadata", manifest)
     _sdist(
@@ -399,47 +437,17 @@ def test_memory_indep_023_package_guard_rejects_dependency_and_metadata_drift(
         },
     )
     with pytest.raises(guard.ReleaseAssetError, match="wheel and sdist metadata differ"):
-        guard.verify_transition_distributions(
-            package_dir,
-            tmp_path / "parity-rebuild",
-            release_tag="v3.1.0",
-            builder=_copy_builder(artifacts, []),
-        )
+        _verify(package_dir, tmp_path / "parity-rebuild", artifacts)
 
-    package_dir, artifacts = _transition_packages(tmp_path / "reverse", manifest)
-    for key in ("memory_wheel", "memory_sdist"):
-        factory = _wheel if key.endswith("wheel") else _sdist
-        factory(
-            artifacts[key],
-            name="avibe-memory",
-            version="3.1.0",
-            requirements=("avibe-os>=4",),
-            files={
-                "avibe_memory/__init__.py": b"from .runtime import start\n",
-                "avibe_memory/runtime.py": b"def start(): return None\n",
-                guard.MEMORY_MANIFEST_PATH: manifest.read_bytes(),
-            },
-        )
+    package_dir, artifacts = _transition_packages(
+        tmp_path / "reverse", manifest, memory_requirements=("avibe-os>=4",)
+    )
     with pytest.raises(guard.ReleaseAssetError, match="must accept the exact core version"):
-        guard.verify_transition_distributions(
-            package_dir,
-            tmp_path / "reverse-rebuild",
-            release_tag="v3.1.0",
-            builder=_copy_builder(artifacts, []),
-        )
+        _verify(package_dir, tmp_path / "reverse-rebuild", artifacts)
 
-
-def test_transition_package_guard_binds_distribution_version_to_release_tag(tmp_path: Path) -> None:
-    manifest, _ = _manifest(tmp_path)
-    package_dir, artifacts = _transition_packages(tmp_path, manifest)
-
+    package_dir, artifacts = _transition_packages(tmp_path / "tag", manifest)
     with pytest.raises(guard.ReleaseAssetError, match="does not match the release tag"):
-        guard.verify_transition_distributions(
-            package_dir,
-            tmp_path / "tag-rebuild",
-            release_tag="v3.1.1",
-            builder=_copy_builder(artifacts, []),
-        )
+        _verify(package_dir, tmp_path / "tag-rebuild", artifacts, release_tag="v3.1.1")
 
 
 def test_guard_rejects_unknown_runtime_provenance(tmp_path: Path) -> None:
@@ -635,12 +643,5 @@ def test_guard_workflow_reports_and_verifies_supported_published_manifests() -> 
     assert "check-policy" in resolution
     assert "Guarded Memory Runtime manifests" in resolution
     assert "Excluded Memory Runtime manifests" in resolution
-    assert "discover-manifest" in resolution
-    assert 'elif [ "$discovery_status" -eq 2 ]' in resolution
-    assert "avibe_memory-*.whl" in resolution
     assert "fromJSON(needs.resolve_manifests.outputs.manifests)" in workflow
     assert "matrix.manifest.release_tag" in workflow
-    assert "matrix.manifest.owner == 'memory'" in workflow
-    assert "verify-packages --asset-dir" in workflow
-    assert workflow.count("python3 -m pip install packaging") == 2
-    assert "python3 -m pip install build" in workflow


### PR DESCRIPTION
## Gate5a capability

Delivers the Wave 3c Gate5a verifier core without workflow integration or Gate5b publication work.

## Precise scope

- discovers legacy core-owned and transition Memory-owned runtime manifests, with manifest-free handling bounded to known legacy tags;
- parses wheel and sdist filenames with `packaging.utils`, then binds normalized distribution/version to metadata and the release tag;
- verifies core and Memory wheels and sdists for exact metadata, dependency, namespace ownership, required implementation, and manifest content;
- validates wheel structure with real pip, including top-level dist-info identity, mandatory WHEEL metadata, and supported Wheel-Version;
- validates the complete combined core/Memory dependency closure with offline pip for every manifest-frozen supported Python version;
- reads Requires-Python and the versioned namespace policy from a release-tag/family keyed policy record frozen in the Memory-owned manifest;
- normalizes wheel `.data/purelib` and `.data/platlib` destinations before ownership/content checks;
- rebuilds every staged sdist in a retry-safe isolated PEP 517 attempt directory and applies the same verifier and resolver to rebuilt wheels;
- exposes `verify-public` to freshly re-download and hash-check the public manifest and every manifest-referenced archive;
- changes only `scripts/memory_runtime_release_guard.py` and `tests/test_memory_runtime_release_guard.py`.

All workflow integration was removed by owner disposition. A successor Gate5a workflow PR owns dual-form scheduling, independent runtime recovery, and read-only credential-free execution of untrusted sdist rebuilds.

## MEMORY-INDEP-022/023 evidence

- `MEMORY-INDEP-022`: explicit legacy/core and transition/Memory discovery; transition-family manifest failures remain visible; public asset re-download and hash verification cover every manifest reference.
- `MEMORY-INDEP-023`: staged core/Memory wheels and sdists receive direct ownership/content/dependency/metadata assertions; both rebuilt wheels receive the same assertions and complete offline resolution.

Evidence:

- focused release/verifier tests: 55 passed;
- Ruff check/format, Python compilation, and `git diff --check`: clean;
- Python 3.10 compatibility verified with `packaging==23.0`;
- cumulative diff: 888 net lines across two files;
- exact-head GitHub lint and Codex review remain the remote gate.

## Residual Gate5a workflow work

The successor workflow PR must wire the verifier into scheduled verification/backup/recovery while preserving recovery independently of package verification, and must run downloaded sdist build hooks in a read-only job with checkout credentials disabled.

## Residual Gate5b work

Gate5b remains intentionally unimplemented. This PR does not change transition dependency pins, execute a release, remove the release block, alter publish/finalizer workflows, or implement publication/checkpoint sequencing. Eventual owner-authorized Gate5b work must invoke public verification immediately before gate removal and implement the contracted publication order.

Manual release and Incus acceptance remain deferred to the orchestrator's integrated transition wheelhouse/publication pass. No local Avibe service or runtime lifecycle was restarted or changed.
