### PR TITLE
feat(memory): validate persisted resolver closure

### DIFF
--- a/tests/scenarios/memory_independence/test_memory_rollback_types.py
+++ b/tests/scenarios/memory_independence/test_memory_rollback_types.py
@@ -7,7 +7,10 @@ import base64
 import csv
 import hashlib
 import io
+import json
+import os
 import subprocess
+import sys
 import zipfile
 from dataclasses import FrozenInstanceError, dataclass
 from pathlib import Path
@@ -471,11 +474,11 @@ def test_memory_indep_019_local_resolution_only_downloads(
         requires_dist=(OPTIONAL_MEMORY_REQUIREMENT,),
     )
     _wheel(wheelhouse, "avibe-memory", "3.0.15")
-    commands: list[tuple[str, ...]] = []
+    calls: list[tuple[tuple[str, ...], dict[str, str]]] = []
     real_run = subprocess.run
 
     def record_run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
-        commands.append(tuple(command))
+        calls.append((tuple(command), kwargs["env"]))
         return real_run(command, **kwargs)
 
     monkeypatch.setattr("vibe.package_shape.subprocess.run", record_run)
@@ -484,42 +487,93 @@ def test_memory_indep_019_local_resolution_only_downloads(
         wheelhouse=wheelhouse,
         staging_dir=tmp_path / "staging",
     )
-    assert len(commands) == 1
-    assert commands[0][1:4] == ("-m", "pip", "download")
-    assert "install" not in commands[0]
+    assert len(calls) == 2
+    snapshot_command, snapshot_env = calls[0]
+    pip_command, pip_env = calls[1]
+    assert snapshot_command[0] == pip_command[0] == os.path.normcase(os.path.abspath(sys.executable))
+    assert snapshot_command[1] == "-c"
+    assert pip_command[1:4] == ("-m", "pip", "download")
+    assert snapshot_env == {key: value for key, value in pip_env.items() if key != "PIP_FIND_LINKS"}
+    assert "install" not in pip_command
 
 
-def test_memory_indep_019_live_resolver_captures_marker_environment(
+@pytest.mark.parametrize("explicit_resolver", [False, True], ids=["default", "explicit"])
+def test_memory_indep_019_polluted_parent_cannot_change_snapshot_or_resolution(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    explicit_resolver: bool,
 ) -> None:
-    shape = _shape("3.0.14", memory_version=None)
     wheelhouse = tmp_path / "wheelhouse"
     wheelhouse.mkdir()
-    _wheel(wheelhouse, "avibe-os", "3.0.14", requires_dist=(OPTIONAL_MEMORY_REQUIREMENT,))
-    environment = {
-        "python_version": "3.12",
-        "python_full_version": "3.12.7",
-        "implementation_name": "cpython",
-        "implementation_version": "3.12.7",
-        "os_name": "posix",
-        "platform_machine": "fixture-machine",
-        "platform_python_implementation": "CPython",
-        "platform_release": "fixture-release",
-        "platform_system": "FixtureOS",
-        "platform_version": "fixture-version",
-        "sys_platform": "fixture",
-    }
-    monkeypatch.setattr("vibe.package_shape.default_environment", lambda: environment)
+    _wheel(
+        wheelhouse,
+        "avibe-os",
+        "3.0.14",
+        requires_dist=(
+            OPTIONAL_MEMORY_REQUIREMENT,
+            'shape-helper==1; platform_machine == "polluted-machine"',
+        ),
+    )
+    hook_dir = tmp_path / "hook"
+    hook_dir.mkdir()
+    (hook_dir / "sitecustomize.py").write_text(
+        'import platform\nplatform.machine = lambda: "polluted-machine"\n',
+        encoding="utf-8",
+    )
+    script = """
+import json
+import platform
+import sys
+from pathlib import Path
+from vibe.package_shape import DistributionProvider, capture_package_shape, resolve_rollback_plan
+from vibe.runtime import ServiceLauncher
 
-    plan = resolve_rollback_plan(
-        shape,
-        wheelhouse=wheelhouse,
-        staging_dir=tmp_path / "staging",
+shape = capture_package_shape(
+    core_version="3.0.14",
+    launcher=ServiceLauncher(python="/opt/avibe/bin/python", main="/opt/avibe/vibe/service_main.py"),
+    providers=(DistributionProvider(
+        name="avibe-os",
+        version="3.0.14",
+        provider_id="/avibe-os-3.0.14.dist-info",
+        requires_dist=(
+            'avibe-memory>=3.0.14.dev0,<3.1; extra == "memory"',
+            'shape-helper==1; platform_machine == "polluted-machine"',
+        ),
+    ),),
+)
+plan = resolve_rollback_plan(
+    shape,
+    wheelhouse=Path(sys.argv[1]),
+    staging_dir=Path(sys.argv[2]),
+    resolver_python=sys.executable if sys.argv[3] == "explicit" else None,
+)
+print(json.dumps({
+    "parent_machine": platform.machine(),
+    "snapshot_machine": plan.resolver_environment.platform_machine,
+    "artifacts": [artifact.distribution for artifact in plan.artifacts],
+}))
+"""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            script,
+            str(wheelhouse),
+            str(tmp_path / "staging"),
+            "explicit" if explicit_resolver else "default",
+        ],
+        cwd=ROOT,
+        env={**os.environ, "PYTHONPATH": str(hook_dir)},
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
     )
 
-    assert plan.resolver_environment.python_full_version == "3.12.7"
-    assert plan.resolver_environment.platform_machine == "fixture-machine"
+    assert result.returncode == 0, result.stderr
+    observed = json.loads(result.stdout)
+    assert observed["parent_machine"] == "polluted-machine"
+    assert observed["snapshot_machine"] != "polluted-machine"
+    assert observed["artifacts"] == ["avibe-os"]
 
 
 def test_memory_indep_019_resolved_plan_constructor_cannot_be_bypassed() -> None:

--- a/tests/scenarios/memory_independence/test_memory_rollback_types.py
+++ b/tests/scenarios/memory_independence/test_memory_rollback_types.py
@@ -17,6 +17,7 @@ from typing import Any
 import pytest
 
 from vibe.package_shape import (
+    ArtifactRole,
     CapturedPackageShape,
     DistributionProvider,
     DuplicateDistributionProviderError,
@@ -235,9 +236,7 @@ def test_memory_indep_019_release_family_property_table(
             wheelhouse,
             "avibe-memory",
             case.memory_version,
-            requires_dist=(MEMORY_FORWARD_CORE_REQUIREMENT,)
-            if case.residual_memory
-            else (),
+            requires_dist=(MEMORY_FORWARD_CORE_REQUIREMENT,) if case.residual_memory else (),
         )
     staging = tmp_path / "staging"
     if case.expected_requirements is None:
@@ -247,19 +246,23 @@ def test_memory_indep_019_release_family_property_table(
         return
 
     plan = resolve_rollback_plan(shape, wheelhouse=wheelhouse, staging_dir=staging)
-    assert tuple(requirement.specifier for requirement in plan.requirements) == (
-        case.expected_requirements
-    )
+    assert tuple(requirement.specifier for requirement in plan.requirements) == (case.expected_requirements)
     assert plan.verification.memory_provider_cardinality == int(case.memory_version is not None)
     assert plan.verification.memory_version == case.memory_version
     assert plan.verification.residual_memory is case.residual_memory
-    expected_absent_core = (
-        "avibe-os" if case.core_distribution == "vibe-remote" else "vibe-remote"
-    )
+    expected_absent_core = "avibe-os" if case.core_distribution == "vibe-remote" else "vibe-remote"
     assert plan.verification.absent_core_distributions == (expected_absent_core,)
     assert plan.staging_dir == staging
     assert all(artifact.path.parent == staging for artifact in plan.artifacts)
     assert all(len(artifact.sha256) == 64 for artifact in plan.artifacts)
+    assert {artifact.distribution: artifact.role for artifact in plan.artifacts} == {
+        requirement.split("==", 1)[0]: (
+            ArtifactRole.RESIDUAL_PRESERVE
+            if case.residual_memory and requirement.startswith("avibe-memory==")
+            else ArtifactRole.INSTALL
+        )
+        for requirement in case.expected_requirements
+    }
     assert [
         (artifact.distribution, artifact.version)
         for artifact in plan.artifacts
@@ -385,9 +388,7 @@ def test_memory_indep_019_repeated_metadata_paths_count_as_one_provider(
     shape = capture_package_shape(
         core_version="3.0.14",
         launcher=LAUNCHER,
-        providers=inspect_installed_distribution_providers(
-            [core, repeated_core, memory, repeated_memory]
-        ),
+        providers=inspect_installed_distribution_providers([core, repeated_core, memory, repeated_memory]),
     )
 
     assert shape.core_provider.provider_id == str(core_path.resolve())
@@ -488,6 +489,39 @@ def test_memory_indep_019_local_resolution_only_downloads(
     assert "install" not in commands[0]
 
 
+def test_memory_indep_019_live_resolver_captures_marker_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shape = _shape("3.0.14", memory_version=None)
+    wheelhouse = tmp_path / "wheelhouse"
+    wheelhouse.mkdir()
+    _wheel(wheelhouse, "avibe-os", "3.0.14", requires_dist=(OPTIONAL_MEMORY_REQUIREMENT,))
+    environment = {
+        "python_version": "3.12",
+        "python_full_version": "3.12.7",
+        "implementation_name": "cpython",
+        "implementation_version": "3.12.7",
+        "os_name": "posix",
+        "platform_machine": "fixture-machine",
+        "platform_python_implementation": "CPython",
+        "platform_release": "fixture-release",
+        "platform_system": "FixtureOS",
+        "platform_version": "fixture-version",
+        "sys_platform": "fixture",
+    }
+    monkeypatch.setattr("vibe.package_shape.default_environment", lambda: environment)
+
+    plan = resolve_rollback_plan(
+        shape,
+        wheelhouse=wheelhouse,
+        staging_dir=tmp_path / "staging",
+    )
+
+    assert plan.resolver_environment.python_full_version == "3.12.7"
+    assert plan.resolver_environment.platform_machine == "fixture-machine"
+
+
 def test_memory_indep_019_resolved_plan_constructor_cannot_be_bypassed() -> None:
     with pytest.raises(TypeError, match="constructed only by rollback resolution"):
         ResolvedRollbackPlan(
@@ -522,8 +556,7 @@ def _call_inventory(function_name: str) -> dict[str, int]:
                 1
                 for node in ast.walk(tree)
                 if isinstance(node, ast.Call)
-                and (getattr(node.func, "id", None) or getattr(node.func, "attr", None))
-                == function_name
+                and (getattr(node.func, "id", None) or getattr(node.func, "attr", None)) == function_name
             )
             if calls:
                 callers[source.relative_to(ROOT).as_posix()] = calls

--- a/tests/test_package_shape_record_codec.py
+++ b/tests/test_package_shape_record_codec.py
@@ -362,10 +362,15 @@ def test_memory_indep_019_resolver_environment_allows_empty_platform_facts(
 
 def test_memory_indep_019_explicit_resolver_snapshot_uses_only_stdlib(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     environment_dir = tmp_path / "resolver"
     venv.EnvBuilder(with_pip=False).create(environment_dir)
     executable = environment_dir / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    hook_dir = tmp_path / "hook"
+    hook_dir.mkdir()
+    (hook_dir / "sitecustomize.py").write_text('print("polluted stdout")\n')
+    monkeypatch.setenv("PYTHONPATH", str(hook_dir))
 
     environment = package_shape._capture_resolver_environment(str(executable))
 

--- a/tests/test_package_shape_record_codec.py
+++ b/tests/test_package_shape_record_codec.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import venv
 from copy import deepcopy
 from dataclasses import FrozenInstanceError, replace
 from pathlib import Path
@@ -320,6 +321,56 @@ def test_memory_indep_019_dependency_closure_uses_only_persisted_snapshot(
         "shape-helper",
         "shape-leaf",
     }
+
+
+def test_memory_indep_019_dependency_markers_use_only_selected_extras(
+    tmp_path: Path,
+) -> None:
+    payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
+    payload["plan"]["artifacts"][0]["requires_dist"].append("shape-helper[foo]==1")  # type: ignore[index]
+    _append_artifact(
+        payload,
+        tmp_path,
+        "shape-helper",
+        "1",
+        requires_dist=('shape-leaf==2; extra != "foo"',),
+    )
+
+    decoded = decode_resolved_rollback_plan_record(payload)
+
+    assert {artifact.distribution for artifact in decoded.artifacts} == {
+        "avibe-os",
+        "avibe-memory",
+        "shape-helper",
+    }
+
+
+def test_memory_indep_019_resolver_environment_allows_empty_platform_facts(
+    tmp_path: Path,
+) -> None:
+    record = decode_resolved_rollback_plan_record(encode_resolved_rollback_plan_record(_resolved(tmp_path)))
+    environment = _resolver_environment(
+        platform_machine="",
+        platform_release="",
+        platform_system="",
+        platform_version="",
+    )
+    expected = replace(record, resolver_environment=environment)
+
+    assert decode_resolved_rollback_plan_record(encode_resolved_rollback_plan_record(expected)) == expected
+
+
+def test_memory_indep_019_explicit_resolver_snapshot_uses_only_stdlib(
+    tmp_path: Path,
+) -> None:
+    environment_dir = tmp_path / "resolver"
+    venv.EnvBuilder(with_pip=False).create(environment_dir)
+    executable = environment_dir / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+    environment = package_shape._capture_resolver_environment(str(executable))
+
+    assert environment.python_version
+    assert environment.implementation_name
 
 
 @pytest.mark.parametrize(

--- a/tests/test_package_shape_record_codec.py
+++ b/tests/test_package_shape_record_codec.py
@@ -24,6 +24,7 @@ from vibe.package_shape import (
     ResolverEnvironment,
     ResolvedRollbackPlan,
     ResolvedRollbackPlanRecord,
+    RollbackResolutionError,
     StagedArtifact,
     decode_captured_package_shape_record,
     decode_resolved_rollback_plan_record,
@@ -309,8 +310,8 @@ def test_memory_indep_019_dependency_closure_uses_only_persisted_snapshot(
     _append_artifact(payload, tmp_path, "shape-leaf", "2")
     monkeypatch.setattr(
         package_shape,
-        "default_environment",
-        lambda: pytest.fail("decode consulted the current resolver environment"),
+        "_capture_resolver_environment",
+        lambda *_args: pytest.fail("decode consulted the current resolver environment"),
     )
 
     decoded = decode_resolved_rollback_plan_record(payload)
@@ -365,7 +366,7 @@ def test_memory_indep_019_explicit_resolver_snapshot_uses_only_stdlib(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     environment_dir = tmp_path / "resolver"
-    venv.EnvBuilder(with_pip=False).create(environment_dir)
+    venv.EnvBuilder(with_pip=False, symlinks=os.name != "nt").create(environment_dir)
     executable = environment_dir / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
     hook_dir = tmp_path / "hook"
     hook_dir.mkdir()
@@ -376,6 +377,37 @@ def test_memory_indep_019_explicit_resolver_snapshot_uses_only_stdlib(
 
     assert environment.python_version
     assert environment.implementation_name
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("executable", "/different/python"), ("python_full_version", "3.11.8")],
+)
+def test_memory_indep_019_resolver_snapshot_rejects_interpreter_identity_mismatch(
+    field: str,
+    value: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolver_python = "/expected/python"
+    payload: dict[str, object] = {
+        "interpreter": {
+            "executable": resolver_python,
+            "python_version": RESOLVER_ENVIRONMENT_VALUES["python_version"],
+            "python_full_version": RESOLVER_ENVIRONMENT_VALUES["python_full_version"],
+            "implementation_name": RESOLVER_ENVIRONMENT_VALUES["implementation_name"],
+            "implementation_version": RESOLVER_ENVIRONMENT_VALUES["implementation_version"],
+        },
+        "environment": RESOLVER_ENVIRONMENT_VALUES,
+    }
+    payload["interpreter"][field] = value  # type: ignore[index]
+    monkeypatch.setattr(
+        package_shape.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(returncode=0, stdout=json.dumps(payload)),
+    )
+
+    with pytest.raises(RollbackResolutionError, match="snapshot failed"):
+        package_shape._capture_resolver_environment(resolver_python)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_package_shape_record_codec.py
+++ b/tests/test_package_shape_record_codec.py
@@ -13,12 +13,14 @@ import pytest
 
 import vibe.package_shape as package_shape
 from vibe.package_shape import (
+    ArtifactRole,
     CapturedPackageShapeRecord,
     DistributionProvider,
     ExactRequirement,
     PackageShapeError,
     PackageShapeRecordError,
     ReleaseFamily,
+    ResolverEnvironment,
     ResolvedRollbackPlan,
     ResolvedRollbackPlanRecord,
     StagedArtifact,
@@ -29,6 +31,25 @@ from vibe.package_shape import (
 )
 from vibe.runtime import ServiceLauncher
 from vibe.upgrade import rollback_target
+
+
+RESOLVER_ENVIRONMENT_VALUES = {
+    "python_version": "3.11",
+    "python_full_version": "3.11.9",
+    "implementation_name": "cpython",
+    "implementation_version": "3.11.9",
+    "os_name": "posix",
+    "platform_machine": "x86_64",
+    "platform_python_implementation": "CPython",
+    "platform_release": "test-release",
+    "platform_system": "Linux",
+    "platform_version": "test-version",
+    "sys_platform": "linux",
+}
+
+
+def _resolver_environment(**overrides: str) -> ResolverEnvironment:
+    return ResolverEnvironment(**{**RESOLVER_ENVIRONMENT_VALUES, **overrides})
 
 
 def _captured() -> package_shape.CapturedPackageShape:
@@ -70,6 +91,7 @@ def _resolved(tmp_path: Path) -> ResolvedRollbackPlan:
             path=(staging_dir / f"{requirement.distribution.replace('-', '_')}-{requirement.version}-py3-none-any.whl"),
             sha256=("a" if index == 0 else "b") * 64,
             requires_dist=(captured.core_provider.requires_dist if index == 0 else ()),
+            role=ArtifactRole.INSTALL,
         )
         for index, requirement in enumerate(requirements)
     )
@@ -78,6 +100,7 @@ def _resolved(tmp_path: Path) -> ResolvedRollbackPlan:
         requirements=requirements,
         artifacts=artifacts,
         staging_dir=staging_dir,
+        resolver_environment=_resolver_environment(),
     )
 
 
@@ -85,6 +108,27 @@ def _json_round_trip(value: dict[str, object]) -> dict[str, object]:
     loaded = json.loads(json.dumps(value))
     assert isinstance(loaded, dict)
     return loaded
+
+
+def _append_artifact(
+    payload: dict[str, object],
+    tmp_path: Path,
+    distribution: str,
+    version: str,
+    *,
+    requires_dist: tuple[str, ...] = (),
+    role: str = "install",
+) -> None:
+    payload["plan"]["artifacts"].append(  # type: ignore[index]
+        {
+            "distribution": distribution,
+            "version": version,
+            "path": str(tmp_path / "staging" / f"{distribution.replace('-', '_')}-{version}-py3-none-any.whl"),
+            "sha256": "c" * 64,
+            "requires_dist": list(requires_dist),
+            "role": role,
+        }
+    )
 
 
 def test_memory_indep_019_captured_codec_is_json_safe_immutable_and_lossless() -> None:
@@ -144,10 +188,15 @@ def test_memory_indep_019_resolved_codec_preserves_complete_non_executable_plan(
 
     assert isinstance(decoded, ResolvedRollbackPlanRecord)
     assert not isinstance(decoded, ResolvedRollbackPlan)
+    assert encoded["schema_version"] == 2
     assert encode_resolved_rollback_plan_record(decoded) == encoded
     assert decoded.staging_dir == str(tmp_path / "staging")
     assert [artifact.sha256 for artifact in decoded.artifacts] == ["a" * 64, "b" * 64]
     assert decoded.verification.memory_version == "3.0.15"
+    assert tuple(encoded["plan"]["resolver_environment"]) == tuple(  # type: ignore[index]
+        RESOLVER_ENVIRONMENT_VALUES
+    )
+    assert {artifact.role for artifact in decoded.artifacts} == {ArtifactRole.INSTALL}
     with pytest.raises(TypeError, match="constructed only by rollback resolution"):
         ResolvedRollbackPlan(**decoded.__dict__)
 
@@ -214,13 +263,100 @@ def test_memory_indep_019_resolved_decoder_rejects_structural_drift(
         decode_resolved_rollback_plan_record(payload)
 
 
+@pytest.mark.parametrize("version", [0, 1, 3, True, "2", None])
 def test_memory_indep_019_resolved_decoder_rejects_unknown_schema(
+    version: object,
     tmp_path: Path,
 ) -> None:
     payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
-    payload["schema_version"] = 2
+    payload["schema_version"] = version
 
     with pytest.raises(PackageShapeRecordError, match="schema version"):
+        decode_resolved_rollback_plan_record(payload)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value["plan"]["resolver_environment"].pop("python_version"),
+        lambda value: value["plan"]["resolver_environment"].update(extra="unknown"),
+        lambda value: value["plan"]["resolver_environment"].update(python_version=3.11),
+        lambda value: value["plan"]["resolver_environment"].update(python_full_version="3.12.1"),
+        lambda value: value["plan"]["artifacts"][0].pop("role"),
+    ],
+)
+def test_memory_indep_019_plan_snapshot_and_roles_are_strict(
+    mutation: object,
+    tmp_path: Path,
+) -> None:
+    payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
+    mutation(payload)  # type: ignore[operator]
+
+    with pytest.raises(PackageShapeRecordError):
+        decode_resolved_rollback_plan_record(payload)
+
+
+def test_memory_indep_019_dependency_closure_uses_only_persisted_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
+    payload["plan"]["artifacts"][0]["requires_dist"].append(  # type: ignore[index]
+        'shape-helper==1; python_version < "3.12"'
+    )
+    _append_artifact(payload, tmp_path, "shape-helper", "1", requires_dist=("shape-leaf==2",))
+    _append_artifact(payload, tmp_path, "shape-leaf", "2")
+    monkeypatch.setattr(
+        package_shape,
+        "default_environment",
+        lambda: pytest.fail("decode consulted the current resolver environment"),
+    )
+
+    decoded = decode_resolved_rollback_plan_record(payload)
+
+    assert {artifact.distribution for artifact in decoded.artifacts} == {
+        "avibe-os",
+        "avibe-memory",
+        "shape-helper",
+        "shape-leaf",
+    }
+
+
+@pytest.mark.parametrize(
+    ("artifact_version", "include_artifact", "expected"),
+    [
+        ("1", False, "missing staged install artifact"),
+        ("2", True, "does not satisfy"),
+    ],
+)
+def test_memory_indep_019_active_dependency_must_resolve_exactly(
+    artifact_version: str,
+    include_artifact: bool,
+    expected: str,
+    tmp_path: Path,
+) -> None:
+    payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
+    payload["plan"]["artifacts"][0]["requires_dist"].append("shape-helper==1")  # type: ignore[index]
+    if include_artifact:
+        _append_artifact(payload, tmp_path, "shape-helper", artifact_version)
+
+    with pytest.raises(PackageShapeRecordError, match=expected):
+        decode_resolved_rollback_plan_record(payload)
+
+
+def test_memory_indep_019_unreachable_install_artifact_fails_closed(tmp_path: Path) -> None:
+    payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
+    _append_artifact(payload, tmp_path, "shape-helper", "1")
+
+    with pytest.raises(PackageShapeRecordError, match="unreachable"):
+        decode_resolved_rollback_plan_record(payload)
+
+
+def test_memory_indep_019_residual_role_requires_bundled_residual_shape(tmp_path: Path) -> None:
+    payload = encode_resolved_rollback_plan_record(_resolved(tmp_path))
+    payload["plan"]["artifacts"][1]["role"] = "residual_preserve"  # type: ignore[index]
+
+    with pytest.raises(PackageShapeRecordError, match="residual-preserve"):
         decode_resolved_rollback_plan_record(payload)
 
 
@@ -291,6 +427,7 @@ def test_memory_indep_019_rejects_invalid_distribution_names(
             "path": str(tmp_path / "staging" / "invalid.whl"),
             "sha256": "c" * 64,
             "requires_dist": [],
+            "role": "install",
         }
     )
     with pytest.raises(PackageShapeRecordError, match="name is invalid"):

--- a/vibe/package_shape.py
+++ b/vibe/package_shape.py
@@ -1,8 +1,7 @@
 """Exact package capture, persisted recovery DTOs, and rollback resolution.
 
-Plan-record dependency-closure semantics belong to the immediate successor
-slice (b). Until that slice merges, consumers must not consume persisted plan
-records for G3-1B outer records or G3-2 rehydration.
+Plan records validate dependency closure offline from their persisted resolver
+environment. They remain factual and cannot authorize rollback execution.
 
 Strictness belongs to our package facts; tolerance belongs only to unrelated
 environmental presence. Live inventory screens relevance tolerantly, then
@@ -11,12 +10,16 @@ validates relevant facts strictly. Persisted record decode is always strict.
 Every persisted executable or module path is owned by one pure lexical
 validator shared by live construction and decode. Ordinary text fields do not
 inherit path constraints.
+
+Identity precedes semantics, snapshots precede evaluation, validation has one
+DTO-construction source, and every policy decision names its persisted source.
 """
 
 from __future__ import annotations
 
 import email.parser
 import hashlib
+import json
 import ntpath
 import os
 import posixpath
@@ -33,6 +36,7 @@ from types import UnionType
 from typing import Any, Union, get_args, get_origin, get_type_hints
 
 from packaging.requirements import InvalidRequirement, Requirement
+from packaging.markers import UndefinedComparison, UndefinedEnvironmentName, default_environment
 from packaging.utils import (
     InvalidName,
     InvalidWheelFilename,
@@ -50,6 +54,7 @@ MEMORY_PACKAGE_NAME = "avibe-memory"
 CORE_DISTRIBUTION_NAMES = frozenset({CORE_PACKAGE_NAME, LEGACY_CORE_PACKAGE_NAME})
 MEMORY_SPLIT_MIN_VERSION = Version("3.0.14.dev0")
 PACKAGE_SHAPE_RECORD_SCHEMA_VERSION = 1
+_RESOLVED_ROLLBACK_PLAN_RECORD_SCHEMA_VERSION = 2
 
 
 class PackageShapeError(ValueError):
@@ -72,6 +77,11 @@ class ReleaseFamily(str, Enum):
     PRE_SPLIT = "pre_split"
     OPTIONAL_SPLIT = "optional_split"
     TRANSITION = "transition"
+
+
+class ArtifactRole(str, Enum):
+    INSTALL = "install"
+    RESIDUAL_PRESERVE = "residual_preserve"
 
 
 def _canonical_distribution_name(
@@ -251,6 +261,32 @@ class ExactRequirement:
         return f"{self.distribution}=={self.version}"
 
 
+@dataclass(frozen=True)
+class ResolverEnvironment:
+    python_version: str
+    python_full_version: str
+    implementation_name: str
+    implementation_version: str
+    os_name: str
+    platform_machine: str
+    platform_python_implementation: str
+    platform_release: str
+    platform_system: str
+    platform_version: str
+    sys_platform: str
+
+    def __post_init__(self) -> None:
+        _validate_record_fields(self)
+        try:
+            full_version = Version(self.python_full_version)
+            Version(self.implementation_version)
+        except InvalidVersion as exc:
+            raise PackageShapeRecordError("resolver environment version is invalid") from exc
+        expected_python_version = ".".join(str(part) for part in full_version.release[:2])
+        if self.python_version != expected_python_version:
+            raise PackageShapeRecordError("resolver environment Python versions disagree")
+
+
 @dataclass(frozen=True, order=True)
 class StagedArtifact:
     distribution: str
@@ -258,6 +294,7 @@ class StagedArtifact:
     path: Path
     sha256: str
     requires_dist: tuple[str, ...]
+    role: ArtifactRole
 
     def __post_init__(self) -> None:
         distribution = _canonical_distribution_name(
@@ -285,6 +322,8 @@ class StagedArtifact:
             or any(character not in "0123456789abcdef" for character in self.sha256)
         ):
             raise PackageShapeError("artifact SHA-256 is not canonical")
+        if type(self.role) is not ArtifactRole:
+            raise PackageShapeError("staged artifact role is invalid")
         object.__setattr__(self, "distribution", distribution)
         object.__setattr__(self, "version", version)
         object.__setattr__(self, "path", path)
@@ -313,6 +352,7 @@ class ResolvedRollbackPlan:
     """A rollback whose complete exact closure already exists in staging."""
 
     captured: CapturedPackageShape
+    resolver_environment: ResolverEnvironment
     requirements: tuple[ExactRequirement, ...]
     artifacts: tuple[StagedArtifact, ...]
     staging_dir: Path
@@ -413,6 +453,7 @@ class ResolvedRollbackPlanRecord:
     """Non-executable persisted form of a resolved rollback plan."""
 
     captured: CapturedPackageShapeRecord
+    resolver_environment: ResolverEnvironment
     requirements: tuple[ExactRequirement, ...]
     artifacts: tuple[StagedArtifact, ...]
     staging_dir: str
@@ -465,12 +506,6 @@ class ResolvedRollbackPlanRecord:
             or staged_memory_version != self.captured.memory_version
         ):
             raise PackageShapeRecordError("staging does not contain the exact captured Memory shape")
-        missing_requirements = {
-            (requirement.distribution, requirement.version) for requirement in self.requirements
-        } - {(artifact.distribution, artifact.version) for artifact in self.artifacts}
-        if missing_requirements:
-            raise PackageShapeRecordError("resolved staging is missing an exact rollback artifact")
-
         staged_core = core_artifacts[0]
         try:
             staged_family, staged_transition = _release_family(
@@ -488,10 +523,101 @@ class ResolvedRollbackPlanRecord:
             or staged_transition != self.captured.transition_memory_version
         ):
             raise PackageShapeRecordError("staged core artifact does not match the captured release family")
+        _validate_resolved_closure(self)
         if self.uninstall_distributions != _rollback_uninstall_distributions():
             raise PackageShapeRecordError("resolved rollback record has an unknown uninstall set")
         if self.verification != _package_shape_verification(self.captured):
             raise PackageShapeRecordError("resolved rollback verification is inconsistent")
+
+
+def _marker_environment(environment: ResolverEnvironment, extra: str) -> dict[str, str]:
+    return {
+        **{field.name: getattr(environment, field.name) for field in fields(environment)},
+        "extra": extra,
+    }
+
+
+def _active_requirement(
+    value: str,
+    environment: ResolverEnvironment,
+    extras: set[str],
+) -> Requirement | None:
+    try:
+        requirement = Requirement(value)
+        active = requirement.marker is None or any(
+            requirement.marker.evaluate(_marker_environment(environment, extra)) for extra in ("", *sorted(extras))
+        )
+    except (InvalidRequirement, UndefinedComparison, UndefinedEnvironmentName) as exc:
+        raise PackageShapeRecordError("staged artifact dependency metadata is invalid") from exc
+    if not active:
+        return None
+    if requirement.url is not None:
+        raise PackageShapeRecordError("staged artifact dependency uses an unverifiable direct URL")
+    return requirement
+
+
+def _validate_resolved_closure(record: ResolvedRollbackPlanRecord) -> None:
+    install = {
+        artifact.distribution: artifact for artifact in record.artifacts if artifact.role is ArtifactRole.INSTALL
+    }
+    residual = tuple(artifact for artifact in record.artifacts if artifact.role is ArtifactRole.RESIDUAL_PRESERVE)
+    expected_residual: tuple[str, str] | None = None
+    if record.captured.release_family is ReleaseFamily.PRE_SPLIT and record.captured.residual_memory:
+        assert record.captured.memory_version is not None
+        expected_residual = (MEMORY_PACKAGE_NAME, record.captured.memory_version)
+    if tuple((artifact.distribution, artifact.version) for artifact in residual) != (
+        (expected_residual,) if expected_residual is not None else ()
+    ):
+        raise PackageShapeRecordError("residual-preserve artifact does not match the bundled residual shape")
+
+    reachable: set[str] = set()
+    active_extras: dict[str, set[str]] = {}
+    pending: list[StagedArtifact] = []
+
+    def schedule(artifact: StagedArtifact, extras: set[str]) -> None:
+        known = active_extras.setdefault(artifact.distribution, set())
+        if artifact.distribution in reachable and extras <= known:
+            return
+        known.update(extras)
+        reachable.add(artifact.distribution)
+        pending.append(artifact)
+
+    for requirement in record.requirements:
+        if expected_residual == (requirement.distribution, requirement.version):
+            continue
+        artifact = install.get(requirement.distribution)
+        if artifact is None:
+            raise PackageShapeRecordError("resolved staging is missing a top-level install artifact")
+        if artifact.version != requirement.version:
+            raise PackageShapeRecordError("top-level install artifact does not match the captured exact pin")
+        schedule(artifact, set())
+
+    while pending:
+        source = pending.pop()
+        for value in source.requires_dist:
+            requirement = _active_requirement(
+                value,
+                record.resolver_environment,
+                active_extras[source.distribution],
+            )
+            if requirement is None:
+                continue
+            distribution = _canonical_distribution_name(
+                requirement.name,
+                field="active dependency distribution",
+                error_type=PackageShapeRecordError,
+            )
+            target = install.get(distribution)
+            if target is None:
+                raise PackageShapeRecordError("active dependency is missing staged install artifact")
+            if not requirement.specifier.contains(target.version):
+                raise PackageShapeRecordError("staged install artifact does not satisfy active dependency")
+            # Requires-Dist edges name distributions. Python stdlib imports are
+            # not package metadata edges and therefore need no ambient allowlist.
+            schedule(target, set(requirement.extras))
+
+    if orphaned := set(install) - reachable:
+        raise PackageShapeRecordError(f"staging contains unreachable install artifacts: {', '.join(sorted(orphaned))}")
 
 
 _RECORD_DTO_TYPES = (
@@ -500,6 +626,7 @@ _RECORD_DTO_TYPES = (
     _ServiceLauncherRecord,
     CapturedPackageShapeRecord,
     ExactRequirement,
+    ResolverEnvironment,
     StagedArtifact,
     PackageShapeVerification,
     ResolvedRollbackPlanRecord,
@@ -697,29 +824,37 @@ def _decode_record_dto(value: object, dto_type: type, *, field: str) -> object:
 
 
 _RECORD_ENVELOPES = {
-    "captured_package_shape": ("shape", CapturedPackageShapeRecord),
-    "resolved_rollback_plan": ("plan", ResolvedRollbackPlanRecord),
+    "captured_package_shape": (
+        "shape",
+        CapturedPackageShapeRecord,
+        PACKAGE_SHAPE_RECORD_SCHEMA_VERSION,
+    ),
+    "resolved_rollback_plan": (
+        "plan",
+        ResolvedRollbackPlanRecord,
+        _RESOLVED_ROLLBACK_PLAN_RECORD_SCHEMA_VERSION,
+    ),
 }
 
 
 def _encode_record(record_type: str, record: object) -> dict[str, object]:
-    payload_name, dto_type = _RECORD_ENVELOPES[record_type]
+    payload_name, dto_type, schema_version = _RECORD_ENVELOPES[record_type]
     if type(record) is not dto_type:
         raise PackageShapeRecordError("record DTO type is unsupported")
     return {
-        "schema_version": PACKAGE_SHAPE_RECORD_SCHEMA_VERSION,
+        "schema_version": schema_version,
         "record_type": record_type,
         payload_name: _encode_record_dto(record),
     }
 
 
 def _decode_record(value: object, record_type: str) -> object:
-    payload_name, dto_type = _RECORD_ENVELOPES[record_type]
+    payload_name, dto_type, schema_version = _RECORD_ENVELOPES[record_type]
     required = frozenset({"schema_version", "record_type", payload_name})
     if type(value) is not dict or frozenset(value) != required:
         raise PackageShapeRecordError("record has unknown or missing fields")
     version = value["schema_version"]
-    if type(version) is not int or version != PACKAGE_SHAPE_RECORD_SCHEMA_VERSION:
+    if type(version) is not int or version != schema_version:
         raise PackageShapeRecordError("package-shape record schema version is unsupported")
     if type(value["record_type"]) is not str or value["record_type"] != record_type:
         raise PackageShapeRecordError("package-shape record type is unsupported")
@@ -771,6 +906,7 @@ def _plan_to_record(
         raise PackageShapeRecordError("resolved rollback plan has an unsupported type")
     return ResolvedRollbackPlanRecord(
         captured=_captured_to_record(plan.captured),
+        resolver_environment=plan.resolver_environment,
         requirements=plan.requirements,
         artifacts=plan.artifacts,
         staging_dir=str(plan.staging_dir),
@@ -1007,7 +1143,11 @@ def _wheel_provider(path: Path) -> DistributionProvider:
     return provider
 
 
-def _staged_artifacts(staging_dir: Path) -> tuple[StagedArtifact, ...]:
+def _staged_artifacts(
+    staging_dir: Path,
+    *,
+    residual_memory: bool,
+) -> tuple[StagedArtifact, ...]:
     artifacts: list[StagedArtifact] = []
     for path in sorted(staging_dir.iterdir()):
         if not path.is_file():
@@ -1021,6 +1161,11 @@ def _staged_artifacts(staging_dir: Path) -> tuple[StagedArtifact, ...]:
                     path=path,
                     sha256=hashlib.sha256(path.read_bytes()).hexdigest(),
                     requires_dist=provider.requires_dist,
+                    role=(
+                        ArtifactRole.RESIDUAL_PRESERVE
+                        if residual_memory and provider.name == MEMORY_PACKAGE_NAME
+                        else ArtifactRole.INSTALL
+                    ),
                 )
             )
         except PackageShapeError as exc:
@@ -1053,9 +1198,11 @@ def _construct_resolved_plan(
     requirements: tuple[ExactRequirement, ...],
     artifacts: tuple[StagedArtifact, ...],
     staging_dir: Path,
+    resolver_environment: ResolverEnvironment,
 ) -> ResolvedRollbackPlan:
     plan = object.__new__(ResolvedRollbackPlan)
     object.__setattr__(plan, "captured", captured)
+    object.__setattr__(plan, "resolver_environment", resolver_environment)
     object.__setattr__(plan, "requirements", requirements)
     object.__setattr__(plan, "artifacts", artifacts)
     object.__setattr__(plan, "staging_dir", staging_dir)
@@ -1076,6 +1223,37 @@ def _construct_resolved_plan(
     return plan
 
 
+def _capture_resolver_environment(resolver_python: str | None) -> ResolverEnvironment:
+    try:
+        if resolver_python is None:
+            payload: object = default_environment()
+        else:
+            result = subprocess.run(
+                [
+                    resolver_python,
+                    "-c",
+                    "import json; from packaging.markers import default_environment; "
+                    "print(json.dumps(default_environment()))",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                raise RollbackResolutionError("resolver environment snapshot failed")
+            payload = json.loads(result.stdout)
+        environment = _decode_record_dto(
+            payload,
+            ResolverEnvironment,
+            field="resolver environment",
+        )
+    except (json.JSONDecodeError, OSError, subprocess.SubprocessError, PackageShapeError) as exc:
+        raise RollbackResolutionError("resolver environment snapshot failed") from exc
+    assert isinstance(environment, ResolverEnvironment)
+    return environment
+
+
 def resolve_rollback_plan(
     captured: CapturedPackageShape,
     *,
@@ -1086,6 +1264,7 @@ def resolve_rollback_plan(
     """Resolve exact requirements from one local wheelhouse without installing."""
 
     requirements = _rollback_requirements(captured)
+    resolver_environment = _capture_resolver_environment(resolver_python)
     wheelhouse = Path(wheelhouse).resolve()
     staging_dir = Path(staging_dir).resolve()
     if not wheelhouse.is_dir():
@@ -1151,24 +1330,32 @@ def resolve_rollback_plan(
             )
             if result.returncode != 0:
                 raise RollbackResolutionError("exact rollback requirements did not resolve from the local wheelhouse")
-        temporary_artifacts = _staged_artifacts(temporary)
+        temporary_artifacts = _staged_artifacts(
+            temporary,
+            residual_memory=captured.residual_memory,
+        )
         _construct_resolved_plan(
             captured=captured,
             requirements=requirements,
             artifacts=temporary_artifacts,
             staging_dir=temporary,
+            resolver_environment=resolver_environment,
         )
 
         if staging_dir.exists():
             raise RollbackResolutionError("rollback staging destination appeared during resolution")
         os.replace(temporary, staging_dir)
         moved_to_staging = True
-        artifacts = _staged_artifacts(staging_dir)
+        artifacts = _staged_artifacts(
+            staging_dir,
+            residual_memory=captured.residual_memory,
+        )
         plan = _construct_resolved_plan(
             captured=captured,
             requirements=requirements,
             artifacts=artifacts,
             staging_dir=staging_dir,
+            resolver_environment=resolver_environment,
         )
         resolved = True
         return plan
@@ -1182,6 +1369,7 @@ def resolve_rollback_plan(
 
 
 __all__ = [
+    "ArtifactRole",
     "CapturedPackageShape",
     "CapturedPackageShapeRecord",
     "DistributionProvider",
@@ -1192,6 +1380,7 @@ __all__ = [
     "PackageShapeRecordError",
     "PackageShapeVerification",
     "ReleaseFamily",
+    "ResolverEnvironment",
     "ResolvedRollbackPlan",
     "ResolvedRollbackPlanRecord",
     "RollbackResolutionError",

--- a/vibe/package_shape.py
+++ b/vibe/package_shape.py
@@ -13,6 +13,10 @@ inherit path constraints.
 
 Identity precedes semantics, snapshots precede evaluation, validation has one
 DTO-construction source, and every policy decision names its persisted source.
+
+Marker snapshots and pip resolution are always subprocess observations using
+one normalized interpreter and one sanitized-environment constructor. The
+parent process is never a resolver marker source.
 """
 
 from __future__ import annotations
@@ -36,7 +40,7 @@ from types import UnionType
 from typing import Any, Union, get_args, get_origin, get_type_hints
 
 from packaging.requirements import InvalidRequirement, Requirement
-from packaging.markers import UndefinedComparison, UndefinedEnvironmentName, default_environment
+from packaging.markers import UndefinedComparison, UndefinedEnvironmentName
 from packaging.utils import (
     InvalidName,
     InvalidWheelFilename,
@@ -1245,13 +1249,15 @@ import os
 import platform
 import sys
 
+executable = os.path.normcase(os.path.abspath(sys.executable))
+python_full_version = platform.python_version()
 version = sys.implementation.version
 implementation_version = f"{version.major}.{version.minor}.{version.micro}"
 if version.releaselevel != "final":
     implementation_version += version.releaselevel[0] + str(version.serial)
-print(json.dumps({
+environment = {
     "python_version": ".".join(platform.python_version_tuple()[:2]),
-    "python_full_version": platform.python_version(),
+    "python_full_version": python_full_version,
     "implementation_name": sys.implementation.name,
     "implementation_version": implementation_version,
     "os_name": os.name,
@@ -1261,6 +1267,15 @@ print(json.dumps({
     "platform_system": platform.system(),
     "platform_version": platform.version(),
     "sys_platform": sys.platform,
+}
+print(json.dumps({
+    "interpreter": {
+        "executable": executable,
+        **{key: environment[key] for key in (
+            "python_version", "python_full_version", "implementation_name", "implementation_version"
+        )},
+    },
+    "environment": environment,
 }))
 """
 
@@ -1278,31 +1293,47 @@ def _resolver_subprocess_environment(*, wheelhouse: Path | None = None) -> dict[
     return environment
 
 
-def _capture_resolver_environment(resolver_python: str | None) -> ResolverEnvironment:
+def _normalize_resolver_python(resolver_python: str | None) -> str:
+    value = resolver_python or sys.executable
+    if not value or "\0" in value:
+        raise RollbackResolutionError("resolver interpreter path is invalid")
+    return os.path.normcase(os.path.abspath(value))
+
+
+def _capture_resolver_environment(resolver_python: str) -> ResolverEnvironment:
     try:
-        if resolver_python is None:
-            payload: object = default_environment()
-        else:
-            result = subprocess.run(
-                [
-                    resolver_python,
-                    "-c",
-                    _RESOLVER_ENVIRONMENT_SNAPSHOT_SCRIPT,
-                ],
-                env=_resolver_subprocess_environment(),
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=30,
+        result = subprocess.run(
+            [resolver_python, "-c", _RESOLVER_ENVIRONMENT_SNAPSHOT_SCRIPT],
+            env=_resolver_subprocess_environment(),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            raise RollbackResolutionError("resolver environment snapshot failed")
+        payload = json.loads(result.stdout)
+        identity_fields = ("python_version", "python_full_version", "implementation_name", "implementation_version")
+        if type(payload) is not dict or frozenset(payload) != {"interpreter", "environment"}:
+            raise PackageShapeRecordError("resolver snapshot fields are invalid")
+        identity = payload["interpreter"]
+        if (
+            type(identity) is not dict
+            or frozenset(identity) != {"executable", *identity_fields}
+            or any(
+                type(identity[field]) is not str or not identity[field] for field in ("executable", *identity_fields)
             )
-            if result.returncode != 0:
-                raise RollbackResolutionError("resolver environment snapshot failed")
-            payload = json.loads(result.stdout)
+        ):
+            raise PackageShapeRecordError("resolver interpreter identity is invalid")
         environment = _decode_record_dto(
-            payload,
+            payload["environment"],
             ResolverEnvironment,
             field="resolver environment",
         )
+        if identity["executable"] != resolver_python or any(
+            identity[field] != getattr(environment, field) for field in identity_fields
+        ):
+            raise PackageShapeRecordError("resolver interpreter identity disagrees with its marker snapshot")
     except (json.JSONDecodeError, OSError, subprocess.SubprocessError, PackageShapeError) as exc:
         raise RollbackResolutionError("resolver environment snapshot failed") from exc
     assert isinstance(environment, ResolverEnvironment)
@@ -1318,6 +1349,7 @@ def resolve_rollback_plan(
 ) -> ResolvedRollbackPlan:
     """Resolve exact requirements from one local wheelhouse without installing."""
 
+    resolver_python = _normalize_resolver_python(resolver_python)
     requirements = _rollback_requirements(captured)
     resolver_environment = _capture_resolver_environment(resolver_python)
     wheelhouse = Path(wheelhouse).resolve()
@@ -1329,7 +1361,7 @@ def resolve_rollback_plan(
     staging_dir.parent.mkdir(parents=True, exist_ok=True)
     temporary = Path(tempfile.mkdtemp(prefix=f".{staging_dir.name}-", dir=staging_dir.parent))
     command_prefix = [
-        resolver_python or sys.executable,
+        resolver_python,
         "-m",
         "pip",
         "download",

--- a/vibe/package_shape.py
+++ b/vibe/package_shape.py
@@ -1265,6 +1265,19 @@ print(json.dumps({
 """
 
 
+def _resolver_subprocess_environment(*, wheelhouse: Path | None = None) -> dict[str, str]:
+    environment = {
+        **{key: value for key, value in os.environ.items() if not key.startswith("PIP_") and key != "PYTHONPATH"},
+        "PIP_CONFIG_FILE": os.devnull,
+        "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+        "PIP_NO_INDEX": "1",
+        "PYTHONNOUSERSITE": "1",
+    }
+    if wheelhouse is not None:
+        environment["PIP_FIND_LINKS"] = str(wheelhouse)
+    return environment
+
+
 def _capture_resolver_environment(resolver_python: str | None) -> ResolverEnvironment:
     try:
         if resolver_python is None:
@@ -1276,6 +1289,7 @@ def _capture_resolver_environment(resolver_python: str | None) -> ResolverEnviro
                     "-c",
                     _RESOLVER_ENVIRONMENT_SNAPSHOT_SCRIPT,
                 ],
+                env=_resolver_subprocess_environment(),
                 capture_output=True,
                 text=True,
                 check=False,
@@ -1344,14 +1358,7 @@ def resolve_rollback_plan(
             (False, core_requirements),
             (True, memory_requirements),
         )
-    env = {
-        **{key: value for key, value in os.environ.items() if not key.startswith("PIP_") and key != "PYTHONPATH"},
-        "PIP_CONFIG_FILE": os.devnull,
-        "PIP_DISABLE_PIP_VERSION_CHECK": "1",
-        "PIP_NO_INDEX": "1",
-        "PIP_FIND_LINKS": str(wheelhouse),
-        "PYTHONNOUSERSITE": "1",
-    }
+    env = _resolver_subprocess_environment(wheelhouse=wheelhouse)
     moved_to_staging = False
     resolved = False
     try:

--- a/vibe/package_shape.py
+++ b/vibe/package_shape.py
@@ -287,6 +287,16 @@ class ResolverEnvironment:
             raise PackageShapeRecordError("resolver environment Python versions disagree")
 
 
+_EMPTY_RESOLVER_ENVIRONMENT_FIELDS = frozenset(
+    {
+        "platform_machine",
+        "platform_release",
+        "platform_system",
+        "platform_version",
+    }
+)
+
+
 @dataclass(frozen=True, order=True)
 class StagedArtifact:
     distribution: str
@@ -540,12 +550,13 @@ def _marker_environment(environment: ResolverEnvironment, extra: str) -> dict[st
 def _active_requirement(
     value: str,
     environment: ResolverEnvironment,
-    extras: set[str],
+    selected_extras: set[str],
 ) -> Requirement | None:
     try:
         requirement = Requirement(value)
+        marker_contexts = selected_extras or {""}
         active = requirement.marker is None or any(
-            requirement.marker.evaluate(_marker_environment(environment, extra)) for extra in ("", *sorted(extras))
+            requirement.marker.evaluate(_marker_environment(environment, extra)) for extra in sorted(marker_contexts)
         )
     except (InvalidRequirement, UndefinedComparison, UndefinedEnvironmentName) as exc:
         raise PackageShapeRecordError("staged artifact dependency metadata is invalid") from exc
@@ -571,14 +582,14 @@ def _validate_resolved_closure(record: ResolvedRollbackPlanRecord) -> None:
         raise PackageShapeRecordError("residual-preserve artifact does not match the bundled residual shape")
 
     reachable: set[str] = set()
-    active_extras: dict[str, set[str]] = {}
+    marker_contexts: dict[str, set[str]] = {}
     pending: list[StagedArtifact] = []
 
-    def schedule(artifact: StagedArtifact, extras: set[str]) -> None:
-        known = active_extras.setdefault(artifact.distribution, set())
-        if artifact.distribution in reachable and extras <= known:
+    def schedule(artifact: StagedArtifact, contexts: set[str]) -> None:
+        known = marker_contexts.setdefault(artifact.distribution, set())
+        if artifact.distribution in reachable and contexts <= known:
             return
-        known.update(extras)
+        known.update(contexts)
         reachable.add(artifact.distribution)
         pending.append(artifact)
 
@@ -590,7 +601,7 @@ def _validate_resolved_closure(record: ResolvedRollbackPlanRecord) -> None:
             raise PackageShapeRecordError("resolved staging is missing a top-level install artifact")
         if artifact.version != requirement.version:
             raise PackageShapeRecordError("top-level install artifact does not match the captured exact pin")
-        schedule(artifact, set())
+        schedule(artifact, {""})
 
     while pending:
         source = pending.pop()
@@ -598,7 +609,7 @@ def _validate_resolved_closure(record: ResolvedRollbackPlanRecord) -> None:
             requirement = _active_requirement(
                 value,
                 record.resolver_environment,
-                active_extras[source.distribution],
+                marker_contexts[source.distribution],
             )
             if requirement is None:
                 continue
@@ -614,7 +625,7 @@ def _validate_resolved_closure(record: ResolvedRollbackPlanRecord) -> None:
                 raise PackageShapeRecordError("staged install artifact does not satisfy active dependency")
             # Requires-Dist edges name distributions. Python stdlib imports are
             # not package metadata edges and therefore need no ambient allowlist.
-            schedule(target, set(requirement.extras))
+            schedule(target, set(requirement.extras) or {""})
 
     if orphaned := set(install) - reachable:
         raise PackageShapeRecordError(f"staging contains unreachable install artifacts: {', '.join(sorted(orphaned))}")
@@ -642,6 +653,7 @@ def _validate_declared_record_value(
     annotation: object,
     *,
     field: str,
+    allow_empty: bool = False,
 ) -> None:
     origin = get_origin(annotation)
     if origin in (Union, UnionType):
@@ -651,7 +663,7 @@ def _validate_declared_record_value(
         candidates = tuple(option for option in options if option is not type(None))
         if len(candidates) != 1:
             raise PackageShapeRecordError(f"{field} has an unsupported field schema")
-        _validate_declared_record_value(value, candidates[0], field=field)
+        _validate_declared_record_value(value, candidates[0], field=field, allow_empty=allow_empty)
         return
     if origin is tuple:
         if type(value) is not tuple:
@@ -677,7 +689,7 @@ def _validate_declared_record_value(
         return
     if type(value) is not annotation:
         raise PackageShapeRecordError(f"{field} has an invalid primitive type")
-    if annotation is str and not value:
+    if annotation is str and not value and not allow_empty:
         raise PackageShapeRecordError(f"{field} is missing")
 
 
@@ -690,6 +702,7 @@ def _validate_record_fields(value: object) -> None:
             getattr(value, name),
             annotation,
             field=f"{type(value).__name__}.{name}",
+            allow_empty=(type(value) is ResolverEnvironment and name in _EMPTY_RESOLVER_ENVIRONMENT_FIELDS),
         )
 
 
@@ -760,6 +773,7 @@ def _decode_declared_record_value(
     annotation: object,
     *,
     field: str,
+    allow_empty: bool = False,
 ) -> object:
     origin = get_origin(annotation)
     if origin in (Union, UnionType):
@@ -770,6 +784,7 @@ def _decode_declared_record_value(
             value,
             next(option for option in options if option is not type(None)),
             field=field,
+            allow_empty=allow_empty,
         )
     if origin is tuple:
         if type(value) is not list:
@@ -791,7 +806,7 @@ def _decode_declared_record_value(
         return Path(value)
     if type(value) is not annotation:
         raise PackageShapeRecordError(f"{field} has an invalid primitive type")
-    if annotation is str and not value:
+    if annotation is str and not value and not allow_empty:
         raise PackageShapeRecordError(f"{field} is missing")
     return value
 
@@ -808,6 +823,7 @@ def _decode_record_dto(value: object, dto_type: type, *, field: str) -> object:
                     value[name],
                     annotation,
                     field=f"{field}.{name}",
+                    allow_empty=(dto_type is ResolverEnvironment and name in _EMPTY_RESOLVER_ENVIRONMENT_FIELDS),
                 )
                 for name, annotation in schema
             }
@@ -1223,6 +1239,32 @@ def _construct_resolved_plan(
     return plan
 
 
+_RESOLVER_ENVIRONMENT_SNAPSHOT_SCRIPT = """
+import json
+import os
+import platform
+import sys
+
+version = sys.implementation.version
+implementation_version = f"{version.major}.{version.minor}.{version.micro}"
+if version.releaselevel != "final":
+    implementation_version += version.releaselevel[0] + str(version.serial)
+print(json.dumps({
+    "python_version": ".".join(platform.python_version_tuple()[:2]),
+    "python_full_version": platform.python_version(),
+    "implementation_name": sys.implementation.name,
+    "implementation_version": implementation_version,
+    "os_name": os.name,
+    "platform_machine": platform.machine(),
+    "platform_python_implementation": platform.python_implementation(),
+    "platform_release": platform.release(),
+    "platform_system": platform.system(),
+    "platform_version": platform.version(),
+    "sys_platform": sys.platform,
+}))
+"""
+
+
 def _capture_resolver_environment(resolver_python: str | None) -> ResolverEnvironment:
     try:
         if resolver_python is None:
@@ -1232,8 +1274,7 @@ def _capture_resolver_environment(resolver_python: str | None) -> ResolverEnviro
                 [
                     resolver_python,
                     "-c",
-                    "import json; from packaging.markers import default_environment; "
-                    "print(json.dumps(default_environment()))",
+                    _RESOLVER_ENVIRONMENT_SNAPSHOT_SCRIPT,
                 ],
                 capture_output=True,
                 text=True,


### PR DESCRIPTION
## Capability

Completes Gate 3 package-shape codec slice (b): persisted rollback plan facts now carry a strict resolver-environment snapshot and artifact roles, and validate their complete active dependency closure offline.

Base: 03f780c7466a72c73050532cf9d6b5963d6c5cc2
Scenario: MEMORY-INDEP-019

## Invariants

- Identity is validated before semantics; the persisted snapshot is established before marker evaluation.
- Resolver environment contains exactly the 11 frozen marker keys with strict primitive types.
- Marker snapshot and pip selection are always subprocess observations using one normalized resolver interpreter and the same sanitized-environment constructor, including the default `None -> sys.executable` path. Parent `default_environment()` is never a snapshot source.
- Snapshot output is strict JSON whose declared executable, Python versions, and implementation identity must agree with the invoked interpreter and persisted marker facts.
- Plan schema v2 requires every artifact role; schema v1 and unknown versions fail closed.
- install artifacts form the complete active closure from captured top-level exact pins under only the persisted marker environment.
- Marker evaluation uses exactly the base or selected-extra contexts that reached each artifact.
- Missing, duplicate, conflicting, and unreachable install artifacts fail closed.
- residual_preserve is permitted only for the exact pre-split bundled residual and contributes no dependency edges.
- Resolver snapshot capture remains stdlib-only; top-level packaging is not an undeclared resolver dependency.
- Validation remains sourced by immutable DTO construction shared by live resolution and record decode.
- Persisted bytes remain factual and never authorize or reconstruct ResolvedRollbackPlan.

## Scope

Three focused files only: `vibe/package_shape.py`, its codec tests, and the MEMORY-INDEP-019 scenario evidence. 631 insertions and 50 deletions, net +581, under the 600-line cap.

No lifecycle outer record, transaction state, recovery execution, rehydration, API, controller, UI, restart, or product entrypoint changes.

## Evidence

- 194 focused and relevant tests passed: package-shape record codec, MEMORY-INDEP-019 rollback types, and upgrade-flow coverage.
- Ruff format/check passed.
- py_compile and git diff --check passed.
- Default and explicit resolver paths were exercised from a genuinely polluted parent whose `sitecustomize` changes `platform.machine`; both persisted the sanitized child snapshot and produced the same correct staged closure.
- Snapshot and pip calls use the same normalized interpreter and sanitized base environment; strict mismatch regressions reject conflicting executable and Python-version identity.
- A packaging-free resolver venv remains stable when caller `PYTHONPATH` contains a stdout-writing `sitecustomize` hook.

Focused regressions also cover exact snapshot schema, old-schema/missing-role rejection, marker-gated transitive closure, selected-extra semantics, legitimate empty platform facts, missing/conflicting dependencies, unreachable installs, residual role restrictions, live snapshot capture, and captured core/Memory pin binding.

CI run 33202823104 on stale head `8c51e472a` had no application/test assertion failure: every shown shard-3 test passed before the GitHub-hosted runner received a shutdown signal and canceled the operation. All other shards, Windows smoke, and install-upgrade regression succeeded. The stale head was not rerun; this fix head creates the new exact-head CI run.

## Blocking handoff

Until this PR merges, G3-1B outer lifecycle records and G3-2 must not consume persisted plan records. After merge, G3-2 must compare the persisted resolver environment with current reality before any validated rehydration or execution. That comparison and all execution authority remain downstream by design.
