### PR TITLE
fix(show): gate Markdown rendering on render_markdown_ssr

### DIFF
--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -126,7 +126,8 @@ SHOW_RUNTIME_CONTEXT_HEADER = "X-Avibe-Show-Context"
 SHOW_RUNTIME_BASE_HEADER = "x-vibe-show-base"
 SHOW_RUNTIME_TARGET_HEADER = "x-vibe-show-target"
 SHOW_RUNTIME_CONTEXT_KEY_FEATURE = "show-context-key-v1"
-SHOW_RUNTIME_RENDER_MARKDOWN_CAPABILITY = "render_markdown"
+SHOW_RUNTIME_RENDER_MARKDOWN_CAPABILITY = "render_markdown_ssr"
+# Phase 2.1 measured ~2 s cold against a 10 s Runtime module-load budget; this margin has no browser-install allowance.
 SHOW_RUNTIME_REQUEST_TIMEOUT_SECONDS = 30.0
 _CAPABILITY_RETRY_BASE_SECONDS = 0.25
 _CAPABILITY_RETRY_MAX_SECONDS = 5.0
@@ -1391,12 +1392,10 @@ class ShowRuntimeManager:
 
         protocol = payload.get("protocol", _MISSING)
         capability = payload.get(SHOW_RUNTIME_RENDER_MARKDOWN_CAPABILITY, _MISSING)
-        if protocol is not _MISSING and (isinstance(protocol, bool) or not isinstance(protocol, int)):
-            return None
-        if capability is not _MISSING and not isinstance(capability, bool):
-            return None
-        return bool(
-            protocol == SHOW_RUNTIME_PROTOCOL_VERSION
+        return (
+            isinstance(protocol, int)
+            and not isinstance(protocol, bool)
+            and protocol == SHOW_RUNTIME_PROTOCOL_VERSION
             and capability is True
         )
 

--- a/tests/test_show_runtime_protocol.py
+++ b/tests/test_show_runtime_protocol.py
@@ -99,13 +99,42 @@ def test_show_live_015_transport_failure_is_transient(monkeypatch, tmp_path):
         (httpx.Response(404), False),
         (httpx.Response(200, json={"protocol": 1}), False),
         (httpx.Response(200, json={"protocol": 1, "render_markdown": False}), False),
-        (httpx.Response(200, json={"protocol": 1, "render_markdown": True}), True),
-        (httpx.Response(200, json={"protocol": 2, "render_markdown": True}), False),
+        (httpx.Response(200, json={"protocol": 1, "render_markdown": True}), False),
+        (
+            httpx.Response(
+                200,
+                json={"protocol": 1, "render_markdown": True, "render_markdown_ssr": False},
+            ),
+            False,
+        ),
+        (
+            httpx.Response(
+                200,
+                json={"protocol": 1, "render_markdown": True, "render_markdown_ssr": "true"},
+            ),
+            False,
+        ),
+        (
+            httpx.Response(
+                200,
+                json={"protocol": 1, "render_markdown": True, "render_markdown_ssr": True},
+            ),
+            True,
+        ),
+        (httpx.Response(200, json={"protocol": 1, "render_markdown_ssr": True}), True),
+        (
+            httpx.Response(
+                200,
+                json={"protocol": 2, "render_markdown": True, "render_markdown_ssr": True},
+            ),
+            False,
+        ),
+        (httpx.Response(200, json={"protocol": True, "render_markdown_ssr": True}), False),
         (httpx.Response(503), None),
         (httpx.Response(200, content=b'{"protocol":1'), None),
     ],
 )
-def test_render_markdown_capability_requires_explicit_protocol_evidence(
+def test_render_markdown_capability_requires_explicit_ssr_protocol_evidence(
     monkeypatch,
     tmp_path,
     response,

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -1924,6 +1924,7 @@ def test_private_show_page_uses_runtime_when_available(monkeypatch, tmp_path):
     assert "authorization" not in manager.calls[0][2]
     assert "cookie" not in manager.calls[0][2]
     assert "x-vibe-csrf-token" not in manager.calls[0][2]
+    assert manager.render_markdown_capability_calls == 0
 
 
 def _markdown_runtime_manager(
@@ -2558,6 +2559,7 @@ def test_show_page_markdown_unavailable_never_falls_back_to_html(
     assert b"Show Page" not in response.content
     _assert_markdown_response_headers(response, success=False)
     if failure == "capability_missing":
+        assert manager.render_markdown_capability_calls == 1
         assert manager.calls == []
 
 


### PR DESCRIPTION
## Summary

- Gate Agent Markdown rendering on Runtime protocol `1` plus the explicit `render_markdown_ssr: true` capability.
- Fail closed with the existing `renderer_unavailable` 503 envelope for older, missing, false, or malformed SSR capability evidence; never call the Runtime Markdown route in that state.
- Preserve the avibe#1673 negotiation, ACL-before-render, caller-header stripping, public/private link rewriting, error mapping, and no-HTML-fallback contract.
- Keep human HTML and non-document proxy traffic unchanged, and retain the 30-second Avibe request timeout with no browser-install allowance.

Part of #1617.

## Frozen contract

- `render_markdown` alone is not sufficient; `render_markdown_ssr` is the authoritative rendering gate.
- Runtime failures continue to use the existing error codes and localized `rendererUnavailable` copy.
- `vibe/show_runtime_manifest.json` is intentionally unchanged. The SSR Runtime asset must be published in a subsequent GitHub-only prerelease before a separate pin update.
- CSS Modules semantics remain owner-deferred.

## Evidence

- Unit: all 30 Show Runtime protocol tests pass, including missing, false, non-boolean, legacy-only, valid SSR, and protocol-mismatch capability evidence.
- Contract: 69 focused Show Page Markdown/request tests pass, covering negotiation, authorization, header stripping, private/public base rewriting, Runtime error mapping, fail-closed behavior, and HTML/non-document isolation.
- Scenario IDs: none; no Show Page Markdown scenario is cataloged under `tests/scenarios`.
- Lint: Ruff passes on all changed Python files.
- Residual manual: browserless private/public Incus E2E remains Phase 4 and is owned by the orchestrator after this PR merges and compatible Runtime assets exist.

## Known by design

- This PR negotiates capability only. It does not publish or pin a new Show Runtime archive.
- A Runtime may omit the legacy `render_markdown` field and still qualify when protocol `1` explicitly advertises `render_markdown_ssr: true`; this follows the frozen Phase 3 capability contract.
