### PR TITLE
refactor(upgrade): remove automatic package rollback

### DIFF
--- a/tests/scenarios/memory_independence/test_memory_rollback_types.py
+++ b/tests/scenarios/memory_independence/test_memory_rollback_types.py
@@ -531,7 +531,7 @@ def _call_inventory(function_name: str) -> dict[str, int]:
 
 
 def test_memory_indep_019_full_tree_caller_inventory_keeps_ownership_private() -> None:
-    assert _call_inventory("capture_installed_package_shape") == {"vibe/upgrade.py": 1}
+    assert _call_inventory("capture_installed_package_shape") == {}
     assert _call_inventory("resolve_rollback_plan") == {}
     assert _call_inventory("ResolvedRollbackPlan") == {}
 
@@ -569,18 +569,3 @@ def test_memory_indep_019_no_resolved_target_has_presence_without_version(tmp_pa
     )
     assert plan.captured.memory_package is False
     assert plan.captured.memory_version is None
-
-
-def test_memory_indep_019_legacy_target_marks_presence_without_version_unavailable() -> None:
-    from vibe.upgrade import RollbackTarget
-
-    target = RollbackTarget(
-        version="3.0.14",
-        package="avibe-os",
-        launcher=LAUNCHER,
-        memory_package=True,
-        memory_version=None,
-    )
-    assert not target
-    assert target.memory_package is False
-    assert target.memory_version is None

--- a/tests/test_memory_upgrade_packaged.py
+++ b/tests/test_memory_upgrade_packaged.py
@@ -14,8 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from vibe import restart_supervisor, runtime
-from vibe.upgrade import RollbackTarget, build_upgrade_plan, execute_upgrade_plan
+from vibe.upgrade import build_upgrade_plan, execute_upgrade_plan
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -229,12 +228,11 @@ assert not any(
 
 
 @pytest.mark.integration
-def test_packaged_memory_shape_survives_synchronous_upgrade_and_supervisor_rollback(
+def test_packaged_memory_shape_survives_synchronous_upgrade(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     packaged_dependency_seed: Path,
 ) -> None:
-    """Run the public planner/executor, then the existing supervisor rollback path."""
+    """Run the public planner and executor across a paired package upgrade."""
 
     if not (ROOT / "vibe" / "show_runtime_manifest.json").is_file():
         pytest.fail("packaged wheel smoke requires the prepared local Show Runtime manifest")
@@ -266,42 +264,6 @@ def test_packaged_memory_shape_survives_synchronous_upgrade_and_supervisor_rollb
     upgraded = _installed_versions(python)
     assert upgraded["avibe-os"] == "3.0.15"
     assert upgraded["avibe-memory"] == "3.0.15"
-
-    launcher = runtime.ServiceLauncher(python=str(python), main=str(ROOT / "main.py"))
-    rollback_target = RollbackTarget(
-        version="3.0.14",
-        package="avibe-os",
-        launcher=launcher,
-        memory_package=True,
-        memory_version="3.0.14",
-    )
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "avibe-home"))
-    monkeypatch.setenv("PIP_NO_INDEX", "1")
-    monkeypatch.setenv("PIP_FIND_LINKS", str(wheelhouse))
-    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda **kwargs: (True, {}, 0, None, True, 0))
-    monkeypatch.setattr(restart_supervisor, "_failed_generation_still_running", lambda **kwargs: False)
-    monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
-    monkeypatch.setattr(restart_supervisor.runtime, "wait_for_service_ready", lambda *args, **kwargs: 901)
-    monkeypatch.setattr(restart_supervisor.runtime, "pid_alive", lambda pid: True)
-    monkeypatch.setattr(
-        restart_supervisor,
-        "_start_runtime_processes",
-        lambda **kwargs: restart_supervisor.StartedRuntime(901, None, None),
-    )
-    events: list[dict] = []
-    rollback = restart_supervisor._roll_back_failed_upgrade(
-        rollback_to=rollback_target,
-        vibe_path=None,
-        start_ui=False,
-        backup_watermark=None,
-        write=lambda message: None,
-        record=lambda payload: events.append(dict(payload)),
-    )
-    assert rollback["state"] == "succeeded"
-    restored = _installed_versions(python)
-    assert restored["avibe-os"] == "3.0.14"
-    assert restored["avibe-memory"] == "3.0.14"
-    assert any(event.get("install", {}).get("ok") is True for event in events)
 
 
 @pytest.mark.integration

--- a/tests/test_package_shape_record_codec.py
+++ b/tests/test_package_shape_record_codec.py
@@ -7,7 +7,6 @@ import os
 from copy import deepcopy
 from dataclasses import FrozenInstanceError, replace
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
@@ -28,7 +27,6 @@ from vibe.package_shape import (
     encode_resolved_rollback_plan_record,
 )
 from vibe.runtime import ServiceLauncher
-from vibe.upgrade import rollback_target
 
 
 def _captured() -> package_shape.CapturedPackageShape:
@@ -295,53 +293,6 @@ def test_memory_indep_019_rejects_invalid_distribution_names(
     )
     with pytest.raises(PackageShapeRecordError, match="name is invalid"):
         decode_resolved_rollback_plan_record(payload)
-
-
-def test_memory_indep_019_rollback_target_skips_unrelated_invalid_distribution_names(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    launcher = ServiceLauncher(
-        python="/opt/avibe/bin/python",
-        main="/opt/avibe/site-packages/vibe/service_main.py",
-    )
-    unrelated = SimpleNamespace(metadata={"Name": "broken/name"})
-    core = SimpleNamespace(
-        metadata={"Name": "avibe-os"},
-        version="3.0.14",
-        _path=tmp_path / "avibe_os-3.0.14.dist-info",
-        requires=('avibe-memory>=3.0.14.dev0,<3.1; extra == "memory"',),
-    )
-    monkeypatch.setattr("vibe.__version__", "3.0.14")
-    monkeypatch.setattr("vibe.runtime.current_service_launcher", lambda: launcher)
-    monkeypatch.setattr("importlib.metadata.distributions", lambda: (unrelated, core))
-
-    target = rollback_target()
-
-    assert target is not None
-    assert target.core_provider.name == "avibe-os"
-    assert target.core_provider.version == "3.0.14"
-
-
-def test_memory_indep_019_rollback_target_rejects_relevant_invalid_distribution_names(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    relevant_but_invalid = SimpleNamespace(
-        metadata={"Name": "avibe-os "},
-        version="3.0.14",
-        _path=tmp_path / "avibe_os-3.0.14.dist-info",
-        requires=(),
-    )
-    monkeypatch.setattr("vibe.__version__", "3.0.14")
-    monkeypatch.setattr(
-        "vibe.runtime.current_service_launcher",
-        lambda: ServiceLauncher(python="/opt/avibe/bin/python", main="/opt/avibe/vibe/service_main.py"),
-    )
-    monkeypatch.setattr("importlib.metadata.distributions", lambda: (relevant_but_invalid,))
-
-    with pytest.raises(PackageShapeError, match="installed distribution name is invalid"):
-        rollback_target()
 
 
 def test_memory_indep_019_artifact_fact_construction_rejects_invalid_state(

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -185,6 +185,50 @@ def test_the_argv_the_job_builds_is_the_argv_the_entry_point_accepts(monkeypatch
     }
 
 
+def test_entry_point_accepts_and_ignores_retired_rollback_argv(monkeypatch):
+    from vibe import cli
+
+    ran = {}
+    monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: None)
+    monkeypatch.setattr(restart_supervisor, "_run_restart_job", lambda **kwargs: ran.update(kwargs) or 0)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "vibe",
+            "__restart-supervisor",
+            "--job-id",
+            "legacy-upgrade",
+            "--trigger",
+            "upgrade",
+            "--rollback-to",
+            "3.0.14",
+            "--rollback-package",
+            "avibe-os",
+            "--rollback-memory-package",
+            "--rollback-memory-version",
+            "3.0.14",
+            "--rollback-python",
+            "/opt/avibe/bin/python",
+            "--rollback-main",
+            "/opt/avibe/vibe/service_main.py",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main()
+
+    assert exit_info.value.code == 0
+    assert ran == {
+        "job_id": "legacy-upgrade",
+        "delay_seconds": 0.0,
+        "vibe_path": None,
+        "trigger": "upgrade",
+        "scope": "all",
+        "prepare_show_runtime": False,
+    }
+
+
 def test_schedule_restart_marks_status_failed_when_spawn_fails(monkeypatch, tmp_path):
     # The "scheduled" status is seeded before spawning; if the spawn fails, no
     # child will overwrite it, so schedule_restart must mark it failed (otherwise

--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -1,48 +1,24 @@
 from __future__ import annotations
 
-import ast
-import inspect
 import io
 import os
-import sqlite3
 import sys
-import textwrap
 import threading
-from contextlib import contextmanager
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from config import paths
-from storage.backups import create_sqlite_migration_backup
 from vibe import restart_supervisor
 from vibe import runtime
-from vibe.upgrade import RollbackTarget
 
-
-#: The install the machine was on before the upgrade replaced it. Deliberately
-#: not this process's own interpreter: the case the launcher exists for is the
-#: `vibe-remote` -> `avibe-os` rename, where the two generations live in
-#: different directories, and a fixture reusing `sys.executable` would pass
-#: whether or not the target's install is carried anywhere at all.
-_REPLACED_INSTALL = runtime.ServiceLauncher(
-    python="/uv/tools/vibe-remote/bin/python",
-    main="/uv/tools/vibe-remote/lib/python3.13/site-packages/vibe/service_main.py",
-)
-
-
-def _rollback_target(version: str = "3.0.10") -> RollbackTarget:
-    """The install to go back to, as the upgrade captured it before installing."""
-
-    return RollbackTarget(version=version, package="vibe-remote", launcher=_REPLACED_INSTALL)
 
 
 def _fake_start_runtime(calls, service_pid: int = 222, ui_pid: int = 333):
     calls.append("start_runtime")
     runtime.write_status("running", f"pid={service_pid}", service_pid, ui_pid)
-    return restart_supervisor.StartedRuntime(service_pid, ui_pid, ("127.0.0.1", 5123))
+    return restart_supervisor.StartedRuntime(service_pid, ui_pid)
 
 
 def _fake_stop_runtime(calls, *, ui_stopped=True, ui_pid=None, service_stopped=True):
@@ -56,60 +32,6 @@ def _fake_stop_runtime(calls, *, ui_stopped=True, ui_pid=None, service_stopped=T
         0.03,
     )
 
-
-def _fake_pinned_install(calls, installs, *, pin: str = "vibe-remote==3.0.10"):
-    """Record only the rollback's pinned install, never host process-table probes.
-
-    Patching ``restart_supervisor.subprocess.run`` replaces the stdlib function
-    for every importer. Rollback then inspects leftover pids through
-    ``get_process_command``, which shells out to ``ps -p <pid>``. Capturing that
-    probe as ``installs[0]`` makes the pin assertion fail on whatever pid the
-    host happens to have live.
-    """
-
-    def run(command, **_kwargs):
-        argv = list(command)
-        if any(pin in str(part) for part in argv):
-            calls.append("install")
-            installs.append(argv)
-        return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-    return run
-
-
-@contextmanager
-def _serve_version_endpoints(responses):
-    requests = []
-
-    class Handler(BaseHTTPRequestHandler):
-        def do_GET(self):
-            requests.append(self.path)
-            status, content_type, body = responses[self.path]
-            self.send_response(status)
-            self.send_header("Content-Type", content_type)
-            self.end_headers()
-            self.wfile.write(body)
-
-        def log_message(self, _format, *_args):
-            return
-
-    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        yield server.server_port, requests
-    finally:
-        server.shutdown()
-        thread.join()
-        server.server_close()
-
-
-def _point_running_ui_probe_at(monkeypatch, port):
-    from core.services import settings as settings_service
-
-    config = SimpleNamespace(ui=SimpleNamespace(setup_port=port))
-    monkeypatch.setattr(settings_service, "load_config", lambda **_kwargs: config)
-    monkeypatch.setattr(runtime, "effective_ui_bind_host", lambda _config: "127.0.0.1")
 
 
 def test_schedule_restart_spawns_supervisor_and_records_status(monkeypatch, tmp_path):
@@ -146,310 +68,6 @@ def test_schedule_restart_spawns_supervisor_and_records_status(monkeypatch, tmp_
     assert calls["kwargs"]["env"] == {"PATH": "/bin"}
     assert runtime.read_json(runtime.get_restart_status_path())["job_id"] == result["job_id"]
 
-
-def test_legacy_upgrade_target_reads_the_running_release_and_launcher(monkeypatch, tmp_path):
-    """A pre-rollback release can still hand the new supervisor its target."""
-
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
-    paths.ensure_data_dirs()
-    tool_root = tmp_path / "uv" / "tools" / "avibe-os"
-    python_path = tool_root / "bin" / "python"
-    vibe_path = tool_root / "bin" / "vibe"
-    service_main = tool_root / "lib" / "python3.12" / "site-packages" / "vibe" / "service_main.py"
-    python_path.parent.mkdir(parents=True)
-    service_main.parent.mkdir(parents=True)
-    python_path.write_text("#!/bin/sh\n", encoding="utf-8")
-    vibe_path.write_text(f"#!{python_path}\n", encoding="utf-8")
-    service_main.write_text("# old release\n", encoding="utf-8")
-    metadata_dir = service_main.parent.parent / "avibe_os-3.0.12.dist-info"
-    metadata_dir.mkdir()
-    (metadata_dir / "METADATA").write_text("Name: avibe-os\nVersion: 3.0.12\n", encoding="utf-8")
-
-    monkeypatch.setattr(restart_supervisor, "_read_recorded_pid", lambda: 123)
-    monkeypatch.setattr(restart_supervisor, "_running_ui_version", lambda: None)
-    monkeypatch.setattr(
-        runtime,
-        "get_process_command",
-        lambda pid: f"{python_path} {service_main}",
-    )
-
-    target = restart_supervisor._discover_legacy_upgrade_target(
-        trigger="upgrade", vibe_path=str(tmp_path / "retargeted-vibe")
-    )
-
-    assert target == RollbackTarget(
-        version="3.0.12",
-        package="avibe-os",
-        launcher=runtime.ServiceLauncher(python=str(python_path), main=str(service_main)),
-    )
-
-
-@pytest.mark.parametrize("core_package", ["avibe-os", "vibe-remote"])
-def test_legacy_upgrade_target_keeps_memory_out_of_core_ownership(
-    monkeypatch, tmp_path, core_package
-):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
-    paths.ensure_data_dirs()
-    package_dir = core_package.replace("-", "_")
-    tool_root = tmp_path / "uv" / "tools" / core_package
-    python_path = tool_root / "bin" / "python"
-    service_main = tool_root / "lib" / "python3.12" / "site-packages" / "vibe" / "service_main.py"
-    python_path.parent.mkdir(parents=True)
-    service_main.parent.mkdir(parents=True)
-    python_path.write_text("#!/bin/sh\n", encoding="utf-8")
-    service_main.write_text("# old release\n", encoding="utf-8")
-    metadata_root = service_main.parent.parent
-    for directory, name in (("avibe_memory", "avibe-memory"), (package_dir, core_package)):
-        metadata_dir = metadata_root / f"{directory}-3.0.14.dist-info"
-        metadata_dir.mkdir()
-        (metadata_dir / "METADATA").write_text(
-            f"Name: {name}\nVersion: 3.0.14\n", encoding="utf-8"
-        )
-
-    monkeypatch.setattr(restart_supervisor, "_read_recorded_pid", lambda: 123)
-    monkeypatch.setattr(restart_supervisor, "_read_recorded_ui_pid", lambda: None)
-    monkeypatch.setattr(restart_supervisor, "_running_ui_version", lambda: "3.0.14")
-    monkeypatch.setattr(runtime, "get_process_command", lambda _pid: f"{python_path} {service_main}")
-
-    target = restart_supervisor._discover_legacy_upgrade_target(
-        trigger="upgrade", vibe_path=str(tmp_path / "retargeted-vibe")
-    )
-
-    assert target == RollbackTarget(
-        version="3.0.14",
-        package=core_package,
-        launcher=runtime.ServiceLauncher(python=str(python_path), main=str(service_main)),
-        memory_package=True,
-        memory_version="3.0.14",
-    )
-
-
-def test_legacy_upgrade_target_skips_broken_metadata_entries(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
-    paths.ensure_data_dirs()
-    tool_root = tmp_path / "uv" / "tools" / "avibe-os"
-    python_path = tool_root / "bin" / "python"
-    service_main = tool_root / "lib" / "python3.12" / "site-packages" / "vibe" / "service_main.py"
-    python_path.parent.mkdir(parents=True)
-    service_main.parent.mkdir(parents=True)
-    python_path.write_text("#!/bin/sh\n", encoding="utf-8")
-    service_main.write_text("# old release\n", encoding="utf-8")
-    metadata_root = service_main.parent.parent
-    broken = metadata_root / "000_broken-1.0.dist-info" / "METADATA"
-    broken.parent.mkdir()
-    broken.write_text("unreadable", encoding="utf-8")
-    non_utf8 = metadata_root / "001_non_utf8-1.0.dist-info" / "METADATA"
-    non_utf8.parent.mkdir()
-    non_utf8.write_bytes(b"\xff")
-    for directory, name in (("avibe_os", "avibe-os"), ("avibe_memory", "avibe-memory")):
-        metadata = metadata_root / f"{directory}-3.0.14.dist-info" / "METADATA"
-        metadata.parent.mkdir()
-        metadata.write_text(f"Name: {name}\nVersion: 3.0.14\n", encoding="utf-8")
-
-    original_read_text = Path.read_text
-
-    def read_text(path, *args, **kwargs):
-        if path == broken:
-            raise OSError("broken metadata")
-        return original_read_text(path, *args, **kwargs)
-
-    monkeypatch.setattr(Path, "read_text", read_text)
-    launcher = runtime.ServiceLauncher(python=str(python_path), main=str(service_main))
-    monkeypatch.setattr(restart_supervisor, "_read_recorded_pid", lambda: 123)
-    monkeypatch.setattr(restart_supervisor, "_read_recorded_ui_pid", lambda: None)
-    monkeypatch.setattr(restart_supervisor, "_running_ui_version", lambda: "3.0.14")
-    monkeypatch.setattr(runtime, "get_process_command", lambda _pid: f"{python_path} {service_main}")
-
-    assert restart_supervisor._launcher_core_dist_metadata(launcher) == [("avibe-os", "3.0.14")]
-    assert restart_supervisor._launcher_memory_version(launcher) == "3.0.14"
-    assert restart_supervisor._discover_legacy_upgrade_target(trigger="upgrade", vibe_path=None) == RollbackTarget(
-        version="3.0.14",
-        package="avibe-os",
-        launcher=launcher,
-        memory_package=True,
-        memory_version="3.0.14",
-    )
-
-
-def test_legacy_upgrade_target_prefers_running_version_over_stale_metadata(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
-    paths.ensure_data_dirs()
-    tool_root = tmp_path / "venv"
-    python_path = tool_root / "bin" / "python"
-    service_main = tool_root / "lib" / "python3.12" / "site-packages" / "vibe" / "service_main.py"
-    python_path.parent.mkdir(parents=True)
-    service_main.parent.mkdir(parents=True)
-    python_path.write_text("#!/bin/sh\n", encoding="utf-8")
-    service_main.write_text("# replaced release\n", encoding="utf-8")
-    metadata_root = service_main.parent.parent
-    for name, version in (("avibe_os", "3.0.13"), ("vibe_remote", "2.9.4")):
-        metadata_dir = metadata_root / f"{name}-{version}.dist-info"
-        metadata_dir.mkdir()
-        package_name = "avibe-os" if name == "avibe_os" else "vibe-remote"
-        (metadata_dir / "METADATA").write_text(
-            f"Name: {package_name}\nVersion: {version}\n", encoding="utf-8"
-        )
-
-    monkeypatch.setattr(restart_supervisor, "_read_recorded_pid", lambda: 123)
-    monkeypatch.setattr(
-        runtime,
-        "get_process_command",
-        lambda pid: f"{python_path} {service_main}",
-    )
-    responses = {
-        "/api/version/local": (200, "text/html", b"<!doctype html><title>Avibe</title>"),
-        "/api/version": (200, "application/json", b'{"current":"3.0.12"}'),
-    }
-    with _serve_version_endpoints(responses) as (port, requests):
-        _point_running_ui_probe_at(monkeypatch, port)
-        target = restart_supervisor._discover_legacy_upgrade_target(
-            trigger="upgrade", vibe_path=str(tmp_path / "retargeted-vibe")
-        )
-
-    assert target == RollbackTarget(
-        version="3.0.12",
-        package="avibe-os",
-        launcher=runtime.ServiceLauncher(python=str(python_path), main=str(service_main)),
-    )
-    assert requests == ["/api/version/local", "/api/version"]
-
-
-def test_running_ui_version_falls_back_from_missing_new_endpoint(monkeypatch):
-    responses = {
-        "/api/version/local": (404, "application/json", b'{"detail":"Not Found"}'),
-        "/api/version": (200, "application/json", b'{"current":"3.0.12"}'),
-    }
-    with _serve_version_endpoints(responses) as (port, requests):
-        _point_running_ui_probe_at(monkeypatch, port)
-
-        version = restart_supervisor._running_ui_version()
-
-    assert version == "3.0.12"
-    assert requests == ["/api/version/local", "/api/version"]
-
-
-def test_legacy_upgrade_target_stays_unavailable_when_all_identity_sources_are_invalid(
-    monkeypatch, tmp_path
-):
-    tool_root = tmp_path / "uv" / "tools" / "avibe-os"
-    python_path = tool_root / "bin" / "python"
-    service_main = tool_root / "lib" / "python3.12" / "site-packages" / "vibe" / "service_main.py"
-    python_path.parent.mkdir(parents=True)
-    service_main.parent.mkdir(parents=True)
-    python_path.write_text("#!/bin/sh\n", encoding="utf-8")
-    service_main.write_text("# replaced release without trusted metadata\n", encoding="utf-8")
-    monkeypatch.setattr(restart_supervisor, "_read_recorded_pid", lambda: 123)
-    monkeypatch.setattr(restart_supervisor, "_read_recorded_ui_pid", lambda: None)
-    monkeypatch.setattr(runtime, "get_process_command", lambda _pid: f"{python_path} {service_main}")
-    responses = {
-        "/api/version/local": (200, "text/html", b"<!doctype html><title>Avibe</title>"),
-        "/api/version": (200, "application/json", b'{"current":"not-a-release"}'),
-    }
-    with _serve_version_endpoints(responses) as (port, requests):
-        _point_running_ui_probe_at(monkeypatch, port)
-        target = restart_supervisor._discover_legacy_upgrade_target(
-            trigger="upgrade", vibe_path=str(tmp_path / "retargeted-vibe")
-        )
-
-    assert target is None
-    assert requests == ["/api/version/local", "/api/version"]
-
-
-def test_legacy_upgrade_target_recovers_from_ui_only_process(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
-    paths.ensure_data_dirs()
-    tool_root = tmp_path / "uv" / "tools" / "vibe-remote"
-    python_path = tool_root / "bin" / "python"
-    service_main = tool_root / "lib" / "python3.12" / "site-packages" / "vibe" / "service_main.py"
-    python_path.parent.mkdir(parents=True)
-    service_main.parent.mkdir(parents=True)
-    python_path.write_text("#!/bin/sh\n", encoding="utf-8")
-    service_main.write_text("# old release\n", encoding="utf-8")
-    metadata_dir = service_main.parent.parent / "vibe_remote-2.9.4.dist-info"
-    metadata_dir.mkdir()
-    (metadata_dir / "METADATA").write_text("Name: vibe-remote\nVersion: 2.9.4\n", encoding="utf-8")
-
-    monkeypatch.setattr(restart_supervisor, "_read_recorded_pid", lambda: 999)
-    monkeypatch.setattr(restart_supervisor, "_read_recorded_ui_pid", lambda: 456)
-    monkeypatch.setattr(
-        runtime,
-        "get_process_command",
-        lambda pid: None if pid == 999 else f'{python_path} -c "from vibe.ui_server import run_ui_server; run_ui_server()"',
-    )
-    monkeypatch.setattr(restart_supervisor, "_running_ui_version", lambda: "2.9.4")
-
-    target = restart_supervisor._discover_legacy_upgrade_target(
-        trigger="upgrade", vibe_path=str(tmp_path / "retargeted-vibe")
-    )
-
-    assert target == RollbackTarget(
-        version="2.9.4",
-        package="vibe-remote",
-        launcher=runtime.ServiceLauncher(python=str(python_path), main=str(service_main)),
-    )
-
-
-def test_service_launcher_from_process_strips_windows_quotes(monkeypatch, tmp_path):
-    python_path = tmp_path / "Program Files" / "uv" / "tools" / "avibe-os" / "Scripts" / "python.exe"
-    service_main = tmp_path / "Program Files" / "uv" / "tools" / "avibe-os" / "Lib" / "site-packages" / "vibe" / "service_main.py"
-    service_main.parent.mkdir(parents=True)
-    service_main.write_text("# old release\n", encoding="utf-8")
-    command = f'"{python_path}" "{service_main}"'
-    monkeypatch.setattr(runtime, "get_process_command", lambda pid: command)
-
-    target = restart_supervisor._service_launcher_from_process(123)
-
-    assert target == runtime.ServiceLauncher(python=str(python_path), main=str(service_main))
-
-
-def test_legacy_upgrade_without_target_leaves_packaged_runtime_running(monkeypatch, tmp_path):
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    paths.ensure_data_dirs()
-    monkeypatch.setattr(restart_supervisor, "get_build_identity", lambda: SimpleNamespace(kind="package"))
-    monkeypatch.setattr(restart_supervisor, "_discover_legacy_upgrade_target", lambda **kwargs: None)
-    monkeypatch.setattr(
-        restart_supervisor,
-        "_stop_runtime_for_restart",
-        lambda **kwargs: pytest.fail("a legacy upgrade without a target must not stop the runtime"),
-    )
-
-    rc = restart_supervisor._run_restart_job(
-        job_id="job-legacy-no-target",
-        delay_seconds=0,
-        vibe_path="/bin/vibe",
-        trigger="upgrade",
-    )
-
-    assert rc == 2
-    status = runtime.read_json(runtime.get_restart_status_path())
-    assert status["state"] == "failed"
-    assert "existing runtime was left running" in status["error"]
-
-
-def test_failed_legacy_upgrade_uses_discovered_target_for_rollback(monkeypatch, tmp_path):
-    """The v3.0.12 path is recoverable even though it passed no rollback argv."""
-
-    armed = _upgrade_restart_that_dies_after_migrating(monkeypatch, tmp_path, service_running=False)
-    monkeypatch.setattr(
-        restart_supervisor,
-        "_discover_legacy_upgrade_target",
-        lambda **kwargs: _rollback_target(),
-    )
-
-    rc = restart_supervisor._run_restart_job(
-        job_id="joblegacy",
-        delay_seconds=0,
-        vibe_path="/bin/vibe",
-        trigger="upgrade",
-        rollback_to=None,
-    )
-
-    assert rc == 1
-    status = runtime.read_json(runtime.get_restart_status_path())
-    assert status["rollback_to"] == "3.0.10"
-    assert status["rollback_target_source"] == "running_service"
-    assert status["rollback"]["state"] == "succeeded"
-    assert armed.observed_by_the_rolled_back_version == [["before the upgrade"]]
 
 
 def test_schedule_restart_can_prepare_show_runtime_after_restart(monkeypatch, tmp_path):
@@ -521,21 +139,7 @@ def test_schedule_restart_passes_memory_ui_secret_only_through_stdin(monkeypatch
 
 
 def test_the_argv_the_job_builds_is_the_argv_the_entry_point_accepts(monkeypatch, tmp_path):
-    """One command, one parser, proved by running the built argv through the CLI.
-
-    `schedule_restart` builds a command line and a detached `vibe` process parses
-    it back. For a while both ends were owned by different parsers -- this module
-    built the `--rollback-*` flags, `vibe/cli.py` declared the ones it knew about,
-    and the top-level parser ran first. So the flags were not merely unsupported,
-    they were rejected: the child exited on `unrecognized arguments`, the seeded
-    "scheduled" record was never overwritten by anyone, and the machine stayed on
-    the release that could not start. Every test in this file called
-    `restart_supervisor.main([...])` directly, so nothing crossed that seam.
-
-    Asserted as a round trip rather than as a list of flags: the spawned argv is
-    taken exactly as `Popen` received it and handed to the real entry point, so a
-    flag added to the builder later is covered without touching this test.
-    """
+    """The detached restart command round-trips through the real CLI parser."""
 
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
@@ -545,80 +149,40 @@ def test_the_argv_the_job_builds_is_the_argv_the_entry_point_accepts(monkeypatch
     monkeypatch.setattr(restart_supervisor, "get_restart_environment", lambda vibe_path=None: None)
     monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
     monkeypatch.setattr(restart_supervisor, "_prune_restart_logs", lambda: None)
+    monkeypatch.setattr(
+        restart_supervisor.subprocess,
+        "Popen",
+        lambda command, **kwargs: spawned.setdefault("command", command) and SimpleNamespace(pid=45678),
+    )
 
-    def fake_popen(command, **kwargs):
-        spawned["command"] = command
-        return SimpleNamespace(pid=45678)
-
-    monkeypatch.setattr(restart_supervisor.subprocess, "Popen", fake_popen)
-
-    rollback_to = _rollback_target("3.0.10")
     restart_supervisor.schedule_restart(
         delay_seconds=0,
         vibe_path="/bin/vibe",
         trigger="upgrade",
         scope="service",
         prepare_show_runtime=True,
-        rollback_to=rollback_to,
     )
+    assert not any(argument.startswith("--rollback") for argument in spawned["command"])
 
     from vibe import cli
 
     ran = {}
-
-    def fake_run_restart_job(**kwargs):
-        ran.update(kwargs)
-        return 0
-
     monkeypatch.setattr(cli, "cache_running_vibe_path", lambda: None)
-    monkeypatch.setattr(restart_supervisor, "_run_restart_job", fake_run_restart_job)
+    monkeypatch.setattr(restart_supervisor, "_run_restart_job", lambda **kwargs: ran.update(kwargs) or 0)
     monkeypatch.setattr(sys, "argv", list(spawned["command"]))
 
     with pytest.raises(SystemExit) as exit_info:
         cli.main()
 
     assert exit_info.value.code == 0
-    # Not just "it parsed": the rollback target has to arrive whole, because a
-    # partially-carried one is the failure this whole path exists to prevent.
-    assert ran["rollback_to"] == rollback_to
-    assert ran["trigger"] == "upgrade"
-    assert ran["scope"] == "service"
-    assert ran["prepare_show_runtime"] is True
-
-
-def test_incomplete_legacy_memory_argv_stays_restartable(monkeypatch):
-    ran = {}
-
-    def fake_run_restart_job(**kwargs):
-        ran.update(kwargs)
-        return 0
-
-    monkeypatch.setattr(restart_supervisor, "_run_restart_job", fake_run_restart_job)
-
-    result = restart_supervisor.main(
-        [
-            "--job-id",
-            "legacy-incomplete-memory",
-            "--trigger",
-            "upgrade",
-            "--rollback-to",
-            "3.0.14",
-            "--rollback-package",
-            "avibe-os",
-            "--rollback-python",
-            "/opt/avibe/bin/python",
-            "--rollback-main",
-            "/opt/avibe/lib/python/site-packages/vibe/service_main.py",
-            "--rollback-memory-package",
-        ]
-    )
-
-    assert result == 0
-    target = ran["rollback_to"]
-    assert target is not None
-    assert not target
-    assert target.memory_package is False
-    assert target.memory_version is None
+    assert ran == {
+        "job_id": ran["job_id"],
+        "delay_seconds": 0.0,
+        "vibe_path": "/bin/vibe",
+        "trigger": "upgrade",
+        "scope": "service",
+        "prepare_show_runtime": True,
+    }
 
 
 def test_schedule_restart_marks_status_failed_when_spawn_fails(monkeypatch, tmp_path):
@@ -758,8 +322,6 @@ def test_restart_job_prepares_show_runtime_after_service_start(monkeypatch, tmp_
     monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
     monkeypatch.setattr(restart_supervisor, "get_restart_command", lambda vibe_path=None: ["/bin/vibe"])
     monkeypatch.setattr(restart_supervisor, "get_restart_environment", lambda vibe_path=None: None)
-    monkeypatch.setattr(restart_supervisor, "_discover_legacy_upgrade_target", lambda **kwargs: None)
-    monkeypatch.setattr(restart_supervisor, "get_build_identity", lambda: SimpleNamespace(kind="source"))
 
     def fake_run(command, **kwargs):
         calls.append(("run", command))
@@ -934,7 +496,7 @@ def test_restart_job_adopts_slow_starting_service_pid(monkeypatch, tmp_path):
             paths.get_runtime_pid_path().unlink()
         except FileNotFoundError:
             pass
-        return restart_supervisor.StartedRuntime(222, 333, ("127.0.0.1", 5123))
+        return restart_supervisor.StartedRuntime(222, 333)
 
     monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", slow_start_runtime)
     # Both halves of the generation this start launched are alive: the status
@@ -1072,30 +634,13 @@ def test_start_runtime_processes_starts_service_and_ui(monkeypatch, tmp_path):
 
     assert started.service_pid == 222
     assert started.ui_pid == 333
-    # The health target is resolved here or nowhere: this is the only place that
-    # loads the config to decide the bind host and port, so it is the only answer
-    # to "where is the UI" that cannot disagree with where the UI was started.
-    assert started.ui_health_target == ("0.0.0.0", 5123)
     assert calls[:2] == ["ensure_data_dirs", "load_config"]
     assert calls[2][:3] == ("start_service", False, 0)
     assert calls[3] == ("bind_host", config)
     assert calls[4][:4] == ("start_ui", "0.0.0.0", 5123, False)
     assert calls[2][3]["memory_ui_secret"] == calls[4][4]["memory_ui_secret"]
-
-    # Every process this helper starts comes from the one install it was given,
-    # asserted over whatever it started rather than over two named spawns: the
-    # service and the UI are two halves of one generation, and a rollback that
-    # started one from the restored install and the other from the replaced one
-    # is a state neither release was ever run in. `None` is "this process",
-    # which is the right answer for every restart except a rollback.
-    def started_from() -> list:
-        return [call[-1].get("launcher") for call in calls if call[0] in ("start_service", "start_ui")]
-
-    assert started_from() == [None, None]
-
-    calls.clear()
-    restart_supervisor._start_runtime_processes(launcher=_REPLACED_INSTALL)
-    assert started_from() == [_REPLACED_INSTALL, _REPLACED_INSTALL]
+    assert "launcher" not in calls[2][3]
+    assert "launcher" not in calls[4][4]
 
     status = runtime.read_status()
     # "starting", not "running", and the stubbed lock says the pid is recorded.
@@ -1207,468 +752,56 @@ def test_restart_job_service_scope_keeps_ui(monkeypatch, tmp_path):
     assert status["scope"] == "service"
 
 
-def _seed_state_database(db_path):
-    """The database as the machine had it before the upgrade touched anything."""
-
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    with sqlite3.connect(db_path) as conn:
-        conn.execute("create table if not exists alembic_version (version_num varchar(32) not null)")
-        conn.execute("delete from alembic_version")
-        conn.execute("insert into alembic_version (version_num) values ('20260806_0047')")
-        conn.execute("create table payload (value text)")
-        conn.execute("insert into payload (value) values ('before the upgrade')")
-
-
-def _payload_rows(db_path) -> list[str]:
-    with sqlite3.connect(db_path) as conn:
-        return [row[0] for row in conn.execute("select value from payload order by rowid")]
-
-
-def _upgrade_restart_that_dies_after_migrating(
-    monkeypatch,
-    tmp_path,
-    *,
-    service_running: bool,
-    ui_serving: bool = True,
-):
-    """Arm the incident this whole path exists for, and hand back what it did.
-
-    The new version stops the old one, starts, takes its pre-migration backup,
-    commits a row, and then dies without ever holding the service lock. Only the
-    two processes and the package index are stubbed: the database, the backup
-    window, and the watermark the job reads out of it are the real ones, because
-    they are the things the rollback has to get right.
-    """
-
+def test_failed_upgrade_restart_reports_terminal_failure_without_package_rollback(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     paths.get_runtime_pid_path().write_text("111", encoding="utf-8")
-    db_path = paths.get_sqlite_state_path()
-    _seed_state_database(db_path)
-
-    calls: list[str] = []
-    installs: list[list[str]] = []
-    launchers: list = []
-    observed_by_the_rolled_back_version: list[list[str]] = []
-
-    def start(start_ui=True, launcher=None):
-        calls.append("start_runtime")
-        launchers.append(launcher)
-        if calls.count("start_runtime") == 1:
-            # The new version gets far enough to take its rollback point and
-            # commit, then dies without ever holding the lock.
-            create_sqlite_migration_backup(db_path, backups_dir=paths.get_state_backups_dir())
-            with sqlite3.connect(db_path) as conn:
-                conn.execute("insert into payload (value) values ('committed by the new version')")
-            raise RuntimeError("service refused to start")
-        observed_by_the_rolled_back_version.append(_payload_rows(db_path))
-        return _fake_start_runtime([], service_pid=222, ui_pid=333)
+    package_commands = []
+    calls = []
 
     monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda stop_ui=True: _fake_stop_runtime(calls))
-    monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", start)
     monkeypatch.setattr(restart_supervisor, "_wait_for_service_lock_release", lambda: True)
-    monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
-    monkeypatch.setattr(restart_supervisor.subprocess, "run", _fake_pinned_install(calls, installs))
-    monkeypatch.setattr(runtime, "verified_service_running", lambda: service_running)
-    monkeypatch.setattr(runtime, "wait_for_service_ready", lambda pid, timeout=None: pid)
-    # The machine as this failure actually leaves it: the version that died in
-    # its migration is gone, and so nothing of it is still holding the database
-    # open. Stated here rather than left to the host's real process table, which
-    # a test may not read and must never depend on.
-    monkeypatch.setattr(restart_supervisor, "_remaining_service_pids_after_stop", list)
-    monkeypatch.setattr(runtime, "ui_pid_file_points_to_running_ui", lambda *args, **kwargs: False)
-    # The UI the rollback restarts, and whether it answers. Both are stubbed
-    # rather than left to the host: `_ui_is_serving` opens a real socket, and a
-    # test that let it would wait out the timeout against whatever happens to be
-    # listening on the developer's machine.
-    ui_probes: list[tuple[str, int]] = []
-    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 333)
+    monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", lambda start_ui=True: _fake_start_runtime(calls))
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 222)
+    monkeypatch.setattr(runtime, "service_pid_recorded", lambda pid: pid == 222)
+    monkeypatch.setattr(runtime, "wait_for_service_ready", lambda pid, timeout: None)
     monkeypatch.setattr(
-        runtime,
-        "wait_for_ui_server",
-        lambda host, port, timeout=None: ui_probes.append((host, port)) or ui_serving,
-    )
-
-    return SimpleNamespace(
-        db_path=db_path,
-        calls=calls,
-        installs=installs,
-        launchers=launchers,
-        ui_probes=ui_probes,
-        observed_by_the_rolled_back_version=observed_by_the_rolled_back_version,
-    )
-
-
-def test_a_rollback_whose_ui_never_serves_is_not_reported_as_recovered(monkeypatch, tmp_path):
-    """A live pid is not a serving UI, and this job is the one that cannot guess.
-
-    The service came back and holds the lock; the UI process was started and is
-    alive, and never answers. Everything a pid-based check can see says the
-    machine is up, which is exactly the evidence this record must not accept:
-    nobody is watching an unattended rollback, so the half that is dark has to be
-    the half that is reported. The service pid is still recorded either way --
-    the run failed, it did not vanish.
-    """
-
-    armed = _upgrade_restart_that_dies_after_migrating(
-        monkeypatch, tmp_path, service_running=False, ui_serving=False
-    )
-
-    restart_supervisor._run_restart_job(
-        job_id="jobdark", delay_seconds=0, vibe_path="/bin/vibe", trigger="upgrade", rollback_to=_rollback_target()
-    )
-
-    rollback = runtime.read_json(runtime.get_restart_status_path())["rollback"]
-    assert rollback["state"] == "failed"
-    assert rollback["ui"] == {"pid": 333, "serving": False}
-    assert rollback["service_pid"] == 222
-    assert "Web UI" in rollback["error"]
-    # It reached the UI at all, rather than failing for want of a probe.
-    assert armed.ui_probes
-
-
-def test_a_restart_that_leaves_nothing_running_puts_the_old_version_back(monkeypatch, tmp_path):
-    """The property the change exists for: an upgrade cannot end with a dark instance.
-
-    Install, then restore, then start -- and the started version has to find the
-    database the version it is reads. That last part is why the order is asserted
-    through what the started process sees rather than through a call log: a
-    restore that lands after the start is a restore that lands after the service
-    has already opened a schema it cannot read.
-    """
-
-    armed = _upgrade_restart_that_dies_after_migrating(monkeypatch, tmp_path, service_running=False)
-
-    rc = restart_supervisor._run_restart_job(
-        job_id="jobroll", delay_seconds=0, vibe_path="/bin/vibe", trigger="upgrade", rollback_to=_rollback_target()
-    )
-
-    # The restart still failed, and still says so: a rollback recovers the
-    # machine, it does not turn a failed upgrade into a successful one.
-    assert rc == 1
-    status = runtime.read_json(runtime.get_restart_status_path())
-    assert status["ok"] is False
-    assert "start runtime failed: service refused to start" in status["error"]
-
-    # Nothing of the failed generation is left alive across the install and the
-    # restore: the second stop is the rollback's own, and without it a process
-    # that never reached the lock is still holding the database file open when
-    # the restore rewrites it -- and is what the final start would adopt.
-    assert armed.calls == ["stop_runtime", "start_runtime", "stop_runtime", "install", "start_runtime"]
-    # The distribution the OLD release was published as, not the one this build
-    # is: a machine that predates the `vibe-remote` -> `avibe-os` rename has no
-    # `avibe-os==3.0.10` to go back to, and pinning one is an index round-trip
-    # that fails and leaves the instance dark.
-    assert "vibe-remote==3.0.10" in armed.installs[0]
-    assert armed.observed_by_the_rolled_back_version == [["before the upgrade"]]
-    assert _payload_rows(armed.db_path) == ["before the upgrade"]
-
-    # The rollback starts the install it just reinstalled, not the one this job
-    # is running out of. An upgrade spawns the job through the `vibe` on PATH,
-    # which the install has already replaced, so by now `sys.executable` names
-    # the failed generation -- and across the `vibe-remote` -> `avibe-os` rename
-    # the two are different directories, both present, both startable. `None`
-    # for the first start is the upgrade's own: it is what should run next.
-    assert armed.launchers == [None, _REPLACED_INSTALL]
-
-    rollback = status["rollback"]
-    assert rollback["target_version"] == "3.0.10"
-    assert rollback["state"] == "succeeded"
-    assert rollback["install"]["ok"] is True
-    assert rollback["database"]["restored"] is True
-    assert runtime.read_status()["service_pid"] == 222
-
-
-def test_a_service_still_holding_the_lock_is_never_rolled_back_underneath(monkeypatch, tmp_path):
-    """The same failure, the opposite answer, decided by one fact: the lock.
-
-    A restart that failed while a service is still serving has not produced the
-    state this recovery exists for, and reinstalling and restoring underneath
-    that live process is the damage rather than the repair. Nothing about the
-    failure itself distinguishes the two cases -- only what is holding the lock
-    when it is over does.
-    """
-
-    armed = _upgrade_restart_that_dies_after_migrating(monkeypatch, tmp_path, service_running=True)
-
-    rc = restart_supervisor._run_restart_job(
-        job_id="jobheld", delay_seconds=0, vibe_path="/bin/vibe", trigger="upgrade", rollback_to=_rollback_target()
-    )
-
-    assert rc == 1
-    assert armed.calls == ["stop_runtime", "start_runtime"]
-    assert armed.installs == []
-    assert _payload_rows(armed.db_path) == ["before the upgrade", "committed by the new version"]
-    status = runtime.read_json(runtime.get_restart_status_path())
-    assert status["rollback"] == {"target_version": "3.0.10", "state": "skipped", "reason": "service_running"}
-
-
-def test_a_service_that_took_the_lock_and_then_died_is_rolled_back(monkeypatch, tmp_path):
-    """The incident this path exists for, in the shape it actually has.
-
-    The lock is taken BEFORE the database is migrated -- it has to be, since the
-    migration is what it excludes. So a release that fails on its migration does
-    hold the lock, for the seconds it takes to get there and die, and a job that
-    stopped at "the pid is recorded" spends those seconds writing
-    `state: succeeded` about an instance that ends them with nothing running.
-
-    Which makes the recorded pid unusable as the finish line, in the one case
-    that matters. What ends the wait is the service saying it is up, which it
-    says after the migration.
-    """
-
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    paths.ensure_data_dirs()
-    paths.get_runtime_pid_path().write_text("111", encoding="utf-8")
-    db_path = paths.get_sqlite_state_path()
-    _seed_state_database(db_path)
-    calls: list[str] = []
-    installs: list[list[str]] = []
-    launchers: list = []
-    observed_by_the_rolled_back_version: list[list[str]] = []
-    alive = {222: True, 333: True, 444: True}
-
-    def start(start_ui=True, launcher=None):
-        calls.append("start_runtime")
-        launchers.append(launcher)
-        if calls.count("start_runtime") == 1:
-            # The new version takes its rollback point, commits, and is now in
-            # the migration that will kill it -- all of it under the lock.
-            create_sqlite_migration_backup(db_path, backups_dir=paths.get_state_backups_dir())
-            with sqlite3.connect(db_path) as conn:
-                conn.execute("insert into payload (value) values ('committed by the new version')")
-            runtime.write_status("running", "pid=222", 222, 333)
-            return restart_supervisor.StartedRuntime(222, 333, ("127.0.0.1", 5123))
-        observed_by_the_rolled_back_version.append(_payload_rows(db_path))
-        return _fake_start_runtime([], service_pid=444, ui_pid=333)
-
-    def started(pid: int) -> bool:
-        # Asking is what finds out: the migration failed, so by the time anyone
-        # looks a second time the holder is gone and the lock with it.
-        alive[pid] = False
-        return pid == 444
-
-    monkeypatch.setattr(restart_supervisor, "_stop_runtime_for_restart", lambda stop_ui=True: _fake_stop_runtime(calls))
-    monkeypatch.setattr(restart_supervisor, "_start_runtime_processes", start)
-    monkeypatch.setattr(restart_supervisor, "_wait_for_service_lock_release", lambda: True)
-    monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
-    monkeypatch.setattr(restart_supervisor.subprocess, "run", _fake_pinned_install(calls, installs))
-    # The failed generation is gone: nothing of it is still holding the database
-    # open. Stated here rather than left to the host's real process table, which
-    # a test may not read and must never depend on -- the sibling helper already
-    # isolates this, and without it ``ps -p 444`` (a pid this test invented)
-    # lands in the shared ``subprocess.run`` mock as a fake install.
-    monkeypatch.setattr(restart_supervisor, "_remaining_service_pids_after_stop", list)
-    monkeypatch.setattr(runtime, "ui_pid_file_points_to_running_ui", lambda *args, **kwargs: False)
-    monkeypatch.setattr(runtime, "pid_alive", lambda pid: alive.get(pid, False))
-    monkeypatch.setattr(runtime, "service_pid_recorded", lambda pid: True)
-    monkeypatch.setattr(runtime, "service_instance_started", started)
-    monkeypatch.setattr(runtime, "verified_service_running", lambda: False)
-    monkeypatch.setattr(runtime, "wait_for_ui_server", lambda host, port, timeout=None: True)
-
-    rc = restart_supervisor._run_restart_job(
-        job_id="jobdark", delay_seconds=0, vibe_path="/bin/vibe", trigger="upgrade", rollback_to=_rollback_target()
-    )
-
-    assert rc == 3
-    status = runtime.read_json(runtime.get_restart_status_path())
-    assert status["ok"] is False
-    assert "did not finish starting" in status["error"]
-    assert status["rollback"]["state"] == "succeeded"
-    assert "vibe-remote==3.0.10" in installs[0]
-    assert observed_by_the_rolled_back_version == [["before the upgrade"]]
-    assert _payload_rows(db_path) == ["before the upgrade"]
-
-
-def test_a_generation_that_was_already_gone_is_quiesced(monkeypatch, tmp_path):
-    """The ordinary case, and the one a stop report gets exactly backwards.
-
-    A version that died in its migration has nothing left to kill, so
-    `stop_service` reports that it stopped nothing -- the same answer it gives
-    for a process that refused to die, because the two states are
-    indistinguishable from the report and distinguishable only from the machine.
-    A rollback gated on the report therefore refuses to run on the failure it was
-    built for, which is the one where the instance is already dark.
-    """
-
-    armed = _upgrade_restart_that_dies_after_migrating(monkeypatch, tmp_path, service_running=False)
-    monkeypatch.setattr(
-        restart_supervisor,
-        "_stop_runtime_for_restart",
-        lambda stop_ui=True: _fake_stop_runtime(armed.calls, service_stopped=False, ui_stopped=False),
+        restart_supervisor.subprocess,
+        "run",
+        lambda command, **kwargs: package_commands.append(command),
     )
 
     rc = restart_supervisor._run_restart_job(
-        job_id="jobgone", delay_seconds=0, vibe_path="/bin/vibe", trigger="upgrade", rollback_to=_rollback_target()
-    )
-
-    assert rc == 1
-    status = runtime.read_json(runtime.get_restart_status_path())
-    assert status["rollback"]["quiesced"] is True
-    assert status["rollback"]["state"] == "succeeded"
-    assert _payload_rows(armed.db_path) == ["before the upgrade"]
-
-
-@pytest.mark.parametrize(
-    "survivor",
-    [
-        {"service_pids": [999]},
-        {"ui_alive": True},
-    ],
-    ids=["a-service-process-of-the-failed-generation", "a-ui-process-that-would-not-die"],
-)
-def test_a_failed_generation_that_will_not_stop_stops_the_rollback_instead(monkeypatch, tmp_path, survivor):
-    """Quiescing is a step with an outcome, not a step with a side effect.
-
-    A process that resists termination is the entire reason the stop is there, so
-    a rollback that ran it and then carried on regardless would be at its most
-    confident in the only case it is about. What follows makes that concrete: the
-    restore rewrites a database file that process holds open, and the final start
-    adopts its live recorded pid instead of launching what was just reinstalled --
-    so the rollback would report success for the version it was rolling back from,
-    over a database it had corrupted underneath it.
-
-    So the database is what this asserts on. Untouched is the whole claim; the
-    status record only has to be readable enough to send someone to look.
-    """
-
-    armed = _upgrade_restart_that_dies_after_migrating(monkeypatch, tmp_path, service_running=False)
-    # Whichever process survived, and whatever the stop said about it: what
-    # decides is the machine afterwards, so the stop is left reporting success.
-    monkeypatch.setattr(
-        restart_supervisor, "_remaining_service_pids_after_stop", lambda: list(survivor.get("service_pids", []))
-    )
-    monkeypatch.setattr(
-        runtime, "ui_pid_file_points_to_running_ui", lambda *args, **kwargs: bool(survivor.get("ui_alive"))
-    )
-
-    rc = restart_supervisor._run_restart_job(
-        job_id="jobstuck", delay_seconds=0, vibe_path="/bin/vibe", trigger="upgrade", rollback_to=_rollback_target()
-    )
-
-    assert rc == 1
-    status = runtime.read_json(runtime.get_restart_status_path())
-    assert status["rollback"]["state"] == "failed"
-    assert status["rollback"]["quiesced"] is False
-    assert "still running" in status["rollback"]["error"]
-    # Nothing was installed and nothing was restored: the machine is left exactly
-    # as the failed upgrade left it, which is recoverable by hand.
-    assert [command for command in armed.installs if any("3.0.10" in argument for argument in command)] == []
-    assert _payload_rows(armed.db_path) == ["before the upgrade", "committed by the new version"]
-
-
-def test_a_restart_with_no_version_to_go_back_to_changes_nothing(monkeypatch, tmp_path):
-    """A plain restart is already running what it would reinstall.
-
-    It has no rollback target, so the failure is left exactly as it happened for
-    whoever looks at it -- including the database, which nothing here is entitled
-    to move backwards. The absent record is the readable part: a failed restart
-    with a `rollback_to` and no `rollback` was armed and killed before it could
-    recover, which is a different incident from one that was never recoverable.
-    """
-
-    armed = _upgrade_restart_that_dies_after_migrating(monkeypatch, tmp_path, service_running=False)
-
-    rc = restart_supervisor._run_restart_job(job_id="jobplain", delay_seconds=0, vibe_path="/bin/vibe", trigger="cli")
-
-    assert rc == 1
-    assert armed.calls == ["stop_runtime", "start_runtime"]
-    assert armed.installs == []
-    assert _payload_rows(armed.db_path) == ["before the upgrade", "committed by the new version"]
-    status = runtime.read_json(runtime.get_restart_status_path())
-    assert status["rollback_to"] is None
-    assert "rollback" not in status
-
-
-def test_no_failure_branch_can_end_the_job_without_the_rollback_decision():
-    """Whether to roll back is asked once, not per failure branch.
-
-    A list of the branches that deserve a rollback is complete only until the
-    next branch is added, and the one nobody remembered is exactly the one that
-    leaves an instance dark. So the job has a single failure exit, and this
-    asserts that structurally: any new branch reaching the raw `_fail` directly
-    fails here, at the moment it is written, rather than in the incident.
-    """
-
-    tree = ast.parse(textwrap.dedent(inspect.getsource(restart_supervisor._run_restart_job)))
-    wrapper = next(
-        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "fail"
-    )
-    inside_the_wrapper = {id(node) for node in ast.walk(wrapper)}
-    calls = [
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "_fail"
-    ]
-
-    assert [node for node in calls if id(node) in inside_the_wrapper], "the wrapper is what ends a failed job"
-    assert [node for node in calls if id(node) not in inside_the_wrapper] == []
-
-
-def test_a_recoverable_restart_carries_its_rollback_target_into_the_job(monkeypatch, tmp_path):
-    """The target survives the process boundary the restart is built on.
-
-    `schedule_restart` spawns a detached job, so the install to go back to has to
-    travel as argv and be read back by the job's own parser. Asserted as a round
-    trip rather than as two independent expectations: the two sides are what can
-    drift, and a flag renamed on one of them would leave every rollback silently
-    disarmed while both halves still look right.
-
-    Asserted as equality against the whole target rather than field by field.
-    Argv is the one place the fields are apart, so it is the one place they can
-    be separated by accident -- a version arriving without its distribution pins
-    a name the old release never had, and one arriving without its install
-    reinstalls the right release and then starts the wrong one -- and a field
-    added later is carried by this test without it being edited, or fails it.
-    """
-
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    paths.ensure_data_dirs()
-    commands: list[list[str]] = []
-
-    monkeypatch.setattr(restart_supervisor, "get_restart_invocation_command", lambda vibe_path=None: ["/bin/vibe", "restart"])
-    monkeypatch.setattr(restart_supervisor, "get_restart_environment", lambda vibe_path=None: {"PATH": "/bin"})
-    monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
-    monkeypatch.setattr(restart_supervisor, "_prune_restart_logs", lambda: None)
-
-    def fake_popen(command, **kwargs):
-        commands.append(command)
-        return SimpleNamespace(pid=4242)
-
-    monkeypatch.setattr(restart_supervisor.subprocess, "Popen", fake_popen)
-
-    target = _rollback_target()
-    restart_supervisor.schedule_restart(
+        job_id="job-upgrade-failed",
         delay_seconds=0,
         vibe_path="/bin/vibe",
         trigger="upgrade",
-        rollback_to=target,
     )
-    upgrade_argv = commands[-1]
-    restart_supervisor.schedule_restart(delay_seconds=0, vibe_path="/bin/vibe", trigger="cli")
-    plain_argv = commands[-1]
-    assert [argument for argument in plain_argv if argument.startswith("--rollback")] == []
 
-    parsed: dict = {}
-    monkeypatch.setattr(restart_supervisor, "_run_restart_job", lambda **kwargs: parsed.update(kwargs) or 0)
-    assert restart_supervisor.main(upgrade_argv[2:]) == 0
-    assert parsed["rollback_to"] == target
-
-    parsed.clear()
-    assert restart_supervisor.main(plain_argv[2:]) == 0
-    assert parsed["rollback_to"] is None
-
-    # A partial set is refused rather than completed from this process. The job
-    # runs the release the rollback is undoing, so "fill in the missing install
-    # from here" is the exact wrong answer, and a silent one.
-    with pytest.raises(SystemExit):
-        restart_supervisor.main(["--job-id", "jobpartial", "--rollback-to", "3.0.10"])
+    assert rc == 3
+    assert calls == ["stop_runtime", "start_runtime"]
+    assert package_commands == []
+    status = runtime.read_json(runtime.get_restart_status_path())
+    assert status["ok"] is False
+    assert status["state"] == "failed"
+    assert status["error"] == "service pid 222 did not finish starting"
+    assert not any("rollback" in key for key in status)
 
 
-def test_recoverable_restart_carries_memory_shape_into_rollback_job(monkeypatch, tmp_path):
+def test_terminal_restart_failure_does_not_block_a_subsequent_attempt(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
-    commands: list[list[str]] = []
+    restart_supervisor._write_status(
+        {
+            "ok": False,
+            "job_id": "failed-attempt",
+            "state": "failed",
+            "trigger": "upgrade",
+            "error": "new release failed readiness",
+        }
+    )
+    spawned = []
+
     monkeypatch.setattr(restart_supervisor, "get_restart_invocation_command", lambda vibe_path=None: ["/bin/vibe", "restart"])
     monkeypatch.setattr(restart_supervisor, "get_restart_environment", lambda vibe_path=None: {"PATH": "/bin"})
     monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
@@ -1676,22 +809,18 @@ def test_recoverable_restart_carries_memory_shape_into_rollback_job(monkeypatch,
     monkeypatch.setattr(
         restart_supervisor.subprocess,
         "Popen",
-        lambda command, **kwargs: commands.append(command) or SimpleNamespace(pid=4242),
-    )
-    target = RollbackTarget(
-        version="3.0.10",
-        package="avibe-os",
-        launcher=_REPLACED_INSTALL,
-        memory_package=True,
-        memory_version="3.0.10",
+        lambda command, **kwargs: spawned.append(command) or SimpleNamespace(pid=45678),
     )
 
-    restart_supervisor.schedule_restart(vibe_path="/bin/vibe", trigger="upgrade", rollback_to=target)
-    argv = commands[-1]
-    assert "--rollback-memory-package" in argv
-    assert argv[argv.index("--rollback-memory-version") + 1] == "3.0.10"
+    admitted = restart_supervisor.schedule_restart(
+        delay_seconds=0,
+        vibe_path="/bin/vibe",
+        trigger="upgrade",
+    )
 
-    parsed: dict = {}
-    monkeypatch.setattr(restart_supervisor, "_run_restart_job", lambda **kwargs: parsed.update(kwargs) or 0)
-    assert restart_supervisor.main(argv[2:]) == 0
-    assert parsed["rollback_to"] == target
+    assert admitted["job_id"] != "failed-attempt"
+    assert spawned
+    status = runtime.read_json(runtime.get_restart_status_path())
+    assert status["job_id"] == admitted["job_id"]
+    assert status["state"] == "scheduled"
+    assert status["error"] is None

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -2400,6 +2400,37 @@ def test_config_restart_fallback_schedules_when_in_flight_finishes_after_marker(
     assert runtime.read_json(restart_supervisor._pending_restart_path()) is None
 
 
+def test_terminal_restart_failure_does_not_block_config_restart_retry(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from vibe import restart_supervisor
+    from vibe import runtime
+
+    runtime.get_restart_status_path().parent.mkdir(parents=True, exist_ok=True)
+    runtime.write_json(
+        runtime.get_restart_status_path(),
+        {
+            "ok": False,
+            "state": "failed",
+            "job_id": "failed-upgrade",
+            "supervisor_pid": 4242,
+            "error": "new release failed readiness",
+        },
+    )
+    scheduled: list[dict] = []
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 4242)
+    monkeypatch.setattr(runtime, "read_status", lambda: {"service_pid": None, "ui_pid": 22})
+    monkeypatch.setattr(
+        restart_supervisor,
+        "schedule_restart",
+        lambda **kwargs: scheduled.append(kwargs) or {"job_id": "retry"},
+    )
+
+    result = ui_server._schedule_service_restart_for_config_fallback()
+
+    assert result == {"ok": True, "restart": {"job_id": "retry"}}
+    assert scheduled == [{"delay_seconds": 0.0, "trigger": "web-ui-config", "scope": "service"}]
+
+
 def test_static_ui_assets_use_cache_headers(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
     ui_dist = tmp_path / "dist"

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import ast
 import os
 import subprocess
 import sys
@@ -13,12 +12,6 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from vibe import api, cli
-from vibe.package_shape import (
-    CapturedPackageShape,
-    DistributionProvider,
-    ReleaseFamily,
-)
-from vibe.runtime import ServiceLauncher
 from vibe.upgrade import (
     MemoryRequirementUnreadableError,
     UpgradePlan,
@@ -35,8 +28,6 @@ from vibe.upgrade import (
     get_safe_cwd,
     installed_package_name,
     pinned_package_spec,
-    RollbackTarget,
-    rollback_target,
     execute_upgrade_plan,
 )
 
@@ -62,30 +53,7 @@ def _tree_is_not_an_installed_distribution(monkeypatch):
 
     monkeypatch.setattr("vibe.upgrade._distributions_providing_this_package", lambda: [])
     monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: False)
-    # Installer-command tests describe synthetic machines. Exact package capture
-    # has its own provider-backed tests below and in MEMORY-INDEP-019; opting out
-    # here prevents the developer or CI environment from becoming test evidence.
-    monkeypatch.setattr("vibe.upgrade.rollback_target", lambda: None)
 
-
-def _captured_shape(
-    version: str,
-    *,
-    package: str,
-    launcher: ServiceLauncher,
-) -> CapturedPackageShape:
-    return CapturedPackageShape(
-        core_provider=DistributionProvider(
-            name=package,
-            version=version,
-            provider_id=f"/{package}-{version}.dist-info",
-        ),
-        launcher=launcher,
-        release_family=ReleaseFamily.PRE_SPLIT,
-        memory_providers=(),
-        transition_memory_version=None,
-        residual_memory=False,
-    )
 
 
 def test_build_upgrade_plan_uses_uv_and_preserves_tool_bin_dir(monkeypatch):
@@ -413,17 +381,7 @@ def test_the_rename_pair_still_names_the_distribution_that_describes_the_code(mo
 
     assert installed_package_name() == "vibe-remote"
 
-    # And the consequence the name is measured for: the pin this machine's next
-    # failed upgrade rolls back to names a release that exists.
-    launcher = ServiceLauncher(python="/uv/tools/vibe-remote/bin/python", main="/uv/tools/vibe-remote/service_main.py")
-    monkeypatch.setattr("vibe.runtime.current_service_launcher", lambda: launcher)
-    monkeypatch.setattr(
-        "vibe.upgrade.capture_installed_package_shape",
-        lambda **kwargs: _captured_shape("2.9.0", package="vibe-remote", launcher=launcher),
-    )
-    target = rollback_target()
-    assert target is not None and target.package == "vibe-remote"
-    assert pinned_package_spec(target.version, package_name=target.package) == "vibe-remote==2.9.0"
+
 
 
 def test_providers_that_cannot_be_told_apart_are_left_to_the_path(monkeypatch):
@@ -473,93 +431,6 @@ def test_a_spec_that_cannot_carry_a_pin_is_refused(monkeypatch):
             version="3.0.10",
         )
 
-
-def test_a_tree_with_no_published_release_has_no_rollback_target(monkeypatch):
-    # A source checkout, an editable install, and a regression build all report
-    # the same placeholder version, which names no release. Handing it on as a
-    # target buys an index round-trip that fails, and then tells whoever is
-    # looking at a dark instance that the rollback mechanism is broken, when the
-    # truth is that this install never had a release to go back to.
-    from vibe import UNKNOWN_VERSION
-
-    monkeypatch.setattr("vibe.__version__", UNKNOWN_VERSION, raising=False)
-    assert rollback_target() is None
-
-    # And a tree that does name a release answers with the distribution and the
-    # install too, in one value: all three are read here, in the process that
-    # still predates the install, and there is no way to obtain one without the
-    # others. The install matters as much as the version -- a rollback across the
-    # `vibe-remote` -> `avibe-os` rename reinstalls into a directory this process
-    # is not running out of, so a target that named only the version would be
-    # restored correctly and then started from the wrong generation.
-    launcher = ServiceLauncher(python="/uv/tools/vibe-remote/bin/python", main="/uv/tools/vibe-remote/service_main.py")
-    monkeypatch.setattr("vibe.__version__", "3.0.10", raising=False)
-    monkeypatch.setattr("vibe.runtime.current_service_launcher", lambda: launcher)
-    captured = _captured_shape("3.0.10", package="vibe-remote", launcher=launcher)
-    monkeypatch.setattr(
-        "vibe.upgrade.capture_installed_package_shape",
-        lambda **kwargs: captured,
-    )
-    assert rollback_target() == captured
-
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-#: Everything shipped to a user's machine.
-SHIPPED_SOURCE_ROOTS = ("main.py", "config", "core", "modules", "storage", "vibe")
-
-
-def test_only_the_plan_builder_can_ask_what_this_install_is():
-    """One caller, found by looking rather than by remembering.
-
-    The measurement has always been documented as something to take before the
-    install and never after, and both upgrade paths took it after anyway --
-    inside `if result.returncode == 0:`, describing an install that by then had
-    already been overwritten. A rule that lives in a docstring is enforced by
-    whoever happens to have read it.
-
-    Moving it into `UpgradePlan` removes the ordering from every caller: a plan
-    is what produces the command, so the measurement cannot happen later than the
-    install unless someone reaches past the plan. This counts over the whole
-    shipped tree so that reaching past it fails here, when it is written, rather
-    than on a machine that predates the rename months later.
-    """
-
-    callers = {}
-    for root in SHIPPED_SOURCE_ROOTS:
-        target = REPO_ROOT / root
-        for source in [target] if target.is_file() else sorted(target.rglob("*.py")):
-            tree = ast.parse(source.read_text(encoding="utf-8"))
-            calls = sum(
-                1
-                for node in ast.walk(tree)
-                if isinstance(node, ast.Call)
-                and (getattr(node.func, "id", None) or getattr(node.func, "attr", None)) == "rollback_target"
-            )
-            if calls:
-                callers[source.relative_to(REPO_ROOT).as_posix()] = calls
-
-    assert callers == {"vibe/upgrade.py": 1}
-
-
-def test_the_plan_that_installs_carries_what_it_is_replacing(monkeypatch):
-    # A forward plan describes an install that is about to stop existing, so it
-    # takes the measurement while there is still something to measure. A pinned
-    # plan IS the rollback -- the process building one is the release that failed
-    # -- so measuring there would hand the failure forward as its own recovery
-    # target, which is the shape of every way this has gone wrong so far.
-    launcher = ServiceLauncher(python="/uv/tools/vibe-remote/bin/python", main="/uv/tools/vibe-remote/service_main.py")
-    monkeypatch.setattr("vibe.__version__", "3.0.10", raising=False)
-    monkeypatch.setattr("vibe.runtime.current_service_launcher", lambda: launcher)
-    captured = _captured_shape("3.0.10", package="vibe-remote", launcher=launcher)
-    monkeypatch.setattr("vibe.upgrade.rollback_target", lambda: captured)
-
-    forward = build_upgrade_plan(python_executable="/usr/bin/python3", uv_path=None, base_env={"PATH": "/usr/bin"})
-    assert forward.rollback_to == captured
-
-    pinned = build_upgrade_plan(
-        python_executable="/usr/bin/python3", uv_path=None, base_env={"PATH": "/usr/bin"}, version="3.0.9"
-    )
-    assert pinned.rollback_to is None
 
 
 def test_build_upgrade_plan_finds_uv_outside_current_path(monkeypatch):
@@ -878,24 +749,12 @@ def test_get_restart_environment_normalizes_relative_pythonpath_entries(monkeypa
     assert env["PYTHONPATH"] == f"{source_root}{os.pathsep}{tmp_path}{os.pathsep}{tmp_path / 'src'}"
 
 
-#: A machine that predates the rename, as its own plan describes it. The upgrade
-#: paths below cannot be handed this any other way, which is the point: the
-#: measurement is a field of the plan precisely so that no caller is left with an
-#: ordering to remember, and a test that could still inject it late would be
-#: describing a seam that no longer exists.
-LEGACY_INSTALL = RollbackTarget(
-    version="3.0.10",
-    package="vibe-remote",
-    launcher=ServiceLauncher("/uv/tools/vibe-remote/bin/python", "/uv/tools/vibe-remote/service_main.py"),
-)
-
 
 def test_do_upgrade_uses_upgrade_plan_env_and_restarts(monkeypatch):
     plan = UpgradePlan(
         command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
         env={"UV_TOOL_BIN_DIR": "/custom/bin"},
         method="uv",
-        rollback_to=LEGACY_INSTALL,
     )
     calls: dict[str, Any] = {}
 
@@ -936,14 +795,43 @@ def test_do_upgrade_uses_upgrade_plan_env_and_restarts(monkeypatch):
         "vibe_path": "/custom/bin/vibe",
         "trigger": "upgrade",
         "prepare_show_runtime": True,
-        # The install this process was running, taken BEFORE it was replaced and
-        # carried here by the plan that replaced it: what the restart reinstalls
-        # if it cannot bring the new one up. Version, distribution and launcher
-        # together, because a pin needs the first two and a machine that predates
-        # the rename does not answer "avibe-os" for either.
-        "rollback_to": LEGACY_INSTALL,
     }
 
+
+def test_do_upgrade_install_failure_is_terminal_and_does_not_restart(monkeypatch):
+    plan = UpgradePlan(
+        command=["/usr/bin/python3", "-m", "pip", "install", "--upgrade", "avibe-os"],
+        env=None,
+        method="pip",
+    )
+    restart = Mock(side_effect=AssertionError("failed install scheduled a restart"))
+
+    monkeypatch.setattr(api, "configured_memory_enabled", lambda: False)
+    monkeypatch.setattr(api, "get_version_info", lambda: {"latest": "3.0.15"})
+    monkeypatch.setattr(api, "build_upgrade_plan", lambda **kwargs: plan)
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
+    monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
+    monkeypatch.setattr(api, "schedule_restart", restart)
+    monkeypatch.setattr(
+        api.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(
+            command,
+            1,
+            stdout="",
+            stderr="resolver rejected the release",
+        ),
+    )
+
+    result = api.do_upgrade(auto_restart=True)
+
+    assert result == {
+        "ok": False,
+        "message": "Upgrade failed",
+        "output": "resolver rejected the release",
+        "restarting": False,
+    }
+    restart.assert_not_called()
 
 def test_do_upgrade_blocks_mutation_when_memory_requirement_is_unreadable(
     monkeypatch,
@@ -1178,7 +1066,6 @@ def test_cmd_upgrade_uses_upgrade_plan_env(monkeypatch):
         command=["/usr/local/bin/uv", "tool", "install", "avibe-os", "--upgrade"],
         env={"UV_TOOL_BIN_DIR": "/custom/bin"},
         method="uv",
-        rollback_to=LEGACY_INSTALL,
     )
     calls: dict[str, Any] = {}
 
@@ -1223,8 +1110,6 @@ def test_cmd_upgrade_uses_upgrade_plan_env(monkeypatch):
         "vibe_path": "/custom/bin/vibe",
         "trigger": "upgrade",
         "prepare_show_runtime": True,
-        # See the do_upgrade case: the restart is handed the install to fall back to.
-        "rollback_to": LEGACY_INSTALL,
     }
 
 

--- a/tests/test_version_identity.py
+++ b/tests/test_version_identity.py
@@ -70,13 +70,6 @@ def test_packaged_install_keeps_semantic_update_behavior(monkeypatch) -> None:
     assert api.get_version_info() == {**expected, "build": {"kind": "package"}}
 
 
-def test_local_version_info_never_queries_package_index(monkeypatch) -> None:
-    monkeypatch.setattr("vibe.__version__", "3.0.12", raising=False)
-    monkeypatch.setattr(api, "get_build_identity", lambda: type("Build", (), {"as_dict": lambda self: {"kind": "package"}})())
-
-    assert api.get_local_version_info() == {"current": "3.0.12", "build": {"kind": "package"}}
-
-
 def test_configured_missing_metadata_stays_a_source_build(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("VIBE_BUILD_METADATA_PATH", str(tmp_path / "not-written-yet.json"))
     monkeypatch.setattr("vibe.__version__", "3.0.6rc5", raising=False)

--- a/vibe/__init__.py
+++ b/vibe/__init__.py
@@ -2,9 +2,8 @@
 
 #: The version a build-less tree reports: a source checkout, an editable
 #: install, or a regression environment built with a pretend version. It names no
-#: published release, so anything that has to INSTALL a specific version has to
-#: treat it as "unknown" instead of as a target -- see
-#: `vibe.upgrade.rollback_target`.
+#: published release, so update comparisons must treat it as "unknown" rather
+#: than as an index-served release.
 UNKNOWN_VERSION = "0.0.0.dev0"
 
 try:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -6108,20 +6108,6 @@ def get_version_info() -> dict:
     return result
 
 
-def get_local_version_info() -> dict:
-    """Return only the version already loaded by this process.
-
-    Upgrade recovery must be able to identify the release that is still
-    running even when the package index is unavailable. Keep this endpoint
-    separate from :func:`get_version_info`, whose update check is intentionally
-    allowed to perform network I/O for the user-facing version screen.
-    """
-
-    from vibe import __version__
-
-    return {"current": __version__, "build": get_build_identity().as_dict()}
-
-
 def do_upgrade(auto_restart: bool = True) -> dict:
     """Perform upgrade to latest version.
 
@@ -6175,7 +6161,6 @@ def do_upgrade(auto_restart: bool = True) -> dict:
                         vibe_path=current_vibe_path,
                         trigger="upgrade",
                         prepare_show_runtime=not should_skip_show_runtime_prepare(),
-                        rollback_to=plan.rollback_to,
                     )
                     restarting = True
                 except Exception as exc:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -14435,7 +14435,6 @@ def cmd_upgrade():
                         vibe_path=current_vibe_path,
                         trigger="upgrade",
                         prepare_show_runtime=not should_skip_show_runtime_prepare(),
-                        rollback_to=plan.rollback_to,
                     )
                 except Exception as exc:
                     print("\033[33mUpgrade installed, but restart scheduling failed.\033[0m")

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -582,6 +582,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--scope", default="all", choices=("all", "service"))
     parser.add_argument("--vibe-path")
     parser.add_argument("--prepare-show-runtime", action="store_true")
+    # A released scheduler can replace the package before launching this parser.
+    # Accept its retired rollback argv so the normal restart still runs, but do
+    # not carry any of these values into job state or behavior.
+    parser.add_argument("--rollback-to", help=argparse.SUPPRESS)
+    parser.add_argument("--rollback-package", help=argparse.SUPPRESS)
+    parser.add_argument("--rollback-memory-package", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--rollback-memory-version", help=argparse.SUPPRESS)
+    parser.add_argument("--rollback-python", help=argparse.SUPPRESS)
+    parser.add_argument("--rollback-main", help=argparse.SUPPRESS)
     args = parser.parse_args(argv)
     return _run_restart_job(
         job_id=args.job_id,

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
 import argparse
-import email.parser
-import json
 import logging
 import os
-import shlex
 import subprocess
 import time
-import urllib.error
-import urllib.request
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -17,60 +12,25 @@ from typing import NamedTuple
 
 from config import paths
 
-# Imported here, at the top, rather than where the rollback path uses it. This
-# process runs the version being rolled back FROM, and a pinned reinstall
-# replaces the source tree underneath it, so a first import taken after that
-# install reads the OTHER release's source into this process. Importing at module
-# load makes every later use a `sys.modules` hit that touches no file. The module
-# is pure stdlib, so paying for it on every restart costs nothing.
-from storage.backups import find_restorable_backup, next_backup_sequence, restore_sqlite_backup
 from vibe import runtime
-from vibe.build_identity import get_build_identity
 from vibe.upgrade import (
-    LEGACY_PACKAGE_NAME,
-    MEMORY_PACKAGE_NAME,
-    PACKAGE_NAME,
-    RollbackTarget,
-    _names_a_published_release,
-    build_upgrade_plan,
-    execute_upgrade_plan,
     get_restart_command,
     get_restart_environment,
     get_restart_invocation_command,
     get_safe_cwd,
-    installed_package_name,
 )
 
 
 logger = logging.getLogger(__name__)
 _RESTART_LOG_RETENTION = 10
 _SERVICE_LOCK_RELEASE_TIMEOUT_SECONDS = 30.0
-# Long enough for a package index to be slow, short enough that a hung download
-# does not leave the machine sitting with no service forever. A rollback that
-# times out is recorded as failed, which is a diagnosable state; a rollback that
-# waits without a bound is not.
-_ROLLBACK_INSTALL_TIMEOUT_SECONDS = 600.0
-# A cold UI process has an interpreter to start and an ASGI app to import before
-# it answers, so the 5s default of `wait_for_ui_server` -- sized for a UI started
-# next to an already-warm CLI -- is not the right bound here. This one is only
-# ever paid in full when the UI is genuinely not coming.
-_ROLLBACK_UI_READY_TIMEOUT_SECONDS = 60.0
 
 
 class StartedRuntime(NamedTuple):
-    """What a start actually launched, and where its UI can be checked.
-
-    The health target travels with the pids because `_start_runtime_processes` is
-    the only place that resolves it -- it loads the config to decide the bind host
-    and port -- and a caller that recomputed it would become a second answer to
-    "where is the UI", free to drift from the one the UI was actually started on.
-    It is `None` when this job does not own the UI, which is also the answer to
-    whether this job is in a position to judge the UI at all.
-    """
+    """The process IDs launched by a restart."""
 
     service_pid: int
     ui_pid: int | None
-    ui_health_target: tuple[str, int] | None
 
 
 def _live_ui_pid(candidate: object) -> int | None:
@@ -85,232 +45,6 @@ def _live_ui_pid(candidate: object) -> int | None:
     if not isinstance(candidate, int) or candidate <= 0:
         return None
     return candidate if runtime.pid_alive(candidate) else None
-
-
-def _ui_is_serving(started: StartedRuntime) -> bool:
-    """Whether the UI this job started is answering its health endpoint."""
-
-    if not started.ui_pid or started.ui_health_target is None:
-        return False
-    if not runtime.pid_alive(started.ui_pid):
-        return False
-    host, port = started.ui_health_target
-    return runtime.wait_for_ui_server(host, port, timeout=_ROLLBACK_UI_READY_TIMEOUT_SECONDS)
-
-
-def _running_ui_version() -> str | None:
-    """Read the version that is still serving while an upgrade is being staged.
-
-    Releases before the rollback protocol cannot pass a target into the detached
-    supervisor. The old service is still alive when that supervisor starts, so
-    its own version endpoint is the last authoritative answer before the old
-    install is stopped and replaced.
-    """
-
-    from core.services import settings as settings_service
-
-    config = settings_service.load_config(default_factory=settings_service.default_config)
-    host = runtime.effective_ui_bind_host(config)
-    if host in {"0.0.0.0", ""}:
-        host = "127.0.0.1"
-    elif host in {"::", "::0"}:
-        host = "::1"
-    if ":" in host and not host.startswith("["):
-        host = f"[{host}]"
-    base_url = f"http://{host}:{config.ui.setup_port}"
-    for endpoint in ("/api/version/local", "/api/version"):
-        try:
-            with urllib.request.urlopen(f"{base_url}{endpoint}", timeout=2.0) as response:
-                payload = json.loads(response.read().decode("utf-8"))
-        except (OSError, ValueError, TypeError, urllib.error.URLError):
-            continue
-        version = payload.get("current") if isinstance(payload, dict) else None
-        if isinstance(version, str) and _names_a_published_release(version):
-            return version
-    return None
-
-
-def _launcher_from_python(python: str) -> runtime.ServiceLauncher | None:
-    """Pair an interpreter with the service entry point in its install."""
-
-    python_path = Path(python)
-    package_root = python_path.parent.parent / "lib"
-    main_candidates = sorted(package_root.glob("python*/site-packages/vibe/service_main.py"))
-    if not main_candidates:
-        package_root = python_path.parent.parent / "Lib" / "site-packages"
-        main_candidates = sorted(package_root.glob("vibe/service_main.py"))
-    if not main_candidates:
-        return None
-    return runtime.ServiceLauncher(python=python, main=str(main_candidates[0]))
-
-
-def _service_launcher_from_process(pid: int | None) -> runtime.ServiceLauncher | None:
-    """Read the old launcher from a still-running service or UI command line."""
-
-    if not pid:
-        return None
-    command = runtime.get_process_command(pid)
-    if not command:
-        return None
-    try:
-        argv = [arg.strip("\"'") for arg in shlex.split(command, posix=(os.name != "nt"))]
-        if Path(argv[0]).name.lower() == "systemd-run" and "--" in argv:
-            argv = argv[argv.index("--") + 1 :]
-        if not argv or not Path(argv[0]).name.lower().startswith("python"):
-            return None
-        entry = next(
-            (arg for arg in argv[1:] if not arg.startswith("-") and Path(arg).name in {"main.py", "service_main.py"}),
-            None,
-        )
-        if entry is not None:
-            return runtime.ServiceLauncher(python=argv[0], main=entry)
-        # The UI is launched with ``python -c`` rather than service_main.py.
-        # Its interpreter still identifies the install that owns the old code.
-        return _launcher_from_python(argv[0])
-    except (IndexError, ValueError):
-        return None
-
-
-def _legacy_service_launcher(
-    vibe_path: str | None, *, service_pid: int | None = None, ui_pid: int | None = None
-) -> runtime.ServiceLauncher:
-    """Recover the launcher that existed before the package-manager replace.
-
-    The service command is authoritative: the normal ``~/.local/bin/vibe``
-    symlink may already point at the replacement by the time this process starts.
-    """
-
-    for pid in (service_pid, ui_pid):
-        process_launcher = _service_launcher_from_process(pid)
-        if process_launcher is not None:
-            return process_launcher
-
-    fallback = runtime.current_service_launcher()
-    if not vibe_path:
-        return fallback
-
-    try:
-        script = Path(vibe_path).resolve()
-        shebang = script.read_text(encoding="utf-8", errors="replace").splitlines()[0]
-        python = shebang[2:].strip().split()[0] if shebang.startswith("#!") else ""
-        python_path = Path(python)
-        if not python or not python_path.is_file():
-            return fallback
-        return _launcher_from_python(str(python_path)) or fallback
-    except (OSError, IndexError, ValueError):
-        return fallback
-
-
-def _launcher_dist_metadata(launcher: runtime.ServiceLauncher) -> list[tuple[str, str]]:
-    """Read valid distributions without letting one broken entry hide the rest."""
-
-    entries: list[tuple[str, str]] = []
-    try:
-        site_packages = Path(launcher.main).resolve().parent.parent
-        metadata_paths = sorted(site_packages.glob("*.dist-info/METADATA"))
-    except (OSError, UnicodeError, ValueError):
-        return entries
-    for metadata_path in metadata_paths:
-        try:
-            payload = email.parser.Parser().parsestr(metadata_path.read_text(encoding="utf-8"))
-            name = str(payload.get("Name") or "").strip()
-            version = str(payload.get("Version") or "").strip()
-            if name and version:
-                entries.append((name, version))
-        except (OSError, UnicodeError, ValueError):
-            continue
-    return entries
-
-
-def _launcher_core_dist_metadata(launcher: runtime.ServiceLauncher) -> list[tuple[str, str]]:
-    """Read only core distributions from the launcher's site-packages."""
-
-    return [
-        (name, version)
-        for name, version in _launcher_dist_metadata(launcher)
-        if name in {PACKAGE_NAME, LEGACY_PACKAGE_NAME}
-    ]
-
-
-def _launcher_memory_version(launcher: runtime.ServiceLauncher) -> str | None:
-    """Read optional Memory metadata without exposing it to core ownership."""
-
-    for name, version in _launcher_dist_metadata(launcher):
-        if name == MEMORY_PACKAGE_NAME:
-            return version
-    return None
-
-
-def _launcher_package_name(launcher: runtime.ServiceLauncher, *, version: str | None = None) -> str:
-    """Infer the distribution name that owns a launcher when metadata is stale."""
-
-    metadata = _launcher_core_dist_metadata(launcher)
-    if version:
-        exact = [name for name, candidate in metadata if candidate == version]
-        if exact:
-            return exact[0]
-
-    executable = launcher.python.replace("\\", "/")
-    for package in (PACKAGE_NAME, LEGACY_PACKAGE_NAME):
-        if f"/uv/tools/{package}/" in executable:
-            return package
-    names = {name for name, _version in metadata}
-    if PACKAGE_NAME in names:
-        return PACKAGE_NAME
-    if LEGACY_PACKAGE_NAME in names:
-        return LEGACY_PACKAGE_NAME
-    return installed_package_name(python_executable=launcher.python) or PACKAGE_NAME
-
-
-def _legacy_install_metadata(
-    launcher: runtime.ServiceLauncher, *, package_name: str
-) -> tuple[str, str] | None:
-    """Read the old release metadata from the launcher-owned site-packages.
-
-    A renamed distribution can leave an older ``vibe-remote`` dist-info beside
-    the current ``avibe-os`` install. The launcher identifies which side was
-    running, so unrelated metadata must never win by directory order.
-    """
-
-    try:
-        from vibe import __version__ as replacement_version
-
-        for name, version in _launcher_core_dist_metadata(launcher):
-            if (
-                name == package_name
-                and version
-                and version != replacement_version
-                and _names_a_published_release(version)
-            ):
-                return version, name
-    except (OSError, UnicodeError, ValueError):
-        return None
-    return None
-
-
-def _discover_legacy_upgrade_target(*, trigger: str, vibe_path: str | None) -> RollbackTarget | None:
-    """Build a rollback target for an upgrade initiated by an older release."""
-
-    if trigger != "upgrade":
-        return None
-    service_pid = _read_recorded_pid()
-    ui_pid = _read_recorded_ui_pid()
-    launcher = _legacy_service_launcher(vibe_path, service_pid=service_pid, ui_pid=ui_pid)
-    version = _running_ui_version()
-    package = _launcher_package_name(launcher, version=version)
-    if version is None:
-        metadata = _legacy_install_metadata(launcher, package_name=package)
-        if metadata is None:
-            return None
-        version, package = metadata
-    memory_version = _launcher_memory_version(launcher)
-    return RollbackTarget(
-        version=version,
-        package=package,
-        launcher=launcher,
-        memory_package=memory_version is not None,
-        memory_version=memory_version,
-    )
 
 
 def _now_iso() -> str:
@@ -455,17 +189,8 @@ def _runtime_ready_for_config(config) -> bool:
 
 def _start_runtime_processes(
     start_ui: bool = True,
-    launcher: runtime.ServiceLauncher | None = None,
 ) -> StartedRuntime:
-    """Start the service, and the UI when this job owns it.
-
-    `launcher` is the install to start them from, and `None` means this one --
-    which is the right answer for every restart except a rollback, where this
-    process is running the release being replaced and so is the one install that
-    must not be started. It is taken once here and handed to both spawns, because
-    the service and the UI are two halves of one generation: starting them from
-    different installs is a state neither release was ever tested in.
-    """
+    """Start the service, and the UI when this job owns it."""
 
     from vibe.memory_ui_access import generate_ui_read_secret, process_ui_read_secret
     from core.services import settings as settings_service
@@ -491,18 +216,14 @@ def _start_runtime_processes(
         wait_for_ready=False,
         initial_ready_timeout=0,
         memory_ui_secret=memory_ui_secret,
-        launcher=launcher,
     )
-    ui_health_target: tuple[str, int] | None = None
     if start_ui:
         bind_host = runtime.effective_ui_bind_host(config)
-        ui_health_target = (bind_host, config.ui.setup_port)
         ui_pid = runtime.start_ui(
             bind_host,
             config.ui.setup_port,
             wait_for_ready=False,
             memory_ui_secret=memory_ui_secret,
-            launcher=launcher,
         )
     else:
         ui_pid = preserved_ui_pid
@@ -518,7 +239,7 @@ def _start_runtime_processes(
         runtime.write_status("error", "service process exited before startup completed", service_pid, ui_pid)
         raise RuntimeError(f"Vibe service process pid={service_pid} exited before acquiring the service lock")
 
-    return StartedRuntime(service_pid, ui_pid, ui_health_target)
+    return StartedRuntime(service_pid, ui_pid)
 
 
 def _stop_ui_for_restart() -> tuple[bool, dict[str, float | bool], float, int | None]:
@@ -549,244 +270,6 @@ def _stop_runtime_for_restart(stop_ui: bool = True) -> tuple[bool, dict[str, flo
     return ui_stopped, ui_timings, stop_ui_seconds, ui_pid, service_stopped, stop_service_seconds
 
 
-def _failed_generation_still_running(*, include_ui: bool) -> bool:
-    """Whether anything the failed generation left behind is still alive.
-
-    Measured -- from the lock, the pid file and the process table -- and never
-    read off whether the stop helpers reported killing something. That report
-    answers a different question and answers it backwards on the ordinary case: a
-    version that died in its migration leaves nothing to kill, so `stop_service`
-    says it stopped nothing, exactly as it does for a process that refused to
-    die. The restart path above already knew this and asks
-    `_remaining_service_pids_after_stop` rather than believe the report; asking
-    it here too is what keeps one fact from having two answers.
-    """
-
-    if _remaining_service_pids_after_stop():
-        return True
-    return bool(include_ui and runtime.ui_pid_file_points_to_running_ui())
-
-
-def _restore_database_for_rollback(backup_watermark: int | None, write) -> dict:
-    """Put back the database the version being rolled back from migrated, if it did.
-
-    Whether a migration happened is decided from a number this job read out of
-    the backup window itself before the new version was allowed to start. Any
-    rollback point recorded at or above it was written during that window, so it
-    was written by the version now being rolled back from -- measured by our own
-    code, before and after, with nothing in between that the failing version got
-    to report about itself.
-
-    Every cheaper test compares labels and every one of them is wrong on a real
-    case: the revision stamp and the schema both stay put when a migration
-    commits rows and then fails, and the wall clock reverses the order of two
-    attempts if it is corrected backwards between them. `storage.backups` refuses
-    to answer from those for the same reason.
-
-    No watermark means the job never reached the point of starting the new
-    version, so no migration of its doing can exist and there is nothing to put
-    back. That is a normal outcome, not a degraded one.
-    """
-
-    if backup_watermark is None:
-        return {"restored": False, "reason": "no_migration_window"}
-
-    backups_dir = paths.get_state_backups_dir()
-    rollback_point = find_restorable_backup(backups_dir, written_at_or_after=backup_watermark)
-    if rollback_point is None:
-        write(f"no rollback point was written at or after backup sequence {backup_watermark}; database left as it is")
-        return {"restored": False, "reason": "no_rollback_point"}
-
-    db_path = paths.get_sqlite_state_path()
-    write(f"restoring the database from {rollback_point}")
-    replaced = restore_sqlite_backup(rollback_point, db_path)
-    write(f"database restored; the one it replaced is at {replaced}" if replaced else "database restored")
-    return {
-        "restored": True,
-        "restored_from": str(rollback_point),
-        "replaced_database": str(replaced) if replaced else None,
-    }
-
-
-def _roll_back_failed_upgrade(
-    *,
-    rollback_to: RollbackTarget,
-    vibe_path: str | None,
-    start_ui: bool,
-    backup_watermark: int | None,
-    write,
-    record,
-) -> dict:
-    """Put the machine back on the version it was upgrading from.
-
-    Reached only when a restart has failed AND nothing holds the service lock.
-    That second half is the whole condition, and it is deliberately not a list of
-    the failure branches that ought to qualify: such a list is complete only
-    until the next branch is added, and the branch nobody remembered is exactly
-    the one that leaves an instance dark. "No service is running" is the property
-    the upgrade must not be able to produce, so it is what gets asked -- and it
-    answers correctly for free on the failures that changed nothing, like a stop
-    that did not stop, where the old service is still serving and rolling back
-    underneath it would be the damage.
-
-    Nothing of the failed generation is left running first. "No service is
-    running" is a statement about the lock, and a process can be alive without it
-    -- one that died before reaching it, or one still on its way there. Left
-    alone that process is not merely litter: `start_service` adopts a live
-    recorded pid instead of launching what was just reinstalled, so the rollback
-    would report success while the failed version is what is running, and the
-    restore would rewrite the database file under a process holding it open.
-
-    Install, then restore, then start. The install is the step that needs a
-    package index and so the step most likely to fail, and it is the only one
-    with no effect on the data: failing there leaves the database exactly as the
-    upgrade left it, and a rollback that changed nothing is a far better thing to
-    find than one that half-changed the schema. Restoring before starting is what
-    makes the started version able to read what it finds.
-
-    Each step is recorded before the next begins, because this process can be
-    killed mid-rollback and what it has already done to the database has to be
-    readable afterwards from the status record rather than inferred from the
-    disk.
-
-    Start comes from `rollback_to.launcher`, never from this process. This
-    process is the release the rollback is undoing: an upgrade spawns the restart
-    job through the `vibe` on PATH, which the install has already replaced, so by
-    the time this runs `sys.executable` names the failed generation. Reading it
-    here was how a rollback across the `vibe-remote` -> `avibe-os` rename
-    reinstalled the right release into the right directory, started the wrong one
-    out of the other directory, and recorded success.
-    """
-
-    version = rollback_to.version
-    rollback: dict = {"target_version": version, "state": "running", "started_at": _now_iso()}
-    record(rollback)
-    write(f"rolling back to {version}: no service is running after the failed restart")
-
-    # `start_ui` is also the answer to whether the UI is this job's to manage: a
-    # service-only restart left the running UI alone on purpose, and quiescing
-    # must not take it down when starting will not bring it back.
-    #
-    # The outcome is then measured rather than taken from what the stop helpers
-    # report, because a process that resists termination is the entire reason
-    # this step exists and "did the stop kill something" is not that question.
-    _stop_runtime_for_restart(stop_ui=start_ui)
-    quiesced = not _failed_generation_still_running(include_ui=start_ui)
-    rollback["quiesced"] = quiesced
-    record(rollback)
-    if not quiesced:
-        # Nothing further is safe. The restore rewrites a database file this
-        # process holds open, and the final start adopts its pid instead of
-        # launching what was reinstalled -- so a rollback that continued here
-        # would report success for the version it was rolling back from.
-        rollback.update(
-            state="failed",
-            error=f"the failed generation is still running; not rolling back to {version}",
-        )
-        record(rollback)
-        write(f"cannot roll back to {version}: the failed generation did not stop")
-        return rollback
-
-    try:
-        plan = build_upgrade_plan(
-            python_executable=rollback_to.launcher.python,
-            vibe_path=vibe_path,
-            version=version,
-            package_name=rollback_to.package,
-            memory_package=rollback_to.memory_package,
-            memory_version=rollback_to.memory_version,
-        )
-    except Exception as exc:
-        rollback.update(state="failed", error=f"cannot build a pinned install for {version}: {exc}")
-        record(rollback)
-        return rollback
-
-    rollback["install"] = {"method": plan.method, "ok": None}
-    record(rollback)
-    try:
-        result = execute_upgrade_plan(
-            plan,
-            run=subprocess.run,
-            capture_output=True,
-            text=True,
-            cwd=get_safe_cwd(),
-            timeout=_ROLLBACK_INSTALL_TIMEOUT_SECONDS,
-        )
-    except Exception as exc:
-        rollback["install"] = {"method": plan.method, "ok": False, "error": str(exc)}
-        rollback.update(state="failed", error=f"installing {version} failed: {exc}")
-        record(rollback)
-        return rollback
-    if result.returncode != 0:
-        # The installer's own stderr, trimmed: it is the only account of why the
-        # rollback could not proceed, and the full text can be megabytes of
-        # resolver output.
-        detail = (result.stderr or result.stdout or "").strip()[-2000:]
-        rollback["install"] = {"method": plan.method, "ok": False, "error": detail or f"exit code {result.returncode}"}
-        rollback.update(state="failed", error=f"installing {version} failed with exit code {result.returncode}")
-        record(rollback)
-        write(f"pinned install of {version} failed: {detail}")
-        return rollback
-    rollback["install"] = {"method": plan.method, "ok": True}
-    record(rollback)
-    write(f"installed {version} using {plan.method}")
-
-    try:
-        rollback["database"] = _restore_database_for_rollback(backup_watermark, write)
-    except Exception as exc:
-        rollback["database"] = {"restored": False, "error": str(exc)}
-        rollback.update(state="failed", error=f"restoring the database failed: {exc}")
-        record(rollback)
-        return rollback
-    record(rollback)
-
-    try:
-        started = _start_runtime_processes(start_ui=start_ui, launcher=rollback_to.launcher)
-    except Exception as exc:
-        rollback.update(state="failed", error=f"starting {version} failed: {exc}")
-        record(rollback)
-        return rollback
-    ready_pid = runtime.wait_for_service_ready(started.service_pid, timeout=runtime.SERVICE_SLOW_START_TIMEOUT_SECONDS)
-    if ready_pid is None:
-        rollback.update(
-            state="failed",
-            service_pid=started.service_pid,
-            error=f"{version} started but service pid {started.service_pid} did not finish starting",
-        )
-        record(rollback)
-        return rollback
-
-    # The UI is checked too, and only here. It is started with
-    # `wait_for_ready=False` so a slow asset load cannot stall the service's own
-    # readiness, but not waiting for it is not the same as not checking it: this
-    # rollback is unattended and is the last line of defence, so "the machine is
-    # back" has to mean every process this job took down came back. An ordinary
-    # `vibe restart` deliberately does not gate on this -- a human is watching it,
-    # and failing a restart on a slow UI would be a worse answer than reporting
-    # it (see the PR's known-by-design ledger).
-    ui_serving: bool | None = None
-    if start_ui:
-        ui_serving = _ui_is_serving(started)
-        rollback["ui"] = {"pid": started.ui_pid, "serving": ui_serving}
-    runtime.write_status("running", f"pid={ready_pid}", ready_pid, _live_ui_pid(started.ui_pid))
-    if ui_serving is False:
-        rollback.update(
-            state="failed",
-            service_pid=ready_pid,
-            error=(
-                f"rolled back to {version} and the service is running as pid {ready_pid}, "
-                f"but the Web UI this rollback restarted never started serving"
-            ),
-        )
-        record(rollback)
-        write(f"rolled back to {version} but the Web UI did not come back; service pid={ready_pid}")
-        return rollback
-    rollback.update(state="succeeded", service_pid=ready_pid, error=None)
-    record(rollback)
-    write(f"rolled back to {version}; service pid={ready_pid}")
-    return rollback
-
-
 def _wait_for_service_lock_release(timeout: float = _SERVICE_LOCK_RELEASE_TIMEOUT_SECONDS) -> bool:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -806,7 +289,6 @@ def _run_restart_job(
     trigger: str,
     scope: str = "all",
     prepare_show_runtime: bool = False,
-    rollback_to: RollbackTarget | None = None,
 ) -> int:
     # "service": restart only the service process, leaving the Web UI process
     # running (a config change shouldn't tear down the open Web UI). "all"
@@ -818,20 +300,6 @@ def _run_restart_job(
     log_path = _restart_log_path(job_id)
     safe_cwd = get_safe_cwd()
     _prune_restart_logs()
-
-    rollback_target_source = "explicit" if rollback_to else None
-    rollback_discovery_error: str | None = None
-    legacy_target_required = trigger == "upgrade" and get_build_identity().kind == "package"
-    if rollback_to is None and trigger == "upgrade":
-        try:
-            rollback_to = _discover_legacy_upgrade_target(trigger=trigger, vibe_path=vibe_path)
-            if rollback_to is not None:
-                rollback_target_source = "running_service"
-        except Exception as exc:
-            # Older releases do not know how to carry a target. Discovery is a
-            # compatibility aid; if it cannot identify one, the job fails closed
-            # before stopping the old runtime rather than creating a dark one.
-            rollback_discovery_error = str(exc)
 
     with log_path.open("a", encoding="utf-8") as log:
         def write(message: str) -> None:
@@ -850,46 +318,9 @@ def _run_restart_job(
         def mark_duration(name: str, started_at: float) -> float:
             return record_duration(name, _rounded_seconds(time.monotonic() - started_at))
 
-        # The backup sequence read just before the new version was allowed to
-        # start, which is what tells a rollback whether that version migrated the
-        # database. None until then, and None is the right answer for a failure
-        # that never got that far: nothing it could have migrated exists.
-        backup_watermark: int | None = None
-
-        def record_rollback(rollback: dict) -> None:
-            payload["rollback"] = dict(rollback)
-            _write_status(payload)
-
         def fail(error: str, return_code: int, *, started_at: float | None = None) -> int:
-            """End this job as failed, rolling back first when nothing is running.
+            """Record a terminal restart failure for operator-visible retry."""
 
-            Every failure in this job goes through here rather than each branch
-            deciding whether it is the kind that warrants a rollback. Which
-            branches those are is not knowable as a list -- the next branch added
-            would not be on it -- so the decision is made once, from the state the
-            upgrade must never be able to produce: no service holding the lock.
-            """
-
-            if rollback_to and not runtime.verified_service_running():
-                try:
-                    _roll_back_failed_upgrade(
-                        rollback_to=rollback_to,
-                        vibe_path=vibe_path,
-                        start_ui=restart_ui,
-                        backup_watermark=backup_watermark,
-                        write=write,
-                        record=record_rollback,
-                    )
-                except Exception as exc:
-                    # A rollback that raises must not swallow the failure that
-                    # caused it: the original error is what the operator needs,
-                    # and the rollback's own is recorded beside it.
-                    record_rollback({"target_version": rollback_to.version, "state": "failed", "error": str(exc)})
-                    write(f"rollback to {rollback_to.version} raised: {exc}")
-            elif rollback_to:
-                record_rollback(
-                    {"target_version": rollback_to.version, "state": "skipped", "reason": "service_running"}
-                )
             return _fail(payload, error, log, return_code, started_at=started_at)
 
         old_pid = _read_recorded_pid()
@@ -907,19 +338,6 @@ def _run_restart_job(
             "trigger": trigger,
             "delay_seconds": delay_seconds,
             "scope": scope,
-            # Recorded whether or not a rollback ends up happening, so a failed
-            # restart with no `rollback` record is readable: armed and killed
-            # before it could recover, versus never recoverable at all. All three
-            # fields of the target, because a record that named the version and
-            # the distribution but not the install would be silent about the one
-            # of the three that has actually been wrong in production.
-            "rollback_to": rollback_to.version if rollback_to else None,
-            "rollback_package": rollback_to.package if rollback_to else None,
-            "rollback_launcher": rollback_to.launcher._asdict() if rollback_to else None,
-            "rollback_memory_package": rollback_to.memory_package if rollback_to else False,
-            "rollback_memory_version": rollback_to.memory_version if rollback_to else None,
-            "rollback_target_source": rollback_target_source,
-            "rollback_discovery_error": rollback_discovery_error,
             "old_pid": old_pid,
             "new_pid": None,
             "log_path": str(log_path),
@@ -939,13 +357,6 @@ def _run_restart_job(
             _write_status(payload)
             write("restart job started after delay")
             restart_started_at = time.monotonic()
-
-        if legacy_target_required and rollback_to is None:
-            return fail(
-                "legacy upgrade rollback target unavailable; existing runtime was left running",
-                2,
-                started_at=restart_started_at,
-            )
 
         write("stopping UI and service" if restart_ui else "stopping service (Web UI kept running)")
         stop_runtime_started_at = time.monotonic()
@@ -975,15 +386,6 @@ def _run_restart_job(
             mark_duration("wait_service_lock_release_seconds", wait_lock_release_started_at)
             return fail("service lock did not release after stopping runtime", 2, started_at=restart_started_at)
         mark_duration("wait_service_lock_release_seconds", wait_lock_release_started_at)
-
-        if rollback_to:
-            # Read here and nowhere else: the service is stopped, its lock is
-            # released, and the new version has not run yet, so this is the last
-            # instant at which the window still holds only what earlier versions
-            # put there. Every backup numbered at or above it afterwards was
-            # written by the version about to start.
-            backup_watermark = next_backup_sequence(paths.get_state_backups_dir())
-            write(f"pre-start backup sequence is {backup_watermark}; rollback target is {rollback_to.version}")
 
         write("starting service")
         start_runtime_started_at = time.monotonic()
@@ -1091,26 +493,8 @@ def schedule_restart(
     scope: str = "all",
     prepare_show_runtime: bool = False,
     memory_ui_secret: str | None = None,
-    rollback_to: RollbackTarget | None = None,
 ) -> dict:
-    """Spawn the detached restart job.
-
-    `rollback_to` is the install currently on the machine, and passing it is what
-    makes this restart recoverable: if the restart fails and leaves nothing
-    holding the service lock, the job reinstalls exactly that release, puts back
-    the database if the new one migrated it, and starts the service again. Only
-    an upgrade has an answer for it -- a plain restart is already running the
-    version it would roll back to, so there is nothing to reinstall and the
-    failure is the operator's to look at.
-
-    It arrives as one value from `rollback_target()` rather than as a version, a
-    distribution name and an install, because a caller that can pass one without
-    the others eventually does, and what it produces then is a pin naming a
-    release that was never published, or a reinstall of the right release
-    followed by a start of the wrong one. The argv below is the only place the
-    three are apart, and only because a command line has no other shape; `main()`
-    is the only place they are put back together.
-    """
+    """Spawn the detached restart job."""
     from vibe.memory_ui_access import process_ui_read_secret
     from storage.migrations import guard_source_checkout_default_state_bootstrap
 
@@ -1129,28 +513,6 @@ def schedule_restart(
         command.extend(["--vibe-path", vibe_path])
     if prepare_show_runtime:
         command.append("--prepare-show-runtime")
-    if rollback_to:
-        command.extend(
-            [
-                "--rollback-to",
-                rollback_to.version,
-                # Not optional the way the package name is. A missing package
-                # name still leaves `build_upgrade_plan` a defensible default,
-                # while a missing launcher leaves the job with only its own --
-                # which, in the case this exists for, is the release being
-                # undone.
-                "--rollback-python",
-                rollback_to.launcher.python,
-                "--rollback-main",
-                rollback_to.launcher.main,
-            ]
-        )
-        if rollback_to.package:
-            command.extend(["--rollback-package", rollback_to.package])
-        if rollback_to.memory_package:
-            command.append("--rollback-memory-package")
-            if rollback_to.memory_version:
-                command.extend(["--rollback-memory-version", rollback_to.memory_version])
     env = get_restart_environment(vibe_path=vibe_path)
     log_path = _restart_log_path(job_id)
     log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1220,29 +582,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--scope", default="all", choices=("all", "service"))
     parser.add_argument("--vibe-path")
     parser.add_argument("--prepare-show-runtime", action="store_true")
-    parser.add_argument("--rollback-to")
-    parser.add_argument("--rollback-package")
-    parser.add_argument("--rollback-memory-package", action="store_true")
-    parser.add_argument("--rollback-memory-version")
-    parser.add_argument("--rollback-python")
-    parser.add_argument("--rollback-main")
     args = parser.parse_args(argv)
-    # The one place a rollback target is apart, and so the one place it is put
-    # back together. Reassembling here rather than passing four values inward
-    # means nothing downstream can hold a version without the install it names --
-    # and an incomplete `--rollback-*` set is refused outright rather than
-    # quietly completed from this process, which is the failed release.
-    rollback_to = None
-    if args.rollback_to:
-        if not args.rollback_python or not args.rollback_main:
-            parser.error("--rollback-to requires --rollback-python and --rollback-main")
-        rollback_to = RollbackTarget(
-            version=args.rollback_to,
-            package=args.rollback_package,
-            launcher=runtime.ServiceLauncher(python=args.rollback_python, main=args.rollback_main),
-            memory_package=args.rollback_memory_package,
-            memory_version=args.rollback_memory_version,
-        )
     return _run_restart_job(
         job_id=args.job_id,
         delay_seconds=max(0.0, args.delay_seconds),
@@ -1250,7 +590,6 @@ def main(argv: list[str] | None = None) -> int:
         trigger=args.trigger,
         scope=args.scope,
         prepare_show_runtime=args.prepare_show_runtime,
-        rollback_to=rollback_to,
     )
 
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6500,13 +6500,6 @@ def version():
     return jsonify(api.get_version_info())
 
 
-@app.route("/api/version/local")
-def local_version():
-    from vibe import api
-
-    return jsonify(api.get_local_version_info())
-
-
 # =============================================================================
 # POST Endpoints
 # =============================================================================

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -12,7 +12,7 @@ import tempfile
 import urllib.parse
 import urllib.request
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
@@ -25,22 +25,11 @@ from packaging.utils import (
 )
 from packaging.version import InvalidVersion, Version
 
-from vibe import runtime as runtime_mod
 from vibe.package_shape import (
     CORE_PACKAGE_NAME,
     LEGACY_CORE_PACKAGE_NAME,
     MEMORY_PACKAGE_NAME as SHAPE_MEMORY_PACKAGE_NAME,
     MEMORY_SPLIT_MIN_VERSION,
-    CapturedPackageShape,
-    DistributionProvider,
-    DuplicateDistributionProviderError,
-    ReleaseFamily,
-    ResolvedRollbackPlan,
-    RollbackResolutionError,
-    capture_installed_package_shape,
-    capture_package_shape,
-    inspect_installed_distribution_providers,
-    resolve_rollback_plan,
 )
 
 
@@ -97,28 +86,11 @@ class MemoryRequirementUnreadableError(ValueError):
 
 @dataclass(frozen=True)
 class UpgradePlan:
-    """A command that installs a version of avibe, and what it will replace.
-
-    `rollback_to` travels with the command because of WHEN it has to be taken,
-    not because the two are related ideas. It describes the install this command
-    is about to overwrite, and running the command is what destroys the evidence
-    it is read from -- so the only safe moment to take it is before there is a
-    command to run.
-
-    Left as a function the caller was told to call early, both call sites called
-    it late: after `subprocess.run(plan.command)` had already installed
-    `avibe-os` over a `vibe-remote` machine, so the question "what was this
-    install published as" had two answers and returned neither, and the rollback
-    pinned `avibe-os==2.x`, a release that was never published under that name.
-    Writing the ordering rule into a docstring is what failed; a field cannot be
-    called late, because there is no plan without the measurement and no install
-    without the plan.
-    """
+    """A validated package-install command and its execution metadata."""
 
     command: list[str]
     env: dict[str, str] | None
     method: str
-    rollback_to: CapturedPackageShape | RollbackTarget | None = None
     preflight_command: list[str] | None = None
     preflight_fallback_command: list[str] | None = None
     cleanup_command: list[str] | None = None
@@ -135,7 +107,7 @@ def execute_upgrade_plan(
 
     The caller owns package mutation sequencing. This helper deliberately does
     not acquire a lifecycle lock: callers can run the plan synchronously while
-    the existing restart supervisor owns any later activation or rollback.
+    the existing restart supervisor owns any later activation.
     """
 
     preflight = preflight_upgrade_plan(plan, run=run, **run_kwargs)
@@ -807,57 +779,6 @@ def get_current_vibe_bin_dir(vibe_path: str | None = None) -> str | None:
     return get_launcher_bin_dir(current_vibe)
 
 
-@dataclass(frozen=True)
-class RollbackTarget:
-    """The install being replaced, described completely enough to restore it.
-
-    Every field travels with the others because they are one measurement, and
-    splitting them is exactly how this went wrong, repeatedly and in the same
-    shape each time: the version was read in the process that predates the
-    install and the distribution in the one that follows it, so a `vibe-remote`
-    machine pinned `avibe-os==2.9.4`, a release that never existed. Then the same
-    seam reappeared one step later -- the right distribution reinstalled, and the
-    service started from whatever interpreter the restarting process happened to
-    be running, which after a rename is the tool that replaced this one. It put
-    the failed release back up and reported the rollback a success.
-
-    So the rule is that nothing about the replaced install is looked up again
-    later. Anything a rollback needs to know about it is measured here, once, in
-    the only process that can still see it, and carried. There is no constructor
-    that reads one field. The one compatibility exception is argv emitted by a
-    released scheduler before it carried an exact Memory version: that form is
-    normalized to a falsey, rollback-unavailable target so restart still runs.
-    """
-
-    version: str
-    package: str | None
-    launcher: runtime_mod.ServiceLauncher
-    memory_package: bool = False
-    memory_version: str | None = None
-    _rollback_available: bool = field(init=False, repr=False)
-
-    def __post_init__(self) -> None:
-        rollback_available = self.memory_package == (self.memory_version is not None)
-        normalized_memory_version = self.memory_version
-        if rollback_available and normalized_memory_version is not None:
-            try:
-                normalized_memory_version = str(Version(normalized_memory_version))
-            except InvalidVersion:
-                rollback_available = False
-
-        # Released schedulers could emit Memory presence without its version.
-        # Keep their restart job runnable, but make the incomplete target falsey
-        # so no rollback path can consume or persist it as restorable evidence.
-        if not rollback_available:
-            object.__setattr__(self, "memory_package", False)
-            normalized_memory_version = None
-        object.__setattr__(self, "memory_version", normalized_memory_version)
-        object.__setattr__(self, "_rollback_available", rollback_available)
-
-    def __bool__(self) -> bool:
-        return self._rollback_available
-
-
 def _names_a_published_release(version: str) -> bool:
     """Whether an index could serve `version`, as opposed to it naming this tree.
 
@@ -879,45 +800,6 @@ def _names_a_published_release(version: str) -> bool:
     if match is None:
         return False
     return not (match.group("dev") or match.group("local"))
-
-
-def rollback_target() -> CapturedPackageShape | None:
-    """The install a failed restart of THIS process could be put back on.
-
-    Everything here is measured from the running process, and that is the whole
-    point rather than an implementation detail: this describes the install the
-    upgrade is about to replace, and once it has been replaced there is nothing
-    left on the machine to measure. Calling this from the detached restart job
-    would answer for the install that did the replacing, which is not a rollback.
-
-    Which is why the only caller is :func:`build_upgrade_plan`, and why the
-    answer reaches everyone else as `UpgradePlan.rollback_to`. As a function
-    anyone could reach, it was reached at the wrong time -- both upgrade paths
-    called it after the install they were describing had already been overwritten.
-
-    So: the version from this process's already-bound `__version__`, which the
-    install on disk cannot change underneath it; the distribution from this
-    install's own metadata; and the launcher that started this process, because
-    reinstalling a distribution does not tell anyone how to run it and a rollback
-    that crosses the `vibe-remote` -> `avibe-os` rename lands in a different tool
-    directory than the one this process is running out of.
-
-    `None` when the running tree reports no release an index could serve -- a
-    source checkout, an editable install, a regression build. Handing that string
-    on as a target would spend the one recovery attempt on a round-trip that
-    fails, and then report a broken rollback mechanism to whoever is looking at a
-    dark instance, when the truth is that this install never had a release to go
-    back to.
-    """
-
-    from vibe import __version__
-
-    if not _names_a_published_release(__version__):
-        return None
-    return capture_installed_package_shape(
-        core_version=__version__,
-        launcher=runtime_mod.current_service_launcher(),
-    )
 
 
 def _with_memory_extra(package_spec: str) -> str:
@@ -1063,11 +945,6 @@ def build_upgrade_plan(
     """
 
     executable = python_executable or sys.executable
-    # Taken here, before the command below exists, because that command is what
-    # makes it unanswerable. A pinned plan is itself a rollback and has none of
-    # its own: the process building one is the release that failed, so measuring
-    # there would carry the failure forward as its own recovery target.
-    rollback_to = None if version else rollback_target()
     # A caller targeting another interpreter (for example a test-owned venv)
     # can provide an explicit package-shape measurement.  Only infer from this
     # process when the caller did not provide one; otherwise ambient metadata
@@ -1122,7 +999,6 @@ def build_upgrade_plan(
             command=command,
             env=env,
             method="uv",
-            rollback_to=rollback_to,
             preflight_command=preflight_command,
         )
 
@@ -1199,7 +1075,6 @@ def build_upgrade_plan(
         command=command,
         env=dict(base_env or os.environ),
         method="pip",
-        rollback_to=rollback_to,
         preflight_command=preflight_command,
         preflight_fallback_command=preflight_fallback_command,
         cleanup_command=cleanup_command,


### PR DESCRIPTION
## Summary

- remove automatic prior-package capture, transport, and reinstall from Avibe/Memory upgrade restarts
- keep install and post-install restart failures as structured terminal failures that an operator can inspect and retry
- remove rollback-only legacy version discovery and restart health state while preserving the successful upgrade/restart path
- accept and ignore every retired `--rollback-*` supervisor argv shape for cross-release parser compatibility, without reconstructing rollback state or behavior
- retain `package_lifecycle_reservation.py`, the package-shape codec/DTO, and Gate5 release verification for the later cleanup steps

## Scenario coverage

- `MEMORY-INDEP-019`: update the full-tree caller inventory to prove the retained package-shape resolver has no live upgrade-path consumer

## Evidence

- Initial unit/API: `233 passed` across `tests/test_upgrade_flow.py`, `tests/test_restart_supervisor.py`, `tests/test_version_identity.py`, and `tests/test_ui_server_fastapi.py`
- Compatibility correction: `166 passed` across `tests/test_restart_supervisor.py`, `tests/test_package_shape_record_codec.py`, and `tests/test_upgrade_flow.py`; the parser/dispatch contract covers every released rollback argv shape and proves normal-only dispatch
- CLI contract: `42 passed` from the upgrade/restart/supervisor/version subset of `tests/test_vibe_cli.py`
- Scenario: `27 passed` in `tests/scenarios/memory_independence/test_memory_rollback_types.py`
- Broader upgrade dependencies: `187 passed` across `tests/test_dev_state_migration_guard.py`, `tests/test_update_checker_platforms.py`, and `tests/test_local_deps.py`
- Lint: Ruff passed for every changed Python file; `git diff --check` and byte-compilation passed
- Exact-head CI: GitHub `lint` run `33223774493` passed all jobs at `199c7b4f53ef651bde834974c4fe2dd3f7ef66c8`, including Ruff, six unit shards, aggregate unit tests, package build, packaged install/upgrade regression, Memory contract, migration guard, npm wrapper, and Windows smoke
- Review: Codex reported no major issues for reviewed commit `199c7b4f53`; all review threads are resolved

## Residual checks

- No local Avibe restart, Incus mutation, UI build, or release action was performed, as required by this lane.
- Packaged smoke execution was deferred locally because this isolated worktree intentionally lacks generated `vibe/show_runtime_manifest.json`; the exact-head CI packaged install/upgrade regression passed in its prepared artifact environment.
