### PR TITLE
feat(memory): define portable wheel path policy

### DIFF
--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -8,17 +8,16 @@ repository-owned declaration.
 
 Wheel archive validation retains O(one bounded member + control metadata),
 never O(the archive's total decompressed payload).
+The archive inventory retains raw RECORD bytes but never interprets ledger rows;
+the immediate RECORD-ledger successor owns those semantics.
 """
 
 from __future__ import annotations
 
 import argparse
 import base64
-import binascii
-import csv
 from email.parser import Parser
 import hashlib
-import io
 import json
 import re
 import shutil
@@ -55,7 +54,6 @@ PACKAGE_POLICY_SUPPORTED_PYTHON_VERSIONS = ("3.10", "3.11", "3.12")
 SUPPORTED_NAMESPACE_POLICY_VERSIONS = frozenset({1})
 MAX_WHEEL_MEMBER_BYTES = 16 * 1024 * 1024
 WHEEL_DATA_SCHEMES = frozenset({"data", "headers", "platlib", "purelib", "scripts"})
-WHEEL_RECORD_HASH_ALGORITHMS = frozenset({"sha256", "sha384", "sha512"})
 
 
 @dataclass(frozen=True)
@@ -385,21 +383,6 @@ def _inventory_wheel_member(
     return entry, bytes(content) if content is not None else None
 
 
-def _valid_record_hash(value: str) -> bool:
-    algorithm, separator, encoded = value.partition("=")
-    if separator != "=" or algorithm not in WHEEL_RECORD_HASH_ALGORITHMS or not encoded or "=" in encoded:
-        return False
-    if re.fullmatch(r"[A-Za-z0-9_-]+", encoded) is None:
-        return False
-    try:
-        decoded = base64.b64decode(
-            encoded + "=" * (-len(encoded) % 4), altchars=b"-_", validate=True
-        )
-    except (ValueError, binascii.Error):
-        return False
-    return len(decoded) == hashlib.new(algorithm).digest_size
-
-
 def _validate_wheel_archive(
     archive: zipfile.ZipFile, wheel: Path, dist_info: str
 ) -> tuple[tuple[_WheelArchiveEntry, ...], dict[str, bytes]]:
@@ -445,33 +428,7 @@ def _validate_wheel_archive(
         if content is not None:
             members[name] = content
     if names.count(record) != 1:
-        raise ReleaseAssetError(f"wheel RECORD structure is invalid: {wheel.name}")
-    try:
-        rows = list(csv.reader(io.StringIO(members[record].decode("utf-8")), strict=True))
-    except Exception as exc:
-        raise ReleaseAssetError(f"wheel RECORD structure is invalid: {wheel.name}") from exc
-    generated = {record, f"{record}.jws", f"{record}.p7s"}
-    observed = {entry.path: entry for entry in inventory if not entry.is_dir}
-    member_names = set(observed)
-    recorded: set[str] = set()
-    recorded_aliases: set[str] = set()
-    for row in rows:
-        if len(row) != 3 or not _is_safe_wheel_path(row[0]):
-            raise ReleaseAssetError(f"wheel RECORD structure is invalid: {wheel.name}")
-        path, digest, size = row
-        alias = path.casefold()
-        if path in recorded or alias in recorded_aliases:
-            raise ReleaseAssetError(f"wheel RECORD structure is invalid: {wheel.name}")
-        if path in generated:
-            valid_fields = not digest and not size
-        else:
-            valid_fields = _valid_record_hash(digest) and re.fullmatch(r"[0-9]+", size) is not None
-        if not valid_fields:
-            raise ReleaseAssetError(f"wheel RECORD structure is invalid: {wheel.name}")
-        recorded.add(path)
-        recorded_aliases.add(alias)
-    if record not in recorded or recorded - generated != member_names - generated:
-        raise ReleaseAssetError(f"wheel RECORD entries differ from archive: {wheel.name}")
+        raise ReleaseAssetError(f"wheel control structure is invalid: {wheel.name}")
     return tuple(inventory), members
 
 

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -67,7 +67,14 @@ class _WheelControlPolicy:
 
 @dataclass(frozen=True)
 class _PortableWheelPathGrammar:
+    """Release-family policy for repository-built avibe-os/avibe-memory wheels.
+
+    Schema v1 is ASCII-only, so its retained NFC rule is vacuously satisfied.
+    Non-ASCII paths require schema v2 plus an explicit versioned Unicode source.
+    """
+
     schema_version: int
+    ascii_components_only: bool
     unicode_normalization: str
     max_component_utf8_bytes: int
     reject_absolute_paths: bool
@@ -91,6 +98,7 @@ _WHEEL_CONTROL_POLICY = _WheelControlPolicy(
 )
 _PORTABLE_WHEEL_PATH_GRAMMAR = _PortableWheelPathGrammar(
     schema_version=1,
+    ascii_components_only=True,
     unicode_normalization="NFC",
     max_component_utf8_bytes=255,
     reject_absolute_paths=True,
@@ -364,6 +372,11 @@ def _portable_wheel_path_key(value: str) -> str | None:
     grammar = _PORTABLE_WHEEL_PATH_GRAMMAR
     if type(value) is not str:
         return None
+    components = value.rstrip("/").split("/")
+    if grammar.ascii_components_only and any(
+        not component.isascii() for component in components
+    ):
+        return None
     normalized = unicodedata.normalize(grammar.unicode_normalization, value)
     if normalized != value:
         return None
@@ -371,7 +384,6 @@ def _portable_wheel_path_key(value: str) -> str | None:
         return None
     path = PurePosixPath(value)
     canonical = str(path) + ("/" if value.endswith("/") else "")
-    components = normalized.rstrip("/").split("/")
     keys = tuple(component.casefold() for component in components)
     try:
         oversized = any(

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -5,6 +5,9 @@ Package policy schema v1 declares ``Requires-Python: >=3.10``, supported minors
 ``3.10``, ``3.11``, and ``3.12``, and universal wheel tag ``py3-none-any``.
 Changing a contract requires a policy schema/version change and an updated
 repository-owned declaration.
+
+Wheel archive validation retains O(one bounded member + control metadata),
+never O(the archive's total decompressed payload).
 """
 
 from __future__ import annotations
@@ -359,6 +362,8 @@ def _valid_record_hash(value: str) -> bool:
     algorithm, separator, encoded = value.partition("=")
     if separator != "=" or algorithm not in WHEEL_RECORD_HASH_ALGORITHMS or not encoded or "=" in encoded:
         return False
+    if re.fullmatch(r"[A-Za-z0-9_-]+", encoded) is None:
+        return False
     try:
         decoded = base64.b64decode(
             encoded + "=" * (-len(encoded) % 4), altchars=b"-_", validate=True
@@ -374,19 +379,24 @@ def _validate_wheel_archive(
     infos = archive.infolist()
     names = [info.filename for info in infos]
     aliases = [name.rstrip("/").casefold() for name in names]
+    data_root = f"{dist_info.removesuffix('.dist-info')}.data"
     unsafe_data = any(
-        name.split("/", 2)[1] not in WHEEL_DATA_SCHEMES
+        parts[0].endswith(".data")
+        and (parts[0] != data_root or len(parts) < 3 or parts[1] not in WHEEL_DATA_SCHEMES or not parts[2])
         for name in names
-        if name.split("/", 1)[0].endswith(".data") and "/" in name
+        for parts in (name.split("/"),)
     )
     if any(not _is_safe_wheel_path(name) for name in names) or len(aliases) != len(set(aliases)) or unsafe_data:
         raise ReleaseAssetError(f"wheel archive structure is invalid: {wheel.name}")
-    members = {
-        info.filename: _read_wheel_member(archive, info, wheel)
-        for info in infos
-        if not info.is_dir()
-    }
     record = f"{dist_info}/RECORD"
+    retained = {record, *(f"{dist_info}/{name}" for name, _ in _WHEEL_CONTROL_POLICY.controls)}
+    member_names = {info.filename for info in infos if not info.is_dir()}
+    members = {}
+    for info in infos:
+        if not info.is_dir():
+            content = _read_wheel_member(archive, info, wheel)
+            if info.filename in retained:
+                members[info.filename] = content
     if names.count(record) != 1:
         raise ReleaseAssetError(f"wheel RECORD structure is invalid: {wheel.name}")
     try:
@@ -411,7 +421,7 @@ def _validate_wheel_archive(
             raise ReleaseAssetError(f"wheel RECORD structure is invalid: {wheel.name}")
         recorded.add(path)
         recorded_aliases.add(alias)
-    if recorded - generated != set(members) - generated:
+    if record not in recorded or recorded - generated != member_names - generated:
         raise ReleaseAssetError(f"wheel RECORD entries differ from archive: {wheel.name}")
     return members
 

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+from bisect import bisect_left
 from email.parser import Parser
 import hashlib
 import json
@@ -76,6 +77,13 @@ class _WheelArchiveEntry:
     sha256: str
 
 
+@dataclass(frozen=True)
+class _PortableWheelPathPolicy:
+    invalid_component_chars: frozenset[str]
+    reserved_component_names: frozenset[str]
+    control_char_pattern: re.Pattern[str]
+
+
 _WHEEL_CONTROL_POLICY = _WheelControlPolicy(
     controls=(("METADATA", 1), ("WHEEL", 1)),
     wheel_version_major=1,
@@ -84,6 +92,15 @@ _WHEEL_CONTROL_POLICY = _WheelControlPolicy(
     tags=("py3-none-any",),
     parser_defects=(),
     parser_body="",
+)
+_PORTABLE_WHEEL_PATH_POLICY = _PortableWheelPathPolicy(
+    invalid_component_chars=frozenset('<>:"|?*'),
+    reserved_component_names=frozenset(
+        {"con", "prn", "aux", "nul"}
+        | {f"com{number}" for number in range(1, 10)}
+        | {f"lpt{number}" for number in range(1, 10)}
+    ),
+    control_char_pattern=re.compile(r"[\x00-\x1f\x7f-\x9f]"),
 )
 
 
@@ -336,18 +353,31 @@ def _compare_wheel_control_policy(wheel: Path, observed: dict[str, object]) -> N
         )
 
 
-def _is_safe_wheel_path(value: str) -> bool:
+def _portable_wheel_path_key(value: str) -> str | None:
+    policy = _PORTABLE_WHEEL_PATH_POLICY
+    if policy.control_char_pattern.search(value):
+        return None
     path = PurePosixPath(value)
     canonical = str(path) + ("/" if value.endswith("/") else "")
-    return (
-        bool(path.parts)
-        and "\x00" not in value
-        and "\\" not in value
-        and not path.is_absolute()
-        and not PureWindowsPath(value).drive
-        and ".." not in path.parts
-        and value == canonical
-    )
+    components = value.rstrip("/").split("/")
+    folded = tuple(component.casefold() for component in components)
+    if (
+        not path.parts
+        or "\\" in value
+        or path.is_absolute()
+        or PureWindowsPath(value).drive
+        or value != canonical
+        or any(
+            not component
+            or component in {".", ".."}
+            or component.endswith((" ", "."))
+            or not policy.invalid_component_chars.isdisjoint(component)
+            or folded_component.split(".", 1)[0] in policy.reserved_component_names
+            for component, folded_component in zip(components, folded, strict=True)
+        )
+    ):
+        return None
+    return "/".join(folded)
 
 
 def _inventory_wheel_member(
@@ -358,7 +388,11 @@ def _inventory_wheel_member(
     *,
     retain: bool,
 ) -> tuple[_WheelArchiveEntry, bytes | None]:
-    if member.file_size < 0 or member.file_size > MAX_WHEEL_MEMBER_BYTES:
+    if (
+        member.file_size < 0
+        or member.file_size > MAX_WHEEL_MEMBER_BYTES
+        or (member.is_dir() and member.file_size != 0)
+    ):
         raise ReleaseAssetError(f"wheel member size is invalid: {wheel.name}")
     digest = hashlib.sha256()
     content = bytearray() if retain else None
@@ -376,7 +410,7 @@ def _inventory_wheel_member(
         raise
     except Exception as exc:
         raise ReleaseAssetError(f"cannot read wheel member: {wheel.name}") from exc
-    if size != member.file_size:
+    if size != member.file_size or (member.is_dir() and size != 0):
         raise ReleaseAssetError(f"wheel member size is invalid: {wheel.name}")
     encoded = base64.urlsafe_b64encode(digest.digest()).rstrip(b"=").decode()
     entry = _WheelArchiveEntry(member.filename, path_key, member.is_dir(), size, encoded)
@@ -390,18 +424,15 @@ def _validate_wheel_archive(
     identities: list[tuple[zipfile.ZipInfo, str, str]] = []
     for info in infos:
         raw_name = info.orig_filename
-        if (
-            type(raw_name) is not str
-            or type(info.filename) is not str
-            or "\x00" in raw_name
-            or raw_name != info.filename
-            or not _is_safe_wheel_path(raw_name)
-        ):
+        if type(raw_name) is not str or type(info.filename) is not str or raw_name != info.filename:
             raise ReleaseAssetError(f"wheel archive structure is invalid: {wheel.name}")
-        identities.append((info, raw_name, raw_name.rstrip("/").casefold()))
+        path_key = _portable_wheel_path_key(raw_name)
+        if path_key is None:
+            raise ReleaseAssetError(f"wheel archive structure is invalid: {wheel.name}")
+        identities.append((info, raw_name, path_key))
     names = [name for _, name, _ in identities]
-    aliases = [alias for _, _, alias in identities]
-    file_aliases = {alias for info, _, alias in identities if not info.is_dir()}
+    topology = sorted((alias, info.is_dir()) for info, _, alias in identities)
+    aliases = [alias for alias, _ in topology]
     data_root = f"{dist_info.removesuffix('.dist-info')}.data"
     unsafe_data = any(
         parts[0].endswith(".data")
@@ -409,12 +440,15 @@ def _validate_wheel_archive(
         for name in names
         for parts in (name.split("/"),)
     )
+    duplicate_or_alias = any(left == right for left, right in zip(aliases, aliases[1:]))
     prefix_conflict = any(
-        other.startswith(f"{file_alias}/")
-        for file_alias in file_aliases
-        for other in aliases
+        index < len(aliases) and aliases[index].startswith(prefix)
+        for alias, is_dir in topology
+        if not is_dir
+        for prefix in (f"{alias}/",)
+        for index in (bisect_left(aliases, prefix),)
     )
-    if len(aliases) != len(set(aliases)) or unsafe_data or prefix_conflict:
+    if duplicate_or_alias or unsafe_data or prefix_conflict:
         raise ReleaseAssetError(f"wheel archive structure is invalid: {wheel.name}")
     record = f"{dist_info}/RECORD"
     retained = {record, *(f"{dist_info}/{name}" for name, _ in _WHEEL_CONTROL_POLICY.controls)}

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -10,8 +10,12 @@ repository-owned declaration.
 from __future__ import annotations
 
 import argparse
+import base64
+import binascii
+import csv
 from email.parser import Parser
 import hashlib
+import io
 import json
 import re
 import shutil
@@ -22,7 +26,7 @@ import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, fields
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 import zipfile
 
 try:
@@ -46,6 +50,9 @@ PACKAGE_POLICY_SCHEMA_VERSION = 1
 PACKAGE_POLICY_REQUIRES_PYTHON = ">=3.10"
 PACKAGE_POLICY_SUPPORTED_PYTHON_VERSIONS = ("3.10", "3.11", "3.12")
 SUPPORTED_NAMESPACE_POLICY_VERSIONS = frozenset({1})
+MAX_WHEEL_MEMBER_BYTES = 16 * 1024 * 1024
+WHEEL_DATA_SCHEMES = frozenset({"data", "headers", "platlib", "purelib", "scripts"})
+WHEEL_RECORD_HASH_ALGORITHMS = frozenset({"sha256", "sha384", "sha512"})
 
 
 @dataclass(frozen=True)
@@ -319,6 +326,96 @@ def _compare_wheel_control_policy(wheel: Path, observed: dict[str, object]) -> N
         )
 
 
+def _is_safe_wheel_path(value: str) -> bool:
+    path = PurePosixPath(value)
+    canonical = str(path) + ("/" if value.endswith("/") else "")
+    return (
+        bool(path.parts)
+        and "\x00" not in value
+        and "\\" not in value
+        and not path.is_absolute()
+        and not PureWindowsPath(value).drive
+        and ".." not in path.parts
+        and value == canonical
+    )
+
+
+def _read_wheel_member(
+    archive: zipfile.ZipFile, member: zipfile.ZipInfo, wheel: Path
+) -> bytes:
+    if member.file_size < 0 or member.file_size > MAX_WHEEL_MEMBER_BYTES:
+        raise ReleaseAssetError(f"wheel member size is invalid: {wheel.name}")
+    try:
+        with archive.open(member) as stream:
+            content = stream.read(MAX_WHEEL_MEMBER_BYTES + 1)
+    except Exception as exc:
+        raise ReleaseAssetError(f"cannot read wheel member: {wheel.name}") from exc
+    if len(content) > MAX_WHEEL_MEMBER_BYTES or len(content) != member.file_size:
+        raise ReleaseAssetError(f"wheel member size is invalid: {wheel.name}")
+    return content
+
+
+def _valid_record_hash(value: str) -> bool:
+    algorithm, separator, encoded = value.partition("=")
+    if separator != "=" or algorithm not in WHEEL_RECORD_HASH_ALGORITHMS or not encoded or "=" in encoded:
+        return False
+    try:
+        decoded = base64.b64decode(
+            encoded + "=" * (-len(encoded) % 4), altchars=b"-_", validate=True
+        )
+    except (ValueError, binascii.Error):
+        return False
+    return len(decoded) == hashlib.new(algorithm).digest_size
+
+
+def _validate_wheel_archive(
+    archive: zipfile.ZipFile, wheel: Path, dist_info: str
+) -> dict[str, bytes]:
+    infos = archive.infolist()
+    names = [info.filename for info in infos]
+    aliases = [name.rstrip("/").casefold() for name in names]
+    unsafe_data = any(
+        name.split("/", 2)[1] not in WHEEL_DATA_SCHEMES
+        for name in names
+        if name.split("/", 1)[0].endswith(".data") and "/" in name
+    )
+    if any(not _is_safe_wheel_path(name) for name in names) or len(aliases) != len(set(aliases)) or unsafe_data:
+        raise ReleaseAssetError(f"wheel archive structure is invalid: {wheel.name}")
+    members = {
+        info.filename: _read_wheel_member(archive, info, wheel)
+        for info in infos
+        if not info.is_dir()
+    }
+    record = f"{dist_info}/RECORD"
+    if names.count(record) != 1:
+        raise ReleaseAssetError(f"wheel RECORD structure is invalid: {wheel.name}")
+    try:
+        rows = list(csv.reader(io.StringIO(members[record].decode("utf-8")), strict=True))
+    except Exception as exc:
+        raise ReleaseAssetError(f"wheel RECORD structure is invalid: {wheel.name}") from exc
+    generated = {record, f"{record}.jws", f"{record}.p7s"}
+    recorded: set[str] = set()
+    recorded_aliases: set[str] = set()
+    for row in rows:
+        if len(row) != 3 or not _is_safe_wheel_path(row[0]):
+            raise ReleaseAssetError(f"wheel RECORD structure is invalid: {wheel.name}")
+        path, digest, size = row
+        alias = path.casefold()
+        if path in recorded or alias in recorded_aliases:
+            raise ReleaseAssetError(f"wheel RECORD structure is invalid: {wheel.name}")
+        if path in generated:
+            valid_fields = not digest and not size
+        else:
+            valid_fields = _valid_record_hash(digest) and re.fullmatch(r"[0-9]+", size) is not None
+        if not valid_fields:
+            raise ReleaseAssetError(f"wheel RECORD structure is invalid: {wheel.name}")
+        recorded.add(path)
+        recorded_aliases.add(alias)
+    if recorded - generated != set(members) - generated:
+        raise ReleaseAssetError(f"wheel RECORD entries differ from archive: {wheel.name}")
+    return members
+
+
 def inspect_wheel(wheel: Path, *, policy: PackageReleasePolicy) -> PackageMetadata:
     """Validate wheel control metadata without inferring installed behavior."""
     if (
@@ -355,8 +452,9 @@ def inspect_wheel(wheel: Path, *, policy: PackageReleasePolicy) -> PackageMetada
                 for name, _ in _WHEEL_CONTROL_POLICY.controls
             )
             _compare_wheel_control_policy(wheel, {"controls": control_counts})
+            members = _validate_wheel_archive(archive, wheel, dist_info)
             metadata_bytes, wheel_bytes = (
-                archive.read(f"{dist_info}/{name}")
+                members[f"{dist_info}/{name}"]
                 for name, _ in _WHEEL_CONTROL_POLICY.controls
             )
     except ReleaseAssetError:

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -6,16 +6,14 @@ Package policy schema v1 declares ``Requires-Python: >=3.10``, supported minors
 Changing a contract requires a policy schema/version change and an updated
 repository-owned declaration.
 
-Wheel archive validation retains O(one bounded member + control metadata),
-never O(the archive's total decompressed payload).
-The archive inventory retains raw RECORD bytes but never interprets ledger rows;
-the immediate RECORD-ledger successor owns those semantics.
+Portable wheel path grammar schema v1 is repository-owned policy. It validates
+only lexical path identity and topology; archive reads and installed-layout
+inference belong to later successors.
 """
 
 from __future__ import annotations
 
 import argparse
-import base64
 from bisect import bisect_left
 from email.parser import Parser
 import hashlib
@@ -26,6 +24,7 @@ import sys
 import tarfile
 import tempfile
 import time
+import unicodedata
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, fields
@@ -53,8 +52,6 @@ PACKAGE_POLICY_SCHEMA_VERSION = 1
 PACKAGE_POLICY_REQUIRES_PYTHON = ">=3.10"
 PACKAGE_POLICY_SUPPORTED_PYTHON_VERSIONS = ("3.10", "3.11", "3.12")
 SUPPORTED_NAMESPACE_POLICY_VERSIONS = frozenset({1})
-MAX_WHEEL_MEMBER_BYTES = 16 * 1024 * 1024
-WHEEL_DATA_SCHEMES = frozenset({"data", "headers", "platlib", "purelib", "scripts"})
 
 
 @dataclass(frozen=True)
@@ -69,19 +66,18 @@ class _WheelControlPolicy:
 
 
 @dataclass(frozen=True)
-class _WheelArchiveEntry:
-    path: str
-    path_key: str
-    is_dir: bool
-    size: int
-    sha256: str
-
-
-@dataclass(frozen=True)
-class _PortableWheelPathPolicy:
-    invalid_component_chars: frozenset[str]
+class _PortableWheelPathGrammar:
+    schema_version: int
+    unicode_normalization: str
+    max_component_utf8_bytes: int
+    reject_absolute_paths: bool
+    reject_windows_drives: bool
+    forbidden_separators: frozenset[str]
+    forbidden_component_names: frozenset[str]
+    forbidden_component_chars: frozenset[str]
+    forbidden_component_suffixes: tuple[str, ...]
+    forbidden_codepoint_ranges: tuple[tuple[int, int], ...]
     reserved_component_names: frozenset[str]
-    control_char_pattern: re.Pattern[str]
 
 
 _WHEEL_CONTROL_POLICY = _WheelControlPolicy(
@@ -93,14 +89,25 @@ _WHEEL_CONTROL_POLICY = _WheelControlPolicy(
     parser_defects=(),
     parser_body="",
 )
-_PORTABLE_WHEEL_PATH_POLICY = _PortableWheelPathPolicy(
-    invalid_component_chars=frozenset('<>:"|?*'),
+_PORTABLE_WHEEL_PATH_GRAMMAR = _PortableWheelPathGrammar(
+    schema_version=1,
+    unicode_normalization="NFC",
+    max_component_utf8_bytes=255,
+    reject_absolute_paths=True,
+    reject_windows_drives=True,
+    forbidden_separators=frozenset({"\\"}),
+    forbidden_component_names=frozenset({"", ".", ".."}),
+    forbidden_component_chars=frozenset('<>:"|?*'),
+    forbidden_component_suffixes=(" ", "."),
+    forbidden_codepoint_ranges=((0, 31), (127, 159)),
     reserved_component_names=frozenset(
-        {"con", "prn", "aux", "nul"}
-        | {f"com{number}" for number in range(1, 10)}
-        | {f"lpt{number}" for number in range(1, 10)}
+        {"con", "prn", "aux", "nul", "conin$", "conout$"}
+        | {
+            f"{prefix}{suffix}"
+            for prefix in ("com", "lpt")
+            for suffix in (*map(str, range(1, 10)), "\u00b9", "\u00b2", "\u00b3")
+        }
     ),
-    control_char_pattern=re.compile(r"[\x00-\x1f\x7f-\x9f]"),
 )
 
 
@@ -354,116 +361,66 @@ def _compare_wheel_control_policy(wheel: Path, observed: dict[str, object]) -> N
 
 
 def _portable_wheel_path_key(value: str) -> str | None:
-    policy = _PORTABLE_WHEEL_PATH_POLICY
-    if policy.control_char_pattern.search(value):
+    grammar = _PORTABLE_WHEEL_PATH_GRAMMAR
+    if type(value) is not str:
+        return None
+    normalized = unicodedata.normalize(grammar.unicode_normalization, value)
+    if normalized != value:
+        return None
+    if any(separator in value for separator in grammar.forbidden_separators):
         return None
     path = PurePosixPath(value)
     canonical = str(path) + ("/" if value.endswith("/") else "")
-    components = value.rstrip("/").split("/")
-    folded = tuple(component.casefold() for component in components)
+    components = normalized.rstrip("/").split("/")
+    keys = tuple(component.casefold() for component in components)
+    try:
+        oversized = any(
+            len(component.encode("utf-8")) > grammar.max_component_utf8_bytes
+            for component in components
+        )
+    except UnicodeEncodeError:
+        return None
     if (
         not path.parts
-        or "\\" in value
-        or path.is_absolute()
-        or PureWindowsPath(value).drive
+        or (grammar.reject_absolute_paths and path.is_absolute())
+        or (grammar.reject_windows_drives and bool(PureWindowsPath(value).drive))
         or value != canonical
+        or oversized
         or any(
-            not component
-            or component in {".", ".."}
-            or component.endswith((" ", "."))
-            or not policy.invalid_component_chars.isdisjoint(component)
-            or folded_component.split(".", 1)[0] in policy.reserved_component_names
-            for component, folded_component in zip(components, folded, strict=True)
+            component in grammar.forbidden_component_names
+            or component.endswith(grammar.forbidden_component_suffixes)
+            or not grammar.forbidden_component_chars.isdisjoint(component)
+            or any(
+                start <= ord(character) <= end
+                for character in component
+                for start, end in grammar.forbidden_codepoint_ranges
+            )
+            or key.split(".", 1)[0] in grammar.reserved_component_names
+            for component, key in zip(components, keys, strict=True)
         )
     ):
         return None
-    return "/".join(folded)
+    return "/".join(keys)
 
 
-def _inventory_wheel_member(
-    archive: zipfile.ZipFile,
-    member: zipfile.ZipInfo,
-    wheel: Path,
-    path_key: str,
-    *,
-    retain: bool,
-) -> tuple[_WheelArchiveEntry, bytes | None]:
-    if (
-        member.file_size < 0
-        or member.file_size > MAX_WHEEL_MEMBER_BYTES
-        or (member.is_dir() and member.file_size != 0)
-    ):
-        raise ReleaseAssetError(f"wheel member size is invalid: {wheel.name}")
-    digest = hashlib.sha256()
-    content = bytearray() if retain else None
-    size = 0
-    try:
-        with archive.open(member) as stream:
-            while chunk := stream.read(min(64 * 1024, MAX_WHEEL_MEMBER_BYTES + 1 - size)):
-                size += len(chunk)
-                if size > MAX_WHEEL_MEMBER_BYTES:
-                    raise ReleaseAssetError(f"wheel member size is invalid: {wheel.name}")
-                digest.update(chunk)
-                if content is not None:
-                    content.extend(chunk)
-    except ReleaseAssetError:
-        raise
-    except Exception as exc:
-        raise ReleaseAssetError(f"cannot read wheel member: {wheel.name}") from exc
-    if size != member.file_size or (member.is_dir() and size != 0):
-        raise ReleaseAssetError(f"wheel member size is invalid: {wheel.name}")
-    encoded = base64.urlsafe_b64encode(digest.digest()).rstrip(b"=").decode()
-    entry = _WheelArchiveEntry(member.filename, path_key, member.is_dir(), size, encoded)
-    return entry, bytes(content) if content is not None else None
-
-
-def _validate_wheel_archive(
-    archive: zipfile.ZipFile, wheel: Path, dist_info: str
-) -> tuple[tuple[_WheelArchiveEntry, ...], dict[str, bytes]]:
-    infos = archive.infolist()
-    identities: list[tuple[zipfile.ZipInfo, str, str]] = []
-    for info in infos:
-        raw_name = info.orig_filename
-        if type(raw_name) is not str or type(info.filename) is not str or raw_name != info.filename:
-            raise ReleaseAssetError(f"wheel archive structure is invalid: {wheel.name}")
-        path_key = _portable_wheel_path_key(raw_name)
-        if path_key is None:
-            raise ReleaseAssetError(f"wheel archive structure is invalid: {wheel.name}")
-        identities.append((info, raw_name, path_key))
-    names = [name for _, name, _ in identities]
-    topology = sorted((alias, info.is_dir()) for info, _, alias in identities)
-    aliases = [alias for alias, _ in topology]
-    data_root = f"{dist_info.removesuffix('.dist-info')}.data"
-    unsafe_data = any(
-        parts[0].endswith(".data")
-        and (parts[0] != data_root or len(parts) < 3 or parts[1] not in WHEEL_DATA_SCHEMES or not parts[2])
-        for name in names
-        for parts in (name.split("/"),)
-    )
-    duplicate_or_alias = any(left == right for left, right in zip(aliases, aliases[1:]))
+def _portable_wheel_topology_is_valid(entries: tuple[tuple[str, bool], ...]) -> bool:
+    topology: list[tuple[str, bool]] = []
+    for value, is_dir in entries:
+        key = _portable_wheel_path_key(value)
+        if key is None or type(is_dir) is not bool:
+            return False
+        topology.append((key, is_dir))
+    topology.sort()
+    keys = [key for key, _ in topology]
+    duplicate_or_alias = any(left == right for left, right in zip(keys, keys[1:]))
     prefix_conflict = any(
-        index < len(aliases) and aliases[index].startswith(prefix)
-        for alias, is_dir in topology
+        index < len(keys) and keys[index].startswith(prefix)
+        for key, is_dir in topology
         if not is_dir
-        for prefix in (f"{alias}/",)
-        for index in (bisect_left(aliases, prefix),)
+        for prefix in (f"{key}/",)
+        for index in (bisect_left(keys, prefix),)
     )
-    if duplicate_or_alias or unsafe_data or prefix_conflict:
-        raise ReleaseAssetError(f"wheel archive structure is invalid: {wheel.name}")
-    record = f"{dist_info}/RECORD"
-    retained = {record, *(f"{dist_info}/{name}" for name, _ in _WHEEL_CONTROL_POLICY.controls)}
-    inventory = []
-    members: dict[str, bytes] = {}
-    for info, name, alias in identities:
-        entry, content = _inventory_wheel_member(
-            archive, info, wheel, alias, retain=name in retained
-        )
-        inventory.append(entry)
-        if content is not None:
-            members[name] = content
-    if names.count(record) != 1:
-        raise ReleaseAssetError(f"wheel control structure is invalid: {wheel.name}")
-    return tuple(inventory), members
+    return not duplicate_or_alias and not prefix_conflict
 
 
 def inspect_wheel(wheel: Path, *, policy: PackageReleasePolicy) -> PackageMetadata:
@@ -489,8 +446,7 @@ def inspect_wheel(wheel: Path, *, policy: PackageReleasePolicy) -> PackageMetada
     dist_info = f"{str(filename_name).replace('-', '_')}-{filename_version}.dist-info"
     try:
         with zipfile.ZipFile(wheel) as archive:
-            inventory, members = _validate_wheel_archive(archive, wheel, dist_info)
-            names = [entry.path for entry in inventory]
+            names = archive.namelist()
             dist_infos = {
                 name.split("/", 1)[0]
                 for name in names
@@ -504,7 +460,7 @@ def inspect_wheel(wheel: Path, *, policy: PackageReleasePolicy) -> PackageMetada
             )
             _compare_wheel_control_policy(wheel, {"controls": control_counts})
             metadata_bytes, wheel_bytes = (
-                members[f"{dist_info}/{name}"]
+                archive.read(f"{dist_info}/{name}")
                 for name, _ in _WHEEL_CONTROL_POLICY.controls
             )
     except ReleaseAssetError:

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -395,7 +395,12 @@ def _portable_wheel_path_key(value: str) -> str | None:
                 for character in component
                 for start, end in grammar.forbidden_codepoint_ranges
             )
-            or key.split(".", 1)[0] in grammar.reserved_component_names
+            or (
+                key.split(".", 1)[0].rstrip(
+                    "".join(grammar.forbidden_component_suffixes)
+                )
+                in grammar.reserved_component_names
+            )
             for component, key in zip(components, keys, strict=True)
         )
     ):

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -69,6 +69,15 @@ class _WheelControlPolicy:
     parser_body: str
 
 
+@dataclass(frozen=True)
+class _WheelArchiveEntry:
+    path: str
+    path_key: str
+    is_dir: bool
+    size: int
+    sha256: str
+
+
 _WHEEL_CONTROL_POLICY = _WheelControlPolicy(
     controls=(("METADATA", 1), ("WHEEL", 1)),
     wheel_version_major=1,
@@ -343,19 +352,37 @@ def _is_safe_wheel_path(value: str) -> bool:
     )
 
 
-def _read_wheel_member(
-    archive: zipfile.ZipFile, member: zipfile.ZipInfo, wheel: Path
-) -> bytes:
+def _inventory_wheel_member(
+    archive: zipfile.ZipFile,
+    member: zipfile.ZipInfo,
+    wheel: Path,
+    path_key: str,
+    *,
+    retain: bool,
+) -> tuple[_WheelArchiveEntry, bytes | None]:
     if member.file_size < 0 or member.file_size > MAX_WHEEL_MEMBER_BYTES:
         raise ReleaseAssetError(f"wheel member size is invalid: {wheel.name}")
+    digest = hashlib.sha256()
+    content = bytearray() if retain else None
+    size = 0
     try:
         with archive.open(member) as stream:
-            content = stream.read(MAX_WHEEL_MEMBER_BYTES + 1)
+            while chunk := stream.read(min(64 * 1024, MAX_WHEEL_MEMBER_BYTES + 1 - size)):
+                size += len(chunk)
+                if size > MAX_WHEEL_MEMBER_BYTES:
+                    raise ReleaseAssetError(f"wheel member size is invalid: {wheel.name}")
+                digest.update(chunk)
+                if content is not None:
+                    content.extend(chunk)
+    except ReleaseAssetError:
+        raise
     except Exception as exc:
         raise ReleaseAssetError(f"cannot read wheel member: {wheel.name}") from exc
-    if len(content) > MAX_WHEEL_MEMBER_BYTES or len(content) != member.file_size:
+    if size != member.file_size:
         raise ReleaseAssetError(f"wheel member size is invalid: {wheel.name}")
-    return content
+    encoded = base64.urlsafe_b64encode(digest.digest()).rstrip(b"=").decode()
+    entry = _WheelArchiveEntry(member.filename, path_key, member.is_dir(), size, encoded)
+    return entry, bytes(content) if content is not None else None
 
 
 def _valid_record_hash(value: str) -> bool:
@@ -375,10 +402,23 @@ def _valid_record_hash(value: str) -> bool:
 
 def _validate_wheel_archive(
     archive: zipfile.ZipFile, wheel: Path, dist_info: str
-) -> dict[str, bytes]:
+) -> tuple[tuple[_WheelArchiveEntry, ...], dict[str, bytes]]:
     infos = archive.infolist()
-    names = [info.filename for info in infos]
-    aliases = [name.rstrip("/").casefold() for name in names]
+    identities: list[tuple[zipfile.ZipInfo, str, str]] = []
+    for info in infos:
+        raw_name = info.orig_filename
+        if (
+            type(raw_name) is not str
+            or type(info.filename) is not str
+            or "\x00" in raw_name
+            or raw_name != info.filename
+            or not _is_safe_wheel_path(raw_name)
+        ):
+            raise ReleaseAssetError(f"wheel archive structure is invalid: {wheel.name}")
+        identities.append((info, raw_name, raw_name.rstrip("/").casefold()))
+    names = [name for _, name, _ in identities]
+    aliases = [alias for _, _, alias in identities]
+    file_aliases = {alias for info, _, alias in identities if not info.is_dir()}
     data_root = f"{dist_info.removesuffix('.dist-info')}.data"
     unsafe_data = any(
         parts[0].endswith(".data")
@@ -386,17 +426,24 @@ def _validate_wheel_archive(
         for name in names
         for parts in (name.split("/"),)
     )
-    if any(not _is_safe_wheel_path(name) for name in names) or len(aliases) != len(set(aliases)) or unsafe_data:
+    prefix_conflict = any(
+        other.startswith(f"{file_alias}/")
+        for file_alias in file_aliases
+        for other in aliases
+    )
+    if len(aliases) != len(set(aliases)) or unsafe_data or prefix_conflict:
         raise ReleaseAssetError(f"wheel archive structure is invalid: {wheel.name}")
     record = f"{dist_info}/RECORD"
     retained = {record, *(f"{dist_info}/{name}" for name, _ in _WHEEL_CONTROL_POLICY.controls)}
-    member_names = {info.filename for info in infos if not info.is_dir()}
-    members = {}
-    for info in infos:
-        if not info.is_dir():
-            content = _read_wheel_member(archive, info, wheel)
-            if info.filename in retained:
-                members[info.filename] = content
+    inventory = []
+    members: dict[str, bytes] = {}
+    for info, name, alias in identities:
+        entry, content = _inventory_wheel_member(
+            archive, info, wheel, alias, retain=name in retained
+        )
+        inventory.append(entry)
+        if content is not None:
+            members[name] = content
     if names.count(record) != 1:
         raise ReleaseAssetError(f"wheel RECORD structure is invalid: {wheel.name}")
     try:
@@ -404,6 +451,8 @@ def _validate_wheel_archive(
     except Exception as exc:
         raise ReleaseAssetError(f"wheel RECORD structure is invalid: {wheel.name}") from exc
     generated = {record, f"{record}.jws", f"{record}.p7s"}
+    observed = {entry.path: entry for entry in inventory if not entry.is_dir}
+    member_names = set(observed)
     recorded: set[str] = set()
     recorded_aliases: set[str] = set()
     for row in rows:
@@ -423,7 +472,7 @@ def _validate_wheel_archive(
         recorded_aliases.add(alias)
     if record not in recorded or recorded - generated != member_names - generated:
         raise ReleaseAssetError(f"wheel RECORD entries differ from archive: {wheel.name}")
-    return members
+    return tuple(inventory), members
 
 
 def inspect_wheel(wheel: Path, *, policy: PackageReleasePolicy) -> PackageMetadata:
@@ -449,7 +498,8 @@ def inspect_wheel(wheel: Path, *, policy: PackageReleasePolicy) -> PackageMetada
     dist_info = f"{str(filename_name).replace('-', '_')}-{filename_version}.dist-info"
     try:
         with zipfile.ZipFile(wheel) as archive:
-            names = archive.namelist()
+            inventory, members = _validate_wheel_archive(archive, wheel, dist_info)
+            names = [entry.path for entry in inventory]
             dist_infos = {
                 name.split("/", 1)[0]
                 for name in names
@@ -462,7 +512,6 @@ def inspect_wheel(wheel: Path, *, policy: PackageReleasePolicy) -> PackageMetada
                 for name, _ in _WHEEL_CONTROL_POLICY.controls
             )
             _compare_wheel_control_policy(wheel, {"controls": control_counts})
-            members = _validate_wheel_archive(archive, wheel, dist_info)
             metadata_bytes, wheel_bytes = (
                 members[f"{dist_info}/{name}"]
                 for name, _ in _WHEEL_CONTROL_POLICY.controls

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import gzip
 import hashlib
 import io
@@ -157,10 +156,6 @@ def _wheel(
     wheel_tags: tuple[str, ...] = ("py3-none-any",),
     wheel_trailer: str = "\n",
     duplicate_control: str | None = None,
-    include_record: bool = True,
-    record_bytes: bytes | None = None,
-    extra_files: dict[str, bytes] | None = None,
-    compression: int = zipfile.ZIP_STORED,
 ) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     dist_info = dist_info or f"{name.replace('-', '_')}-3.1.0.dist-info"
@@ -177,25 +172,14 @@ def _wheel(
         + "".join(f"Tag: {value}\n" for value in wheel_tags)
         + wheel_trailer
     ).encode()
-    files = {f"{name.replace('-', '_')}/__init__.py": b"x = 1\n"}
-    files.update(extra_files or {})
+    files: dict[str, bytes] = {}
     if include_metadata:
         files[f"{dist_info}/METADATA"] = metadata
     if include_wheel:
         files[f"{dist_info}/WHEEL"] = wheel
     if extra_dist_info:
         files["other-3.1.0.dist-info/METADATA"] = metadata
-    record = f"{dist_info}/RECORD"
-    if include_record:
-        if record_bytes is None:
-            rows = []
-            for member, content in files.items():
-                digest = base64.urlsafe_b64encode(hashlib.sha256(content).digest()).rstrip(b"=").decode()
-                rows.append(f"{member},sha256={digest},{len(content)}\n")
-            rows.append(f"{record},,\n")
-            record_bytes = "".join(rows).encode()
-        files[record] = record_bytes
-    with zipfile.ZipFile(path, "w", compression=compression) as archive:
+    with zipfile.ZipFile(path, "w") as archive:
         for member, content in files.items():
             archive.writestr(member, content)
         if duplicate_control is not None:
@@ -440,7 +424,7 @@ def test_wheel_rejects_duplicate_control_files(tmp_path: Path, control: str) -> 
     manifest, _ = _manifest(tmp_path)
 
     with pytest.warns(UserWarning, match="Duplicate name"):
-        with pytest.raises(guard.ReleaseAssetError, match="control|archive structure"):
+        with pytest.raises(guard.ReleaseAssetError, match="control"):
             _verify_wheels(
                 tmp_path / control,
                 manifest,
@@ -568,7 +552,7 @@ def test_wheel_inspector_rejects_policy_without_declared_source(tmp_path: Path) 
 
 
 @pytest.mark.parametrize("encrypted", [False, True], ids=["unsupported-compression", "encrypted"])
-def test_wheel_translates_unreadable_members_to_asset_failure(
+def test_wheel_translates_unreadable_controls_to_asset_failure(
     tmp_path: Path, encrypted: bool
 ) -> None:
     manifest, _ = _manifest(tmp_path)
@@ -579,109 +563,97 @@ def test_wheel_translates_unreadable_members_to_asset_failure(
     wheel = _wheel(tmp_path / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os")
     _make_first_zip_member_unreadable(wheel, encrypted=encrypted)
 
-    with pytest.raises(guard.ReleaseAssetError, match="cannot read wheel"):
+    with pytest.raises(guard.ReleaseAssetError, match="cannot read wheel controls"):
         guard.inspect_wheel(wheel, policy=policy)
 
 
 @pytest.mark.parametrize(
-    "member",
+    "value",
     [
-        "/absolute",
-        "../outside",
-        "pkg/./module.py",
-        "bad\\path",
-        "C:/absolute",
-        *(f"pkg/a{character}b" for character in '<>:"|?*'),
-        "pkg/trailing.",
-        "pkg/trailing ",
-        *(f"pkg/{name}" for name in ("CON", "prn.txt", "AUX", "NUL.bin", "COM1", "LPT9.py")),
-        "pkg/control\x1f",
+        pytest.param("", id="empty-path"),
+        pytest.param("/absolute", id="posix-absolute"),
+        pytest.param("//server/share", id="unc-absolute"),
+        pytest.param("C:/absolute", id="drive-absolute"),
+        pytest.param("C:relative", id="drive-relative"),
+        pytest.param("../outside", id="leading-dotdot"),
+        pytest.param("pkg/../outside", id="embedded-dotdot"),
+        pytest.param("pkg/./module.py", id="dot-component"),
+        pytest.param("pkg//module.py", id="empty-component"),
+        pytest.param("pkg\\module.py", id="backslash"),
+        *(
+            pytest.param(f"pkg/a{character}b", id=f"forbidden-{ord(character)}")
+            for character in '<>:"|?*'
+        ),
+        pytest.param("pkg/trailing.", id="trailing-dot"),
+        pytest.param("pkg/trailing ", id="trailing-space"),
+        pytest.param("pkg/control\x00", id="nul"),
+        pytest.param("pkg/control\x1f", id="c0-control"),
+        pytest.param("pkg/control\x7f", id="delete-control"),
+        pytest.param("pkg/control\x9f", id="c1-control"),
     ],
 )
-def test_wheel_rejects_unsafe_archive_paths(tmp_path: Path, member: str) -> None:
-    manifest, _ = _manifest(tmp_path)
-
-    with pytest.raises(guard.ReleaseAssetError, match="archive structure"):
-        _verify_wheels(
-            tmp_path / "wheels", manifest, core_options={"extra_files": {member: b"x"}}
-        )
+def test_portable_wheel_path_grammar_rejects_each_declared_rule(value: str) -> None:
+    assert guard._portable_wheel_path_key(value) is None
 
 
-def test_wheel_rejects_archive_aliases(tmp_path: Path) -> None:
-    manifest, _ = _manifest(tmp_path)
+def test_portable_wheel_path_grammar_is_versioned_repository_policy() -> None:
+    grammar = guard._PORTABLE_WHEEL_PATH_GRAMMAR
+    expected_devices = {"con", "prn", "aux", "nul", "conin$", "conout$"} | {
+        f"{prefix}{suffix}"
+        for prefix in ("com", "lpt")
+        for suffix in (*map(str, range(1, 10)), "\u00b9", "\u00b2", "\u00b3")
+    }
 
-    with pytest.raises(guard.ReleaseAssetError, match="archive structure"):
-        _verify_wheels(
-            tmp_path / "wheels",
-            manifest,
-            core_options={"extra_files": {"AVIBE_OS/__init__.py": b"x"}},
-        )
-
-
-def test_wheel_data_schemes_are_an_explicit_structural_allowlist(tmp_path: Path) -> None:
-    manifest, _ = _manifest(tmp_path)
-    allowed = {f"avibe_os-3.1.0.data/{scheme}/payload": b"x" for scheme in guard.WHEEL_DATA_SCHEMES}
-
-    _verify_wheels(tmp_path / "allowed", manifest, core_options={"extra_files": allowed})
-    for member in (
-        "avibe_os-3.1.0.data/unknown/payload",
-        "avibe_os-3.1.0.data/scripts",
-        "avibe_os-3.1.0.data/scripts/",
-        "other-9.9.data/scripts/vibe",
-    ):
-        with pytest.raises(guard.ReleaseAssetError, match="archive structure"):
-            _verify_wheels(
-                tmp_path / member.replace("/", "-"),
-                manifest,
-                core_options={"extra_files": {member: b"x"}},
-            )
+    assert grammar.schema_version == 1
+    assert grammar.unicode_normalization == "NFC"
+    assert grammar.max_component_utf8_bytes == 255
+    assert grammar.reject_absolute_paths
+    assert grammar.reject_windows_drives
+    assert grammar.reserved_component_names == expected_devices
 
 
-def test_wheel_rejects_raw_nul_member_name_before_zipfile_sanitization(
-    tmp_path: Path,
+@pytest.mark.parametrize(
+    "device", sorted(guard._PORTABLE_WHEEL_PATH_GRAMMAR.reserved_component_names)
+)
+def test_portable_wheel_path_rejects_every_reserved_device_alias(device: str) -> None:
+    assert guard._portable_wheel_path_key(f"pkg/{device.upper()}.txt") is None
+
+
+def test_portable_wheel_path_enforces_utf8_component_byte_limit() -> None:
+    assert guard._portable_wheel_path_key("a" * 255) == "a" * 255
+    assert guard._portable_wheel_path_key("a" * 256) is None
+    assert guard._portable_wheel_path_key("\u00e9" * 127 + "a") is not None
+    assert guard._portable_wheel_path_key("\u00e9" * 128) is None
+
+
+def test_portable_wheel_path_requires_nfc_and_returns_one_alias_key() -> None:
+    assert guard._portable_wheel_path_key("PKG/CAF\u00c9.py") == "pkg/caf\u00e9.py"
+    assert guard._portable_wheel_path_key("pkg/cafe\u0301.py") is None
+    assert guard._portable_wheel_path_key("pkg/data/") == "pkg/data"
+
+
+@pytest.mark.parametrize(
+    ("entries", "accepted"),
+    [
+        ((("pkg/", True), ("pkg/module.py", False)), True),
+        ((("pkg/module.py", False), ("pkg/module.py", False)), False),
+        ((("PKG/module.py", False), ("pkg/MODULE.py", False)), False),
+        ((("conflict", False), ("conflict/child", False)), False),
+        ((("Conflict", False), ("conflict/child", False)), False),
+        ((("pkg/cafe\u0301.py", False),), False),
+    ],
+    ids=["valid", "duplicate", "casefold-alias", "prefix", "casefold-prefix", "non-nfc"],
+)
+def test_portable_wheel_topology_uses_grammar_keys(
+    entries: tuple[tuple[str, bool], ...], accepted: bool
 ) -> None:
-    manifest, _ = _manifest(tmp_path)
-    manifest_bytes = manifest.read_bytes()
-    policy = guard.load_package_release_policy(
-        manifest_bytes, expected_manifest=manifest_bytes, release_tag="v3.1.0"
-    )
-    wheel = _wheel(
-        tmp_path / "avibe_os-3.1.0-py3-none-any.whl",
-        "avibe-os",
-        extra_files={"evilXtail": b"x"},
-    )
-    wheel.write_bytes(wheel.read_bytes().replace(b"evilXtail", b"evil\x00tail"))
-
-    with zipfile.ZipFile(wheel) as archive:
-        member = next(info for info in archive.infolist() if info.filename == "evil")
-        assert member.orig_filename == "evil\x00tail"
-
-    with pytest.raises(guard.ReleaseAssetError, match="archive structure"):
-        guard.inspect_wheel(wheel, policy=policy)
+    assert guard._portable_wheel_topology_is_valid(entries) is accepted
 
 
-@pytest.mark.parametrize("ancestor", ["conflict", "Conflict"], ids=["exact", "casefold"])
-def test_wheel_rejects_file_and_descendant_topology(
-    tmp_path: Path, ancestor: str
+def test_portable_wheel_topology_uses_one_binary_search_per_file(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    manifest, _ = _manifest(tmp_path)
-
-    with pytest.raises(guard.ReleaseAssetError, match="archive structure"):
-        _verify_wheels(
-            tmp_path / "wheels",
-            manifest,
-            core_options={"extra_files": {ancestor: b"x", "conflict/child": b"y"}},
-        )
-
-
-def test_wheel_topology_uses_one_binary_search_per_file(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    wheel = _wheel(
-        tmp_path / "avibe_os-3.1.0-py3-none-any.whl",
-        "avibe-os",
-        extra_files={f"payload/item-{index:04d}": b"" for index in range(256)},
-    )
+    entries = tuple((f"payload/item-{index:04d}", False) for index in range(256))
     calls = 0
     bisect_left = guard.bisect_left
 
@@ -691,125 +663,8 @@ def test_wheel_topology_uses_one_binary_search_per_file(
         return bisect_left(values, prefix)
 
     monkeypatch.setattr(guard, "bisect_left", tracking_bisect)
-    with zipfile.ZipFile(wheel) as archive:
-        inventory, _ = guard._validate_wheel_archive(
-            archive, wheel, "avibe_os-3.1.0.dist-info"
-        )
-
-    assert calls == sum(not entry.is_dir for entry in inventory)
-
-
-@pytest.mark.parametrize(
-    ("declared_size", "payload"),
-    [(1, b""), (0, b"x")],
-    ids=["declared-payload", "observed-payload"],
-)
-def test_wheel_rejects_payload_bearing_directory_member(
-    tmp_path: Path, declared_size: int, payload: bytes
-) -> None:
-    member = zipfile.ZipInfo("payload/")
-    member.file_size = declared_size
-
-    class Archive:
-        @staticmethod
-        def open(_member: zipfile.ZipInfo) -> io.BytesIO:
-            return io.BytesIO(payload)
-
-    with pytest.raises(guard.ReleaseAssetError, match="member size"):
-        guard._inventory_wheel_member(
-            Archive(),
-            member,
-            tmp_path / "wheel.whl",
-            "payload",
-            retain=False,
-        )
-
-
-def test_wheel_requires_raw_record_control(tmp_path: Path) -> None:
-    manifest, _ = _manifest(tmp_path)
-
-    with pytest.raises(guard.ReleaseAssetError, match="control structure"):
-        _verify_wheels(
-            tmp_path / "wheels", manifest, core_options={"include_record": False}
-        )
-
-
-def test_wheel_rejects_duplicate_raw_record_control(tmp_path: Path) -> None:
-    manifest, _ = _manifest(tmp_path)
-
-    with pytest.warns(UserWarning, match="Duplicate name"):
-        with pytest.raises(
-            guard.ReleaseAssetError, match="archive structure|control structure"
-        ):
-            _verify_wheels(
-                tmp_path / "wheels",
-                manifest,
-                core_options={"duplicate_control": "RECORD"},
-            )
-
-
-def test_wheel_inventory_retains_raw_record_without_interpreting_ledger(
-    tmp_path: Path,
-) -> None:
-    manifest, _ = _manifest(tmp_path)
-    opaque_record = b"\xffnot,a,ledger\n"
-    wheels = tmp_path / "wheels"
-
-    _verify_wheels(wheels, manifest, core_options={"record_bytes": opaque_record})
-    wheel = wheels / "avibe_os-3.1.0-py3-none-any.whl"
-    dist_info = "avibe_os-3.1.0.dist-info"
-    record = f"{dist_info}/RECORD"
-    with zipfile.ZipFile(wheel) as archive:
-        inventory, retained = guard._validate_wheel_archive(archive, wheel, dist_info)
-    entry = next(item for item in inventory if item.path == record)
-
-    assert retained[record] == opaque_record
-    assert entry.size == len(opaque_record)
-    assert entry.sha256 == base64.urlsafe_b64encode(
-        hashlib.sha256(opaque_record).digest()
-    ).rstrip(b"=").decode()
-
-
-@pytest.mark.parametrize(
-    "compression",
-    [zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED],
-    ids=["oversized", "high-compression"],
-)
-def test_wheel_bounds_every_member_read(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, compression: int
-) -> None:
-    manifest, _ = _manifest(tmp_path)
-    monkeypatch.setattr(guard, "MAX_WHEEL_MEMBER_BYTES", 32)
-
-    with pytest.raises(guard.ReleaseAssetError, match="member size"):
-        _verify_wheels(
-            tmp_path / "wheels",
-            manifest,
-            core_options={"extra_files": {"payload.bin": b"x" * 33}, "compression": compression},
-        )
-
-
-def test_wheel_reads_every_member_for_integrity(tmp_path: Path) -> None:
-    manifest, _ = _manifest(tmp_path)
-    wheel = _wheel(tmp_path / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os")
-    wheel.write_bytes(wheel.read_bytes().replace(b"x = 1\n", b"x = 2\n"))
-    manifest_bytes = manifest.read_bytes()
-    policy = guard.load_package_release_policy(
-        manifest_bytes, expected_manifest=manifest_bytes, release_tag="v3.1.0"
-    )
-
-    with pytest.raises(guard.ReleaseAssetError, match="cannot read wheel"):
-        guard.inspect_wheel(wheel, policy=policy)
-
-
-def test_wheel_archive_discards_payload_bytes_after_integrity_read(tmp_path: Path) -> None:
-    wheel = _wheel(tmp_path / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os")
-    dist_info = "avibe_os-3.1.0.dist-info"
-
-    with zipfile.ZipFile(wheel) as archive:
-        _, retained = guard._validate_wheel_archive(archive, wheel, dist_info)
-
-    assert set(retained) == {f"{dist_info}/{name}" for name in ("METADATA", "WHEEL", "RECORD")}
+    assert guard._portable_wheel_topology_is_valid(entries)
+    assert calls == len(entries)
 
 
 def test_existing_guard_commands_remain_stdlib_only(tmp_path: Path) -> None:

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import gzip
 import hashlib
 import io
@@ -156,6 +157,12 @@ def _wheel(
     wheel_tags: tuple[str, ...] = ("py3-none-any",),
     wheel_trailer: str = "\n",
     duplicate_control: str | None = None,
+    include_record: bool = True,
+    record_bytes: bytes | None = None,
+    record_extra: tuple[str, ...] = (),
+    record_omit: tuple[str, ...] = (),
+    extra_files: dict[str, bytes] | None = None,
+    compression: int = zipfile.ZIP_STORED,
 ) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     dist_info = dist_info or f"{name.replace('-', '_')}-3.1.0.dist-info"
@@ -172,14 +179,28 @@ def _wheel(
         + "".join(f"Tag: {value}\n" for value in wheel_tags)
         + wheel_trailer
     ).encode()
-    files: dict[str, bytes] = {}
+    files = {f"{name.replace('-', '_')}/__init__.py": b"x = 1\n"}
+    files.update(extra_files or {})
     if include_metadata:
         files[f"{dist_info}/METADATA"] = metadata
     if include_wheel:
         files[f"{dist_info}/WHEEL"] = wheel
     if extra_dist_info:
         files["other-3.1.0.dist-info/METADATA"] = metadata
-    with zipfile.ZipFile(path, "w") as archive:
+    record = f"{dist_info}/RECORD"
+    if include_record:
+        if record_bytes is None:
+            rows = []
+            for member, content in files.items():
+                if member not in record_omit:
+                    digest = base64.urlsafe_b64encode(hashlib.sha256(content).digest()).rstrip(b"=").decode()
+                    rows.append(f"{member},sha256={digest},{len(content)}\n")
+            empty_digest = base64.urlsafe_b64encode(hashlib.sha256(b"").digest()).rstrip(b"=").decode()
+            rows.extend(f"{member},sha256={empty_digest},0\n" for member in record_extra)
+            rows.append(f"{record},,\n")
+            record_bytes = "".join(rows).encode()
+        files[record] = record_bytes
+    with zipfile.ZipFile(path, "w", compression=compression) as archive:
         for member, content in files.items():
             archive.writestr(member, content)
         if duplicate_control is not None:
@@ -552,7 +573,7 @@ def test_wheel_inspector_rejects_policy_without_declared_source(tmp_path: Path) 
 
 
 @pytest.mark.parametrize("encrypted", [False, True], ids=["unsupported-compression", "encrypted"])
-def test_wheel_translates_unreadable_controls_to_asset_failure(
+def test_wheel_translates_unreadable_members_to_asset_failure(
     tmp_path: Path, encrypted: bool
 ) -> None:
     manifest, _ = _manifest(tmp_path)
@@ -563,7 +584,119 @@ def test_wheel_translates_unreadable_controls_to_asset_failure(
     wheel = _wheel(tmp_path / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os")
     _make_first_zip_member_unreadable(wheel, encrypted=encrypted)
 
-    with pytest.raises(guard.ReleaseAssetError, match="cannot read wheel controls"):
+    with pytest.raises(guard.ReleaseAssetError, match="cannot read wheel"):
+        guard.inspect_wheel(wheel, policy=policy)
+
+
+@pytest.mark.parametrize(
+    "member",
+    ["/absolute", "../outside", "pkg/./module.py", "bad\\path", "C:/absolute"],
+)
+def test_wheel_rejects_unsafe_archive_paths(tmp_path: Path, member: str) -> None:
+    manifest, _ = _manifest(tmp_path)
+
+    with pytest.raises(guard.ReleaseAssetError, match="archive structure"):
+        _verify_wheels(
+            tmp_path / "wheels", manifest, core_options={"extra_files": {member: b"x"}}
+        )
+
+
+@pytest.mark.parametrize(
+    "record_bytes",
+    [
+        b"\n",
+        b"pkg/module.py,sha256=abc\n",
+        b"pkg/module.py,sha256=not*base64,1\n",
+        b"pkg/module.py,md5=YWJj,3\n",
+        b"pkg/module.py,sha256=YWJj,-1\n",
+        b"pkg/module.py,sha256=YWJj,\xd9\xa3\n",
+        b"../../outside,sha256=YWJj,3\n",
+        b"pkg/./module.py,sha256=YWJj,3\n",
+        b"bad\\path,sha256=YWJj,3\n",
+        b"bad\x00path,sha256=YWJj,3\n",
+    ],
+)
+def test_wheel_rejects_invalid_record_rows(tmp_path: Path, record_bytes: bytes) -> None:
+    manifest, _ = _manifest(tmp_path)
+
+    with pytest.raises(guard.ReleaseAssetError, match="RECORD"):
+        _verify_wheels(
+            tmp_path / "wheels", manifest, core_options={"record_bytes": record_bytes}
+        )
+
+
+def test_wheel_rejects_archive_and_record_aliases(tmp_path: Path) -> None:
+    manifest, _ = _manifest(tmp_path)
+
+    for directory, options in (
+        ("archive", {"extra_files": {"AVIBE_OS/__init__.py": b"x"}}),
+        ("record", {"record_extra": ("AVIBE_OS/__init__.py",)}),
+    ):
+        with pytest.raises(guard.ReleaseAssetError, match="archive structure|RECORD"):
+            _verify_wheels(tmp_path / directory, manifest, core_options=options)
+
+
+def test_wheel_data_schemes_are_an_explicit_structural_allowlist(tmp_path: Path) -> None:
+    manifest, _ = _manifest(tmp_path)
+    allowed = {f"avibe_os-3.1.0.data/{scheme}/payload": b"x" for scheme in guard.WHEEL_DATA_SCHEMES}
+
+    _verify_wheels(tmp_path / "allowed", manifest, core_options={"extra_files": allowed})
+    with pytest.raises(guard.ReleaseAssetError, match="archive structure"):
+        _verify_wheels(
+            tmp_path / "unknown",
+            manifest,
+            core_options={"extra_files": {"avibe_os-3.1.0.data/unknown/payload": b"x"}},
+        )
+
+
+@pytest.mark.parametrize(
+    "core_options",
+    [
+        {"include_record": False},
+        {"record_omit": ("avibe_os/__init__.py",)},
+        {"record_extra": ("safe/absent.py",)},
+        {"record_extra": ("avibe_os/__init__.py",)},
+    ],
+    ids=["missing-record", "missing-row", "absent-path", "duplicate-row"],
+)
+def test_wheel_record_is_bidirectionally_bound_to_archive(
+    tmp_path: Path, core_options: dict[str, object]
+) -> None:
+    manifest, _ = _manifest(tmp_path)
+
+    with pytest.raises(guard.ReleaseAssetError, match="RECORD"):
+        _verify_wheels(tmp_path / "wheels", manifest, core_options=core_options)
+
+
+@pytest.mark.parametrize(
+    "compression",
+    [zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED],
+    ids=["oversized", "high-compression"],
+)
+def test_wheel_bounds_every_member_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, compression: int
+) -> None:
+    manifest, _ = _manifest(tmp_path)
+    monkeypatch.setattr(guard, "MAX_WHEEL_MEMBER_BYTES", 32)
+
+    with pytest.raises(guard.ReleaseAssetError, match="member size"):
+        _verify_wheels(
+            tmp_path / "wheels",
+            manifest,
+            core_options={"extra_files": {"payload.bin": b"x" * 33}, "compression": compression},
+        )
+
+
+def test_wheel_reads_every_member_for_integrity(tmp_path: Path) -> None:
+    manifest, _ = _manifest(tmp_path)
+    wheel = _wheel(tmp_path / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os")
+    wheel.write_bytes(wheel.read_bytes().replace(b"x = 1\n", b"x = 2\n"))
+    manifest_bytes = manifest.read_bytes()
+    policy = guard.load_package_release_policy(
+        manifest_bytes, expected_manifest=manifest_bytes, release_tag="v3.1.0"
+    )
+
+    with pytest.raises(guard.ReleaseAssetError, match="cannot read wheel"):
         guard.inspect_wheel(wheel, policy=policy)
 
 

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -158,10 +158,7 @@ def _wheel(
     wheel_trailer: str = "\n",
     duplicate_control: str | None = None,
     include_record: bool = True,
-    record_self: bool = True,
     record_bytes: bytes | None = None,
-    record_extra: tuple[str, ...] = (),
-    record_omit: tuple[str, ...] = (),
     extra_files: dict[str, bytes] | None = None,
     compression: int = zipfile.ZIP_STORED,
 ) -> Path:
@@ -193,13 +190,9 @@ def _wheel(
         if record_bytes is None:
             rows = []
             for member, content in files.items():
-                if member not in record_omit:
-                    digest = base64.urlsafe_b64encode(hashlib.sha256(content).digest()).rstrip(b"=").decode()
-                    rows.append(f"{member},sha256={digest},{len(content)}\n")
-            empty_digest = base64.urlsafe_b64encode(hashlib.sha256(b"").digest()).rstrip(b"=").decode()
-            rows.extend(f"{member},sha256={empty_digest},0\n" for member in record_extra)
-            if record_self:
-                rows.append(f"{record},,\n")
+                digest = base64.urlsafe_b64encode(hashlib.sha256(content).digest()).rstrip(b"=").decode()
+                rows.append(f"{member},sha256={digest},{len(content)}\n")
+            rows.append(f"{record},,\n")
             record_bytes = "".join(rows).encode()
         files[record] = record_bytes
     with zipfile.ZipFile(path, "w", compression=compression) as archive:
@@ -429,7 +422,7 @@ def test_wheel_binds_filename_metadata_and_top_level_dist_info(
 ) -> None:
     manifest, _ = _manifest(tmp_path)
 
-    with pytest.raises(guard.ReleaseAssetError, match="identity|control structure|RECORD structure"):
+    with pytest.raises(guard.ReleaseAssetError, match="identity|control structure"):
         _verify_wheels(tmp_path / "wheels", manifest, core_options=core_options)
 
 
@@ -603,39 +596,15 @@ def test_wheel_rejects_unsafe_archive_paths(tmp_path: Path, member: str) -> None
         )
 
 
-@pytest.mark.parametrize(
-    "record_bytes",
-    [
-        b"\n",
-        b"pkg/module.py,sha256=abc\n",
-        b"pkg/module.py,sha256=not*base64,1\n",
-        b"pkg/module.py,md5=YWJj,3\n",
-        b"pkg/module.py,sha256=YWJj,-1\n",
-        b"pkg/module.py,sha256=YWJj,\xd9\xa3\n",
-        b"../../outside,sha256=YWJj,3\n",
-        b"pkg/./module.py,sha256=YWJj,3\n",
-        b"bad\\path,sha256=YWJj,3\n",
-        b"bad\x00path,sha256=YWJj,3\n",
-    ],
-)
-def test_wheel_rejects_invalid_record_rows(tmp_path: Path, record_bytes: bytes) -> None:
+def test_wheel_rejects_archive_aliases(tmp_path: Path) -> None:
     manifest, _ = _manifest(tmp_path)
 
-    with pytest.raises(guard.ReleaseAssetError, match="RECORD"):
+    with pytest.raises(guard.ReleaseAssetError, match="archive structure"):
         _verify_wheels(
-            tmp_path / "wheels", manifest, core_options={"record_bytes": record_bytes}
+            tmp_path / "wheels",
+            manifest,
+            core_options={"extra_files": {"AVIBE_OS/__init__.py": b"x"}},
         )
-
-
-def test_wheel_rejects_archive_and_record_aliases(tmp_path: Path) -> None:
-    manifest, _ = _manifest(tmp_path)
-
-    for directory, options in (
-        ("archive", {"extra_files": {"AVIBE_OS/__init__.py": b"x"}}),
-        ("record", {"record_extra": ("AVIBE_OS/__init__.py",)}),
-    ):
-        with pytest.raises(guard.ReleaseAssetError, match="archive structure|RECORD"):
-            _verify_wheels(tmp_path / directory, manifest, core_options=options)
 
 
 def test_wheel_data_schemes_are_an_explicit_structural_allowlist(tmp_path: Path) -> None:
@@ -655,10 +624,6 @@ def test_wheel_data_schemes_are_an_explicit_structural_allowlist(tmp_path: Path)
                 manifest,
                 core_options={"extra_files": {member: b"x"}},
             )
-
-
-def test_wheel_record_hashes_use_unpadded_urlsafe_base64() -> None:
-    assert not guard._valid_record_hash("sha256=" + "/" * 43)
 
 
 def test_wheel_rejects_raw_nul_member_name_before_zipfile_sanitization(
@@ -698,24 +663,49 @@ def test_wheel_rejects_file_and_descendant_topology(
         )
 
 
-@pytest.mark.parametrize(
-    "core_options",
-    [
-        {"include_record": False},
-        {"record_self": False},
-        {"record_omit": ("avibe_os/__init__.py",)},
-        {"record_extra": ("safe/absent.py",)},
-        {"record_extra": ("avibe_os/__init__.py",)},
-    ],
-    ids=["missing-record", "missing-self-row", "missing-row", "absent-path", "duplicate-row"],
-)
-def test_wheel_record_is_bidirectionally_bound_to_archive(
-    tmp_path: Path, core_options: dict[str, object]
-) -> None:
+def test_wheel_requires_raw_record_control(tmp_path: Path) -> None:
     manifest, _ = _manifest(tmp_path)
 
-    with pytest.raises(guard.ReleaseAssetError, match="RECORD"):
-        _verify_wheels(tmp_path / "wheels", manifest, core_options=core_options)
+    with pytest.raises(guard.ReleaseAssetError, match="control structure"):
+        _verify_wheels(
+            tmp_path / "wheels", manifest, core_options={"include_record": False}
+        )
+
+
+def test_wheel_rejects_duplicate_raw_record_control(tmp_path: Path) -> None:
+    manifest, _ = _manifest(tmp_path)
+
+    with pytest.warns(UserWarning, match="Duplicate name"):
+        with pytest.raises(
+            guard.ReleaseAssetError, match="archive structure|control structure"
+        ):
+            _verify_wheels(
+                tmp_path / "wheels",
+                manifest,
+                core_options={"duplicate_control": "RECORD"},
+            )
+
+
+def test_wheel_inventory_retains_raw_record_without_interpreting_ledger(
+    tmp_path: Path,
+) -> None:
+    manifest, _ = _manifest(tmp_path)
+    opaque_record = b"\xffnot,a,ledger\n"
+    wheels = tmp_path / "wheels"
+
+    _verify_wheels(wheels, manifest, core_options={"record_bytes": opaque_record})
+    wheel = wheels / "avibe_os-3.1.0-py3-none-any.whl"
+    dist_info = "avibe_os-3.1.0.dist-info"
+    record = f"{dist_info}/RECORD"
+    with zipfile.ZipFile(wheel) as archive:
+        inventory, retained = guard._validate_wheel_archive(archive, wheel, dist_info)
+    entry = next(item for item in inventory if item.path == record)
+
+    assert retained[record] == opaque_record
+    assert entry.size == len(opaque_record)
+    assert entry.sha256 == base64.urlsafe_b64encode(
+        hashlib.sha256(opaque_record).digest()
+    ).rstrip(b"=").decode()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -590,6 +590,9 @@ def test_wheel_translates_unreadable_controls_to_asset_failure(
         pytest.param("pkg/control\x1f", id="c0-control"),
         pytest.param("pkg/control\x7f", id="delete-control"),
         pytest.param("pkg/control\x9f", id="c1-control"),
+        pytest.param("pkg/caf\u00e9.py", id="non-ascii-letter"),
+        pytest.param("pkg/\U00010570.py", id="ucd13-vithkuqi-capital"),
+        pytest.param("pkg/\U00010597.py", id="ucd14-vithkuqi-small"),
     ],
 )
 def test_portable_wheel_path_grammar_rejects_each_declared_rule(value: str) -> None:
@@ -605,6 +608,7 @@ def test_portable_wheel_path_grammar_is_versioned_repository_policy() -> None:
     }
 
     assert grammar.schema_version == 1
+    assert grammar.ascii_components_only
     assert grammar.unicode_normalization == "NFC"
     assert grammar.max_component_utf8_bytes == 255
     assert grammar.reject_absolute_paths
@@ -645,12 +649,11 @@ def test_portable_wheel_path_allows_space_inside_ordinary_stem() -> None:
 def test_portable_wheel_path_enforces_utf8_component_byte_limit() -> None:
     assert guard._portable_wheel_path_key("a" * 255) == "a" * 255
     assert guard._portable_wheel_path_key("a" * 256) is None
-    assert guard._portable_wheel_path_key("\u00e9" * 127 + "a") is not None
-    assert guard._portable_wheel_path_key("\u00e9" * 128) is None
 
 
-def test_portable_wheel_path_requires_nfc_and_returns_one_alias_key() -> None:
-    assert guard._portable_wheel_path_key("PKG/CAF\u00c9.py") == "pkg/caf\u00e9.py"
+def test_portable_wheel_path_is_ascii_before_nfc_and_alias_key() -> None:
+    assert guard._portable_wheel_path_key("PKG/CAFE.py") == "pkg/cafe.py"
+    assert guard._portable_wheel_path_key("pkg/caf\u00e9.py") is None
     assert guard._portable_wheel_path_key("pkg/cafe\u0301.py") is None
     assert guard._portable_wheel_path_key("pkg/data/") == "pkg/data"
 

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -158,6 +158,7 @@ def _wheel(
     wheel_trailer: str = "\n",
     duplicate_control: str | None = None,
     include_record: bool = True,
+    record_self: bool = True,
     record_bytes: bytes | None = None,
     record_extra: tuple[str, ...] = (),
     record_omit: tuple[str, ...] = (),
@@ -197,7 +198,8 @@ def _wheel(
                     rows.append(f"{member},sha256={digest},{len(content)}\n")
             empty_digest = base64.urlsafe_b64encode(hashlib.sha256(b"").digest()).rstrip(b"=").decode()
             rows.extend(f"{member},sha256={empty_digest},0\n" for member in record_extra)
-            rows.append(f"{record},,\n")
+            if record_self:
+                rows.append(f"{record},,\n")
             record_bytes = "".join(rows).encode()
         files[record] = record_bytes
     with zipfile.ZipFile(path, "w", compression=compression) as archive:
@@ -641,23 +643,34 @@ def test_wheel_data_schemes_are_an_explicit_structural_allowlist(tmp_path: Path)
     allowed = {f"avibe_os-3.1.0.data/{scheme}/payload": b"x" for scheme in guard.WHEEL_DATA_SCHEMES}
 
     _verify_wheels(tmp_path / "allowed", manifest, core_options={"extra_files": allowed})
-    with pytest.raises(guard.ReleaseAssetError, match="archive structure"):
-        _verify_wheels(
-            tmp_path / "unknown",
-            manifest,
-            core_options={"extra_files": {"avibe_os-3.1.0.data/unknown/payload": b"x"}},
-        )
+    for member in (
+        "avibe_os-3.1.0.data/unknown/payload",
+        "avibe_os-3.1.0.data/scripts",
+        "avibe_os-3.1.0.data/scripts/",
+        "other-9.9.data/scripts/vibe",
+    ):
+        with pytest.raises(guard.ReleaseAssetError, match="archive structure"):
+            _verify_wheels(
+                tmp_path / member.replace("/", "-"),
+                manifest,
+                core_options={"extra_files": {member: b"x"}},
+            )
+
+
+def test_wheel_record_hashes_use_unpadded_urlsafe_base64() -> None:
+    assert not guard._valid_record_hash("sha256=" + "/" * 43)
 
 
 @pytest.mark.parametrize(
     "core_options",
     [
         {"include_record": False},
+        {"record_self": False},
         {"record_omit": ("avibe_os/__init__.py",)},
         {"record_extra": ("safe/absent.py",)},
         {"record_extra": ("avibe_os/__init__.py",)},
     ],
-    ids=["missing-record", "missing-row", "absent-path", "duplicate-row"],
+    ids=["missing-record", "missing-self-row", "missing-row", "absent-path", "duplicate-row"],
 )
 def test_wheel_record_is_bidirectionally_bound_to_archive(
     tmp_path: Path, core_options: dict[str, object]
@@ -698,6 +711,16 @@ def test_wheel_reads_every_member_for_integrity(tmp_path: Path) -> None:
 
     with pytest.raises(guard.ReleaseAssetError, match="cannot read wheel"):
         guard.inspect_wheel(wheel, policy=policy)
+
+
+def test_wheel_archive_discards_payload_bytes_after_integrity_read(tmp_path: Path) -> None:
+    wheel = _wheel(tmp_path / "avibe_os-3.1.0-py3-none-any.whl", "avibe-os")
+    dist_info = "avibe_os-3.1.0.dist-info"
+
+    with zipfile.ZipFile(wheel) as archive:
+        retained = guard._validate_wheel_archive(archive, wheel, dist_info)
+
+    assert set(retained) == {f"{dist_info}/{name}" for name in ("METADATA", "WHEEL", "RECORD")}
 
 
 def test_existing_guard_commands_remain_stdlib_only(tmp_path: Path) -> None:

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -585,7 +585,18 @@ def test_wheel_translates_unreadable_members_to_asset_failure(
 
 @pytest.mark.parametrize(
     "member",
-    ["/absolute", "../outside", "pkg/./module.py", "bad\\path", "C:/absolute"],
+    [
+        "/absolute",
+        "../outside",
+        "pkg/./module.py",
+        "bad\\path",
+        "C:/absolute",
+        *(f"pkg/a{character}b" for character in '<>:"|?*'),
+        "pkg/trailing.",
+        "pkg/trailing ",
+        *(f"pkg/{name}" for name in ("CON", "prn.txt", "AUX", "NUL.bin", "COM1", "LPT9.py")),
+        "pkg/control\x1f",
+    ],
 )
 def test_wheel_rejects_unsafe_archive_paths(tmp_path: Path, member: str) -> None:
     manifest, _ = _manifest(tmp_path)
@@ -660,6 +671,57 @@ def test_wheel_rejects_file_and_descendant_topology(
             tmp_path / "wheels",
             manifest,
             core_options={"extra_files": {ancestor: b"x", "conflict/child": b"y"}},
+        )
+
+
+def test_wheel_topology_uses_one_binary_search_per_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    wheel = _wheel(
+        tmp_path / "avibe_os-3.1.0-py3-none-any.whl",
+        "avibe-os",
+        extra_files={f"payload/item-{index:04d}": b"" for index in range(256)},
+    )
+    calls = 0
+    bisect_left = guard.bisect_left
+
+    def tracking_bisect(values: list[str], prefix: str) -> int:
+        nonlocal calls
+        calls += 1
+        return bisect_left(values, prefix)
+
+    monkeypatch.setattr(guard, "bisect_left", tracking_bisect)
+    with zipfile.ZipFile(wheel) as archive:
+        inventory, _ = guard._validate_wheel_archive(
+            archive, wheel, "avibe_os-3.1.0.dist-info"
+        )
+
+    assert calls == sum(not entry.is_dir for entry in inventory)
+
+
+@pytest.mark.parametrize(
+    ("declared_size", "payload"),
+    [(1, b""), (0, b"x")],
+    ids=["declared-payload", "observed-payload"],
+)
+def test_wheel_rejects_payload_bearing_directory_member(
+    tmp_path: Path, declared_size: int, payload: bytes
+) -> None:
+    member = zipfile.ZipInfo("payload/")
+    member.file_size = declared_size
+
+    class Archive:
+        @staticmethod
+        def open(_member: zipfile.ZipInfo) -> io.BytesIO:
+            return io.BytesIO(payload)
+
+    with pytest.raises(guard.ReleaseAssetError, match="member size"):
+        guard._inventory_wheel_member(
+            Archive(),
+            member,
+            tmp_path / "wheel.whl",
+            "payload",
+            retain=False,
         )
 
 

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -429,7 +429,7 @@ def test_wheel_binds_filename_metadata_and_top_level_dist_info(
 ) -> None:
     manifest, _ = _manifest(tmp_path)
 
-    with pytest.raises(guard.ReleaseAssetError, match="identity|control structure"):
+    with pytest.raises(guard.ReleaseAssetError, match="identity|control structure|RECORD structure"):
         _verify_wheels(tmp_path / "wheels", manifest, core_options=core_options)
 
 
@@ -447,7 +447,7 @@ def test_wheel_rejects_duplicate_control_files(tmp_path: Path, control: str) -> 
     manifest, _ = _manifest(tmp_path)
 
     with pytest.warns(UserWarning, match="Duplicate name"):
-        with pytest.raises(guard.ReleaseAssetError, match="control"):
+        with pytest.raises(guard.ReleaseAssetError, match="control|archive structure"):
             _verify_wheels(
                 tmp_path / control,
                 manifest,
@@ -661,6 +661,43 @@ def test_wheel_record_hashes_use_unpadded_urlsafe_base64() -> None:
     assert not guard._valid_record_hash("sha256=" + "/" * 43)
 
 
+def test_wheel_rejects_raw_nul_member_name_before_zipfile_sanitization(
+    tmp_path: Path,
+) -> None:
+    manifest, _ = _manifest(tmp_path)
+    manifest_bytes = manifest.read_bytes()
+    policy = guard.load_package_release_policy(
+        manifest_bytes, expected_manifest=manifest_bytes, release_tag="v3.1.0"
+    )
+    wheel = _wheel(
+        tmp_path / "avibe_os-3.1.0-py3-none-any.whl",
+        "avibe-os",
+        extra_files={"evilXtail": b"x"},
+    )
+    wheel.write_bytes(wheel.read_bytes().replace(b"evilXtail", b"evil\x00tail"))
+
+    with zipfile.ZipFile(wheel) as archive:
+        member = next(info for info in archive.infolist() if info.filename == "evil")
+        assert member.orig_filename == "evil\x00tail"
+
+    with pytest.raises(guard.ReleaseAssetError, match="archive structure"):
+        guard.inspect_wheel(wheel, policy=policy)
+
+
+@pytest.mark.parametrize("ancestor", ["conflict", "Conflict"], ids=["exact", "casefold"])
+def test_wheel_rejects_file_and_descendant_topology(
+    tmp_path: Path, ancestor: str
+) -> None:
+    manifest, _ = _manifest(tmp_path)
+
+    with pytest.raises(guard.ReleaseAssetError, match="archive structure"):
+        _verify_wheels(
+            tmp_path / "wheels",
+            manifest,
+            core_options={"extra_files": {ancestor: b"x", "conflict/child": b"y"}},
+        )
+
+
 @pytest.mark.parametrize(
     "core_options",
     [
@@ -718,7 +755,7 @@ def test_wheel_archive_discards_payload_bytes_after_integrity_read(tmp_path: Pat
     dist_info = "avibe_os-3.1.0.dist-info"
 
     with zipfile.ZipFile(wheel) as archive:
-        retained = guard._validate_wheel_archive(archive, wheel, dist_info)
+        _, retained = guard._validate_wheel_archive(archive, wheel, dist_info)
 
     assert set(retained) == {f"{dist_info}/{name}" for name in ("METADATA", "WHEEL", "RECORD")}
 

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -619,6 +619,29 @@ def test_portable_wheel_path_rejects_every_reserved_device_alias(device: str) ->
     assert guard._portable_wheel_path_key(f"pkg/{device.upper()}.txt") is None
 
 
+@pytest.mark.parametrize(
+    "component",
+    [
+        "NUL .txt",
+        "CON..cfg",
+        "COM1  .py",
+        "LPT9..bin",
+        "COM\u00b9 .txt",
+        "LPT\u00b2..cfg",
+        "CONIN$ .txt",
+        "CONOUT$..cfg",
+    ],
+)
+def test_portable_wheel_path_rejects_padded_reserved_device_stems(
+    component: str,
+) -> None:
+    assert guard._portable_wheel_path_key(f"pkg/{component}") is None
+
+
+def test_portable_wheel_path_allows_space_inside_ordinary_stem() -> None:
+    assert guard._portable_wheel_path_key("pkg/normal .txt") == "pkg/normal .txt"
+
+
 def test_portable_wheel_path_enforces_utf8_component_byte_limit() -> None:
     assert guard._portable_wheel_path_key("a" * 255) == "a" * 255
     assert guard._portable_wheel_path_key("a" * 256) is None


### PR DESCRIPTION
## Summary

- capability: Gate5a A2b portable wheel path and topology policy
- user-visible change: none; this freezes the lexical path interface consumed by the immediate archive-inventory successor
- base identity: exact `origin/dev` `9eac6d4e23e67879c1543db13a1320091276d9ec`
- scope: 2 files, 247 net lines (production 121 net; tests 126 net), below the owner-bound 250-line cap

## Frozen Path Interface

- one module-private, immutable, repository-owned `_PortableWheelPathGrammar` declares schema v1
- one `_portable_wheel_path_key` comparator rejects non-ASCII components before NFC/casefold and returns the sole deterministic ASCII casefold alias key
- schema v1 declares ASCII-only components for repository-built avibe-os/avibe-memory wheels; this is release-family policy, not a general wheel-standard claim
- NFC remains declared and vacuously satisfied after the ASCII identity gate; non-ASCII assets require schema v2 plus an explicit versioned Unicode data source in a separate policy PR
- schema v1 declares a 255-byte UTF-8 component ceiling independent of the host filesystem
- the grammar declares controls/NUL, backslash, absolute/drive/UNC forms, dot/dotdot/empty aliases, Windows-invalid characters and ADS colon, trailing space/dot, and the complete case-insensitive reserved-device table including extensions, superscript COM/LPT aliases, and CONIN$/CONOUT$
- Windows reserved-device comparison derives the pre-extension basename and strips its trailing spaces/dots using the grammar's existing suffix declaration; ordinary internal stem spaces remain allowed
- `_portable_wheel_topology_is_valid` consumes only that key, sorts once, rejects duplicate/alias and file/descendant conflicts, and performs one binary search per file for O(n log n) topology validation
- this interface performs no archive I/O, installed-layout inference, runtime/importability probe, or RECORD interpretation

## Path / Topology Obligation Ledger

- `3882649054` / `3883011052`: one canonical lexical path declaration and one alias key for archive and later RECORD consumers
- `3884266254`: reject exact and casefolded file/descendant conflicts
- `3884468065`: replace pairwise prefix scans with sorted keys plus one binary search per file
- `3884468072`: declare portable separators, component aliases, Windows-invalid characters, trailing space/dot, and reserved device policy
- `3884534813`: enforce the repository-owned 255-byte UTF-8 component limit
- `3884534823`: include COM/LPT superscript aliases and CONIN$/CONOUT$, including extension forms
- `3884534831`: reject non-NFC raw spelling and derive the only alias key as NFC + casefold
- `3884623004`: normalize trailing spaces/dots on the pre-extension device basename before consulting the sole reserved-device table, without globally rejecting ordinary internal stem spaces
- `3884668510`: reject non-ASCII components before host NFC/casefold so Python 3.10/UCD 13 and Python 3.11/UCD 14 cannot produce different topology decisions

## Immediate Archive-Inventory Successor Obligations

These obligations are explicitly transferred, not fixed or claimed by this path-policy PR:

- `3882442262`: locate exactly one raw RECORD control at the matching A2a dist-info identity
- `3882649065`: inspect/read every relevant member for ZIP integrity
- `3882731892` / `3884174908`: declare the structural `.data` scheme allowlist and require a destination below each scheme
- `3883925643`: use one bounded chunked reader with declared-size precheck, `archive.open`, limit+1 enforcement, post-read length verification, and foreign-exception translation
- `3884174914`: retain O(one bounded member + control metadata) aggregate memory by discarding payload bytes after facts are computed
- `3884174922`: bind every `.data` root to the exact normalized wheel distribution/version identity
- `3884266251`: enforce exact `ZipInfo.orig_filename` identity, including NUL rejection, before the frozen grammar/key
- `3884468076`: require directory members to declare and produce exactly zero bytes
- emit canonical path/type plus observed uncompressed size and SHA-256 facts, while retaining only the raw controls required by A2a and the ledger successor
- the inventory successor starts only after this PR merges, measures a fresh cap before edits, and opens a fresh combined Watch

## Immediate RECORD-Ledger Successor Obligations

The ledger consumer starts after the archive-inventory successor freezes its facts. These obligations remain transferred one-for-one:

- `3882877027`: parse every nonblank RECORD row as exactly three columns with consumer-owned hash/size structure rules
- `3883011052`: apply the frozen path grammar/key to every RECORD path; reject duplicate and alias rows
- `3883145291`: reconcile RECORD paths bidirectionally with the frozen archive inventory under one declared generated-file policy
- `3884174896`: require the RECORD self-entry and enforce its declared blank-field policy
- `3884174901`: require the unpadded URL-safe Base64 alphabet for declared hashes
- `3884266245`: compare every declared non-RECORD digest and size with observed inventory facts (natural handoff estimate previously recorded as approximately 31 net lines)
- `3884390843`: define signature presence/blank policy once; nonexistent RECORD.jws/RECORD.p7s rows cannot pass as generated exceptions
- `3884390853`: require canonical URL-safe digest encoding by decode plus exact re-encode equality
- complete inherited surface: UTF-8/CSV validity, nonblank rows, three-column shape, safe canonical paths, duplicate/alias rejection, supported hash and size grammar, self/signature/generated-file exceptions, and declared/observed bidirectional reconciliation

Effective installed-destination alias/casefold proof remains successor B via real pip installed inventories. No static stage claims that runtime property.

## Scenario Coverage

- scenario IDs: MEMORY-INDEP-022, MEMORY-INDEP-023
- unit / contract evidence: every declared invalid path rule; ASCII control characters; representative Unicode letter and the U+10570/U+10597 UCD-sensitive pair rejected before NFC/casefold; complete reserved-device table including extension forms; representative NUL/CON, COM/LPT, superscript COM/LPT, and CONIN$/CONOUT$ basenames padded by spaces/dots before extensions; allowed `normal .txt` control; ASCII 255/256-byte boundary; valid/duplicate/casefold/non-NFC topology; exact and casefold file/descendant conflicts; deterministic one-binary-search-per-file bound
- scenario evidence: MEMORY-INDEP-022 keeps manifest identity before wheel parsing; MEMORY-INDEP-023 retains the A2a declared-policy wheel transition while this PR adds the frozen path-policy interface for its successor
- residual manual checks: none; evidence is strictly static

## Validation

- focused path-policy tests: 75 passed
- `uv run --no-sync pytest -q tests/test_memory_runtime_release_guard.py`: 149 passed
- `uv run --no-sync ruff check scripts/memory_runtime_release_guard.py tests/test_memory_runtime_release_guard.py`: passed
- `uvx pre-commit run --files scripts/memory_runtime_release_guard.py tests/test_memory_runtime_release_guard.py`: passed
- `git diff --check`: passed

## Risks / Follow-Ups

- known boundary: the grammar/topology interface is frozen on merge but is intentionally not wired to archive reading until the immediate inventory successor
- future non-ASCII wheel paths require a schema-v2 policy change and an explicit versioned Unicode data source; schema v1 never takes Unicode semantics from the host interpreter
- exclusions: no manifest/release-policy change, archive/member reading, RECORD semantics, pip install/build/solve, installed-layout/runtime/importability inference, raw sdist inspection, workflow, recovery, publication, Gate5b, or release action
- ordering: A1 -> A2a -> path policy (#1768) -> archive inventory -> RECORD ledger -> B -> C -> workflow
- inherited laws: identity before semantics; policy has an explicit declared source; static evidence does not infer runtime properties
