### PR TITLE
fix(release): publish memory before core

### DIFF
--- a/.github/workflows/memory-runtime-release-guard.yml
+++ b/.github/workflows/memory-runtime-release-guard.yml
@@ -44,25 +44,25 @@ jobs:
           mkdir -p "$candidate_dir"
           : > "$records_file"
           : > "$excluded_file"
-          while IFS= read -r candidate_tag; do
+          while IFS=$'\t' read -r candidate_tag manifest_owner wheel_pattern; do
             rm -rf "$candidate_dir"
             mkdir -p "$candidate_dir"
             if ! gh release download "$candidate_tag" --repo "$GITHUB_REPOSITORY" \
-              --pattern 'avibe_memory-*.whl' --dir "$candidate_dir" >/dev/null 2>&1; then
+              --pattern "$wheel_pattern" --dir "$candidate_dir" >/dev/null 2>&1; then
               jq -nc --arg release_tag "$candidate_tag" \
-                --arg reason "published wheel could not be downloaded" \
+                --arg reason "published $manifest_owner wheel could not be downloaded" \
                 '{release_tag: $release_tag, reason: $reason}' >> "$excluded_file"
               continue
             fi
             set +e
-            CANDIDATE_TAG="$candidate_tag" CANDIDATE_DIR="$candidate_dir" \
+            CANDIDATE_TAG="$candidate_tag" CANDIDATE_DIR="$candidate_dir" WHEEL_PATTERN="$wheel_pattern" \
               python3 - <<'PY'
           import json
           import os
           import zipfile
           from pathlib import Path
 
-          wheels = sorted(Path(os.environ["CANDIDATE_DIR"]).glob("avibe_memory-*.whl"))
+          wheels = sorted(Path(os.environ["CANDIDATE_DIR"]).glob(os.environ["WHEEL_PATTERN"]))
           if len(wheels) != 1:
               raise SystemExit(1)
           with zipfile.ZipFile(wheels[0]) as wheel:
@@ -77,12 +77,19 @@ jobs:
           PY
             manifest_status=$?
             set -e
-            # Memory wheels without a manifest predate Memory Runtime and are not scope exclusions.
+            # Only legacy core wheels may predate Memory Runtime. Once the
+            # Memory wheel exists, it is authoritative and must not fall back.
             if [ "$manifest_status" -eq 4 ]; then
+              if [ "$manifest_owner" = "avibe-os" ]; then
+                continue
+              fi
+              jq -nc --arg release_tag "$candidate_tag" \
+                --arg reason "$manifest_owner wheel does not contain a self-pinned published manifest" \
+                '{release_tag: $release_tag, reason: $reason}' >> "$excluded_file"
               continue
             elif [ "$manifest_status" -ne 0 ]; then
               jq -nc --arg release_tag "$candidate_tag" \
-                --arg reason "wheel does not contain a self-pinned published manifest" \
+                --arg reason "$manifest_owner wheel does not contain a valid self-pinned published manifest" \
                 '{release_tag: $release_tag, reason: $reason}' >> "$excluded_file"
               continue
             fi
@@ -97,7 +104,9 @@ jobs:
             set -e
             if [ "$policy_status" -eq 0 ]; then
               jq -nc --arg release_tag "$candidate_tag" --arg sha256 "$manifest_sha" \
-                '{release_tag: $release_tag, sha256: $sha256}' >> "$records_file"
+                --arg manifest_owner "$manifest_owner" --arg wheel_pattern "$wheel_pattern" \
+                '{release_tag: $release_tag, sha256: $sha256, manifest_owner: $manifest_owner,
+                  wheel_pattern: $wheel_pattern}' >> "$records_file"
             elif [ "$policy_status" -eq 2 ]; then
               policy_reason="$(jq -r '.error // "manifest excluded by policy"' <<<"$policy_output")"
               jq -nc --arg release_tag "$candidate_tag" --arg reason "$policy_reason" \
@@ -108,7 +117,15 @@ jobs:
             fi
           done < <(
             gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
-              --jq '.[] | select(any(.assets[]?; (.name | startswith("avibe_memory-")) and (.name | endswith(".whl")))) | .tag_name'
+              --jq '
+                .[] |
+                if any(.assets[]?; (.name | startswith("avibe_memory-")) and (.name | endswith(".whl"))) then
+                  [.tag_name, "avibe-memory", "avibe_memory-*.whl"] | @tsv
+                elif any(.assets[]?; (.name | startswith("avibe_os-")) and (.name | endswith(".whl"))) then
+                  [.tag_name, "avibe-os", "avibe_os-*.whl"] | @tsv
+                else
+                  empty
+                end'
           )
           RECORDS_FILE="$records_file" EXCLUDED_FILE="$excluded_file" python3 - <<'PY'
           import json
@@ -172,6 +189,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ matrix.manifest.release_tag }}
           EXPECTED_SHA256: ${{ matrix.manifest.sha256 }}
+          MANIFEST_OWNER: ${{ matrix.manifest.manifest_owner }}
+          WHEEL_PATTERN: ${{ matrix.manifest.wheel_pattern }}
         shell: bash
         run: |
           set -euo pipefail
@@ -179,17 +198,18 @@ jobs:
           rm -rf "$manifest_dir"
           mkdir -p "$manifest_dir"
           gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
-            --pattern 'avibe_memory-*.whl' --dir "$manifest_dir" >/dev/null
+            --pattern "$WHEEL_PATTERN" --dir "$manifest_dir" >/dev/null
           CANDIDATE_TAG="$RELEASE_TAG" CANDIDATE_DIR="$manifest_dir" \
+            MANIFEST_OWNER="$MANIFEST_OWNER" WHEEL_PATTERN="$WHEEL_PATTERN" \
             python3 - <<'PY'
           import json
           import os
           import zipfile
           from pathlib import Path
 
-          wheels = sorted(Path(os.environ["CANDIDATE_DIR"]).glob("avibe_memory-*.whl"))
+          wheels = sorted(Path(os.environ["CANDIDATE_DIR"]).glob(os.environ["WHEEL_PATTERN"]))
           if len(wheels) != 1:
-              raise SystemExit("expected exactly one avibe_memory wheel")
+              raise SystemExit(f"expected exactly one {os.environ['MANIFEST_OWNER']} wheel")
           with zipfile.ZipFile(wheels[0]) as wheel:
               manifest = wheel.read("vibe/memory_runtime_manifest.json")
           payload = json.loads(manifest)

--- a/.github/workflows/memory-runtime-release-guard.yml
+++ b/.github/workflows/memory-runtime-release-guard.yml
@@ -48,7 +48,7 @@ jobs:
             rm -rf "$candidate_dir"
             mkdir -p "$candidate_dir"
             if ! gh release download "$candidate_tag" --repo "$GITHUB_REPOSITORY" \
-              --pattern 'avibe_os-*.whl' --dir "$candidate_dir" >/dev/null 2>&1; then
+              --pattern 'avibe_memory-*.whl' --dir "$candidate_dir" >/dev/null 2>&1; then
               jq -nc --arg release_tag "$candidate_tag" \
                 --arg reason "published wheel could not be downloaded" \
                 '{release_tag: $release_tag, reason: $reason}' >> "$excluded_file"
@@ -62,7 +62,7 @@ jobs:
           import zipfile
           from pathlib import Path
 
-          wheels = sorted(Path(os.environ["CANDIDATE_DIR"]).glob("avibe_os-*.whl"))
+          wheels = sorted(Path(os.environ["CANDIDATE_DIR"]).glob("avibe_memory-*.whl"))
           if len(wheels) != 1:
               raise SystemExit(1)
           with zipfile.ZipFile(wheels[0]) as wheel:
@@ -77,7 +77,7 @@ jobs:
           PY
             manifest_status=$?
             set -e
-            # Wheels without a manifest predate Memory Runtime and are not scope exclusions.
+            # Memory wheels without a manifest predate Memory Runtime and are not scope exclusions.
             if [ "$manifest_status" -eq 4 ]; then
               continue
             elif [ "$manifest_status" -ne 0 ]; then
@@ -108,7 +108,7 @@ jobs:
             fi
           done < <(
             gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
-              --jq '.[] | select(any(.assets[]?; (.name | startswith("avibe_os-")) and (.name | endswith(".whl")))) | .tag_name'
+              --jq '.[] | select(any(.assets[]?; (.name | startswith("avibe_memory-")) and (.name | endswith(".whl")))) | .tag_name'
           )
           RECORDS_FILE="$records_file" EXCLUDED_FILE="$excluded_file" python3 - <<'PY'
           import json
@@ -179,7 +179,7 @@ jobs:
           rm -rf "$manifest_dir"
           mkdir -p "$manifest_dir"
           gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
-            --pattern 'avibe_os-*.whl' --dir "$manifest_dir" >/dev/null
+            --pattern 'avibe_memory-*.whl' --dir "$manifest_dir" >/dev/null
           CANDIDATE_TAG="$RELEASE_TAG" CANDIDATE_DIR="$manifest_dir" \
             python3 - <<'PY'
           import json
@@ -187,9 +187,9 @@ jobs:
           import zipfile
           from pathlib import Path
 
-          wheels = sorted(Path(os.environ["CANDIDATE_DIR"]).glob("avibe_os-*.whl"))
+          wheels = sorted(Path(os.environ["CANDIDATE_DIR"]).glob("avibe_memory-*.whl"))
           if len(wheels) != 1:
-              raise SystemExit("expected exactly one avibe_os wheel")
+              raise SystemExit("expected exactly one avibe_memory wheel")
           with zipfile.ZipFile(wheels[0]) as wheel:
               manifest = wheel.read("vibe/memory_runtime_manifest.json")
           payload = json.loads(manifest)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -256,11 +256,7 @@ jobs:
           PACKAGE_VERSION="$(python scripts/release_package_version.py "$RELEASE_TAG")"
           echo "SETUPTOOLS_SCM_PRETEND_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
           echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_OS=$PACKAGE_VERSION" >> "$GITHUB_ENV"
-
-      - name: Block Memory Wave 3a release until Waves 3b and 3c
-        run: |
-          echo "::error title=Memory Wave 3a release blocked::Wave 3b must preserve the optional package across upgrade and rollback, and Wave 3c must own manifest validation and memory-first publication."
-          exit 1
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_MEMORY=$PACKAGE_VERSION" >> "$GITHUB_ENV"
 
       - name: Verify Show Runtime release assets
         run: |
@@ -304,8 +300,29 @@ jobs:
       - name: Install build and test dependencies
         run: pip install -e . build pytest
 
-      - name: Build package
-        run: python -m build
+      - name: Build Python distributions
+        run: |
+          python -m build --outdir dist packaging/avibe-memory
+          python -m build
+
+      - name: Verify Python distribution asset matrix
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          patterns = (
+              "avibe_memory-*.whl",
+              "avibe_memory-*.tar.gz",
+              "avibe_os-*.whl",
+              "avibe_os-*.tar.gz",
+          )
+          for pattern in patterns:
+              matches = sorted(Path("dist").glob(pattern))
+              if len(matches) != 1:
+                  raise SystemExit(
+                      f"Expected exactly one release asset matching {pattern}, found {len(matches)}"
+                  )
+          PY
 
       - name: Build 3.0 compatibility legacy PyPI shim
         shell: bash
@@ -324,30 +341,50 @@ jobs:
           import zipfile
           from pathlib import Path
 
-          wheels = [
+          core_wheels = [
               wheel
               for wheel in sorted(Path("dist").glob("*.whl"))
               if wheel.name.startswith("avibe_os-")
           ]
-          if len(wheels) != 1:
-              raise SystemExit(f"Expected exactly one avibe-os wheel, found {len(wheels)}")
+          memory_wheels = [
+              wheel
+              for wheel in sorted(Path("dist").glob("*.whl"))
+              if wheel.name.startswith("avibe_memory-")
+          ]
+          if len(core_wheels) != 1:
+              raise SystemExit(f"Expected exactly one avibe-os wheel, found {len(core_wheels)}")
+          if len(memory_wheels) != 1:
+              raise SystemExit(f"Expected exactly one avibe-memory wheel, found {len(memory_wheels)}")
 
-          with zipfile.ZipFile(wheels[0]) as wheel:
-              names = set(wheel.namelist())
+          with zipfile.ZipFile(core_wheels[0]) as wheel:
+              core_names = set(wheel.namelist())
               archives = {
-                  name for name in names
+                  name for name in core_names
                   if name.startswith("vibe/show_runtime/") and name.endswith(".tgz")
               }
 
           if archives:
               raise SystemExit("Wheel unexpectedly contains Show Runtime archives:\n" + "\n".join(sorted(archives)))
-          if "vibe/show_runtime_manifest.json" not in names:
+          if "vibe/show_runtime_manifest.json" not in core_names:
               raise SystemExit("Wheel is missing vibe/show_runtime_manifest.json")
-          if any(name.startswith("vibe/memory_runtime/") for name in names):
+          if any(name.startswith("vibe/memory_runtime/") for name in core_names):
               raise SystemExit("Wheel unexpectedly contains Memory Runtime archives")
-          if "vibe/memory_runtime_manifest.json" not in names:
-              raise SystemExit("Wheel is missing vibe/memory_runtime_manifest.json")
+          if "vibe/memory_runtime_manifest.json" in core_names:
+              raise SystemExit("avibe-os wheel unexpectedly owns the Memory Runtime manifest")
+
+          with zipfile.ZipFile(memory_wheels[0]) as wheel:
+              memory_names = set(wheel.namelist())
+          if "vibe/memory_runtime_manifest.json" not in memory_names:
+              raise SystemExit("avibe-memory wheel is missing vibe/memory_runtime_manifest.json")
+          if any(name.startswith("vibe/memory_runtime/") for name in memory_names):
+              raise SystemExit("avibe-memory wheel unexpectedly contains Memory Runtime archives")
           PY
+
+      - name: Verify distribution package matrix
+        run: |
+          AVIBE_CORE_WHEEL="$(ls dist/avibe_os-*.whl)" \
+          AVIBE_MEMORY_WHEEL="$(ls dist/avibe_memory-*.whl)" \
+            pytest tests/test_memory_distribution.py -v
 
       - name: Run Memory Runtime release guard before publication
         run: |
@@ -435,10 +472,111 @@ jobs:
           name: dist
           path: dist/
 
+  publish-avibe-memory:
+    needs:
+      - build
+      - finalize-github-release
+    runs-on: ubuntu-latest
+    environment: pypi-avibe-memory
+    permissions:
+      id-token: write  # Required for trusted publishing
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: dist
+          path: dist/
+
+      - name: Keep avibe-memory distributions only
+        shell: bash
+        run: |
+          find dist -type f ! \( -name 'avibe_memory-*' -o -name 'avibe-memory-*' \) -delete
+          test -n "$(find dist -maxdepth 1 -type f -name 'avibe_memory-*.whl' -print -quit)"
+          test -n "$(find dist -maxdepth 1 -type f -name 'avibe_memory-*.tar.gz' -print -quit)"
+
+      - name: Publish avibe-memory to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1
+        with:
+          skip-existing: true
+        # Uses trusted publishing (OIDC), no API token needed
+        # Configure at: https://pypi.org/manage/project/avibe-memory/settings/publishing/
+
+  verify-avibe-memory-pypi:
+    needs:
+      - resolve-tag
+      - build
+      - publish-avibe-memory
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+        with:
+          ref: ${{ needs.resolve-tag.outputs.tag }}
+
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        with:
+          python-version: "3.12"
+
+      - name: Download staged distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: dist
+          path: dist/
+
+      - name: Verify PyPI serves the exact avibe-memory wheel
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.resolve-tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          staged_wheels=(dist/avibe_memory-*.whl)
+          if [ "${#staged_wheels[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one staged avibe-memory wheel, found ${#staged_wheels[@]}." >&2
+            exit 1
+          fi
+
+          package_version="$(python scripts/release_package_version.py "$RELEASE_TAG")"
+          download_dir="$RUNNER_TEMP/avibe-memory-pypi"
+          mkdir -p "$download_dir"
+
+          for attempt in {1..12}; do
+            find "$download_dir" -mindepth 1 -maxdepth 1 -type f -delete
+            if python -m pip --isolated download \
+              --index-url https://pypi.org/simple \
+              --disable-pip-version-check \
+              --no-deps \
+              --no-cache-dir \
+              --only-binary=:all: \
+              --dest "$download_dir" \
+              "avibe-memory==$package_version"; then
+              public_wheels=("$download_dir"/avibe_memory-*.whl)
+              if [ "${#public_wheels[@]}" -ne 1 ]; then
+                echo "::error::Expected exactly one public avibe-memory wheel, found ${#public_wheels[@]}." >&2
+                exit 1
+              fi
+              if cmp -s "${staged_wheels[0]}" "${public_wheels[0]}"; then
+                echo "PyPI serves the exact staged avibe-memory wheel for $package_version."
+                exit 0
+              fi
+              echo "::error::PyPI already serves a non-identical avibe-memory wheel for $package_version." >&2
+              exit 1
+            fi
+
+            if [ "$attempt" -eq 12 ]; then
+              echo "::error::PyPI did not serve the avibe-memory wheel for $package_version after $attempt attempts." >&2
+              exit 1
+            fi
+            sleep 10
+          done
+
   publish-avibe-os:
     needs:
       - build
       - finalize-github-release
+      - verify-avibe-memory-pypi
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -454,7 +592,8 @@ jobs:
         shell: bash
         run: |
           find dist -type f ! \( -name 'avibe_os-*' -o -name 'avibe-os-*' \) -delete
-          test -n "$(find dist -maxdepth 1 -type f -name 'avibe_os-*' -print -quit)"
+          test -n "$(find dist -maxdepth 1 -type f -name 'avibe_os-*.whl' -print -quit)"
+          test -n "$(find dist -maxdepth 1 -type f -name 'avibe_os-*.tar.gz' -print -quit)"
 
       - name: Publish avibe-os to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # release/v1

--- a/.github/workflows/release_ai.yml
+++ b/.github/workflows/release_ai.yml
@@ -200,16 +200,32 @@ jobs:
           PACKAGE_VERSION="$(python scripts/release_package_version.py "$RELEASE_TAG")"
           echo "SETUPTOOLS_SCM_PRETEND_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
           echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_OS=$PACKAGE_VERSION" >> "$GITHUB_ENV"
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_MEMORY=$PACKAGE_VERSION" >> "$GITHUB_ENV"
 
-      - name: Block Memory Wave 3a release until Waves 3b and 3c
+      - name: Build Python distributions
         run: |
-          echo "::error title=Memory Wave 3a release blocked::Wave 3b must preserve the optional package across upgrade and rollback, and Wave 3c must own manifest validation and memory-first publication."
-          exit 1
-
-      - name: Build Python package
-        run: |
-          pip install build
+          pip install -e . build pytest
+          python -m build --outdir dist packaging/avibe-memory
           python -m build
+
+      - name: Verify Python distribution asset matrix
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          patterns = (
+              "avibe_memory-*.whl",
+              "avibe_memory-*.tar.gz",
+              "avibe_os-*.whl",
+              "avibe_os-*.tar.gz",
+          )
+          for pattern in patterns:
+              matches = sorted(Path("dist").glob(pattern))
+              if len(matches) != 1:
+                  raise SystemExit(
+                      f"Expected exactly one release asset matching {pattern}, found {len(matches)}"
+                  )
+          PY
 
       - name: Verify bundled runtime manifests
         run: |
@@ -218,29 +234,45 @@ jobs:
           import zipfile
           from pathlib import Path
 
-          wheels = sorted(Path("dist").glob("*.whl"))
-          if len(wheels) != 1:
-              raise SystemExit(f"Expected exactly one wheel, found {len(wheels)}")
+          core_wheels = sorted(Path("dist").glob("avibe_os-*.whl"))
+          memory_wheels = sorted(Path("dist").glob("avibe_memory-*.whl"))
+          if len(core_wheels) != 1:
+              raise SystemExit(f"Expected exactly one avibe-os wheel, found {len(core_wheels)}")
+          if len(memory_wheels) != 1:
+              raise SystemExit(f"Expected exactly one avibe-memory wheel, found {len(memory_wheels)}")
 
-          with zipfile.ZipFile(wheels[0]) as wheel:
-              names = set(wheel.namelist())
+          with zipfile.ZipFile(core_wheels[0]) as wheel:
+              core_names = set(wheel.namelist())
               archives = {
-                  name for name in names
+                  name for name in core_names
                   if name.startswith("vibe/show_runtime/") and name.endswith(".tgz")
               }
 
           if archives:
               raise SystemExit("Wheel unexpectedly contains Show Runtime archives:\n" + "\n".join(sorted(archives)))
-          if "vibe/show_runtime_manifest.json" not in names:
+          if "vibe/show_runtime_manifest.json" not in core_names:
               raise SystemExit("Wheel is missing vibe/show_runtime_manifest.json")
-          if any(name.startswith("vibe/memory_runtime/") for name in names):
+          if any(name.startswith("vibe/memory_runtime/") for name in core_names):
               raise SystemExit("Wheel unexpectedly contains Memory Runtime archives")
-          if "vibe/memory_runtime_manifest.json" not in names:
-              raise SystemExit("Wheel is missing vibe/memory_runtime_manifest.json")
+          if "vibe/memory_runtime_manifest.json" in core_names:
+              raise SystemExit("avibe-os wheel unexpectedly owns the Memory Runtime manifest")
+
+          with zipfile.ZipFile(memory_wheels[0]) as wheel:
+              memory_names = set(wheel.namelist())
+          if "vibe/memory_runtime_manifest.json" not in memory_names:
+              raise SystemExit("avibe-memory wheel is missing vibe/memory_runtime_manifest.json")
+          if any(name.startswith("vibe/memory_runtime/") for name in memory_names):
+              raise SystemExit("avibe-memory wheel unexpectedly contains Memory Runtime archives")
 
           print("vibe/show_runtime_manifest.json")
           print("vibe/memory_runtime_manifest.json")
           PY
+
+      - name: Verify distribution package matrix
+        run: |
+          AVIBE_CORE_WHEEL="$(ls dist/avibe_os-*.whl)" \
+          AVIBE_MEMORY_WHEEL="$(ls dist/avibe_memory-*.whl)" \
+            pytest tests/test_memory_distribution.py -v
 
       - name: Run Memory Runtime release guard for GitHub-only assets
         shell: bash

--- a/docs/plans/memory-wave3c-release-migration-contract.md
+++ b/docs/plans/memory-wave3c-release-migration-contract.md
@@ -90,20 +90,20 @@ does not remove older supported entries. A manifest with unsupported provenance
 is excluded visibly by `check-policy`; it is not treated as a byte-recovery
 failure.
 
-Published wheels that predate the Memory Runtime manifest are skipped by the
-scheduled inventory. A wheel that contains a candidate manifest must self-pin
-the selected release tag and pass current policy before it enters guarded backup
-and recovery coverage. Changes to a shipped manifest shape require compatible
-loading or a deliberate visible exclusion, never startup or workflow failure by
-accident.
+Published `avibe-memory` wheels that predate the Memory Runtime manifest are
+skipped by the scheduled inventory. A wheel that contains a candidate manifest
+must self-pin the selected release tag and pass current policy before it enters
+guarded backup and recovery coverage. Changes to a shipped manifest shape
+require compatible loading or a deliberate visible exclusion, never startup or
+workflow failure by accident.
 
 ## Availability, Backup, And Recovery
 
 The scheduled `Memory Runtime Release Guard` preserves the managed-runtime
 availability contract:
 
-1. Enumerate published releases with an `avibe-os` wheel and extract each
-   self-pinned Memory Runtime manifest.
+1. Enumerate published releases with an `avibe-memory` wheel and extract each
+   self-pinned Memory Runtime manifest from that wheel.
 2. Record the exact manifest hash, run `check-policy`, and report guarded and
    excluded releases separately.
 3. Run `fetch` for every guarded manifest. A successful fetch is the public

--- a/docs/plans/memory-wave3c-release-migration-contract.md
+++ b/docs/plans/memory-wave3c-release-migration-contract.md
@@ -8,9 +8,10 @@
 ## Scope
 
 This document retains the release behavior that current workflows enforce for
-Memory Runtime assets. It covers release identity, immutable runtime bytes,
-publication ordering, public availability, exact hash and archive validation,
-published-manifest compatibility, and scheduled backup/recovery.
+the independent `avibe-memory` distribution and Memory Runtime assets. It
+covers release identity, immutable runtime bytes, publication ordering, public
+availability, exact hash and archive validation, published-manifest
+compatibility, and scheduled backup/recovery.
 
 It does not define an upgrade rollback protocol, a package-transition verifier,
 or a future release architecture. Historical scenario IDs
@@ -26,31 +27,41 @@ must not be marked covered or reused for a different capability.
 - Runtime archives and manifests are immutable per tag. A rerun may reuse a
   byte-identical asset, but a same-name mismatch fails and requires a new
   version. It must never overwrite the hosted runtime bytes.
-- A GitHub-only `gh-v*` prerelease carries the installable wheel, sdist, runtime
-  archives, and manifests under the same identity. It does not trigger PyPI.
+- A GitHub-only `gh-v*` prerelease carries the `avibe-memory` and `avibe-os`
+  wheel/sdist pairs, runtime archives, and manifests under the same identity.
+  It does not trigger PyPI.
 
 ## Publication Order
 
 The existing workflows keep one asset-complete GitHub Draft and one official
 finalizer:
 
-1. Build the Python distributions and the Show and Memory Runtime archives and
-   manifests from the tagged source.
-2. Verify the locally staged Memory Runtime manifest and exact asset set before
+1. Derive one package version from the tagged source and use explicit VCS
+   pretend-version variables for both `avibe-memory` and `avibe-os`.
+2. Build both wheel/sdist pairs plus the Show and Memory Runtime archives and
+   manifests from that source.
+3. Verify the distributions have the same version, independent contents and
+   metadata, and pass the core-only/core-plus-Memory installation matrix.
+4. Verify the locally staged Memory Runtime manifest and exact asset set before
    any release publication.
-3. Create or reuse the Draft for that tag. Check every existing runtime asset
-   for byte identity before mutating any release asset.
-4. Upload missing runtime archives and manifests before uploading package
-   artifacts whose manifests advertise those runtime bytes.
-5. `Release (AI Notes)` may update the Draft notes and assets, but it never
+5. Create or reuse the Draft for that tag. Check every existing runtime asset
+   for byte identity before mutating any release asset, then upload both
+   distribution pairs and the runtime assets.
+6. `Release (AI Notes)` may update the Draft notes and assets, but it never
    publishes an official release.
-6. `Publish to PyPI` verifies the exact notes run and the asset-complete Draft,
-   publishes the GitHub Release, and only then permits PyPI publication. PyPI
-   uses immutable, skip-existing uploads for the matching package version.
+7. `Publish to PyPI` verifies the exact notes run and the asset-complete Draft,
+   then publishes the GitHub Release before either distribution reaches PyPI.
+8. Publish only `avibe-memory` through its trusted-publishing environment with
+   skip-existing semantics. Retry a direct PyPI wheel download without
+   dependencies or cache and byte-compare it with the staged wheel. An existing
+   non-identical wheel fails closed.
+9. Publish only `avibe-os` through its existing trusted-publishing environment
+   after the public `avibe-memory` wheel verification succeeds.
 
 A release failure resumes through the same tag and Draft only when all existing
-runtime bytes are identical. It does not mint a replacement identity or publish
-around a failed integrity check.
+runtime bytes are identical. It does not mint a replacement identity, publish
+around a failed integrity check, or invoke automatic package rollback or
+lifecycle recovery.
 
 ## Guard CLI Contract
 
@@ -111,6 +122,10 @@ window, and the retained backup remains tied to one exact manifest hash.
 
 - Do not pre-create or manually edit an official `v*` GitHub Release; the
   annotated tag and workflows own release state.
+- Before the first `avibe-memory` publication, configure its PyPI
+  pending/trusted publisher for repository `avibe-bot/avibe`, workflow
+  `publish.yml`, and GitHub environment `pypi-avibe-memory`. This external
+  configuration is a required operator action and is not performed by CI.
 - Do not overwrite a mismatched runtime asset, weaken a digest, bypass the
   public re-fetch, or continue to PyPI before the GitHub Release is published.
 - Do not classify policy exclusions as recoverable missing bytes.

--- a/docs/plans/memory-wave3c-release-migration-contract.md
+++ b/docs/plans/memory-wave3c-release-migration-contract.md
@@ -90,29 +90,35 @@ does not remove older supported entries. A manifest with unsupported provenance
 is excluded visibly by `check-policy`; it is not treated as a byte-recovery
 failure.
 
-Published `avibe-memory` wheels that predate the Memory Runtime manifest are
-skipped by the scheduled inventory. A wheel that contains a candidate manifest
-must self-pin the selected release tag and pass current policy before it enters
-guarded backup and recovery coverage. Changes to a shipped manifest shape
-require compatible loading or a deliberate visible exclusion, never startup or
-workflow failure by accident.
+For split releases, the `avibe-memory` wheel is the authoritative manifest
+owner. A published release may fall back to its legacy `avibe-os` wheel only
+when no `avibe-memory` wheel exists. A present but missing or invalid Memory
+manifest is excluded visibly and never masked by the legacy fallback. Legacy
+core wheels that predate the Memory Runtime manifest are skipped by the
+scheduled inventory. Any candidate manifest must self-pin the selected release
+tag and pass current policy before it enters guarded backup and recovery
+coverage. Changes to a shipped manifest shape require compatible loading or a
+deliberate visible exclusion, never startup or workflow failure by accident.
 
 ## Availability, Backup, And Recovery
 
 The scheduled `Memory Runtime Release Guard` preserves the managed-runtime
 availability contract:
 
-1. Enumerate published releases with an `avibe-memory` wheel and extract each
-   self-pinned Memory Runtime manifest from that wheel.
-2. Record the exact manifest hash, run `check-policy`, and report guarded and
+1. Enumerate published releases with either distribution wheel. Prefer
+   `avibe-memory`; select `avibe-os` only for a release with no Memory wheel.
+2. Extract the manifest from that selected wheel, record its owner, exact wheel
+   pattern, and manifest hash, then run `check-policy` and report guarded and
    excluded releases separately.
-3. Run `fetch` for every guarded manifest. A successful fetch is the public
+3. Re-download the exact recorded owner during verification instead of
+   rediscovering package ownership.
+4. Run `fetch` for every guarded manifest. A successful fetch is the public
    availability and integrity check.
-4. Keep a verified backup artifact keyed by the exact manifest SHA-256.
-5. On a byte failure, locate the latest non-expired matching backup, run
+5. Keep a verified backup artifact keyed by the exact manifest SHA-256.
+6. On a byte failure, locate the latest non-expired matching backup, run
    `verify` on it, and upload only asset names that are missing from the release.
    Existing names are never clobbered; a same-name integrity failure stops.
-6. Run `fetch` again after recovery so restored public bytes must pass the same
+7. Run `fetch` again after recovery so restored public bytes must pass the same
    release-tag, manifest, archive, and hash checks.
 
 The backup lookup follows the artifact identity rather than a fixed recent-run

--- a/packaging/avibe-memory/README.md
+++ b/packaging/avibe-memory/README.md
@@ -19,22 +19,33 @@ Build the independent distribution from the repository root:
 python -m build packaging/avibe-memory
 ```
 
-For the first `avibe-os` release that exposes the `memory` extra, publish the
-matching `avibe-memory` release first and verify that the package index serves
-it before publishing `avibe-os`. This order is required because the host extra
-must resolve at the moment it becomes public.
+Both release workflows derive one package version from the release tag and use
+that version to build an `avibe-memory` wheel and sdist alongside the matching
+`avibe-os` wheel and sdist. They run the independent-content, metadata, and
+core-only/core-plus-Memory installation matrix before staging release assets.
 
-This package split is not release-ready by itself. Do not tag or publish that
-first host release until the upgrade and rollback package-shape planner (Wave
-3b) and the release automation and manifest ownership changes (Wave 3c) have
-landed. Wave 3c owns building and publishing `avibe-memory` first and verifying
-its package-index availability. Wave 3a intentionally leaves both the upgrade
-planner and release workflows unchanged.
+An official release follows this forward-only order:
+
+1. Verify the runtime assets, both distribution pairs, and their shared version.
+2. Finalize the asset-complete GitHub Release before any PyPI publication.
+3. Publish `avibe-memory` with trusted publishing and skip-existing semantics.
+4. Retry a no-dependency, no-cache PyPI download and require its wheel to be
+   byte-identical to the staged wheel.
+5. Publish `avibe-os` only after that verification succeeds.
+
+A `gh-v*` GitHub-only release attaches both wheel/sdist pairs and the existing
+runtime assets without publishing either distribution to PyPI.
+
+The first official publication requires the PyPI pending/trusted publisher for
+project `avibe-memory` to match repository `avibe-bot/avibe`, workflow
+`publish.yml`, and GitHub environment `pypi-avibe-memory`. That external
+configuration is an operator prerequisite; the repository workflow does not
+create it.
 
 The package split changes distribution ownership only. The installed import
 path remains `avibe_memory`, the host keeps its fixed loader and protocol
 constant, and the EverOS artifact manifest remains available as
 `vibe/memory_runtime_manifest.json`. Runtime, storage, configuration, and data
-formats are unchanged, so the previous source-compatible Avibe release can
-load the same persisted state. Upgrade and rollback package-shape planning is
-owned by the subsequent migration wave.
+formats are unchanged, so a source-compatible Avibe release can load the same
+persisted state. Release failures stop at the failed forward step; this contract
+does not add automatic package rollback, lifecycle reservation, or recovery.

--- a/tests/test_github_release.py
+++ b/tests/test_github_release.py
@@ -378,7 +378,7 @@ def test_release_workflows_stage_then_finalize_once() -> None:
     assert "python release-automation/scripts/github_release.py ensure-draft" in publish
     assert "path: release-automation" in publish
     assert "ref: ${{ needs.resolve-tag.outputs.workflow_sha }}" in publish
-    assert publish.index("- name: Build package") < publish.index(
+    assert publish.index("- name: Build Python distributions") < publish.index(
         "- name: Checkout release automation"
     )
     assert "finalize-github-release:" in publish
@@ -386,12 +386,22 @@ def test_release_workflows_stage_then_finalize_once() -> None:
     assert "--run-sha \"${{ needs.resolve-tag.outputs.workflow_sha }}\"" in publish
     assert "--source-sha \"${{ needs.resolve-tag.outputs.source_sha }}\"" in publish
     assert "python scripts/github_release.py finalize" in publish
+    memory_publish = publish.split("  publish-avibe-memory:", 1)[1].split(
+        "  verify-avibe-memory-pypi:", 1
+    )[0]
+    memory_verify = publish.split("  verify-avibe-memory-pypi:", 1)[1].split(
+        "  publish-avibe-os:", 1
+    )[0]
     avibe_publish = publish.split("  publish-avibe-os:", 1)[1].split(
         "  publish-vibe-remote:", 1
     )[0]
     legacy_publish = publish.split("  publish-vibe-remote:", 1)[1].split(
         "  finalize-github-release:", 1
     )[0]
+    assert "- finalize-github-release" in memory_publish
+    assert "environment: pypi-avibe-memory" in memory_publish
+    assert "- publish-avibe-memory" in memory_verify
+    assert "- verify-avibe-memory-pypi" in avibe_publish
     assert "- finalize-github-release" in avibe_publish
     assert "- finalize-github-release" in legacy_publish
 

--- a/tests/test_memory_distribution.py
+++ b/tests/test_memory_distribution.py
@@ -24,11 +24,26 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
 ROOT = Path(__file__).resolve().parents[1]
 MEMORY_PROJECT = ROOT / "packaging" / "avibe-memory"
 COMPATIBILITY = SpecifierSet(">=3.0.14.dev0,<3.1")
-RELEASE_GATE = "Block Memory Wave 3a release until Waves 3b and 3c"
+WORKFLOW_DIR = ROOT / ".github" / "workflows"
 
 
 def _project(path: Path) -> dict[str, Any]:
     return tomllib.loads(path.read_text(encoding="utf-8"))["project"]
+
+
+def _workflow(name: str) -> dict[str, Any]:
+    return yaml.safe_load((WORKFLOW_DIR / name).read_text(encoding="utf-8"))
+
+
+def _step(job: dict[str, Any], name: str) -> dict[str, Any]:
+    matches = [step for step in job["steps"] if step.get("name") == name]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _needs(job: dict[str, Any]) -> set[str]:
+    needs = job.get("needs", [])
+    return {needs} if isinstance(needs, str) else set(needs)
 
 
 def _requirement(requirements: list[str], name: str) -> Requirement:
@@ -86,47 +101,166 @@ def test_memory_extra_and_distribution_share_one_compatibility_window() -> None:
     assert host_requirement.specifier == COMPATIBILITY
 
 
-def test_publish_order_guard_requires_memory_before_the_first_host_extra() -> None:
+def test_distribution_release_contract_is_forward_only_and_memory_first() -> None:
     contract = " ".join(
         (MEMORY_PROJECT / "README.md").read_text(encoding="utf-8").split()
     )
 
-    assert "publish the matching `avibe-memory` release first" in contract
-    assert "before publishing `avibe-os`" in contract
-    assert "This package split is not release-ready by itself" in contract
-    assert "upgrade and rollback package-shape planner (Wave 3b)" in contract
-    assert "release automation and manifest ownership changes (Wave 3c)" in contract
-    assert "Wave 3a intentionally leaves both the upgrade planner" in contract
-    assert "Upgrade and rollback package-shape planning is" in contract
+    assert "asset-complete GitHub Release" in contract
+    assert "Publish `avibe-memory`" in contract
+    assert "byte-identical to the staged wheel" in contract
+    assert "Publish `avibe-os` only after that verification succeeds" in contract
+    assert "forward-only" in contract
+    assert "not release-ready by itself" not in contract
+    assert "Wave 3b" not in contract
+    assert "Wave 3c" not in contract
 
 
-def test_release_workflows_fail_closed_before_the_split_package_builds() -> None:
-    expectations = (
-        ("publish.yml", "Build package", "Verify package runtime manifests"),
-        ("release_ai.yml", "Build Python package", "Verify bundled runtime manifests"),
+def test_release_workflows_have_no_unconditional_memory_wave_blocker() -> None:
+    for name in ("publish.yml", "release_ai.yml"):
+        workflow = (WORKFLOW_DIR / name).read_text(encoding="utf-8")
+        assert "Block Memory Wave" not in workflow
+        assert "Memory Wave 3a release blocked" not in workflow
+
+
+@pytest.mark.parametrize(
+    ("workflow_name", "job_name", "manifest_step"),
+    [
+        ("publish.yml", "build", "Verify package runtime manifests"),
+        ("release_ai.yml", "build-assets", "Verify bundled runtime manifests"),
+    ],
+)
+def test_release_paths_build_and_verify_both_distributions(
+    workflow_name: str,
+    job_name: str,
+    manifest_step: str,
+) -> None:
+    job = _workflow(workflow_name)["jobs"][job_name]
+    names = [step.get("name") for step in job["steps"]]
+    pin = _step(job, "Pin package version to release tag")["run"]
+    build = _step(job, "Build Python distributions")["run"]
+    assets = _step(job, "Verify Python distribution asset matrix")["run"]
+    manifests = _step(job, manifest_step)["run"]
+    package_matrix = _step(job, "Verify distribution package matrix")["run"]
+
+    assert "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_OS=$PACKAGE_VERSION" in pin
+    assert "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_MEMORY=$PACKAGE_VERSION" in pin
+    assert "python -m build --outdir dist packaging/avibe-memory" in build
+    assert "python -m build" in build
+    for pattern in (
+        "avibe_memory-*.whl",
+        "avibe_memory-*.tar.gz",
+        "avibe_os-*.whl",
+        "avibe_os-*.tar.gz",
+    ):
+        assert pattern in assets
+    assert 'AVIBE_CORE_WHEEL="$(ls dist/avibe_os-*.whl)"' in package_matrix
+    assert 'AVIBE_MEMORY_WHEEL="$(ls dist/avibe_memory-*.whl)"' in package_matrix
+    assert "pytest tests/test_memory_distribution.py" in package_matrix
+    assert 'Path("dist").glob("avibe_os-*.whl")' in manifests or "avibe_os-" in manifests
+    assert "avibe_memory-" in manifests
+    assert "avibe-os wheel unexpectedly owns the Memory Runtime manifest" in manifests
+    assert "avibe-memory wheel is missing vibe/memory_runtime_manifest.json" in manifests
+    assert names.index("Build Python distributions") < names.index(manifest_step)
+    assert names.index(manifest_step) < names.index("Verify distribution package matrix")
+
+
+def test_github_only_release_uploads_both_distribution_pairs() -> None:
+    workflow = _workflow("release_ai.yml")
+    build_job = workflow["jobs"]["build-assets"]
+    release_job = workflow["jobs"]["release"]
+    artifact_upload = _step(build_job, "Upload release artifacts")
+    release_upload = _step(release_job, "Create GitHub-only Release")["run"]
+
+    assert artifact_upload["with"]["path"] == "dist/"
+    assert "for path in dist/*" in release_upload
+    assert 'package_assets+=("$path")' in release_upload
+    assert 'gh release upload "$TAG"' in release_upload
+    assert '"${package_assets[@]}" --clobber' in release_upload
+
+
+def test_official_draft_uploads_both_verified_distribution_pairs() -> None:
+    build_job = _workflow("publish.yml")["jobs"]["build"]
+    names = [step.get("name") for step in build_job["steps"]]
+    release_upload = _step(build_job, "Upload GitHub release assets")["run"]
+
+    assert names.index("Verify Python distribution asset matrix") < names.index(
+        "Upload GitHub release assets"
     )
+    assert 'gh release upload "$TAG" --repo "${GITHUB_REPOSITORY}" dist/* --clobber' in release_upload
 
-    for workflow_name, build_step, wheel_assertion_step in expectations:
-        workflow = yaml.safe_load(
-            (ROOT / ".github" / "workflows" / workflow_name).read_text(
-                encoding="utf-8"
-            )
-        )
-        matching_jobs = []
-        for job in workflow["jobs"].values():
-            steps = job.get("steps", [])
-            names = [step.get("name") for step in steps]
-            if RELEASE_GATE in names:
-                matching_jobs.append((steps, names))
 
-        assert len(matching_jobs) == 1
-        steps, names = matching_jobs[0]
-        gate_index = names.index(RELEASE_GATE)
-        gate_command = steps[gate_index]["run"]
-        assert gate_index < names.index(build_step) < names.index(wheel_assertion_step)
-        assert "Wave 3b" in gate_command
-        assert "Wave 3c" in gate_command
-        assert "exit 1" in gate_command
+def test_official_release_publishes_and_verifies_memory_before_core() -> None:
+    jobs = _workflow("publish.yml")["jobs"]
+
+    assert {"build", "finalize-github-release"} <= _needs(
+        jobs["publish-avibe-memory"]
+    )
+    assert jobs["publish-avibe-memory"]["environment"] == "pypi-avibe-memory"
+    assert "publish-avibe-memory" in _needs(jobs["verify-avibe-memory-pypi"])
+    assert "verify-avibe-memory-pypi" in _needs(jobs["publish-avibe-os"])
+    assert "finalize-github-release" in _needs(jobs["publish-avibe-os"])
+
+    verify = _step(
+        jobs["verify-avibe-memory-pypi"],
+        "Verify PyPI serves the exact avibe-memory wheel",
+    )["run"]
+    for fragment in (
+        "for attempt in {1..12}",
+        "python -m pip --isolated download",
+        "--index-url https://pypi.org/simple",
+        "--no-deps",
+        "--no-cache-dir",
+        "--only-binary=:all:",
+        'cmp -s "${staged_wheels[0]}" "${public_wheels[0]}"',
+        "PyPI already serves a non-identical avibe-memory wheel",
+    ):
+        assert fragment in verify
+
+
+@pytest.mark.parametrize(
+    ("job_name", "keep_step", "allowed", "excluded"),
+    [
+        (
+            "publish-avibe-memory",
+            "Keep avibe-memory distributions only",
+            "avibe_memory-*",
+            "avibe_os-*",
+        ),
+        (
+            "publish-avibe-os",
+            "Keep avibe-os distributions only",
+            "avibe_os-*",
+            "avibe_memory-*",
+        ),
+        (
+            "publish-vibe-remote",
+            "Keep vibe-remote distributions only",
+            "vibe_remote-*",
+            "avibe_",
+        ),
+    ],
+)
+def test_each_trusted_publisher_receives_only_its_distribution(
+    job_name: str,
+    keep_step: str,
+    allowed: str,
+    excluded: str,
+) -> None:
+    job = _workflow("publish.yml")["jobs"][job_name]
+    names = [step.get("name") for step in job["steps"]]
+    keep = _step(job, keep_step)["run"]
+    publish_steps = [
+        step
+        for step in job["steps"]
+        if str(step.get("uses", "")).startswith("pypa/gh-action-pypi-publish@")
+    ]
+
+    assert len(publish_steps) == 1
+    assert names.index(keep_step) < job["steps"].index(publish_steps[0])
+    assert allowed in keep
+    assert excluded not in keep
+    assert publish_steps[0]["with"]["skip-existing"] is True
 
 
 def test_built_wheels_have_independent_contents_and_compatible_metadata() -> None:

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -371,11 +371,47 @@ def test_guard_workflow_reports_and_verifies_supported_published_manifests() -> 
     assert "matrix.manifest.release_tag" in workflow
 
 
-def test_guard_workflow_reads_manifests_from_memory_distribution() -> None:
-    workflow = (ROOT / ".github/workflows/memory-runtime-release-guard.yml").read_text(encoding="utf-8")
+def _guard_workflow() -> str:
+    return (ROOT / ".github/workflows/memory-runtime-release-guard.yml").read_text(encoding="utf-8")
 
-    assert workflow.count("--pattern 'avibe_memory-*.whl'") == 2
-    assert workflow.count('glob("avibe_memory-*.whl")') == 2
-    assert 'startsWith("avibe_memory-")' not in workflow
-    assert 'startswith("avibe_memory-")' in workflow
-    assert "avibe_os-*.whl" not in workflow
+
+def test_guard_workflow_prefers_memory_distribution_for_split_releases() -> None:
+    workflow = _guard_workflow()
+    memory_selection = '[.tag_name, "avibe-memory", "avibe_memory-*.whl"] | @tsv'
+    legacy_selection = '[.tag_name, "avibe-os", "avibe_os-*.whl"] | @tsv'
+
+    assert memory_selection in workflow
+    assert legacy_selection in workflow
+    assert workflow.index(memory_selection) < workflow.index(legacy_selection)
+
+
+def test_guard_workflow_keeps_legacy_core_only_releases_guarded() -> None:
+    workflow = _guard_workflow()
+
+    assert 'elif any(.assets[]?; (.name | startswith("avibe_os-"))' in workflow
+    assert '[.tag_name, "avibe-os", "avibe_os-*.whl"] | @tsv' in workflow
+    assert 'if [ "$manifest_owner" = "avibe-os" ]; then' in workflow
+
+
+def test_guard_workflow_never_falls_back_from_an_invalid_memory_owner() -> None:
+    workflow = _guard_workflow()
+    resolution = workflow.split("- name: Resolve every published Memory Runtime manifest", 1)[1]
+    resolution = resolution.split("  guard:", 1)[0]
+
+    assert resolution.count("gh release download") == 1
+    assert '--pattern "$wheel_pattern"' in resolution
+    assert "Memory wheel exists, it is authoritative and must not fall back." in resolution
+    assert '$manifest_owner wheel does not contain a valid self-pinned published manifest' in resolution
+
+
+def test_guard_workflow_verification_consumes_recorded_manifest_owner() -> None:
+    workflow = (ROOT / ".github/workflows/memory-runtime-release-guard.yml").read_text(encoding="utf-8")
+    verification = workflow.split("- name: Resolve selected published Memory Runtime manifest", 1)[1]
+    verification = verification.split("- name: Fetch and verify published assets", 1)[0]
+
+    assert "manifest_owner: $manifest_owner" in workflow
+    assert "wheel_pattern: $wheel_pattern" in workflow
+    assert "MANIFEST_OWNER: ${{ matrix.manifest.manifest_owner }}" in verification
+    assert "WHEEL_PATTERN: ${{ matrix.manifest.wheel_pattern }}" in verification
+    assert '--pattern "$WHEEL_PATTERN"' in verification
+    assert 'glob(os.environ["WHEEL_PATTERN"])' in verification

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -369,3 +369,13 @@ def test_guard_workflow_reports_and_verifies_supported_published_manifests() -> 
     assert "Excluded Memory Runtime manifests" in resolution
     assert "fromJSON(needs.resolve_manifests.outputs.manifests)" in workflow
     assert "matrix.manifest.release_tag" in workflow
+
+
+def test_guard_workflow_reads_manifests_from_memory_distribution() -> None:
+    workflow = (ROOT / ".github/workflows/memory-runtime-release-guard.yml").read_text(encoding="utf-8")
+
+    assert workflow.count("--pattern 'avibe_memory-*.whl'") == 2
+    assert workflow.count('glob("avibe_memory-*.whl")') == 2
+    assert 'startsWith("avibe_memory-")' not in workflow
+    assert 'startswith("avibe_memory-")' in workflow
+    assert "avibe_os-*.whl" not in workflow

--- a/tests/test_release_package_version.py
+++ b/tests/test_release_package_version.py
@@ -34,3 +34,4 @@ def test_package_release_workflows_pin_scm_version_to_release_tag() -> None:
         assert "python scripts/release_package_version.py" in workflow
         assert "SETUPTOOLS_SCM_PRETEND_VERSION=$PACKAGE_VERSION" in workflow
         assert "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_OS=$PACKAGE_VERSION" in workflow
+        assert "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_MEMORY=$PACKAGE_VERSION" in workflow


### PR DESCRIPTION
## Capability

Unblocks official and GitHub-only releases for the final independent Memory
distribution architecture. Both release paths now build and validate matching
`avibe-memory` and `avibe-os` wheel/sdist pairs from one tag-derived version.

## Release order

Official releases preserve the existing runtime/Draft safety gates, then run:

1. finalize the asset-complete GitHub Release;
2. publish only `avibe-memory` with skip-existing semantics;
3. retry-download the exact public Memory wheel without dependencies or cache
   and byte-compare it with the staged wheel;
4. publish only `avibe-os` after that verification succeeds.

GitHub-only `gh-v*` releases attach both distribution pairs plus the existing
runtime assets and do not publish to PyPI.

## Scenario IDs

Affected Memory scenario IDs: none. `MEMORY-INDEP-024` remains covered by the
unchanged forward-upgrade package-shape contract. Retired IDs
`MEMORY-INDEP-020`, `MEMORY-INDEP-022`, and `MEMORY-INDEP-023` remain retired.

## Evidence

- Unit: focused release/runtime tests (`48 passed`, with three artifact-only
  cases skipped in the source-only run).
- Contract: both workflow YAML files parse; workflow graph, per-publisher
  filtering, asset pairs, retry/download flags, and byte comparison are asserted.
- Package matrix: both wheel/sdist pairs built at explicit version `3.0.99rc1`;
  the independent-content, metadata, core-only, and core-plus-Memory matrix
  passed (`13 passed`).
- Scenario: no catalog entry changes; no current scenario maps to release
  orchestration.
- Lint/docs: Ruff, markdownlint/CommonMark, and `git diff --check` pass.
- Residual manual checks: exact-head GitHub `lint` remains the slow gate. No tag,
  GitHub Release, PyPI upload, service restart, or Incus action was performed.

## Operator prerequisite

Before the first official `avibe-memory` publication, configure the PyPI
pending/trusted publisher for project `avibe-memory` to match repository
`avibe-bot/avibe`, workflow `publish.yml`, and GitHub environment
`pypi-avibe-memory`. This PR intentionally does not perform external
configuration.

## Dependencies

None.

## Known by design

- The release path is forward-only. It does not restore automatic package
  rollback, lifecycle reservation/recovery, Gate5, or the retired static
  package-transition verifier.
- Existing `vibe-remote` compatibility publication keeps its current independent
  dependency path.
