### PR TITLE
feat(memory): add static release identity verifier

### DIFF
--- a/docs/plans/memory-wave3c-release-migration-contract.md
+++ b/docs/plans/memory-wave3c-release-migration-contract.md
@@ -217,14 +217,12 @@ defective, never merely because core publication failed. Recovery does not
 publish another Memory version, create a second finalizer, or mint a replacement
 release identity.
 
-The release guard scans both wheels and sdists plus the staged/public asset set.
-It proves that the core wheel and sdist contain no Memory implementation or
-EverOS manifest, while the Memory wheel and sdist contain the owned
-implementation, manifest, and complete matching content/metadata. Direct sdist
-inspection is necessary but not sufficient: before any public action, each
-staged sdist is built into a wheel in an isolated environment and that wheel must
-pass the exact ownership, dependency, content, and metadata assertions applied
-to the staged wheel. A rebuild failure prevents GitHub Release finalization. The
+The release guard verifies wheels plus the staged/public asset set. It does not
+open sdists or inspect their raw members, source namespaces, or source content.
+The executable sdist contract is an isolated build, equivalence between each
+rebuilt wheel and its staged wheel, and the rebuilt wheel passing every
+wheel-level identity, dependency, content, and metadata check. Successor B owns
+the rebuild mechanism. A rebuild failure prevents GitHub Release finalization. The
 guard also proves resolver compatibility at the staged and public gates,
 same-finalizer continuation from exact GitHub/Memory checkpoints, and the
 stranded-Memory keep/yank policy.

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Verify and materialize manifest-pinned Memory Runtime release assets.
 
-Package policy schema v1 declares ``Requires-Python: >=3.10``. Changing that
-contract requires a policy schema/version change and a new declared literal.
+Package policy schema v1 declares ``Requires-Python: >=3.10`` and supported
+minors ``3.10``, ``3.11``, and ``3.12``. Changing either contract requires a
+policy schema/version change and an updated repository-owned declaration.
 """
 
 from __future__ import annotations
@@ -40,6 +41,7 @@ POLICY_EXCLUSION_EXIT = 2
 INTERNAL_GUARD_FAILURE_EXIT = 3
 PACKAGE_POLICY_SCHEMA_VERSION = 1
 PACKAGE_POLICY_REQUIRES_PYTHON = ">=3.10"
+PACKAGE_POLICY_SUPPORTED_PYTHON_VERSIONS = ("3.10", "3.11", "3.12")
 SUPPORTED_NAMESPACE_POLICY_VERSIONS = frozenset({1})
 
 
@@ -118,7 +120,6 @@ class PackageMetadata:
 class PackageReleasePolicy:
     requires_python: str
     supported_python_versions: tuple[str, ...]
-    wheel_tag: str
     namespace_policy_version: int
 
 
@@ -134,10 +135,10 @@ class RequirementClassification:
 
 def _packaging_modules():
     try:
-        from packaging import requirements, specifiers, tags, utils, version
+        from packaging import requirements, specifiers, utils, version
     except ModuleNotFoundError as exc:
         raise ReleaseAssetError("static release verification requires packaging") from exc
-    return requirements, specifiers, tags, utils, version
+    return requirements, specifiers, utils, version
 
 
 def _release_version(release_tag: str) -> str:
@@ -172,14 +173,13 @@ def load_package_release_policy(
         "release_family",
         "requires_python",
         "supported_python_versions",
-        "wheel_tag",
         "namespace_policy_version",
     }
     if type(raw) is not dict or set(raw) != keys:
         raise ManifestPolicyError("manifest package_policy schema is invalid")
     if type(raw["schema_version"]) is not int or raw["schema_version"] != PACKAGE_POLICY_SCHEMA_VERSION:
         raise ManifestPolicyError("manifest package_policy schema_version must be integer 1")
-    if any(type(raw[key]) is not str or not raw[key] for key in ("release_tag", "release_family", "requires_python", "wheel_tag")):
+    if any(type(raw[key]) is not str or not raw[key] for key in ("release_tag", "release_family", "requires_python")):
         raise ManifestPolicyError("manifest package_policy string fields are invalid")
     versions = raw["supported_python_versions"]
     namespace_version = raw["namespace_policy_version"]
@@ -187,29 +187,28 @@ def load_package_release_policy(
         type(versions) is not list
         or not versions
         or any(type(version) is not str or re.fullmatch(r"[0-9]+\.[0-9]+", version) is None for version in versions)
-        or len(versions) != len(set(versions))
         or type(namespace_version) is not int
         or namespace_version not in SUPPORTED_NAMESPACE_POLICY_VERSIONS
     ):
         raise ManifestPolicyError("manifest package_policy typed fields are invalid")
+    if tuple(versions) != PACKAGE_POLICY_SUPPORTED_PYTHON_VERSIONS:
+        raise ManifestPolicyError("manifest supported Python versions differ from schema 1 policy")
     release_parts = _release_version(release_tag).split(".")
     if raw["release_tag"] != release_tag or raw["release_family"] != ".".join(release_parts[:2]):
         raise ManifestPolicyError("manifest package_policy release identity is invalid")
-    if raw["wheel_tag"] != "py3-none-any":
-        raise ManifestPolicyError("manifest package_policy wheel_tag must be py3-none-any for schema 1")
-    _, specifiers, _, _, _ = _packaging_modules()
+    _, specifiers, _, _ = _packaging_modules()
     try:
         requires_python = str(specifiers.SpecifierSet(raw["requires_python"]))
     except specifiers.InvalidSpecifier as exc:
         raise ManifestPolicyError("manifest package_policy Python contract is invalid") from exc
     if requires_python != PACKAGE_POLICY_REQUIRES_PYTHON:
         raise ManifestPolicyError("manifest package_policy Requires-Python differs from schema 1 policy")
-    return PackageReleasePolicy(requires_python, tuple(versions), raw["wheel_tag"], namespace_version)
+    return PackageReleasePolicy(requires_python, tuple(versions), namespace_version)
 
 
 def classify_requirement(raw: str) -> RequirementClassification:
     """Classify one valid requirement without treating wildcard equality as exact."""
-    requirements, _, _, utils, versions = _packaging_modules()
+    requirements, _, utils, versions = _packaging_modules()
     try:
         requirement = requirements.Requirement(raw)
     except requirements.InvalidRequirement as exc:
@@ -237,10 +236,9 @@ def _verify_package_identity(
     *,
     expected_name: str,
     expected_version: str,
-    expected_wheel_tag: str,
 ) -> None:
     """Bind an A2-supplied metadata record to filename and declared policy."""
-    _, _, tags, utils, versions = _packaging_modules()
+    _, _, utils, versions = _packaging_modules()
     if (
         type(metadata) is not PackageMetadata
         or type(wheel_filename) is not str
@@ -252,10 +250,9 @@ def _verify_package_identity(
     ):
         raise ReleaseAssetError("transition package metadata types are invalid")
     try:
-        filename_name, filename_version, _, filename_tags = utils.parse_wheel_filename(wheel_filename)
+        filename_name, filename_version, _, _ = utils.parse_wheel_filename(wheel_filename)
         metadata_name = str(utils.canonicalize_name(metadata.name))
         metadata_version = str(versions.Version(metadata.version))
-        policy_tags = tags.parse_tag(expected_wheel_tag)
     except (TypeError, ValueError, utils.InvalidWheelFilename, versions.InvalidVersion) as exc:
         raise ReleaseAssetError(f"transition package identity is invalid: {wheel_filename!r}") from exc
     if metadata_name != str(filename_name) or metadata_version != str(filename_version):
@@ -264,12 +261,10 @@ def _verify_package_identity(
         raise ReleaseAssetError("transition wheel distribution identity is invalid")
     if metadata_version != expected_version:
         raise ReleaseAssetError("wheel metadata version does not match the release tag")
-    if filename_tags != policy_tags:
-        raise ReleaseAssetError(f"wheel tags differ from release policy: {wheel_filename}")
 
 
 def _requirements_for(metadata: PackageMetadata, name: str) -> tuple[RequirementClassification, ...]:
-    _, _, _, utils, _ = _packaging_modules()
+    _, _, utils, _ = _packaging_modules()
     expected = str(utils.canonicalize_name(name))
     classified = tuple(classify_requirement(raw) for raw in metadata.requires_dist)
     return tuple(item for item in classified if item.name == expected)
@@ -293,14 +288,12 @@ def verify_static_transition(
         core_metadata,
         expected_name="avibe-os",
         expected_version=expected_version,
-        expected_wheel_tag=policy.wheel_tag,
     )
     _verify_package_identity(
         memory_wheel_filename,
         memory_metadata,
         expected_name="avibe-memory",
         expected_version=expected_version,
-        expected_wheel_tag=policy.wheel_tag,
     )
     if core_metadata.requires_python != policy.requires_python or memory_metadata.requires_python != policy.requires_python:
         raise ReleaseAssetError(f"wheel Requires-Python must match release policy {policy.requires_python}")

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -38,6 +38,7 @@ POLICY_EXCLUSION_EXIT = 2
 INTERNAL_GUARD_FAILURE_EXIT = 3
 PACKAGE_POLICY_SCHEMA_VERSION = 1
 SUPPORTED_NAMESPACE_POLICY_VERSIONS = frozenset({1})
+WHEEL_DATA_SCHEMES = frozenset({"data", "headers", "platlib", "purelib", "scripts"})
 
 
 class ReleaseGuardError(RuntimeError):
@@ -225,7 +226,7 @@ def classify_requirement(raw: str) -> RequirementClassification:
     return RequirementClassification(str(utils.canonicalize_name(requirement.name)), str(requirement.specifier), exact_version, bool(requirement.extras), requirement.marker is not None, requirement.url is not None)
 
 
-def inspect_wheel(wheel: Path) -> PackageMetadata:
+def inspect_wheel(wheel: Path, *, supported_python_versions: tuple[str, ...] = ()) -> PackageMetadata:
     """Validate wheel controls and metadata without installing the wheel."""
     _, _, tags, utils, versions = _packaging_modules()
     try:
@@ -236,7 +237,7 @@ def inspect_wheel(wheel: Path) -> PackageMetadata:
         with zipfile.ZipFile(wheel) as archive:
             names = archive.namelist()
             canonical = [str(PurePosixPath(name)) + ("/" if name.endswith("/") else "") for name in names]
-            unsafe = any("\\" in name or PurePosixPath(name).is_absolute() or ".." in PurePosixPath(name).parts or name != clean for name, clean in zip(names, canonical))
+            unsafe = any("\\" in name or PurePosixPath(name).is_absolute() or ".." in PurePosixPath(name).parts or name != clean or ("/" in name and name.split("/", 1)[0].endswith(".data") and name.split("/", 2)[1] not in WHEEL_DATA_SCHEMES) for name, clean in zip(names, canonical))
             dist_infos = {name.split("/", 1)[0] for name in names if "/" in name and name.split("/", 1)[0].endswith(".dist-info")}
             if len(names) != len({name.rstrip("/").casefold() for name in canonical}) or unsafe or len(dist_infos) != 1:
                 raise ReleaseAssetError(f"wheel control structure is invalid: {wheel.name}")
@@ -268,6 +269,11 @@ def inspect_wheel(wheel: Path) -> PackageMetadata:
         raise ReleaseAssetError(f"wheel metadata version is unsupported: {wheel.name}")
     if declared_tags != filename_tags:
         raise ReleaseAssetError(f"wheel metadata tags differ from filename: {wheel.name}")
+    platforms = {tag.platform for tag in filename_tags}
+    for supported_version in supported_python_versions:
+        python_version = tuple(map(int, supported_version.split(".")[:2]))
+        if filename_tags.isdisjoint((*tags.cpython_tags(python_version, platforms=platforms), *tags.compatible_tags(python_version, platforms=platforms))):
+            raise ReleaseAssetError(f"wheel tags do not cover supported Python {supported_version}: {wheel.name}")
     parsed = PackageMetadata(str(utils.canonicalize_name(name)), parsed_version, requires_python, tuple(sorted(metadata_message.get_all("Requires-Dist") or [])))
     expected_dist_info = f"{str(filename_name).replace('-', '_')}-{filename_version}.dist-info"
     if parsed.name != str(filename_name) or parsed.version != str(filename_version) or dist_info != expected_dist_info:
@@ -292,8 +298,8 @@ def verify_static_transition(
 ) -> tuple[PackageMetadata, PackageMetadata, PackageReleasePolicy]:
     """Freeze A's static contract for successor B's staged and rebuilt wheels."""
     policy = load_package_release_policy(manifest_bytes, expected_manifest=expected_manifest, release_tag=release_tag)
-    core = inspect_wheel(core_wheel)
-    memory = inspect_wheel(memory_wheel)
+    core = inspect_wheel(core_wheel, supported_python_versions=policy.supported_python_versions)
+    memory = inspect_wheel(memory_wheel, supported_python_versions=policy.supported_python_versions)
     expected_version = _release_version(release_tag)
     if core.name != "avibe-os" or memory.name != "avibe-memory":
         raise ReleaseAssetError("transition wheel distribution identity is invalid")

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -130,10 +130,10 @@ class RequirementClassification:
 
 def _packaging_modules():
     try:
-        from packaging import requirements, specifiers, utils, version
+        from packaging import requirements, specifiers, tags, utils, version
     except ModuleNotFoundError as exc:
         raise ReleaseAssetError("static release verification requires packaging") from exc
-    return requirements, specifiers, utils, version
+    return requirements, specifiers, tags, utils, version
 
 
 def _release_version(release_tag: str) -> str:
@@ -190,7 +190,7 @@ def load_package_release_policy(
     release_parts = _release_version(release_tag).split(".")
     if raw["release_tag"] != release_tag or raw["release_family"] != ".".join(release_parts[:2]):
         raise ManifestPolicyError("manifest package_policy release identity is invalid")
-    _, specifiers, _, parsed_versions = _packaging_modules()
+    _, specifiers, _, _, parsed_versions = _packaging_modules()
     try:
         requires_python = specifiers.SpecifierSet(raw["requires_python"])
         supported = tuple(parsed_versions.Version(version) for version in versions)
@@ -203,7 +203,7 @@ def load_package_release_policy(
 
 def classify_requirement(raw: str) -> RequirementClassification:
     """Classify one valid requirement without treating wildcard equality as exact."""
-    requirements, _, utils, versions = _packaging_modules()
+    requirements, _, _, utils, versions = _packaging_modules()
     try:
         requirement = requirements.Requirement(raw)
     except requirements.InvalidRequirement as exc:
@@ -227,22 +227,25 @@ def classify_requirement(raw: str) -> RequirementClassification:
 
 def inspect_wheel(wheel: Path) -> PackageMetadata:
     """Validate wheel controls and metadata without installing the wheel."""
-    _, _, utils, versions = _packaging_modules()
+    _, _, tags, utils, versions = _packaging_modules()
     try:
-        filename_name, filename_version = utils.parse_wheel_filename(wheel.name)[:2]
+        filename_name, filename_version, _, filename_tags = utils.parse_wheel_filename(wheel.name)
     except utils.InvalidWheelFilename as exc:
         raise ReleaseAssetError(f"invalid wheel filename: {wheel.name}") from exc
     try:
         with zipfile.ZipFile(wheel) as archive:
             names = archive.namelist()
-            unsafe = any("\\" in name or PurePosixPath(name).is_absolute() or ".." in PurePosixPath(name).parts for name in names)
+            canonical = [str(PurePosixPath(name)) + ("/" if name.endswith("/") else "") for name in names]
+            unsafe = any("\\" in name or PurePosixPath(name).is_absolute() or ".." in PurePosixPath(name).parts or name != clean for name, clean in zip(names, canonical))
             dist_infos = {name.split("/", 1)[0] for name in names if "/" in name and name.split("/", 1)[0].endswith(".dist-info")}
-            if len(names) != len(set(names)) or unsafe or len(dist_infos) != 1:
+            if len(names) != len({name.rstrip("/").casefold() for name in canonical}) or unsafe or len(dist_infos) != 1:
                 raise ReleaseAssetError(f"wheel control structure is invalid: {wheel.name}")
             dist_info = next(iter(dist_infos))
             required = {f"{dist_info}/{name}" for name in ("METADATA", "WHEEL", "RECORD")}
             if not required <= set(names):
                 raise ReleaseAssetError(f"wheel control structure is invalid: {wheel.name}")
+            if archive.testzip() is not None:
+                raise ReleaseAssetError(f"wheel member integrity is invalid: {wheel.name}")
             metadata_message = Parser().parsestr(archive.read(f"{dist_info}/METADATA").decode("utf-8"))
             wheel_message = Parser().parsestr(archive.read(f"{dist_info}/WHEEL").decode("utf-8"))
     except (OSError, UnicodeDecodeError, zipfile.BadZipFile) as exc:
@@ -254,14 +257,17 @@ def inspect_wheel(wheel: Path) -> PackageMetadata:
     name, version, requires_python = (field[0] for field in values)
     try:
         parsed_version = str(versions.Version(version))
+        declared_tags = {tag for value in wheel_message.get_all("Tag") or [] for tag in tags.parse_tag(value)}
         wheel_version = re.fullmatch(r"([0-9]+)\.([0-9]+)", wheel_versions[0])
         if wheel_version is None:
             raise ValueError
         wheel_major = int(wheel_version.group(1))
     except (ValueError, versions.InvalidVersion) as exc:
-        raise ReleaseAssetError(f"wheel metadata version is invalid: {wheel.name}") from exc
+        raise ReleaseAssetError(f"wheel metadata version or tags are invalid: {wheel.name}") from exc
     if wheel_major > 1:
         raise ReleaseAssetError(f"wheel metadata version is unsupported: {wheel.name}")
+    if declared_tags != filename_tags:
+        raise ReleaseAssetError(f"wheel metadata tags differ from filename: {wheel.name}")
     parsed = PackageMetadata(str(utils.canonicalize_name(name)), parsed_version, requires_python, tuple(sorted(metadata_message.get_all("Requires-Dist") or [])))
     expected_dist_info = f"{str(filename_name).replace('-', '_')}-{filename_version}.dist-info"
     if parsed.name != str(filename_name) or parsed.version != str(filename_version) or dist_info != expected_dist_info:
@@ -270,7 +276,7 @@ def inspect_wheel(wheel: Path) -> PackageMetadata:
 
 
 def _requirements_for(metadata: PackageMetadata, name: str) -> tuple[RequirementClassification, ...]:
-    _, _, utils, _ = _packaging_modules()
+    _, _, _, utils, _ = _packaging_modules()
     expected = str(utils.canonicalize_name(name))
     classified = tuple(classify_requirement(raw) for raw in metadata.requires_dist)
     return tuple(item for item in classified if item.name == expected)
@@ -302,7 +308,7 @@ def verify_static_transition(
     if len(core_dependencies) != 1:
         raise ReleaseAssetError("Memory metadata must contain exactly one avibe-os dependency")
     reverse = core_dependencies[0]
-    _, specifiers, _, versions = _packaging_modules()
+    _, specifiers, _, _, versions = _packaging_modules()
     if reverse.is_direct or reverse.has_marker or reverse.has_extras or not reverse.specifier or versions.Version(expected_version) not in specifiers.SpecifierSet(reverse.specifier):
         raise ReleaseAssetError("Memory avibe-os dependency must accept the release version")
     return core, memory, policy

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Verify and materialize manifest-pinned Memory Runtime release assets."""
+"""Verify and materialize manifest-pinned Memory Runtime release assets.
+
+Package policy schema v1 declares ``Requires-Python: >=3.10``. Changing that
+contract requires a policy schema/version change and a new declared literal.
+"""
 
 from __future__ import annotations
 
@@ -35,6 +39,7 @@ ASSET_FAILURE_EXIT = 1
 POLICY_EXCLUSION_EXIT = 2
 INTERNAL_GUARD_FAILURE_EXIT = 3
 PACKAGE_POLICY_SCHEMA_VERSION = 1
+PACKAGE_POLICY_REQUIRES_PYTHON = ">=3.10"
 SUPPORTED_NAMESPACE_POLICY_VERSIONS = frozenset({1})
 
 
@@ -192,15 +197,14 @@ def load_package_release_policy(
         raise ManifestPolicyError("manifest package_policy release identity is invalid")
     if raw["wheel_tag"] != "py3-none-any":
         raise ManifestPolicyError("manifest package_policy wheel_tag must be py3-none-any for schema 1")
-    _, specifiers, _, _, parsed_versions = _packaging_modules()
+    _, specifiers, _, _, _ = _packaging_modules()
     try:
-        requires_python = specifiers.SpecifierSet(raw["requires_python"])
-        supported = tuple(parsed_versions.Version(version) for version in versions)
-    except (specifiers.InvalidSpecifier, parsed_versions.InvalidVersion) as exc:
+        requires_python = str(specifiers.SpecifierSet(raw["requires_python"]))
+    except specifiers.InvalidSpecifier as exc:
         raise ManifestPolicyError("manifest package_policy Python contract is invalid") from exc
-    if len(supported) != len(set(supported)) or any(version not in requires_python for version in supported):
-        raise ManifestPolicyError("manifest package_policy excludes a supported Python version")
-    return PackageReleasePolicy(raw["requires_python"], tuple(map(str, supported)), raw["wheel_tag"], namespace_version)
+    if requires_python != PACKAGE_POLICY_REQUIRES_PYTHON:
+        raise ManifestPolicyError("manifest package_policy Requires-Python differs from schema 1 policy")
+    return PackageReleasePolicy(requires_python, tuple(versions), raw["wheel_tag"], namespace_version)
 
 
 def classify_requirement(raw: str) -> RequirementClassification:

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import shutil
+import subprocess
 import sys
 import tarfile
 import tempfile
@@ -15,6 +17,16 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.utils import InvalidWheelFilename, canonicalize_name, parse_wheel_filename
+from packaging.version import InvalidVersion, Version
+
+try:
+    from scripts.release_package_version import package_version_from_release_tag
+except ModuleNotFoundError:  # Direct execution adds scripts/, not the repository root.
+    from release_package_version import package_version_from_release_tag
 
 RELEASE_DOWNLOAD_ROOT = "https://github.com/avibe-bot/avibe/releases/download"
 EXPECTED_EVEROS_VERSION = "1.2.3"
@@ -28,6 +40,8 @@ MAX_ARCHIVE_BYTES = 1024 * 1024 * 1024
 ASSET_FAILURE_EXIT = 1
 POLICY_EXCLUSION_EXIT = 2
 INTERNAL_GUARD_FAILURE_EXIT = 3
+PACKAGE_POLICY_SCHEMA_VERSION = 1
+SUPPORTED_NAMESPACE_POLICY_VERSIONS = frozenset({1})
 
 
 class ReleaseGuardError(RuntimeError):
@@ -93,6 +107,205 @@ class ReleaseSpec:
         return {"memory-runtime-manifest.json", *(archive.name for archive in self.archives)}
 
 
+@dataclass(frozen=True)
+class PackageMetadata:
+    name: str
+    version: Version
+    requires_python: str
+    requires_dist: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PackageReleasePolicy:
+    requires_python: str
+    supported_python_versions: tuple[Version, ...]
+    namespace_policy_version: int
+
+
+@dataclass(frozen=True)
+class RequirementClassification:
+    requirement: Requirement
+    exact_version: Version | None
+
+
+@dataclass(frozen=True)
+class StaticTransitionVerification:
+    core: PackageMetadata
+    memory: PackageMetadata
+    policy: PackageReleasePolicy
+
+
+def _release_version(release_tag: str) -> Version:
+    try:
+        return Version(package_version_from_release_tag(release_tag))
+    except (ValueError, InvalidVersion) as exc:
+        raise ReleaseAssetError(f"invalid release tag: {release_tag!r}") from exc
+
+
+def load_package_release_policy(
+    manifest_bytes: bytes,
+    *,
+    expected_manifest: bytes,
+    release_tag: str,
+) -> PackageReleasePolicy:
+    """Load the B-facing package policy only after exact manifest identity."""
+    if manifest_bytes != expected_manifest:
+        raise ReleaseAssetError("transition package manifest does not match the selected manifest")
+    try:
+        payload = json.loads(manifest_bytes)
+    except (TypeError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ManifestPolicyError("Memory artifact package policy manifest is invalid") from exc
+    if type(payload) is not dict or type(payload.get("schema_version")) is not int or payload["schema_version"] != 1:
+        raise ManifestPolicyError("Memory Runtime manifest schema_version must be integer 1")
+    raw = payload.get("package_policy")
+    keys = {
+        "schema_version",
+        "release_tag",
+        "release_family",
+        "requires_python",
+        "supported_python_versions",
+        "namespace_policy_version",
+    }
+    if type(raw) is not dict or set(raw) != keys:
+        raise ManifestPolicyError("manifest package_policy schema is invalid")
+    if type(raw["schema_version"]) is not int or raw["schema_version"] != PACKAGE_POLICY_SCHEMA_VERSION:
+        raise ManifestPolicyError("manifest package_policy schema_version must be integer 1")
+    if any(type(raw[key]) is not str or not raw[key] for key in ("release_tag", "release_family", "requires_python")):
+        raise ManifestPolicyError("manifest package_policy string fields are invalid")
+    versions = raw["supported_python_versions"]
+    namespace_version = raw["namespace_policy_version"]
+    if (
+        type(versions) is not list
+        or not versions
+        or any(type(version) is not str or not version for version in versions)
+        or len(versions) != len(set(versions))
+        or type(namespace_version) is not int
+        or namespace_version not in SUPPORTED_NAMESPACE_POLICY_VERSIONS
+    ):
+        raise ManifestPolicyError("manifest package_policy typed fields are invalid")
+    release_version = _release_version(release_tag)
+    if raw["release_tag"] != release_tag or raw["release_family"] != f"{release_version.major}.{release_version.minor}":
+        raise ManifestPolicyError("manifest package_policy release identity is invalid")
+    try:
+        requires_python = SpecifierSet(raw["requires_python"])
+        supported = tuple(Version(version) for version in versions)
+    except (InvalidSpecifier, InvalidVersion) as exc:
+        raise ManifestPolicyError("manifest package_policy Python contract is invalid") from exc
+    if len(supported) != len(set(supported)) or any(version not in requires_python for version in supported):
+        raise ManifestPolicyError("manifest package_policy excludes a supported Python version")
+    return PackageReleasePolicy(raw["requires_python"], supported, namespace_version)
+
+
+def classify_requirement(raw: str) -> RequirementClassification:
+    """Classify one valid requirement without treating wildcard equality as exact."""
+    try:
+        requirement = Requirement(raw)
+    except InvalidRequirement as exc:
+        raise ReleaseAssetError(f"invalid Requires-Dist requirement: {raw!r}") from exc
+    specifiers = tuple(requirement.specifier)
+    exact_version = None
+    if (
+        not requirement.extras
+        and requirement.url is None
+        and requirement.marker is None
+        and len(specifiers) == 1
+        and specifiers[0].operator == "=="
+        and "*" not in specifiers[0].version
+    ):
+        try:
+            exact_version = Version(specifiers[0].version)
+        except InvalidVersion as exc:
+            raise ReleaseAssetError(f"invalid exact requirement version: {raw!r}") from exc
+    return RequirementClassification(requirement, exact_version)
+
+
+def inspect_wheel(wheel: Path, *, python_executable: Path = Path(sys.executable)) -> PackageMetadata:
+    """Validate and inspect a wheel through packaging and pip's no-install report."""
+    try:
+        filename_name, filename_version = parse_wheel_filename(wheel.name)[:2]
+    except InvalidWheelFilename as exc:
+        raise ReleaseAssetError(f"invalid wheel filename: {wheel.name}") from exc
+    environment = {key: value for key, value in os.environ.items() if not key.startswith("PIP_")}
+    environment.update(PIP_CONFIG_FILE=os.devnull, PIP_NO_CACHE_DIR="1", PYTHONPATH="")
+    command = [
+        str(python_executable), "-m", "pip", "--isolated", "install", "--dry-run",
+        "--ignore-installed", "--ignore-requires-python", "--no-deps", "--no-index",
+        "--no-cache-dir", "--disable-pip-version-check", "--report", "-", "--quiet",
+        str(wheel.resolve()),
+    ]
+    try:
+        result = subprocess.run(command, env=environment, capture_output=True, text=True, check=False)
+    except OSError as exc:
+        raise ReleaseAssetError(f"wheel structure validation could not run for {wheel.name}: {exc}") from exc
+    if result.returncode:
+        raise ReleaseAssetError(f"wheel structure validation failed for {wheel.name}: {result.stderr}")
+    try:
+        report = json.loads(result.stdout)
+        installs = report["install"]
+        if type(installs) is not list or len(installs) != 1 or type(installs[0]) is not dict:
+            raise ValueError
+        metadata = installs[0]["metadata"]
+        if type(metadata) is not dict:
+            raise ValueError
+        raw_requires_dist = metadata.get("requires_dist", [])
+        if any(type(metadata.get(key)) is not str or not metadata[key] for key in ("name", "version", "requires_python")):
+            raise ValueError
+        if type(raw_requires_dist) is not list or any(type(item) is not str for item in raw_requires_dist):
+            raise ValueError
+        parsed_version = Version(metadata["version"])
+    except (KeyError, IndexError, TypeError, ValueError, InvalidVersion, json.JSONDecodeError) as exc:
+        raise ReleaseAssetError(f"pip returned invalid wheel metadata for {wheel.name}") from exc
+    parsed = PackageMetadata(
+        str(canonicalize_name(metadata["name"])),
+        parsed_version,
+        metadata["requires_python"],
+        tuple(sorted(raw_requires_dist)),
+    )
+    if parsed.name != str(filename_name) or parsed.version != filename_version:
+        raise ReleaseAssetError(f"wheel filename identity differs from metadata: {wheel.name}")
+    return parsed
+
+
+def _requirements_for(metadata: PackageMetadata, name: str) -> tuple[RequirementClassification, ...]:
+    expected = canonicalize_name(name)
+    classified = tuple(classify_requirement(raw) for raw in metadata.requires_dist)
+    return tuple(item for item in classified if canonicalize_name(item.requirement.name) == expected)
+
+
+def verify_static_transition(
+    core_wheel: Path,
+    memory_wheel: Path,
+    *,
+    release_tag: str,
+    manifest_bytes: bytes,
+    expected_manifest: bytes,
+    python_executable: Path = Path(sys.executable),
+) -> StaticTransitionVerification:
+    """Freeze A's static contract for successor B's staged and rebuilt wheels."""
+    policy = load_package_release_policy(
+        manifest_bytes, expected_manifest=expected_manifest, release_tag=release_tag
+    )
+    core = inspect_wheel(core_wheel, python_executable=python_executable)
+    memory = inspect_wheel(memory_wheel, python_executable=python_executable)
+    expected_version = _release_version(release_tag)
+    if core.name != "avibe-os" or memory.name != "avibe-memory":
+        raise ReleaseAssetError("transition wheel distribution identity is invalid")
+    if core.version != expected_version or memory.version != expected_version:
+        raise ReleaseAssetError("wheel metadata version does not match the release tag")
+    if core.requires_python != policy.requires_python or memory.requires_python != policy.requires_python:
+        raise ReleaseAssetError(f"wheel Requires-Python must match release policy {policy.requires_python}")
+    memory_dependencies = _requirements_for(core, "avibe-memory")
+    if len(memory_dependencies) != 1 or memory_dependencies[0].exact_version != expected_version:
+        raise ReleaseAssetError("transition core must hard-depend on the exact Memory version")
+    core_dependencies = _requirements_for(memory, "avibe-os")
+    if len(core_dependencies) != 1:
+        raise ReleaseAssetError("Memory metadata must contain exactly one avibe-os dependency")
+    reverse = core_dependencies[0].requirement
+    if reverse.url is not None or reverse.marker is not None or reverse.extras or not reverse.specifier or expected_version not in reverse.specifier:
+        raise ReleaseAssetError("Memory avibe-os dependency must accept the release version")
+    return StaticTransitionVerification(core, memory, policy)
+
+
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as stream:
@@ -114,7 +327,7 @@ def load_release_spec(manifest_path: Path) -> ReleaseSpec:
         payload = json.loads(manifest_bytes)
     except (OSError, json.JSONDecodeError) as exc:
         raise ManifestPolicyError(f"cannot read Memory Runtime manifest: {exc}") from exc
-    if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+    if not isinstance(payload, dict) or type(payload.get("schema_version")) is not int or payload["schema_version"] != 1:
         raise ManifestPolicyError("Memory Runtime manifest schema_version must be 1")
     everos_version = payload.get("everos_version")
     provenance = (

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -7,6 +7,7 @@ import argparse
 from email.parser import Parser
 import hashlib
 import json
+import re
 import shutil
 import sys
 import tarfile
@@ -253,7 +254,10 @@ def inspect_wheel(wheel: Path) -> PackageMetadata:
     name, version, requires_python = (field[0] for field in values)
     try:
         parsed_version = str(versions.Version(version))
-        wheel_major = int(wheel_versions[0].split(".", 1)[0])
+        wheel_version = re.fullmatch(r"([0-9]+)\.([0-9]+)", wheel_versions[0])
+        if wheel_version is None:
+            raise ValueError
+        wheel_major = int(wheel_version.group(1))
     except (ValueError, versions.InvalidVersion) as exc:
         raise ReleaseAssetError(f"wheel metadata version is invalid: {wheel.name}") from exc
     if wheel_major > 1:

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -4,8 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import csv
-from email.parser import Parser
 import hashlib
 import json
 import re
@@ -17,8 +15,7 @@ import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath, PureWindowsPath
-import zipfile
+from pathlib import Path
 
 try:
     from scripts.release_package_version import package_version_from_release_tag
@@ -39,7 +36,6 @@ POLICY_EXCLUSION_EXIT = 2
 INTERNAL_GUARD_FAILURE_EXIT = 3
 PACKAGE_POLICY_SCHEMA_VERSION = 1
 SUPPORTED_NAMESPACE_POLICY_VERSIONS = frozenset({1})
-WHEEL_DATA_SCHEMES = frozenset({"data", "headers", "platlib", "purelib", "scripts"})
 
 
 class ReleaseGuardError(RuntimeError):
@@ -147,20 +143,6 @@ def _release_version(release_tag: str) -> str:
         raise ReleaseAssetError(f"invalid release tag: {release_tag!r}") from exc
 
 
-def _is_safe_relative_path(value: str) -> bool:
-    path = PurePosixPath(value)
-    canonical = str(path) + ("/" if value.endswith("/") else "")
-    return (
-        bool(path.parts)
-        and "\x00" not in value
-        and "\\" not in value
-        and not path.is_absolute()
-        and not PureWindowsPath(value).drive
-        and ".." not in path.parts
-        and value == canonical
-    )
-
-
 def load_package_release_policy(
     manifest_bytes: bytes,
     *,
@@ -245,82 +227,41 @@ def classify_requirement(raw: str) -> RequirementClassification:
     return RequirementClassification(str(utils.canonicalize_name(requirement.name)), str(requirement.specifier), exact_version, bool(requirement.extras), requirement.marker is not None, requirement.url is not None)
 
 
-def inspect_wheel(
-    wheel: Path,
+def _verify_package_identity(
+    wheel_filename: str,
+    metadata: PackageMetadata,
     *,
-    supported_python_versions: tuple[str, ...] = (),
-    expected_wheel_tag: str | None = None,
-) -> PackageMetadata:
-    """Validate wheel controls and metadata without installing the wheel."""
+    expected_name: str,
+    expected_version: str,
+    expected_wheel_tag: str,
+) -> None:
+    """Bind an A2-supplied metadata record to filename and declared policy."""
     _, _, tags, utils, versions = _packaging_modules()
+    if (
+        type(metadata) is not PackageMetadata
+        or type(wheel_filename) is not str
+        or type(metadata.name) is not str
+        or type(metadata.version) is not str
+        or type(metadata.requires_python) is not str
+        or type(metadata.requires_dist) is not tuple
+        or any(type(requirement) is not str for requirement in metadata.requires_dist)
+    ):
+        raise ReleaseAssetError("transition package metadata types are invalid")
     try:
-        filename_name, filename_version, _, filename_tags = utils.parse_wheel_filename(wheel.name)
-    except utils.InvalidWheelFilename as exc:
-        raise ReleaseAssetError(f"invalid wheel filename: {wheel.name}") from exc
-    try:
-        with zipfile.ZipFile(wheel) as archive:
-            names = archive.namelist()
-            canonical = [str(PurePosixPath(name)) + ("/" if name.endswith("/") else "") for name in names]
-            unsafe = any(not _is_safe_relative_path(name) or ("/" in name and name.split("/", 1)[0].endswith(".data") and name.split("/", 2)[1] not in WHEEL_DATA_SCHEMES) for name in names)
-            dist_infos = {name.split("/", 1)[0] for name in names if "/" in name and name.split("/", 1)[0].endswith(".dist-info")}
-            if len(names) != len({name.rstrip("/").casefold() for name in canonical}) or unsafe or len(dist_infos) != 1:
-                raise ReleaseAssetError(f"wheel control structure is invalid: {wheel.name}")
-            dist_info = next(iter(dist_infos))
-            required = {f"{dist_info}/{name}" for name in ("METADATA", "WHEEL", "RECORD")}
-            if not required <= set(names):
-                raise ReleaseAssetError(f"wheel control structure is invalid: {wheel.name}")
-            if archive.testzip() is not None:
-                raise ReleaseAssetError(f"wheel member integrity is invalid: {wheel.name}")
-            metadata_bytes = archive.read(f"{dist_info}/METADATA")
-            try:
-                from packaging.metadata import Metadata
-
-                Metadata.from_email(metadata_bytes, validate=True)
-            except Exception as exc:
-                raise ReleaseAssetError(f"wheel core metadata is invalid: {wheel.name}") from exc
-            metadata_message = Parser().parsestr(metadata_bytes.decode("utf-8"))
-            wheel_message = Parser().parsestr(archive.read(f"{dist_info}/WHEEL").decode("utf-8"))
-            record_rows = list(csv.reader(archive.read(f"{dist_info}/RECORD").decode("utf-8").splitlines()))
-            if not record_rows or any(len(row) != 3 or not _is_safe_relative_path(row[0]) for row in record_rows):
-                raise ReleaseAssetError(f"wheel RECORD structure is invalid: {wheel.name}")
-    except (OSError, UnicodeDecodeError, zipfile.BadZipFile) as exc:
-        raise ReleaseAssetError(f"cannot read wheel structure: {wheel.name}") from exc
-    values = [metadata_message.get_all(key) or [] for key in ("Name", "Version", "Requires-Python")]
-    wheel_versions = wheel_message.get_all("Wheel-Version") or []
-    if any(len(field) != 1 or not field[0] for field in values) or len(wheel_versions) != 1:
-        raise ReleaseAssetError(f"wheel metadata identity is invalid: {wheel.name}")
-    name, version, requires_python = (field[0] for field in values)
-    try:
-        parsed_version = str(versions.Version(version))
-        declared_tags = {tag for value in wheel_message.get_all("Tag") or [] for tag in tags.parse_tag(value)}
-        policy_tags = tags.parse_tag(expected_wheel_tag) if expected_wheel_tag is not None else filename_tags
-        wheel_version = re.fullmatch(r"([0-9]+)\.([0-9]+)", wheel_versions[0])
-        if wheel_version is None:
-            raise ValueError
-        wheel_major = int(wheel_version.group(1))
-    except (ValueError, versions.InvalidVersion) as exc:
-        raise ReleaseAssetError(f"wheel metadata version or tags are invalid: {wheel.name}") from exc
-    if wheel_major > 1:
-        raise ReleaseAssetError(f"wheel metadata version is unsupported: {wheel.name}")
-    if declared_tags != filename_tags:
-        raise ReleaseAssetError(f"wheel metadata tags differ from filename: {wheel.name}")
-    if expected_wheel_tag is not None and filename_tags != policy_tags:
-        raise ReleaseAssetError(f"wheel tags differ from release policy: {wheel.name}")
-    platforms = {tag.platform for tag in policy_tags}
-    for supported_version in supported_python_versions:
-        try:
-            if re.fullmatch(r"[0-9]+\.[0-9]+", supported_version) is None:
-                raise ValueError
-            python_version = tuple(map(int, supported_version.split(".")))
-        except (TypeError, ValueError) as exc:
-            raise ReleaseAssetError(f"supported Python version is invalid: {supported_version!r}") from exc
-        if policy_tags.isdisjoint((*tags.cpython_tags(python_version, platforms=platforms), *tags.compatible_tags(python_version, platforms=platforms))):
-            raise ReleaseAssetError(f"wheel tags do not cover supported Python {supported_version}: {wheel.name}")
-    parsed = PackageMetadata(str(utils.canonicalize_name(name)), parsed_version, requires_python, tuple(sorted(metadata_message.get_all("Requires-Dist") or [])))
-    expected_dist_info = f"{str(filename_name).replace('-', '_')}-{filename_version}.dist-info"
-    if parsed.name != str(filename_name) or parsed.version != str(filename_version) or dist_info != expected_dist_info:
-        raise ReleaseAssetError(f"wheel filename identity differs from metadata: {wheel.name}")
-    return parsed
+        filename_name, filename_version, _, filename_tags = utils.parse_wheel_filename(wheel_filename)
+        metadata_name = str(utils.canonicalize_name(metadata.name))
+        metadata_version = str(versions.Version(metadata.version))
+        policy_tags = tags.parse_tag(expected_wheel_tag)
+    except (TypeError, ValueError, utils.InvalidWheelFilename, versions.InvalidVersion) as exc:
+        raise ReleaseAssetError(f"transition package identity is invalid: {wheel_filename!r}") from exc
+    if metadata_name != str(filename_name) or metadata_version != str(filename_version):
+        raise ReleaseAssetError(f"wheel filename identity differs from metadata: {wheel_filename}")
+    if metadata_name != expected_name:
+        raise ReleaseAssetError("transition wheel distribution identity is invalid")
+    if metadata_version != expected_version:
+        raise ReleaseAssetError("wheel metadata version does not match the release tag")
+    if filename_tags != policy_tags:
+        raise ReleaseAssetError(f"wheel tags differ from release policy: {wheel_filename}")
 
 
 def _requirements_for(metadata: PackageMetadata, name: str) -> tuple[RequirementClassification, ...]:
@@ -331,34 +272,44 @@ def _requirements_for(metadata: PackageMetadata, name: str) -> tuple[Requirement
 
 
 def verify_static_transition(
-    core_wheel: Path,
-    memory_wheel: Path,
     *,
+    core_wheel_filename: str,
+    core_metadata: PackageMetadata,
+    memory_wheel_filename: str,
+    memory_metadata: PackageMetadata,
     release_tag: str,
     manifest_bytes: bytes,
     expected_manifest: bytes,
 ) -> tuple[PackageMetadata, PackageMetadata, PackageReleasePolicy]:
-    """Freeze A's static contract for successor B's staged and rebuilt wheels."""
+    """Freeze A1's policy interface for A2-supplied wheel metadata."""
     policy = load_package_release_policy(manifest_bytes, expected_manifest=expected_manifest, release_tag=release_tag)
-    core = inspect_wheel(core_wheel, supported_python_versions=policy.supported_python_versions, expected_wheel_tag=policy.wheel_tag)
-    memory = inspect_wheel(memory_wheel, supported_python_versions=policy.supported_python_versions, expected_wheel_tag=policy.wheel_tag)
     expected_version = _release_version(release_tag)
-    if core.name != "avibe-os" or memory.name != "avibe-memory":
-        raise ReleaseAssetError("transition wheel distribution identity is invalid")
-    if core.version != expected_version or memory.version != expected_version:
-        raise ReleaseAssetError("wheel metadata version does not match the release tag")
-    if core.requires_python != policy.requires_python or memory.requires_python != policy.requires_python:
+    _verify_package_identity(
+        core_wheel_filename,
+        core_metadata,
+        expected_name="avibe-os",
+        expected_version=expected_version,
+        expected_wheel_tag=policy.wheel_tag,
+    )
+    _verify_package_identity(
+        memory_wheel_filename,
+        memory_metadata,
+        expected_name="avibe-memory",
+        expected_version=expected_version,
+        expected_wheel_tag=policy.wheel_tag,
+    )
+    if core_metadata.requires_python != policy.requires_python or memory_metadata.requires_python != policy.requires_python:
         raise ReleaseAssetError(f"wheel Requires-Python must match release policy {policy.requires_python}")
-    memory_dependencies = _requirements_for(core, "avibe-memory")
+    memory_dependencies = _requirements_for(core_metadata, "avibe-memory")
     if len(memory_dependencies) != 1 or memory_dependencies[0].exact_version != expected_version:
         raise ReleaseAssetError("transition core must hard-depend on the exact Memory version")
-    core_dependencies = _requirements_for(memory, "avibe-os")
+    core_dependencies = _requirements_for(memory_metadata, "avibe-os")
     if len(core_dependencies) != 1:
         raise ReleaseAssetError("Memory metadata must contain exactly one avibe-os dependency")
     reverse = core_dependencies[0]
     if reverse.exact_version != expected_version:
         raise ReleaseAssetError("Memory must hard-depend on the exact avibe-os release version")
-    return core, memory, policy
+    return core_metadata, memory_metadata, policy
 
 
 def _sha256(path: Path) -> str:

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -17,7 +17,7 @@ import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 import zipfile
 
 try:
@@ -147,6 +147,20 @@ def _release_version(release_tag: str) -> str:
         raise ReleaseAssetError(f"invalid release tag: {release_tag!r}") from exc
 
 
+def _is_safe_relative_path(value: str) -> bool:
+    path = PurePosixPath(value)
+    canonical = str(path) + ("/" if value.endswith("/") else "")
+    return (
+        bool(path.parts)
+        and "\x00" not in value
+        and "\\" not in value
+        and not path.is_absolute()
+        and not PureWindowsPath(value).drive
+        and ".." not in path.parts
+        and value == canonical
+    )
+
+
 def load_package_release_policy(
     manifest_bytes: bytes,
     *,
@@ -185,7 +199,7 @@ def load_package_release_policy(
     if (
         type(versions) is not list
         or not versions
-        or any(type(version) is not str or not version for version in versions)
+        or any(type(version) is not str or re.fullmatch(r"[0-9]+\.[0-9]+", version) is None for version in versions)
         or len(versions) != len(set(versions))
         or type(namespace_version) is not int
         or namespace_version not in SUPPORTED_NAMESPACE_POLICY_VERSIONS
@@ -247,7 +261,7 @@ def inspect_wheel(
         with zipfile.ZipFile(wheel) as archive:
             names = archive.namelist()
             canonical = [str(PurePosixPath(name)) + ("/" if name.endswith("/") else "") for name in names]
-            unsafe = any("\\" in name or PurePosixPath(name).is_absolute() or ".." in PurePosixPath(name).parts or name != clean or ("/" in name and name.split("/", 1)[0].endswith(".data") and name.split("/", 2)[1] not in WHEEL_DATA_SCHEMES) for name, clean in zip(names, canonical))
+            unsafe = any(not _is_safe_relative_path(name) or ("/" in name and name.split("/", 1)[0].endswith(".data") and name.split("/", 2)[1] not in WHEEL_DATA_SCHEMES) for name in names)
             dist_infos = {name.split("/", 1)[0] for name in names if "/" in name and name.split("/", 1)[0].endswith(".dist-info")}
             if len(names) != len({name.rstrip("/").casefold() for name in canonical}) or unsafe or len(dist_infos) != 1:
                 raise ReleaseAssetError(f"wheel control structure is invalid: {wheel.name}")
@@ -257,10 +271,17 @@ def inspect_wheel(
                 raise ReleaseAssetError(f"wheel control structure is invalid: {wheel.name}")
             if archive.testzip() is not None:
                 raise ReleaseAssetError(f"wheel member integrity is invalid: {wheel.name}")
-            metadata_message = Parser().parsestr(archive.read(f"{dist_info}/METADATA").decode("utf-8"))
+            metadata_bytes = archive.read(f"{dist_info}/METADATA")
+            try:
+                from packaging.metadata import Metadata
+
+                Metadata.from_email(metadata_bytes, validate=True)
+            except Exception as exc:
+                raise ReleaseAssetError(f"wheel core metadata is invalid: {wheel.name}") from exc
+            metadata_message = Parser().parsestr(metadata_bytes.decode("utf-8"))
             wheel_message = Parser().parsestr(archive.read(f"{dist_info}/WHEEL").decode("utf-8"))
             record_rows = list(csv.reader(archive.read(f"{dist_info}/RECORD").decode("utf-8").splitlines()))
-            if not record_rows or any(len(row) != 3 or not row[0] for row in record_rows):
+            if not record_rows or any(len(row) != 3 or not _is_safe_relative_path(row[0]) for row in record_rows):
                 raise ReleaseAssetError(f"wheel RECORD structure is invalid: {wheel.name}")
     except (OSError, UnicodeDecodeError, zipfile.BadZipFile) as exc:
         raise ReleaseAssetError(f"cannot read wheel structure: {wheel.name}") from exc
@@ -287,7 +308,12 @@ def inspect_wheel(
         raise ReleaseAssetError(f"wheel tags differ from release policy: {wheel.name}")
     platforms = {tag.platform for tag in policy_tags}
     for supported_version in supported_python_versions:
-        python_version = tuple(map(int, supported_version.split(".")[:2]))
+        try:
+            if re.fullmatch(r"[0-9]+\.[0-9]+", supported_version) is None:
+                raise ValueError
+            python_version = tuple(map(int, supported_version.split(".")))
+        except (TypeError, ValueError) as exc:
+            raise ReleaseAssetError(f"supported Python version is invalid: {supported_version!r}") from exc
         if policy_tags.isdisjoint((*tags.cpython_tags(python_version, platforms=platforms), *tags.compatible_tags(python_version, platforms=platforms))):
             raise ReleaseAssetError(f"wheel tags do not cover supported Python {supported_version}: {wheel.name}")
     parsed = PackageMetadata(str(utils.canonicalize_name(name)), parsed_version, requires_python, tuple(sorted(metadata_message.get_all("Requires-Dist") or [])))

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import csv
 from email.parser import Parser
 import hashlib
 import json
@@ -116,6 +117,7 @@ class PackageMetadata:
 class PackageReleasePolicy:
     requires_python: str
     supported_python_versions: tuple[str, ...]
+    wheel_tag: str
     namespace_policy_version: int
 
 
@@ -169,13 +171,14 @@ def load_package_release_policy(
         "release_family",
         "requires_python",
         "supported_python_versions",
+        "wheel_tag",
         "namespace_policy_version",
     }
     if type(raw) is not dict or set(raw) != keys:
         raise ManifestPolicyError("manifest package_policy schema is invalid")
     if type(raw["schema_version"]) is not int or raw["schema_version"] != PACKAGE_POLICY_SCHEMA_VERSION:
         raise ManifestPolicyError("manifest package_policy schema_version must be integer 1")
-    if any(type(raw[key]) is not str or not raw[key] for key in ("release_tag", "release_family", "requires_python")):
+    if any(type(raw[key]) is not str or not raw[key] for key in ("release_tag", "release_family", "requires_python", "wheel_tag")):
         raise ManifestPolicyError("manifest package_policy string fields are invalid")
     versions = raw["supported_python_versions"]
     namespace_version = raw["namespace_policy_version"]
@@ -191,6 +194,8 @@ def load_package_release_policy(
     release_parts = _release_version(release_tag).split(".")
     if raw["release_tag"] != release_tag or raw["release_family"] != ".".join(release_parts[:2]):
         raise ManifestPolicyError("manifest package_policy release identity is invalid")
+    if raw["wheel_tag"] != "py3-none-any":
+        raise ManifestPolicyError("manifest package_policy wheel_tag must be py3-none-any for schema 1")
     _, specifiers, _, _, parsed_versions = _packaging_modules()
     try:
         requires_python = specifiers.SpecifierSet(raw["requires_python"])
@@ -199,7 +204,7 @@ def load_package_release_policy(
         raise ManifestPolicyError("manifest package_policy Python contract is invalid") from exc
     if len(supported) != len(set(supported)) or any(version not in requires_python for version in supported):
         raise ManifestPolicyError("manifest package_policy excludes a supported Python version")
-    return PackageReleasePolicy(raw["requires_python"], tuple(map(str, supported)), namespace_version)
+    return PackageReleasePolicy(raw["requires_python"], tuple(map(str, supported)), raw["wheel_tag"], namespace_version)
 
 
 def classify_requirement(raw: str) -> RequirementClassification:
@@ -226,7 +231,12 @@ def classify_requirement(raw: str) -> RequirementClassification:
     return RequirementClassification(str(utils.canonicalize_name(requirement.name)), str(requirement.specifier), exact_version, bool(requirement.extras), requirement.marker is not None, requirement.url is not None)
 
 
-def inspect_wheel(wheel: Path, *, supported_python_versions: tuple[str, ...] = ()) -> PackageMetadata:
+def inspect_wheel(
+    wheel: Path,
+    *,
+    supported_python_versions: tuple[str, ...] = (),
+    expected_wheel_tag: str | None = None,
+) -> PackageMetadata:
     """Validate wheel controls and metadata without installing the wheel."""
     _, _, tags, utils, versions = _packaging_modules()
     try:
@@ -249,6 +259,9 @@ def inspect_wheel(wheel: Path, *, supported_python_versions: tuple[str, ...] = (
                 raise ReleaseAssetError(f"wheel member integrity is invalid: {wheel.name}")
             metadata_message = Parser().parsestr(archive.read(f"{dist_info}/METADATA").decode("utf-8"))
             wheel_message = Parser().parsestr(archive.read(f"{dist_info}/WHEEL").decode("utf-8"))
+            record_rows = list(csv.reader(archive.read(f"{dist_info}/RECORD").decode("utf-8").splitlines()))
+            if not record_rows or any(len(row) != 3 or not row[0] for row in record_rows):
+                raise ReleaseAssetError(f"wheel RECORD structure is invalid: {wheel.name}")
     except (OSError, UnicodeDecodeError, zipfile.BadZipFile) as exc:
         raise ReleaseAssetError(f"cannot read wheel structure: {wheel.name}") from exc
     values = [metadata_message.get_all(key) or [] for key in ("Name", "Version", "Requires-Python")]
@@ -259,6 +272,7 @@ def inspect_wheel(wheel: Path, *, supported_python_versions: tuple[str, ...] = (
     try:
         parsed_version = str(versions.Version(version))
         declared_tags = {tag for value in wheel_message.get_all("Tag") or [] for tag in tags.parse_tag(value)}
+        policy_tags = tags.parse_tag(expected_wheel_tag) if expected_wheel_tag is not None else filename_tags
         wheel_version = re.fullmatch(r"([0-9]+)\.([0-9]+)", wheel_versions[0])
         if wheel_version is None:
             raise ValueError
@@ -269,10 +283,12 @@ def inspect_wheel(wheel: Path, *, supported_python_versions: tuple[str, ...] = (
         raise ReleaseAssetError(f"wheel metadata version is unsupported: {wheel.name}")
     if declared_tags != filename_tags:
         raise ReleaseAssetError(f"wheel metadata tags differ from filename: {wheel.name}")
-    platforms = {tag.platform for tag in filename_tags}
+    if expected_wheel_tag is not None and filename_tags != policy_tags:
+        raise ReleaseAssetError(f"wheel tags differ from release policy: {wheel.name}")
+    platforms = {tag.platform for tag in policy_tags}
     for supported_version in supported_python_versions:
         python_version = tuple(map(int, supported_version.split(".")[:2]))
-        if filename_tags.isdisjoint((*tags.cpython_tags(python_version, platforms=platforms), *tags.compatible_tags(python_version, platforms=platforms))):
+        if policy_tags.isdisjoint((*tags.cpython_tags(python_version, platforms=platforms), *tags.compatible_tags(python_version, platforms=platforms))):
             raise ReleaseAssetError(f"wheel tags do not cover supported Python {supported_version}: {wheel.name}")
     parsed = PackageMetadata(str(utils.canonicalize_name(name)), parsed_version, requires_python, tuple(sorted(metadata_message.get_all("Requires-Dist") or [])))
     expected_dist_info = f"{str(filename_name).replace('-', '_')}-{filename_version}.dist-info"
@@ -298,8 +314,8 @@ def verify_static_transition(
 ) -> tuple[PackageMetadata, PackageMetadata, PackageReleasePolicy]:
     """Freeze A's static contract for successor B's staged and rebuilt wheels."""
     policy = load_package_release_policy(manifest_bytes, expected_manifest=expected_manifest, release_tag=release_tag)
-    core = inspect_wheel(core_wheel, supported_python_versions=policy.supported_python_versions)
-    memory = inspect_wheel(memory_wheel, supported_python_versions=policy.supported_python_versions)
+    core = inspect_wheel(core_wheel, supported_python_versions=policy.supported_python_versions, expected_wheel_tag=policy.wheel_tag)
+    memory = inspect_wheel(memory_wheel, supported_python_versions=policy.supported_python_versions, expected_wheel_tag=policy.wheel_tag)
     expected_version = _release_version(release_tag)
     if core.name != "avibe-os" or memory.name != "avibe-memory":
         raise ReleaseAssetError("transition wheel distribution identity is invalid")
@@ -314,9 +330,8 @@ def verify_static_transition(
     if len(core_dependencies) != 1:
         raise ReleaseAssetError("Memory metadata must contain exactly one avibe-os dependency")
     reverse = core_dependencies[0]
-    _, specifiers, _, _, versions = _packaging_modules()
-    if reverse.is_direct or reverse.has_marker or reverse.has_extras or not reverse.specifier or versions.Version(expected_version) not in specifiers.SpecifierSet(reverse.specifier):
-        raise ReleaseAssetError("Memory avibe-os dependency must accept the release version")
+    if reverse.exact_version != expected_version:
+        raise ReleaseAssetError("Memory must hard-depend on the exact avibe-os release version")
     return core, memory, policy
 
 

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -4,11 +4,10 @@
 from __future__ import annotations
 
 import argparse
+from email.parser import Parser
 import hashlib
 import json
-import os
 import shutil
-import subprocess
 import sys
 import tarfile
 import tempfile
@@ -16,12 +15,8 @@ import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
-from pathlib import Path
-
-from packaging.requirements import InvalidRequirement, Requirement
-from packaging.specifiers import InvalidSpecifier, SpecifierSet
-from packaging.utils import InvalidWheelFilename, canonicalize_name, parse_wheel_filename
-from packaging.version import InvalidVersion, Version
+from pathlib import Path, PurePosixPath
+import zipfile
 
 try:
     from scripts.release_package_version import package_version_from_release_tag
@@ -110,7 +105,7 @@ class ReleaseSpec:
 @dataclass(frozen=True)
 class PackageMetadata:
     name: str
-    version: Version
+    version: str
     requires_python: str
     requires_dist: tuple[str, ...]
 
@@ -118,27 +113,33 @@ class PackageMetadata:
 @dataclass(frozen=True)
 class PackageReleasePolicy:
     requires_python: str
-    supported_python_versions: tuple[Version, ...]
+    supported_python_versions: tuple[str, ...]
     namespace_policy_version: int
 
 
 @dataclass(frozen=True)
 class RequirementClassification:
-    requirement: Requirement
-    exact_version: Version | None
+    name: str
+    specifier: str
+    exact_version: str | None
+    has_extras: bool
+    has_marker: bool
+    is_direct: bool
 
 
-@dataclass(frozen=True)
-class StaticTransitionVerification:
-    core: PackageMetadata
-    memory: PackageMetadata
-    policy: PackageReleasePolicy
-
-
-def _release_version(release_tag: str) -> Version:
+def _packaging_modules():
     try:
-        return Version(package_version_from_release_tag(release_tag))
-    except (ValueError, InvalidVersion) as exc:
+        from packaging import requirements, specifiers, utils, version
+    except ModuleNotFoundError as exc:
+        raise ReleaseAssetError("static release verification requires packaging") from exc
+    return requirements, specifiers, utils, version
+
+
+def _release_version(release_tag: str) -> str:
+    *_, versions = _packaging_modules()
+    try:
+        return str(versions.Version(package_version_from_release_tag(release_tag)))
+    except (ValueError, versions.InvalidVersion) as exc:
         raise ReleaseAssetError(f"invalid release tag: {release_tag!r}") from exc
 
 
@@ -157,6 +158,8 @@ def load_package_release_policy(
         raise ManifestPolicyError("Memory artifact package policy manifest is invalid") from exc
     if type(payload) is not dict or type(payload.get("schema_version")) is not int or payload["schema_version"] != 1:
         raise ManifestPolicyError("Memory Runtime manifest schema_version must be integer 1")
+    if type(payload.get("release_tag")) is not str or payload["release_tag"] != release_tag:
+        raise ManifestPolicyError("manifest release_tag differs from the selected release")
     raw = payload.get("package_policy")
     keys = {
         "schema_version",
@@ -183,24 +186,26 @@ def load_package_release_policy(
         or namespace_version not in SUPPORTED_NAMESPACE_POLICY_VERSIONS
     ):
         raise ManifestPolicyError("manifest package_policy typed fields are invalid")
-    release_version = _release_version(release_tag)
-    if raw["release_tag"] != release_tag or raw["release_family"] != f"{release_version.major}.{release_version.minor}":
+    release_parts = _release_version(release_tag).split(".")
+    if raw["release_tag"] != release_tag or raw["release_family"] != ".".join(release_parts[:2]):
         raise ManifestPolicyError("manifest package_policy release identity is invalid")
+    _, specifiers, _, parsed_versions = _packaging_modules()
     try:
-        requires_python = SpecifierSet(raw["requires_python"])
-        supported = tuple(Version(version) for version in versions)
-    except (InvalidSpecifier, InvalidVersion) as exc:
+        requires_python = specifiers.SpecifierSet(raw["requires_python"])
+        supported = tuple(parsed_versions.Version(version) for version in versions)
+    except (specifiers.InvalidSpecifier, parsed_versions.InvalidVersion) as exc:
         raise ManifestPolicyError("manifest package_policy Python contract is invalid") from exc
     if len(supported) != len(set(supported)) or any(version not in requires_python for version in supported):
         raise ManifestPolicyError("manifest package_policy excludes a supported Python version")
-    return PackageReleasePolicy(raw["requires_python"], supported, namespace_version)
+    return PackageReleasePolicy(raw["requires_python"], tuple(map(str, supported)), namespace_version)
 
 
 def classify_requirement(raw: str) -> RequirementClassification:
     """Classify one valid requirement without treating wildcard equality as exact."""
+    requirements, _, utils, versions = _packaging_modules()
     try:
-        requirement = Requirement(raw)
-    except InvalidRequirement as exc:
+        requirement = requirements.Requirement(raw)
+    except requirements.InvalidRequirement as exc:
         raise ReleaseAssetError(f"invalid Requires-Dist requirement: {raw!r}") from exc
     specifiers = tuple(requirement.specifier)
     exact_version = None
@@ -213,63 +218,58 @@ def classify_requirement(raw: str) -> RequirementClassification:
         and "*" not in specifiers[0].version
     ):
         try:
-            exact_version = Version(specifiers[0].version)
-        except InvalidVersion as exc:
+            exact_version = str(versions.Version(specifiers[0].version))
+        except versions.InvalidVersion as exc:
             raise ReleaseAssetError(f"invalid exact requirement version: {raw!r}") from exc
-    return RequirementClassification(requirement, exact_version)
+    return RequirementClassification(str(utils.canonicalize_name(requirement.name)), str(requirement.specifier), exact_version, bool(requirement.extras), requirement.marker is not None, requirement.url is not None)
 
 
-def inspect_wheel(wheel: Path, *, python_executable: Path = Path(sys.executable)) -> PackageMetadata:
-    """Validate and inspect a wheel through packaging and pip's no-install report."""
+def inspect_wheel(wheel: Path) -> PackageMetadata:
+    """Validate wheel controls and metadata without installing the wheel."""
+    _, _, utils, versions = _packaging_modules()
     try:
-        filename_name, filename_version = parse_wheel_filename(wheel.name)[:2]
-    except InvalidWheelFilename as exc:
+        filename_name, filename_version = utils.parse_wheel_filename(wheel.name)[:2]
+    except utils.InvalidWheelFilename as exc:
         raise ReleaseAssetError(f"invalid wheel filename: {wheel.name}") from exc
-    environment = {key: value for key, value in os.environ.items() if not key.startswith("PIP_")}
-    environment.update(PIP_CONFIG_FILE=os.devnull, PIP_NO_CACHE_DIR="1", PYTHONPATH="")
-    command = [
-        str(python_executable), "-m", "pip", "--isolated", "install", "--dry-run",
-        "--ignore-installed", "--ignore-requires-python", "--no-deps", "--no-index",
-        "--no-cache-dir", "--disable-pip-version-check", "--report", "-", "--quiet",
-        str(wheel.resolve()),
-    ]
     try:
-        result = subprocess.run(command, env=environment, capture_output=True, text=True, check=False)
-    except OSError as exc:
-        raise ReleaseAssetError(f"wheel structure validation could not run for {wheel.name}: {exc}") from exc
-    if result.returncode:
-        raise ReleaseAssetError(f"wheel structure validation failed for {wheel.name}: {result.stderr}")
+        with zipfile.ZipFile(wheel) as archive:
+            names = archive.namelist()
+            unsafe = any("\\" in name or PurePosixPath(name).is_absolute() or ".." in PurePosixPath(name).parts for name in names)
+            dist_infos = {name.split("/", 1)[0] for name in names if "/" in name and name.split("/", 1)[0].endswith(".dist-info")}
+            if len(names) != len(set(names)) or unsafe or len(dist_infos) != 1:
+                raise ReleaseAssetError(f"wheel control structure is invalid: {wheel.name}")
+            dist_info = next(iter(dist_infos))
+            required = {f"{dist_info}/{name}" for name in ("METADATA", "WHEEL", "RECORD")}
+            if not required <= set(names):
+                raise ReleaseAssetError(f"wheel control structure is invalid: {wheel.name}")
+            metadata_message = Parser().parsestr(archive.read(f"{dist_info}/METADATA").decode("utf-8"))
+            wheel_message = Parser().parsestr(archive.read(f"{dist_info}/WHEEL").decode("utf-8"))
+    except (OSError, UnicodeDecodeError, zipfile.BadZipFile) as exc:
+        raise ReleaseAssetError(f"cannot read wheel structure: {wheel.name}") from exc
+    values = [metadata_message.get_all(key) or [] for key in ("Name", "Version", "Requires-Python")]
+    wheel_versions = wheel_message.get_all("Wheel-Version") or []
+    if any(len(field) != 1 or not field[0] for field in values) or len(wheel_versions) != 1:
+        raise ReleaseAssetError(f"wheel metadata identity is invalid: {wheel.name}")
+    name, version, requires_python = (field[0] for field in values)
     try:
-        report = json.loads(result.stdout)
-        installs = report["install"]
-        if type(installs) is not list or len(installs) != 1 or type(installs[0]) is not dict:
-            raise ValueError
-        metadata = installs[0]["metadata"]
-        if type(metadata) is not dict:
-            raise ValueError
-        raw_requires_dist = metadata.get("requires_dist", [])
-        if any(type(metadata.get(key)) is not str or not metadata[key] for key in ("name", "version", "requires_python")):
-            raise ValueError
-        if type(raw_requires_dist) is not list or any(type(item) is not str for item in raw_requires_dist):
-            raise ValueError
-        parsed_version = Version(metadata["version"])
-    except (KeyError, IndexError, TypeError, ValueError, InvalidVersion, json.JSONDecodeError) as exc:
-        raise ReleaseAssetError(f"pip returned invalid wheel metadata for {wheel.name}") from exc
-    parsed = PackageMetadata(
-        str(canonicalize_name(metadata["name"])),
-        parsed_version,
-        metadata["requires_python"],
-        tuple(sorted(raw_requires_dist)),
-    )
-    if parsed.name != str(filename_name) or parsed.version != filename_version:
+        parsed_version = str(versions.Version(version))
+        wheel_major = int(wheel_versions[0].split(".", 1)[0])
+    except (ValueError, versions.InvalidVersion) as exc:
+        raise ReleaseAssetError(f"wheel metadata version is invalid: {wheel.name}") from exc
+    if wheel_major > 1:
+        raise ReleaseAssetError(f"wheel metadata version is unsupported: {wheel.name}")
+    parsed = PackageMetadata(str(utils.canonicalize_name(name)), parsed_version, requires_python, tuple(sorted(metadata_message.get_all("Requires-Dist") or [])))
+    expected_dist_info = f"{str(filename_name).replace('-', '_')}-{filename_version}.dist-info"
+    if parsed.name != str(filename_name) or parsed.version != str(filename_version) or dist_info != expected_dist_info:
         raise ReleaseAssetError(f"wheel filename identity differs from metadata: {wheel.name}")
     return parsed
 
 
 def _requirements_for(metadata: PackageMetadata, name: str) -> tuple[RequirementClassification, ...]:
-    expected = canonicalize_name(name)
+    _, _, utils, _ = _packaging_modules()
+    expected = str(utils.canonicalize_name(name))
     classified = tuple(classify_requirement(raw) for raw in metadata.requires_dist)
-    return tuple(item for item in classified if canonicalize_name(item.requirement.name) == expected)
+    return tuple(item for item in classified if item.name == expected)
 
 
 def verify_static_transition(
@@ -279,14 +279,11 @@ def verify_static_transition(
     release_tag: str,
     manifest_bytes: bytes,
     expected_manifest: bytes,
-    python_executable: Path = Path(sys.executable),
-) -> StaticTransitionVerification:
+) -> tuple[PackageMetadata, PackageMetadata, PackageReleasePolicy]:
     """Freeze A's static contract for successor B's staged and rebuilt wheels."""
-    policy = load_package_release_policy(
-        manifest_bytes, expected_manifest=expected_manifest, release_tag=release_tag
-    )
-    core = inspect_wheel(core_wheel, python_executable=python_executable)
-    memory = inspect_wheel(memory_wheel, python_executable=python_executable)
+    policy = load_package_release_policy(manifest_bytes, expected_manifest=expected_manifest, release_tag=release_tag)
+    core = inspect_wheel(core_wheel)
+    memory = inspect_wheel(memory_wheel)
     expected_version = _release_version(release_tag)
     if core.name != "avibe-os" or memory.name != "avibe-memory":
         raise ReleaseAssetError("transition wheel distribution identity is invalid")
@@ -300,10 +297,11 @@ def verify_static_transition(
     core_dependencies = _requirements_for(memory, "avibe-os")
     if len(core_dependencies) != 1:
         raise ReleaseAssetError("Memory metadata must contain exactly one avibe-os dependency")
-    reverse = core_dependencies[0].requirement
-    if reverse.url is not None or reverse.marker is not None or reverse.extras or not reverse.specifier or expected_version not in reverse.specifier:
+    reverse = core_dependencies[0]
+    _, specifiers, _, versions = _packaging_modules()
+    if reverse.is_direct or reverse.has_marker or reverse.has_extras or not reverse.specifier or versions.Version(expected_version) not in specifiers.SpecifierSet(reverse.specifier):
         raise ReleaseAssetError("Memory avibe-os dependency must accept the release version")
-    return StaticTransitionVerification(core, memory, policy)
+    return core, memory, policy
 
 
 def _sha256(path: Path) -> str:

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -189,6 +189,33 @@ def test_package_policy_pins_universal_wheel_tag(tmp_path: Path) -> None:
         guard.load_package_release_policy(candidate, expected_manifest=candidate, release_tag="v3.1.0")
 
 
+@pytest.mark.parametrize("requires_python", [">=3.10", ">= 3.10"])
+def test_package_policy_accepts_declared_requires_python_literal(
+    tmp_path: Path, requires_python: str
+) -> None:
+    manifest, _ = _manifest(tmp_path, requires_python=requires_python)
+    manifest_bytes = manifest.read_bytes()
+
+    policy = guard.load_package_release_policy(
+        manifest_bytes, expected_manifest=manifest_bytes, release_tag="v3.1.0"
+    )
+
+    assert policy.requires_python == ">=3.10"
+
+
+@pytest.mark.parametrize("requires_python", ["==3.10", ">=3.10,<3.10.2", ">=3.10,!=3.10.1"])
+def test_package_policy_rejects_undeclared_requires_python_contract(
+    tmp_path: Path, requires_python: str
+) -> None:
+    manifest, _ = _manifest(tmp_path, requires_python=requires_python)
+    manifest_bytes = manifest.read_bytes()
+
+    with pytest.raises(guard.ManifestPolicyError, match="Requires-Python"):
+        guard.load_package_release_policy(
+            manifest_bytes, expected_manifest=manifest_bytes, release_tag="v3.1.0"
+        )
+
+
 def test_wheel_filename_metadata_and_release_tag_are_independent_identities(tmp_path: Path) -> None:
     manifest, _ = _manifest(tmp_path / "metadata")
     with pytest.raises(guard.ReleaseAssetError, match="filename identity"):

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -80,6 +80,7 @@ def _manifest(
             "release_family": "3.1",
             "requires_python": requires_python,
             "supported_python_versions": list(supported_python_versions),
+            "wheel_tag": "py3-none-any",
             "namespace_policy_version": 1,
         },
         "archives": archives,
@@ -133,7 +134,7 @@ def _transition_wheels(
     requires_python: str = ">=3.10",
     wheel_tag: str = "py3-none-any",
     core_requirement: str = "avibe-memory==3.1.0",
-    memory_requirement: str = "avibe-os>=3.1,<3.2",
+    memory_requirement: str = "avibe-os==3.1.0",
 ) -> tuple[Path, Path]:
     tmp_path.mkdir(parents=True, exist_ok=True)
     def build(name: str, requirement: str) -> Path:
@@ -159,6 +160,7 @@ def _verify_static(tmp_path: Path, manifest: Path, **wheel_options):
         ("package_policy", "schema_version", 1.0),
         ("package_policy", "release_tag", 1),
         ("package_policy", "supported_python_versions", "3.11"),
+        ("package_policy", "wheel_tag", True),
         ("package_policy", "namespace_policy_version", True),
     ],
 )
@@ -187,6 +189,16 @@ def test_manifest_byte_mismatch_precedes_invalid_semantic_policy(tmp_path: Path)
         guard.load_package_release_policy(mismatched, expected_manifest=selected.read_bytes(), release_tag="v3.1.0")
 
 
+def test_package_policy_pins_universal_wheel_tag(tmp_path: Path) -> None:
+    manifest, _ = _manifest(tmp_path)
+    payload = json.loads(manifest.read_bytes())
+    payload["package_policy"]["wheel_tag"] = "py3-none-manylinux_2_17_x86_64"
+    candidate = json.dumps(payload).encode()
+
+    with pytest.raises(guard.ManifestPolicyError, match="wheel_tag"):
+        guard.load_package_release_policy(candidate, expected_manifest=candidate, release_tag="v3.1.0")
+
+
 def test_wheel_filename_metadata_and_release_tag_are_independent_identities(tmp_path: Path) -> None:
     wheel = _wheel(tmp_path / "avibe_os-3.1.1-py3-none-any.whl", "avibe-os")
     with pytest.raises(guard.ReleaseAssetError, match="filename identity"):
@@ -212,8 +224,10 @@ def test_wheel_tags_match_filename_tags(tmp_path: Path) -> None:
     with pytest.raises(guard.ReleaseAssetError, match="tags"):
         guard.inspect_wheel(wheel)
     manifest, _ = _manifest(tmp_path / "policy")
-    with pytest.raises(guard.ReleaseAssetError, match="supported Python"):
+    with pytest.raises(guard.ReleaseAssetError, match="release policy"):
         _verify_static(tmp_path / "supported", manifest, wheel_tag="cp312-cp312-manylinux_2_17_x86_64")
+    with pytest.raises(guard.ReleaseAssetError, match="release policy"):
+        _verify_static(tmp_path / "platform", manifest, wheel_tag="py3-none-manylinux_2_17_x86_64")
 
 
 def test_wheel_rejects_path_aliases_and_corrupt_members(tmp_path: Path) -> None:
@@ -230,11 +244,25 @@ def test_wheel_rejects_path_aliases_and_corrupt_members(tmp_path: Path) -> None:
             guard.inspect_wheel(wheel)
 
 
+def test_wheel_rejects_blank_record_rows(tmp_path: Path) -> None:
+    wheel = _wheel(
+        tmp_path / "avibe_os-3.1.0-py3-none-any.whl",
+        "avibe-os",
+        include_record=False,
+    )
+    with zipfile.ZipFile(wheel, "a") as archive:
+        archive.writestr("avibe_os-3.1.0.dist-info/RECORD", b"\n\n")
+
+    with pytest.raises(guard.ReleaseAssetError, match="RECORD"):
+        guard.inspect_wheel(wheel)
+
+
 def test_static_transition_uses_release_bound_requires_python(tmp_path: Path) -> None:
     manifest, _ = _manifest(tmp_path)
     core, memory, policy = _verify_static(tmp_path / "valid", manifest)
     assert core.version == memory.version == "3.1.0"
     assert policy.requires_python == ">=3.10"
+    assert policy.wheel_tag == "py3-none-any"
 
     with pytest.raises(guard.ReleaseAssetError, match="Requires-Python"):
         _verify_static(tmp_path / "mismatch", manifest, requires_python=">=3.11")
@@ -247,8 +275,10 @@ def test_requirement_classification_keeps_wildcard_equality_non_exact(tmp_path: 
     manifest, _ = _manifest(tmp_path)
     with pytest.raises(guard.ReleaseAssetError, match="hard-depend"):
         _verify_static(tmp_path / "wildcard", manifest, core_requirement="avibe-memory==3.1.*")
-    with pytest.raises(guard.ReleaseAssetError, match="accept the release version"):
+    with pytest.raises(guard.ReleaseAssetError, match="exact avibe-os"):
         _verify_static(tmp_path / "reverse", manifest, memory_requirement="avibe-os>=4")
+    with pytest.raises(guard.ReleaseAssetError, match="exact avibe-os"):
+        _verify_static(tmp_path / "overbroad", manifest, memory_requirement="avibe-os>=0")
 
 
 def test_existing_guard_commands_remain_stdlib_only(tmp_path: Path) -> None:

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -98,6 +98,7 @@ def _wheel(
     version: str = "3.1.0",
     requires_python: str = ">=3.10",
     requires_dist: tuple[str, ...] = (),
+    wheel_version: str = "1.0",
     include_wheel_metadata: bool = True,
     include_record: bool = True,
 ) -> Path:
@@ -112,9 +113,9 @@ def _wheel(
     files = {f"{dist_info}/METADATA": metadata}
     if include_wheel_metadata:
         files[f"{dist_info}/WHEEL"] = (
-            b"Wheel-Version: 1.0\nGenerator: gate5a-test\n"
-            b"Root-Is-Purelib: true\nTag: py3-none-any\n\n"
-        )
+            f"Wheel-Version: {wheel_version}\nGenerator: gate5a-test\n"
+            "Root-Is-Purelib: true\nTag: py3-none-any\n\n"
+        ).encode()
     if include_record:
         record = f"{dist_info}/RECORD"
         files[record] = ("".join(f"{item},,\n" for item in sorted(files)) + f"{record},,\n").encode()
@@ -196,6 +197,12 @@ def test_wheel_filename_metadata_and_release_tag_are_independent_identities(tmp_
     manifest, _ = _manifest(tmp_path / "release", release_tag="v3.1.1")
     with pytest.raises(guard.ReleaseAssetError, match="release tag"):
         _verify_static(tmp_path / "wheels", manifest)
+
+
+def test_wheel_version_requires_complete_major_minor_syntax(tmp_path: Path) -> None:
+    wheel = _wheel(tmp_path / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os", wheel_version="1.foo")
+    with pytest.raises(guard.ReleaseAssetError, match="metadata version"):
+        guard.inspect_wheel(wheel)
 
 
 def test_static_transition_uses_release_bound_requires_python(tmp_path: Path) -> None:

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -79,7 +79,6 @@ def _manifest(
             "release_family": "3.1",
             "requires_python": requires_python,
             "supported_python_versions": list(supported_python_versions),
-            "wheel_tag": "py3-none-any",
             "namespace_policy_version": 1,
         },
         "archives": archives,
@@ -107,7 +106,6 @@ def _verify_static(
     metadata_version: str = "3.1.0",
     filename_version: str | None = None,
     requires_python: str = ">=3.10",
-    wheel_tag: str = "py3-none-any",
     core_requirement: str = "avibe-memory==3.1.0",
     memory_requirement: str = "avibe-os==3.1.0",
 ) -> tuple[guard.PackageMetadata, guard.PackageMetadata, guard.PackageReleasePolicy]:
@@ -126,9 +124,9 @@ def _verify_static(
     )
     manifest_bytes = manifest.read_bytes()
     return guard.verify_static_transition(
-        core_wheel_filename=f"avibe_os-{filename_version}-{wheel_tag}.whl",
+        core_wheel_filename=f"avibe_os-{filename_version}-py3-none-any.whl",
         core_metadata=core,
-        memory_wheel_filename=f"avibe_memory-{filename_version}-{wheel_tag}.whl",
+        memory_wheel_filename=f"avibe_memory-{filename_version}-py3-none-any.whl",
         memory_metadata=memory,
         release_tag=json.loads(manifest_bytes)["release_tag"],
         manifest_bytes=manifest_bytes,
@@ -150,7 +148,6 @@ def _verify_static(
         ("package_policy", "supported_python_versions", ["3.11+local"]),
         ("package_policy", "supported_python_versions", ["3.11.post1"]),
         ("package_policy", "supported_python_versions", ["3.11.dev1"]),
-        ("package_policy", "wheel_tag", True),
         ("package_policy", "namespace_policy_version", True),
     ],
 )
@@ -179,16 +176,6 @@ def test_manifest_byte_mismatch_precedes_invalid_semantic_policy(tmp_path: Path)
         guard.load_package_release_policy(mismatched, expected_manifest=selected.read_bytes(), release_tag="v3.1.0")
 
 
-def test_package_policy_pins_universal_wheel_tag(tmp_path: Path) -> None:
-    manifest, _ = _manifest(tmp_path)
-    payload = json.loads(manifest.read_bytes())
-    payload["package_policy"]["wheel_tag"] = "py3-none-manylinux_2_17_x86_64"
-    candidate = json.dumps(payload).encode()
-
-    with pytest.raises(guard.ManifestPolicyError, match="wheel_tag"):
-        guard.load_package_release_policy(candidate, expected_manifest=candidate, release_tag="v3.1.0")
-
-
 @pytest.mark.parametrize("requires_python", [">=3.10", ">= 3.10"])
 def test_package_policy_accepts_declared_requires_python_literal(
     tmp_path: Path, requires_python: str
@@ -201,6 +188,29 @@ def test_package_policy_accepts_declared_requires_python_literal(
     )
 
     assert policy.requires_python == ">=3.10"
+    assert policy.supported_python_versions == guard.PACKAGE_POLICY_SUPPORTED_PYTHON_VERSIONS
+
+
+@pytest.mark.parametrize(
+    "supported_python_versions",
+    [
+        ("3.9",),
+        ("3.10", "3.11"),
+        ("3.10", "3.11", "3.12", "3.13"),
+        ("3.10", "3.11", "3.12", "3.12"),
+        ("3.12", "3.11", "3.10"),
+    ],
+)
+def test_package_policy_rejects_undeclared_supported_python_versions(
+    tmp_path: Path, supported_python_versions: tuple[str, ...]
+) -> None:
+    manifest, _ = _manifest(tmp_path, supported_python_versions=supported_python_versions)
+    manifest_bytes = manifest.read_bytes()
+
+    with pytest.raises(guard.ManifestPolicyError, match="supported Python"):
+        guard.load_package_release_policy(
+            manifest_bytes, expected_manifest=manifest_bytes, release_tag="v3.1.0"
+        )
 
 
 @pytest.mark.parametrize("requires_python", ["==3.10", ">=3.10,<3.10.2", ">=3.10,!=3.10.1"])
@@ -226,20 +236,11 @@ def test_wheel_filename_metadata_and_release_tag_are_independent_identities(tmp_
         _verify_static(manifest)
 
 
-def test_declared_wheel_tag_binds_wheel_filenames(tmp_path: Path) -> None:
-    manifest, _ = _manifest(tmp_path)
-    with pytest.raises(guard.ReleaseAssetError, match="release policy"):
-        _verify_static(manifest, wheel_tag="cp312-cp312-manylinux_2_17_x86_64")
-    with pytest.raises(guard.ReleaseAssetError, match="release policy"):
-        _verify_static(manifest, wheel_tag="py3-none-manylinux_2_17_x86_64")
-
-
 def test_static_transition_uses_release_bound_requires_python(tmp_path: Path) -> None:
     manifest, _ = _manifest(tmp_path)
     core, memory, policy = _verify_static(manifest)
     assert core.version == memory.version == "3.1.0"
     assert policy.requires_python == ">=3.10"
-    assert policy.wheel_tag == "py3-none-any"
 
     with pytest.raises(guard.ReleaseAssetError, match="Requires-Python"):
         _verify_static(manifest, requires_python=">=3.11")

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -4,13 +4,17 @@ import gzip
 import hashlib
 import io
 import json
+import sys
 import tarfile
 from pathlib import Path
+import zipfile
 
 import pytest
 
 from scripts import memory_runtime_release_guard as guard
 from scripts.build_memory_runtime import LOCK_SHA256 as RUNTIME_LOCK_SHA256
+
+PIP_PYTHON = Path(sys._base_executable)
 
 
 def test_guard_platform_contract_keeps_no_follow_capable_shipped_targets_enabled() -> None:
@@ -40,8 +44,12 @@ def _manifest(
     *,
     everos_version: str = "1.2.3",
     lock_sha256: str = guard.EXPECTED_LOCK_SHA256,
+    release_tag: str = "v3.1.0",
+    requires_python: str = ">=3.10",
+    supported_python_versions: tuple[str, ...] = ("3.10", "3.11", "3.12"),
 ) -> tuple[Path, dict[str, bytes]]:
-    tag = "v3.1.0"
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    tag = release_tag
     base_url = f"{guard.RELEASE_DOWNLOAD_ROOT}/{tag}"
     archives: dict[str, dict[str, object]] = {}
     remote: dict[str, bytes] = {}
@@ -68,6 +76,14 @@ def _manifest(
         "uv_version": guard.EXPECTED_UV_VERSION,
         "release_state": "published",
         "release_tag": tag,
+        "package_policy": {
+            "schema_version": 1,
+            "release_tag": tag,
+            "release_family": "3.1",
+            "requires_python": requires_python,
+            "supported_python_versions": list(supported_python_versions),
+            "namespace_policy_version": 1,
+        },
         "archives": archives,
     }
     manifest = tmp_path / "memory-runtime-manifest.json"
@@ -75,6 +91,155 @@ def _manifest(
     manifest.write_bytes(manifest_bytes)
     remote[f"{base_url}/memory-runtime-manifest.json"] = manifest_bytes
     return manifest, remote
+
+
+def _wheel(
+    path: Path,
+    name: str,
+    *,
+    version: str = "3.1.0",
+    requires_python: str = ">=3.10",
+    requires_dist: tuple[str, ...] = (),
+    include_wheel_metadata: bool = True,
+) -> Path:
+    dist_info = f"{name.replace('-', '_')}-{version}.dist-info"
+    metadata = (
+        f"Metadata-Version: 2.4\nName: {name}\nVersion: {version}\n"
+        f"Requires-Python: {requires_python}\n"
+        + "".join(f"Requires-Dist: {requirement}\n" for requirement in requires_dist)
+        + "\n"
+    ).encode()
+    files = {f"{dist_info}/METADATA": metadata}
+    if include_wheel_metadata:
+        files[f"{dist_info}/WHEEL"] = (
+            b"Wheel-Version: 1.0\nGenerator: gate5a-test\n"
+            b"Root-Is-Purelib: true\nTag: py3-none-any\n\n"
+        )
+    record = f"{dist_info}/RECORD"
+    files[record] = ("".join(f"{item},,\n" for item in sorted(files)) + f"{record},,\n").encode()
+    with zipfile.ZipFile(path, "w") as archive:
+        for member, content in files.items():
+            archive.writestr(member, content)
+    return path
+
+
+def _transition_wheels(
+    tmp_path: Path,
+    *,
+    version: str = "3.1.0",
+    requires_python: str = ">=3.10",
+    core_requirement: str = "avibe-memory==3.1.0",
+    memory_requirement: str = "avibe-os>=3.1,<3.2",
+) -> tuple[Path, Path]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    return (
+        _wheel(
+            tmp_path / f"avibe_os-{version}-py3-none-any.whl",
+            "avibe-os",
+            version=version,
+            requires_python=requires_python,
+            requires_dist=(core_requirement,),
+        ),
+        _wheel(
+            tmp_path / f"avibe_memory-{version}-py3-none-any.whl",
+            "avibe-memory",
+            version=version,
+            requires_python=requires_python,
+            requires_dist=(memory_requirement,),
+        ),
+    )
+
+
+def _verify_static(tmp_path: Path, manifest: Path, **wheel_options):
+    core, memory = _transition_wheels(tmp_path, **wheel_options)
+    manifest_bytes = manifest.read_bytes()
+    return guard.verify_static_transition(
+        core,
+        memory,
+        release_tag=json.loads(manifest_bytes)["release_tag"],
+        manifest_bytes=manifest_bytes,
+        expected_manifest=manifest_bytes,
+        python_executable=PIP_PYTHON,
+    )
+
+
+@pytest.mark.parametrize(
+    ("section", "field", "value"),
+    [
+        (None, "schema_version", True),
+        (None, "schema_version", 1.0),
+        ("package_policy", "schema_version", True),
+        ("package_policy", "schema_version", 1.0),
+        ("package_policy", "release_tag", 1),
+        ("package_policy", "supported_python_versions", "3.11"),
+        ("package_policy", "namespace_policy_version", True),
+    ],
+)
+def test_package_policy_requires_exact_json_types(
+    tmp_path: Path, section: str | None, field: str, value: object
+) -> None:
+    manifest, _ = _manifest(tmp_path)
+    payload = json.loads(manifest.read_bytes())
+    target = payload if section is None else payload[section]
+    target[field] = value
+    candidate = json.dumps(payload).encode()
+
+    with pytest.raises(guard.ManifestPolicyError):
+        guard.load_package_release_policy(
+            candidate, expected_manifest=candidate, release_tag="v3.1.0"
+        )
+    if section is None:
+        manifest.write_bytes(candidate)
+        with pytest.raises(guard.ManifestPolicyError):
+            guard.load_release_spec(manifest)
+
+
+def test_manifest_byte_mismatch_precedes_invalid_semantic_policy(tmp_path: Path) -> None:
+    selected, _ = _manifest(tmp_path)
+    mismatched = b'{"schema_version":1,"package_policy":{"schema_version":2}}'
+
+    with pytest.raises(guard.ReleaseAssetError, match="does not match"):
+        guard.load_package_release_policy(
+            mismatched, expected_manifest=selected.read_bytes(), release_tag="v3.1.0"
+        )
+
+
+def test_wheel_filename_metadata_and_release_tag_are_independent_identities(tmp_path: Path) -> None:
+    wheel = _wheel(tmp_path / "avibe_os-3.1.1-py3-none-any.whl", "avibe-os")
+    with pytest.raises(guard.ReleaseAssetError, match="filename identity"):
+        guard.inspect_wheel(wheel, python_executable=PIP_PYTHON)
+    invalid = _wheel(
+        tmp_path / "avibe_os-3.1.0-py3-none-any.whl",
+        "avibe-os",
+        include_wheel_metadata=False,
+    )
+    with pytest.raises(guard.ReleaseAssetError, match="wheel structure validation failed"):
+        guard.inspect_wheel(invalid, python_executable=PIP_PYTHON)
+
+    manifest, _ = _manifest(tmp_path / "release", release_tag="v3.1.1")
+    with pytest.raises(guard.ReleaseAssetError, match="release tag"):
+        _verify_static(tmp_path / "wheels", manifest)
+
+
+def test_static_transition_uses_release_bound_requires_python(tmp_path: Path) -> None:
+    manifest, _ = _manifest(tmp_path)
+    verified = _verify_static(tmp_path / "valid", manifest)
+    assert str(verified.core.version) == str(verified.memory.version) == "3.1.0"
+    assert verified.policy.requires_python == ">=3.10"
+
+    with pytest.raises(guard.ReleaseAssetError, match="Requires-Python"):
+        _verify_static(tmp_path / "mismatch", manifest, requires_python=">=3.11")
+
+
+def test_requirement_classification_keeps_wildcard_equality_non_exact(tmp_path: Path) -> None:
+    classification = guard.classify_requirement("avibe-memory==3.1.*")
+    assert classification.exact_version is None
+
+    manifest, _ = _manifest(tmp_path)
+    with pytest.raises(guard.ReleaseAssetError, match="hard-depend"):
+        _verify_static(tmp_path / "wildcard", manifest, core_requirement="avibe-memory==3.1.*")
+    with pytest.raises(guard.ReleaseAssetError, match="accept the release version"):
+        _verify_static(tmp_path / "reverse", manifest, memory_requirement="avibe-os>=4")
 
 
 @pytest.mark.parametrize("everos_version", sorted(guard.PUBLISHED_RUNTIME_PROVENANCE))

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -8,7 +8,6 @@ import subprocess
 import sys
 import tarfile
 from pathlib import Path
-import zipfile
 
 import pytest
 
@@ -92,64 +91,49 @@ def _manifest(
     return manifest, remote
 
 
-def _wheel(
-    path: Path,
+def _package_metadata(
     name: str,
     *,
     version: str = "3.1.0",
     requires_python: str = ">=3.10",
     requires_dist: tuple[str, ...] = (),
-    metadata_version: str | None = "2.4",
-    wheel_version: str = "1.0",
-    wheel_tag: str = "py3-none-any",
-    include_wheel_metadata: bool = True,
-    include_record: bool = True,
-) -> Path:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    dist_info = f"{name.replace('-', '_')}-{version}.dist-info"
-    metadata_header = "" if metadata_version is None else f"Metadata-Version: {metadata_version}\n"
-    metadata = (
-        f"{metadata_header}Name: {name}\nVersion: {version}\n"
-        f"Requires-Python: {requires_python}\n"
-        + "".join(f"Requires-Dist: {requirement}\n" for requirement in requires_dist)
-        + "\n"
-    ).encode()
-    files = {f"{dist_info}/METADATA": metadata, f"{name.replace('-', '_')}/__init__.py": b"x = 1\n"}
-    if include_wheel_metadata:
-        files[f"{dist_info}/WHEEL"] = (
-            f"Wheel-Version: {wheel_version}\nGenerator: gate5a-test\n"
-            f"Root-Is-Purelib: true\nTag: {wheel_tag}\n\n"
-        ).encode()
-    if include_record:
-        record = f"{dist_info}/RECORD"
-        files[record] = ("".join(f"{item},,\n" for item in sorted(files)) + f"{record},,\n").encode()
-    with zipfile.ZipFile(path, "w") as archive:
-        for member, content in files.items():
-            archive.writestr(member, content)
-    return path
+) -> guard.PackageMetadata:
+    return guard.PackageMetadata(name, version, requires_python, requires_dist)
 
 
-def _transition_wheels(
-    tmp_path: Path,
+def _verify_static(
+    manifest: Path,
     *,
-    version: str = "3.1.0",
+    metadata_version: str = "3.1.0",
+    filename_version: str | None = None,
     requires_python: str = ">=3.10",
     wheel_tag: str = "py3-none-any",
     core_requirement: str = "avibe-memory==3.1.0",
     memory_requirement: str = "avibe-os==3.1.0",
-) -> tuple[Path, Path]:
-    tmp_path.mkdir(parents=True, exist_ok=True)
-    def build(name: str, requirement: str) -> Path:
-        stem = name.replace("-", "_")
-        return _wheel(tmp_path / f"{stem}-{version}-{wheel_tag}.whl", name, version=version, requires_python=requires_python, requires_dist=(requirement,), wheel_tag=wheel_tag)
-
-    return build("avibe-os", core_requirement), build("avibe-memory", memory_requirement)
-
-
-def _verify_static(tmp_path: Path, manifest: Path, **wheel_options):
-    core, memory = _transition_wheels(tmp_path, **wheel_options)
+) -> tuple[guard.PackageMetadata, guard.PackageMetadata, guard.PackageReleasePolicy]:
+    filename_version = filename_version or metadata_version
+    core = _package_metadata(
+        "avibe-os",
+        version=metadata_version,
+        requires_python=requires_python,
+        requires_dist=(core_requirement,),
+    )
+    memory = _package_metadata(
+        "avibe-memory",
+        version=metadata_version,
+        requires_python=requires_python,
+        requires_dist=(memory_requirement,),
+    )
     manifest_bytes = manifest.read_bytes()
-    return guard.verify_static_transition(core, memory, release_tag=json.loads(manifest_bytes)["release_tag"], manifest_bytes=manifest_bytes, expected_manifest=manifest_bytes)
+    return guard.verify_static_transition(
+        core_wheel_filename=f"avibe_os-{filename_version}-{wheel_tag}.whl",
+        core_metadata=core,
+        memory_wheel_filename=f"avibe_memory-{filename_version}-{wheel_tag}.whl",
+        memory_metadata=memory,
+        release_tag=json.loads(manifest_bytes)["release_tag"],
+        manifest_bytes=manifest_bytes,
+        expected_manifest=manifest_bytes,
+    )
 
 
 @pytest.mark.parametrize(
@@ -206,89 +190,32 @@ def test_package_policy_pins_universal_wheel_tag(tmp_path: Path) -> None:
 
 
 def test_wheel_filename_metadata_and_release_tag_are_independent_identities(tmp_path: Path) -> None:
-    wheel = _wheel(tmp_path / "avibe_os-3.1.1-py3-none-any.whl", "avibe-os")
+    manifest, _ = _manifest(tmp_path / "metadata")
     with pytest.raises(guard.ReleaseAssetError, match="filename identity"):
-        guard.inspect_wheel(wheel)
-    for directory, options in (("wheel", {"include_wheel_metadata": False}), ("record", {"include_record": False})):
-        invalid = _wheel(tmp_path / directory / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os", **options)
-        with pytest.raises(guard.ReleaseAssetError, match="control structure"):
-            guard.inspect_wheel(invalid)
+        _verify_static(manifest, filename_version="3.1.1")
 
     manifest, _ = _manifest(tmp_path / "release", release_tag="v3.1.1")
     with pytest.raises(guard.ReleaseAssetError, match="release tag"):
-        _verify_static(tmp_path / "wheels", manifest)
+        _verify_static(manifest)
 
 
-def test_wheel_version_requires_complete_major_minor_syntax(tmp_path: Path) -> None:
-    wheel = _wheel(tmp_path / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os", wheel_version="1.foo")
-    with pytest.raises(guard.ReleaseAssetError, match="metadata version"):
-        guard.inspect_wheel(wheel)
-
-
-@pytest.mark.parametrize(("metadata_version", "accepted"), [(None, False), ("999.0", False), ("2.4", True)])
-def test_wheel_validates_core_metadata_version(tmp_path: Path, metadata_version: str | None, accepted: bool) -> None:
-    wheel = _wheel(tmp_path / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os", metadata_version=metadata_version)
-    if accepted:
-        assert guard.inspect_wheel(wheel).name == "avibe-os"
-    else:
-        with pytest.raises(guard.ReleaseAssetError, match="core metadata"):
-            guard.inspect_wheel(wheel)
-
-
-def test_wheel_tags_match_filename_tags(tmp_path: Path) -> None:
-    wheel = _wheel(tmp_path / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os", wheel_tag="cp312-cp312-linux_x86_64")
-    with pytest.raises(guard.ReleaseAssetError, match="tags"):
-        guard.inspect_wheel(wheel)
-    manifest, _ = _manifest(tmp_path / "policy")
+def test_declared_wheel_tag_binds_wheel_filenames(tmp_path: Path) -> None:
+    manifest, _ = _manifest(tmp_path)
     with pytest.raises(guard.ReleaseAssetError, match="release policy"):
-        _verify_static(tmp_path / "supported", manifest, wheel_tag="cp312-cp312-manylinux_2_17_x86_64")
+        _verify_static(manifest, wheel_tag="cp312-cp312-manylinux_2_17_x86_64")
     with pytest.raises(guard.ReleaseAssetError, match="release policy"):
-        _verify_static(tmp_path / "platform", manifest, wheel_tag="py3-none-manylinux_2_17_x86_64")
-    invalid_python = _wheel(tmp_path / "python" / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os")
-    with pytest.raises(guard.ReleaseAssetError, match="supported Python"):
-        guard.inspect_wheel(invalid_python, supported_python_versions=("3.11+local",))
-
-
-def test_wheel_rejects_path_aliases_and_corrupt_members(tmp_path: Path) -> None:
-    alias = _wheel(tmp_path / "alias" / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os")
-    with zipfile.ZipFile(alias, "a") as archive:
-        archive.writestr("avibe_os-3.1.0.dist-info/./METADATA", b"alias")
-    corrupt = _wheel(tmp_path / "corrupt" / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os")
-    corrupt.write_bytes(corrupt.read_bytes().replace(b"x = 1\n", b"x = 2\n"))
-    unsupported = _wheel(tmp_path / "data" / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os")
-    with zipfile.ZipFile(unsupported, "a") as archive:
-        archive.writestr("avibe_os-3.1.0.data/unknown/payload", b"data")
-    for wheel in (alias, corrupt, unsupported):
-        with pytest.raises(guard.ReleaseAssetError):
-            guard.inspect_wheel(wheel)
-
-
-@pytest.mark.parametrize(
-    "record",
-    (b"\n\n", b"../../outside-victim,,\n", b"/absolute/path,,\n", b"bad\\path,,\n", b"bad\x00path,,\n", b"C:/absolute/path,,\n"),
-)
-def test_wheel_rejects_invalid_record_rows(tmp_path: Path, record: bytes) -> None:
-    wheel = _wheel(
-        tmp_path / "avibe_os-3.1.0-py3-none-any.whl",
-        "avibe-os",
-        include_record=False,
-    )
-    with zipfile.ZipFile(wheel, "a") as archive:
-        archive.writestr("avibe_os-3.1.0.dist-info/RECORD", record)
-
-    with pytest.raises(guard.ReleaseAssetError, match="RECORD"):
-        guard.inspect_wheel(wheel)
+        _verify_static(manifest, wheel_tag="py3-none-manylinux_2_17_x86_64")
 
 
 def test_static_transition_uses_release_bound_requires_python(tmp_path: Path) -> None:
     manifest, _ = _manifest(tmp_path)
-    core, memory, policy = _verify_static(tmp_path / "valid", manifest)
+    core, memory, policy = _verify_static(manifest)
     assert core.version == memory.version == "3.1.0"
     assert policy.requires_python == ">=3.10"
     assert policy.wheel_tag == "py3-none-any"
 
     with pytest.raises(guard.ReleaseAssetError, match="Requires-Python"):
-        _verify_static(tmp_path / "mismatch", manifest, requires_python=">=3.11")
+        _verify_static(manifest, requires_python=">=3.11")
 
 
 def test_requirement_classification_keeps_wildcard_equality_non_exact(tmp_path: Path) -> None:
@@ -297,11 +224,11 @@ def test_requirement_classification_keeps_wildcard_equality_non_exact(tmp_path: 
 
     manifest, _ = _manifest(tmp_path)
     with pytest.raises(guard.ReleaseAssetError, match="hard-depend"):
-        _verify_static(tmp_path / "wildcard", manifest, core_requirement="avibe-memory==3.1.*")
+        _verify_static(manifest, core_requirement="avibe-memory==3.1.*")
     with pytest.raises(guard.ReleaseAssetError, match="exact avibe-os"):
-        _verify_static(tmp_path / "reverse", manifest, memory_requirement="avibe-os>=4")
+        _verify_static(manifest, memory_requirement="avibe-os>=4")
     with pytest.raises(guard.ReleaseAssetError, match="exact avibe-os"):
-        _verify_static(tmp_path / "overbroad", manifest, memory_requirement="avibe-os>=0")
+        _verify_static(manifest, memory_requirement="avibe-os>=0")
 
 
 def test_existing_guard_commands_remain_stdlib_only(tmp_path: Path) -> None:

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -99,6 +99,7 @@ def _wheel(
     requires_python: str = ">=3.10",
     requires_dist: tuple[str, ...] = (),
     wheel_version: str = "1.0",
+    wheel_tag: str = "py3-none-any",
     include_wheel_metadata: bool = True,
     include_record: bool = True,
 ) -> Path:
@@ -110,11 +111,11 @@ def _wheel(
         + "".join(f"Requires-Dist: {requirement}\n" for requirement in requires_dist)
         + "\n"
     ).encode()
-    files = {f"{dist_info}/METADATA": metadata}
+    files = {f"{dist_info}/METADATA": metadata, f"{name.replace('-', '_')}/__init__.py": b"x = 1\n"}
     if include_wheel_metadata:
         files[f"{dist_info}/WHEEL"] = (
             f"Wheel-Version: {wheel_version}\nGenerator: gate5a-test\n"
-            "Root-Is-Purelib: true\nTag: py3-none-any\n\n"
+            f"Root-Is-Purelib: true\nTag: {wheel_tag}\n\n"
         ).encode()
     if include_record:
         record = f"{dist_info}/RECORD"
@@ -203,6 +204,23 @@ def test_wheel_version_requires_complete_major_minor_syntax(tmp_path: Path) -> N
     wheel = _wheel(tmp_path / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os", wheel_version="1.foo")
     with pytest.raises(guard.ReleaseAssetError, match="metadata version"):
         guard.inspect_wheel(wheel)
+
+
+def test_wheel_tags_match_filename_tags(tmp_path: Path) -> None:
+    wheel = _wheel(tmp_path / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os", wheel_tag="cp312-cp312-linux_x86_64")
+    with pytest.raises(guard.ReleaseAssetError, match="tags"):
+        guard.inspect_wheel(wheel)
+
+
+def test_wheel_rejects_path_aliases_and_corrupt_members(tmp_path: Path) -> None:
+    alias = _wheel(tmp_path / "alias" / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os")
+    with zipfile.ZipFile(alias, "a") as archive:
+        archive.writestr("avibe_os-3.1.0.dist-info/./METADATA", b"alias")
+    corrupt = _wheel(tmp_path / "corrupt" / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os")
+    corrupt.write_bytes(corrupt.read_bytes().replace(b"x = 1\n", b"x = 2\n"))
+    for wheel in (alias, corrupt):
+        with pytest.raises(guard.ReleaseAssetError):
+            guard.inspect_wheel(wheel)
 
 
 def test_static_transition_uses_release_bound_requires_python(tmp_path: Path) -> None:

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -131,13 +131,14 @@ def _transition_wheels(
     *,
     version: str = "3.1.0",
     requires_python: str = ">=3.10",
+    wheel_tag: str = "py3-none-any",
     core_requirement: str = "avibe-memory==3.1.0",
     memory_requirement: str = "avibe-os>=3.1,<3.2",
 ) -> tuple[Path, Path]:
     tmp_path.mkdir(parents=True, exist_ok=True)
     def build(name: str, requirement: str) -> Path:
         stem = name.replace("-", "_")
-        return _wheel(tmp_path / f"{stem}-{version}-py3-none-any.whl", name, version=version, requires_python=requires_python, requires_dist=(requirement,))
+        return _wheel(tmp_path / f"{stem}-{version}-{wheel_tag}.whl", name, version=version, requires_python=requires_python, requires_dist=(requirement,), wheel_tag=wheel_tag)
 
     return build("avibe-os", core_requirement), build("avibe-memory", memory_requirement)
 
@@ -210,6 +211,9 @@ def test_wheel_tags_match_filename_tags(tmp_path: Path) -> None:
     wheel = _wheel(tmp_path / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os", wheel_tag="cp312-cp312-linux_x86_64")
     with pytest.raises(guard.ReleaseAssetError, match="tags"):
         guard.inspect_wheel(wheel)
+    manifest, _ = _manifest(tmp_path / "policy")
+    with pytest.raises(guard.ReleaseAssetError, match="supported Python"):
+        _verify_static(tmp_path / "supported", manifest, wheel_tag="cp312-cp312-manylinux_2_17_x86_64")
 
 
 def test_wheel_rejects_path_aliases_and_corrupt_members(tmp_path: Path) -> None:
@@ -218,7 +222,10 @@ def test_wheel_rejects_path_aliases_and_corrupt_members(tmp_path: Path) -> None:
         archive.writestr("avibe_os-3.1.0.dist-info/./METADATA", b"alias")
     corrupt = _wheel(tmp_path / "corrupt" / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os")
     corrupt.write_bytes(corrupt.read_bytes().replace(b"x = 1\n", b"x = 2\n"))
-    for wheel in (alias, corrupt):
+    unsupported = _wheel(tmp_path / "data" / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os")
+    with zipfile.ZipFile(unsupported, "a") as archive:
+        archive.writestr("avibe_os-3.1.0.data/unknown/payload", b"data")
+    for wheel in (alias, corrupt, unsupported):
         with pytest.raises(guard.ReleaseAssetError):
             guard.inspect_wheel(wheel)
 

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -4,6 +4,7 @@ import gzip
 import hashlib
 import io
 import json
+import subprocess
 import sys
 import tarfile
 from pathlib import Path
@@ -13,9 +14,6 @@ import pytest
 
 from scripts import memory_runtime_release_guard as guard
 from scripts.build_memory_runtime import LOCK_SHA256 as RUNTIME_LOCK_SHA256
-
-PIP_PYTHON = Path(sys._base_executable)
-
 
 def test_guard_platform_contract_keeps_no_follow_capable_shipped_targets_enabled() -> None:
     assert guard.EXPECTED_PLATFORMS == frozenset({"darwin-arm64", "linux-arm64", "linux-x64"})
@@ -101,7 +99,9 @@ def _wheel(
     requires_python: str = ">=3.10",
     requires_dist: tuple[str, ...] = (),
     include_wheel_metadata: bool = True,
+    include_record: bool = True,
 ) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
     dist_info = f"{name.replace('-', '_')}-{version}.dist-info"
     metadata = (
         f"Metadata-Version: 2.4\nName: {name}\nVersion: {version}\n"
@@ -115,8 +115,9 @@ def _wheel(
             b"Wheel-Version: 1.0\nGenerator: gate5a-test\n"
             b"Root-Is-Purelib: true\nTag: py3-none-any\n\n"
         )
-    record = f"{dist_info}/RECORD"
-    files[record] = ("".join(f"{item},,\n" for item in sorted(files)) + f"{record},,\n").encode()
+    if include_record:
+        record = f"{dist_info}/RECORD"
+        files[record] = ("".join(f"{item},,\n" for item in sorted(files)) + f"{record},,\n").encode()
     with zipfile.ZipFile(path, "w") as archive:
         for member, content in files.items():
             archive.writestr(member, content)
@@ -132,35 +133,17 @@ def _transition_wheels(
     memory_requirement: str = "avibe-os>=3.1,<3.2",
 ) -> tuple[Path, Path]:
     tmp_path.mkdir(parents=True, exist_ok=True)
-    return (
-        _wheel(
-            tmp_path / f"avibe_os-{version}-py3-none-any.whl",
-            "avibe-os",
-            version=version,
-            requires_python=requires_python,
-            requires_dist=(core_requirement,),
-        ),
-        _wheel(
-            tmp_path / f"avibe_memory-{version}-py3-none-any.whl",
-            "avibe-memory",
-            version=version,
-            requires_python=requires_python,
-            requires_dist=(memory_requirement,),
-        ),
-    )
+    def build(name: str, requirement: str) -> Path:
+        stem = name.replace("-", "_")
+        return _wheel(tmp_path / f"{stem}-{version}-py3-none-any.whl", name, version=version, requires_python=requires_python, requires_dist=(requirement,))
+
+    return build("avibe-os", core_requirement), build("avibe-memory", memory_requirement)
 
 
 def _verify_static(tmp_path: Path, manifest: Path, **wheel_options):
     core, memory = _transition_wheels(tmp_path, **wheel_options)
     manifest_bytes = manifest.read_bytes()
-    return guard.verify_static_transition(
-        core,
-        memory,
-        release_tag=json.loads(manifest_bytes)["release_tag"],
-        manifest_bytes=manifest_bytes,
-        expected_manifest=manifest_bytes,
-        python_executable=PIP_PYTHON,
-    )
+    return guard.verify_static_transition(core, memory, release_tag=json.loads(manifest_bytes)["release_tag"], manifest_bytes=manifest_bytes, expected_manifest=manifest_bytes)
 
 
 @pytest.mark.parametrize(
@@ -168,6 +151,7 @@ def _verify_static(tmp_path: Path, manifest: Path, **wheel_options):
     [
         (None, "schema_version", True),
         (None, "schema_version", 1.0),
+        (None, "release_tag", "v9.9.9"),
         ("package_policy", "schema_version", True),
         ("package_policy", "schema_version", 1.0),
         ("package_policy", "release_tag", 1),
@@ -185,10 +169,8 @@ def test_package_policy_requires_exact_json_types(
     candidate = json.dumps(payload).encode()
 
     with pytest.raises(guard.ManifestPolicyError):
-        guard.load_package_release_policy(
-            candidate, expected_manifest=candidate, release_tag="v3.1.0"
-        )
-    if section is None:
+        guard.load_package_release_policy(candidate, expected_manifest=candidate, release_tag="v3.1.0")
+    if section is None and field == "schema_version":
         manifest.write_bytes(candidate)
         with pytest.raises(guard.ManifestPolicyError):
             guard.load_release_spec(manifest)
@@ -199,22 +181,17 @@ def test_manifest_byte_mismatch_precedes_invalid_semantic_policy(tmp_path: Path)
     mismatched = b'{"schema_version":1,"package_policy":{"schema_version":2}}'
 
     with pytest.raises(guard.ReleaseAssetError, match="does not match"):
-        guard.load_package_release_policy(
-            mismatched, expected_manifest=selected.read_bytes(), release_tag="v3.1.0"
-        )
+        guard.load_package_release_policy(mismatched, expected_manifest=selected.read_bytes(), release_tag="v3.1.0")
 
 
 def test_wheel_filename_metadata_and_release_tag_are_independent_identities(tmp_path: Path) -> None:
     wheel = _wheel(tmp_path / "avibe_os-3.1.1-py3-none-any.whl", "avibe-os")
     with pytest.raises(guard.ReleaseAssetError, match="filename identity"):
-        guard.inspect_wheel(wheel, python_executable=PIP_PYTHON)
-    invalid = _wheel(
-        tmp_path / "avibe_os-3.1.0-py3-none-any.whl",
-        "avibe-os",
-        include_wheel_metadata=False,
-    )
-    with pytest.raises(guard.ReleaseAssetError, match="wheel structure validation failed"):
-        guard.inspect_wheel(invalid, python_executable=PIP_PYTHON)
+        guard.inspect_wheel(wheel)
+    for directory, options in (("wheel", {"include_wheel_metadata": False}), ("record", {"include_record": False})):
+        invalid = _wheel(tmp_path / directory / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os", **options)
+        with pytest.raises(guard.ReleaseAssetError, match="control structure"):
+            guard.inspect_wheel(invalid)
 
     manifest, _ = _manifest(tmp_path / "release", release_tag="v3.1.1")
     with pytest.raises(guard.ReleaseAssetError, match="release tag"):
@@ -223,9 +200,9 @@ def test_wheel_filename_metadata_and_release_tag_are_independent_identities(tmp_
 
 def test_static_transition_uses_release_bound_requires_python(tmp_path: Path) -> None:
     manifest, _ = _manifest(tmp_path)
-    verified = _verify_static(tmp_path / "valid", manifest)
-    assert str(verified.core.version) == str(verified.memory.version) == "3.1.0"
-    assert verified.policy.requires_python == ">=3.10"
+    core, memory, policy = _verify_static(tmp_path / "valid", manifest)
+    assert core.version == memory.version == "3.1.0"
+    assert policy.requires_python == ">=3.10"
 
     with pytest.raises(guard.ReleaseAssetError, match="Requires-Python"):
         _verify_static(tmp_path / "mismatch", manifest, requires_python=">=3.11")
@@ -240,6 +217,13 @@ def test_requirement_classification_keeps_wildcard_equality_non_exact(tmp_path: 
         _verify_static(tmp_path / "wildcard", manifest, core_requirement="avibe-memory==3.1.*")
     with pytest.raises(guard.ReleaseAssetError, match="accept the release version"):
         _verify_static(tmp_path / "reverse", manifest, memory_requirement="avibe-os>=4")
+
+
+def test_existing_guard_commands_remain_stdlib_only(tmp_path: Path) -> None:
+    manifest, _ = _manifest(tmp_path)
+    script = Path(__file__).resolve().parents[1] / "scripts/memory_runtime_release_guard.py"
+    result = subprocess.run([sys._base_executable, "-S", str(script), "--manifest", str(manifest), "check-policy"], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.parametrize("everos_version", sorted(guard.PUBLISHED_RUNTIME_PROVENANCE))

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -99,6 +99,7 @@ def _wheel(
     version: str = "3.1.0",
     requires_python: str = ">=3.10",
     requires_dist: tuple[str, ...] = (),
+    metadata_version: str | None = "2.4",
     wheel_version: str = "1.0",
     wheel_tag: str = "py3-none-any",
     include_wheel_metadata: bool = True,
@@ -106,8 +107,9 @@ def _wheel(
 ) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     dist_info = f"{name.replace('-', '_')}-{version}.dist-info"
+    metadata_header = "" if metadata_version is None else f"Metadata-Version: {metadata_version}\n"
     metadata = (
-        f"Metadata-Version: 2.4\nName: {name}\nVersion: {version}\n"
+        f"{metadata_header}Name: {name}\nVersion: {version}\n"
         f"Requires-Python: {requires_python}\n"
         + "".join(f"Requires-Dist: {requirement}\n" for requirement in requires_dist)
         + "\n"
@@ -160,6 +162,10 @@ def _verify_static(tmp_path: Path, manifest: Path, **wheel_options):
         ("package_policy", "schema_version", 1.0),
         ("package_policy", "release_tag", 1),
         ("package_policy", "supported_python_versions", "3.11"),
+        ("package_policy", "supported_python_versions", ["3.11rc1"]),
+        ("package_policy", "supported_python_versions", ["3.11+local"]),
+        ("package_policy", "supported_python_versions", ["3.11.post1"]),
+        ("package_policy", "supported_python_versions", ["3.11.dev1"]),
         ("package_policy", "wheel_tag", True),
         ("package_policy", "namespace_policy_version", True),
     ],
@@ -219,6 +225,16 @@ def test_wheel_version_requires_complete_major_minor_syntax(tmp_path: Path) -> N
         guard.inspect_wheel(wheel)
 
 
+@pytest.mark.parametrize(("metadata_version", "accepted"), [(None, False), ("999.0", False), ("2.4", True)])
+def test_wheel_validates_core_metadata_version(tmp_path: Path, metadata_version: str | None, accepted: bool) -> None:
+    wheel = _wheel(tmp_path / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os", metadata_version=metadata_version)
+    if accepted:
+        assert guard.inspect_wheel(wheel).name == "avibe-os"
+    else:
+        with pytest.raises(guard.ReleaseAssetError, match="core metadata"):
+            guard.inspect_wheel(wheel)
+
+
 def test_wheel_tags_match_filename_tags(tmp_path: Path) -> None:
     wheel = _wheel(tmp_path / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os", wheel_tag="cp312-cp312-linux_x86_64")
     with pytest.raises(guard.ReleaseAssetError, match="tags"):
@@ -228,6 +244,9 @@ def test_wheel_tags_match_filename_tags(tmp_path: Path) -> None:
         _verify_static(tmp_path / "supported", manifest, wheel_tag="cp312-cp312-manylinux_2_17_x86_64")
     with pytest.raises(guard.ReleaseAssetError, match="release policy"):
         _verify_static(tmp_path / "platform", manifest, wheel_tag="py3-none-manylinux_2_17_x86_64")
+    invalid_python = _wheel(tmp_path / "python" / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os")
+    with pytest.raises(guard.ReleaseAssetError, match="supported Python"):
+        guard.inspect_wheel(invalid_python, supported_python_versions=("3.11+local",))
 
 
 def test_wheel_rejects_path_aliases_and_corrupt_members(tmp_path: Path) -> None:
@@ -244,14 +263,18 @@ def test_wheel_rejects_path_aliases_and_corrupt_members(tmp_path: Path) -> None:
             guard.inspect_wheel(wheel)
 
 
-def test_wheel_rejects_blank_record_rows(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "record",
+    (b"\n\n", b"../../outside-victim,,\n", b"/absolute/path,,\n", b"bad\\path,,\n", b"bad\x00path,,\n", b"C:/absolute/path,,\n"),
+)
+def test_wheel_rejects_invalid_record_rows(tmp_path: Path, record: bytes) -> None:
     wheel = _wheel(
         tmp_path / "avibe_os-3.1.0-py3-none-any.whl",
         "avibe-os",
         include_record=False,
     )
     with zipfile.ZipFile(wheel, "a") as archive:
-        archive.writestr("avibe_os-3.1.0.dist-info/RECORD", b"\n\n")
+        archive.writestr("avibe_os-3.1.0.dist-info/RECORD", record)
 
     with pytest.raises(guard.ReleaseAssetError, match="RECORD"):
         guard.inspect_wheel(wheel)


### PR DESCRIPTION
## Capability

Adds Gate5a successor A1: the manifest/release-policy half of the static release verifier. The A2-facing interface is `PackageMetadata`, `load_package_release_policy`, `classify_requirement`, and `verify_static_transition`; it is frozen for successor A2 when this PR merges. A2 supplies structurally validated metadata plus wheel filenames, and A1 applies release identity and policy without opening package archives.

## Ordering and dependency

This PR is based directly on exact `origin/dev` commit `9c946042aee5e75b327859a3f5ff143b7bd731bc` and has no unmerged code dependency. The owner split makes the concrete delivery order **A1 -> A2 -> B -> C -> workflow**, preserving the required **A -> B -> C -> workflow** ordering. A2 must consume A1's merged interface; B follows the completed A lane; C follows B; workflow integration follows C. For A2, B, and C, release policy must have an explicit declared source and must never be derived from the inspected object.

## MEMORY-INDEP-022/023

- `MEMORY-INDEP-022`: freezes exact manifest byte identity before semantic parsing and binds the top-level and nested manifest release identity to the selected release tag/family.
- `MEMORY-INDEP-023`: binds wheel filename name/version, supplied metadata, release tag, Requires-Python, the exact repository-owned supported-minor policy, and structured mutual dependency requirements; valid wildcard equality is classified as non-exact.

## Evidence

- Unit: 43 focused guard tests pass, including JSON `true`/`1.0` schema rejection, invalid-policy byte-mismatch precedence, top-level/nested tag drift, filename/metadata/release drift, Requires-Python drift, exact supported-minor policy drift, wildcard/range specifiers, exact forward/reverse pins, normalized schema-v1 Requires-Python literal acceptance and rejection, and the stdlib-only legacy guard entry.
- Policy structure: schema 1 requires exact `major.minor` lexical entries and rejects prerelease, local, post, and dev forms. The ordered, duplicate-free list must equal the repository-owned `3.10/3.11/3.12` declaration, and normalized Requires-Python must exactly equal the declared `>=3.10` literal. Future changes require a policy schema/version change plus updated repository-owned constants.
- Interface: `verify_static_transition` consumes A2-supplied filenames and `PackageMetadata`, checks the byte-identified policy first, then binds filename name/version to metadata and release tag before enforcing dependency policy.
- Scenario: `MEMORY-INDEP-022` and `MEMORY-INDEP-023` are covered by the focused static verifier suite.
- Residual manual checks: none; this evidence is intentionally static identity/policy only.
- Validation: focused pytest 43 passed; Ruff, Python compile, and `git diff --check` pass.

## Scope and cap

Only these allowed files changed:

- `scripts/memory_runtime_release_guard.py`
- `tests/test_memory_runtime_release_guard.py`
- `docs/plans/memory-wave3c-release-migration-contract.md` for the owner-required sdist contract correction

Cumulative diff from the exact base is 415 additions and 12 deletions: 403 net lines and exactly 427 total changed lines. The owner-authorized A1 cap is <=410 net lines. Tests and presentation remain uncompressed.

## A2 wheel-structure handoff ledger

Per the owner A1/A2 evidence-nature split, the following review findings are in-scope merge obligations for the successor A2 PR. Earlier replies that said these fixes were present in A are superseded because the corresponding implementation and tests were deliberately removed from A1:

- `3882442262`: require the matching `.dist-info` control members, including `METADATA`, `WHEEL`, and `RECORD`.
- `3882544946`: validate the complete supported `Wheel-Version` syntax/value.
- `3882649044`: bind the complete WHEEL `Tag` set to filename tags.
- `3882649054`: reject noncanonical and casefold-equivalent archive path aliases.
- `3882649065`: read and integrity-check every wheel member.
- `3882731892`: enforce the explicit standard `.data` scheme allowlist.
- `3882731901`: validate wheel compatibility tags against every policy-supported Python without current-runtime assumptions.
- `3882877022`: own the repository-declared schema-v1 `py3-none-any` wheel-tag policy source and bind all filename/WHEEL/platform consumers to it; future platform wheels require a policy schema/version and constant change.
- `3882877027`: parse RECORD and reject blank or malformed rows.
- `3883011052`: apply one canonical safe-relative-path predicate to archive members and non-empty RECORD paths.
- `3883011061` (inspection-side part): translate malformed inspector inputs to `ReleaseAssetError`; A1 retains the exact `major.minor` manifest schema constraint.
- `3883011070`: validate core `METADATA` through `packaging.metadata.Metadata.from_email(..., validate=True)`, including Metadata-Version support.
- `3883145291`: bind RECORD and `archive.namelist()` bidirectionally, with neither missing nor ghost rows.
- `3883145301`: require exactly one `Root-Is-Purelib: true` for the A2-declared universal-wheel policy.

A2 additionally owns the matching `.dist-info` identity, the `py3-none-any` policy constant, and filename/control-tag/Root-Is-Purelib enforcement. The wheel-tag policy has no cross-PR field in the frozen A1 interface. A2 must estimate the natural extraction before implementation and stop for owner disposition if the suggested 400-net-line cap cannot hold.

## Successor B correction

The sdist contract does not inspect raw sdist source namespaces or content. B owns an isolated build, rebuilt-wheel equivalence, and proof that the rebuilt wheel passes all wheel-level identity, dependency, content, and metadata checks.

B also owns effective installed-destination collision evidence from `3882877019`. Its PR must use real pip installed inventories with casefolded comparison and list that proof as an in-scope merge obligation; neither A1 nor A2 performs installed-layout inference.

## Known boundary

A1 performs static manifest/release identity and policy validation only. Its new interface does not open wheel or sdist archives and performs no wheel-tag policy enforcement, WHEEL/METADATA/RECORD structural validation, installation, importability or installed-layout inference, runtime probe, recovery, release publication, or release action. No workflow or packaging configuration changes are included.
