### PR TITLE
feat(memory): add package shape record codec

### DIFF
--- a/tests/test_package_shape_record_codec.py
+++ b/tests/test_package_shape_record_codec.py
@@ -1,0 +1,189 @@
+"""Strict persisted DTO codec evidence for package-shape recovery records."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+import vibe.package_shape as package_shape
+from vibe.package_shape import (
+    CapturedPackageShapeRecord,
+    DistributionProvider,
+    ExactRequirement,
+    PackageShapeRecordError,
+    ReleaseFamily,
+    ResolvedRollbackPlan,
+    ResolvedRollbackPlanRecord,
+    StagedArtifact,
+    decode_captured_package_shape_record,
+    decode_resolved_rollback_plan_record,
+    encode_captured_package_shape_record,
+    encode_resolved_rollback_plan_record,
+)
+from vibe.runtime import ServiceLauncher
+
+
+def _captured() -> package_shape.CapturedPackageShape:
+    return package_shape.CapturedPackageShape(
+        core_provider=DistributionProvider(
+            name="avibe-os",
+            version="3.0.14",
+            provider_id="/opt/avibe/avibe_os-3.0.14.dist-info",
+            requires_dist=('avibe-memory>=3.0.14.dev0,<3.1; extra == "memory"',),
+        ),
+        launcher=ServiceLauncher(
+            python="/opt/avibe/bin/python",
+            main="/opt/avibe/site-packages/vibe/service_main.py",
+        ),
+        release_family=ReleaseFamily.OPTIONAL_SPLIT,
+        memory_providers=(
+            DistributionProvider(
+                name="avibe-memory",
+                version="3.0.15",
+                provider_id="/opt/avibe/avibe_memory-3.0.15.dist-info",
+            ),
+        ),
+        transition_memory_version=None,
+        residual_memory=False,
+    )
+
+
+def _resolved(tmp_path: Path) -> ResolvedRollbackPlan:
+    captured = _captured()
+    staging_dir = tmp_path / "staging"
+    requirements = (
+        ExactRequirement("avibe-os", "3.0.14"),
+        ExactRequirement("avibe-memory", "3.0.15"),
+    )
+    artifacts = tuple(
+        StagedArtifact(
+            distribution=requirement.distribution,
+            version=requirement.version,
+            path=staging_dir / f"{requirement.distribution}-{requirement.version}.whl",
+            sha256=("a" if index == 0 else "b") * 64,
+            requires_dist=("dependency==1",) if index == 0 else (),
+        )
+        for index, requirement in enumerate(requirements)
+    )
+    return package_shape._construct_resolved_plan(
+        captured=captured,
+        requirements=requirements,
+        artifacts=artifacts,
+        staging_dir=staging_dir,
+    )
+
+
+def _json_round_trip(value: dict[str, object]) -> dict[str, object]:
+    loaded = json.loads(json.dumps(value))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def test_captured_record_codec_is_json_safe_immutable_and_lossless() -> None:
+    encoded = _json_round_trip(encode_captured_package_shape_record(_captured()))
+
+    decoded = decode_captured_package_shape_record(encoded)
+
+    assert isinstance(decoded, CapturedPackageShapeRecord)
+    assert encode_captured_package_shape_record(decoded) == encoded
+    assert decoded.core_provider.provider_id.endswith("avibe_os-3.0.14.dist-info")
+    assert decoded.memory_providers[0].version == "3.0.15"
+    with pytest.raises(FrozenInstanceError):
+        decoded.residual_memory = True  # type: ignore[misc]
+
+
+def test_resolved_record_codec_preserves_complete_non_executable_plan(
+    tmp_path: Path,
+) -> None:
+    encoded = _json_round_trip(encode_resolved_rollback_plan_record(_resolved(tmp_path)))
+
+    decoded = decode_resolved_rollback_plan_record(encoded)
+
+    assert isinstance(decoded, ResolvedRollbackPlanRecord)
+    assert not isinstance(decoded, ResolvedRollbackPlan)
+    assert encode_resolved_rollback_plan_record(decoded) == encoded
+    assert decoded.staging_dir == str(tmp_path / "staging")
+    assert [artifact.sha256 for artifact in decoded.artifacts] == ["a" * 64, "b" * 64]
+    assert decoded.verification.memory_version == "3.0.15"
+    with pytest.raises(TypeError, match="constructed only by rollback resolution"):
+        ResolvedRollbackPlan(**decoded.__dict__)
+
+
+@pytest.mark.parametrize("version", [0, 2, True, "1", None])
+def test_record_codec_rejects_unknown_or_non_integer_schema_versions(
+    version: object,
+) -> None:
+    payload = encode_captured_package_shape_record(_captured())
+    payload["schema_version"] = version
+
+    with pytest.raises(PackageShapeRecordError, match="schema version"):
+        decode_captured_package_shape_record(payload)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value.update(extra="unknown"),
+        lambda value: value.pop("record_type"),
+        lambda value: value.update(record_type="resolved_rollback_plan"),
+        lambda value: value["shape"].update(extra="unknown"),
+        lambda value: value["shape"].pop("launcher"),
+        lambda value: value["shape"]["core_provider"].update(version=3),
+        lambda value: value["shape"].update(memory_providers="not-a-list"),
+        lambda value: value["shape"].update(residual_memory=1),
+        lambda value: value["shape"].update(release_family="transition"),
+        lambda value: value["shape"].update(residual_memory=True),
+    ],
+)
+def test_captured_decoder_rejects_structural_drift(mutation: object) -> None:
+    payload = deepcopy(encode_captured_package_shape_record(_captured()))
+    mutation(payload)  # type: ignore[operator]
+
+    with pytest.raises(PackageShapeRecordError):
+        decode_captured_package_shape_record(payload)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value.update(extra="unknown"),
+        lambda value: value["plan"].pop("verification"),
+        lambda value: value["plan"]["requirements"][0].update(extra="unknown"),
+        lambda value: value["plan"]["artifacts"][0].update(sha256="not-a-digest"),
+        lambda value: value["plan"]["artifacts"][0].update(path=4),
+        lambda value: value["plan"].update(uninstall_distributions=["Avibe_OS"]),
+        lambda value: value["plan"]["verification"].update(memory_provider_cardinality=True),
+        lambda value: value["plan"]["verification"].update(core_version="3.0.13"),
+        lambda value: value["plan"]["requirements"][0].update(version="3.0.13"),
+        lambda value: value["plan"].update(requirements="not-a-list"),
+    ],
+)
+def test_resolved_decoder_rejects_structural_drift(
+    mutation: object,
+    tmp_path: Path,
+) -> None:
+    payload = deepcopy(encode_resolved_rollback_plan_record(_resolved(tmp_path)))
+    mutation(payload)  # type: ignore[operator]
+
+    with pytest.raises(PackageShapeRecordError):
+        decode_resolved_rollback_plan_record(payload)
+
+
+def test_resolved_decoder_rejects_unknown_schema_version(tmp_path: Path) -> None:
+    payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
+    payload["schema_version"] = 2
+
+    with pytest.raises(PackageShapeRecordError, match="schema version"):
+        decode_resolved_rollback_plan_record(payload)
+
+
+def test_decoded_record_reencodes_without_live_files(tmp_path: Path) -> None:
+    payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
+    decoded = decode_resolved_rollback_plan_record(_json_round_trip(payload))
+
+    assert not (tmp_path / "staging").exists()
+    assert encode_resolved_rollback_plan_record(decoded) == payload

--- a/tests/test_package_shape_record_codec.py
+++ b/tests/test_package_shape_record_codec.py
@@ -65,7 +65,7 @@ def _resolved(tmp_path: Path) -> ResolvedRollbackPlan:
         StagedArtifact(
             distribution=requirement.distribution,
             version=requirement.version,
-            path=staging_dir / f"{requirement.distribution}-{requirement.version}.whl",
+            path=(staging_dir / f"{requirement.distribution.replace('-', '_')}-{requirement.version}-py3-none-any.whl"),
             sha256=("a" if index == 0 else "b") * 64,
             requires_dist=(captured.core_provider.requires_dist if index == 0 else ()),
         )
@@ -198,6 +198,7 @@ def test_memory_indep_019_decoder_binds_closure_to_captured_target(
     payload["plan"]["artifacts"][0].update(  # type: ignore[index]
         distribution="unrelated",
         version="1",
+        path=str(tmp_path / "staging" / "unrelated-1-py3-none-any.whl"),
     )
 
     with pytest.raises(PackageShapeRecordError, match="captured rollback target"):
@@ -210,17 +211,18 @@ def test_memory_indep_019_decoder_rejects_duplicate_staged_distribution(
     payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
     duplicate = deepcopy(payload["plan"]["artifacts"][0])  # type: ignore[index]
     duplicate["version"] = "3.0.13"
+    duplicate["path"] = str(tmp_path / "staging" / "avibe_os-3.0.13-py3-none-any.whl")
     payload["plan"]["artifacts"].append(duplicate)  # type: ignore[index]
 
     with pytest.raises(PackageShapeRecordError, match="duplicate distribution"):
         decode_resolved_rollback_plan_record(payload)
 
 
-def test_memory_indep_019_captured_dto_construction_rejects_invalid_state() -> None:
+def test_memory_indep_019_provider_fact_construction_rejects_invalid_state() -> None:
     record = decode_captured_package_shape_record(encode_captured_package_shape_record(_captured()))
 
-    with pytest.raises(PackageShapeRecordError, match="not canonical"):
-        replace(record.core_provider, version="03.0.14")
+    with pytest.raises(PackageShapeError, match="identity is missing"):
+        replace(record.core_provider, provider_id="")
 
 
 def test_memory_indep_019_decoder_derives_family_from_core_metadata() -> None:
@@ -258,12 +260,12 @@ def test_memory_indep_019_rejects_invalid_distribution_names(
         decode_resolved_rollback_plan_record(payload)
 
 
-def test_memory_indep_019_resolved_dto_construction_rejects_invalid_state(
+def test_memory_indep_019_artifact_fact_construction_rejects_invalid_state(
     tmp_path: Path,
 ) -> None:
     record = decode_resolved_rollback_plan_record(encode_resolved_rollback_plan_record(_resolved(tmp_path)))
 
-    with pytest.raises(PackageShapeRecordError, match="SHA-256"):
+    with pytest.raises(PackageShapeError, match="SHA-256"):
         replace(record.artifacts[0], sha256="not-a-digest")
 
 
@@ -293,7 +295,7 @@ def test_memory_indep_019_dto_binds_artifacts_to_staging_directory(
         else:
             artifact = replace(
                 record.artifacts[0],
-                path=str(tmp_path / "outside.whl"),
+                path=tmp_path / record.artifacts[0].path.name,
             )
             replace(record, artifacts=(artifact, *record.artifacts[1:]))
 
@@ -305,14 +307,8 @@ def test_memory_indep_019_dto_requires_canonical_unique_artifact_paths(
 
     with pytest.raises(PackageShapeRecordError, match="canonical absolute path"):
         replace(record, staging_dir=f"{record.staging_dir}{os.sep}.")
-    duplicate_path = replace(
-        record.artifacts[1],
-        distribution="dependency",
-        version="1",
-        path=record.artifacts[0].path,
-    )
     with pytest.raises(PackageShapeRecordError, match="duplicate artifact paths"):
-        replace(record, artifacts=(record.artifacts[0], duplicate_path))
+        replace(record, artifacts=(record.artifacts[0], record.artifacts[0]))
 
 
 def test_memory_indep_019_dto_rejects_conflicting_provider_identity() -> None:
@@ -334,3 +330,51 @@ def test_memory_indep_019_decoded_record_reencodes_without_live_files(
 
     assert not (tmp_path / "staging").exists()
     assert encode_resolved_rollback_plan_record(decoded) == payload
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink drift fixture requires POSIX symlinks")
+def test_memory_indep_019_provider_decode_is_stable_across_symlink_drift(
+    tmp_path: Path,
+) -> None:
+    first_target = tmp_path / "first"
+    second_target = tmp_path / "second"
+    first_target.mkdir()
+    second_target.mkdir()
+    provider_link = tmp_path / "provider"
+    provider_link.symlink_to(first_target, target_is_directory=True)
+    captured = _captured()
+    provider_id = str(provider_link / "avibe_os-3.0.14.dist-info")
+    captured = replace(
+        captured,
+        core_provider=replace(captured.core_provider, provider_id=provider_id),
+    )
+    payload = _json_round_trip(encode_captured_package_shape_record(captured))
+
+    decoded_before = decode_captured_package_shape_record(payload)
+    provider_link.unlink()
+    provider_link.symlink_to(second_target, target_is_directory=True)
+    decoded_after = decode_captured_package_shape_record(payload)
+
+    assert decoded_before == decoded_after
+    assert decoded_after.core_provider.provider_id == provider_id
+    assert encode_captured_package_shape_record(decoded_after) == payload
+
+
+@pytest.mark.parametrize(
+    "wheel_name",
+    [
+        "unrelated-3.0.14-py3-none-any.whl",
+        "avibe_os-9-py3-none-any.whl",
+    ],
+)
+def test_memory_indep_019_decoder_binds_artifact_identity_to_wheel_filename(
+    wheel_name: str,
+    tmp_path: Path,
+) -> None:
+    payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
+    payload["plan"]["artifacts"][0]["path"] = str(  # type: ignore[index]
+        tmp_path / "staging" / wheel_name
+    )
+
+    with pytest.raises(PackageShapeRecordError, match="filename and recorded identity"):
+        decode_resolved_rollback_plan_record(payload)

--- a/tests/test_package_shape_record_codec.py
+++ b/tests/test_package_shape_record_codec.py
@@ -100,6 +100,41 @@ def test_memory_indep_019_captured_codec_is_json_safe_immutable_and_lossless() -
         decoded.residual_memory = True  # type: ignore[misc]
 
 
+@pytest.mark.parametrize(
+    ("field", "invalid"),
+    [
+        ("python", "/opt/avibe/bin/py\0thon"),
+        ("main", "/opt/avibe/service\0_main.py"),
+        ("python", "python"),
+        ("main", "/opt/avibe/service_main"),
+    ],
+)
+def test_memory_indep_019_launcher_dto_and_decode_reject_invalid_paths(
+    field: str,
+    invalid: str,
+) -> None:
+    record = decode_captured_package_shape_record(encode_captured_package_shape_record(_captured()))
+    with pytest.raises(PackageShapeRecordError, match="path"):
+        replace(record.launcher, **{field: invalid})
+
+    payload = encode_captured_package_shape_record(record)
+    payload["shape"]["launcher"][field] = invalid  # type: ignore[index]
+    with pytest.raises(PackageShapeRecordError, match="path"):
+        decode_captured_package_shape_record(payload)
+
+
+def test_memory_indep_019_launcher_dto_paths_round_trip_offline() -> None:
+    record = decode_captured_package_shape_record(encode_captured_package_shape_record(_captured()))
+    launcher = replace(
+        record.launcher,
+        python=r"C:\Avibe\python.exe",
+        main=r"C:\Avibe\vibe\service_main.py",
+    )
+    expected = replace(record, launcher=launcher)
+
+    assert decode_captured_package_shape_record(encode_captured_package_shape_record(expected)) == expected
+
+
 def test_memory_indep_019_resolved_codec_preserves_complete_non_executable_plan(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_package_shape_record_codec.py
+++ b/tests/test_package_shape_record_codec.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from copy import deepcopy
 from dataclasses import FrozenInstanceError, replace
 from pathlib import Path
@@ -66,7 +67,7 @@ def _resolved(tmp_path: Path) -> ResolvedRollbackPlan:
             version=requirement.version,
             path=staging_dir / f"{requirement.distribution}-{requirement.version}.whl",
             sha256=("a" if index == 0 else "b") * 64,
-            requires_dist=("dependency==1",) if index == 0 else (),
+            requires_dist=(captured.core_provider.requires_dist if index == 0 else ()),
         )
         for index, requirement in enumerate(requirements)
     )
@@ -215,17 +216,11 @@ def test_memory_indep_019_decoder_rejects_duplicate_staged_distribution(
         decode_resolved_rollback_plan_record(payload)
 
 
-def test_memory_indep_019_captured_encoder_rejects_unvalidated_dto() -> None:
-    record = decode_captured_package_shape_record(
-        encode_captured_package_shape_record(_captured())
-    )
-    invalid = replace(
-        record,
-        core_provider=replace(record.core_provider, version="03.0.14"),
-    )
+def test_memory_indep_019_captured_dto_construction_rejects_invalid_state() -> None:
+    record = decode_captured_package_shape_record(encode_captured_package_shape_record(_captured()))
 
     with pytest.raises(PackageShapeRecordError, match="not canonical"):
-        encode_captured_package_shape_record(invalid)
+        replace(record.core_provider, version="03.0.14")
 
 
 def test_memory_indep_019_decoder_derives_family_from_core_metadata() -> None:
@@ -263,19 +258,72 @@ def test_memory_indep_019_rejects_invalid_distribution_names(
         decode_resolved_rollback_plan_record(payload)
 
 
-def test_memory_indep_019_resolved_encoder_rejects_unvalidated_dto(
+def test_memory_indep_019_resolved_dto_construction_rejects_invalid_state(
     tmp_path: Path,
 ) -> None:
-    record = decode_resolved_rollback_plan_record(
-        encode_resolved_rollback_plan_record(_resolved(tmp_path))
-    )
-    invalid = replace(
-        record,
-        artifacts=(replace(record.artifacts[0], sha256="not-a-digest"), *record.artifacts[1:]),
-    )
+    record = decode_resolved_rollback_plan_record(encode_resolved_rollback_plan_record(_resolved(tmp_path)))
 
     with pytest.raises(PackageShapeRecordError, match="SHA-256"):
-        encode_resolved_rollback_plan_record(invalid)
+        replace(record.artifacts[0], sha256="not-a-digest")
+
+
+def test_memory_indep_019_dto_rejects_staged_core_family_disagreement(
+    tmp_path: Path,
+) -> None:
+    record = decode_resolved_rollback_plan_record(encode_resolved_rollback_plan_record(_resolved(tmp_path)))
+    staged_core = replace(
+        record.artifacts[0],
+        requires_dist=("avibe-memory==3.0.14",),
+    )
+
+    with pytest.raises(PackageShapeRecordError, match="captured release family"):
+        replace(record, artifacts=(staged_core, *record.artifacts[1:]))
+
+
+@pytest.mark.parametrize("target", ["staging_dir", "artifact_path"])
+def test_memory_indep_019_dto_binds_artifacts_to_staging_directory(
+    target: str,
+    tmp_path: Path,
+) -> None:
+    record = decode_resolved_rollback_plan_record(encode_resolved_rollback_plan_record(_resolved(tmp_path)))
+
+    with pytest.raises(PackageShapeRecordError, match="staging directory"):
+        if target == "staging_dir":
+            replace(record, staging_dir=str(tmp_path / "elsewhere"))
+        else:
+            artifact = replace(
+                record.artifacts[0],
+                path=str(tmp_path / "outside.whl"),
+            )
+            replace(record, artifacts=(artifact, *record.artifacts[1:]))
+
+
+def test_memory_indep_019_dto_requires_canonical_unique_artifact_paths(
+    tmp_path: Path,
+) -> None:
+    record = decode_resolved_rollback_plan_record(encode_resolved_rollback_plan_record(_resolved(tmp_path)))
+
+    with pytest.raises(PackageShapeRecordError, match="canonical absolute path"):
+        replace(record, staging_dir=f"{record.staging_dir}{os.sep}.")
+    duplicate_path = replace(
+        record.artifacts[1],
+        distribution="dependency",
+        version="1",
+        path=record.artifacts[0].path,
+    )
+    with pytest.raises(PackageShapeRecordError, match="duplicate artifact paths"):
+        replace(record, artifacts=(record.artifacts[0], duplicate_path))
+
+
+def test_memory_indep_019_dto_rejects_conflicting_provider_identity() -> None:
+    record = decode_captured_package_shape_record(encode_captured_package_shape_record(_captured()))
+    memory_provider = replace(
+        record.memory_providers[0],
+        provider_id=record.core_provider.provider_id,
+    )
+
+    with pytest.raises(PackageShapeRecordError, match="conflicting metadata"):
+        replace(record, memory_providers=(memory_provider,))
 
 
 def test_memory_indep_019_decoded_record_reencodes_without_live_files(

--- a/tests/test_package_shape_record_codec.py
+++ b/tests/test_package_shape_record_codec.py
@@ -14,6 +14,7 @@ from vibe.package_shape import (
     CapturedPackageShapeRecord,
     DistributionProvider,
     ExactRequirement,
+    PackageShapeError,
     PackageShapeRecordError,
     ReleaseFamily,
     ResolvedRollbackPlan,
@@ -83,7 +84,7 @@ def _json_round_trip(value: dict[str, object]) -> dict[str, object]:
     return loaded
 
 
-def test_captured_record_codec_is_json_safe_immutable_and_lossless() -> None:
+def test_memory_indep_019_captured_codec_is_json_safe_immutable_and_lossless() -> None:
     encoded = _json_round_trip(encode_captured_package_shape_record(_captured()))
 
     decoded = decode_captured_package_shape_record(encoded)
@@ -96,7 +97,7 @@ def test_captured_record_codec_is_json_safe_immutable_and_lossless() -> None:
         decoded.residual_memory = True  # type: ignore[misc]
 
 
-def test_resolved_record_codec_preserves_complete_non_executable_plan(
+def test_memory_indep_019_resolved_codec_preserves_complete_non_executable_plan(
     tmp_path: Path,
 ) -> None:
     encoded = _json_round_trip(encode_resolved_rollback_plan_record(_resolved(tmp_path)))
@@ -114,7 +115,7 @@ def test_resolved_record_codec_preserves_complete_non_executable_plan(
 
 
 @pytest.mark.parametrize("version", [0, 2, True, "1", None])
-def test_record_codec_rejects_unknown_or_non_integer_schema_versions(
+def test_memory_indep_019_codec_rejects_unknown_or_non_integer_schema_versions(
     version: object,
 ) -> None:
     payload = encode_captured_package_shape_record(_captured())
@@ -139,7 +140,9 @@ def test_record_codec_rejects_unknown_or_non_integer_schema_versions(
         lambda value: value["shape"].update(residual_memory=True),
     ],
 )
-def test_captured_decoder_rejects_structural_drift(mutation: object) -> None:
+def test_memory_indep_019_captured_decoder_rejects_structural_drift(
+    mutation: object,
+) -> None:
     payload = deepcopy(encode_captured_package_shape_record(_captured()))
     mutation(payload)  # type: ignore[operator]
 
@@ -162,7 +165,7 @@ def test_captured_decoder_rejects_structural_drift(mutation: object) -> None:
         lambda value: value["plan"].update(requirements="not-a-list"),
     ],
 )
-def test_resolved_decoder_rejects_structural_drift(
+def test_memory_indep_019_resolved_decoder_rejects_structural_drift(
     mutation: object,
     tmp_path: Path,
 ) -> None:
@@ -173,7 +176,9 @@ def test_resolved_decoder_rejects_structural_drift(
         decode_resolved_rollback_plan_record(payload)
 
 
-def test_resolved_decoder_rejects_unknown_schema_version(tmp_path: Path) -> None:
+def test_memory_indep_019_resolved_decoder_rejects_unknown_schema(
+    tmp_path: Path,
+) -> None:
     payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
     payload["schema_version"] = 2
 
@@ -181,7 +186,9 @@ def test_resolved_decoder_rejects_unknown_schema_version(tmp_path: Path) -> None
         decode_resolved_rollback_plan_record(payload)
 
 
-def test_resolved_decoder_binds_closure_to_captured_target(tmp_path: Path) -> None:
+def test_memory_indep_019_decoder_binds_closure_to_captured_target(
+    tmp_path: Path,
+) -> None:
     payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
     payload["plan"]["requirements"][0].update(  # type: ignore[index]
         distribution="unrelated",
@@ -196,7 +203,9 @@ def test_resolved_decoder_binds_closure_to_captured_target(tmp_path: Path) -> No
         decode_resolved_rollback_plan_record(payload)
 
 
-def test_resolved_decoder_rejects_duplicate_staged_distribution(tmp_path: Path) -> None:
+def test_memory_indep_019_decoder_rejects_duplicate_staged_distribution(
+    tmp_path: Path,
+) -> None:
     payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
     duplicate = deepcopy(payload["plan"]["artifacts"][0])  # type: ignore[index]
     duplicate["version"] = "3.0.13"
@@ -206,7 +215,7 @@ def test_resolved_decoder_rejects_duplicate_staged_distribution(tmp_path: Path) 
         decode_resolved_rollback_plan_record(payload)
 
 
-def test_captured_encoder_rejects_unvalidated_record_dto() -> None:
+def test_memory_indep_019_captured_encoder_rejects_unvalidated_dto() -> None:
     record = decode_captured_package_shape_record(
         encode_captured_package_shape_record(_captured())
     )
@@ -219,7 +228,44 @@ def test_captured_encoder_rejects_unvalidated_record_dto() -> None:
         encode_captured_package_shape_record(invalid)
 
 
-def test_resolved_encoder_rejects_unvalidated_record_dto(tmp_path: Path) -> None:
+def test_memory_indep_019_decoder_derives_family_from_core_metadata() -> None:
+    payload = encode_captured_package_shape_record(_captured())
+    payload["shape"].update(  # type: ignore[union-attr]
+        release_family="pre_split",
+        residual_memory=True,
+    )
+
+    with pytest.raises(PackageShapeRecordError, match="release family"):
+        decode_captured_package_shape_record(payload)
+
+
+@pytest.mark.parametrize("invalid_name", ["/", "@"])
+def test_memory_indep_019_rejects_invalid_distribution_names(
+    invalid_name: str,
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(PackageShapeError, match="name is invalid"):
+        DistributionProvider(invalid_name, "1", f"/{invalid_name}.dist-info")
+    with pytest.raises(PackageShapeError, match="name is invalid"):
+        ExactRequirement(invalid_name, "1")
+
+    payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
+    payload["plan"]["artifacts"].append(  # type: ignore[index]
+        {
+            "distribution": invalid_name,
+            "version": "1",
+            "path": str(tmp_path / "staging" / "invalid.whl"),
+            "sha256": "c" * 64,
+            "requires_dist": [],
+        }
+    )
+    with pytest.raises(PackageShapeRecordError, match="name is invalid"):
+        decode_resolved_rollback_plan_record(payload)
+
+
+def test_memory_indep_019_resolved_encoder_rejects_unvalidated_dto(
+    tmp_path: Path,
+) -> None:
     record = decode_resolved_rollback_plan_record(
         encode_resolved_rollback_plan_record(_resolved(tmp_path))
     )
@@ -232,7 +278,9 @@ def test_resolved_encoder_rejects_unvalidated_record_dto(tmp_path: Path) -> None
         encode_resolved_rollback_plan_record(invalid)
 
 
-def test_decoded_record_reencodes_without_live_files(tmp_path: Path) -> None:
+def test_memory_indep_019_decoded_record_reencodes_without_live_files(
+    tmp_path: Path,
+) -> None:
     payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
     decoded = decode_resolved_rollback_plan_record(_json_round_trip(payload))
 

--- a/tests/test_package_shape_record_codec.py
+++ b/tests/test_package_shape_record_codec.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from copy import deepcopy
-from dataclasses import FrozenInstanceError
+from dataclasses import FrozenInstanceError, replace
 from pathlib import Path
 
 import pytest
@@ -179,6 +179,57 @@ def test_resolved_decoder_rejects_unknown_schema_version(tmp_path: Path) -> None
 
     with pytest.raises(PackageShapeRecordError, match="schema version"):
         decode_resolved_rollback_plan_record(payload)
+
+
+def test_resolved_decoder_binds_closure_to_captured_target(tmp_path: Path) -> None:
+    payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
+    payload["plan"]["requirements"][0].update(  # type: ignore[index]
+        distribution="unrelated",
+        version="1",
+    )
+    payload["plan"]["artifacts"][0].update(  # type: ignore[index]
+        distribution="unrelated",
+        version="1",
+    )
+
+    with pytest.raises(PackageShapeRecordError, match="captured rollback target"):
+        decode_resolved_rollback_plan_record(payload)
+
+
+def test_resolved_decoder_rejects_duplicate_staged_distribution(tmp_path: Path) -> None:
+    payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
+    duplicate = deepcopy(payload["plan"]["artifacts"][0])  # type: ignore[index]
+    duplicate["version"] = "3.0.13"
+    payload["plan"]["artifacts"].append(duplicate)  # type: ignore[index]
+
+    with pytest.raises(PackageShapeRecordError, match="duplicate distribution"):
+        decode_resolved_rollback_plan_record(payload)
+
+
+def test_captured_encoder_rejects_unvalidated_record_dto() -> None:
+    record = decode_captured_package_shape_record(
+        encode_captured_package_shape_record(_captured())
+    )
+    invalid = replace(
+        record,
+        core_provider=replace(record.core_provider, version="03.0.14"),
+    )
+
+    with pytest.raises(PackageShapeRecordError, match="not canonical"):
+        encode_captured_package_shape_record(invalid)
+
+
+def test_resolved_encoder_rejects_unvalidated_record_dto(tmp_path: Path) -> None:
+    record = decode_resolved_rollback_plan_record(
+        encode_resolved_rollback_plan_record(_resolved(tmp_path))
+    )
+    invalid = replace(
+        record,
+        artifacts=(replace(record.artifacts[0], sha256="not-a-digest"), *record.artifacts[1:]),
+    )
+
+    with pytest.raises(PackageShapeRecordError, match="SHA-256"):
+        encode_resolved_rollback_plan_record(invalid)
 
 
 def test_decoded_record_reencodes_without_live_files(tmp_path: Path) -> None:

--- a/tests/test_package_shape_record_codec.py
+++ b/tests/test_package_shape_record_codec.py
@@ -7,6 +7,7 @@ import os
 from copy import deepcopy
 from dataclasses import FrozenInstanceError, replace
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -27,6 +28,7 @@ from vibe.package_shape import (
     encode_resolved_rollback_plan_record,
 )
 from vibe.runtime import ServiceLauncher
+from vibe.upgrade import rollback_target
 
 
 def _captured() -> package_shape.CapturedPackageShape:
@@ -258,6 +260,53 @@ def test_memory_indep_019_rejects_invalid_distribution_names(
     )
     with pytest.raises(PackageShapeRecordError, match="name is invalid"):
         decode_resolved_rollback_plan_record(payload)
+
+
+def test_memory_indep_019_rollback_target_skips_unrelated_invalid_distribution_names(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    launcher = ServiceLauncher(
+        python="/opt/avibe/bin/python",
+        main="/opt/avibe/site-packages/vibe/service_main.py",
+    )
+    unrelated = SimpleNamespace(metadata={"Name": "broken/name"})
+    core = SimpleNamespace(
+        metadata={"Name": "avibe-os"},
+        version="3.0.14",
+        _path=tmp_path / "avibe_os-3.0.14.dist-info",
+        requires=('avibe-memory>=3.0.14.dev0,<3.1; extra == "memory"',),
+    )
+    monkeypatch.setattr("vibe.__version__", "3.0.14")
+    monkeypatch.setattr("vibe.runtime.current_service_launcher", lambda: launcher)
+    monkeypatch.setattr("importlib.metadata.distributions", lambda: (unrelated, core))
+
+    target = rollback_target()
+
+    assert target is not None
+    assert target.core_provider.name == "avibe-os"
+    assert target.core_provider.version == "3.0.14"
+
+
+def test_memory_indep_019_rollback_target_rejects_relevant_invalid_distribution_names(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    relevant_but_invalid = SimpleNamespace(
+        metadata={"Name": "avibe-os "},
+        version="3.0.14",
+        _path=tmp_path / "avibe_os-3.0.14.dist-info",
+        requires=(),
+    )
+    monkeypatch.setattr("vibe.__version__", "3.0.14")
+    monkeypatch.setattr(
+        "vibe.runtime.current_service_launcher",
+        lambda: ServiceLauncher(python="/opt/avibe/bin/python", main="/opt/avibe/vibe/service_main.py"),
+    )
+    monkeypatch.setattr("importlib.metadata.distributions", lambda: (relevant_but_invalid,))
+
+    with pytest.raises(PackageShapeError, match="installed distribution name is invalid"):
+        rollback_target()
 
 
 def test_memory_indep_019_artifact_fact_construction_rejects_invalid_state(

--- a/vibe/package_shape.py
+++ b/vibe/package_shape.py
@@ -11,10 +11,11 @@ import sys
 import tempfile
 import zipfile
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from types import UnionType
+from typing import Any, Union, get_args, get_origin, get_type_hints
 
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import (
@@ -139,7 +140,10 @@ class CapturedPackageShape:
             )
         object.__setattr__(self, "memory_providers", tuple(self.memory_providers))
         object.__setattr__(self, "transition_memory_version", transition_memory_version)
-        _validate_canonical_package_shape(self, error_type=PackageShapeError)
+        try:
+            _captured_to_record(self)
+        except PackageShapeRecordError as exc:
+            raise PackageShapeError(str(exc)) from exc
 
     @property
     def core_version(self) -> str:
@@ -242,17 +246,75 @@ class DistributionProviderRecord:
     provider_id: str
     requires_dist: tuple[str, ...]
 
+    def __post_init__(self) -> None:
+        _validate_record_fields(self)
+        _require_record_distribution(self.name, field="distribution provider")
+        _require_record_version(self.version, field=f"{self.name} version")
+        if self.provider_id != _normalized_provider_id(self.provider_id):
+            raise PackageShapeRecordError("distribution provider identity is not canonical")
+
+
+@dataclass(frozen=True)
+class _ProviderInventoryRecord:
+    providers: tuple[DistributionProviderRecord, ...]
+
+    def __post_init__(self) -> None:
+        _validate_record_fields(self)
+        by_identity: dict[str, DistributionProviderRecord] = {}
+        for provider in self.providers:
+            existing = by_identity.get(provider.provider_id)
+            if existing is not None and existing != provider:
+                raise PackageShapeRecordError("canonical distribution provider identity has conflicting metadata")
+            by_identity[provider.provider_id] = provider
+
+
+@dataclass(frozen=True)
+class _ServiceLauncherRecord:
+    python: str
+    main: str
+
+    def __post_init__(self) -> None:
+        _validate_record_fields(self)
+
 
 @dataclass(frozen=True)
 class CapturedPackageShapeRecord:
     """Non-executable persisted form of a captured package shape."""
 
     core_provider: DistributionProviderRecord
-    launcher: ServiceLauncher
+    launcher: _ServiceLauncherRecord
     release_family: ReleaseFamily
     memory_providers: tuple[DistributionProviderRecord, ...]
     transition_memory_version: str | None
     residual_memory: bool
+
+    def __post_init__(self) -> None:
+        _validate_record_fields(self)
+        if self.core_provider.name not in CORE_DISTRIBUTION_NAMES:
+            raise PackageShapeRecordError("captured core provider is not an Avibe distribution")
+        if len(self.memory_providers) > 1:
+            raise PackageShapeRecordError("multiple canonical avibe-memory providers are not representable")
+        if any(provider.name != MEMORY_PACKAGE_NAME for provider in self.memory_providers):
+            raise PackageShapeRecordError("captured Memory provider has the wrong canonical name")
+        if self.transition_memory_version is not None:
+            _require_record_version(
+                self.transition_memory_version,
+                field="transition Memory requirement",
+            )
+
+        _ProviderInventoryRecord(providers=(self.core_provider, *self.memory_providers))
+
+        try:
+            derived_family, derived_transition = _release_family(self.core_provider)
+        except PackageShapeError as exc:
+            raise PackageShapeRecordError(str(exc)) from exc
+        if self.release_family is not derived_family:
+            raise PackageShapeRecordError("captured release family disagrees with core metadata")
+        if self.transition_memory_version != derived_transition:
+            raise PackageShapeRecordError("captured transition pin disagrees with core metadata")
+        expected_residual = derived_family is ReleaseFamily.PRE_SPLIT and self.memory_present
+        if self.residual_memory is not expected_residual:
+            raise PackageShapeRecordError("residual Memory marker disagrees with the derived family")
 
     @property
     def core_version(self) -> str:
@@ -285,6 +347,13 @@ class StagedArtifactRecord:
     sha256: str
     requires_dist: tuple[str, ...]
 
+    def __post_init__(self) -> None:
+        _validate_record_fields(self)
+        _require_record_distribution(self.distribution, field="artifact distribution")
+        _require_record_version(self.version, field=f"{self.distribution} version")
+        if len(self.sha256) != 64 or any(character not in "0123456789abcdef" for character in self.sha256):
+            raise PackageShapeRecordError("artifact SHA-256 is not canonical")
+
 
 @dataclass(frozen=True)
 class ResolvedRollbackPlanRecord:
@@ -297,74 +366,302 @@ class ResolvedRollbackPlanRecord:
     uninstall_distributions: tuple[str, ...]
     verification: PackageShapeVerification
 
+    def __post_init__(self) -> None:
+        _validate_record_fields(self)
+        staging_dir = _require_record_absolute_path(
+            self.staging_dir,
+            field="staging directory",
+        )
+        if not self.requirements or not self.artifacts:
+            raise PackageShapeRecordError("resolved rollback record has an empty closure")
 
-def _record_object(
+        try:
+            expected_requirements = _rollback_requirements(self.captured)
+        except PackageShapeError as exc:
+            raise PackageShapeRecordError(str(exc)) from exc
+        if self.requirements != expected_requirements:
+            raise PackageShapeRecordError("resolved requirements do not match the captured rollback target")
+
+        by_distribution: dict[str, StagedArtifactRecord] = {}
+        artifact_paths: set[str] = set()
+        for artifact in self.artifacts:
+            if artifact.distribution in by_distribution:
+                raise PackageShapeRecordError("staging contains duplicate distribution artifacts")
+            by_distribution[artifact.distribution] = artifact
+            artifact_path = _require_record_absolute_path(
+                artifact.path,
+                field="artifact path",
+            )
+            if artifact_path.parent != staging_dir:
+                raise PackageShapeRecordError("artifact path is not a direct child of the staging directory")
+            if artifact.path in artifact_paths:
+                raise PackageShapeRecordError("staging contains duplicate artifact paths")
+            artifact_paths.add(artifact.path)
+
+        core_artifacts = tuple(
+            artifact for artifact in self.artifacts if artifact.distribution in CORE_DISTRIBUTION_NAMES
+        )
+        if len(core_artifacts) != 1 or (
+            core_artifacts[0].distribution,
+            core_artifacts[0].version,
+        ) != (self.captured.core_distribution, self.captured.core_version):
+            raise PackageShapeRecordError("staging does not contain the exact captured core shape")
+        memory_artifacts = tuple(
+            artifact for artifact in self.artifacts if artifact.distribution == MEMORY_PACKAGE_NAME
+        )
+        staged_memory_version = memory_artifacts[0].version if len(memory_artifacts) == 1 else None
+        if (
+            len(memory_artifacts) != self.captured.memory_provider_cardinality
+            or staged_memory_version != self.captured.memory_version
+        ):
+            raise PackageShapeRecordError("staging does not contain the exact captured Memory shape")
+        missing_requirements = {
+            (requirement.distribution, requirement.version) for requirement in self.requirements
+        } - {(artifact.distribution, artifact.version) for artifact in self.artifacts}
+        if missing_requirements:
+            raise PackageShapeRecordError("resolved staging is missing an exact rollback artifact")
+
+        staged_core = core_artifacts[0]
+        try:
+            staged_family, staged_transition = _release_family(
+                DistributionProviderRecord(
+                    name=staged_core.distribution,
+                    version=staged_core.version,
+                    provider_id=staged_core.path,
+                    requires_dist=staged_core.requires_dist,
+                )
+            )
+        except PackageShapeError as exc:
+            raise PackageShapeRecordError(str(exc)) from exc
+        if (
+            staged_family is not self.captured.release_family
+            or staged_transition != self.captured.transition_memory_version
+        ):
+            raise PackageShapeRecordError("staged core artifact does not match the captured release family")
+        if self.uninstall_distributions != _rollback_uninstall_distributions():
+            raise PackageShapeRecordError("resolved rollback record has an unknown uninstall set")
+        if self.verification != _package_shape_verification(self.captured):
+            raise PackageShapeRecordError("resolved rollback verification is inconsistent")
+
+
+_RECORD_DTO_TYPES = (
+    DistributionProviderRecord,
+    _ProviderInventoryRecord,
+    _ServiceLauncherRecord,
+    CapturedPackageShapeRecord,
+    ExactRequirement,
+    StagedArtifactRecord,
+    PackageShapeVerification,
+    ResolvedRollbackPlanRecord,
+)
+_RECORD_FIELD_SCHEMAS = {
+    dto_type: tuple((field.name, get_type_hints(dto_type)[field.name]) for field in fields(dto_type))
+    for dto_type in _RECORD_DTO_TYPES
+}
+
+
+def _validate_declared_record_value(
     value: object,
-    keys: frozenset[str],
+    annotation: object,
     *,
     field: str,
-) -> dict[str, object]:
-    if type(value) is not dict or frozenset(value) != keys:
-        raise PackageShapeRecordError(f"{field} has unknown or missing fields")
-    return value
-
-
-def _record_list(value: object, *, field: str) -> list[object]:
-    if type(value) is not list:
-        raise PackageShapeRecordError(f"{field} is not a JSON array")
-    return value
-
-
-def _record_string(value: object, *, field: str) -> str:
-    if type(value) is not str or not value:
+) -> None:
+    origin = get_origin(annotation)
+    if origin in (Union, UnionType):
+        options = get_args(annotation)
+        if value is None and type(None) in options:
+            return
+        candidates = tuple(option for option in options if option is not type(None))
+        if len(candidates) != 1:
+            raise PackageShapeRecordError(f"{field} has an unsupported field schema")
+        _validate_declared_record_value(value, candidates[0], field=field)
+        return
+    if origin is tuple:
+        if type(value) is not tuple:
+            raise PackageShapeRecordError(f"{field} is not an immutable sequence")
+        item_type, marker = get_args(annotation)
+        if marker is not Ellipsis:
+            raise PackageShapeRecordError(f"{field} has an unsupported field schema")
+        for item in value:
+            _validate_declared_record_value(item, item_type, field=f"{field} item")
+        return
+    if annotation in _RECORD_FIELD_SCHEMAS:
+        if type(value) is not annotation:
+            raise PackageShapeRecordError(f"{field} has an invalid DTO type")
+        _validate_record_fields(value)
+        return
+    if isinstance(annotation, type) and issubclass(annotation, Enum):
+        if type(value) is not annotation:
+            raise PackageShapeRecordError(f"{field} has an invalid enum value")
+        return
+    if type(value) is not annotation:
+        raise PackageShapeRecordError(f"{field} has an invalid primitive type")
+    if annotation is str and not value:
         raise PackageShapeRecordError(f"{field} is missing")
-    return value
 
 
-def _record_strings(value: object, *, field: str) -> tuple[str, ...]:
-    return tuple(
-        _record_string(item, field=f"{field} item")
-        for item in _record_list(value, field=field)
-    )
+def _validate_record_fields(value: object) -> None:
+    schema = _RECORD_FIELD_SCHEMAS.get(type(value))
+    if schema is None:
+        raise PackageShapeRecordError("record DTO type is unsupported")
+    for name, annotation in schema:
+        _validate_declared_record_value(
+            getattr(value, name),
+            annotation,
+            field=f"{type(value).__name__}.{name}",
+        )
 
 
-def _record_bool(value: object, *, field: str) -> bool:
-    if type(value) is not bool:
-        raise PackageShapeRecordError(f"{field} is not a boolean")
-    return value
-
-
-def _record_int(value: object, *, field: str) -> int:
-    if type(value) is not int:
-        raise PackageShapeRecordError(f"{field} is not an integer")
-    return value
-
-
-def _record_version(value: object, *, field: str) -> str:
-    raw = _record_string(value, field=field)
+def _require_record_version(value: str, *, field: str) -> None:
     try:
-        normalized = _normalized_version(raw, field=field)
+        normalized = _normalized_version(value, field=field)
     except PackageShapeError as exc:
         raise PackageShapeRecordError(str(exc)) from exc
-    if raw != normalized:
+    if value != normalized:
         raise PackageShapeRecordError(f"{field} is not canonical")
-    return raw
 
 
-def _record_distribution(value: object, *, field: str) -> str:
-    raw = _record_string(value, field=field)
-    return _canonical_distribution_name(
-        raw,
+def _require_record_distribution(value: str, *, field: str) -> None:
+    _canonical_distribution_name(
+        value,
         field=field,
         error_type=PackageShapeRecordError,
         require_canonical=True,
     )
 
 
-def _record_schema(envelope: dict[str, object]) -> None:
-    version = envelope["schema_version"]
+def _require_record_absolute_path(value: str, *, field: str) -> Path:
+    path = Path(value)
+    if not path.is_absolute() or os.path.normpath(value) != value:
+        raise PackageShapeRecordError(f"{field} is not a canonical absolute path")
+    return path
+
+
+def _encode_declared_record_value(value: object, annotation: object) -> object:
+    origin = get_origin(annotation)
+    if origin in (Union, UnionType):
+        if value is None:
+            return None
+        return _encode_declared_record_value(
+            value,
+            next(option for option in get_args(annotation) if option is not type(None)),
+        )
+    if origin is tuple:
+        item_type = get_args(annotation)[0]
+        return [_encode_declared_record_value(item, item_type) for item in value]
+    if annotation in _RECORD_FIELD_SCHEMAS:
+        return _encode_record_dto(value)
+    if isinstance(annotation, type) and issubclass(annotation, Enum):
+        return value.value
+    return value
+
+
+def _encode_record_dto(value: object) -> dict[str, object]:
+    _validate_record_fields(value)
+    schema = _RECORD_FIELD_SCHEMAS[type(value)]
+    try:
+        reconstructed = type(value)(**{name: getattr(value, name) for name, _ in schema})
+    except PackageShapeError:
+        raise
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise PackageShapeRecordError("record DTO is invalid") from exc
+    if reconstructed != value:
+        raise PackageShapeRecordError("record DTO is not canonical")
+    return {name: _encode_declared_record_value(getattr(value, name), annotation) for name, annotation in schema}
+
+
+def _decode_declared_record_value(
+    value: object,
+    annotation: object,
+    *,
+    field: str,
+) -> object:
+    origin = get_origin(annotation)
+    if origin in (Union, UnionType):
+        options = get_args(annotation)
+        if value is None and type(None) in options:
+            return None
+        return _decode_declared_record_value(
+            value,
+            next(option for option in options if option is not type(None)),
+            field=field,
+        )
+    if origin is tuple:
+        if type(value) is not list:
+            raise PackageShapeRecordError(f"{field} is not a JSON array")
+        item_type = get_args(annotation)[0]
+        return tuple(_decode_declared_record_value(item, item_type, field=f"{field} item") for item in value)
+    if annotation in _RECORD_FIELD_SCHEMAS:
+        return _decode_record_dto(value, annotation, field=field)
+    if isinstance(annotation, type) and issubclass(annotation, Enum):
+        if type(value) is not str:
+            raise PackageShapeRecordError(f"{field} has an invalid enum value")
+        try:
+            return annotation(value)
+        except ValueError as exc:
+            raise PackageShapeRecordError(f"{field} has an invalid enum value") from exc
+    if type(value) is not annotation:
+        raise PackageShapeRecordError(f"{field} has an invalid primitive type")
+    if annotation is str and not value:
+        raise PackageShapeRecordError(f"{field} is missing")
+    return value
+
+
+def _decode_record_dto(value: object, dto_type: type, *, field: str) -> object:
+    schema = _RECORD_FIELD_SCHEMAS[dto_type]
+    required = frozenset(name for name, _ in schema)
+    if type(value) is not dict or frozenset(value) != required:
+        raise PackageShapeRecordError(f"{field} has unknown or missing fields")
+    try:
+        decoded = dto_type(
+            **{
+                name: _decode_declared_record_value(
+                    value[name],
+                    annotation,
+                    field=f"{field}.{name}",
+                )
+                for name, annotation in schema
+            }
+        )
+    except PackageShapeRecordError:
+        raise
+    except PackageShapeError as exc:
+        raise PackageShapeRecordError(str(exc)) from exc
+    except (TypeError, ValueError) as exc:
+        raise PackageShapeRecordError(f"{field} is invalid") from exc
+    if _encode_record_dto(decoded) != value:
+        raise PackageShapeRecordError(f"{field} is not canonical")
+    return decoded
+
+
+_RECORD_ENVELOPES = {
+    "captured_package_shape": ("shape", CapturedPackageShapeRecord),
+    "resolved_rollback_plan": ("plan", ResolvedRollbackPlanRecord),
+}
+
+
+def _encode_record(record_type: str, record: object) -> dict[str, object]:
+    payload_name, dto_type = _RECORD_ENVELOPES[record_type]
+    if type(record) is not dto_type:
+        raise PackageShapeRecordError("record DTO type is unsupported")
+    return {
+        "schema_version": PACKAGE_SHAPE_RECORD_SCHEMA_VERSION,
+        "record_type": record_type,
+        payload_name: _encode_record_dto(record),
+    }
+
+
+def _decode_record(value: object, record_type: str) -> object:
+    payload_name, dto_type = _RECORD_ENVELOPES[record_type]
+    required = frozenset({"schema_version", "record_type", payload_name})
+    if type(value) is not dict or frozenset(value) != required:
+        raise PackageShapeRecordError("record has unknown or missing fields")
+    version = value["schema_version"]
     if type(version) is not int or version != PACKAGE_SHAPE_RECORD_SCHEMA_VERSION:
         raise PackageShapeRecordError("package-shape record schema version is unsupported")
+    if type(value["record_type"]) is not str or value["record_type"] != record_type:
+        raise PackageShapeRecordError("package-shape record type is unsupported")
+    return _decode_record_dto(value[payload_name], dto_type, field=payload_name)
 
 
 def _provider_to_record(provider: DistributionProvider) -> DistributionProviderRecord:
@@ -376,32 +673,6 @@ def _provider_to_record(provider: DistributionProvider) -> DistributionProviderR
     )
 
 
-def _decode_provider(value: object, *, field: str) -> DistributionProviderRecord:
-    payload = _record_object(
-        value,
-        frozenset({"name", "version", "provider_id", "requires_dist"}),
-        field=field,
-    )
-    return DistributionProviderRecord(
-        name=_record_distribution(payload["name"], field=f"{field} name"),
-        version=_record_version(payload["version"], field=f"{field} version"),
-        provider_id=_record_string(payload["provider_id"], field=f"{field} identity"),
-        requires_dist=_record_strings(
-            payload["requires_dist"],
-            field=f"{field} requirements",
-        ),
-    )
-
-
-def _encode_provider(provider: DistributionProviderRecord) -> dict[str, object]:
-    return {
-        "name": provider.name,
-        "version": provider.version,
-        "provider_id": provider.provider_id,
-        "requires_dist": list(provider.requires_dist),
-    }
-
-
 def _captured_to_record(
     captured: CapturedPackageShape | CapturedPackageShapeRecord,
 ) -> CapturedPackageShapeRecord:
@@ -411,11 +682,12 @@ def _captured_to_record(
         raise PackageShapeRecordError("captured package shape has an unsupported type")
     return CapturedPackageShapeRecord(
         core_provider=_provider_to_record(captured.core_provider),
-        launcher=captured.launcher,
-        release_family=captured.release_family,
-        memory_providers=tuple(
-            _provider_to_record(item) for item in captured.memory_providers
+        launcher=_ServiceLauncherRecord(
+            python=captured.launcher.python,
+            main=captured.launcher.main,
         ),
+        release_family=captured.release_family,
+        memory_providers=tuple(_provider_to_record(item) for item in captured.memory_providers),
         transition_memory_version=captured.transition_memory_version,
         residual_memory=captured.residual_memory,
     )
@@ -426,187 +698,15 @@ def encode_captured_package_shape_record(
 ) -> dict[str, object]:
     """Encode captured evidence into a versioned JSON-safe object."""
 
-    record = _captured_to_record(captured)
-    try:
-        payload: dict[str, object] = {
-            "schema_version": PACKAGE_SHAPE_RECORD_SCHEMA_VERSION,
-            "record_type": "captured_package_shape",
-            "shape": {
-                "core_provider": _encode_provider(record.core_provider),
-                "launcher": {
-                    "python": record.launcher.python,
-                    "main": record.launcher.main,
-                },
-                "release_family": record.release_family.value,
-                "memory_providers": [
-                    _encode_provider(provider) for provider in record.memory_providers
-                ],
-                "transition_memory_version": record.transition_memory_version,
-                "residual_memory": record.residual_memory,
-            },
-        }
-    except PackageShapeRecordError:
-        raise
-    except (AttributeError, TypeError) as exc:
-        raise PackageShapeRecordError("captured record DTO is invalid") from exc
-    if decode_captured_package_shape_record(payload) != record:
-        raise PackageShapeRecordError("captured record DTO is not canonical")
-    return payload
+    return _encode_record("captured_package_shape", _captured_to_record(captured))
 
 
 def decode_captured_package_shape_record(value: object) -> CapturedPackageShapeRecord:
     """Decode captured evidence without consulting installed package state."""
 
-    envelope = _record_object(
-        value,
-        frozenset({"schema_version", "record_type", "shape"}),
-        field="captured package-shape record",
-    )
-    _record_schema(envelope)
-    if envelope["record_type"] != "captured_package_shape":
-        raise PackageShapeRecordError("captured package-shape record type is unsupported")
-    shape = _record_object(
-        envelope["shape"],
-        frozenset(
-            {
-                "core_provider",
-                "launcher",
-                "release_family",
-                "memory_providers",
-                "transition_memory_version",
-                "residual_memory",
-            }
-        ),
-        field="captured package shape",
-    )
-    launcher = _record_object(
-        shape["launcher"],
-        frozenset({"python", "main"}),
-        field="service launcher",
-    )
-    family_value = _record_string(shape["release_family"], field="release family")
-    try:
-        family = ReleaseFamily(family_value)
-    except ValueError as exc:
-        raise PackageShapeRecordError("captured release family is unknown") from exc
-    transition = shape["transition_memory_version"]
-    if transition is not None:
-        transition = _record_version(transition, field="transition Memory version")
-    record = CapturedPackageShapeRecord(
-        core_provider=_decode_provider(shape["core_provider"], field="core provider"),
-        launcher=ServiceLauncher(
-            python=_record_string(launcher["python"], field="launcher Python"),
-            main=_record_string(launcher["main"], field="launcher main"),
-        ),
-        release_family=family,
-        memory_providers=tuple(
-            _decode_provider(item, field="Memory provider")
-            for item in _record_list(
-                shape["memory_providers"],
-                field="Memory providers",
-            )
-        ),
-        transition_memory_version=transition,
-        residual_memory=_record_bool(
-            shape["residual_memory"],
-            field="residual Memory",
-        ),
-    )
-    _validate_canonical_package_shape(
-        record,
-        error_type=PackageShapeRecordError,
-    )
+    record = _decode_record(value, "captured_package_shape")
+    assert isinstance(record, CapturedPackageShapeRecord)
     return record
-
-
-def _decode_requirement(value: object) -> ExactRequirement:
-    payload = _record_object(
-        value,
-        frozenset({"distribution", "version"}),
-        field="rollback requirement",
-    )
-    return ExactRequirement(
-        distribution=_record_distribution(
-            payload["distribution"],
-            field="requirement distribution",
-        ),
-        version=_record_version(payload["version"], field="requirement version"),
-    )
-
-
-def _decode_artifact(value: object) -> StagedArtifactRecord:
-    payload = _record_object(
-        value,
-        frozenset({"distribution", "version", "path", "sha256", "requires_dist"}),
-        field="staged artifact",
-    )
-    digest = _record_string(payload["sha256"], field="artifact SHA-256")
-    if len(digest) != 64 or any(
-        character not in "0123456789abcdef" for character in digest
-    ):
-        raise PackageShapeRecordError("artifact SHA-256 is not canonical")
-    return StagedArtifactRecord(
-        distribution=_record_distribution(
-            payload["distribution"],
-            field="artifact distribution",
-        ),
-        version=_record_version(payload["version"], field="artifact version"),
-        path=_record_string(payload["path"], field="artifact path"),
-        sha256=digest,
-        requires_dist=_record_strings(
-            payload["requires_dist"],
-            field="artifact requirements",
-        ),
-    )
-
-
-def _decode_verification(value: object) -> PackageShapeVerification:
-    payload = _record_object(
-        value,
-        frozenset(
-            {
-                "core_distribution",
-                "core_version",
-                "absent_core_distributions",
-                "memory_provider_cardinality",
-                "memory_version",
-                "residual_memory",
-            }
-        ),
-        field="package-shape verification",
-    )
-    memory_version = payload["memory_version"]
-    if memory_version is not None:
-        memory_version = _record_version(
-            memory_version,
-            field="verified Memory version",
-        )
-    return PackageShapeVerification(
-        core_distribution=_record_distribution(
-            payload["core_distribution"],
-            field="verified core distribution",
-        ),
-        core_version=_record_version(
-            payload["core_version"],
-            field="verified core version",
-        ),
-        absent_core_distributions=tuple(
-            _record_distribution(item, field="absent core distribution")
-            for item in _record_list(
-                payload["absent_core_distributions"],
-                field="absent core distributions",
-            )
-        ),
-        memory_provider_cardinality=_record_int(
-            payload["memory_provider_cardinality"],
-            field="Memory provider cardinality",
-        ),
-        memory_version=memory_version,
-        residual_memory=_record_bool(
-            payload["residual_memory"],
-            field="verified residual Memory",
-        ),
-    )
 
 
 def _plan_to_record(
@@ -635,137 +735,19 @@ def _plan_to_record(
     )
 
 
-def _validate_plan_record(record: ResolvedRollbackPlanRecord) -> None:
-    _validate_canonical_package_shape(
-        record.captured,
-        error_type=PackageShapeRecordError,
-    )
-    if not record.requirements or not record.artifacts:
-        raise PackageShapeRecordError("resolved rollback record has an empty closure")
-    try:
-        expected_requirements = _rollback_requirements(record.captured)
-    except PackageShapeError as exc:
-        raise PackageShapeRecordError(str(exc)) from exc
-    if record.requirements != expected_requirements:
-        raise PackageShapeRecordError(
-            "resolved requirements do not match the captured rollback target"
-        )
-    try:
-        _verify_staged_shape(record.captured, record.artifacts)
-    except PackageShapeError as exc:
-        raise PackageShapeRecordError(str(exc)) from exc
-    if record.uninstall_distributions != _rollback_uninstall_distributions():
-        raise PackageShapeRecordError("resolved rollback record has an unknown uninstall set")
-    if record.verification != _package_shape_verification(record.captured):
-        raise PackageShapeRecordError("resolved rollback verification is inconsistent")
-
-
 def encode_resolved_rollback_plan_record(
     plan: ResolvedRollbackPlan | ResolvedRollbackPlanRecord,
 ) -> dict[str, object]:
     """Encode a plan as data that cannot itself authorize execution."""
 
-    record = _plan_to_record(plan)
-    try:
-        payload: dict[str, object] = {
-            "schema_version": PACKAGE_SHAPE_RECORD_SCHEMA_VERSION,
-            "record_type": "resolved_rollback_plan",
-            "plan": {
-                "captured": encode_captured_package_shape_record(record.captured),
-                "requirements": [
-                    {
-                        "distribution": item.distribution,
-                        "version": item.version,
-                    }
-                    for item in record.requirements
-                ],
-                "artifacts": [
-                    {
-                        "distribution": item.distribution,
-                        "version": item.version,
-                        "path": item.path,
-                        "sha256": item.sha256,
-                        "requires_dist": list(item.requires_dist),
-                    }
-                    for item in record.artifacts
-                ],
-                "staging_dir": record.staging_dir,
-                "uninstall_distributions": list(record.uninstall_distributions),
-                "verification": {
-                    "core_distribution": record.verification.core_distribution,
-                    "core_version": record.verification.core_version,
-                    "absent_core_distributions": list(
-                        record.verification.absent_core_distributions
-                    ),
-                    "memory_provider_cardinality": (
-                        record.verification.memory_provider_cardinality
-                    ),
-                    "memory_version": record.verification.memory_version,
-                    "residual_memory": record.verification.residual_memory,
-                },
-            },
-        }
-    except PackageShapeRecordError:
-        raise
-    except (AttributeError, TypeError) as exc:
-        raise PackageShapeRecordError("resolved record DTO is invalid") from exc
-    if decode_resolved_rollback_plan_record(payload) != record:
-        raise PackageShapeRecordError("resolved record DTO is not canonical")
-    return payload
+    return _encode_record("resolved_rollback_plan", _plan_to_record(plan))
 
 
 def decode_resolved_rollback_plan_record(value: object) -> ResolvedRollbackPlanRecord:
     """Decode plan data without constructing an executable rollback plan."""
 
-    envelope = _record_object(
-        value,
-        frozenset({"schema_version", "record_type", "plan"}),
-        field="resolved rollback record",
-    )
-    _record_schema(envelope)
-    if envelope["record_type"] != "resolved_rollback_plan":
-        raise PackageShapeRecordError("resolved rollback record type is unsupported")
-    plan = _record_object(
-        envelope["plan"],
-        frozenset(
-            {
-                "captured",
-                "requirements",
-                "artifacts",
-                "staging_dir",
-                "uninstall_distributions",
-                "verification",
-            }
-        ),
-        field="resolved rollback plan",
-    )
-    record = ResolvedRollbackPlanRecord(
-        captured=decode_captured_package_shape_record(plan["captured"]),
-        requirements=tuple(
-            _decode_requirement(item)
-            for item in _record_list(
-                plan["requirements"],
-                field="rollback requirements",
-            )
-        ),
-        artifacts=tuple(
-            _decode_artifact(item)
-            for item in _record_list(plan["artifacts"], field="staged artifacts")
-        ),
-        staging_dir=_record_string(
-            plan["staging_dir"],
-            field="staging directory",
-        ),
-        uninstall_distributions=tuple(
-            _record_distribution(item, field="uninstall distribution")
-            for item in _record_list(
-                plan["uninstall_distributions"],
-                field="uninstall distributions",
-            )
-        ),
-        verification=_decode_verification(plan["verification"]),
-    )
-    _validate_plan_record(record)
+    record = _decode_record(value, "resolved_rollback_plan")
+    assert isinstance(record, ResolvedRollbackPlanRecord)
     return record
 
 
@@ -826,48 +808,6 @@ def _release_family(
     return ReleaseFamily.TRANSITION, required_version
 
 
-def _validate_canonical_package_shape(
-    shape: CapturedPackageShape | CapturedPackageShapeRecord,
-    *,
-    error_type: type[PackageShapeError],
-) -> None:
-    provider_type = (
-        DistributionProviderRecord
-        if isinstance(shape, CapturedPackageShapeRecord)
-        else DistributionProvider
-    )
-    if not isinstance(shape.release_family, ReleaseFamily):
-        raise error_type("captured release family is unknown")
-    if not isinstance(shape.core_provider, provider_type):
-        raise error_type("captured core provider is invalid")
-    if shape.core_provider.name not in CORE_DISTRIBUTION_NAMES:
-        raise error_type("captured core provider is not an Avibe distribution")
-    if not isinstance(shape.launcher, ServiceLauncher):
-        raise error_type("captured service launcher is invalid")
-    if type(shape.memory_providers) is not tuple or any(
-        not isinstance(provider, provider_type) for provider in shape.memory_providers
-    ):
-        raise error_type("captured Memory providers are invalid")
-    if len(shape.memory_providers) > 1:
-        raise error_type("multiple canonical avibe-memory providers are not representable")
-    if any(provider.name != MEMORY_PACKAGE_NAME for provider in shape.memory_providers):
-        raise error_type("captured Memory provider has the wrong canonical name")
-    if type(shape.residual_memory) is not bool:
-        raise error_type("captured residual Memory marker is invalid")
-
-    try:
-        derived_family, derived_transition = _release_family(shape.core_provider)
-    except PackageShapeError as exc:
-        raise error_type(str(exc)) from exc
-    if shape.release_family is not derived_family:
-        raise error_type("captured release family disagrees with core metadata")
-    if shape.transition_memory_version != derived_transition:
-        raise error_type("captured transition pin disagrees with core metadata")
-    expected_residual = derived_family is ReleaseFamily.PRE_SPLIT and shape.memory_present
-    if shape.residual_memory is not expected_residual:
-        raise error_type("residual Memory marker disagrees with the derived family")
-
-
 def capture_package_shape(
     *,
     core_version: str,
@@ -882,28 +822,20 @@ def capture_package_shape(
         for provider in providers
         if provider.name in CORE_DISTRIBUTION_NAMES or provider.name == MEMORY_PACKAGE_NAME
     )
-    by_identity: dict[str, DistributionProvider] = {}
-    for provider in observed:
-        existing = by_identity.get(provider.provider_id)
-        if existing is not None and existing != provider:
-            raise PackageShapeError(
-                "canonical distribution provider identity has conflicting metadata"
-            )
-        by_identity[provider.provider_id] = provider
-    relevant = tuple(by_identity.values())
+    try:
+        _ProviderInventoryRecord(providers=tuple(_provider_to_record(provider) for provider in observed))
+    except PackageShapeRecordError as exc:
+        raise PackageShapeError(str(exc)) from exc
+    relevant = tuple({provider.provider_id: provider for provider in observed}.values())
 
     by_name: dict[str, list[DistributionProvider]] = {}
     for provider in relevant:
         by_name.setdefault(provider.name, []).append(provider)
     duplicate = next((name for name, values in by_name.items() if len(values) > 1), None)
     if duplicate is not None:
-        raise DuplicateDistributionProviderError(
-            f"multiple canonical {duplicate} dist-info providers are installed"
-        )
+        raise DuplicateDistributionProviderError(f"multiple canonical {duplicate} dist-info providers are installed")
 
-    installed_core_providers = tuple(
-        provider for provider in relevant if provider.name in CORE_DISTRIBUTION_NAMES
-    )
+    installed_core_providers = tuple(provider for provider in relevant if provider.name in CORE_DISTRIBUTION_NAMES)
     if not installed_core_providers:
         raise PackageShapeError("running core has no canonical distribution provider")
 
@@ -916,9 +848,7 @@ def capture_package_shape(
     )
     if len(core_candidates) != 1:
         raise PackageShapeError("running core does not have exactly one canonical distribution provider")
-    memory_providers = tuple(
-        provider for provider in relevant if provider.name == MEMORY_PACKAGE_NAME
-    )
+    memory_providers = tuple(provider for provider in relevant if provider.name == MEMORY_PACKAGE_NAME)
     family, transition_memory_version = _release_family(core_candidates[0])
     return CapturedPackageShape(
         core_provider=core_candidates[0],
@@ -997,13 +927,9 @@ def _rollback_requirements(
 ) -> tuple[ExactRequirement, ...]:
     if captured.release_family is ReleaseFamily.TRANSITION:
         if not captured.memory_present:
-            raise RollbackResolutionError(
-                "transition package shape is missing its exact Memory distribution"
-            )
+            raise RollbackResolutionError("transition package shape is missing its exact Memory distribution")
         if captured.memory_version != captured.transition_memory_version:
-            raise RollbackResolutionError(
-                "transition package shape does not match its exact Memory dependency"
-            )
+            raise RollbackResolutionError("transition package shape does not match its exact Memory dependency")
 
     requirements = [
         ExactRequirement(captured.core_distribution, captured.core_version),
@@ -1067,43 +993,6 @@ def _staged_artifacts(staging_dir: Path) -> tuple[StagedArtifact, ...]:
     return tuple(artifacts)
 
 
-def _verify_staged_shape(
-    captured: CapturedPackageShape | CapturedPackageShapeRecord,
-    artifacts: tuple[StagedArtifact, ...] | tuple[StagedArtifactRecord, ...],
-) -> None:
-    by_distribution: dict[
-        str,
-        list[StagedArtifact | StagedArtifactRecord],
-    ] = {}
-    for artifact in artifacts:
-        by_distribution.setdefault(artifact.distribution, []).append(artifact)
-    if any(len(values) != 1 for values in by_distribution.values()):
-        raise RollbackResolutionError("staging contains duplicate distribution artifacts")
-
-    core_artifacts = tuple(
-        artifact
-        for artifact in artifacts
-        if artifact.distribution in CORE_DISTRIBUTION_NAMES
-    )
-    if len(core_artifacts) != 1 or (
-        core_artifacts[0].distribution,
-        core_artifacts[0].version,
-    ) != (captured.core_distribution, captured.core_version):
-        raise RollbackResolutionError("staging does not contain the exact captured core shape")
-
-    memory_artifacts = tuple(
-        artifact
-        for artifact in artifacts
-        if artifact.distribution == MEMORY_PACKAGE_NAME
-    )
-    staged_memory_version = memory_artifacts[0].version if len(memory_artifacts) == 1 else None
-    if (
-        len(memory_artifacts) != captured.memory_provider_cardinality
-        or staged_memory_version != captured.memory_version
-    ):
-        raise RollbackResolutionError("staging does not contain the exact captured Memory shape")
-
-
 def _rollback_uninstall_distributions() -> tuple[str, ...]:
     return tuple(sorted((*CORE_DISTRIBUTION_NAMES, MEMORY_PACKAGE_NAME)))
 
@@ -1114,9 +1003,7 @@ def _package_shape_verification(
     return PackageShapeVerification(
         core_distribution=captured.core_distribution,
         core_version=captured.core_version,
-        absent_core_distributions=tuple(
-            sorted(CORE_DISTRIBUTION_NAMES - {captured.core_distribution})
-        ),
+        absent_core_distributions=tuple(sorted(CORE_DISTRIBUTION_NAMES - {captured.core_distribution})),
         memory_provider_cardinality=captured.memory_provider_cardinality,
         memory_version=captured.memory_version,
         residual_memory=captured.residual_memory,
@@ -1145,6 +1032,10 @@ def _construct_resolved_plan(
         "verification",
         _package_shape_verification(captured),
     )
+    try:
+        _plan_to_record(plan)
+    except PackageShapeRecordError as exc:
+        raise RollbackResolutionError(str(exc)) from exc
     return plan
 
 
@@ -1187,25 +1078,17 @@ def resolve_rollback_plan(
         # Resolve the legacy core closure normally, then stage that exact
         # residual wheel without following its forward-core dependency.
         core_requirements = tuple(
-            requirement
-            for requirement in requirements
-            if requirement.distribution != MEMORY_PACKAGE_NAME
+            requirement for requirement in requirements if requirement.distribution != MEMORY_PACKAGE_NAME
         )
         memory_requirements = tuple(
-            requirement
-            for requirement in requirements
-            if requirement.distribution == MEMORY_PACKAGE_NAME
+            requirement for requirement in requirements if requirement.distribution == MEMORY_PACKAGE_NAME
         )
         resolver_requests = (
             (False, core_requirements),
             (True, memory_requirements),
         )
     env = {
-        **{
-            key: value
-            for key, value in os.environ.items()
-            if not key.startswith("PIP_") and key != "PYTHONPATH"
-        },
+        **{key: value for key, value in os.environ.items() if not key.startswith("PIP_") and key != "PYTHONPATH"},
         "PIP_CONFIG_FILE": os.devnull,
         "PIP_DISABLE_PIP_VERSION_CHECK": "1",
         "PIP_NO_INDEX": "1",
@@ -1230,43 +1113,14 @@ def resolve_rollback_plan(
                 timeout=300,
             )
             if result.returncode != 0:
-                raise RollbackResolutionError(
-                    "exact rollback requirements did not resolve from the local wheelhouse"
-                )
+                raise RollbackResolutionError("exact rollback requirements did not resolve from the local wheelhouse")
         temporary_artifacts = _staged_artifacts(temporary)
-        _verify_staged_shape(captured, temporary_artifacts)
-        staged_versions = {
-            (artifact.distribution, artifact.version) for artifact in temporary_artifacts
-        }
-        missing = [
-            requirement.specifier
-            for requirement in requirements
-            if (requirement.distribution, requirement.version) not in staged_versions
-        ]
-        if missing:
-            raise RollbackResolutionError("resolved staging is missing an exact rollback artifact")
-
-        staged_core = next(
-            artifact
-            for artifact in temporary_artifacts
-            if artifact.distribution == captured.core_distribution
-            and artifact.version == captured.core_version
+        _construct_resolved_plan(
+            captured=captured,
+            requirements=requirements,
+            artifacts=temporary_artifacts,
+            staging_dir=temporary,
         )
-        staged_family, staged_transition_version = _release_family(
-            DistributionProvider(
-                name=staged_core.distribution,
-                version=staged_core.version,
-                provider_id=str(staged_core.path),
-                requires_dist=staged_core.requires_dist,
-            )
-        )
-        if (
-            staged_family is not captured.release_family
-            or staged_transition_version != captured.transition_memory_version
-        ):
-            raise RollbackResolutionError(
-                "staged core artifact does not match the captured release family"
-            )
 
         if staging_dir.exists():
             raise RollbackResolutionError("rollback staging destination appeared during resolution")

--- a/vibe/package_shape.py
+++ b/vibe/package_shape.py
@@ -17,7 +17,12 @@ from pathlib import Path
 from typing import Any
 
 from packaging.requirements import InvalidRequirement, Requirement
-from packaging.utils import InvalidWheelFilename, canonicalize_name, parse_wheel_filename
+from packaging.utils import (
+    InvalidName,
+    InvalidWheelFilename,
+    canonicalize_name,
+    parse_wheel_filename,
+)
 from packaging.version import InvalidVersion, Version
 
 from vibe.runtime import ServiceLauncher
@@ -53,6 +58,24 @@ class ReleaseFamily(str, Enum):
     TRANSITION = "transition"
 
 
+def _canonical_distribution_name(
+    value: object,
+    *,
+    field: str,
+    error_type: type[PackageShapeError] = PackageShapeError,
+    require_canonical: bool = False,
+) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise error_type(f"{field} name is missing")
+    try:
+        canonical = canonicalize_name(value, validate=True)
+    except InvalidName as exc:
+        raise error_type(f"{field} name is invalid") from exc
+    if require_canonical and value != canonical:
+        raise error_type(f"{field} is not canonical")
+    return canonical
+
+
 def _normalized_version(value: object, *, field: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise PackageShapeError(f"{field} is missing")
@@ -82,9 +105,10 @@ class DistributionProvider:
     requires_dist: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
-        canonical_name = canonicalize_name(self.name)
-        if not canonical_name:
-            raise PackageShapeError("distribution provider name is missing")
+        canonical_name = _canonical_distribution_name(
+            self.name,
+            field="distribution provider",
+        )
         object.__setattr__(self, "name", canonical_name)
         object.__setattr__(
             self,
@@ -107,19 +131,6 @@ class CapturedPackageShape:
     residual_memory: bool
 
     def __post_init__(self) -> None:
-        if not isinstance(self.release_family, ReleaseFamily):
-            raise PackageShapeError("captured release family is unknown")
-        if self.core_provider.name not in CORE_DISTRIBUTION_NAMES:
-            raise PackageShapeError("captured core provider is not an Avibe distribution")
-        if not isinstance(self.launcher, ServiceLauncher):
-            raise PackageShapeError("captured service launcher is invalid")
-        if len(self.memory_providers) > 1:
-            raise DuplicateDistributionProviderError(
-                "multiple canonical avibe-memory providers are not representable"
-            )
-        if any(provider.name != MEMORY_PACKAGE_NAME for provider in self.memory_providers):
-            raise PackageShapeError("captured Memory provider has the wrong canonical name")
-
         transition_memory_version = self.transition_memory_version
         if transition_memory_version is not None:
             transition_memory_version = _normalized_version(
@@ -128,16 +139,7 @@ class CapturedPackageShape:
             )
         object.__setattr__(self, "memory_providers", tuple(self.memory_providers))
         object.__setattr__(self, "transition_memory_version", transition_memory_version)
-
-        if self.release_family is ReleaseFamily.TRANSITION:
-            if transition_memory_version is None:
-                raise PackageShapeError("transition family is missing its exact Memory requirement")
-        elif transition_memory_version is not None:
-            raise PackageShapeError("only the transition family may carry a hard Memory requirement")
-
-        expected_residual = self.release_family is ReleaseFamily.PRE_SPLIT and self.memory_present
-        if self.residual_memory != expected_residual:
-            raise PackageShapeError("residual Memory marker does not match the captured family")
+        _validate_canonical_package_shape(self, error_type=PackageShapeError)
 
     @property
     def core_version(self) -> str:
@@ -181,9 +183,10 @@ class ExactRequirement:
     version: str
 
     def __post_init__(self) -> None:
-        canonical_name = canonicalize_name(self.distribution)
-        if not canonical_name:
-            raise PackageShapeError("rollback requirement distribution is missing")
+        canonical_name = _canonical_distribution_name(
+            self.distribution,
+            field="rollback requirement distribution",
+        )
         object.__setattr__(self, "distribution", canonical_name)
         object.__setattr__(
             self,
@@ -250,6 +253,26 @@ class CapturedPackageShapeRecord:
     memory_providers: tuple[DistributionProviderRecord, ...]
     transition_memory_version: str | None
     residual_memory: bool
+
+    @property
+    def core_version(self) -> str:
+        return self.core_provider.version
+
+    @property
+    def core_distribution(self) -> str:
+        return self.core_provider.name
+
+    @property
+    def memory_present(self) -> bool:
+        return bool(self.memory_providers)
+
+    @property
+    def memory_version(self) -> str | None:
+        return self.memory_providers[0].version if self.memory_providers else None
+
+    @property
+    def memory_provider_cardinality(self) -> int:
+        return len(self.memory_providers)
 
 
 @dataclass(frozen=True, order=True)
@@ -330,9 +353,12 @@ def _record_version(value: object, *, field: str) -> str:
 
 def _record_distribution(value: object, *, field: str) -> str:
     raw = _record_string(value, field=field)
-    if raw != canonicalize_name(raw):
-        raise PackageShapeRecordError(f"{field} is not canonical")
-    return raw
+    return _canonical_distribution_name(
+        raw,
+        field=field,
+        error_type=PackageShapeRecordError,
+        require_canonical=True,
+    )
 
 
 def _record_schema(envelope: dict[str, object]) -> None:
@@ -395,25 +421,6 @@ def _captured_to_record(
     )
 
 
-def _validate_captured_record(record: CapturedPackageShapeRecord) -> None:
-    if record.core_provider.name not in CORE_DISTRIBUTION_NAMES:
-        raise PackageShapeRecordError("captured core provider is not an Avibe distribution")
-    if len(record.memory_providers) > 1:
-        raise PackageShapeRecordError("captured record has multiple Memory providers")
-    if any(provider.name != MEMORY_PACKAGE_NAME for provider in record.memory_providers):
-        raise PackageShapeRecordError("captured Memory provider has the wrong name")
-    if record.release_family is ReleaseFamily.TRANSITION:
-        if record.transition_memory_version is None:
-            raise PackageShapeRecordError("transition record is missing its Memory version")
-    elif record.transition_memory_version is not None:
-        raise PackageShapeRecordError("non-transition record carries a transition version")
-    expected_residual = (
-        record.release_family is ReleaseFamily.PRE_SPLIT and bool(record.memory_providers)
-    )
-    if record.residual_memory is not expected_residual:
-        raise PackageShapeRecordError("residual Memory marker is inconsistent")
-
-
 def encode_captured_package_shape_record(
     captured: CapturedPackageShape | CapturedPackageShapeRecord,
 ) -> dict[str, object]:
@@ -421,7 +428,6 @@ def encode_captured_package_shape_record(
 
     record = _captured_to_record(captured)
     try:
-        _validate_captured_record(record)
         payload: dict[str, object] = {
             "schema_version": PACKAGE_SHAPE_RECORD_SCHEMA_VERSION,
             "record_type": "captured_package_shape",
@@ -506,7 +512,10 @@ def decode_captured_package_shape_record(value: object) -> CapturedPackageShapeR
             field="residual Memory",
         ),
     )
-    _validate_captured_record(record)
+    _validate_canonical_package_shape(
+        record,
+        error_type=PackageShapeRecordError,
+    )
     return record
 
 
@@ -627,89 +636,27 @@ def _plan_to_record(
 
 
 def _validate_plan_record(record: ResolvedRollbackPlanRecord) -> None:
-    _validate_captured_record(record.captured)
+    _validate_canonical_package_shape(
+        record.captured,
+        error_type=PackageShapeRecordError,
+    )
     if not record.requirements or not record.artifacts:
         raise PackageShapeRecordError("resolved rollback record has an empty closure")
-    captured = record.captured
-    if captured.release_family is ReleaseFamily.TRANSITION and (
-        not captured.memory_providers
-        or captured.memory_providers[0].version != captured.transition_memory_version
-    ):
-        raise PackageShapeRecordError(
-            "resolved transition record does not contain its exact Memory target"
-        )
-    expected_requirements = [
-        ExactRequirement(captured.core_provider.name, captured.core_provider.version)
-    ]
-    if captured.memory_providers:
-        memory_provider = captured.memory_providers[0]
-        expected_requirements.append(
-            ExactRequirement(memory_provider.name, memory_provider.version)
-        )
-    if record.requirements != tuple(expected_requirements):
+    try:
+        expected_requirements = _rollback_requirements(record.captured)
+    except PackageShapeError as exc:
+        raise PackageShapeRecordError(str(exc)) from exc
+    if record.requirements != expected_requirements:
         raise PackageShapeRecordError(
             "resolved requirements do not match the captured rollback target"
         )
-
-    by_distribution: dict[str, list[StagedArtifactRecord]] = {}
-    for artifact in record.artifacts:
-        by_distribution.setdefault(artifact.distribution, []).append(artifact)
-    if any(len(artifacts) != 1 for artifacts in by_distribution.values()):
-        raise PackageShapeRecordError(
-            "resolved staging contains a duplicate distribution"
-        )
-    core_artifacts = tuple(
-        artifact
-        for artifact in record.artifacts
-        if artifact.distribution in CORE_DISTRIBUTION_NAMES
-    )
-    if len(core_artifacts) != 1 or (
-        core_artifacts[0].distribution,
-        core_artifacts[0].version,
-    ) != (captured.core_provider.name, captured.core_provider.version):
-        raise PackageShapeRecordError(
-            "resolved staging does not match the captured core target"
-        )
-    memory_artifacts = tuple(
-        artifact
-        for artifact in record.artifacts
-        if artifact.distribution == MEMORY_PACKAGE_NAME
-    )
-    staged_memory_version = (
-        memory_artifacts[0].version if len(memory_artifacts) == 1 else None
-    )
-    captured_memory_version = (
-        captured.memory_providers[0].version
-        if captured.memory_providers
-        else None
-    )
-    if (
-        len(memory_artifacts) != len(captured.memory_providers)
-        or staged_memory_version != captured_memory_version
-    ):
-        raise PackageShapeRecordError(
-            "resolved staging does not match the captured Memory target"
-        )
-    expected_uninstalls = tuple(
-        sorted((*CORE_DISTRIBUTION_NAMES, MEMORY_PACKAGE_NAME))
-    )
-    if record.uninstall_distributions != expected_uninstalls:
+    try:
+        _verify_staged_shape(record.captured, record.artifacts)
+    except PackageShapeError as exc:
+        raise PackageShapeRecordError(str(exc)) from exc
+    if record.uninstall_distributions != _rollback_uninstall_distributions():
         raise PackageShapeRecordError("resolved rollback record has an unknown uninstall set")
-    expected_verification = PackageShapeVerification(
-        core_distribution=captured.core_provider.name,
-        core_version=captured.core_provider.version,
-        absent_core_distributions=tuple(
-            sorted(CORE_DISTRIBUTION_NAMES - {captured.core_provider.name})
-        ),
-        memory_provider_cardinality=len(captured.memory_providers),
-        memory_version=(
-            captured.memory_providers[0].version
-            if captured.memory_providers
-            else None
-        ),
-        residual_memory=captured.residual_memory,
-    )
-    if record.verification != expected_verification:
+    if record.verification != _package_shape_verification(record.captured):
         raise PackageShapeRecordError("resolved rollback verification is inconsistent")
 
 
@@ -720,7 +667,6 @@ def encode_resolved_rollback_plan_record(
 
     record = _plan_to_record(plan)
     try:
-        _validate_plan_record(record)
         payload: dict[str, object] = {
             "schema_version": PACKAGE_SHAPE_RECORD_SCHEMA_VERSION,
             "record_type": "resolved_rollback_plan",
@@ -823,19 +769,29 @@ def decode_resolved_rollback_plan_record(value: object) -> ResolvedRollbackPlanR
     return record
 
 
-def _parsed_memory_requirements(provider: DistributionProvider) -> tuple[Requirement, ...]:
+def _parsed_memory_requirements(
+    provider: DistributionProvider | DistributionProviderRecord,
+) -> tuple[Requirement, ...]:
     parsed: list[Requirement] = []
     for value in provider.requires_dist:
         try:
             requirement = Requirement(value)
         except (InvalidRequirement, TypeError) as exc:
             raise PackageShapeError("core distribution contains unreadable dependency metadata") from exc
-        if canonicalize_name(requirement.name) == MEMORY_PACKAGE_NAME:
+        if (
+            _canonical_distribution_name(
+                requirement.name,
+                field="core requirement distribution",
+            )
+            == MEMORY_PACKAGE_NAME
+        ):
             parsed.append(requirement)
     return tuple(parsed)
 
 
-def _release_family(provider: DistributionProvider) -> tuple[ReleaseFamily, str | None]:
+def _release_family(
+    provider: DistributionProvider | DistributionProviderRecord,
+) -> tuple[ReleaseFamily, str | None]:
     memory_requirements = _parsed_memory_requirements(provider)
     hard: list[Requirement] = []
     for requirement in memory_requirements:
@@ -868,6 +824,48 @@ def _release_family(provider: DistributionProvider) -> tuple[ReleaseFamily, str 
     if required_version != provider.version:
         raise PackageShapeError("transition core does not require its matching Memory release")
     return ReleaseFamily.TRANSITION, required_version
+
+
+def _validate_canonical_package_shape(
+    shape: CapturedPackageShape | CapturedPackageShapeRecord,
+    *,
+    error_type: type[PackageShapeError],
+) -> None:
+    provider_type = (
+        DistributionProviderRecord
+        if isinstance(shape, CapturedPackageShapeRecord)
+        else DistributionProvider
+    )
+    if not isinstance(shape.release_family, ReleaseFamily):
+        raise error_type("captured release family is unknown")
+    if not isinstance(shape.core_provider, provider_type):
+        raise error_type("captured core provider is invalid")
+    if shape.core_provider.name not in CORE_DISTRIBUTION_NAMES:
+        raise error_type("captured core provider is not an Avibe distribution")
+    if not isinstance(shape.launcher, ServiceLauncher):
+        raise error_type("captured service launcher is invalid")
+    if type(shape.memory_providers) is not tuple or any(
+        not isinstance(provider, provider_type) for provider in shape.memory_providers
+    ):
+        raise error_type("captured Memory providers are invalid")
+    if len(shape.memory_providers) > 1:
+        raise error_type("multiple canonical avibe-memory providers are not representable")
+    if any(provider.name != MEMORY_PACKAGE_NAME for provider in shape.memory_providers):
+        raise error_type("captured Memory provider has the wrong canonical name")
+    if type(shape.residual_memory) is not bool:
+        raise error_type("captured residual Memory marker is invalid")
+
+    try:
+        derived_family, derived_transition = _release_family(shape.core_provider)
+    except PackageShapeError as exc:
+        raise error_type(str(exc)) from exc
+    if shape.release_family is not derived_family:
+        raise error_type("captured release family disagrees with core metadata")
+    if shape.transition_memory_version != derived_transition:
+        raise error_type("captured transition pin disagrees with core metadata")
+    expected_residual = derived_family is ReleaseFamily.PRE_SPLIT and shape.memory_present
+    if shape.residual_memory is not expected_residual:
+        raise error_type("residual Memory marker disagrees with the derived family")
 
 
 def capture_package_shape(
@@ -960,7 +958,10 @@ def inspect_installed_distribution_providers(
             name = distribution.metadata["Name"]
             if not isinstance(name, str) or not name.strip():
                 raise PackageShapeError("installed distribution name is unreadable")
-            canonical_name = canonicalize_name(name)
+            canonical_name = _canonical_distribution_name(
+                name,
+                field="installed distribution",
+            )
             if canonical_name not in CORE_DISTRIBUTION_NAMES and canonical_name != MEMORY_PACKAGE_NAME:
                 continue
             providers.append(
@@ -991,7 +992,9 @@ def capture_installed_package_shape(
     )
 
 
-def _rollback_requirements(captured: CapturedPackageShape) -> tuple[ExactRequirement, ...]:
+def _rollback_requirements(
+    captured: CapturedPackageShape | CapturedPackageShapeRecord,
+) -> tuple[ExactRequirement, ...]:
     if captured.release_family is ReleaseFamily.TRANSITION:
         if not captured.memory_present:
             raise RollbackResolutionError(
@@ -1034,7 +1037,12 @@ def _wheel_provider(path: Path) -> DistributionProvider:
         provider_id=str(path),
         requires_dist=tuple(metadata.get_all("Requires-Dist", [])),
     )
-    if provider.name != canonicalize_name(str(filename_name)) or provider.version != str(filename_version):
+    filename_distribution = _canonical_distribution_name(
+        str(filename_name),
+        field="wheel filename distribution",
+        error_type=RollbackResolutionError,
+    )
+    if provider.name != filename_distribution or provider.version != str(filename_version):
         raise RollbackResolutionError("staged wheel filename and metadata disagree")
     return provider
 
@@ -1060,10 +1068,13 @@ def _staged_artifacts(staging_dir: Path) -> tuple[StagedArtifact, ...]:
 
 
 def _verify_staged_shape(
-    captured: CapturedPackageShape,
-    artifacts: tuple[StagedArtifact, ...],
+    captured: CapturedPackageShape | CapturedPackageShapeRecord,
+    artifacts: tuple[StagedArtifact, ...] | tuple[StagedArtifactRecord, ...],
 ) -> None:
-    by_distribution: dict[str, list[StagedArtifact]] = {}
+    by_distribution: dict[
+        str,
+        list[StagedArtifact | StagedArtifactRecord],
+    ] = {}
     for artifact in artifacts:
         by_distribution.setdefault(artifact.distribution, []).append(artifact)
     if any(len(values) != 1 for values in by_distribution.values()):
@@ -1093,6 +1104,25 @@ def _verify_staged_shape(
         raise RollbackResolutionError("staging does not contain the exact captured Memory shape")
 
 
+def _rollback_uninstall_distributions() -> tuple[str, ...]:
+    return tuple(sorted((*CORE_DISTRIBUTION_NAMES, MEMORY_PACKAGE_NAME)))
+
+
+def _package_shape_verification(
+    captured: CapturedPackageShape | CapturedPackageShapeRecord,
+) -> PackageShapeVerification:
+    return PackageShapeVerification(
+        core_distribution=captured.core_distribution,
+        core_version=captured.core_version,
+        absent_core_distributions=tuple(
+            sorted(CORE_DISTRIBUTION_NAMES - {captured.core_distribution})
+        ),
+        memory_provider_cardinality=captured.memory_provider_cardinality,
+        memory_version=captured.memory_version,
+        residual_memory=captured.residual_memory,
+    )
+
+
 def _construct_resolved_plan(
     *,
     captured: CapturedPackageShape,
@@ -1108,21 +1138,12 @@ def _construct_resolved_plan(
     object.__setattr__(
         plan,
         "uninstall_distributions",
-        tuple(sorted((*CORE_DISTRIBUTION_NAMES, MEMORY_PACKAGE_NAME))),
+        _rollback_uninstall_distributions(),
     )
     object.__setattr__(
         plan,
         "verification",
-        PackageShapeVerification(
-            core_distribution=captured.core_distribution,
-            core_version=captured.core_version,
-            absent_core_distributions=tuple(
-                sorted(CORE_DISTRIBUTION_NAMES - {captured.core_distribution})
-            ),
-            memory_provider_cardinality=captured.memory_provider_cardinality,
-            memory_version=captured.memory_version,
-            residual_memory=captured.residual_memory,
-        ),
+        _package_shape_verification(captured),
     )
     return plan
 

--- a/vibe/package_shape.py
+++ b/vibe/package_shape.py
@@ -1,4 +1,4 @@
-"""Exact pre-mutation package capture and staged rollback resolution."""
+"""Exact package capture, persisted recovery DTOs, and rollback resolution."""
 
 from __future__ import annotations
 
@@ -28,6 +28,7 @@ LEGACY_CORE_PACKAGE_NAME = "vibe-remote"
 MEMORY_PACKAGE_NAME = "avibe-memory"
 CORE_DISTRIBUTION_NAMES = frozenset({CORE_PACKAGE_NAME, LEGACY_CORE_PACKAGE_NAME})
 MEMORY_SPLIT_MIN_VERSION = Version("3.0.14.dev0")
+PACKAGE_SHAPE_RECORD_SCHEMA_VERSION = 1
 
 
 class PackageShapeError(ValueError):
@@ -40,6 +41,10 @@ class DuplicateDistributionProviderError(PackageShapeError):
 
 class RollbackResolutionError(PackageShapeError):
     """An exact rollback target could not be resolved entirely into staging."""
+
+
+class PackageShapeRecordError(PackageShapeError):
+    """Persisted package-shape data is unknown, incomplete, or inconsistent."""
 
 
 class ReleaseFamily(str, Enum):
@@ -223,6 +228,533 @@ class ResolvedRollbackPlan:
 
     def __init__(self, *args: object, **kwargs: object) -> None:
         raise TypeError("ResolvedRollbackPlan is constructed only by rollback resolution")
+
+
+@dataclass(frozen=True, order=True)
+class DistributionProviderRecord:
+    """Filesystem-independent evidence for one captured provider."""
+
+    name: str
+    version: str
+    provider_id: str
+    requires_dist: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CapturedPackageShapeRecord:
+    """Non-executable persisted form of a captured package shape."""
+
+    core_provider: DistributionProviderRecord
+    launcher: ServiceLauncher
+    release_family: ReleaseFamily
+    memory_providers: tuple[DistributionProviderRecord, ...]
+    transition_memory_version: str | None
+    residual_memory: bool
+
+
+@dataclass(frozen=True, order=True)
+class StagedArtifactRecord:
+    """Recorded artifact identity; existence and hashes require live revalidation."""
+
+    distribution: str
+    version: str
+    path: str
+    sha256: str
+    requires_dist: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ResolvedRollbackPlanRecord:
+    """Non-executable persisted form of a resolved rollback plan."""
+
+    captured: CapturedPackageShapeRecord
+    requirements: tuple[ExactRequirement, ...]
+    artifacts: tuple[StagedArtifactRecord, ...]
+    staging_dir: str
+    uninstall_distributions: tuple[str, ...]
+    verification: PackageShapeVerification
+
+
+def _record_object(
+    value: object,
+    keys: frozenset[str],
+    *,
+    field: str,
+) -> dict[str, object]:
+    if type(value) is not dict or frozenset(value) != keys:
+        raise PackageShapeRecordError(f"{field} has unknown or missing fields")
+    return value
+
+
+def _record_list(value: object, *, field: str) -> list[object]:
+    if type(value) is not list:
+        raise PackageShapeRecordError(f"{field} is not a JSON array")
+    return value
+
+
+def _record_string(value: object, *, field: str) -> str:
+    if type(value) is not str or not value:
+        raise PackageShapeRecordError(f"{field} is missing")
+    return value
+
+
+def _record_strings(value: object, *, field: str) -> tuple[str, ...]:
+    return tuple(
+        _record_string(item, field=f"{field} item")
+        for item in _record_list(value, field=field)
+    )
+
+
+def _record_bool(value: object, *, field: str) -> bool:
+    if type(value) is not bool:
+        raise PackageShapeRecordError(f"{field} is not a boolean")
+    return value
+
+
+def _record_int(value: object, *, field: str) -> int:
+    if type(value) is not int:
+        raise PackageShapeRecordError(f"{field} is not an integer")
+    return value
+
+
+def _record_version(value: object, *, field: str) -> str:
+    raw = _record_string(value, field=field)
+    try:
+        normalized = _normalized_version(raw, field=field)
+    except PackageShapeError as exc:
+        raise PackageShapeRecordError(str(exc)) from exc
+    if raw != normalized:
+        raise PackageShapeRecordError(f"{field} is not canonical")
+    return raw
+
+
+def _record_distribution(value: object, *, field: str) -> str:
+    raw = _record_string(value, field=field)
+    if raw != canonicalize_name(raw):
+        raise PackageShapeRecordError(f"{field} is not canonical")
+    return raw
+
+
+def _record_schema(envelope: dict[str, object]) -> None:
+    version = envelope["schema_version"]
+    if type(version) is not int or version != PACKAGE_SHAPE_RECORD_SCHEMA_VERSION:
+        raise PackageShapeRecordError("package-shape record schema version is unsupported")
+
+
+def _provider_to_record(provider: DistributionProvider) -> DistributionProviderRecord:
+    return DistributionProviderRecord(
+        name=provider.name,
+        version=provider.version,
+        provider_id=provider.provider_id,
+        requires_dist=provider.requires_dist,
+    )
+
+
+def _decode_provider(value: object, *, field: str) -> DistributionProviderRecord:
+    payload = _record_object(
+        value,
+        frozenset({"name", "version", "provider_id", "requires_dist"}),
+        field=field,
+    )
+    return DistributionProviderRecord(
+        name=_record_distribution(payload["name"], field=f"{field} name"),
+        version=_record_version(payload["version"], field=f"{field} version"),
+        provider_id=_record_string(payload["provider_id"], field=f"{field} identity"),
+        requires_dist=_record_strings(
+            payload["requires_dist"],
+            field=f"{field} requirements",
+        ),
+    )
+
+
+def _encode_provider(provider: DistributionProviderRecord) -> dict[str, object]:
+    return {
+        "name": provider.name,
+        "version": provider.version,
+        "provider_id": provider.provider_id,
+        "requires_dist": list(provider.requires_dist),
+    }
+
+
+def _captured_to_record(
+    captured: CapturedPackageShape | CapturedPackageShapeRecord,
+) -> CapturedPackageShapeRecord:
+    if isinstance(captured, CapturedPackageShapeRecord):
+        return captured
+    if not isinstance(captured, CapturedPackageShape):
+        raise PackageShapeRecordError("captured package shape has an unsupported type")
+    return CapturedPackageShapeRecord(
+        core_provider=_provider_to_record(captured.core_provider),
+        launcher=captured.launcher,
+        release_family=captured.release_family,
+        memory_providers=tuple(
+            _provider_to_record(item) for item in captured.memory_providers
+        ),
+        transition_memory_version=captured.transition_memory_version,
+        residual_memory=captured.residual_memory,
+    )
+
+
+def _validate_captured_record(record: CapturedPackageShapeRecord) -> None:
+    if record.core_provider.name not in CORE_DISTRIBUTION_NAMES:
+        raise PackageShapeRecordError("captured core provider is not an Avibe distribution")
+    if len(record.memory_providers) > 1:
+        raise PackageShapeRecordError("captured record has multiple Memory providers")
+    if any(provider.name != MEMORY_PACKAGE_NAME for provider in record.memory_providers):
+        raise PackageShapeRecordError("captured Memory provider has the wrong name")
+    if record.release_family is ReleaseFamily.TRANSITION:
+        if record.transition_memory_version is None:
+            raise PackageShapeRecordError("transition record is missing its Memory version")
+    elif record.transition_memory_version is not None:
+        raise PackageShapeRecordError("non-transition record carries a transition version")
+    expected_residual = (
+        record.release_family is ReleaseFamily.PRE_SPLIT and bool(record.memory_providers)
+    )
+    if record.residual_memory is not expected_residual:
+        raise PackageShapeRecordError("residual Memory marker is inconsistent")
+
+
+def encode_captured_package_shape_record(
+    captured: CapturedPackageShape | CapturedPackageShapeRecord,
+) -> dict[str, object]:
+    """Encode captured evidence into a versioned JSON-safe object."""
+
+    record = _captured_to_record(captured)
+    _validate_captured_record(record)
+    return {
+        "schema_version": PACKAGE_SHAPE_RECORD_SCHEMA_VERSION,
+        "record_type": "captured_package_shape",
+        "shape": {
+            "core_provider": _encode_provider(record.core_provider),
+            "launcher": {
+                "python": record.launcher.python,
+                "main": record.launcher.main,
+            },
+            "release_family": record.release_family.value,
+            "memory_providers": [
+                _encode_provider(provider) for provider in record.memory_providers
+            ],
+            "transition_memory_version": record.transition_memory_version,
+            "residual_memory": record.residual_memory,
+        },
+    }
+
+
+def decode_captured_package_shape_record(value: object) -> CapturedPackageShapeRecord:
+    """Decode captured evidence without consulting installed package state."""
+
+    envelope = _record_object(
+        value,
+        frozenset({"schema_version", "record_type", "shape"}),
+        field="captured package-shape record",
+    )
+    _record_schema(envelope)
+    if envelope["record_type"] != "captured_package_shape":
+        raise PackageShapeRecordError("captured package-shape record type is unsupported")
+    shape = _record_object(
+        envelope["shape"],
+        frozenset(
+            {
+                "core_provider",
+                "launcher",
+                "release_family",
+                "memory_providers",
+                "transition_memory_version",
+                "residual_memory",
+            }
+        ),
+        field="captured package shape",
+    )
+    launcher = _record_object(
+        shape["launcher"],
+        frozenset({"python", "main"}),
+        field="service launcher",
+    )
+    family_value = _record_string(shape["release_family"], field="release family")
+    try:
+        family = ReleaseFamily(family_value)
+    except ValueError as exc:
+        raise PackageShapeRecordError("captured release family is unknown") from exc
+    transition = shape["transition_memory_version"]
+    if transition is not None:
+        transition = _record_version(transition, field="transition Memory version")
+    record = CapturedPackageShapeRecord(
+        core_provider=_decode_provider(shape["core_provider"], field="core provider"),
+        launcher=ServiceLauncher(
+            python=_record_string(launcher["python"], field="launcher Python"),
+            main=_record_string(launcher["main"], field="launcher main"),
+        ),
+        release_family=family,
+        memory_providers=tuple(
+            _decode_provider(item, field="Memory provider")
+            for item in _record_list(
+                shape["memory_providers"],
+                field="Memory providers",
+            )
+        ),
+        transition_memory_version=transition,
+        residual_memory=_record_bool(
+            shape["residual_memory"],
+            field="residual Memory",
+        ),
+    )
+    _validate_captured_record(record)
+    return record
+
+
+def _decode_requirement(value: object) -> ExactRequirement:
+    payload = _record_object(
+        value,
+        frozenset({"distribution", "version"}),
+        field="rollback requirement",
+    )
+    return ExactRequirement(
+        distribution=_record_distribution(
+            payload["distribution"],
+            field="requirement distribution",
+        ),
+        version=_record_version(payload["version"], field="requirement version"),
+    )
+
+
+def _decode_artifact(value: object) -> StagedArtifactRecord:
+    payload = _record_object(
+        value,
+        frozenset({"distribution", "version", "path", "sha256", "requires_dist"}),
+        field="staged artifact",
+    )
+    digest = _record_string(payload["sha256"], field="artifact SHA-256")
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise PackageShapeRecordError("artifact SHA-256 is not canonical")
+    return StagedArtifactRecord(
+        distribution=_record_distribution(
+            payload["distribution"],
+            field="artifact distribution",
+        ),
+        version=_record_version(payload["version"], field="artifact version"),
+        path=_record_string(payload["path"], field="artifact path"),
+        sha256=digest,
+        requires_dist=_record_strings(
+            payload["requires_dist"],
+            field="artifact requirements",
+        ),
+    )
+
+
+def _decode_verification(value: object) -> PackageShapeVerification:
+    payload = _record_object(
+        value,
+        frozenset(
+            {
+                "core_distribution",
+                "core_version",
+                "absent_core_distributions",
+                "memory_provider_cardinality",
+                "memory_version",
+                "residual_memory",
+            }
+        ),
+        field="package-shape verification",
+    )
+    memory_version = payload["memory_version"]
+    if memory_version is not None:
+        memory_version = _record_version(
+            memory_version,
+            field="verified Memory version",
+        )
+    return PackageShapeVerification(
+        core_distribution=_record_distribution(
+            payload["core_distribution"],
+            field="verified core distribution",
+        ),
+        core_version=_record_version(
+            payload["core_version"],
+            field="verified core version",
+        ),
+        absent_core_distributions=tuple(
+            _record_distribution(item, field="absent core distribution")
+            for item in _record_list(
+                payload["absent_core_distributions"],
+                field="absent core distributions",
+            )
+        ),
+        memory_provider_cardinality=_record_int(
+            payload["memory_provider_cardinality"],
+            field="Memory provider cardinality",
+        ),
+        memory_version=memory_version,
+        residual_memory=_record_bool(
+            payload["residual_memory"],
+            field="verified residual Memory",
+        ),
+    )
+
+
+def _plan_to_record(
+    plan: ResolvedRollbackPlan | ResolvedRollbackPlanRecord,
+) -> ResolvedRollbackPlanRecord:
+    if isinstance(plan, ResolvedRollbackPlanRecord):
+        return plan
+    if not isinstance(plan, ResolvedRollbackPlan):
+        raise PackageShapeRecordError("resolved rollback plan has an unsupported type")
+    return ResolvedRollbackPlanRecord(
+        captured=_captured_to_record(plan.captured),
+        requirements=plan.requirements,
+        artifacts=tuple(
+            StagedArtifactRecord(
+                distribution=item.distribution,
+                version=item.version,
+                path=str(item.path),
+                sha256=item.sha256,
+                requires_dist=item.requires_dist,
+            )
+            for item in plan.artifacts
+        ),
+        staging_dir=str(plan.staging_dir),
+        uninstall_distributions=plan.uninstall_distributions,
+        verification=plan.verification,
+    )
+
+
+def _validate_plan_record(record: ResolvedRollbackPlanRecord) -> None:
+    _validate_captured_record(record.captured)
+    if not record.requirements or not record.artifacts:
+        raise PackageShapeRecordError("resolved rollback record has an empty closure")
+    requirement_keys = {
+        (item.distribution, item.version) for item in record.requirements
+    }
+    artifact_keys = {(item.distribution, item.version) for item in record.artifacts}
+    if (
+        len(requirement_keys) != len(record.requirements)
+        or not requirement_keys <= artifact_keys
+    ):
+        raise PackageShapeRecordError("resolved rollback record has an inconsistent closure")
+    expected_uninstalls = tuple(
+        sorted((*CORE_DISTRIBUTION_NAMES, MEMORY_PACKAGE_NAME))
+    )
+    if record.uninstall_distributions != expected_uninstalls:
+        raise PackageShapeRecordError("resolved rollback record has an unknown uninstall set")
+    captured = record.captured
+    expected_verification = PackageShapeVerification(
+        core_distribution=captured.core_provider.name,
+        core_version=captured.core_provider.version,
+        absent_core_distributions=tuple(
+            sorted(CORE_DISTRIBUTION_NAMES - {captured.core_provider.name})
+        ),
+        memory_provider_cardinality=len(captured.memory_providers),
+        memory_version=(
+            captured.memory_providers[0].version
+            if captured.memory_providers
+            else None
+        ),
+        residual_memory=captured.residual_memory,
+    )
+    if record.verification != expected_verification:
+        raise PackageShapeRecordError("resolved rollback verification is inconsistent")
+
+
+def encode_resolved_rollback_plan_record(
+    plan: ResolvedRollbackPlan | ResolvedRollbackPlanRecord,
+) -> dict[str, object]:
+    """Encode a plan as data that cannot itself authorize execution."""
+
+    record = _plan_to_record(plan)
+    _validate_plan_record(record)
+    return {
+        "schema_version": PACKAGE_SHAPE_RECORD_SCHEMA_VERSION,
+        "record_type": "resolved_rollback_plan",
+        "plan": {
+            "captured": encode_captured_package_shape_record(record.captured),
+            "requirements": [
+                {
+                    "distribution": item.distribution,
+                    "version": item.version,
+                }
+                for item in record.requirements
+            ],
+            "artifacts": [
+                {
+                    "distribution": item.distribution,
+                    "version": item.version,
+                    "path": item.path,
+                    "sha256": item.sha256,
+                    "requires_dist": list(item.requires_dist),
+                }
+                for item in record.artifacts
+            ],
+            "staging_dir": record.staging_dir,
+            "uninstall_distributions": list(record.uninstall_distributions),
+            "verification": {
+                "core_distribution": record.verification.core_distribution,
+                "core_version": record.verification.core_version,
+                "absent_core_distributions": list(
+                    record.verification.absent_core_distributions
+                ),
+                "memory_provider_cardinality": (
+                    record.verification.memory_provider_cardinality
+                ),
+                "memory_version": record.verification.memory_version,
+                "residual_memory": record.verification.residual_memory,
+            },
+        },
+    }
+
+
+def decode_resolved_rollback_plan_record(value: object) -> ResolvedRollbackPlanRecord:
+    """Decode plan data without constructing an executable rollback plan."""
+
+    envelope = _record_object(
+        value,
+        frozenset({"schema_version", "record_type", "plan"}),
+        field="resolved rollback record",
+    )
+    _record_schema(envelope)
+    if envelope["record_type"] != "resolved_rollback_plan":
+        raise PackageShapeRecordError("resolved rollback record type is unsupported")
+    plan = _record_object(
+        envelope["plan"],
+        frozenset(
+            {
+                "captured",
+                "requirements",
+                "artifacts",
+                "staging_dir",
+                "uninstall_distributions",
+                "verification",
+            }
+        ),
+        field="resolved rollback plan",
+    )
+    record = ResolvedRollbackPlanRecord(
+        captured=decode_captured_package_shape_record(plan["captured"]),
+        requirements=tuple(
+            _decode_requirement(item)
+            for item in _record_list(
+                plan["requirements"],
+                field="rollback requirements",
+            )
+        ),
+        artifacts=tuple(
+            _decode_artifact(item)
+            for item in _record_list(plan["artifacts"], field="staged artifacts")
+        ),
+        staging_dir=_record_string(
+            plan["staging_dir"],
+            field="staging directory",
+        ),
+        uninstall_distributions=tuple(
+            _record_distribution(item, field="uninstall distribution")
+            for item in _record_list(
+                plan["uninstall_distributions"],
+                field="uninstall distributions",
+            )
+        ),
+        verification=_decode_verification(plan["verification"]),
+    )
+    _validate_plan_record(record)
+    return record
 
 
 def _parsed_memory_requirements(provider: DistributionProvider) -> tuple[Requirement, ...]:
@@ -673,17 +1205,27 @@ def resolve_rollback_plan(
 
 __all__ = [
     "CapturedPackageShape",
+    "CapturedPackageShapeRecord",
     "DistributionProvider",
+    "DistributionProviderRecord",
     "DuplicateDistributionProviderError",
     "ExactRequirement",
+    "PACKAGE_SHAPE_RECORD_SCHEMA_VERSION",
     "PackageShapeError",
+    "PackageShapeRecordError",
     "PackageShapeVerification",
     "ReleaseFamily",
     "ResolvedRollbackPlan",
+    "ResolvedRollbackPlanRecord",
     "RollbackResolutionError",
     "StagedArtifact",
+    "StagedArtifactRecord",
     "capture_installed_package_shape",
     "capture_package_shape",
+    "decode_captured_package_shape_record",
+    "decode_resolved_rollback_plan_record",
+    "encode_captured_package_shape_record",
+    "encode_resolved_rollback_plan_record",
     "inspect_installed_distribution_providers",
     "resolve_rollback_plan",
 ]

--- a/vibe/package_shape.py
+++ b/vibe/package_shape.py
@@ -1,4 +1,9 @@
-"""Exact package capture, persisted recovery DTOs, and rollback resolution."""
+"""Exact package capture, persisted recovery DTOs, and rollback resolution.
+
+Plan-record dependency-closure semantics belong to the immediate successor
+slice (b). Until that slice merges, consumers must not consume persisted plan
+records for G3-1B outer records or G3-2 rehydration.
+"""
 
 from __future__ import annotations
 

--- a/vibe/package_shape.py
+++ b/vibe/package_shape.py
@@ -3,6 +3,10 @@
 Plan-record dependency-closure semantics belong to the immediate successor
 slice (b). Until that slice merges, consumers must not consume persisted plan
 records for G3-1B outer records or G3-2 rehydration.
+
+Strictness belongs to our package facts; tolerance belongs only to unrelated
+environmental presence. Live inventory screens relevance tolerantly, then
+validates relevant facts strictly. Persisted record decode is always strict.
 """
 
 from __future__ import annotations
@@ -907,14 +911,15 @@ def inspect_installed_distribution_providers(
     try:
         for distribution in distributions:
             name = distribution.metadata["Name"]
-            if not isinstance(name, str) or not name.strip():
-                raise PackageShapeError("installed distribution name is unreadable")
+            if not isinstance(name, str) or canonicalize_name(name.strip()) not in (
+                *CORE_DISTRIBUTION_NAMES,
+                MEMORY_PACKAGE_NAME,
+            ):
+                continue
             canonical_name = _canonical_distribution_name(
                 name,
                 field="installed distribution",
             )
-            if canonical_name not in CORE_DISTRIBUTION_NAMES and canonical_name != MEMORY_PACKAGE_NAME:
-                continue
             providers.append(
                 DistributionProvider(
                     name=canonical_name,

--- a/vibe/package_shape.py
+++ b/vibe/package_shape.py
@@ -86,14 +86,40 @@ def _normalized_version(value: object, *, field: str) -> str:
         raise PackageShapeError(f"{field} is not a valid package version") from exc
 
 
-def _normalized_provider_id(value: object) -> str:
+def _opaque_provider_id(value: object) -> str:
     try:
         provider_id = os.fsdecode(os.fspath(value)).strip()
     except TypeError as exc:
         raise PackageShapeError("distribution provider identity is missing") from exc
-    if not provider_id:
+    if not provider_id or "\0" in provider_id:
         raise PackageShapeError("distribution provider identity is missing")
+    return provider_id
+
+
+def _normalized_observed_provider_id(value: object) -> str:
+    provider_id = _opaque_provider_id(value)
     return os.path.normcase(os.path.realpath(os.path.abspath(provider_id)))
+
+
+def _immutable_requirements(value: object, *, field: str) -> tuple[str, ...]:
+    try:
+        requirements = tuple(value)  # type: ignore[arg-type]
+    except TypeError as exc:
+        raise PackageShapeError(f"{field} are invalid") from exc
+    if any(type(requirement) is not str or not requirement for requirement in requirements):
+        raise PackageShapeError(f"{field} are invalid")
+    return requirements
+
+
+def _canonical_artifact_path(value: object) -> Path:
+    try:
+        raw = os.fsdecode(os.fspath(value))
+    except TypeError as exc:
+        raise PackageShapeError("staged artifact path is invalid") from exc
+    path = Path(raw)
+    if not path.is_absolute() or os.path.normpath(raw) != raw:
+        raise PackageShapeError("staged artifact path is not canonical and absolute")
+    return path
 
 
 @dataclass(frozen=True, order=True)
@@ -116,8 +142,15 @@ class DistributionProvider:
             "version",
             _normalized_version(self.version, field=f"{canonical_name} version"),
         )
-        object.__setattr__(self, "provider_id", _normalized_provider_id(self.provider_id))
-        object.__setattr__(self, "requires_dist", tuple(self.requires_dist))
+        object.__setattr__(self, "provider_id", _opaque_provider_id(self.provider_id))
+        object.__setattr__(
+            self,
+            "requires_dist",
+            _immutable_requirements(
+                self.requires_dist,
+                field="distribution provider requirements",
+            ),
+        )
 
 
 @dataclass(frozen=True)
@@ -211,6 +244,44 @@ class StagedArtifact:
     sha256: str
     requires_dist: tuple[str, ...]
 
+    def __post_init__(self) -> None:
+        distribution = _canonical_distribution_name(
+            self.distribution,
+            field="staged artifact distribution",
+        )
+        version = _normalized_version(
+            self.version,
+            field=f"{distribution} staged artifact version",
+        )
+        path = _canonical_artifact_path(self.path)
+        try:
+            filename_name, filename_version, _, _ = parse_wheel_filename(path.name)
+        except InvalidWheelFilename as exc:
+            raise PackageShapeError("staged artifact path does not name a canonical wheel") from exc
+        filename_distribution = _canonical_distribution_name(
+            str(filename_name),
+            field="wheel filename distribution",
+        )
+        if distribution != filename_distribution or version != str(filename_version):
+            raise PackageShapeError("staged wheel filename and recorded identity disagree")
+        if (
+            type(self.sha256) is not str
+            or len(self.sha256) != 64
+            or any(character not in "0123456789abcdef" for character in self.sha256)
+        ):
+            raise PackageShapeError("artifact SHA-256 is not canonical")
+        object.__setattr__(self, "distribution", distribution)
+        object.__setattr__(self, "version", version)
+        object.__setattr__(self, "path", path)
+        object.__setattr__(
+            self,
+            "requires_dist",
+            _immutable_requirements(
+                self.requires_dist,
+                field="staged artifact requirements",
+            ),
+        )
+
 
 @dataclass(frozen=True)
 class PackageShapeVerification:
@@ -237,30 +308,13 @@ class ResolvedRollbackPlan:
         raise TypeError("ResolvedRollbackPlan is constructed only by rollback resolution")
 
 
-@dataclass(frozen=True, order=True)
-class DistributionProviderRecord:
-    """Filesystem-independent evidence for one captured provider."""
-
-    name: str
-    version: str
-    provider_id: str
-    requires_dist: tuple[str, ...]
-
-    def __post_init__(self) -> None:
-        _validate_record_fields(self)
-        _require_record_distribution(self.name, field="distribution provider")
-        _require_record_version(self.version, field=f"{self.name} version")
-        if self.provider_id != _normalized_provider_id(self.provider_id):
-            raise PackageShapeRecordError("distribution provider identity is not canonical")
-
-
 @dataclass(frozen=True)
 class _ProviderInventoryRecord:
-    providers: tuple[DistributionProviderRecord, ...]
+    providers: tuple[DistributionProvider, ...]
 
     def __post_init__(self) -> None:
         _validate_record_fields(self)
-        by_identity: dict[str, DistributionProviderRecord] = {}
+        by_identity: dict[str, DistributionProvider] = {}
         for provider in self.providers:
             existing = by_identity.get(provider.provider_id)
             if existing is not None and existing != provider:
@@ -281,10 +335,10 @@ class _ServiceLauncherRecord:
 class CapturedPackageShapeRecord:
     """Non-executable persisted form of a captured package shape."""
 
-    core_provider: DistributionProviderRecord
+    core_provider: DistributionProvider
     launcher: _ServiceLauncherRecord
     release_family: ReleaseFamily
-    memory_providers: tuple[DistributionProviderRecord, ...]
+    memory_providers: tuple[DistributionProvider, ...]
     transition_memory_version: str | None
     residual_memory: bool
 
@@ -337,31 +391,13 @@ class CapturedPackageShapeRecord:
         return len(self.memory_providers)
 
 
-@dataclass(frozen=True, order=True)
-class StagedArtifactRecord:
-    """Recorded artifact identity; existence and hashes require live revalidation."""
-
-    distribution: str
-    version: str
-    path: str
-    sha256: str
-    requires_dist: tuple[str, ...]
-
-    def __post_init__(self) -> None:
-        _validate_record_fields(self)
-        _require_record_distribution(self.distribution, field="artifact distribution")
-        _require_record_version(self.version, field=f"{self.distribution} version")
-        if len(self.sha256) != 64 or any(character not in "0123456789abcdef" for character in self.sha256):
-            raise PackageShapeRecordError("artifact SHA-256 is not canonical")
-
-
 @dataclass(frozen=True)
 class ResolvedRollbackPlanRecord:
     """Non-executable persisted form of a resolved rollback plan."""
 
     captured: CapturedPackageShapeRecord
     requirements: tuple[ExactRequirement, ...]
-    artifacts: tuple[StagedArtifactRecord, ...]
+    artifacts: tuple[StagedArtifact, ...]
     staging_dir: str
     uninstall_distributions: tuple[str, ...]
     verification: PackageShapeVerification
@@ -382,21 +418,18 @@ class ResolvedRollbackPlanRecord:
         if self.requirements != expected_requirements:
             raise PackageShapeRecordError("resolved requirements do not match the captured rollback target")
 
-        by_distribution: dict[str, StagedArtifactRecord] = {}
-        artifact_paths: set[str] = set()
+        by_distribution: dict[str, StagedArtifact] = {}
+        artifact_paths: set[Path] = set()
         for artifact in self.artifacts:
+            artifact_path = artifact.path
+            if artifact_path.parent != staging_dir:
+                raise PackageShapeRecordError("artifact path is not a direct child of the staging directory")
+            if artifact_path in artifact_paths:
+                raise PackageShapeRecordError("staging contains duplicate artifact paths")
+            artifact_paths.add(artifact_path)
             if artifact.distribution in by_distribution:
                 raise PackageShapeRecordError("staging contains duplicate distribution artifacts")
             by_distribution[artifact.distribution] = artifact
-            artifact_path = _require_record_absolute_path(
-                artifact.path,
-                field="artifact path",
-            )
-            if artifact_path.parent != staging_dir:
-                raise PackageShapeRecordError("artifact path is not a direct child of the staging directory")
-            if artifact.path in artifact_paths:
-                raise PackageShapeRecordError("staging contains duplicate artifact paths")
-            artifact_paths.add(artifact.path)
 
         core_artifacts = tuple(
             artifact for artifact in self.artifacts if artifact.distribution in CORE_DISTRIBUTION_NAMES
@@ -424,10 +457,10 @@ class ResolvedRollbackPlanRecord:
         staged_core = core_artifacts[0]
         try:
             staged_family, staged_transition = _release_family(
-                DistributionProviderRecord(
+                DistributionProvider(
                     name=staged_core.distribution,
                     version=staged_core.version,
-                    provider_id=staged_core.path,
+                    provider_id=str(staged_core.path),
                     requires_dist=staged_core.requires_dist,
                 )
             )
@@ -445,12 +478,12 @@ class ResolvedRollbackPlanRecord:
 
 
 _RECORD_DTO_TYPES = (
-    DistributionProviderRecord,
+    DistributionProvider,
     _ProviderInventoryRecord,
     _ServiceLauncherRecord,
     CapturedPackageShapeRecord,
     ExactRequirement,
-    StagedArtifactRecord,
+    StagedArtifact,
     PackageShapeVerification,
     ResolvedRollbackPlanRecord,
 )
@@ -494,6 +527,10 @@ def _validate_declared_record_value(
         if type(value) is not annotation:
             raise PackageShapeRecordError(f"{field} has an invalid enum value")
         return
+    if annotation is Path:
+        if not isinstance(value, Path):
+            raise PackageShapeRecordError(f"{field} has an invalid path type")
+        return
     if type(value) is not annotation:
         raise PackageShapeRecordError(f"{field} has an invalid primitive type")
     if annotation is str and not value:
@@ -521,15 +558,6 @@ def _require_record_version(value: str, *, field: str) -> None:
         raise PackageShapeRecordError(f"{field} is not canonical")
 
 
-def _require_record_distribution(value: str, *, field: str) -> None:
-    _canonical_distribution_name(
-        value,
-        field=field,
-        error_type=PackageShapeRecordError,
-        require_canonical=True,
-    )
-
-
 def _require_record_absolute_path(value: str, *, field: str) -> Path:
     path = Path(value)
     if not path.is_absolute() or os.path.normpath(value) != value:
@@ -553,6 +581,8 @@ def _encode_declared_record_value(value: object, annotation: object) -> object:
         return _encode_record_dto(value)
     if isinstance(annotation, type) and issubclass(annotation, Enum):
         return value.value
+    if annotation is Path:
+        return str(value)
     return value
 
 
@@ -600,6 +630,10 @@ def _decode_declared_record_value(
             return annotation(value)
         except ValueError as exc:
             raise PackageShapeRecordError(f"{field} has an invalid enum value") from exc
+    if annotation is Path:
+        if type(value) is not str or not value:
+            raise PackageShapeRecordError(f"{field} has an invalid path value")
+        return Path(value)
     if type(value) is not annotation:
         raise PackageShapeRecordError(f"{field} has an invalid primitive type")
     if annotation is str and not value:
@@ -664,15 +698,6 @@ def _decode_record(value: object, record_type: str) -> object:
     return _decode_record_dto(value[payload_name], dto_type, field=payload_name)
 
 
-def _provider_to_record(provider: DistributionProvider) -> DistributionProviderRecord:
-    return DistributionProviderRecord(
-        name=provider.name,
-        version=provider.version,
-        provider_id=provider.provider_id,
-        requires_dist=provider.requires_dist,
-    )
-
-
 def _captured_to_record(
     captured: CapturedPackageShape | CapturedPackageShapeRecord,
 ) -> CapturedPackageShapeRecord:
@@ -681,13 +706,13 @@ def _captured_to_record(
     if not isinstance(captured, CapturedPackageShape):
         raise PackageShapeRecordError("captured package shape has an unsupported type")
     return CapturedPackageShapeRecord(
-        core_provider=_provider_to_record(captured.core_provider),
+        core_provider=captured.core_provider,
         launcher=_ServiceLauncherRecord(
             python=captured.launcher.python,
             main=captured.launcher.main,
         ),
         release_family=captured.release_family,
-        memory_providers=tuple(_provider_to_record(item) for item in captured.memory_providers),
+        memory_providers=captured.memory_providers,
         transition_memory_version=captured.transition_memory_version,
         residual_memory=captured.residual_memory,
     )
@@ -719,16 +744,7 @@ def _plan_to_record(
     return ResolvedRollbackPlanRecord(
         captured=_captured_to_record(plan.captured),
         requirements=plan.requirements,
-        artifacts=tuple(
-            StagedArtifactRecord(
-                distribution=item.distribution,
-                version=item.version,
-                path=str(item.path),
-                sha256=item.sha256,
-                requires_dist=item.requires_dist,
-            )
-            for item in plan.artifacts
-        ),
+        artifacts=plan.artifacts,
         staging_dir=str(plan.staging_dir),
         uninstall_distributions=plan.uninstall_distributions,
         verification=plan.verification,
@@ -752,7 +768,7 @@ def decode_resolved_rollback_plan_record(value: object) -> ResolvedRollbackPlanR
 
 
 def _parsed_memory_requirements(
-    provider: DistributionProvider | DistributionProviderRecord,
+    provider: DistributionProvider,
 ) -> tuple[Requirement, ...]:
     parsed: list[Requirement] = []
     for value in provider.requires_dist:
@@ -772,7 +788,7 @@ def _parsed_memory_requirements(
 
 
 def _release_family(
-    provider: DistributionProvider | DistributionProviderRecord,
+    provider: DistributionProvider,
 ) -> tuple[ReleaseFamily, str | None]:
     memory_requirements = _parsed_memory_requirements(provider)
     hard: list[Requirement] = []
@@ -823,7 +839,7 @@ def capture_package_shape(
         if provider.name in CORE_DISTRIBUTION_NAMES or provider.name == MEMORY_PACKAGE_NAME
     )
     try:
-        _ProviderInventoryRecord(providers=tuple(_provider_to_record(provider) for provider in observed))
+        _ProviderInventoryRecord(providers=observed)
     except PackageShapeRecordError as exc:
         raise PackageShapeError(str(exc)) from exc
     relevant = tuple({provider.provider_id: provider for provider in observed}.values())
@@ -898,7 +914,7 @@ def inspect_installed_distribution_providers(
                 DistributionProvider(
                     name=canonical_name,
                     version=distribution.version,
-                    provider_id=_distribution_provider_id(distribution),
+                    provider_id=_normalized_observed_provider_id(_distribution_provider_id(distribution)),
                     requires_dist=tuple(distribution.requires or ()),
                 )
             )
@@ -945,10 +961,6 @@ def _rollback_requirements(
 
 def _wheel_provider(path: Path) -> DistributionProvider:
     try:
-        filename_name, filename_version, _, _ = parse_wheel_filename(path.name)
-    except InvalidWheelFilename as exc:
-        raise RollbackResolutionError("staging contains a non-wheel package artifact") from exc
-    try:
         with zipfile.ZipFile(path) as archive:
             metadata_names = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
             if len(metadata_names) != 1:
@@ -960,16 +972,9 @@ def _wheel_provider(path: Path) -> DistributionProvider:
     provider = DistributionProvider(
         name=metadata.get("Name"),
         version=metadata.get("Version"),
-        provider_id=str(path),
+        provider_id=_normalized_observed_provider_id(path),
         requires_dist=tuple(metadata.get_all("Requires-Dist", [])),
     )
-    filename_distribution = _canonical_distribution_name(
-        str(filename_name),
-        field="wheel filename distribution",
-        error_type=RollbackResolutionError,
-    )
-    if provider.name != filename_distribution or provider.version != str(filename_version):
-        raise RollbackResolutionError("staged wheel filename and metadata disagree")
     return provider
 
 
@@ -979,15 +984,18 @@ def _staged_artifacts(staging_dir: Path) -> tuple[StagedArtifact, ...]:
         if not path.is_file():
             raise RollbackResolutionError("staging contains a non-artifact entry")
         provider = _wheel_provider(path)
-        artifacts.append(
-            StagedArtifact(
-                distribution=provider.name,
-                version=provider.version,
-                path=path,
-                sha256=hashlib.sha256(path.read_bytes()).hexdigest(),
-                requires_dist=provider.requires_dist,
+        try:
+            artifacts.append(
+                StagedArtifact(
+                    distribution=provider.name,
+                    version=provider.version,
+                    path=path,
+                    sha256=hashlib.sha256(path.read_bytes()).hexdigest(),
+                    requires_dist=provider.requires_dist,
+                )
             )
-        )
+        except PackageShapeError as exc:
+            raise RollbackResolutionError(str(exc)) from exc
     if not artifacts:
         raise RollbackResolutionError("rollback resolution produced no staged artifacts")
     return tuple(artifacts)
@@ -1148,7 +1156,6 @@ __all__ = [
     "CapturedPackageShape",
     "CapturedPackageShapeRecord",
     "DistributionProvider",
-    "DistributionProviderRecord",
     "DuplicateDistributionProviderError",
     "ExactRequirement",
     "PACKAGE_SHAPE_RECORD_SCHEMA_VERSION",
@@ -1160,7 +1167,6 @@ __all__ = [
     "ResolvedRollbackPlanRecord",
     "RollbackResolutionError",
     "StagedArtifact",
-    "StagedArtifactRecord",
     "capture_installed_package_shape",
     "capture_package_shape",
     "decode_captured_package_shape_record",

--- a/vibe/package_shape.py
+++ b/vibe/package_shape.py
@@ -7,13 +7,19 @@ records for G3-1B outer records or G3-2 rehydration.
 Strictness belongs to our package facts; tolerance belongs only to unrelated
 environmental presence. Live inventory screens relevance tolerantly, then
 validates relevant facts strictly. Persisted record decode is always strict.
+
+Every persisted executable or module path is owned by one pure lexical
+validator shared by live construction and decode. Ordinary text fields do not
+inherit path constraints.
 """
 
 from __future__ import annotations
 
 import email.parser
 import hashlib
+import ntpath
 import os
+import posixpath
 import shutil
 import subprocess
 import sys
@@ -338,6 +344,8 @@ class _ServiceLauncherRecord:
 
     def __post_init__(self) -> None:
         _validate_record_fields(self)
+        _require_launcher_path(self.python, field="launcher python", kind="executable")
+        _require_launcher_path(self.main, field="launcher main", kind="module")
 
 
 @dataclass(frozen=True)
@@ -572,6 +580,17 @@ def _require_record_absolute_path(value: str, *, field: str) -> Path:
     if not path.is_absolute() or os.path.normpath(value) != value:
         raise PackageShapeRecordError(f"{field} is not a canonical absolute path")
     return path
+
+
+def _require_launcher_path(value: str, *, field: str, kind: str) -> None:
+    if "\0" in value:
+        raise PackageShapeRecordError(f"{field} is not a usable {kind} path")
+    path_module = posixpath if posixpath.isabs(value) else ntpath
+    if not path_module.isabs(value) or path_module.normpath(value) != value:
+        raise PackageShapeRecordError(f"{field} is not a canonical absolute {kind} path")
+    basename = path_module.basename(value)
+    if not basename or (kind == "module" and not basename.lower().endswith(".py")):
+        raise PackageShapeRecordError(f"{field} is not a usable {kind} path")
 
 
 def _encode_declared_record_value(value: object, annotation: object) -> object:

--- a/vibe/package_shape.py
+++ b/vibe/package_shape.py
@@ -420,24 +420,32 @@ def encode_captured_package_shape_record(
     """Encode captured evidence into a versioned JSON-safe object."""
 
     record = _captured_to_record(captured)
-    _validate_captured_record(record)
-    return {
-        "schema_version": PACKAGE_SHAPE_RECORD_SCHEMA_VERSION,
-        "record_type": "captured_package_shape",
-        "shape": {
-            "core_provider": _encode_provider(record.core_provider),
-            "launcher": {
-                "python": record.launcher.python,
-                "main": record.launcher.main,
+    try:
+        _validate_captured_record(record)
+        payload: dict[str, object] = {
+            "schema_version": PACKAGE_SHAPE_RECORD_SCHEMA_VERSION,
+            "record_type": "captured_package_shape",
+            "shape": {
+                "core_provider": _encode_provider(record.core_provider),
+                "launcher": {
+                    "python": record.launcher.python,
+                    "main": record.launcher.main,
+                },
+                "release_family": record.release_family.value,
+                "memory_providers": [
+                    _encode_provider(provider) for provider in record.memory_providers
+                ],
+                "transition_memory_version": record.transition_memory_version,
+                "residual_memory": record.residual_memory,
             },
-            "release_family": record.release_family.value,
-            "memory_providers": [
-                _encode_provider(provider) for provider in record.memory_providers
-            ],
-            "transition_memory_version": record.transition_memory_version,
-            "residual_memory": record.residual_memory,
-        },
-    }
+        }
+    except PackageShapeRecordError:
+        raise
+    except (AttributeError, TypeError) as exc:
+        raise PackageShapeRecordError("captured record DTO is invalid") from exc
+    if decode_captured_package_shape_record(payload) != record:
+        raise PackageShapeRecordError("captured record DTO is not canonical")
+    return payload
 
 
 def decode_captured_package_shape_record(value: object) -> CapturedPackageShapeRecord:
@@ -622,21 +630,71 @@ def _validate_plan_record(record: ResolvedRollbackPlanRecord) -> None:
     _validate_captured_record(record.captured)
     if not record.requirements or not record.artifacts:
         raise PackageShapeRecordError("resolved rollback record has an empty closure")
-    requirement_keys = {
-        (item.distribution, item.version) for item in record.requirements
-    }
-    artifact_keys = {(item.distribution, item.version) for item in record.artifacts}
-    if (
-        len(requirement_keys) != len(record.requirements)
-        or not requirement_keys <= artifact_keys
+    captured = record.captured
+    if captured.release_family is ReleaseFamily.TRANSITION and (
+        not captured.memory_providers
+        or captured.memory_providers[0].version != captured.transition_memory_version
     ):
-        raise PackageShapeRecordError("resolved rollback record has an inconsistent closure")
+        raise PackageShapeRecordError(
+            "resolved transition record does not contain its exact Memory target"
+        )
+    expected_requirements = [
+        ExactRequirement(captured.core_provider.name, captured.core_provider.version)
+    ]
+    if captured.memory_providers:
+        memory_provider = captured.memory_providers[0]
+        expected_requirements.append(
+            ExactRequirement(memory_provider.name, memory_provider.version)
+        )
+    if record.requirements != tuple(expected_requirements):
+        raise PackageShapeRecordError(
+            "resolved requirements do not match the captured rollback target"
+        )
+
+    by_distribution: dict[str, list[StagedArtifactRecord]] = {}
+    for artifact in record.artifacts:
+        by_distribution.setdefault(artifact.distribution, []).append(artifact)
+    if any(len(artifacts) != 1 for artifacts in by_distribution.values()):
+        raise PackageShapeRecordError(
+            "resolved staging contains a duplicate distribution"
+        )
+    core_artifacts = tuple(
+        artifact
+        for artifact in record.artifacts
+        if artifact.distribution in CORE_DISTRIBUTION_NAMES
+    )
+    if len(core_artifacts) != 1 or (
+        core_artifacts[0].distribution,
+        core_artifacts[0].version,
+    ) != (captured.core_provider.name, captured.core_provider.version):
+        raise PackageShapeRecordError(
+            "resolved staging does not match the captured core target"
+        )
+    memory_artifacts = tuple(
+        artifact
+        for artifact in record.artifacts
+        if artifact.distribution == MEMORY_PACKAGE_NAME
+    )
+    staged_memory_version = (
+        memory_artifacts[0].version if len(memory_artifacts) == 1 else None
+    )
+    captured_memory_version = (
+        captured.memory_providers[0].version
+        if captured.memory_providers
+        else None
+    )
+    if (
+        len(memory_artifacts) != len(captured.memory_providers)
+        or staged_memory_version != captured_memory_version
+    ):
+        raise PackageShapeRecordError(
+            "resolved staging does not match the captured Memory target"
+        )
     expected_uninstalls = tuple(
         sorted((*CORE_DISTRIBUTION_NAMES, MEMORY_PACKAGE_NAME))
     )
     if record.uninstall_distributions != expected_uninstalls:
         raise PackageShapeRecordError("resolved rollback record has an unknown uninstall set")
-    captured = record.captured
     expected_verification = PackageShapeVerification(
         core_distribution=captured.core_provider.name,
         core_version=captured.core_provider.version,
@@ -661,45 +719,53 @@ def encode_resolved_rollback_plan_record(
     """Encode a plan as data that cannot itself authorize execution."""
 
     record = _plan_to_record(plan)
-    _validate_plan_record(record)
-    return {
-        "schema_version": PACKAGE_SHAPE_RECORD_SCHEMA_VERSION,
-        "record_type": "resolved_rollback_plan",
-        "plan": {
-            "captured": encode_captured_package_shape_record(record.captured),
-            "requirements": [
-                {
-                    "distribution": item.distribution,
-                    "version": item.version,
-                }
-                for item in record.requirements
-            ],
-            "artifacts": [
-                {
-                    "distribution": item.distribution,
-                    "version": item.version,
-                    "path": item.path,
-                    "sha256": item.sha256,
-                    "requires_dist": list(item.requires_dist),
-                }
-                for item in record.artifacts
-            ],
-            "staging_dir": record.staging_dir,
-            "uninstall_distributions": list(record.uninstall_distributions),
-            "verification": {
-                "core_distribution": record.verification.core_distribution,
-                "core_version": record.verification.core_version,
-                "absent_core_distributions": list(
-                    record.verification.absent_core_distributions
-                ),
-                "memory_provider_cardinality": (
-                    record.verification.memory_provider_cardinality
-                ),
-                "memory_version": record.verification.memory_version,
-                "residual_memory": record.verification.residual_memory,
+    try:
+        _validate_plan_record(record)
+        payload: dict[str, object] = {
+            "schema_version": PACKAGE_SHAPE_RECORD_SCHEMA_VERSION,
+            "record_type": "resolved_rollback_plan",
+            "plan": {
+                "captured": encode_captured_package_shape_record(record.captured),
+                "requirements": [
+                    {
+                        "distribution": item.distribution,
+                        "version": item.version,
+                    }
+                    for item in record.requirements
+                ],
+                "artifacts": [
+                    {
+                        "distribution": item.distribution,
+                        "version": item.version,
+                        "path": item.path,
+                        "sha256": item.sha256,
+                        "requires_dist": list(item.requires_dist),
+                    }
+                    for item in record.artifacts
+                ],
+                "staging_dir": record.staging_dir,
+                "uninstall_distributions": list(record.uninstall_distributions),
+                "verification": {
+                    "core_distribution": record.verification.core_distribution,
+                    "core_version": record.verification.core_version,
+                    "absent_core_distributions": list(
+                        record.verification.absent_core_distributions
+                    ),
+                    "memory_provider_cardinality": (
+                        record.verification.memory_provider_cardinality
+                    ),
+                    "memory_version": record.verification.memory_version,
+                    "residual_memory": record.verification.residual_memory,
+                },
             },
-        },
-    }
+        }
+    except PackageShapeRecordError:
+        raise
+    except (AttributeError, TypeError) as exc:
+        raise PackageShapeRecordError("resolved record DTO is invalid") from exc
+    if decode_resolved_rollback_plan_record(payload) != record:
+        raise PackageShapeRecordError("resolved record DTO is not canonical")
+    return payload
 
 
 def decode_resolved_rollback_plan_record(value: object) -> ResolvedRollbackPlanRecord:


### PR DESCRIPTION
## Capability

Freezes slice (a) of the Gate2b-owned persisted package-shape boundary required by G3-1B: shared immutable pure-fact DTOs plus versioned, JSON-safe, strict fail-closed codecs for captured package evidence and resolved rollback data.

## Root cause and split

The hard G3-1B estimate was about 1,335 net lines (about 1,005 lifecycle record/state/admission plus about 330 codec/DTO), above the 1,000-line circuit breaker. Per PM binding, this independent Gate2b follow-up lands the shared fact/schema codec surface first rather than compressing lifecycle scope.

Plan-record dependency-closure semantics are explicitly excluded from slice (a) and owned by the immediate successor slice (b). Slice (a) contains no marker-blind or unmarked-only dependency validation, resolver-environment schema, artifact-role schema, or dependency graph.

## Invariants

- `vibe.package_shape` exclusively owns persisted captured/resolved DTO semantics and codec versions.
- Existing `DistributionProvider` and `StagedArtifact` are the sole shared pure fact types used by live observation and persisted decode; no record-only provider/artifact twins or parallel validation paths exist.
- Every current `CapturedPackageShape` and `ResolvedRollbackPlan` factual field is preserved in an exact-key JSON-safe envelope.
- Unknown older/newer schema versions, unknown/missing fields, wrong JSON types, noncanonical versions/names/hashes, and in-scope factual cross-field inconsistencies fail closed.
- Decoding returns immutable record DTOs and never reconstructs `ResolvedRollbackPlan`.
- Decoding is filesystem-independent: live observation normalizes provider paths before fact construction, while persisted provider identity remains opaque and deterministic offline.
- Live inventory tolerantly screens environmental rows for relevance, then strictly validates every core/Memory fact; unrelated malformed names never enter the codec.
- Persisted path ownership is explicit: launcher.python and launcher.main use _require_launcher_path; DistributionProvider.provider_id uses _opaque_provider_id; StagedArtifact.path uses _canonical_artifact_path; ResolvedRollbackPlanRecord.staging_dir uses _require_record_absolute_path. Ordinary text fields do not inherit path constraints.
- Staged wheel filenames are lexically bound to their recorded distribution and version by the shared `StagedArtifact` constructor.
- Disk bytes alone never authorize a live rollback plan.

## Scope

- `vibe/package_shape.py`: shared fact DTOs and record encode/decode surface.
- `tests/test_package_shape_record_codec.py`: focused codec contract evidence.
- No lifecycle record, admission, nonce, state machine, recovery execution, reservation changes, API/controller/UI/restart/catalog, or product entrypoints.
- No plan-record dependency-closure semantics; those belong exclusively to immediate successor slice (b).
- Scenario contract: extends MEMORY-INDEP-019 package-shape ownership and unblocks later MEMORY-INDEP-020 Gate 3 evidence; no scenario catalog edit.

## Evidence

- `pytest -q tests/test_package_shape_record_codec.py tests/scenarios/memory_independence/test_memory_rollback_types.py` (79 passed)
- `ruff check vibe/package_shape.py tests/test_package_shape_record_codec.py`
- `ruff format --check vibe/package_shape.py tests/test_package_shape_record_codec.py`
- `python -m py_compile vibe/package_shape.py tests/test_package_shape_record_codec.py`
- `git diff --check`

## Known by design / blocking handoff

- **Hard consumer gate:** until immediate successor slice (b) merges, no consumer may consume persisted plan records. G3-1B outer-record work and G3-2 rehydration are both blocked from consuming `ResolvedRollbackPlanRecord`.
- Successor slice (b) owns the strict versioned resolver-environment snapshot, required artifact roles, persisted-marker-only active dependency closure, orphan/duplicate/conflict rejection, residual-preserve exception, and captured core/Memory top-pin binding.
- G3-2 later compares the persisted resolver environment with current reality and revalidates staging/artifact existence, hashes, and constraints before any owner-private live rehydration.
- G3-1B lifecycle outer schema/current+terminal audit/admission/state/projection remains unimplemented.
- The five downstream obligations tracked in #1760 remain assigned to G3-2/G3-3.
- Product entrypoints remain uncollected until G3-3.

Base commit: `9c946042aee5e75b327859a3f5ff143b7bd731bc`.
Diff size after slice (a) launcher fix: 1,155 additions, 173 deletions (982 net lines).

