### PR TITLE
feat(model-hub): implement wide gateway layout

### DIFF
--- a/ui/src/components/settings/models/AgentCard.test.tsx
+++ b/ui/src/components/settings/models/AgentCard.test.tsx
@@ -119,7 +119,7 @@ describe('AgentCard', () => {
   it.each([
     ['en', 'Adjust priority', 'Switch to direct', 'Switch to gateway'],
     ['zh', '调整优先级', '切到直连', '切换到模型网关'],
-  ] as const)('uses explicit gateway action labels and icons in %s', (lng, orderCopy, directCopy, gatewayCopy) => {
+  ] as const)('uses explicit gateway action labels and icons in %s', async (lng, orderCopy, directCopy, gatewayCopy) => {
     const directAgent: AgentSupply = {
       ...hubAgent,
       backend: 'codex',
@@ -149,16 +149,16 @@ describe('AgentCard', () => {
     );
 
     const order = screen.getByRole('button', { name: orderCopy });
-    const direct = screen.getByRole('button', { name: directCopy });
     const gateway = screen.getByRole('button', { name: gatewayCopy });
+    await userEvent.click(screen.getByRole('button', { name: /Runtime mode:|运行模式[:：]/i }));
+    const direct = await screen.findByRole('menuitem', { name: new RegExp(directCopy, 'i') });
     expect(order.querySelector('svg')).toBeTruthy();
-    expect(direct.querySelector('svg')).toBeTruthy();
+    expect(direct.querySelector('.lucide-power')).toBeTruthy();
     expect(gateway.querySelector('svg')).toBeTruthy();
     expect(order.parentElement?.parentElement?.className).toContain('sm:flex-wrap');
     expect(order.parentElement?.className).toContain('items-center');
     expect(order.parentElement?.className).toContain('min-w-0');
-    expect(order.parentElement?.parentElement?.parentElement?.className).toContain('sm:min-h-[66px]');
-    expect(order.parentElement?.parentElement?.parentElement?.className).not.toContain('sm:h-[66px]');
+    expect(order.parentElement?.parentElement?.parentElement?.className).toContain('min-h-[52px]');
     expect(gateway.className).toContain('bg-primary');
   });
 
@@ -229,7 +229,8 @@ describe('AgentCard', () => {
     render(<I18nextProvider i18n={i18n}><AgentCard agents={[hubAgent]} sources={[]} chains={{}} pendingBackends={new Set()} switchFailures={new Set(['claude'])} connectingBackend={null} onConnectHub={vi.fn()} onSwitchDirect={onSwitchDirect} onOpenOrder={vi.fn()} onOpenRoute={vi.fn()} onProbeSettled={vi.fn()} /></I18nextProvider>);
 
     expect(screen.getByText(/did not go through/i)).toBeTruthy();
-    await userEvent.click(screen.getByRole('button', { name: /retry/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Runtime mode:|运行模式[:：]/i }));
+    await userEvent.click(await screen.findByRole('menuitem', { name: /retry|重试/i }));
     expect(onSwitchDirect).toHaveBeenCalledWith(hubAgent);
   });
 });

--- a/ui/src/components/settings/models/AgentCard.test.tsx
+++ b/ui/src/components/settings/models/AgentCard.test.tsx
@@ -1,11 +1,10 @@
 // @vitest-environment jsdom
 import type { ComponentProps } from 'react';
-import { render, screen } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import { createInstance } from 'i18next';
 import userEvent from '@testing-library/user-event';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup } from '@testing-library/react';
 
 import i18n from '@/i18n';
 import en from '../../../i18n/en.json';
@@ -151,7 +150,9 @@ describe('AgentCard', () => {
     const order = screen.getByRole('button', { name: orderCopy });
     const gateway = screen.getByRole('button', { name: gatewayCopy });
     await userEvent.click(screen.getByRole('button', { name: /Runtime mode:|运行模式[:：]/i }));
-    const direct = await screen.findByRole('menuitem', { name: new RegExp(directCopy, 'i') });
+    const modeGroup = await screen.findByRole('group', { name: /Runtime mode|运行模式/i });
+    const direct = within(modeGroup).getByRole('button', { name: new RegExp(directCopy, 'i') });
+    expect(within(modeGroup).queryByRole('menuitem')).toBeNull();
     expect(order.querySelector('svg')).toBeTruthy();
     expect(direct.querySelector('.lucide-power')).toBeTruthy();
     expect(gateway.querySelector('svg')).toBeTruthy();
@@ -230,7 +231,7 @@ describe('AgentCard', () => {
 
     expect(screen.getByText(/did not go through/i)).toBeTruthy();
     await userEvent.click(screen.getByRole('button', { name: /Runtime mode:|运行模式[:：]/i }));
-    await userEvent.click(await screen.findByRole('menuitem', { name: /retry|重试/i }));
+    await userEvent.click(await screen.findByRole('button', { name: /retry|重试/i }));
     expect(onSwitchDirect).toHaveBeenCalledWith(hubAgent);
   });
 });

--- a/ui/src/components/settings/models/AgentCard.tsx
+++ b/ui/src/components/settings/models/AgentCard.tsx
@@ -171,30 +171,32 @@ const AgentModelCard: React.FC<{
                 )}
               >
                 <p className="model-hub-mode-menu-title px-2.5 pb-1.5 pt-1 text-[10px] font-bold uppercase text-muted max-md:hidden">{t('settings.models.gateway.modeMenu.title')}</p>
-                <div role="menuitem" aria-current="true" className="model-hub-mode-menu-current flex items-start gap-2.5 rounded-[7px] px-2.5 py-2.5">
-                  <Route className="model-hub-ink-mint mt-0.5 size-4 shrink-0" aria-hidden="true" />
-                  <span className="min-w-0 flex-1">
-                    <span className="block text-[12px] font-bold text-foreground">{t('settings.models.gateway.modeMenu.gatewayCurrent')}</span>
-                    <span className="mt-0.5 block text-[10.5px] leading-[15px] text-muted">{t('settings.models.gateway.modeMenu.gatewayDescription')}</span>
-                  </span>
-                  <Check className="model-hub-ink-mint mt-0.5 size-4 shrink-0" aria-hidden="true" />
+                <div role="group" aria-label={t('settings.models.gateway.modeMenu.title') as string}>
+                  <button type="button" aria-pressed="true" className="model-hub-mode-menu-current flex w-full items-start gap-2.5 rounded-[7px] px-2.5 py-2.5 text-left" onClick={() => setModeMenuOpen(false)}>
+                    <Route className="model-hub-ink-mint mt-0.5 size-4 shrink-0" aria-hidden="true" />
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-[12px] font-bold text-foreground">{t('settings.models.gateway.modeMenu.gatewayCurrent')}</span>
+                      <span className="mt-0.5 block text-[10.5px] leading-[15px] text-muted">{t('settings.models.gateway.modeMenu.gatewayDescription')}</span>
+                    </span>
+                    <Check className="model-hub-ink-mint mt-0.5 size-4 shrink-0" aria-hidden="true" />
+                  </button>
+                  <button
+                    type="button"
+                    aria-pressed="false"
+                    disabled={pending}
+                    className="model-hub-mode-menu-item mt-0.5 flex w-full items-start gap-2.5 rounded-[7px] px-2.5 py-2.5 text-left hover:bg-surface-2 disabled:opacity-50"
+                    onClick={() => {
+                      setModeMenuOpen(false);
+                      onSwitchDirect(agent);
+                    }}
+                  >
+                    <Power className="mt-0.5 size-4 shrink-0 text-muted" aria-hidden="true" />
+                    <span className="min-w-0">
+                      <span className="block text-[12px] font-bold text-foreground">{t(switchFailed ? 'settings.models.gateway.retry' : 'settings.models.gateway.switchToDirect')}</span>
+                      <span className="mt-0.5 block text-[10.5px] leading-[15px] text-muted">{t('settings.models.gateway.modeMenu.directDescription', { backend: t(`settings.models.backends.${agent.backend}`, { defaultValue: agent.backend }) })}</span>
+                    </span>
+                  </button>
                 </div>
-                <button
-                  type="button"
-                  role="menuitem"
-                  disabled={pending}
-                  className="model-hub-mode-menu-item mt-0.5 flex w-full items-start gap-2.5 rounded-[7px] px-2.5 py-2.5 text-left hover:bg-surface-2 disabled:opacity-50"
-                  onClick={() => {
-                    setModeMenuOpen(false);
-                    onSwitchDirect(agent);
-                  }}
-                >
-                  <Power className="mt-0.5 size-4 shrink-0 text-muted" aria-hidden="true" />
-                  <span className="min-w-0">
-                    <span className="block text-[12px] font-bold text-foreground">{t(switchFailed ? 'settings.models.gateway.retry' : 'settings.models.gateway.switchToDirect')}</span>
-                    <span className="mt-0.5 block text-[10.5px] leading-[15px] text-muted">{t('settings.models.gateway.modeMenu.directDescription', { backend: t(`settings.models.backends.${agent.backend}`, { defaultValue: agent.backend }) })}</span>
-                  </span>
-                </button>
               </ResponsiveMenu>
               <Button variant="outline" size="xs" className="model-hub-agent-head-action rounded-md bg-background px-2.5 text-[11px] font-semibold shadow-sm" onClick={() => onOpenOrder(agent)} disabled={pending}><ArrowDownUp aria-hidden="true" />{t('settings.models.gateway.sourceOrder')}</Button>
             </div>

--- a/ui/src/components/settings/models/AgentCard.tsx
+++ b/ui/src/components/settings/models/AgentCard.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { ArrowDownUp, ChevronDown, ChevronRight, ChevronUp, PlugZap, PowerOff, RefreshCw } from 'lucide-react';
+import { ArrowDownUp, Check, ChevronDown, ChevronRight, ChevronUp, PlugZap, Power, RefreshCw, Route } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { ResponsiveMenu } from '@/components/ui/responsive-menu';
 import { cn } from '@/lib/utils';
-import { ModelHubInfoHint } from './ModelHubInfoHint';
 import { collapsedModelRows, listedModelIds, modelChainKey, modelSupplyState, type ModelChainIndex, type ModelChainRead } from './modelRows';
 import { foldRegionRead } from './regionRead';
 import { agentGroupStatus } from './supply';
@@ -91,6 +91,7 @@ const AgentModelCard: React.FC<{
   const { t } = useTranslation();
   const { Icon, accent } = backendVisual(agent.backend);
   const [expanded, setExpanded] = React.useState(false);
+  const [modeMenuOpen, setModeMenuOpen] = React.useState(false);
   const allModels = listedModelIds(agent);
   const chainProjectionLive = agentHasLiveChainProjection(runtime, agent);
   const collapsed = collapsedModelRows(agent, expanded);
@@ -129,12 +130,15 @@ const AgentModelCard: React.FC<{
       : health === 'ok' && agent.mode === 'hub'
         ? 'bg-mint'
         : 'bg-muted';
+  const modeStatus = switchFailed
+    ? t('settings.models.gateway.fail.switchToDirect') as string
+    : subtitle;
   return (
     <section className="overflow-hidden rounded-lg border border-border bg-background" data-agent-backend={agent.backend}>
       <div
         tabIndex={-1}
         data-agent-group-head={agent.backend}
-        className="flex min-h-[66px] flex-col justify-center gap-[7px] border-b border-border px-3.5 py-3 sm:min-h-[66px] sm:py-1"
+        className="flex min-h-[52px] flex-col justify-center border-b border-border px-3.5 py-2"
       >
         <div className="flex min-w-0 flex-col items-stretch gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:gap-3">
           <div className="flex min-w-0 items-center gap-[9px]">
@@ -146,13 +150,56 @@ const AgentModelCard: React.FC<{
               </Badge>
             </span>
           </div>
-          {agent.mode === 'hub' ? <div className="flex min-w-0 flex-1 flex-wrap items-center justify-end gap-2"><Button variant="secondary" size="sm" className="model-hub-agent-head-action rounded-md px-3 text-[11.5px] font-bold" onClick={() => onOpenOrder(agent)} disabled={pending}><ArrowDownUp aria-hidden="true" />{t('settings.models.gateway.sourceOrder')}</Button><Button variant="outline" size="sm" className="model-hub-agent-head-action rounded-md px-3 text-[11.5px] font-bold" onClick={() => onSwitchDirect(agent)} disabled={pending}><PowerOff aria-hidden="true" />{t(switchFailed ? 'settings.models.gateway.retry' : 'settings.models.gateway.switchToDirect')}</Button></div> : <Button variant="default" size="sm" className="model-hub-agent-head-action shrink-0 self-start rounded-md px-3 text-[11.5px] font-bold sm:self-auto" onClick={() => onConnectHub(agent)} disabled={connecting}><PlugZap aria-hidden="true" />{t('settings.models.gateway.switchToGateway')}</Button>}
+          {agent.mode === 'hub' ? (
+            <div className="flex min-w-0 flex-1 flex-wrap items-center justify-end gap-2">
+              <ResponsiveMenu
+                open={modeMenuOpen}
+                onOpenChange={setModeMenuOpen}
+                sheetTitle={t('settings.models.gateway.modeMenu.title') as string}
+                className="model-hub-mode-menu w-[324px] rounded-[10px] border-border-strong bg-card p-1.5 !shadow-[var(--model-hub-menu-shadow)]"
+                trigger={(
+                  <button
+                    type="button"
+                    disabled={pending}
+                    aria-label={`${t('settings.models.gateway.modeMenu.title')}: ${modeStatus}`}
+                    className={cn('model-hub-agent-mode-trigger flex min-w-0 items-center gap-1.5 rounded-md px-2.5 text-[11px] font-semibold transition-colors hover:text-foreground disabled:opacity-50', statusClass)}
+                  >
+                    <span className={cn('size-[5px] shrink-0 rounded-full', statusDot)} />
+                    <span className="truncate">{modeStatus}</span>
+                    <ChevronDown className={cn('size-3 shrink-0 transition-transform', modeMenuOpen && 'rotate-180')} aria-hidden="true" />
+                  </button>
+                )}
+              >
+                <p className="model-hub-mode-menu-title px-2.5 pb-1.5 pt-1 text-[10px] font-bold uppercase text-muted max-md:hidden">{t('settings.models.gateway.modeMenu.title')}</p>
+                <div role="menuitem" aria-current="true" className="model-hub-mode-menu-current flex items-start gap-2.5 rounded-[7px] px-2.5 py-2.5">
+                  <Route className="model-hub-ink-mint mt-0.5 size-4 shrink-0" aria-hidden="true" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-[12px] font-bold text-foreground">{t('settings.models.gateway.modeMenu.gatewayCurrent')}</span>
+                    <span className="mt-0.5 block text-[10.5px] leading-[15px] text-muted">{t('settings.models.gateway.modeMenu.gatewayDescription')}</span>
+                  </span>
+                  <Check className="model-hub-ink-mint mt-0.5 size-4 shrink-0" aria-hidden="true" />
+                </div>
+                <button
+                  type="button"
+                  role="menuitem"
+                  disabled={pending}
+                  className="model-hub-mode-menu-item mt-0.5 flex w-full items-start gap-2.5 rounded-[7px] px-2.5 py-2.5 text-left hover:bg-surface-2 disabled:opacity-50"
+                  onClick={() => {
+                    setModeMenuOpen(false);
+                    onSwitchDirect(agent);
+                  }}
+                >
+                  <Power className="mt-0.5 size-4 shrink-0 text-muted" aria-hidden="true" />
+                  <span className="min-w-0">
+                    <span className="block text-[12px] font-bold text-foreground">{t(switchFailed ? 'settings.models.gateway.retry' : 'settings.models.gateway.switchToDirect')}</span>
+                    <span className="mt-0.5 block text-[10.5px] leading-[15px] text-muted">{t('settings.models.gateway.modeMenu.directDescription', { backend: t(`settings.models.backends.${agent.backend}`, { defaultValue: agent.backend }) })}</span>
+                  </span>
+                </button>
+              </ResponsiveMenu>
+              <Button variant="outline" size="xs" className="model-hub-agent-head-action rounded-md bg-background px-2.5 text-[11px] font-semibold shadow-sm" onClick={() => onOpenOrder(agent)} disabled={pending}><ArrowDownUp aria-hidden="true" />{t('settings.models.gateway.sourceOrder')}</Button>
+            </div>
+          ) : <Button variant="default" size="xs" className="model-hub-agent-head-action shrink-0 self-start rounded-md px-2.5 text-[11px] font-semibold sm:self-auto" onClick={() => onConnectHub(agent)} disabled={connecting}><PlugZap aria-hidden="true" />{t('settings.models.gateway.switchToGateway')}</Button>}
         </div>
-        <span className={cn('model-hub-agent-head-status flex items-center gap-1.5 text-[11px] font-semibold sm:ml-[42px]', statusClass)}>
-          <span className={cn('size-[5px] shrink-0 rounded-full', statusDot)} />
-          {switchFailed ? t('settings.models.gateway.fail.switchToDirect') : subtitle}
-          <ModelHubInfoHint label={switchFailed ? t('settings.models.gateway.fail.switchToDirect') : subtitle} content={switchFailed ? t('settings.models.gateway.fail.switchToDirect') : subtitle} className="model-hub-overview-info size-[13px]" />
-        </span>
       </div>
       {agent.mode === 'hub' && (models.length === 0 ? <div className="px-4 py-10 text-center sm:px-5"><p className="text-[12.5px] text-muted">{t('settings.models.gateway.group.emptyModels')}</p></div> : <div className="space-y-2 p-2">{noUsableSource && <p className="px-3 py-1 text-[11px] font-semibold text-muted">{t('settings.models.gateway.supply.none')}</p>}{models.map((modelId) => <ModelRow key={modelId} agent={agent} modelId={modelId} sources={sources} read={chainProjectionLive ? chains[modelChainKey(agent.backend, modelId)] : undefined} onOpenRoute={onOpenRoute} />)}{canCollapse ? <button type="button" onClick={toggleCollapsed} className="model-hub-model-collapse flex h-6 w-full items-center gap-1.5 hover:text-foreground">{expanded ? <ChevronUp /> : <ChevronDown />}{expanded ? t('settings.models.gateway.collapse') : t('settings.models.gateway.moreModels', { count: collapsed.hidden.length })}</button> : needsChainRepair ? <button type="button" onClick={retryChains} className="model-hub-model-collapse flex h-6 w-full items-center gap-1.5 hover:text-foreground"><RefreshCw />{t('settings.models.gateway.retry')}</button> : null}</div>)}
     </section>

--- a/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
@@ -154,7 +154,7 @@ describe('SettingsModelsPage surface branches', () => {
   it('coalesces the OAuth success landing with its trailing stale-row notification', () => {
     const page = readFileSync(join(process.cwd(), 'src/components/settings/models/SettingsModelsPage.tsx'), 'utf8');
     const start = page.indexOf('const subscriptionAdded');
-    const callback = page.slice(start, page.indexOf('React.useEffect(() => {', start));
+    const callback = page.slice(start, page.indexOf('const closeSubscription', start));
 
     expect(callback).toMatch(/if \(!source\) \{[\s\S]*?subscriptionSuccessReconcileRef\.current/);
     expect(callback).toMatch(/sourceEntityAuthority\.landLatest\(source\)[\s\S]*?subscriptionSuccessReconcileRef\.current = true;[\s\S]*?void refresh\(\)/);
@@ -187,15 +187,19 @@ describe('SettingsModelsPage surface branches', () => {
     await screen.findByText('Retained source');
     const listSources = vi.mocked(modelsApi.listSources);
     const refreshesBeforeCreate = listSources.mock.calls.length;
+    listSources.mockResolvedValue([retainedSource, created]);
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: /Add subscription|添加订阅/i }));
     await user.click(await screen.findByRole('menuitem', { name: /Claude subscription|Claude 订阅/i }));
     await user.click(screen.getByRole('button', { name: /Sign in|去登录/i }));
 
     await waitFor(() => expect(status).toHaveBeenCalledWith(terminal.flow_id));
+    expect(screen.getAllByRole('dialog')).toHaveLength(1);
+    expect(screen.queryByRole('dialog', { name: 'Created subscription' })).toBeNull();
     await waitFor(() => expect(listSources).toHaveBeenCalledTimes(refreshesBeforeCreate + 1));
     await act(async () => Promise.resolve());
     expect(listSources).toHaveBeenCalledTimes(refreshesBeforeCreate + 1);
+    await waitFor(() => expect(screen.getByRole('dialog', { name: 'Created subscription' })).toBeTruthy(), { timeout: 2500 });
   });
 
   it('renders Frame 09 as the sources tab when every backend is direct and no source exists', async () => {
@@ -471,7 +475,8 @@ describe('SettingsModelsPage surface branches', () => {
     renderPage([editableSource]);
     const user = userEvent.setup();
 
-    await user.click((await screen.findByText('Retained source')).closest('button') as HTMLButtonElement);
+    const sourceOpener = (await screen.findByText('Retained source')).closest('button') as HTMLButtonElement;
+    await user.click(sourceOpener);
     const sourceDialog = await screen.findByRole('dialog', { name: 'Retained source' });
     await user.click(within(sourceDialog).getByRole('button', { name: /high/i }));
     const tierInput = within(sourceDialog).getByPlaceholderText(/Enter to add|回车添加/i);
@@ -482,7 +487,16 @@ describe('SettingsModelsPage surface branches', () => {
     expect(within(sourceDialog).queryByPlaceholderText(/Enter to add|回车添加/i)).toBeNull();
 
     await user.click(within(sourceDialog).getByRole('button', { name: /^Add model$|^添加模型$/i }));
-    const manualDraft = sourceDialog.querySelector('[data-manual-model-draft]');
+    let manualDraft = sourceDialog.querySelector('[data-manual-model-draft]');
+    const modelIdInput = within(manualDraft as HTMLElement).getByPlaceholderText(/^Model ID$|^模型 ID$/i);
+    await user.type(modelIdInput, 'draft-model');
+    await user.keyboard('{Escape}');
+
+    expect(screen.getByRole('dialog', { name: 'Retained source' })).toBeTruthy();
+    expect(sourceDialog.querySelector('[data-manual-model-draft]')).toBeNull();
+
+    await user.click(within(sourceDialog).getByRole('button', { name: /^Add model$|^添加模型$/i }));
+    manualDraft = sourceDialog.querySelector('[data-manual-model-draft]');
     const draftTierInput = within(manualDraft as HTMLElement).getByPlaceholderText(/Enter to add|回车添加/i);
     await user.type(draftTierInput, 'draft');
     await user.keyboard('{Escape}');
@@ -492,6 +506,7 @@ describe('SettingsModelsPage surface branches', () => {
 
     await user.keyboard('{Escape}');
     await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Retained source' })).toBeNull());
+    await waitFor(() => expect(document.activeElement).toBe(sourceOpener));
   });
 
   it('moves recent switches into the Logs tab and removes the Advanced placeholder', async () => {

--- a/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
@@ -133,7 +133,8 @@ const renderPage = (sources: Source[]) => {
 
 const switchFirstGatewayAgentToDirect = async () => {
   await userEvent.click((await screen.findAllByRole('button', { name: /Runtime mode:|运行模式[:：]/i }))[0]);
-  await userEvent.click(await screen.findByRole('menuitem', { name: /Switch to direct|切到直连|Retry|重试/i }));
+  const modeGroup = await screen.findByRole('group', { name: /Runtime mode|运行模式/i });
+  await userEvent.click(within(modeGroup).getByRole('button', { name: /Switch to direct|切到直连|Retry|重试/i }));
 };
 
 const closeSourceDetails = async () => {

--- a/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
@@ -131,6 +131,15 @@ const renderPage = (sources: Source[]) => {
   );
 };
 
+const switchFirstGatewayAgentToDirect = async () => {
+  await userEvent.click((await screen.findAllByRole('button', { name: /Runtime mode:|运行模式[:：]/i }))[0]);
+  await userEvent.click(await screen.findByRole('menuitem', { name: /Switch to direct|切到直连|Retry|重试/i }));
+};
+
+const closeSourceDetails = async () => {
+  await userEvent.click(screen.getByRole('button', { name: /Close provider details|关闭供应商详情/i }));
+};
+
 beforeEach(() => {
   vi.spyOn(modelsApi, 'refreshAgentPresence').mockReturnValue(new Promise(() => {}));
 });
@@ -373,7 +382,7 @@ describe('SettingsModelsPage surface branches', () => {
     expect(toggle.getAttribute('aria-checked')).toBe('true');
     expect((toggle as HTMLButtonElement).disabled).toBe(true);
     expect(await screen.findByText('Retained source')).toBeTruthy();
-    expect(screen.getByRole('button', { name: /^Switch to direct$|^切到直连$/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Runtime mode:|运行模式[:：]/i })).toBeTruthy();
     expect(screen.queryAllByRole('tab')).toHaveLength(3);
   });
 
@@ -894,6 +903,8 @@ describe('SettingsModelsPage surface branches', () => {
         </ToastProvider>,
       );
       await userEvent.click((await screen.findByText('Retained source')).closest('button') as HTMLButtonElement);
+      const sourceDialog = await screen.findByRole('dialog', { name: 'Retained source' });
+      expect(within(sourceDialog).getByRole('textbox', { name: /Search model IDs|搜索模型 ID/i })).toBeTruthy();
       await waitFor(() => expect(overviewRead).toHaveBeenCalledOnce());
 
       await userEvent.click(screen.getByRole('button', { name: /Manage Retained source|管理 Retained source/i }));
@@ -968,7 +979,7 @@ describe('SettingsModelsPage surface branches', () => {
     );
 
     await waitFor(() => expect(chainRead).toHaveBeenCalledOnce());
-    await userEvent.click(screen.getByRole('button', { name: /^Switch to direct$|^切到直连$/i }));
+    await switchFirstGatewayAgentToDirect();
     await waitFor(() => expect(agentRead).toHaveBeenCalledTimes(2));
     expect(await screen.findByRole('button', { name: /^Switch to Gateway$|^切换到模型网关$/i })).toBeTruthy();
 
@@ -1099,7 +1110,7 @@ describe('SettingsModelsPage surface branches', () => {
       </ToastProvider>,
     );
 
-    await userEvent.click(await screen.findByRole('button', { name: /^Switch to direct$|^切到直连$/i }));
+    await switchFirstGatewayAgentToDirect();
 
     expect(await screen.findByRole('button', { name: /^Switch to Gateway$|^切换到模型网关$/i })).toBeTruthy();
     expect(screen.queryByText(/did not go through|没切换成功/i)).toBeNull();
@@ -1143,7 +1154,7 @@ describe('SettingsModelsPage surface branches', () => {
     await userEvent.click(await screen.findByRole('button', { name: /^Refetch$|^重新拉取$/i }));
 
     await waitFor(() => expect(agentRead).toHaveBeenCalledTimes(2));
-    await userEvent.click(screen.getByRole('button', { name: /^Back to sources$|^返回模型供应商列表$/i }));
+    await closeSourceDetails();
     expect(await screen.findByText(/Could not read this backend's supply|没有读到后端列表/i)).toBeTruthy();
     expect(screen.queryByText(/From: Replacement source \(takeover\)|来自 Replacement source（接管）/i)).toBeNull();
     expect(screen.getAllByText('—').length).toBeGreaterThan(0);
@@ -1174,7 +1185,7 @@ describe('SettingsModelsPage surface branches', () => {
     await userEvent.click(await screen.findByRole('button', { name: /^Refetch$|^重新拉取$/i }));
 
     await waitFor(() => expect(runtimeRead).toHaveBeenCalledTimes(2));
-    await userEvent.click(screen.getByRole('button', { name: /^Back to sources$|^返回模型供应商列表$/i }));
+    await closeSourceDetails();
     expect(await screen.findByText(/^Gateway status unavailable$|^模型网关状态不可用$/i)).toBeTruthy();
     expect(screen.queryByText(/From: Replacement source \(takeover\)|来自 Replacement source（接管）/i)).toBeNull();
     expect(screen.queryByText(/^Taken over$|^已自动切换$/i)).toBeNull();

--- a/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
@@ -463,6 +463,37 @@ describe('SettingsModelsPage surface branches', () => {
     expect(screen.queryByText(/^Switch to the gateway and you gain three things$|^切换到模型网关，你会多出三件事$/i)).toBeNull();
   });
 
+  it('keeps tier-editor Escape local to the provider dialog', async () => {
+    const editableSource: Source = {
+      ...retainedSource,
+      models: [{ id: 'model-a', display_name: null, origin: 'manual', reasoning_efforts: ['high'] }],
+    };
+    renderPage([editableSource]);
+    const user = userEvent.setup();
+
+    await user.click((await screen.findByText('Retained source')).closest('button') as HTMLButtonElement);
+    const sourceDialog = await screen.findByRole('dialog', { name: 'Retained source' });
+    await user.click(within(sourceDialog).getByRole('button', { name: /high/i }));
+    const tierInput = within(sourceDialog).getByPlaceholderText(/Enter to add|回车添加/i);
+    await user.type(tierInput, 'draft');
+    await user.keyboard('{Escape}');
+
+    expect(screen.getByRole('dialog', { name: 'Retained source' })).toBeTruthy();
+    expect(within(sourceDialog).queryByPlaceholderText(/Enter to add|回车添加/i)).toBeNull();
+
+    await user.click(within(sourceDialog).getByRole('button', { name: /^Add model$|^添加模型$/i }));
+    const manualDraft = sourceDialog.querySelector('[data-manual-model-draft]');
+    const draftTierInput = within(manualDraft as HTMLElement).getByPlaceholderText(/Enter to add|回车添加/i);
+    await user.type(draftTierInput, 'draft');
+    await user.keyboard('{Escape}');
+
+    expect(screen.getByRole('dialog', { name: 'Retained source' })).toBeTruthy();
+    expect((draftTierInput as HTMLInputElement).value).toBe('');
+
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Retained source' })).toBeNull());
+  });
+
   it('moves recent switches into the Logs tab and removes the Advanced placeholder', async () => {
     renderPage([retainedSource]);
 

--- a/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
@@ -13,7 +13,7 @@ import type { ModelsSurfaceKind } from './modelHubSurfaceState';
 import { modelsApi } from './modelsApi';
 import { SOURCE_MUTATION_REPORT_PROJECTIONS } from './mutationSettlement';
 import { SettingsModelsPage } from './SettingsModelsPage';
-import type { AgentBackend, AgentChain, AgentSupply, RuntimeDependency, Source, UsageSummary } from './types';
+import { CONTRACT_VERSION, type AgentBackend, type AgentChain, type AgentSupply, type RuntimeDependency, type Source, type UsageSummary } from './types';
 
 const directAgent = (backend: AgentBackend): AgentSupply => ({
   backend,
@@ -189,7 +189,8 @@ describe('SettingsModelsPage surface branches', () => {
     const refreshesBeforeCreate = listSources.mock.calls.length;
     listSources.mockResolvedValue([retainedSource, created]);
     const user = userEvent.setup();
-    await user.click(screen.getByRole('button', { name: /Add subscription|添加订阅/i }));
+    const trigger = screen.getByRole('button', { name: /Add subscription|添加订阅/i });
+    await user.click(trigger);
     await user.click(await screen.findByRole('menuitem', { name: /Claude subscription|Claude 订阅/i }));
     await user.click(screen.getByRole('button', { name: /Sign in|去登录/i }));
 
@@ -199,7 +200,48 @@ describe('SettingsModelsPage surface branches', () => {
     await waitFor(() => expect(listSources).toHaveBeenCalledTimes(refreshesBeforeCreate + 1));
     await act(async () => Promise.resolve());
     expect(listSources).toHaveBeenCalledTimes(refreshesBeforeCreate + 1);
-    await waitFor(() => expect(screen.getByRole('dialog', { name: 'Created subscription' })).toBeTruthy(), { timeout: 2500 });
+    const detail = await screen.findByRole('dialog', { name: 'Created subscription' }, { timeout: 2500 });
+    await user.click(within(detail).getByRole('button', { name: /Close provider details|关闭供应商详情/i }));
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+
+  it('returns focus to Add API key after opening and closing the created provider', async () => {
+    const created: Source = {
+      ...retainedSource,
+      id: 'src_created_api_key',
+      vendor: 'custom',
+      display_name: 'Created API key',
+      protocol: 'openai_chat',
+      base_url: 'https://relay.example/v1',
+    };
+    vi.spyOn(modelsApi, 'observeApiKeySource').mockResolvedValue({
+      contract_version: CONTRACT_VERSION,
+      outcome: 'observed',
+      reachable: true,
+      authenticated: 'authenticated',
+      protocol: 'openai_chat',
+      discovery: 'succeeded',
+      models: ['model-a'],
+    });
+    vi.spyOn(modelsApi, 'createApiKeySource').mockResolvedValue({
+      source: created,
+      added_to: [],
+      adopted_by: [],
+    });
+    renderPage([retainedSource]);
+
+    await screen.findByText('Retained source');
+    vi.mocked(modelsApi.listSources).mockResolvedValue([retainedSource, created]);
+    const user = userEvent.setup();
+    const trigger = screen.getByRole('button', { name: /Add API key|添加 API Key/i });
+    await user.click(trigger);
+    await user.type(screen.getByRole('textbox', { name: /^Base URL$/i }), 'https://relay.example/v1');
+    await user.type(screen.getByLabelText(/^API key$/i), 'secret-key');
+    await user.click(screen.getByRole('button', { name: /^Add$|^添加$/i }));
+
+    const detail = await screen.findByRole('dialog', { name: 'Created API key' });
+    await user.click(within(detail).getByRole('button', { name: /Close provider details|关闭供应商详情/i }));
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
   });
 
   it('renders Frame 09 as the sources tab when every backend is direct and no source exists', async () => {

--- a/ui/src/components/settings/models/SettingsModelsPage.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.tsx
@@ -375,7 +375,7 @@ export const SettingsModelsPage: React.FC = () => {
   // so it cannot launch a second refresh that overwrites a successful landing.
   const subscriptionSuccessReconcileRef = React.useRef(false);
   const sourceDetailHeadingRef = React.useRef<HTMLHeadingElement>(null);
-  const focusSourceDetailPendingRef = React.useRef(false);
+  const sourceDetailOpenerRef = React.useRef<HTMLButtonElement | null>(null);
   const [orderBackend, setOrderBackend] = React.useState<AgentBackend | null>(null);
   const [adoptAgent, setAdoptAgent] = React.useState<AgentSupply | null>(null);
   const [routeTarget, setRouteTarget] = React.useState<{ agent: AgentSupply; modelId: string; opener: HTMLElement | null } | null>(null);
@@ -914,6 +914,7 @@ export const SettingsModelsPage: React.FC = () => {
     sourceIntentAuthority.commit(() => setSelectedSourceId(sourceId));
   }, [sourceIntentAuthority]);
   const selectedSource = sources.find((source) => source.id === selectedSourceId) ?? null;
+  const sourceDetailOpen = selectedSourceId !== null && subscriptionVendor === null;
   const orderAgent = agents.find((agent) => agent.backend === orderBackend && agent.mode === 'hub') ?? null;
   const currentRouteAgent = routeTarget
     ? installedAgents.find((agent) => agent.backend === routeTarget.agent.backend) ?? null
@@ -1095,9 +1096,8 @@ export const SettingsModelsPage: React.FC = () => {
       void refresh();
       return;
     }
-    // Keep the success panel readable until its existing handoff timer closes it;
-    // the effect below then moves focus into the committed source detail surface.
-    focusSourceDetailPendingRef.current = true;
+    // Keep the success panel as the only active dialog until its handoff timer
+    // closes it. The provider dialog then opens and owns its normal autofocus.
     sourceEntityAuthority.landLatest(source);
     selectSource(source.id);
     subscriptionSuccessReconcileRef.current = true;
@@ -1108,11 +1108,6 @@ export const SettingsModelsPage: React.FC = () => {
       setSubscriptionVendor(null);
     }, 1400);
   }, [refresh, selectSource, sourceEntityAuthority]);
-  React.useEffect(() => {
-    if (!focusSourceDetailPendingRef.current || subscriptionVendor !== null || !selectedSourceId || !selectedSource) return;
-    focusSourceDetailPendingRef.current = false;
-    window.requestAnimationFrame(() => sourceDetailHeadingRef.current?.focus());
-  }, [selectedSource, selectedSourceId, subscriptionVendor]);
   const closeSubscription = React.useCallback(() => {
     if (subscriptionCloseTimer.current !== null) {
       window.clearTimeout(subscriptionCloseTimer.current);
@@ -1216,7 +1211,7 @@ export const SettingsModelsPage: React.FC = () => {
                           onOpenChange={(open) => { if (!open) closeSubscriptionPicker(); }}
                         >
                           <PopoverAnchor virtualRef={subscriptionAnchorRef} />
-                          <SourcesCard read={sourcesRead} activeBackends={activeBackends} readFailureCopy={routeCommitStatus?.failed.has('sources') ? t('settings.models.routeDialog.impact.refreshFail') : undefined} onRetry={() => routeCommitStatus?.failed.has('sources') ? retryRouteCommit() : void retrySources()} onOpenSource={(source) => selectSource(source.id)} onAddApiKey={() => setApiKeyOpen(true)} onAddSubscription={toggleSubscriptionPicker} subscriptionPickerOpen={subscriptionPickerOpen} subscriptionTriggerRef={subscriptionTriggerRef} />
+                          <SourcesCard read={sourcesRead} activeBackends={activeBackends} readFailureCopy={routeCommitStatus?.failed.has('sources') ? t('settings.models.routeDialog.impact.refreshFail') : undefined} onRetry={() => routeCommitStatus?.failed.has('sources') ? retryRouteCommit() : void retrySources()} onOpenSource={(source, opener) => { sourceDetailOpenerRef.current = opener; selectSource(source.id); }} onAddApiKey={() => setApiKeyOpen(true)} onAddSubscription={toggleSubscriptionPicker} subscriptionPickerOpen={subscriptionPickerOpen} subscriptionTriggerRef={subscriptionTriggerRef} />
                           <PopoverContent
                             role="menu"
                             aria-label={t('settings.models.upstream.addSubscription')}
@@ -1305,14 +1300,21 @@ export const SettingsModelsPage: React.FC = () => {
                   </div>}
                 </div>}
       {runtimeConfigurationVisible && <>
-      <Dialog open={selectedSourceId !== null} onOpenChange={(open) => { if (!open) selectSource(null); }}>
+      <Dialog open={sourceDetailOpen} onOpenChange={(open) => { if (!open) selectSource(null); }}>
         <DialogContent
           mobileSheetHeight="tall"
           closeLabel={t('settings.models.sourceDetail.close') as string}
           className="model-hub-source-dialog flex h-[min(624px,calc(100dvh-32px))] w-[min(720px,calc(100vw-32px))] max-w-[720px] flex-col gap-0 overflow-hidden rounded-[14px] border-border-strong bg-surface p-0 shadow-[var(--model-hub-dialog-shadow)] max-md:w-full max-md:max-w-none max-md:rounded-t-2xl"
           onOpenAutoFocus={(event) => {
             event.preventDefault();
-            window.requestAnimationFrame(() => sourceDetailHeadingRef.current?.focus());
+            sourceDetailHeadingRef.current?.focus();
+          }}
+          onCloseAutoFocus={(event) => {
+            const opener = sourceDetailOpenerRef.current;
+            sourceDetailOpenerRef.current = null;
+            if (!opener?.isConnected) return;
+            event.preventDefault();
+            opener.focus();
           }}
           onEscapeKeyDown={(event) => {
             // Radix observes Escape before React's row handlers; marked editors own it locally.

--- a/ui/src/components/settings/models/SettingsModelsPage.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.tsx
@@ -365,6 +365,7 @@ export const SettingsModelsPage: React.FC = () => {
   // owns the success-landing timer and reconcile flag below.
   const [reauthSource, setReauthSource] = React.useState<Source | null>(null);
   const subscriptionTriggerRef = React.useRef<HTMLButtonElement>(null);
+  const apiKeyTriggerRef = React.useRef<HTMLButtonElement | null>(null);
   const subscriptionAnchorRef = subscriptionTriggerRef as React.RefObject<HTMLButtonElement>;
   const subscriptionPickerRefs = React.useRef<Partial<Record<SubscriptionPickerVendor, HTMLButtonElement | null>>>({});
   const subscriptionPickerHandoffRef = React.useRef(false);
@@ -375,7 +376,7 @@ export const SettingsModelsPage: React.FC = () => {
   // so it cannot launch a second refresh that overwrites a successful landing.
   const subscriptionSuccessReconcileRef = React.useRef(false);
   const sourceDetailHeadingRef = React.useRef<HTMLHeadingElement>(null);
-  const sourceDetailOpenerRef = React.useRef<HTMLButtonElement | null>(null);
+  const sourceDetailReturnFocusRef = React.useRef<(() => HTMLElement | null) | null>(null);
   const [orderBackend, setOrderBackend] = React.useState<AgentBackend | null>(null);
   const [adoptAgent, setAdoptAgent] = React.useState<AgentSupply | null>(null);
   const [routeTarget, setRouteTarget] = React.useState<{ agent: AgentSupply; modelId: string; opener: HTMLElement | null } | null>(null);
@@ -910,9 +911,17 @@ export const SettingsModelsPage: React.FC = () => {
     unread: (retryable) => unreadRegion(retryable),
     degraded: (_staleData, cause, retryable) => degradedRegion(installedAgents, cause, retryable),
   });
-  const selectSource = React.useCallback((sourceId: string | null) => {
-    sourceIntentAuthority.commit(() => setSelectedSourceId(sourceId));
-  }, [sourceIntentAuthority]);
+  type SourceDetailSelection = {
+    sourceId: string;
+    returnFocus: () => HTMLElement | null;
+  };
+  const applySourceDetailSelection = React.useCallback((selection: SourceDetailSelection | null) => {
+    if (selection) sourceDetailReturnFocusRef.current = selection.returnFocus;
+    setSelectedSourceId(selection?.sourceId ?? null);
+  }, []);
+  const selectSource = React.useCallback((selection: SourceDetailSelection | null) => {
+    sourceIntentAuthority.commit(() => applySourceDetailSelection(selection));
+  }, [applySourceDetailSelection, sourceIntentAuthority]);
   const selectedSource = sources.find((source) => source.id === selectedSourceId) ?? null;
   const sourceDetailOpen = selectedSourceId !== null && subscriptionVendor === null;
   const orderAgent = agents.find((agent) => agent.backend === orderBackend && agent.mode === 'hub') ?? null;
@@ -1081,7 +1090,10 @@ export const SettingsModelsPage: React.FC = () => {
         authority: sourceIntentAuthority,
         apply: () => {
           setApiKeyOpen(false);
-          setSelectedSourceId(created.source.id);
+          applySourceDetailSelection({
+            sourceId: created.source.id,
+            returnFocus: () => apiKeyTriggerRef.current,
+          });
         },
       },
       reconcile: refresh,
@@ -1099,7 +1111,10 @@ export const SettingsModelsPage: React.FC = () => {
     // Keep the success panel as the only active dialog until its handoff timer
     // closes it. The provider dialog then opens and owns its normal autofocus.
     sourceEntityAuthority.landLatest(source);
-    selectSource(source.id);
+    selectSource({
+      sourceId: source.id,
+      returnFocus: () => subscriptionTriggerRef.current,
+    });
     subscriptionSuccessReconcileRef.current = true;
     void refresh();
     if (subscriptionCloseTimer.current !== null) window.clearTimeout(subscriptionCloseTimer.current);
@@ -1211,7 +1226,7 @@ export const SettingsModelsPage: React.FC = () => {
                           onOpenChange={(open) => { if (!open) closeSubscriptionPicker(); }}
                         >
                           <PopoverAnchor virtualRef={subscriptionAnchorRef} />
-                          <SourcesCard read={sourcesRead} activeBackends={activeBackends} readFailureCopy={routeCommitStatus?.failed.has('sources') ? t('settings.models.routeDialog.impact.refreshFail') : undefined} onRetry={() => routeCommitStatus?.failed.has('sources') ? retryRouteCommit() : void retrySources()} onOpenSource={(source, opener) => { sourceDetailOpenerRef.current = opener; selectSource(source.id); }} onAddApiKey={() => setApiKeyOpen(true)} onAddSubscription={toggleSubscriptionPicker} subscriptionPickerOpen={subscriptionPickerOpen} subscriptionTriggerRef={subscriptionTriggerRef} />
+                          <SourcesCard read={sourcesRead} activeBackends={activeBackends} readFailureCopy={routeCommitStatus?.failed.has('sources') ? t('settings.models.routeDialog.impact.refreshFail') : undefined} onRetry={() => routeCommitStatus?.failed.has('sources') ? retryRouteCommit() : void retrySources()} onOpenSource={(source, opener) => selectSource({ sourceId: source.id, returnFocus: () => opener })} onAddApiKey={(opener) => { apiKeyTriggerRef.current = opener; setApiKeyOpen(true); }} onAddSubscription={toggleSubscriptionPicker} subscriptionPickerOpen={subscriptionPickerOpen} subscriptionTriggerRef={subscriptionTriggerRef} />
                           <PopoverContent
                             role="menu"
                             aria-label={t('settings.models.upstream.addSubscription')}
@@ -1310,11 +1325,12 @@ export const SettingsModelsPage: React.FC = () => {
             sourceDetailHeadingRef.current?.focus();
           }}
           onCloseAutoFocus={(event) => {
-            const opener = sourceDetailOpenerRef.current;
-            sourceDetailOpenerRef.current = null;
-            if (!opener?.isConnected) return;
+            const returnFocus = sourceDetailReturnFocusRef.current;
+            sourceDetailReturnFocusRef.current = null;
+            const target = returnFocus?.();
+            if (!target?.isConnected) return;
             event.preventDefault();
-            opener.focus();
+            target.focus();
           }}
           onEscapeKeyDown={(event) => {
             // Radix observes Escape before React's row handlers; marked editors own it locally.

--- a/ui/src/components/settings/models/SettingsModelsPage.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { ArrowLeft, Gauge, LoaderCircle, Power, RefreshCw, Route, ScrollText } from 'lucide-react';
+import { Gauge, LoaderCircle, Power, RefreshCw, Route, ScrollText } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
 import { useToast } from '@/context/ToastContext';
 import { cn } from '@/lib/utils';
@@ -252,21 +253,19 @@ const RuntimeClosedState: React.FC<{
   );
 };
 
-const ModelHubShell: React.FC<{ actions?: React.ReactNode; detailBack?: () => void; children: React.ReactNode; rootRef?: React.Ref<HTMLDivElement> }> = ({ actions, detailBack, children, rootRef }) => {
+const ModelHubShell: React.FC<{ actions?: React.ReactNode; children: React.ReactNode; rootRef?: React.Ref<HTMLDivElement> }> = ({ actions, children, rootRef }) => {
   const { t } = useTranslation();
   return (
     <div ref={rootRef} className="model-hub-shell">
       <header className="model-hub-shell-head">
-        {detailBack
-          ? <button type="button" onClick={detailBack} aria-label={t('settings.models.sourceDetail.back') as string} title={t('settings.models.sourceDetail.back') as string} className="model-hub-detail-back"><ArrowLeft aria-hidden="true" /></button>
-          : <span className="flex items-center gap-[9px]">
-              <h1>{t('settings.models.shell.title')}</h1>
-              <ModelHubInfoHint
-                label={t('settings.models.shell.modelsInfo.label')}
-                content={t('settings.models.shell.modelsInfo.body')}
-                className="model-hub-shell-info"
-              />
-            </span>}
+        <span className="flex items-center gap-[9px]">
+          <h1>{t('settings.models.shell.title')}</h1>
+          <ModelHubInfoHint
+            label={t('settings.models.shell.modelsInfo.label')}
+            content={t('settings.models.shell.modelsInfo.body')}
+            className="model-hub-shell-info"
+          />
+        </span>
         {actions}
       </header>
       {children}
@@ -1166,7 +1165,6 @@ export const SettingsModelsPage: React.FC = () => {
   return (
     <ModelHubShell
       rootRef={pageRef}
-      detailBack={runtimeConfigurationVisible && selectedSourceId ? () => selectSource(null) : undefined}
       actions={!landingLoading
         ? <span className="flex items-center gap-2">
               <RuntimePill
@@ -1200,17 +1198,6 @@ export const SettingsModelsPage: React.FC = () => {
       {landingLoading ? <div className="text-[13px] text-muted">{t('common.loading')}</div>
         : !runtimeConfigurationVisible
           ? <RuntimeClosedState read={runtimeRead} runtime={retainedRuntime} starting={startingRuntime} stopping={stoppingRuntime} />
-        : selectedSourceId
-          ? selectedSource
-              ? <SourceDetailPanel
-                source={selectedSource}
-                activeBackends={activeBackends}
-                headingRef={sourceDetailHeadingRef}
-                trackMutation={trackSourceMutation(selectedSource.id)}
-                onReauth={setReauthSource}
-                onMutationCommitted={sourceMutationReport.present}
-              />
-            : <section className="rounded-xl border border-border bg-surface px-5 py-12 text-center text-[12px] text-muted">{t('settings.models.sourceDetail.gone')}</section>
           : <div className="space-y-[22px]">
                   {/* The tab strip belongs to the Hub, not to the source
                       inventory. Usage and switch history both outlive the Sources
@@ -1309,7 +1296,7 @@ export const SettingsModelsPage: React.FC = () => {
                             })}
                           </PopoverContent>
                         </Popover>
-                        <div className="hidden lg:block" aria-hidden="true" />
+                        <div className="hidden xl:block" aria-hidden="true" />
                         <GatewayModule supply={installedSupplyRead} readFailureCopy={routeCommitStatus?.failed.has('agents') ? t('settings.models.routeDialog.impact.refreshFail') : undefined} sources={sources} chains={chains} runtime={runtime} runtimeSnapshot={retainedRuntime} onRetry={() => routeCommitStatus?.failed.has('agents') ? retryRouteCommit() : void retrySupply()} pendingBackends={agentWrites} switchFailures={switchFailures} connectingBackend={adoptAgent?.backend ?? null} onConnectHub={setAdoptAgent} onSwitchDirect={switchToDirect} onOpenOrder={(agent) => setOrderBackend(agent.backend)} onOpenRoute={(agent, modelId, opener) => setRouteTarget({ agent, modelId, opener })} onProbeSettled={(agent) => void refreshAgentChains(agent)} />
                         <SupplyGraph containerRef={overviewRef} relations={supplyRelations} />
                       </div>
@@ -1318,6 +1305,31 @@ export const SettingsModelsPage: React.FC = () => {
                   </div>}
                 </div>}
       {runtimeConfigurationVisible && <>
+      <Dialog open={selectedSourceId !== null} onOpenChange={(open) => { if (!open) selectSource(null); }}>
+        <DialogContent
+          mobileSheetHeight="tall"
+          closeLabel={t('settings.models.sourceDetail.close') as string}
+          className="model-hub-source-dialog flex h-[min(624px,calc(100dvh-32px))] w-[min(720px,calc(100vw-32px))] max-w-[720px] flex-col gap-0 overflow-hidden rounded-[14px] border-border-strong bg-surface p-0 shadow-[var(--model-hub-dialog-shadow)] max-md:w-full max-md:max-w-none max-md:rounded-t-2xl"
+          onOpenAutoFocus={(event) => {
+            event.preventDefault();
+            window.requestAnimationFrame(() => sourceDetailHeadingRef.current?.focus());
+          }}
+        >
+          <DialogTitle className="sr-only">{selectedSource?.display_name ?? t('settings.models.sourceDetail.gone')}</DialogTitle>
+          <DialogDescription className="sr-only">{t('settings.models.sourceDetail.footnote')}</DialogDescription>
+          {selectedSource
+            ? <SourceDetailPanel
+                key={selectedSource.id}
+                source={selectedSource}
+                activeBackends={activeBackends}
+                headingRef={sourceDetailHeadingRef}
+                trackMutation={trackSourceMutation(selectedSource.id)}
+                onReauth={setReauthSource}
+                onMutationCommitted={sourceMutationReport.present}
+              />
+            : <section className="grid min-h-0 flex-1 place-items-center px-5 py-12 text-center text-[12px] text-muted">{t('settings.models.sourceDetail.gone')}</section>}
+        </DialogContent>
+      </Dialog>
       <SourceMutationReport
         report={sourceMutationReport.report}
         onComplete={() => { void sourceMutationReport.complete(); }}

--- a/ui/src/components/settings/models/SettingsModelsPage.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.tsx
@@ -1314,6 +1314,12 @@ export const SettingsModelsPage: React.FC = () => {
             event.preventDefault();
             window.requestAnimationFrame(() => sourceDetailHeadingRef.current?.focus());
           }}
+          onEscapeKeyDown={(event) => {
+            // Radix observes Escape before React's row handlers; marked editors own it locally.
+            if (event.target instanceof Element && event.target.closest('[data-source-dialog-local-escape]')) {
+              event.preventDefault();
+            }
+          }}
         >
           <DialogTitle className="sr-only">{selectedSource?.display_name ?? t('settings.models.sourceDetail.gone')}</DialogTitle>
           <DialogDescription className="sr-only">{t('settings.models.sourceDetail.footnote')}</DialogDescription>

--- a/ui/src/components/settings/models/SourceDetailPanel.test.tsx
+++ b/ui/src/components/settings/models/SourceDetailPanel.test.tsx
@@ -239,6 +239,18 @@ describe('SourceDetailPanel', () => {
     expect(document.activeElement).toBe(headingRef.current);
   });
 
+  it('filters the model table by model ID without changing the source inventory', async () => {
+    renderPanel();
+
+    const search = screen.getByRole('textbox', { name: /Search model IDs|搜索模型 ID/i });
+    await userEvent.type(search, 'missing-model');
+
+    expect(screen.queryByText('model-a')).toBeNull();
+    expect(screen.getByText(/No models match this search|没有匹配的模型/i)).toBeTruthy();
+    await userEvent.clear(search);
+    expect(screen.getByText('model-a')).toBeTruthy();
+  });
+
   it('keeps the detail surface to inventory, entry kind, tiers, and refetch', () => {
     renderPanel();
     expect(screen.queryByText(/latency|延迟|enrollment|protocol|协议/i)).toBeNull();

--- a/ui/src/components/settings/models/SourceDetailPanel.test.tsx
+++ b/ui/src/components/settings/models/SourceDetailPanel.test.tsx
@@ -245,10 +245,30 @@ describe('SourceDetailPanel', () => {
     const search = screen.getByRole('textbox', { name: /Search model IDs|搜索模型 ID/i });
     await userEvent.type(search, 'missing-model');
 
-    expect(screen.queryByText('model-a')).toBeNull();
+    const filteredRow = screen.getByText('model-a').closest('.model-hub-source-table-row') as HTMLElement;
+    expect(filteredRow.hidden).toBe(true);
     expect(screen.getByText(/No models match this search|没有匹配的模型/i)).toBeTruthy();
     await userEvent.clear(search);
-    expect(screen.getByText('model-a')).toBeTruthy();
+    expect(filteredRow.hidden).toBe(false);
+  });
+
+  it('keeps a row-local tier failure answerable while search filters the row', async () => {
+    vi.spyOn(modelsApi, 'updateModelReasoningEfforts').mockRejectedValueOnce(new Error('write failed'));
+    renderPanel();
+    await userEvent.click(screen.getByRole('button', { name: /high/i }));
+    await userEvent.type(screen.getByPlaceholderText(/Enter to add|回车添加/i), 'draft{Enter}');
+    const failure = await screen.findByText(/tier was not saved|档位没保存上/i);
+    const row = failure.closest('.model-hub-source-table-row') as HTMLElement;
+
+    const search = screen.getByRole('textbox', { name: /Search model IDs|搜索模型 ID/i });
+    await userEvent.type(search, 'missing-model');
+    expect(row.hidden).toBe(true);
+    expect(document.activeElement).toBe(search);
+
+    await userEvent.clear(search);
+    expect(row.hidden).toBe(false);
+    expect(screen.getByRole('button', { name: /^Try again$|^重试$/i })).toBeTruthy();
+    expect(document.activeElement).toBe(search);
   });
 
   it('keeps the detail surface to inventory, entry kind, tiers, and refetch', () => {
@@ -1161,7 +1181,16 @@ describe('SourceDetailPanel', () => {
     expect(pointer).toMatch(/\.model-hub-source-tier-reveal \{ opacity: 0;/);
     expect(pointer).toMatch(/\.model-hub-source-table-row:hover \.model-hub-source-tier-reveal,[\s\S]*?opacity: 1;/);
     expect(pointer).not.toMatch(/display: none|height|padding|margin|border/);
+    expect(pointer).toMatch(/\.model-hub-source-row-action \{ opacity: 0;/);
+    expect(pointer).not.toMatch(/\.model-hub-source-row-actions \{ opacity: 0;/);
     expect(touch).toMatch(/\.model-hub-source-tier-reveal \{ display: none; \}/);
+  });
+
+  it('bounds refetch notices inside the fixed-height detail dialog', () => {
+    const css = readFileSync(join(process.cwd(), 'src/components/settings/models/modelHubSurface.css'), 'utf8');
+    const notices = css.match(/\.model-hub-source-notices\s*\{([^}]*)\}/)?.[1] ?? '';
+    expect(notices).toContain('max-height: var(--model-hub-source-notices-max-height)');
+    expect(notices).toContain('overflow-y: auto');
   });
 
   // The reveal is a paint, so what a tap has to find cannot be part of it: the

--- a/ui/src/components/settings/models/SourceDetailPanel.tsx
+++ b/ui/src/components/settings/models/SourceDetailPanel.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { Info, Loader2, LogIn, MoreHorizontal, Plus, RefreshCw, X } from 'lucide-react';
+import { Info, Loader2, LogIn, MoreHorizontal, Pencil, Plus, RefreshCw, Search, Trash2, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
@@ -51,7 +51,7 @@ import { activeSourceAdoption, sourceStatePresentation } from './sourceStatePres
 import { tierMutationPayload, type TierMutationIntent } from './tierMutation';
 import { TIER_SUGGESTIONS } from './tierSuggestions';
 import { useDeadlineClock } from './useDeadlineClock';
-import { ACCENT_ICON, ACCENT_TILE, isCustomEndpoint, sourceVisual } from './vendorMeta';
+import { ACCENT_ICON, ACCENT_TILE, sourceVisual } from './vendorMeta';
 import type {
   AgentBackend,
   RouteHopRef,
@@ -76,7 +76,7 @@ const ManualModelMenu: React.FC<{
       onOpenChange={setOpen}
       sheetTitle={model.id}
       className="w-40"
-      trigger={<button type="button" disabled={busy} aria-label={label} title={label} className="model-hub-source-more grid place-items-center text-muted hover:bg-surface-2 hover:text-foreground"><MoreHorizontal className="size-4" /></button>}
+      trigger={<button type="button" disabled={busy} aria-label={label} title={label} className="model-hub-source-row-action grid place-items-center text-destructive-ink hover:bg-destructive/[0.08]"><Trash2 className="size-3.5" /></button>}
     >
       <button type="button" role="menuitem" className="flex w-full items-center rounded-md px-2.5 py-2 text-left text-[12px] font-semibold text-destructive-ink hover:bg-destructive/[0.08]" onClick={() => { setOpen(false); onRemove(); }}>{t('settings.models.sourceDetail.row.remove')}</button>
     </ResponsiveMenu>
@@ -146,15 +146,6 @@ const committedPlan = (hops: RouteHopRef[], gaps: SupplyGap[]): ManageGuardPlan 
 type SourceReconciliation =
   | { kind: 'source'; source: Source }
   | { kind: 'gone'; sources: Source[]; snapshot: number };
-
-const enteredHost = (source: Source): string | null => {
-  if (!source.base_url || !isCustomEndpoint(source)) return null;
-  try {
-    return new URL(source.base_url).host;
-  } catch {
-    return null;
-  }
-};
 
 const TierEditor: React.FC<{
   model: SuppliedModel;
@@ -396,7 +387,12 @@ export const SourceDetailPanel: React.FC<{
   const [result, setResult] = React.useState<{ added: string[]; removed: string[] } | null>(null);
   const [refetchFailed, setRefetchFailed] = React.useState(false);
   const [removeFailure, setRemoveFailure] = React.useState<{ modelId: string; retryRead: boolean } | null>(null);
+  const [query, setQuery] = React.useState('');
   const models = source.models;
+  const normalizedQuery = query.trim().toLocaleLowerCase(i18n.language);
+  const filteredModels = normalizedQuery
+    ? models.filter((model) => model.id.toLocaleLowerCase(i18n.language).includes(normalizedQuery))
+    : models;
   const editDraft = 'draft' in manageStage ? manageStage.draft : null;
   const editAssessment = editDraft
     ? assessSourceEdit(source, editDraft)
@@ -824,7 +820,6 @@ export const SourceDetailPanel: React.FC<{
     backends: adoptedBackends,
     native: source.supply_channel === 'native_cli',
   });
-  const host = enteredHost(source);
   // One authority picks the remedy and another total Record names its concrete
   // control. In particular, `retest` points at the existing refetch button; it is
   // not a special case that can fall out of destination-completeness checks.
@@ -845,53 +840,67 @@ export const SourceDetailPanel: React.FC<{
   const providerCopyKey = SOURCE_PROVIDER_COPY_KEYS[providerIdentity];
   const providerLabel = providerCopyKey ? t(providerCopyKey) : providerIdentity;
   const interfaceLabel = `${providerLabel} · ${t(PROTOCOL_COPY_KEYS[source.protocol])}`;
+  const credentialLabel = source.kind === 'api_key'
+    ? t('settings.models.sourceDetail.metadata.apiKey')
+    : t('settings.models.sourceDetail.metadata.account');
+  const credentialValue = source.kind === 'api_key'
+    ? source.masked_credential ?? '—'
+    : source.account_label ?? '—';
+  const endpoint = source.base_url ?? t('settings.models.sourceDetail.metadata.officialEndpoint');
+  const lastFetched = source.last_discovered_at
+    ? formatRelativeTime(source.last_discovered_at, t)
+    : t('settings.models.sourceDetail.metadata.neverFetched');
+  const usageSummary = adoptedBackends.length > 0
+    ? t('settings.models.sourceDetail.usageSummary', { count: source.models.length, backends: adoptedBackends.join(i18n.language.startsWith('zh') ? '、' : ', ') })
+    : t('settings.models.gateway.modelCount', { count: source.models.length });
 
   return (
     <div className="model-hub-source-detail">
-      <section className="model-hub-source-bar flex flex-col border border-border bg-surface sm:flex-row sm:items-center">
+      <section className="model-hub-source-bar flex shrink-0 items-center border-b border-border bg-surface">
         <span className={cn('model-hub-source-tile flex shrink-0 items-center justify-center', ACCENT_TILE[accent])}><Icon className={cn('size-[18px]', ACCENT_ICON[accent])} /></span>
-        {/* Two lines inside a 64px bar, as the design draws it: identity and
-            state share the first, and the mono endpoint summary owns the
-            second. The name leads line one rather than taking a line of its own
-            — the design omits it entirely, but a subscription source has no
-            host to fall back on and would be unidentifiable without it. */}
         <div className="model-hub-source-copy flex min-w-0 flex-1 flex-col">
-          <div className={cn('model-hub-source-line flex min-w-0 flex-wrap items-center gap-x-[7px]', state.textClass)}>
+          <span className="model-hub-source-eyebrow">{t('settings.models.upstream.heading')}</span>
+          <div className="model-hub-source-line flex min-w-0 flex-wrap items-center gap-x-[7px]">
             <h2 ref={headingRef} tabIndex={-1} className="model-hub-source-title truncate font-bold text-foreground">{source.display_name}</h2>
-            <span className="model-hub-pill model-hub-source-interface-pill border" title={interfaceLabel}>
-              <span className="truncate">{interfaceLabel}</span>
-            </span>
-            {/* 备用 is the first thing a just-added source says about itself, and
-                on its own it reads as a failed add. The explanation sits on the
-                label rather than in a subtitle line — the bar draws two lines and
-                the copy register keeps explanations behind a compact info
-                affordance — and the hint is a real control, so keyboard and touch
-                reach the sentence hover alone would keep from them. */}
-            {state.key && <span className="model-hub-source-state flex items-center gap-1.5"><span className={cn('size-[5px] shrink-0 rounded-full', state.dotClass)} />{t(state.key, state.values)}{state.hint && <ModelHubInfoHint label={t(state.hint.labelKey) as string} content={t(state.hint.bodyKey)} className="size-[13px]" />}</span>}
-            {source.last_discovered_at && <span className="model-hub-source-age text-muted">{t('settings.models.sourceDetail.status.listUpdated', { time: formatRelativeTime(source.last_discovered_at, t) })}</span>}
+            {state.key && <span className={cn('model-hub-source-state model-hub-pill flex items-center gap-1.5 border', state.textClass)}><span className={cn('size-[5px] shrink-0 rounded-full', state.dotClass)} />{t(state.key, state.values)}{state.hint && <ModelHubInfoHint label={t(state.hint.labelKey) as string} content={t(state.hint.bodyKey)} className="size-[13px]" />}</span>}
           </div>
-          <p className="model-hub-source-summary truncate font-mono">{t(host ? 'settings.models.sourceDetail.summary' : 'settings.models.gateway.modelCount', { host, count: source.models.length })}</p>
+          <p className="model-hub-source-summary truncate">{usageSummary}</p>
         </div>
-        <div className="flex shrink-0 gap-2">
-          {repairDestination === 'reauth_dialog' && <Button size="sm" className="model-hub-source-action" data-repair-kind={repair} data-repair-destination={repairDestination} disabled={busy} onClick={() => setConfirmingReauth(true)}><LogIn />{t(REPAIR_LABEL_KEY.reauth)}</Button>}
-          {repairDestination === 'replace_key_dialog' && <Button size="sm" className="model-hub-source-action" data-repair-kind={repair} data-repair-destination={repairDestination} disabled={busy} onClick={() => setReplacingKey(true)}>{t(REPAIR_LABEL_KEY.replace_key)}</Button>}
-          {source.supply_channel === 'hub' && <Button variant="outline" size="sm" className="model-hub-source-action" data-repair-kind={repairDestination === 'refetch_button' ? repair : undefined} data-repair-destination={repairDestination === 'refetch_button' ? repairDestination : undefined} disabled={busy} onClick={() => void refetch()}>{busy ? <Loader2 className="animate-spin" /> : <RefreshCw />}{t('settings.models.sourceDetail.action.refetch')}</Button>}
-          {source.kind === 'api_key' && <Button size="sm" className="model-hub-source-action" disabled={busy || manualDraft !== null} onClick={() => setManualDraft({ modelId: '', tiers: [], failed: false, retryRead: false })}><Plus />{t('settings.models.sourceDetail.action.addModel')}</Button>}
+      </section>
+      <dl className="model-hub-source-metadata grid shrink-0 grid-cols-2 gap-x-5 gap-y-3 border-b border-border bg-background px-5 py-3 sm:grid-cols-4">
+        <div className="min-w-0"><dt>{t('settings.models.sourceDetail.metadata.endpoint')}</dt><dd className="truncate font-mono" title={endpoint as string}>{endpoint}</dd></div>
+        <div className="min-w-0"><dt>{credentialLabel}</dt><dd className="truncate font-mono" title={credentialValue}>{credentialValue}</dd></div>
+        <div className="min-w-0"><dt>{t('settings.models.sourceDetail.metadata.type')}</dt><dd className="truncate" title={interfaceLabel}>{interfaceLabel}</dd></div>
+        <div className="min-w-0"><dt>{t('settings.models.sourceDetail.metadata.lastFetched')}</dt><dd className="truncate">{lastFetched}</dd></div>
+      </dl>
+      {(result || refetchFailed || manageStage.kind === 'delete_failed') && <div className="model-hub-source-notices shrink-0 space-y-2 px-5 pt-3">
+        {result && result.removed.length > 0 && <p className="model-hub-status-gold rounded-lg border px-3 py-2 text-[11.5px]">{t('settings.models.sourceDetail.refetch.removed', { count: result.removed.length, models: result.removed.join(', ') })}</p>}
+        {result && result.added.length === 0 && result.removed.length === 0 && <p className="model-hub-status-mint rounded-lg border px-3 py-2 text-[11.5px]">{t('settings.models.sourceDetail.refetch.unchangedOnly')}</p>}
+        {refetchFailed && <p className="rounded-lg border border-destructive/25 bg-destructive/[0.08] px-3 py-2 text-[11.5px] text-destructive-ink">{t('settings.models.sourceDetail.fail.refetch')}</p>}
+        {manageStage.kind === 'delete_failed' && <p data-manage-failure="delete" data-manage-retry-read={String(manageStage.retryRead)} className="rounded-lg border border-destructive/25 bg-destructive/[0.08] px-3 py-2 text-[11.5px] text-destructive-ink">{t(manageStage.retryRead ? 'settings.models.sourceDetail.fail.verifyDeleteSource' : 'settings.models.sourceDetail.fail.deleteSource')} <button type="button" disabled={busy} onClick={retryDelete} className="font-semibold underline underline-offset-2">{t('settings.models.sourceDetail.retry')}</button> <button type="button" disabled={busy} onClick={manageStage.retryRead ? dismissUnresolvedManage : cancelManage} className="font-semibold underline underline-offset-2">{t(manageStage.retryRead ? 'settings.models.sourceDetail.dismissUnverified' : 'common.cancel')}</button></p>}
+      </div>}
+      <section className="model-hub-source-toolbar flex shrink-0 flex-col gap-2 border-b border-border px-5 py-2.5 sm:flex-row sm:items-center">
+        <span className="flex shrink-0 items-center gap-2"><h3 className="text-[13px] font-bold text-foreground">{t('settings.models.sourceDetail.modelsHeading')}</h3><span className="model-hub-pill model-hub-fill-0a border border-border text-muted">{models.length}</span></span>
+        <div className="relative min-w-0 flex-1 sm:ml-auto sm:max-w-[200px]">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted" aria-hidden="true" />
+          <Input value={query} onChange={(event) => setQuery(event.target.value)} aria-label={t('settings.models.sourceDetail.search') as string} placeholder={t('settings.models.sourceDetail.search') as string} className="model-hub-source-search h-8 pl-8 text-[11.5px]" />
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {repairDestination === 'reauth_dialog' && <Button size="xs" className="model-hub-source-action" data-repair-kind={repair} data-repair-destination={repairDestination} disabled={busy} onClick={() => setConfirmingReauth(true)}><LogIn />{t(REPAIR_LABEL_KEY.reauth)}</Button>}
+          {repairDestination === 'replace_key_dialog' && <Button size="xs" className="model-hub-source-action" data-repair-kind={repair} data-repair-destination={repairDestination} disabled={busy} onClick={() => setReplacingKey(true)}>{t(REPAIR_LABEL_KEY.replace_key)}</Button>}
+          {source.supply_channel === 'hub' && <Button variant="outline" size="xs" className="model-hub-source-action" data-repair-kind={repairDestination === 'refetch_button' ? repair : undefined} data-repair-destination={repairDestination === 'refetch_button' ? repairDestination : undefined} disabled={busy} onClick={() => void refetch()}>{busy ? <Loader2 className="animate-spin" /> : <RefreshCw />}{t('settings.models.sourceDetail.action.refetch')}</Button>}
+          {source.kind === 'api_key' && <Button size="xs" className="model-hub-source-action" disabled={busy || manualDraft !== null} onClick={() => setManualDraft({ modelId: '', tiers: [], failed: false, retryRead: false })}><Plus />{t('settings.models.sourceDetail.action.addModel')}</Button>}
           <SourceManageMenu source={source} busy={busy || manageStage.kind !== 'idle'} onEdit={beginEdit} onDelete={beginDelete} />
         </div>
       </section>
-      {result && result.removed.length > 0 && <p className="model-hub-status-gold rounded-lg border px-3 py-2 text-[11.5px]">{t('settings.models.sourceDetail.refetch.removed', { count: result.removed.length, models: result.removed.join(', ') })}</p>}
-      {result && result.added.length === 0 && result.removed.length === 0 && <p className="model-hub-status-mint rounded-lg border px-3 py-2 text-[11.5px]">{t('settings.models.sourceDetail.refetch.unchangedOnly')}</p>}
-      {refetchFailed && <p className="rounded-lg border border-destructive/25 bg-destructive/[0.08] px-3 py-2 text-[11.5px] text-destructive-ink">{t('settings.models.sourceDetail.fail.refetch')}</p>}
-      {manageStage.kind === 'delete_failed' && <p data-manage-failure="delete" data-manage-retry-read={String(manageStage.retryRead)} className="rounded-lg border border-destructive/25 bg-destructive/[0.08] px-3 py-2 text-[11.5px] text-destructive-ink">{t(manageStage.retryRead ? 'settings.models.sourceDetail.fail.verifyDeleteSource' : 'settings.models.sourceDetail.fail.deleteSource')} <button type="button" disabled={busy} onClick={retryDelete} className="font-semibold underline underline-offset-2">{t('settings.models.sourceDetail.retry')}</button> <button type="button" disabled={busy} onClick={manageStage.retryRead ? dismissUnresolvedManage : cancelManage} className="font-semibold underline underline-offset-2">{t(manageStage.retryRead ? 'settings.models.sourceDetail.dismissUnverified' : 'common.cancel')}</button></p>}
-      <section className="model-hub-source-table overflow-hidden border border-border bg-surface">
+      <section className="model-hub-source-table flex min-h-0 flex-1 flex-col overflow-hidden bg-surface">
         <div className="model-hub-source-table-head hidden border-b border-border font-semibold md:grid">
-          <span className="truncate">{t('settings.models.sourceDetail.col.id')}</span><span className="truncate">{t('settings.models.sourceDetail.col.entry')}</span><span className="flex min-w-0 items-center gap-1"><span className="truncate">{t('settings.models.sourceDetail.col.tiers')}</span><Info className="model-hub-ink-59 size-[13px] shrink-0" /></span><span />
+          <span className="truncate">{t('settings.models.sourceDetail.col.id')}</span><span className="flex min-w-0 items-center gap-1"><span className="truncate">{t('settings.models.sourceDetail.col.tiers')}</span><Info className="model-hub-ink-59 size-[13px] shrink-0" /></span><span />
         </div>
-        {models.length === 0 && !manualDraft ? <p className="px-5 py-12 text-center text-[12px] text-muted">{t(source.last_discovered_at ? 'settings.models.sourceDetail.empty' : 'settings.models.sourceDetail.emptyNeverFetched')}</p> : models.map((model) => (
+        <div className="model-hub-source-table-scroll min-h-0 flex-1 overflow-y-auto">
+        {filteredModels.length === 0 && !manualDraft ? <p className="px-5 py-12 text-center text-[12px] text-muted">{t(normalizedQuery ? 'settings.models.sourceDetail.searchEmpty' : source.last_discovered_at ? 'settings.models.sourceDetail.empty' : 'settings.models.sourceDetail.emptyNeverFetched')}</p> : filteredModels.map((model) => (
           <div key={model.id} className="model-hub-source-table-row grid gap-3 border-b border-border last:border-b-0 md:items-center md:gap-y-0">
-            <span className="flex min-w-0 items-center gap-2"><span className="model-hub-source-model truncate font-mono text-foreground" title={model.id}>{model.id}</span>{result?.added.includes(model.id) && <span className="model-hub-accent-pill--mint model-hub-source-pill rounded-full border px-2 py-0.5 font-semibold">{t('settings.models.sourceDetail.refetch.added')}</span>}</span>
-            <span className={cn('model-hub-source-pill model-hub-source-entry-pill w-fit rounded-full border font-semibold', model.origin !== 'discovered' && 'model-hub-source-entry-pill--manual')}>{t(`settings.models.sourceDetail.entry.${model.origin === 'discovered' ? 'auto' : 'manual'}`)}</span>
+            <span className="flex min-w-0 items-center gap-2"><span className="model-hub-source-model truncate font-mono text-foreground" title={model.id}>{model.id}</span>{model.origin !== 'discovered' && <span className="model-hub-source-pill model-hub-source-entry-pill model-hub-source-entry-pill--manual w-fit rounded-full border font-semibold">{t('settings.models.sourceDetail.entry.manual')}</span>}{result?.added.includes(model.id) && <span className="model-hub-accent-pill--mint model-hub-source-pill rounded-full border px-2 py-0.5 font-semibold">{t('settings.models.sourceDetail.refetch.added')}</span>}</span>
             <TierEditor
               model={model}
               protocol={source.protocol}
@@ -904,7 +913,7 @@ export const SourceDetailPanel: React.FC<{
               onMutating={() => { setResult(null); setRefetchFailed(false); }}
               trackMutation={trackMutation}
             />
-            <div className="flex items-center justify-end gap-2">
+            <div className="model-hub-source-row-actions flex items-center justify-end gap-1">
               {removeFailure?.modelId === model.id && <span className="model-hub-source-tier text-right text-destructive-ink">{t('settings.models.sourceDetail.fail.removeModel')} <button type="button" disabled={busy} onClick={() => {
                 if (!removeFailure.retryRead) void remove(model);
                 else {
@@ -913,40 +922,29 @@ export const SourceDetailPanel: React.FC<{
                     .finally(() => setBusy(false));
                 }
               }} className="font-semibold underline underline-offset-2">{t('settings.models.sourceDetail.retry')}</button></span>}
-              {model.origin === 'manual' && <ManualModelMenu model={model} busy={busy} onRemove={() => void remove(model)} />}
+              {model.origin === 'manual' && <><button type="button" disabled={busy} aria-label={t('settings.models.sourceDetail.row.edit', { model: model.id }) as string} title={t('settings.models.sourceDetail.row.edit', { model: model.id }) as string} className="model-hub-source-row-action grid place-items-center text-muted hover:bg-surface-2 hover:text-foreground" onClick={() => setEditingTiers(model.id)}><Pencil className="size-3.5" /></button><ManualModelMenu model={model} busy={busy} onRemove={() => void remove(model)} /></>}
             </div>
           </div>
         ))}
         {manualDraft && (
           <div data-manual-model-draft className="model-hub-source-table-draft grid gap-3 border-y border-mint/20 bg-mint/[0.05] md:items-center md:gap-y-0">
-            <Input
-              autoFocus
-              value={manualDraft.modelId}
-              onChange={(event) => setManualDraft((current) => current ? { ...current, modelId: event.target.value, failed: false, retryRead: false } : current)}
-              placeholder={t('settings.models.sourceDetail.col.id') as string}
-              className="model-hub-source-manual-id model-hub-source-model h-8 font-mono"
-            />
-            <span className="model-hub-source-pill model-hub-source-entry-pill model-hub-source-entry-pill--manual w-fit rounded-full border font-semibold">{t('settings.models.sourceDetail.entry.manual')}</span>
+            <span className="flex min-w-0 items-center gap-2"><Input
+                autoFocus
+                value={manualDraft.modelId}
+                onChange={(event) => setManualDraft((current) => current ? { ...current, modelId: event.target.value, failed: false, retryRead: false } : current)}
+                placeholder={t('settings.models.sourceDetail.col.id') as string}
+                className="model-hub-source-manual-id model-hub-source-model h-8 min-w-0 font-mono"
+              /><span className="model-hub-source-pill model-hub-source-entry-pill model-hub-source-entry-pill--manual w-fit rounded-full border font-semibold">{t('settings.models.sourceDetail.entry.manual')}</span></span>
             <DraftTiers tiers={manualDraft.tiers} onChange={(tiers) => setManualDraft((current) => current ? { ...current, tiers, failed: false, retryRead: false } : current)} />
             <div className="flex justify-end gap-2">
               <Button variant="ghost" size="xs" disabled={busy} onClick={() => setManualDraft(null)}>{t('common.cancel')}</Button>
               <Button size="xs" disabled={busy || !manualDraft.modelId.trim() || source.models.some((model) => model.id === manualDraft.modelId.trim())} onClick={() => void addManualModel()}>{manualDraft.failed ? t('settings.models.sourceDetail.retry') : t('settings.models.sourceDetail.action.addModel')}</Button>
             </div>
-            {manualDraft.failed && <p className="text-[11px] text-destructive-ink md:col-span-4">{t('settings.models.sourceDetail.fail.addModel')}</p>}
+            {manualDraft.failed && <p className="text-[11px] text-destructive-ink md:col-span-3">{t('settings.models.sourceDetail.fail.addModel')}</p>}
           </div>
         )}
-        {source.kind === 'api_key' && !manualDraft && (
-          <button type="button" className="model-hub-source-table-add model-hub-source-model model-hub-ink-mint flex w-full items-center gap-2 text-left font-semibold" onClick={() => setManualDraft({ modelId: '', tiers: [], failed: false, retryRead: false })}>
-            <Plus className="size-3.5 shrink-0" />
-            {t('settings.models.sourceDetail.action.addModel')}
-            <span className="model-hub-source-add-hint truncate font-mono font-normal">{t('settings.models.sourceDetail.addRow.hint')}</span>
-          </button>
-        )}
+        </div>
       </section>
-      <p className="model-hub-source-footnote flex gap-2">
-        <Info className="model-hub-ink-59 mt-px size-[13px] shrink-0" aria-hidden="true" />
-        <span>{t('settings.models.sourceDetail.footnote')}</span>
-      </p>
       {/* Confirmed before the journey opens, not inside it: `OAuthConnectDialog`
           POSTs the re-auth as it mounts, and on a native source that call is the
           irreversible half — `mark_native_irreversible_start` empties every

--- a/ui/src/components/settings/models/SourceDetailPanel.tsx
+++ b/ui/src/components/settings/models/SourceDetailPanel.tsx
@@ -393,6 +393,7 @@ export const SourceDetailPanel: React.FC<{
   const filteredModels = normalizedQuery
     ? models.filter((model) => model.id.toLocaleLowerCase(i18n.language).includes(normalizedQuery))
     : models;
+  const visibleModelIds = new Set(filteredModels.map((model) => model.id));
   const editDraft = 'draft' in manageStage ? manageStage.draft : null;
   const editAssessment = editDraft
     ? assessSourceEdit(source, editDraft)
@@ -898,8 +899,9 @@ export const SourceDetailPanel: React.FC<{
           <span className="truncate">{t('settings.models.sourceDetail.col.id')}</span><span className="flex min-w-0 items-center gap-1"><span className="truncate">{t('settings.models.sourceDetail.col.tiers')}</span><Info className="model-hub-ink-59 size-[13px] shrink-0" /></span><span />
         </div>
         <div className="model-hub-source-table-scroll min-h-0 flex-1 overflow-y-auto">
-        {filteredModels.length === 0 && !manualDraft ? <p className="px-5 py-12 text-center text-[12px] text-muted">{t(normalizedQuery ? 'settings.models.sourceDetail.searchEmpty' : source.last_discovered_at ? 'settings.models.sourceDetail.empty' : 'settings.models.sourceDetail.emptyNeverFetched')}</p> : filteredModels.map((model) => (
-          <div key={model.id} className="model-hub-source-table-row grid gap-3 border-b border-border last:border-b-0 md:items-center md:gap-y-0">
+        {filteredModels.length === 0 && !manualDraft && <p className="px-5 py-12 text-center text-[12px] text-muted">{t(normalizedQuery ? 'settings.models.sourceDetail.searchEmpty' : source.last_discovered_at ? 'settings.models.sourceDetail.empty' : 'settings.models.sourceDetail.emptyNeverFetched')}</p>}
+        {models.map((model) => (
+          <div key={model.id} hidden={!visibleModelIds.has(model.id)} className="model-hub-source-table-row grid gap-3 border-b border-border last:border-b-0 md:items-center md:gap-y-0">
             <span className="flex min-w-0 items-center gap-2"><span className="model-hub-source-model truncate font-mono text-foreground" title={model.id}>{model.id}</span>{model.origin !== 'discovered' && <span className="model-hub-source-pill model-hub-source-entry-pill model-hub-source-entry-pill--manual w-fit rounded-full border font-semibold">{t('settings.models.sourceDetail.entry.manual')}</span>}{result?.added.includes(model.id) && <span className="model-hub-accent-pill--mint model-hub-source-pill rounded-full border px-2 py-0.5 font-semibold">{t('settings.models.sourceDetail.refetch.added')}</span>}</span>
             <TierEditor
               model={model}

--- a/ui/src/components/settings/models/SourceDetailPanel.tsx
+++ b/ui/src/components/settings/models/SourceDetailPanel.tsx
@@ -266,6 +266,7 @@ const TierEditor: React.FC<{
   // Containment is that same rule stated once, at the boundary it is about.
   return (
     <div
+      data-source-dialog-local-escape
       className="flex min-w-0 flex-col gap-1.5"
       onBlur={(event) => { if (!event.currentTarget.contains(event.relatedTarget)) onClose(); }}
       onKeyDown={(event) => {
@@ -338,6 +339,7 @@ const DraftTiers: React.FC<{
         </span>
       ))}
       <Input
+        data-source-dialog-local-escape
         value={draft}
         onChange={(event) => setDraft(event.target.value)}
         onKeyDown={(event) => {

--- a/ui/src/components/settings/models/SourceDetailPanel.tsx
+++ b/ui/src/components/settings/models/SourceDetailPanel.tsx
@@ -339,12 +339,11 @@ const DraftTiers: React.FC<{
         </span>
       ))}
       <Input
-        data-source-dialog-local-escape
         value={draft}
         onChange={(event) => setDraft(event.target.value)}
         onKeyDown={(event) => {
           if (event.key === 'Enter') { event.preventDefault(); add(); }
-          if (event.key === 'Escape') { event.preventDefault(); setDraft(''); event.currentTarget.blur(); }
+          if (event.key === 'Escape') { event.preventDefault(); event.stopPropagation(); setDraft(''); event.currentTarget.blur(); }
         }}
         placeholder={t('settings.models.sourceDetail.tiers.inputHint') as string}
         className="model-hub-source-tier h-7 w-36 rounded-full border-mint/40 px-2.5"
@@ -931,7 +930,16 @@ export const SourceDetailPanel: React.FC<{
           </div>
         ))}
         {manualDraft && (
-          <div data-manual-model-draft className="model-hub-source-table-draft grid gap-3 border-y border-mint/20 bg-mint/[0.05] md:items-center md:gap-y-0">
+          <div
+            data-manual-model-draft
+            data-source-dialog-local-escape
+            className="model-hub-source-table-draft grid gap-3 border-y border-mint/20 bg-mint/[0.05] md:items-center md:gap-y-0"
+            onKeyDown={(event) => {
+              if (event.key !== 'Escape') return;
+              event.preventDefault();
+              if (!busy) setManualDraft(null);
+            }}
+          >
             <span className="flex min-w-0 items-center gap-2"><Input
                 autoFocus
                 value={manualDraft.modelId}

--- a/ui/src/components/settings/models/SourceRow.test.tsx
+++ b/ui/src/components/settings/models/SourceRow.test.tsx
@@ -23,8 +23,9 @@ describe('SourceRow', () => {
   it('opens the Source detail without exposing inline source mutations', async () => {
     const onOpen = vi.fn();
     render(<I18nextProvider i18n={i18n}><SourceRow source={source} onOpen={onOpen} /></I18nextProvider>);
-    await userEvent.click(screen.getByRole('button', { name: /Production/ }));
-    expect(onOpen).toHaveBeenCalledWith(source);
+    const opener = screen.getByRole('button', { name: /Production/ });
+    await userEvent.click(opener);
+    expect(onOpen).toHaveBeenCalledWith(source, opener);
     expect(screen.queryByText(/latency/i)).toBeNull();
     expect(screen.getByText('Anthropic · Anthropic Messages')).toBeTruthy();
   });

--- a/ui/src/components/settings/models/SourceRow.tsx
+++ b/ui/src/components/settings/models/SourceRow.tsx
@@ -16,7 +16,7 @@ import type { AgentBackend, Source } from './types';
 
 export const SourceRow: React.FC<{
   source: Source;
-  onOpen: (source: Source) => void;
+  onOpen: (source: Source, opener: HTMLButtonElement) => void;
   activeBackends?: ReadonlySet<AgentBackend>;
 }> = ({ source, onOpen, activeBackends }) => {
   const { t, i18n } = useTranslation();
@@ -44,7 +44,7 @@ export const SourceRow: React.FC<{
     <button
       type="button"
       data-source-id={source.id}
-      onClick={() => onOpen(source)}
+      onClick={(event) => onOpen(source, event.currentTarget)}
       className={cn(
         'flex h-auto min-h-[96px] w-full items-center gap-2.5 rounded-[10px] border border-border bg-background px-3 py-2 text-left transition-colors hover:border-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
         adopted && source.supply_channel === 'native_cli' && 'border-cyan/30 bg-cyan/[0.04]',

--- a/ui/src/components/settings/models/SourcesCard.test.tsx
+++ b/ui/src/components/settings/models/SourcesCard.test.tsx
@@ -82,8 +82,9 @@ describe('SourcesCard footer', () => {
     expect((subscription as HTMLButtonElement).disabled).toBe(false);
     expect(screen.queryByRole('button', { name: /^Add source$|^添加供应商$/i })).toBeNull();
 
-    await userEvent.click(screen.getByRole('button', { name: /Add API key|添加 API Key/i }));
-    expect(onAddApiKey).toHaveBeenCalledOnce();
+    const apiKey = screen.getByRole('button', { name: /Add API key|添加 API Key/i });
+    await userEvent.click(apiKey);
+    expect(onAddApiKey).toHaveBeenCalledWith(apiKey);
     await userEvent.click(subscription);
     expect(onAddSubscription).toHaveBeenCalledOnce();
   });

--- a/ui/src/components/settings/models/SourcesCard.tsx
+++ b/ui/src/components/settings/models/SourcesCard.tsx
@@ -12,7 +12,7 @@ export const SourcesCard: React.FC<{
   read: RegionRead<Source[]>;
   onRetry: () => void;
   readFailureCopy?: string;
-  onOpenSource: (source: Source) => void;
+  onOpenSource: (source: Source, opener: HTMLButtonElement) => void;
   onAddApiKey: () => void;
   onAddSubscription: () => void;
   subscriptionPickerOpen?: boolean;

--- a/ui/src/components/settings/models/SourcesCard.tsx
+++ b/ui/src/components/settings/models/SourcesCard.tsx
@@ -13,7 +13,7 @@ export const SourcesCard: React.FC<{
   onRetry: () => void;
   readFailureCopy?: string;
   onOpenSource: (source: Source, opener: HTMLButtonElement) => void;
-  onAddApiKey: () => void;
+  onAddApiKey: (opener: HTMLButtonElement) => void;
   onAddSubscription: () => void;
   subscriptionPickerOpen?: boolean;
   subscriptionTriggerRef?: React.Ref<HTMLButtonElement>;
@@ -74,7 +74,7 @@ export const SourcesCard: React.FC<{
           variant="outline"
           size="xs"
           className="model-hub-footer-action model-hub-footer-action--outlined model-hub-fill-0a"
-          onClick={onAddApiKey}
+          onClick={(event) => onAddApiKey(event.currentTarget)}
         >
           <Plus className="size-3" />
           {t('settings.models.upstream.addApiKey')}

--- a/ui/src/components/settings/models/SupplyGraph.tsx
+++ b/ui/src/components/settings/models/SupplyGraph.tsx
@@ -61,7 +61,7 @@ export const SupplyGraph: React.FC<{
   if (!drawing || drawing.wires.length === 0) return null;
   const yValues = drawing.wires.flatMap((wire) => [wire.startY, wire.endY]);
   return (
-    <svg aria-hidden="true" className="pointer-events-none absolute inset-0 z-10 hidden size-full overflow-hidden lg:block" viewBox={`0 0 ${drawing.width} ${drawing.height}`} preserveAspectRatio="none">
+    <svg aria-hidden="true" className="pointer-events-none absolute inset-0 z-10 hidden size-full overflow-hidden xl:block" viewBox={`0 0 ${drawing.width} ${drawing.height}`} preserveAspectRatio="none">
       <line className="model-hub-rail-line" x1={drawing.railX} x2={drawing.railX} y1={Math.min(...yValues)} y2={Math.max(...yValues)} />
       {drawing.wires.map((wire) => (
         <g key={`${wire.sourceId}:${wire.backend}`}>

--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -338,9 +338,9 @@
 }
 
 .model-hub-overview {
-  --model-hub-upstream-track: 384px;
-  --model-hub-rail-track: 72px;
-  --model-hub-track-gap: 16px;
+  --model-hub-upstream-track: 420px;
+  --model-hub-rail-track: 80px;
+  --model-hub-track-gap: 0px;
   --model-hub-legend-height: 34px;
   --model-hub-wire-active-width: 1.75px;
   --model-hub-wire-muted-width: 1px;
@@ -356,8 +356,8 @@
   --model-hub-model-current-ink: var(--model-hub-muted-cc);
   --model-hub-model-collapse-ink: var(--model-hub-ink-59);
   --model-hub-takeover-current-ink: var(--model-hub-violet-ink);
-  --model-hub-agent-head-action-height: 36px;
-  --model-hub-agent-head-action-leading: 17px;
+  --model-hub-agent-head-action-height: 28px;
+  --model-hub-agent-head-action-leading: 16px;
   --model-hub-agent-head-status-height: 16px;
   display: flex;
   flex-direction: column;
@@ -375,6 +375,13 @@
   line-height: var(--model-hub-agent-head-action-leading, 17px);
 }
 .model-hub-agent-head-status { line-height: var(--model-hub-agent-head-status-height, 16px); }
+.model-hub-agent-mode-trigger {
+  height: var(--model-hub-agent-head-action-height, 28px);
+  max-width: 190px;
+  background: var(--model-hub-wash-0a);
+}
+.model-hub-mode-menu-current { background: var(--model-hub-wash-0a); }
+.model-hub-mode-menu-title { letter-spacing: 0; }
 .model-hub-upstream-count {
   border-color: var(--model-hub-wash-14);
   background: var(--model-hub-wash-0a);
@@ -871,27 +878,25 @@
 .model-hub-route-foot { height: var(--model-hub-dialog-foot-height); flex-shrink: 0; padding: 14px 20px; border-color: var(--model-hub-wash-14); }
 
 .model-hub-source-detail {
-  --model-hub-source-gap: 16px;
-  --model-hub-source-radius: 12px;
-  --model-hub-source-bar-height: 64px;
+  --model-hub-source-gap: 0px;
+  --model-hub-source-radius: 0px;
+  --model-hub-source-bar-height: 82px;
   --model-hub-source-bar-padding-y: 14px;
-  --model-hub-source-bar-padding-x: 18px;
-  --model-hub-source-bar-gap: 14px;
+  --model-hub-source-bar-padding-x: 20px;
+  --model-hub-source-bar-gap: 12px;
   --model-hub-source-tile-size: 36px;
   --model-hub-source-tile-radius: 9px;
-  --model-hub-source-action-width: 95px;
-  --model-hub-source-action-height: 33px;
+  --model-hub-source-action-height: 32px;
   --model-hub-source-action-radius: 7px;
   --model-hub-source-action-size: 12px;
   --model-hub-source-table-head-height: 36px;
-  --model-hub-source-table-row-height: 55px;
-  --model-hub-source-table-draft-height: 55px;
-  --model-hub-source-table-add-height: 41px;
-  --model-hub-source-table-columns: 250px 84px minmax(220px, 470px) 1fr;
-  --model-hub-source-table-gap: 16px;
-  --model-hub-source-table-padding-x: 18px;
-  --model-hub-source-table-padding-y: 11px;
-  --model-hub-source-title-size: 12px;
+  --model-hub-source-table-row-height: 40px;
+  --model-hub-source-table-draft-height: 56px;
+  --model-hub-source-table-columns: minmax(0, 1fr) minmax(120px, 180px) 64px;
+  --model-hub-source-table-gap: 12px;
+  --model-hub-source-table-padding-x: 20px;
+  --model-hub-source-table-padding-y: 7px;
+  --model-hub-source-title-size: 15px;
   --model-hub-source-state-size: 12px;
   --model-hub-source-age-size: 11px;
   --model-hub-source-summary-size: 10.5px;
@@ -916,14 +921,28 @@
   --model-hub-source-entry-fill: var(--model-hub-wash-0a);
   --model-hub-source-entry-manual-fill: var(--model-hub-wash-14);
   display: flex;
+  min-height: 0;
+  height: 100%;
   flex-direction: column;
   gap: var(--model-hub-source-gap);
+}
+
+.model-hub-source-dialog { display: flex; }
+.model-hub-source-dialog > button {
+  top: 18px;
+  right: 18px;
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  padding: 0;
 }
 
 .model-hub-source-bar {
   min-height: var(--model-hub-source-bar-height);
   padding: var(--model-hub-source-bar-padding-y) var(--model-hub-source-bar-padding-x);
   gap: var(--model-hub-source-bar-gap);
+  padding-right: 58px;
   border-radius: var(--model-hub-source-radius);
 }
 .model-hub-source-tile {
@@ -932,6 +951,13 @@
   border-radius: var(--model-hub-source-tile-radius);
 }
 .model-hub-source-copy { gap: var(--model-hub-source-copy-gap); }
+.model-hub-source-eyebrow {
+  color: var(--model-hub-ink-59);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 13px;
+}
 .model-hub-source-line { min-height: var(--model-hub-source-line-height); line-height: var(--model-hub-source-line-height); }
 .model-hub-source-title { font-size: var(--model-hub-source-title-size); }
 .model-hub-source-state { font-size: var(--model-hub-source-state-size); }
@@ -942,8 +968,9 @@
   line-height: var(--model-hub-source-summary-line);
 }
 .model-hub-source-action {
-  width: var(--model-hub-source-action-width);
+  width: auto;
   height: var(--model-hub-source-action-height);
+  padding-inline: 11px;
   border-radius: var(--model-hub-source-action-radius);
   font-size: var(--model-hub-source-action-size);
   font-weight: 600;
@@ -952,10 +979,24 @@
    a slightly wide, slightly short box so it reads as part of that row rather than
    as an icon button dropped beside it. */
 .model-hub-source-more {
-  width: 33px;
-  height: 30px;
+  width: 32px;
+  height: 32px;
   border-radius: var(--model-hub-source-action-radius);
 }
+.model-hub-source-metadata dt {
+  color: var(--model-hub-source-label-ink);
+  font-size: 9.5px;
+  font-weight: 600;
+  line-height: 14px;
+}
+.model-hub-source-metadata dd {
+  margin-top: 2px;
+  color: var(--foreground);
+  font-size: 10.5px;
+  font-weight: 500;
+  line-height: 15px;
+}
+.model-hub-source-search { background: var(--model-hub-wash-05); }
 .model-hub-source-table { border-radius: var(--model-hub-source-radius); }
 .model-hub-source-table-head,
 .model-hub-source-table-row,
@@ -963,6 +1004,13 @@
   grid-template-columns: var(--model-hub-source-table-columns);
   column-gap: var(--model-hub-source-table-gap);
   padding-inline: var(--model-hub-source-table-padding-x);
+}
+.model-hub-source-row-action {
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--background);
 }
 .model-hub-source-table-head {
   height: var(--model-hub-source-table-head-height);
@@ -1042,6 +1090,9 @@
   .model-hub-source-tier-reveal { opacity: 0; transition: opacity 120ms ease; }
   .model-hub-source-table-row:hover .model-hub-source-tier-reveal,
   .model-hub-source-tier-cell:focus-visible .model-hub-source-tier-reveal { opacity: 1; }
+  .model-hub-source-row-actions { opacity: 0; transition: opacity 120ms ease; }
+  .model-hub-source-table-row:hover .model-hub-source-row-actions,
+  .model-hub-source-table-row:focus-within .model-hub-source-row-actions { opacity: 1; }
 }
 @media (hover: none) {
   .model-hub-source-tier-reveal { display: none; }
@@ -1731,7 +1782,8 @@
   .model-hub-source-table-head { display: none; }
   .model-hub-source-table-row,
   .model-hub-source-table-draft { grid-template-columns: minmax(0, 1fr); }
-  .model-hub-source-bar { align-items: stretch; }
+  .model-hub-source-bar { align-items: center; }
+  .model-hub-source-toolbar > div:last-child { flex-wrap: wrap; }
   .model-hub-source-action { width: auto; flex: 1 1 0; }
   .model-hub-direct-card { min-height: 0; }
   /* Stacked, each cell carries its own label, so the column gutter becomes a
@@ -1741,6 +1793,9 @@
 
 @media (min-width: 1024px) {
   .model-hub-shell { padding-top: 4px; }
+}
+
+@media (min-width: 1280px) {
   .model-hub-overview-grid {
     display: grid;
     grid-template-columns: var(--model-hub-upstream-track) var(--model-hub-rail-track) minmax(0, 1fr);

--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -896,6 +896,7 @@
   --model-hub-source-table-gap: 12px;
   --model-hub-source-table-padding-x: 20px;
   --model-hub-source-table-padding-y: 7px;
+  --model-hub-source-notices-max-height: min(160px, 25dvh);
   --model-hub-source-title-size: 15px;
   --model-hub-source-state-size: 12px;
   --model-hub-source-age-size: 11px;
@@ -928,6 +929,12 @@
 }
 
 .model-hub-source-dialog { display: flex; }
+.model-hub-source-notices {
+  max-height: var(--model-hub-source-notices-max-height);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  overflow-wrap: anywhere;
+}
 .model-hub-source-dialog > button {
   top: 18px;
   right: 18px;
@@ -1090,9 +1097,9 @@
   .model-hub-source-tier-reveal { opacity: 0; transition: opacity 120ms ease; }
   .model-hub-source-table-row:hover .model-hub-source-tier-reveal,
   .model-hub-source-tier-cell:focus-visible .model-hub-source-tier-reveal { opacity: 1; }
-  .model-hub-source-row-actions { opacity: 0; transition: opacity 120ms ease; }
-  .model-hub-source-table-row:hover .model-hub-source-row-actions,
-  .model-hub-source-table-row:focus-within .model-hub-source-row-actions { opacity: 1; }
+  .model-hub-source-row-action { opacity: 0; transition: opacity 120ms ease; }
+  .model-hub-source-table-row:hover .model-hub-source-row-action,
+  .model-hub-source-table-row:focus-within .model-hub-source-row-action { opacity: 1; }
 }
 @media (hover: none) {
   .model-hub-source-tier-reveal { display: none; }

--- a/ui/src/components/ui/dialog.tsx
+++ b/ui/src/components/ui/dialog.tsx
@@ -27,12 +27,14 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 type DialogContentProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
   /** Give content-heavy phone dialogs a resolved, near-full-screen sheet height. */
   mobileSheetHeight?: 'content' | 'tall';
+  /** Accessible label for the built-in close control. */
+  closeLabel?: string;
 };
 
 export const DialogContent = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Content>,
   DialogContentProps
->(({ className, children, mobileSheetHeight = 'content', ...props }, ref) => (
+>(({ className, children, mobileSheetHeight = 'content', closeLabel = 'Close', ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -55,7 +57,7 @@ export const DialogContent = React.forwardRef<
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-md p-1 text-muted opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring">
         <X className="size-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">{closeLabel}</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -894,6 +894,12 @@
         "sourceOrder": "Adjust priority",
         "switchToGateway": "Switch to gateway",
         "switchToDirect": "Switch to direct",
+        "modeMenu": {
+          "title": "Runtime mode",
+          "gatewayCurrent": "Gateway (current)",
+          "gatewayDescription": "Assign requests to model providers by route and priority",
+          "directDescription": "Use {{backend}}'s own models and credentials; gateway routes and priority no longer apply"
+        },
         "fail": {
           "switchToDirect": "The switch back to direct did not go through"
         },
@@ -1456,6 +1462,19 @@
       },
       "sourceDetail": {
         "back": "Back to sources",
+        "close": "Close provider details",
+        "modelsHeading": "Models",
+        "usageSummary_one": "{{count}} model · used by {{backends}}",
+        "usageSummary_other": "{{count}} models · used by {{backends}}",
+        "metadata": {
+          "endpoint": "Endpoint",
+          "apiKey": "API key",
+          "account": "Account",
+          "type": "Provider type",
+          "lastFetched": "Last fetched",
+          "officialEndpoint": "Provider default endpoint",
+          "neverFetched": "Not fetched yet"
+        },
         "status": {
           "inUse": "In use",
           "needsAction": {
@@ -1525,7 +1544,8 @@
           "unchangedOnly": "Nothing changed in this fetch"
         },
         "row": {
-          "remove": "Remove"
+          "remove": "Remove",
+          "edit": "Edit reasoning tiers for {{model}}"
         },
         "fail": {
           "refetch": "The fetch did not come back. The list below is the last one this page actually read",
@@ -1538,6 +1558,7 @@
         "retry": "Try again",
         "dismissUnverified": "Dismiss unverified result",
         "search": "Search model IDs",
+        "searchEmpty": "No models match this search",
         "col": {
           "id": "Model ID",
           "entry": "Entry",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -894,6 +894,12 @@
         "sourceOrder": "调整优先级",
         "switchToGateway": "切换到模型网关",
         "switchToDirect": "切到直连",
+        "modeMenu": {
+          "title": "运行模式",
+          "gatewayCurrent": "网关（当前）",
+          "gatewayDescription": "按路由与优先级分配到模型供应商",
+          "directDescription": "改用 {{backend}} 自带的模型与凭据，路由与优先级不再生效"
+        },
         "fail": {
           "switchToDirect": "没能切回直连"
         },
@@ -1456,6 +1462,19 @@
       },
       "sourceDetail": {
         "back": "返回模型供应商列表",
+        "close": "关闭供应商详情",
+        "modelsHeading": "模型",
+        "usageSummary_one": "{{count}} 个模型 · 被 {{backends}} 使用",
+        "usageSummary_other": "{{count}} 个模型 · 被 {{backends}} 使用",
+        "metadata": {
+          "endpoint": "接入地址",
+          "apiKey": "API Key",
+          "account": "账号",
+          "type": "供应商类型",
+          "lastFetched": "最近拉取",
+          "officialEndpoint": "供应商官方地址",
+          "neverFetched": "尚未拉取"
+        },
         "status": {
           "inUse": "使用中",
           "needsAction": {
@@ -1525,7 +1544,8 @@
           "unchangedOnly": "本次拉取没有变化"
         },
         "row": {
-          "remove": "移除"
+          "remove": "移除",
+          "edit": "编辑 {{model}} 的推理强度"
         },
         "fail": {
           "refetch": "拉取没有回来，下面是这一页最后一次真的读到的列表",
@@ -1538,6 +1558,7 @@
         "retry": "重试",
         "dismissUnverified": "忽略未确认的结果",
         "search": "搜索模型 ID",
+        "searchEmpty": "没有匹配的模型",
         "col": {
           "id": "模型 ID",
           "entry": "录入",


### PR DESCRIPTION
## Summary

- present model providers and agent routes side by side on desktop, with the existing live connector graph visible between them
- consolidate each agent's runtime state and mode switch into one compact menu, using the requested Power icon for direct mode
- move provider details into a focused, responsive dialog with searchable models, compact metadata, and contextual row actions

## Validation

- `npm run lint`
- `npm run validate:theme`
- `npm test -- --run` (260 files, 3328 tests)
- `npm run build`
- visually verified the overview, mode menu, and provider dialog at 1440px and 390px widths
