### PR TITLE
fix(runtime): scope settings invalidation to settings writes

### DIFF
--- a/config/v2_settings.py
+++ b/config/v2_settings.py
@@ -476,7 +476,7 @@ class SettingsStore:
     def get_instance(cls, settings_path: Optional[Path] = None) -> "SettingsStore":
         """Return the process-wide singleton, creating it on first call.
 
-        Automatically reloads from disk if the file has changed.
+        Automatically reloads if the runtime-settings revision has changed.
         """
         with cls._instance_lock:
             target_path = settings_path or paths.get_settings_path()
@@ -499,7 +499,10 @@ class SettingsStore:
         self.db_path = self.settings_path.with_name("vibe.sqlite")
         self.settings: SettingsState = SettingsState()
         self._bind_lock = threading.Lock()  # Guards atomic bind operations
-        self._file_mtime: float = 0
+        self._reload_lock = threading.RLock()
+        self._generation = 0
+        self._observed_revision: str | None = None
+        self._reload_count = 0
         from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
         from storage.settings_service import SQLiteSettingsService
 
@@ -509,33 +512,56 @@ class SettingsStore:
             primary_platform=resolve_primary_platform_from_config(self.settings_path.parent),
         )
         self._service = SQLiteSettingsService(self.db_path)
-        self._load()
-        self._service.has_external_write()
+        self._load_with_revision()
 
     def close(self) -> None:
         service = getattr(self, "_service", None)
         if service is not None:
             service.close()
 
-    def maybe_reload(self) -> None:
-        """Reload from SQLite if another connection has committed changes."""
-        if self._service.has_external_write():
+    @property
+    def generation(self) -> int:
+        return self._generation
+
+    @property
+    def reload_count(self) -> int:
+        return self._reload_count
+
+    def maybe_reload(self) -> bool:
+        """Reload once when another transaction changed runtime settings."""
+        with self._reload_lock:
+            revision = self._service.current_revision()
+            if revision == self._observed_revision:
+                return False
             self._load()
+            # Record the revision read before the load. If a newer write races
+            # with the load, the next check sees it instead of losing it.
+            self._observed_revision = revision
+            self._reload_count += 1
+            return True
+
+    def _load_with_revision(self) -> None:
+        revision = self._service.current_revision()
+        self._load()
+        self._observed_revision = revision
 
     def _load(self) -> None:
         self.settings = self._service.load_state()
-        self._file_mtime += 1
+        self._generation += 1
 
     def save(self) -> None:
-        try:
-            self._service.save_state(self.settings)
-        except Exception:
-            # API helpers mutate the singleton before saving. A refused transaction
-            # must restore the durable snapshot before any later read or save.
-            self._load()
-            raise
-        self._service.has_external_write()
-        self._file_mtime += 1
+        with self._reload_lock:
+            try:
+                revision = self._service.save_state(self.settings)
+            except Exception:
+                # API helpers mutate the singleton before saving. A refused transaction
+                # must restore the durable snapshot before any later read or save.
+                self._load_with_revision()
+                raise
+            # Use the exact revision committed by this transaction. Reading the
+            # current value here could absorb a later external write without loading it.
+            self._observed_revision = revision
+            self._generation += 1
 
     # --- Channel helpers ---
 

--- a/core/chat_discovery.py
+++ b/core/chat_discovery.py
@@ -26,6 +26,10 @@ from storage.models import (
     state_meta,
 )
 from storage.settings_service import make_scope_id, upsert_scope
+from storage.settings_revision import (
+    RUNTIME_SETTINGS_SCOPE_TYPES,
+    mark_runtime_settings_changed,
+)
 from config.v2_settings import make_thread_native_id, split_thread_native_id
 
 logger = logging.getLogger(__name__)
@@ -1011,10 +1015,17 @@ def _descendant_scope_rows(conn: Connection, scope_id: str) -> list[dict[str, An
     return descendants
 
 
-def _remove_scope_row_preserving_history(conn: Connection, row: dict[str, Any]) -> dict[str, bool]:
+def _remove_scope_row_preserving_history(
+    conn: Connection, row: dict[str, Any]
+) -> tuple[dict[str, bool], bool]:
     """Delete one scope's settings, then delete or dismiss its scope row."""
     scope_id = str(row["id"])
-    conn.execute(scope_settings.delete().where(scope_settings.c.scope_id == scope_id))
+    settings_result = conn.execute(
+        scope_settings.delete().where(scope_settings.c.scope_id == scope_id)
+    )
+    runtime_settings_changed = bool(settings_result.rowcount) and str(
+        row["scope_type"]
+    ) in RUNTIME_SETTINGS_SCOPE_TYPES
     if _scope_has_history(conn, scope_id):
         now = _utc_now_iso()
         metadata = _json_loads(row["metadata_json"], {})
@@ -1024,9 +1035,9 @@ def _remove_scope_row_preserving_history(conn: Connection, row: dict[str, Any]) 
             .where(scopes.c.id == scope_id)
             .values(metadata_json=_json_dumps(metadata), updated_at=now)
         )
-        return {"removed": False, "dismissed": True}
+        return {"removed": False, "dismissed": True}, runtime_settings_changed
     result = conn.execute(scopes.delete().where(scopes.c.id == scope_id))
-    return {"removed": bool(result.rowcount), "dismissed": False}
+    return {"removed": bool(result.rowcount), "dismissed": False}, runtime_settings_changed
 
 
 def _clear_scope_debounce_entries(db_path: Path | None, rows: list[dict[str, Any]]) -> None:
@@ -1072,9 +1083,14 @@ def delete_scope(
             if row is None:
                 return {"removed": False, "dismissed": False}
             descendants = _descendant_scope_rows(conn, scope_id)
+            runtime_settings_changed = False
             for descendant in reversed(descendants):
-                _remove_scope_row_preserving_history(conn, descendant)
-            outcome = _remove_scope_row_preserving_history(conn, dict(row))
+                _, descendant_changed = _remove_scope_row_preserving_history(conn, descendant)
+                runtime_settings_changed = runtime_settings_changed or descendant_changed
+            outcome, row_changed = _remove_scope_row_preserving_history(conn, dict(row))
+            runtime_settings_changed = runtime_settings_changed or row_changed
+            if runtime_settings_changed:
+                mark_runtime_settings_changed(conn)
             _clear_scope_debounce_entries(db_path, [dict(row), *descendants])
             return outcome
     finally:

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -28,9 +28,14 @@ from storage.models import (
     messages,
     run_definitions,
     scope_settings,
+    scopes,
     state_meta,
 )
 from storage.session_reclaim import DEFINITION_AGENT_BINDING_REVISION_KEY
+from storage.settings_revision import (
+    RUNTIME_SETTINGS_SCOPE_TYPES,
+    mark_runtime_settings_changed,
+)
 from vibe.authorization import (
     instance_owner_context,
 )
@@ -1465,8 +1470,14 @@ class VibeAgentStore:
             )
 
         scope_rows = conn.execute(
-            select(scope_settings.c.scope_id, scope_settings.c.agent_name, scope_settings.c.settings_json)
+            select(
+                scope_settings.c.scope_id,
+                scope_settings.c.agent_name,
+                scope_settings.c.settings_json,
+                scopes.c.scope_type,
+            ).select_from(scope_settings.join(scopes, scopes.c.id == scope_settings.c.scope_id))
         ).mappings().all()
+        runtime_settings_changed = False
         for row in scope_rows:
             values: dict[str, Any] = {}
             if _matches_agent_reference(row["agent_name"], reference_names):
@@ -1482,6 +1493,11 @@ class VibeAgentStore:
                     .where(scope_settings.c.scope_id == row["scope_id"])
                     .values(**values)
                 )
+                if str(row["scope_type"]) in RUNTIME_SETTINGS_SCOPE_TYPES:
+                    runtime_settings_changed = True
+
+        if runtime_settings_changed:
+            mark_runtime_settings_changed(conn)
 
         definition_rows = conn.execute(
             select(run_definitions.c.id, run_definitions.c.agent_name, run_definitions.c.metadata_json)

--- a/modules/settings_manager.py
+++ b/modules/settings_manager.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List, Optional, Union
 from pathlib import Path
@@ -114,7 +115,11 @@ class SettingsManager:
         if sessions_store is None:
             self.sessions_store.load()
         self.sessions = sessions_facade or SessionsFacade(self.sessions_store)
-        self._last_seen_store_mtime: Optional[float] = None
+        self._runtime_settings_lock = threading.RLock()
+        self._last_seen_store_generation: Optional[int] = None
+        self._runtime_rebuild_count = 0
+        self._last_changed_channel_count = 0
+        self._last_changed_dm_user_count = 0
         self._load_settings()
 
     # ---------------------------------------------
@@ -202,34 +207,80 @@ class SettingsManager:
         bound.routing = _clone_routing(settings.channel_routing)
 
     def _load_settings(self):
-        """Load settings from JSON file"""
+        """Load runtime settings from the shared settings store."""
         self.store = SettingsStore.get_instance(self.settings_file)
-        self._rebuild_runtime_settings()
-        self._last_seen_store_mtime = self.store._file_mtime
+        self._rebuild_runtime_settings(reason="initial_load")
+        self._last_seen_store_generation = self.store.generation
 
     def _reload_if_changed(self) -> None:
-        """Reload runtime settings if the underlying store has changed on disk.
+        """Reload runtime settings after a committed settings-domain change.
 
-        Uses a locally tracked mtime so that same-process writes (e.g. from
+        Uses a locally tracked generation so that same-process writes (e.g. from
         the UI API hitting the singleton store) are detected correctly.
         """
-        self.store.maybe_reload()
-        if self.store._file_mtime != self._last_seen_store_mtime:
-            logger.info("Settings file changed on disk, rebuilding runtime settings")
-            self._rebuild_runtime_settings()
-            self._last_seen_store_mtime = self.store._file_mtime
+        with self._runtime_settings_lock:
+            self.store.maybe_reload()
+            if self.store.generation != self._last_seen_store_generation:
+                self._rebuild_runtime_settings(reason="settings_revision_changed")
+                self._last_seen_store_generation = self.store.generation
 
-    def _rebuild_runtime_settings(self) -> None:
-        """Rebuild the in-memory settings dicts from the store."""
-        self.channel_settings = {}
-        self.dm_user_settings = {}
-        for cid, cs in self.store.get_channels_for_platform(self.platform).items():
-            self.channel_settings[str(cid)] = self._from_channel_settings(cs)
-        for uid, us in self.store.get_users_for_platform(self.platform).items():
-            self.dm_user_settings[str(uid)] = self._from_bound_user_settings(us)
-        logger.info(
-            f"Rebuilt runtime settings for {len(self.channel_settings)} channels, {len(self.dm_user_settings)} DM users"
+    def _rebuild_runtime_settings(self, *, reason: str = "manual") -> None:
+        """Synchronize only runtime entries whose persisted settings changed."""
+        channels = {
+            str(cid): self._from_channel_settings(settings)
+            for cid, settings in self.store.get_channels_for_platform(self.platform).items()
+        }
+        dm_users = {
+            str(uid): self._from_bound_user_settings(settings)
+            for uid, settings in self.store.get_users_for_platform(self.platform).items()
+        }
+        changed_channels = set(self.channel_settings) ^ set(channels)
+        changed_channels.update(
+            key
+            for key in self.channel_settings.keys() & channels.keys()
+            if self.channel_settings[key] != channels[key]
         )
+        changed_dm_users = set(self.dm_user_settings) ^ set(dm_users)
+        changed_dm_users.update(
+            key
+            for key in self.dm_user_settings.keys() & dm_users.keys()
+            if self.dm_user_settings[key] != dm_users[key]
+        )
+        for key in changed_channels:
+            if key in channels:
+                self.channel_settings[key] = channels[key]
+            else:
+                self.channel_settings.pop(key, None)
+        for key in changed_dm_users:
+            if key in dm_users:
+                self.dm_user_settings[key] = dm_users[key]
+            else:
+                self.dm_user_settings.pop(key, None)
+        self._runtime_rebuild_count += 1
+        self._last_changed_channel_count = len(changed_channels)
+        self._last_changed_dm_user_count = len(changed_dm_users)
+        logger.info(
+            "Runtime settings synchronized reason=%s sync_count=%d "
+            "changed_channels=%d changed_dm_users=%d total_channels=%d total_dm_users=%d",
+            reason,
+            self._runtime_rebuild_count,
+            self._last_changed_channel_count,
+            self._last_changed_dm_user_count,
+            len(self.channel_settings),
+            len(self.dm_user_settings),
+        )
+
+    def runtime_settings_diagnostics(self) -> dict[str, int]:
+        """Return bounded counters for reload-frequency diagnostics."""
+        with self._runtime_settings_lock:
+            return {
+                "store_reload_count": self.store.reload_count,
+                "rebuild_count": self._runtime_rebuild_count,
+                "changed_channels": self._last_changed_channel_count,
+                "changed_dm_users": self._last_changed_dm_user_count,
+                "channels": len(self.channel_settings),
+                "dm_users": len(self.dm_user_settings),
+            }
 
     def _save_settings(self):
         """Save settings to JSON file.
@@ -253,9 +304,9 @@ class SettingsManager:
             for uid, s in self.dm_user_settings.items():
                 self._sync_to_bound_user(uid, s)
             self.store.save()
-            # Keep local mtime in sync so _reload_if_changed doesn't
+            # Keep the local generation in sync so _reload_if_changed doesn't
             # trigger an unnecessary rebuild right after our own save.
-            self._last_seen_store_mtime = self.store._file_mtime
+            self._last_seen_store_generation = self.store.generation
             logger.info("Settings saved successfully")
         except Exception as e:
             logger.error(f"Error saving settings: {e}")
@@ -322,7 +373,7 @@ class SettingsManager:
             if existing_thread is None and updated.require_mention is None:
                 updated.require_mention = bool(self.require_mention_default())
             self.store.update_thread(channel_id, thread_id, updated, platform=self.platform)
-            self._last_seen_store_mtime = self.store._file_mtime
+            self._last_seen_store_generation = self.store.generation
             return
 
         if normalized_id in self.dm_user_settings:
@@ -543,7 +594,7 @@ class SettingsManager:
                     )
             channel_settings.require_mention = value
             self.store.update_thread(parent_id, thread_id, channel_settings, platform=self.platform)
-            self._last_seen_store_mtime = self.store._file_mtime
+            self._last_seen_store_generation = self.store.generation
             logger.info("Updated require_mention for thread %s/%s: %s", parent_id, thread_id, value)
             return
         channel_settings = self.store.get_channel(key, platform=self.platform)

--- a/storage/settings_revision.py
+++ b/storage/settings_revision.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from sqlalchemy import Connection, select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+from storage.models import state_meta
+
+RUNTIME_SETTINGS_REVISION_KEY = "runtime_settings_revision"
+RUNTIME_SETTINGS_SCOPE_TYPES = frozenset({"channel", "thread", "platform", "guild", "user"})
+
+
+def read_runtime_settings_revision(conn: Connection) -> str | None:
+    value = conn.execute(
+        select(state_meta.c.value_json).where(state_meta.c.key == RUNTIME_SETTINGS_REVISION_KEY)
+    ).scalar_one_or_none()
+    if value is None:
+        return None
+    try:
+        payload = json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    revision = payload.get("revision") if isinstance(payload, dict) else None
+    return str(revision) if revision else None
+
+
+def mark_runtime_settings_changed(conn: Connection) -> str:
+    """Publish one settings-domain revision in the caller's transaction."""
+    revision = uuid4().hex
+    now = datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+    stmt = sqlite_insert(state_meta).values(
+        key=RUNTIME_SETTINGS_REVISION_KEY,
+        value_json=json.dumps({"revision": revision}, separators=(",", ":")),
+        updated_at=now,
+    )
+    conn.execute(
+        stmt.on_conflict_do_update(
+            index_elements=[state_meta.c.key],
+            set_={"value_json": stmt.excluded.value_json, "updated_at": stmt.excluded.updated_at},
+        )
+    )
+    return revision

--- a/storage/settings_service.py
+++ b/storage/settings_service.py
@@ -25,17 +25,16 @@ from config.v2_settings import (
     split_thread_native_id,
 )
 from storage.agent_session_rows import reserve_write_lock
-from storage.db import SqliteInvalidationProbe, create_sqlite_engine
+from storage.db import create_sqlite_engine
 from storage.models import agents, auth_codes, scope_settings, scopes
+from storage.settings_revision import (
+    RUNTIME_SETTINGS_SCOPE_TYPES,
+    mark_runtime_settings_changed,
+    read_runtime_settings_revision,
+)
 
 SETTINGS_VERSION = 1
 GUILD_POLICY_KIND = "guild_policy"
-# Scope types whose settings this store owns. avibe project scopes
-# (storage.projects_service) share the scope_settings table but are NOT managed
-# here, so save_state must never delete or overwrite their rows.
-_MANAGED_SCOPE_TYPES = ("channel", "thread", "platform", "guild", "user")
-
-
 class StaleScopeAgentBindingError(ValueError):
     code = "settings_conflict"
 
@@ -56,14 +55,13 @@ class SQLiteSettingsService:
     def __init__(self, db_path: Path):
         self.db_path = db_path
         self.engine = create_sqlite_engine(db_path)
-        self._probe = SqliteInvalidationProbe(self.engine)
 
     def close(self) -> None:
-        self._probe.close()
         self.engine.dispose()
 
-    def has_external_write(self) -> bool:
-        return self._probe.has_external_write()
+    def current_revision(self) -> str | None:
+        with self.engine.connect() as conn:
+            return read_runtime_settings_revision(conn)
 
     def load_state(self) -> SettingsState:
         with self.engine.connect() as conn:
@@ -77,7 +75,7 @@ class SQLiteSettingsService:
                 bind_codes=self._load_bind_codes(conn),
             )
 
-    def save_state(self, state: SettingsState) -> None:
+    def save_state(self, state: SettingsState) -> str:
         saved_bindings: list[tuple[ChannelSettings | UserSettings, RoutingSettings]] = []
         with self.engine.begin() as conn:
             reserve_write_lock(conn)
@@ -240,10 +238,12 @@ class SQLiteSettingsService:
 
             self._delete_removed_scope_settings(conn, kept)
             self._sync_bind_codes(conn, state.bind_codes, now)
+            revision = mark_runtime_settings_changed(conn)
 
         for item, routing in saved_bindings:
             item.routing = routing
             item._agent_name_at_load = routing.agent_name
+        return revision
 
     @staticmethod
     def _reconcile_agent_binding(
@@ -306,11 +306,13 @@ class SQLiteSettingsService:
     def _delete_removed_scope_settings(self, conn: Connection, kept: set[str]) -> None:
         """Delete settings rows for managed scopes no longer present in the state.
 
-        Scoped to ``_MANAGED_SCOPE_TYPES`` so avibe project scopes (owned by
+        Scoped to ``RUNTIME_SETTINGS_SCOPE_TYPES`` so avibe project scopes (owned by
         projects_service) keep their settings/workdir even though they live in
         the same table.
         """
-        managed_scope_ids = select(scopes.c.id).where(scopes.c.scope_type.in_(_MANAGED_SCOPE_TYPES))
+        managed_scope_ids = select(scopes.c.id).where(
+            scopes.c.scope_type.in_(RUNTIME_SETTINGS_SCOPE_TYPES)
+        )
         stmt = scope_settings.delete().where(scope_settings.c.scope_id.in_(managed_scope_ids))
         if kept:
             stmt = stmt.where(scope_settings.c.scope_id.notin_(kept))

--- a/tests/test_sqlite_settings_store.py
+++ b/tests/test_sqlite_settings_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -9,9 +10,12 @@ from sqlalchemy.exc import OperationalError
 
 from config import paths
 from config import v2_settings
+from config.v2_sessions import SessionsStore
 from config.v2_settings import ChannelSettings, RoutingSettings, SettingsState, SettingsStore, UserSettings
+from core import chat_discovery
 from core.vibe_agents import VibeAgentStore
-from storage import projects_service
+from storage import agent_events_service, messages_service, projects_service
+from storage.background import SQLiteBackgroundTaskStore
 from storage.db import create_sqlite_engine
 from storage.migrations import run_migrations
 from storage.models import scope_settings, scopes
@@ -352,6 +356,204 @@ def test_settings_store_reloads_external_sqlite_writes(tmp_path: Path) -> None:
         assert user.is_admin is True
     finally:
         external.close()
+        store.close()
+
+
+def test_runtime_settings_ignore_agent_harness_and_project_writes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    settings_path = tmp_path / "settings.json"
+    db_path = tmp_path / "vibe.sqlite"
+    monkeypatch.setattr(paths, "ensure_data_dirs", lambda: None)
+    SettingsStore.reset_instance()
+    run_migrations(db_path)
+    sessions = SessionsStore(tmp_path / "sessions.json")
+    seed = SQLiteSettingsService(db_path)
+    seed.save_state(
+        SettingsState(channels={"slack::C1": ChannelSettings(enabled=True)})
+    )
+    seed.close()
+    manager = SettingsManager(
+        settings_file=str(settings_path),
+        platform="slack",
+        sessions_store=sessions,
+    )
+    engine = create_sqlite_engine(db_path)
+    harness = SQLiteBackgroundTaskStore(db_path)
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    try:
+        initial = manager.runtime_settings_diagnostics()
+        with engine.begin() as conn:
+            agent_events_service.append(
+                conn,
+                scope_id=None,
+                session_id=None,
+                platform="slack",
+                event_type="tool_call",
+                text="bounded test event",
+            )
+            messages_service.append(
+                conn,
+                scope_id=None,
+                session_id=None,
+                platform="slack",
+                author="agent",
+                message_type="assistant",
+                text="bounded test message",
+                source="agent",
+            )
+            projects_service.create_project(conn, str(project_dir), display_name="Project")
+        assert harness.upsert_watch(
+            {
+                "id": "watch-settings-invalidation",
+                "name": "settings invalidation",
+                "shell_command": "true",
+                "enabled": True,
+                "created_at": "2026-08-29T00:00:00Z",
+                "updated_at": "2026-08-29T00:00:00Z",
+            }
+        )
+
+        assert manager.get_user_settings("C1").enabled is True
+        assert manager.runtime_settings_diagnostics() == initial
+    finally:
+        harness.close()
+        engine.dispose()
+        sessions.close()
+        SettingsStore.reset_instance()
+
+
+def test_legitimate_settings_changes_coalesce_under_concurrent_reads(
+    tmp_path: Path, monkeypatch
+) -> None:
+    settings_path = tmp_path / "settings.json"
+    db_path = tmp_path / "vibe.sqlite"
+    monkeypatch.setattr(paths, "ensure_data_dirs", lambda: None)
+    SettingsStore.reset_instance()
+    sessions = SessionsStore(tmp_path / "sessions.json")
+    external = SQLiteSettingsService(db_path)
+    external.save_state(
+        SettingsState(
+            channels={
+                "slack::C1": ChannelSettings(enabled=True, custom_cwd="/initial"),
+                "slack::C2": ChannelSettings(enabled=True, custom_cwd="/steady"),
+            },
+            users={
+                "slack::U1": UserSettings(
+                    display_name="Alex", enabled=True, custom_cwd="/dm-initial"
+                )
+            },
+            guild_scope_platforms={"slack"},
+            guild_default_enabled={"slack": False},
+        )
+    )
+    manager = SettingsManager(
+        settings_file=str(settings_path),
+        platform="slack",
+        sessions_store=sessions,
+    )
+    try:
+        unchanged_channel = manager.channel_settings["C2"]
+        for custom_cwd in ("/first", "/second", "/final"):
+            external.save_state(
+                SettingsState(
+                    channels={
+                        "slack::C1": ChannelSettings(enabled=True, custom_cwd=custom_cwd),
+                        "slack::C2": ChannelSettings(enabled=True, custom_cwd="/steady"),
+                    },
+                    users={
+                        "slack::U1": UserSettings(
+                            display_name="Alex", enabled=True, custom_cwd="/dm"
+                        )
+                    },
+                    guild_scope_platforms={"slack"},
+                    guild_default_enabled={"slack": True},
+                )
+            )
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            results = list(executor.map(lambda _: manager.get_user_settings("C1"), range(16)))
+
+        assert {settings.custom_cwd for settings in results} == {"/final"}
+        assert manager.get_user_settings("U1").custom_cwd == "/dm"
+        assert manager.store.get_guild_default_enabled_for_platform("slack") is True
+        assert manager.channel_settings["C2"] is unchanged_channel
+        assert manager.runtime_settings_diagnostics() == {
+            "store_reload_count": 1,
+            "rebuild_count": 2,
+            "changed_channels": 1,
+            "changed_dm_users": 1,
+            "channels": 2,
+            "dm_users": 1,
+        }
+    finally:
+        external.close()
+        sessions.close()
+        SettingsStore.reset_instance()
+
+
+def test_settings_save_does_not_absorb_a_newer_external_revision(
+    tmp_path: Path, monkeypatch
+) -> None:
+    settings_path = tmp_path / "settings.json"
+    store = SettingsStore(settings_path)
+    external = SQLiteSettingsService(tmp_path / "vibe.sqlite")
+    original_save = store._service.save_state
+
+    def save_then_race(state: SettingsState) -> str:
+        committed_revision = original_save(state)
+        external.save_state(
+            SettingsState(
+                channels={
+                    "slack::C1": ChannelSettings(enabled=True, custom_cwd="/external")
+                }
+            )
+        )
+        return committed_revision
+
+    monkeypatch.setattr(store._service, "save_state", save_then_race)
+    try:
+        store.settings.channels = {
+            "slack::C1": ChannelSettings(enabled=True, custom_cwd="/local")
+        }
+        store.save()
+
+        assert store.maybe_reload() is True
+        assert store.find_channel("C1", platform="slack").custom_cwd == "/external"
+        assert store.reload_count == 1
+    finally:
+        external.close()
+        store.close()
+
+
+def test_scope_delete_and_agent_rename_publish_settings_revisions(tmp_path: Path) -> None:
+    settings_path = tmp_path / "settings.json"
+    store = SettingsStore(settings_path)
+    agents_store = VibeAgentStore(tmp_path / "vibe.sqlite")
+    try:
+        agents_store.create(name="reviewer", backend="codex")
+        store.update_channel(
+            "C1",
+            ChannelSettings(
+                enabled=True,
+                routing=RoutingSettings(agent_name="reviewer"),
+            ),
+            platform="slack",
+        )
+
+        agents_store.rename("reviewer", "renamed")
+        assert store.maybe_reload() is True
+        assert store.find_channel("C1", platform="slack").routing.agent_name == "renamed"
+
+        assert chat_discovery.delete_scope("slack", "C1", db_path=store.db_path) == {
+            "removed": True,
+            "dismissed": False,
+        }
+        assert store.maybe_reload() is True
+        assert store.find_channel("C1", platform="slack") is None
+    finally:
+        agents_store.close()
         store.close()
 
 


### PR DESCRIPTION
## Summary

- capability: replace database-wide settings invalidation with a settings-domain revision committed atomically by every current runtime-settings writer; coalesce concurrent reads and incrementally synchronize only changed channel/DM entries
- user-visible change: ordinary Agent events, message persistence, project updates, and Harness watch writes no longer rebuild runtime settings; real settings changes still become visible without a restart
- motivation: a shared `PRAGMA data_version` probe treated every commit to `vibe.sqlite` as a settings change, causing repeated full rebuilds across hundreds of configured channels

## Scenario Coverage

- scenario IDs: issue #1763 acceptance paths
- unit / contract coverage: Agent tool event, message, project, and Harness writes do not reload; channel, DM, and platform-global settings do reload; concurrent reads coalesce; unchanged scopes retain identity; scope deletion and Agent rename publish revisions; a post-save race cannot be absorbed
- scenario coverage: exercised the real SQLite Agent event/message writers and Harness watch store against `SettingsManager`
- residual manual checks: none

## Validation

- commands run: focused settings/discovery/Agent archive/global-config suites; adjacent auth, UI API, guild, settings-handler, and multi-platform suites; Ruff checks on all touched Python files
- result: 112 focused tests passed, 235 adjacent tests passed, targeted concurrency/invalidation tests passed, Ruff passed

## Risks / Follow-ups

- risk: future code that directly mutates runtime `scope_settings` or `auth_codes` must publish through `mark_runtime_settings_changed`; the current writer census is covered across the normal settings service and both direct mutation paths
- follow-up: none

Closes #1763
