### PR TITLE
refactor(memory): finish forward-only cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,10 +177,15 @@ Persisted-shape rule:
 - a schema change must load older releases' files via migration or safe
   degradation (a broken optional-feature section disables that feature and
   warns; startup never fails), with load fixtures covering the released shapes
-- installed-shape restoration and runtime readiness are orthogonal: rollback may
-  exactly restore a captured shape that remains non-ready and repairable. Report
-  both outcomes separately; current health criteria must not invalidate exact
-  restoration.
+- Memory package upgrades are forward-only: success follows the ordinary restart
+  path, while install, upgrade, or restart failures are structured terminal
+  results and do not prevent a later explicit attempt. Do not add automatic
+  package rollback, rollback plans, lifecycle reservations, quarantine, Gate 5
+  verification, or recovery bootstrap.
+- Memory Runtime manifest/hash/fetch/verify and backup safeguards protect
+  published artifact availability. They are not installed-package rollback
+  machinery; existing backup creation and manual restore primitives remain
+  manual recovery tools.
 
 Source-of-truth rule:
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -85,6 +85,25 @@ diagnostics. It contains no Memory payload and is not a delivery queue or
 recovery state machine. The later sections define the product behavior at these
 seams.
 
+## Optional package and upgrades
+
+The implementation is the optional `avibe-memory` distribution. Avibe loads it
+in-process only when Memory is required; a missing, incompatible, or failed
+package degrades Memory without making Avibe or its Agent unavailable.
+
+Forward upgrades preserve the Memory package when Memory is enabled or the
+package is already present. A successful upgrade schedules the ordinary Avibe
+restart when the runtime is active. Package resolution, installation, upgrade,
+or restart failures are structured terminal results, and a later explicit
+attempt is allowed. Avibe performs no automatic package rollback and keeps no
+rollback plan, lifecycle reservation, quarantine, Gate 5 lifecycle verifier, or
+recovery bootstrap.
+
+Published Memory Runtime artifacts retain their manifest, hash, fetch, verify,
+and backup availability safeguards. Those checks protect immutable release
+assets and manual recovery inputs; they do not compensate for or reverse an
+installed-package transition.
+
 ## User and Agent memory ownership
 
 Automatic capture of a user's messages continues to target that user's Memory
@@ -106,10 +125,8 @@ Existing Memory data is not moved. Agent-recorded facts written before this
 split remain under the user owner and are still searchable there. A newer
 installation preserves the released four-field provider-session shape, but
 delivery remains process-local; pending Agent-owner work may be lost across restart,
-rollback, or runtime replacement and is never replayed from an older queue.
-On rollback, already-delivered Agent-owner memories remain stored but are hidden
-from an older reader until Avibe is upgraded again. Already submitted provider
-outcomes are never replayed by this path.
+or runtime replacement and is never replayed from an older queue. Already
+submitted provider outcomes are never replayed by this path.
 
 ## IM attachment capture
 

--- a/docs/plans/memory-plugin-isolation-refactor.md
+++ b/docs/plans/memory-plugin-isolation-refactor.md
@@ -1,15 +1,15 @@
 # Memory Optional Package Isolation Refactor
 
-> Status: proposed, revised after PM review
+> Status: complete (2026-08-29)
 >
-> Baseline: `origin/master` at `36118911b` (2026-08-25)
+> Completion baseline: `origin/dev` at `8033662fa` (post-#1774)
 >
-> `docs/MEMORY.md` remains the current product contract until this plan is
-> implemented.
+> `docs/MEMORY.md` is the current product contract. This plan records the
+> completed isolation waves and their retained boundaries.
 
 ## Decision
 
-Memory runtime implementation will move into an independently published,
+Memory runtime implementation now lives in an independently published,
 optional Python package loaded in the Avibe process only when Memory is enabled.
 EverOS remains the one Memory child process. This refactor does not add another
 sidecar, UDS protocol, process supervisor, generic plugin host, or dynamic plugin
@@ -62,26 +62,24 @@ arbitrary infinite CPU loop inside Python. A second process is considered only
 after a reproducible fault shows that the in-process adapter cannot meet the
 bounded contract.
 
-## Current Gaps
+## Completed Scope
 
-The current implementation already keeps capture outside Agent completion and
-makes `/new` and archive barriers best effort. The remaining independence gaps
-are more specific:
+The waves closed the following independence gaps without changing Memory product
+behavior:
 
-1. Controller imports Memory implementation at module import time.
-2. Controller constructs `MemoryRuntime` when `memory.enabled` is false.
-3. Disabled construction opens `memory.sqlite` and creates attachment, state,
+1. Controller no longer imports Memory implementation at module import time.
+2. Disabled startup does not construct `MemoryRuntime`.
+3. Disabled startup does not open `memory.sqlite` or create attachment, state,
    and lock directories.
-4. Controller and `MessageHandler` own Memory admission, capture tasks,
-   capacity reservations, and attachment-specific scheduling.
-5. Workbench and delivery persistence write `_memory_*` metadata, and queue
-   segmentation depends on it.
-6. Memory task and destructive-operation shutdown paths contain unbounded waits.
-7. Generic helpers and host contracts live under `core.memory`, so deleting the
-   implementation package also deletes code needed by archive, UI auth, config,
-   and internal clients.
-8. The install/upgrade path assumes Memory implementation ships inside the
-   `avibe-os` wheel.
+4. The optional adapter owns Memory admission, capture tasks, capacity, and
+   attachment scheduling.
+5. New Workbench and delivery persistence does not write `_memory_*` metadata or
+   depend on it for queue segmentation.
+6. Memory task and destructive-operation shutdown paths are bounded.
+7. Generic helpers and host contracts needed by archive, UI auth, config, and
+   internal clients live outside the optional implementation.
+8. Install and upgrade paths resolve `avibe-memory` as an optional independent
+   distribution.
 
 The refactor targets these gaps. It does not reimplement working Memory product
 behavior.
@@ -256,7 +254,7 @@ host continues to enforce:
 - `transition_notice_pending`, applied embedding identity, and organization
   transition behavior;
 - `legacy_needs_repair` / `repair_required`; and
-- rollback-compatible serialization of released config shapes.
+- compatible loading of released config shapes.
 
 The optional package receives a validated config snapshot. This plan does not
 make the Memory mapping opaque and does not change config behavior.
@@ -326,7 +324,7 @@ existing functional owner.
 
 ## Installation and Upgrade Contract
 
-The package split must not silently disable Memory for existing users.
+The package split does not silently disable Memory for existing users.
 
 1. Publish `avibe-memory` before the first `avibe-os` release that can load it.
 2. Add an `avibe-os[memory]` extra that resolves a host-compatible
@@ -334,11 +332,12 @@ The package split must not silently disable Memory for existing users.
 3. The existing upgrade planner chooses the extra when either Memory is enabled
    or the optional package is already installed. Disabled core-only installs
    continue upgrading without it.
-4. Record whether the optional package was present in `RollbackTarget`; a pinned
-   rollback restores the matching core-only or core-plus-Memory shape.
-5. An enabled upgrade fails before replacing the current installation if the
+4. An enabled upgrade fails before replacing the current installation if the
    compatible optional package cannot be resolved. It does not install a new
    core and silently drop Memory.
+5. A successful upgrade schedules the ordinary Avibe restart when the runtime is
+   active. Install, upgrade, or restart failures are structured terminal results;
+   they do not block a later explicit attempt.
 6. The existing Dependencies/Memory install action may explicitly reinstall the
    current tool with the Memory extra. Controller startup never installs or
    downloads Python packages.
@@ -347,18 +346,24 @@ The package split must not silently disable Memory for existing users.
 8. EverOS runtime download/install remains an explicit Memory dependency action,
    but its manifest and implementation move with `avibe-memory`.
 
+There is no automatic package rollback, rollback plan, package-lifecycle
+reservation, quarantine, Gate 5 lifecycle verifier, or recovery bootstrap. The
+retained manifest, hash, fetch, verify, and backup safeguards protect published
+Memory Runtime artifact availability; they do not mutate installed Python
+packages or recover an upgrade attempt.
+
 Core and optional-package protocol compatibility is checked at lazy load. A
 mismatch selects `DisabledMemoryAdapter` and reports
 `memory_plugin_incompatible`; it never fails service startup.
 
-## Migration Waves
+## Completed Migration Waves
 
-Each wave is a focused, green PR. Tests are written red and fixed in the same PR;
-the repository does not merge placeholder scenario IDs or permanent xfails.
+Each wave landed as a focused, green PR. The repository did not merge placeholder
+scenario IDs or permanent xfails.
 
-### Wave 0: Make disabled Memory truly off
+### Wave 0: Make disabled Memory truly off (complete)
 
-Scope:
+Delivered:
 
 - choose `DisabledMemoryAdapter` before importing or constructing Memory runtime;
 - stop opening Memory store, attachments, artifact state, and operation locks
@@ -371,7 +376,7 @@ Scope:
 - preserve asynchronous cleanup of pre-existing owned EverOS processes without
   creating new Memory state.
 
-Add scenarios when the fixes land:
+Evidence added:
 
 - `MEMORY-INDEP-013`: disabled fresh startup has zero Memory filesystem/process
   side effects;
@@ -379,15 +384,14 @@ Add scenarios when the fixes land:
   implementation imports are blocked; and
 - `MEMORY-INDEP-015`: a frozen Memory task cannot make Avibe shutdown unbounded.
 
-Exit gate: these scenarios and existing `MEMORY-INDEP-001..012` pass. No enabled
+Completion evidence: these scenarios and existing `MEMORY-INDEP-001..012` pass. No enabled
 Memory product behavior changes.
 
-Rollback: restore eager construction only; no persisted format changes occur in
-this wave.
+Compatibility: this wave introduced no persisted format change.
 
-### Wave 1: Return message and session ownership to core
+### Wave 1: Return message and session ownership to core (complete)
 
-Scope:
+Delivered:
 
 - rename archive to a core session operation and keep its Memory observation
   after commit;
@@ -401,7 +405,7 @@ Scope:
   scheduling behind the enabled adapter; and
 - preserve the exact attachment, prompt, config, and explicit-route behavior.
 
-Add:
+Evidence added:
 
 - `MEMORY-INDEP-016`: new rows use author/message-kind merge identity and contain
   no Memory-private metadata;
@@ -409,15 +413,15 @@ Add:
   forwarded/edited input, scheduled delivery, and legacy/new queued rows; and
 - attachment tests proving retain/pin/text-only fallback behavior is unchanged.
 
-Exit gate: removing or forcing the adapter to raise does not change chat,
+Completion evidence: removing or forcing the adapter to raise does not change chat,
 `/new`, archive, queue grouping, or Agent attachment delivery.
 
-Rollback: re-enable the legacy metadata writer while the compatibility reader is
-still present. No bulk data migration exists to reverse.
+Compatibility: the legacy metadata reader remains; no bulk data migration was
+introduced.
 
-### Wave 2: Extract the optional in-process package
+### Wave 2: Extract the optional in-process package (complete)
 
-Scope:
+Delivered:
 
 - introduce the fixed lazy loader and enabled adapter implementation;
 - move implementation modules listed above to `avibe-memory` without changing
@@ -428,7 +432,7 @@ Scope:
 - fail closed to `DisabledMemoryAdapter` on absent package, import failure,
   incompatible protocol, or construction failure.
 
-Add:
+Evidence added:
 
 - `MEMORY-INDEP-017`: core-only installation imports and runs chat, `/new`,
   archive, UI server, internal server, CLI help, and shutdown;
@@ -436,40 +440,40 @@ Add:
 - package import/construction failure containment; and
 - core-plus-Memory parity for all existing Memory scenarios.
 
-Exit gate: the Avibe process imports no optional implementation when disabled;
+Completion evidence: the Avibe process imports no optional implementation when disabled;
 blocking `avibe_memory` imports leaves all core scenarios green; enabled Memory
 passes its existing suite against unchanged data.
 
-Rollback: the package move is source-compatible and keeps current data/config
-formats; the previous release can load the same state.
+Compatibility: the package move kept current data and config formats readable.
 
-### Wave 3: Ship the package split and delete compatibility code
+### Wave 3: Ship the package split and delete compatibility code (complete)
 
-Scope:
+Delivered:
 
 - publish the matched optional distribution and `avibe-os[memory]` extra;
-- update forward upgrade and rollback plans to preserve plugin presence;
+- update forward upgrades to preserve plugin presence;
 - move runtime manifest/build/release guard ownership;
 - add core-only and core-plus-Memory wheel matrices;
 - remove `core.memory`, temporary adapters, new-write legacy metadata paths, and
   duplicate tests after the legacy read window; and
 - update `docs/MEMORY.md` and user installation documentation.
 
-Add:
+Evidence added:
 
 - the retired `MEMORY-INDEP-018` package-shape assignment remains historical
   lineage only and is not an implementation target;
 - wheel-content assertions proving `avibe-os` contains no Memory runtime
   implementation or EverOS artifact manifest; and
-- packaged install smoke for missing, disabled, enabled, incompatible, upgrade,
-  and rollback cases.
+- packaged install smoke for missing, disabled, enabled, incompatible, and
+  upgrade cases.
 
-Exit gate: both package matrices pass CI; local Incus `master` regression passes
+Completion evidence: both package matrices pass CI; local Incus `master` regression passes
 Workbench and Slack/Discord/Telegram/Feishu/WeChat capture; service health is
 verified; no temporary fallback implementation remains.
 
-The proposed Wave 3c lifecycle, rollback, and Gate 5 transition designs were
-abandoned and their detailed contracts were retired. Historical scenario IDs
+The proposed Wave 3c rollback plan, lifecycle reservation, quarantine, Gate 5
+verifier, and recovery bootstrap were abandoned and retired. Historical
+scenario IDs
 `MEMORY-INDEP-018` through `020`, `022`, and `023` remain unassigned and must not
 be repurposed. Current executable import and package-shape evidence is owned by
 the scenario catalog under `MEMORY-INDEP-021` and `MEMORY-INDEP-024`.
@@ -487,7 +491,7 @@ the scenario catalog under `MEMORY-INDEP-021` and `MEMORY-INDEP-024`.
 | Attachments | current lease, pin, integrity, fallback, and cleanup scenarios remain green |
 | Config | stale write, confirm-loss, cloud transition, repair fence, and released-shape fixtures remain green |
 | Explicit surfaces | UI, named internal routes, CLI output/exit codes, and prompt routing retain parity |
-| Packaging | core-only, core-plus-Memory, enabled upgrade, disabled upgrade, and rollback matrices |
+| Packaging | core-only, core-plus-Memory, enabled upgrade, disabled upgrade, terminal failure, and retry evidence |
 
 ## Complexity Guardrails
 
@@ -519,7 +523,7 @@ The refactor is complete when:
 - core session and delivery state no longer depends on Memory-private metadata;
 - attachment, config safety, prompt, UI, CLI, and enabled Memory behavior remain
   unchanged;
-- existing enabled users receive the compatible package during upgrade and can
-  roll back without data movement;
+- existing enabled users receive the compatible package during forward upgrade,
+  and a terminal failure does not prevent a later attempt;
 - `core.memory` and every temporary migration adapter are deleted; and
 - no second sidecar or generic plugin framework was introduced.

--- a/packaging/avibe-memory/README.md
+++ b/packaging/avibe-memory/README.md
@@ -48,4 +48,9 @@ constant, and the EverOS artifact manifest remains available as
 `vibe/memory_runtime_manifest.json`. Runtime, storage, configuration, and data
 formats are unchanged, so a source-compatible Avibe release can load the same
 persisted state. Release failures stop at the failed forward step; this contract
-does not add automatic package rollback, lifecycle reservation, or recovery.
+does not add automatic package rollback, a rollback plan, lifecycle reservation,
+quarantine, a Gate 5 lifecycle verifier, or recovery bootstrap. Successful
+upgrades follow the ordinary Avibe restart path. Package installation, upgrade,
+and restart failures are structured terminal results and do not prevent a later
+explicit attempt. Manifest/hash/fetch/verify and backup safeguards remain release
+asset availability controls, not installed-package rollback machinery.

--- a/tests/scenarios/memory_independence/catalog.yaml
+++ b/tests/scenarios/memory_independence/catalog.yaml
@@ -146,3 +146,9 @@ scenarios:
     kind: guardrail
     layer: scenario
     test: tests/scenarios/memory_independence/test_memory_package_shape.py::test_memory_indep_024_forward_package_shape_and_import_contract
+  - id: MEMORY-INDEP-025
+    name: A failed upgrade is terminal, has no compensating package mutation, and permits retry
+    status: covered
+    kind: correctness
+    layer: scenario
+    test: tests/test_upgrade_flow.py::test_memory_indep_025_failed_upgrade_is_terminal_and_retryable

--- a/tests/scenarios/memory_independence/test_memory_package_shape.py
+++ b/tests/scenarios/memory_independence/test_memory_package_shape.py
@@ -5,14 +5,10 @@ from __future__ import annotations
 import ast
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
-from vibe.upgrade import (
-    installed_memory_package_version,
-    memory_package_installed,
-)
+from vibe.upgrade import memory_package_installed
 
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -21,23 +17,21 @@ FORWARD_PACKAGE_SHAPE_IMPORTS = {
     "CORE_PACKAGE_NAME",
     "LEGACY_CORE_PACKAGE_NAME",
     "MEMORY_PACKAGE_NAME",
-    "MEMORY_SPLIT_MIN_VERSION",
 }
 
 
 @pytest.mark.parametrize(
-    ("metadata_result", "expected_present", "expected_version"),
+    ("metadata_result", "expected_present"),
     [
-        pytest.param(SimpleNamespace(version="3.0.15"), True, "3.0.15", id="installed"),
-        pytest.param(PackageNotFoundError(), False, None, id="absent"),
-        pytest.param(OSError("unreadable"), True, None, id="unreadable"),
+        pytest.param(object(), True, id="installed"),
+        pytest.param(PackageNotFoundError(), False, id="absent"),
+        pytest.param(OSError("unreadable"), True, id="unreadable"),
     ],
 )
 def test_memory_indep_024_forward_package_shape_and_import_contract(
     monkeypatch: pytest.MonkeyPatch,
     metadata_result: object,
     expected_present: bool,
-    expected_version: str | None,
 ) -> None:
     """Forward upgrades preserve installed Memory unless absence is certain."""
 
@@ -49,7 +43,6 @@ def test_memory_indep_024_forward_package_shape_and_import_contract(
     monkeypatch.setattr("importlib.metadata.distribution", distribution)
 
     assert memory_package_installed() is expected_present
-    assert installed_memory_package_version() == expected_version
 
     package_shape_imports, reservation_imports = _production_imports()
 

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -26,7 +26,6 @@ from vibe.upgrade import (
     get_restart_shell_command,
     get_running_vibe_path,
     get_safe_cwd,
-    installed_package_name,
     pinned_package_spec,
     execute_upgrade_plan,
 )
@@ -36,19 +35,9 @@ from vibe.upgrade import (
 def _tree_is_not_an_installed_distribution(monkeypatch):
     """Every test here describes a machine, not the machine running the tests.
 
-    `installed_package_name()` asks this process's own metadata which
-    distribution provides `vibe`, and the answer differs by checkout: a developer
-    running from a source tree gets nothing, while CI installs the package first
-    and gets `avibe-os`. Tests written against the first answer pass locally and
-    then fail on a runner for a reason that has nothing to do with the change --
-    `test_a_spec_that_cannot_carry_a_pin_is_refused` did exactly that, because an
-    installed name outranks the configured spec whose refusal it was asserting.
-
-    Answering `[]` here is the honest state for a checkout, and it is the state
-    every test in this module was already written against. Only the ambient
-    metadata is removed; the interpreter-path heuristic stays live, so a test can
-    still hand in a uv tool path and be answered from it, and a test that wants a
-    measured name sets one explicitly.
+    Installed provider metadata differs between a source checkout and CI. Empty
+    provider metadata keeps forward-plan tests deterministic; tests for a mixed
+    provider state replace it explicitly.
     """
 
     monkeypatch.setattr("vibe.upgrade._distributions_providing_this_package", lambda: [])
@@ -127,24 +116,15 @@ def test_build_upgrade_plan_uses_env_package_spec(monkeypatch):
 #: How each installer spells "do it even though you believe it is already done".
 #: Written as a mapping rather than as two assertions so that an installer added
 #: to `build_upgrade_plan` later fails this test until someone decides what its
-#: word is, instead of silently shipping a rollback path that can no-op.
+#: word is, instead of silently shipping an exact install that can no-op.
 FORCES_THE_INSTALL = {"uv": "--force", "pip": "--force-reinstall"}
 
 
-def test_a_pinned_plan_never_asks_for_an_upgrade_and_always_forces_the_install(monkeypatch):
-    # Two ways for a rollback command to install nothing and still exit 0, one
-    # per word, and both silent on every installer path.
-    #
-    # Asking for an upgrade resolves forward to the exact release being rolled
-    # back FROM: uv resolves past the pin, pip declines to move backwards at all.
-    #
-    # Not forcing leaves the installer free to decide the pin is already
-    # satisfied -- and on the case this change exists for, it is. Installing
-    # `avibe-os` over a `vibe-remote` machine never uninstalls `vibe-remote`, so
-    # that distribution's metadata still stands and still claims the old version,
-    # while the files under `vibe/` are the new release's, written over the top.
-    # `pip install vibe-remote==<old>` reads as satisfied, pip does nothing, and
-    # the supervisor starts the failed generation again and calls it a recovery.
+def test_an_exact_plan_never_asks_for_an_upgrade_and_always_forces_the_install(monkeypatch):
+    # The explicit Memory install targets the running core release. Asking for an
+    # upgrade would widen that request, while omitting force lets the installer
+    # declare the already-present core requirement satisfied without applying the
+    # matching optional package.
     monkeypatch.setattr("vibe.upgrade.os.path.exists", lambda path: True)
     monkeypatch.setattr("vibe.upgrade.os.access", lambda path, mode: True)
 
@@ -154,6 +134,7 @@ def test_a_pinned_plan_never_asks_for_an_upgrade_and_always_forces_the_install(m
         vibe_path="/custom/bin/vibe",
         base_env={"PATH": "/usr/bin"},
         version="3.0.10",
+        package_name="avibe-os",
     )
     assert uv_plan.method == "uv"
     assert uv_plan.command == [
@@ -172,6 +153,7 @@ def test_a_pinned_plan_never_asks_for_an_upgrade_and_always_forces_the_install(m
         uv_path=None,
         base_env={"PATH": "/usr/bin"},
         version="3.0.10",
+        package_name="avibe-os",
     )
     assert pip_plan.method == "pip"
     assert pip_plan.command == [
@@ -196,23 +178,7 @@ def _metadata_records(monkeypatch, distribution: str, version: str) -> None:
 
 
 def test_a_forward_upgrade_forces_the_install_once_metadata_stops_describing_the_code(monkeypatch):
-    """The rollback's own no-op, one release later and with a person watching.
-
-    A rollback installs `vibe-remote==3.0.10` over a machine whose forward upgrade
-    installed `avibe-os==3.0.11`, and pip never uninstalls the distribution it
-    replaced. So the tree ends up holding both: the files under `vibe/` are 3.0.10,
-    and `avibe-os` still records 3.0.11 with nothing on disk behind it.
-
-    Then `vibe upgrade` runs. It compares this process's 3.0.10 against the
-    published 3.0.11 and decides to install; pip reads `avibe-os==3.0.11` as
-    already satisfied and does nothing; the command reports success and the
-    machine keeps running 3.0.10 -- silently, indefinitely, and now on the path a
-    user invokes by hand.
-
-    So `--force-reinstall` is not a property of pinned plans, it is a property of
-    asking for a version that is not the version on disk. Measured from our own
-    two answers, never read off the metadata that is the thing in doubt.
-    """
+    """A forward install cannot trust stale metadata over the running files."""
 
     monkeypatch.setattr("vibe.upgrade.os.path.exists", lambda path: True)
     monkeypatch.setattr("vibe.upgrade.os.access", lambda path, mode: True)
@@ -233,18 +199,8 @@ def test_a_forward_upgrade_forces_the_install_once_metadata_stops_describing_the
     assert "--force-reinstall" in plan.command
 
 
-def test_the_rename_pair_left_by_a_rollback_forces_the_next_install(monkeypatch):
-    """The state this check exists for is the one where two distributions are present.
-
-    A rollback across the rename installs `vibe-remote==3.0.10` over a tree whose
-    forward upgrade installed `avibe-os==3.0.11`, and pip does not uninstall the
-    distribution it replaced. So both are recorded and only one of them can be
-    describing the files under `vibe/`. Asking a single distribution -- or
-    treating "more than one" as unreadable -- would make this exact machine the
-    one machine that answers "metadata agrees", which is how the no-op ships:
-    the next upgrade asks pip for a version `avibe-os` already claims, pip does
-    nothing, and the instance keeps running the rolled-back code forever.
-    """
+def test_a_stale_rename_pair_forces_the_next_install(monkeypatch):
+    """Two disagreeing distribution records cannot make an upgrade a no-op."""
 
     monkeypatch.setattr("vibe.upgrade.os.path.exists", lambda path: True)
     monkeypatch.setattr("vibe.upgrade.os.access", lambda path, mode: True)
@@ -329,107 +285,8 @@ def test_an_unknown_install_shape_is_never_forced_on_a_guess(monkeypatch, case, 
     assert "--force-reinstall" not in plan.command, case
 
 
-def test_a_rollback_pins_the_distribution_the_install_actually_came_from(monkeypatch):
-    # Which distribution published the running version and which one the next
-    # upgrade should ask for are different questions, and on a machine that
-    # predates the rename they have different answers. Going forward wants the
-    # configured spec -- that is what the rename is for. Going back wants this,
-    # because `avibe-os==2.x` names a release that was never published under that
-    # name, so the rollback resolves to nothing and the instance stays dark.
-    monkeypatch.setenv("VIBE_UPGRADE_PACKAGE_SPEC", "avibe-os")
-
-    legacy = "/home/ai/.local/share/uv/tools/vibe-remote/bin/python"
-    assert pinned_package_spec("2.9.4", python_executable=legacy) == "vibe-remote==2.9.4"
-    plan = build_upgrade_plan(
-        python_executable=legacy,
-        uv_path="/usr/local/bin/uv",
-        base_env={"PATH": "/usr/bin"},
-        version="2.9.4",
-    )
-    assert "vibe-remote==2.9.4" in plan.command
-    assert not any(argument.startswith("avibe-os") for argument in plan.command)
-
-    # An install whose path says nothing about a distribution -- pip into a shared
-    # environment -- has only the configured spec to go on, and gets it.
-    assert pinned_package_spec("3.0.10", python_executable="/usr/bin/python3") == "avibe-os==3.0.10"
-
-
-def test_the_rename_pair_still_names_the_distribution_that_describes_the_code(monkeypatch):
-    """Two providers is not an unreadable machine, it is the aftermath of a rollback.
-
-    Installing `avibe-os` over a `vibe-remote` machine never uninstalls the older
-    distribution, so once a rollback has crossed the rename the tree holds both
-    for good. Every upgrade after that measures its rollback target in this state,
-    which is why reading two providers as unanswerable does not cost one recovery
-    -- it costs every recovery the machine will ever attempt.
-
-    The metadata is what tells them apart: `avibe-os` records the release that
-    failed, `vibe-remote` records the files that are running. Naming neither left
-    `package=None`, `pinned_package_spec` fell back to the configured forward
-    name, and `avibe-os==2.9.0` was never published under that name -- so the one
-    recovery attempt could only fail, on an instance that is already down.
-    """
-
-    monkeypatch.setenv("VIBE_UPGRADE_PACKAGE_SPEC", "avibe-os")
-    monkeypatch.setattr(
-        "vibe.upgrade._distributions_providing_this_package",
-        lambda: ["avibe-os", "vibe-remote"],
-    )
-    recorded = {"avibe-os": "3.0.11", "vibe-remote": "2.9.0"}
-    monkeypatch.setattr("importlib.metadata.version", lambda name: recorded[name])
-    monkeypatch.setattr("vibe.__version__", "2.9.0", raising=False)
-
-    assert installed_package_name() == "vibe-remote"
-
-
-
-
-def test_providers_that_cannot_be_told_apart_are_left_to_the_path(monkeypatch):
-    """Metadata answers this only while it distinguishes them.
-
-    Two distributions recording the same release is a vendored or mid-rename
-    environment, not a rollback, and there is nothing in the metadata to prefer
-    one name over the other. Guessing would put the pin on a distribution that may
-    never have published the version -- the same failure, arrived at from the
-    opposite direction -- so the interpreter path answers instead, and `None` when
-    it cannot either.
-    """
-
-    monkeypatch.setattr(
-        "vibe.upgrade._distributions_providing_this_package",
-        lambda: ["avibe-os", "vibe-remote"],
-    )
-    monkeypatch.setattr("importlib.metadata.version", lambda name: "3.0.11")
-    monkeypatch.setattr("vibe.__version__", "3.0.11", raising=False)
-
-    monkeypatch.setattr("vibe.upgrade.sys.executable", "/usr/bin/python3")
-    assert installed_package_name() is None
-
-    monkeypatch.setattr("vibe.upgrade.sys.executable", "/home/ai/.local/share/uv/tools/vibe-remote/bin/python")
-    assert installed_package_name() == "vibe-remote"
-
-
-def test_a_spec_that_cannot_carry_a_pin_is_refused(monkeypatch):
-    # The alternative to refusing is falling back to the unpinned spec, which is
-    # the reinstall-the-failure command above. Whoever configured a wheel path or
-    # an index URL as the upgrade source gets a rollback that fails loudly instead
-    # of one that lies. The message must not quote the spec: it can be an index
-    # URL carrying credentials, and it is written to a restart log.
-    monkeypatch.setenv("VIBE_UPGRADE_PACKAGE_SPEC", "https://user:secret@example.invalid/simple/avibe-os")
-
-    with pytest.raises(ValueError) as refusal:
-        pinned_package_spec("3.0.10")
-    assert "secret" not in str(refusal.value)
-
-    monkeypatch.setattr("vibe.upgrade.os.path.exists", lambda path: True)
-    monkeypatch.setattr("vibe.upgrade.os.access", lambda path, mode: True)
-    with pytest.raises(ValueError):
-        build_upgrade_plan(
-            python_executable="/usr/bin/python3",
-            uv_path=None,
-            base_env={"PATH": "/usr/bin"},
-            version="3.0.10",
-        )
+def test_exact_package_spec_uses_the_explicit_distribution() -> None:
+    assert pinned_package_spec("3.0.10", package_name="avibe-os") == "avibe-os==3.0.10"
 
 
 
@@ -798,13 +655,29 @@ def test_do_upgrade_uses_upgrade_plan_env_and_restarts(monkeypatch):
     }
 
 
-def test_do_upgrade_install_failure_is_terminal_and_does_not_restart(monkeypatch):
+def test_memory_indep_025_failed_upgrade_is_terminal_and_retryable(monkeypatch):
     plan = UpgradePlan(
         command=["/usr/bin/python3", "-m", "pip", "install", "--upgrade", "avibe-os"],
         env=None,
         method="pip",
     )
-    restart = Mock(side_effect=AssertionError("failed install scheduled a restart"))
+    restart = Mock(return_value={"job_id": "retry-restart"})
+    install = Mock(
+        side_effect=[
+            subprocess.CompletedProcess(
+                plan.command,
+                1,
+                stdout="",
+                stderr="resolver rejected the release",
+            ),
+            subprocess.CompletedProcess(
+                plan.command,
+                0,
+                stdout="installed on retry",
+                stderr="",
+            ),
+        ]
+    )
 
     monkeypatch.setattr(api, "configured_memory_enabled", lambda: False)
     monkeypatch.setattr(api, "get_version_info", lambda: {"latest": "3.0.15"})
@@ -812,26 +685,28 @@ def test_do_upgrade_install_failure_is_terminal_and_does_not_restart(monkeypatch
     monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/custom/bin/vibe")
     monkeypatch.setattr(api, "_runtime_process_was_running", lambda: True)
     monkeypatch.setattr(api, "schedule_restart", restart)
-    monkeypatch.setattr(
-        api.subprocess,
-        "run",
-        lambda command, **kwargs: subprocess.CompletedProcess(
-            command,
-            1,
-            stdout="",
-            stderr="resolver rejected the release",
-        ),
-    )
+    monkeypatch.setattr(api.subprocess, "run", install)
 
-    result = api.do_upgrade(auto_restart=True)
+    failed = api.do_upgrade(auto_restart=True)
+    succeeded = api.do_upgrade(auto_restart=True)
 
-    assert result == {
+    assert failed == {
         "ok": False,
         "message": "Upgrade failed",
         "output": "resolver rejected the release",
         "restarting": False,
     }
-    restart.assert_not_called()
+    assert succeeded == {
+        "ok": True,
+        "message": "Upgrade successful. Restarting...",
+        "output": "installed on retry",
+        "restarting": True,
+    }
+    assert [call.args[0] for call in install.call_args_list] == [
+        plan.command,
+        plan.command,
+    ]
+    restart.assert_called_once()
 
 def test_do_upgrade_blocks_mutation_when_memory_requirement_is_unreadable(
     monkeypatch,
@@ -1711,9 +1586,8 @@ def test_uv_forward_plan_locks_memory_to_target_release(monkeypatch):
     ]
 
 
-def test_pinned_rollback_keeps_exact_memory_version(monkeypatch):
+def test_explicit_memory_install_keeps_exact_package_version(monkeypatch):
     monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
-    monkeypatch.setattr("vibe.upgrade.memory_package_installed", lambda: True)
 
     plan = build_upgrade_plan(
         python_executable="/usr/bin/python3",

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -29,7 +29,6 @@ from vibe.package_shape import (
     CORE_PACKAGE_NAME,
     LEGACY_CORE_PACKAGE_NAME,
     MEMORY_PACKAGE_NAME as SHAPE_MEMORY_PACKAGE_NAME,
-    MEMORY_SPLIT_MIN_VERSION,
 )
 
 
@@ -39,7 +38,6 @@ PACKAGE_NAME = CORE_PACKAGE_NAME
 LEGACY_PACKAGE_NAME = LEGACY_CORE_PACKAGE_NAME
 MEMORY_PACKAGE_NAME = SHAPE_MEMORY_PACKAGE_NAME
 MEMORY_EXTRA_NAME = "memory"
-_MEMORY_SPLIT_MIN_VERSION = MEMORY_SPLIT_MIN_VERSION
 PIP_DOWNLOAD_DEST_PLACEHOLDER = "{avibe-pip-download-destination}"
 DEFAULT_UPDATE_METADATA_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
 CURRENT_VIBE_EXECUTABLE_ENV = "VIBE_CURRENT_EXECUTABLE"
@@ -51,9 +49,6 @@ UV_FALLBACK_BIN_DIRS = (".local/bin", ".cargo/bin")
 # anything with a path separator, a URL scheme, extras, a marker, or a version
 # of its own is deliberately excluded. See `pinned_package_spec`.
 _BARE_PACKAGE_NAME_RE = re.compile(r"[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?")
-# uv names a tool's directory after the distribution it installed, so this reads
-# back the name THIS process was installed under. See `installed_package_name`.
-_UV_TOOL_PATH_RE = re.compile(r"/uv/tools/(?P<name>[^/]+)/")
 # PEP 440-ish parser: release + optional pre-release (a/b/rc) + optional
 # post + optional dev, plus a local version segment (``+local``) that we
 # accept but ignore for ordering. Word forms (alpha/beta/preview) are listed
@@ -93,8 +88,6 @@ class UpgradePlan:
     method: str
     preflight_command: list[str] | None = None
     preflight_fallback_command: list[str] | None = None
-    cleanup_command: list[str] | None = None
-    cleanup_after_command: bool = False
 
 
 def execute_upgrade_plan(
@@ -103,7 +96,7 @@ def execute_upgrade_plan(
     run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
     **run_kwargs: object,
 ) -> subprocess.CompletedProcess[str]:
-    """Run a validated plan in its recorded preflight/cleanup order.
+    """Run a validated plan after its non-mutating preflight.
 
     The caller owns package mutation sequencing. This helper deliberately does
     not acquire a lifecycle lock: callers can run the plan synchronously while
@@ -115,21 +108,7 @@ def execute_upgrade_plan(
         if preflight.returncode != 0:
             return preflight
 
-    if plan.cleanup_command is not None and not plan.cleanup_after_command:
-        cleaned = run(plan.cleanup_command, env=plan.env, **run_kwargs)
-        if cleaned.returncode != 0:
-            return cleaned
-
-    installed = run(plan.command, env=plan.env, **run_kwargs)
-    if installed.returncode != 0:
-        return installed
-
-    if plan.cleanup_command is not None and plan.cleanup_after_command:
-        cleaned = run(plan.cleanup_command, env=plan.env, **run_kwargs)
-        if cleaned.returncode != 0:
-            return cleaned
-
-    return installed
+    return run(plan.command, env=plan.env, **run_kwargs)
 
 
 def preflight_upgrade_plan(
@@ -557,51 +536,6 @@ def is_legacy_uv_tool_install(python_executable: str | None = None) -> bool:
     return f"/uv/tools/{LEGACY_PACKAGE_NAME}/" in executable
 
 
-def installed_package_name(python_executable: str | None = None) -> str | None:
-    """The distribution this install was published as.
-
-    Which distribution published the running version is not the same question as
-    which one the next install should ask for, and the two genuinely differ: a
-    machine still on `vibe-remote` upgrades to `avibe-os`, that being the rename.
-    Anything going FORWARD wants the configured spec. Anything going BACK wants
-    this, because `avibe-os==2.x` names a release that was never published under
-    that name and an install of it can only fail.
-
-    Asked of the installed metadata first, because that is where the answer
-    actually is: the distribution that provides the running `vibe` package says
-    so itself, whatever layout it was installed into. Reading it off the
-    interpreter path recognised exactly one layout -- uv's tool directory -- and
-    answered `None` for every supported install that is not one, pip into a
-    virtualenv among them. `None` there is not neutral: the caller falls back to
-    the configured FORWARD package, so a `vibe-remote` install in a virtualenv
-    armed a rollback to `avibe-os==2.x` and spent the one recovery attempt on a
-    release that was never published.
-
-    The path heuristic stays as the fallback for the case metadata genuinely
-    cannot answer -- a source checkout, or providers that record the same release,
-    where naming one would be a guess. `None` when neither can say, which is the
-    honest answer for a tree that was never installed at all.
-    """
-
-    executable = (python_executable or sys.executable or "").replace("\\", "/")
-    # Only this process can be asked about its own metadata. A path belonging to
-    # some OTHER interpreter is answerable only by the layout it is written in.
-    if not python_executable or executable == (sys.executable or "").replace("\\", "/"):
-        distributions = _distributions_providing_this_package()
-        if len(distributions) == 1:
-            return distributions[0]
-        # More than one provider is not an unanswerable environment. It is the
-        # state a rollback leaves behind and never cleans up, so it is the state
-        # every subsequent upgrade measures its own rollback target in -- see
-        # `_providers_describing_running_code`.
-        describing = _providers_describing_running_code()
-        if len(describing) == 1:
-            return describing[0]
-
-    match = _UV_TOOL_PATH_RE.search(executable)
-    return match.group("name") if match else None
-
-
 def memory_package_installed() -> bool:
     """Return whether the optional Memory distribution is installed."""
 
@@ -615,19 +549,6 @@ def memory_package_installed() -> bool:
         logger.warning("Could not inspect %s metadata; preserving package shape", MEMORY_PACKAGE_NAME, exc_info=True)
         return True
     return True
-
-
-def installed_memory_package_version() -> str | None:
-    try:
-        from importlib.metadata import PackageNotFoundError, distribution
-
-        version = distribution(MEMORY_PACKAGE_NAME).version
-    except PackageNotFoundError:
-        return None
-    except Exception:
-        logger.warning("Could not inspect %s version", MEMORY_PACKAGE_NAME, exc_info=True)
-        return None
-    return str(version).strip() or None
 
 
 def configured_memory_enabled() -> bool:
@@ -696,24 +617,11 @@ def _providers_recording_a_published_release() -> list[tuple[str, str]]:
 
 
 def _providers_describing_running_code() -> list[str]:
-    """The providers whose recorded release is the one this process is running.
+    """Return providers whose recorded release matches the running code.
 
-    One owner for a question two callers ask for different purposes:
-    `installed_package_name` wants WHICH provider describes the files on disk,
-    and `installed_metadata_describes_running_code` wants WHETHER they all do.
-    Answering them separately is how the rename pair got two different rulings one
-    function apart -- the second was taught that two providers is the state it
-    exists for, while the first went on reading it as unanswerable.
-
-    That asymmetry is not academic, because the pair is permanent: installing
-    `avibe-os` over a `vibe-remote` machine never uninstalls the older
-    distribution, so once a rollback has crossed the rename the tree holds both
-    forever. `avibe-os` records the release that failed and `vibe-remote` records
-    the files actually running, and the metadata is what distinguishes them --
-    naming neither meant every later upgrade armed its rollback with no
-    distribution, and `pinned_package_spec` fell back to the configured forward
-    name. `avibe-os==2.9.0` was never published, so that one recovery attempt
-    could only fail, on a machine that is already down.
+    Multiple providers can remain after the `vibe-remote` to `avibe-os` rename.
+    Comparing every published record prevents a forward install from becoming a
+    silent no-op when stale metadata claims the requested release is present.
     """
 
     from vibe import __version__
@@ -726,35 +634,12 @@ def _providers_describing_running_code() -> list[str]:
 
 
 def installed_metadata_describes_running_code() -> bool:
-    """Whether the installed distribution's recorded version matches the files.
+    """Whether every published provider record matches the running files.
 
-    pip decides whether to act by reading metadata, and a rollback is the one
-    operation that makes metadata stop describing the code. Installing `avibe-os`
-    over a `vibe-remote` machine never uninstalls the older distribution, so
-    after the rollback reinstalls `vibe-remote==3.0.10` the tree holds two: the
-    files under `vibe/` are 3.0.10, and `avibe-os` still records 3.0.11 with
-    nothing on disk to back it.
-
-    The next forward upgrade is then a silent no-op. `vibe upgrade` compares this
-    process's 3.0.10 against the published 3.0.11 and decides to install; pip
-    reads `avibe-os==3.0.11` as already satisfied and does nothing; the command
-    reports success and the machine keeps running 3.0.10. Same shape as the
-    rollback no-op, one release later and with a person watching it happen.
-
-    Measured by comparing our own two answers rather than by trusting either --
-    the version this process bound at import against the version the metadata
-    records for each distribution providing it. Unknown answers `True`: only a
-    disagreement between two published releases is evidence, so a source checkout
-    or an editable install is never forced on a guess.
-
-    Every provider is asked, not just a single one, because the rename pair is
-    the state this exists for: after a rollback across `vibe-remote` ->
-    `avibe-os` the tree holds BOTH, and only one of them can be describing the
-    files on disk. Treating "more than one provider" as unknown would have made
-    the exact state described above the one state that answers `True` -- the
-    check declining to fire on its own scenario. `installed_package_name` reads
-    the same measurement for the other half of that state; both go through
-    `_providers_describing_running_code` so neither can be taught it alone.
+    pip trusts installed metadata when deciding whether an upgrade has work to
+    do. A mismatch therefore forces the forward reinstall. Unknown source or
+    editable layouts remain unforced because they provide no reliable published
+    version to compare.
     """
 
     from vibe import __version__
@@ -785,10 +670,7 @@ def _names_a_published_release(version: str) -> bool:
     A development build's version describes the tree it was built from rather
     than anything published: PEP 440 spells that as a `dev` segment, a local
     segment (`+<sha>`), or both, and the regression builder emits exactly that
-    shape. Testing for one hard-coded sentinel string recognised the fallback
-    version and nothing else, so a regression instance armed a rollback to
-    `avibe-os==0.0.0.dev0+<sha>` and spent its one recovery attempt asking an
-    index for a release that cannot exist there.
+    shape.
 
     Asking the property instead of listing the strings is what stops the next
     unlisted shape from costing the same attempt. Unparseable reads as
@@ -876,45 +758,21 @@ def _memory_target_version(package_spec: str, target_version: str | None) -> str
 def pinned_package_spec(
     version: str,
     *,
-    python_executable: str | None = None,
-    package_name: str | None = None,
-    memory_package: bool = False,
+    package_name: str,
 ) -> str:
-    """The distribution this install came from, pinned to exactly one version.
+    """Pin one explicit distribution name to one exact published version.
 
-    `package_name` is the name measured before the forward install ran, and it
-    wins when given. Reading the name here instead would read it on the wrong side
-    of the event: the upgrade replaces the tool before it schedules the restart,
-    so by the time the detached supervisor asks, the install it can see is the new
-    one. Only the caller that ran before the install can answer for what was
-    replaced.
-
-    Falling back to the install on disk, and to configuration after that. A pin is
-    a claim that a specific release exists under a specific name, and something
-    has to witness which name that was.
-
-    Raises when the resulting name cannot carry a pin -- a local path, a direct
-    URL, or a spec that already states its own version. Refusing is the whole
-    point of the function existing: the caller that wants a pin is rolling back,
-    and an unpinned command resolves forward to the release it is rolling back
-    FROM, reinstalling the failure and reporting success. A rollback that cannot
-    be pinned has to fail loudly instead.
+    The explicit Memory install uses this to reinstall the running core release
+    together with its matching optional package. The distribution name must be a
+    bare package name; direct URLs and pre-versioned requirements are rejected.
 
     The message never quotes the spec. An operator-supplied spec can be an index
-    URL carrying credentials, and this error is written to a restart log.
-
-    `memory_package` remains a compatibility argument for existing callers. It
-    never changes the core requirement: rollback Memory is always a separate
-    exact pin.
+    URL carrying credentials.
     """
 
-    spec = package_name or installed_package_name(python_executable) or get_upgrade_package_spec()
+    spec = package_name
     if _BARE_PACKAGE_NAME_RE.fullmatch(spec) is None:
         raise ValueError("The configured upgrade package spec cannot carry a version pin")
-    # Rollback requirements are independent exact pins. An extra couples the
-    # core pin back to whichever Memory constraint that historical core happens
-    # to declare, which cannot express optional-era mismatches or residual
-    # Memory next to a bundled pre-split core.
     return f"{spec}=={version}"
 
 
@@ -934,14 +792,9 @@ def build_upgrade_plan(
 ) -> UpgradePlan:
     """How to install avibe: the newest release, or `version` exactly.
 
-    A pinned plan is not an upgrade plan with an extra argument. It never asks
-    for the newest release, because the caller pinning a version is going
-    backwards from one -- and both package managers treat "upgrade" as a
-    direction, not a preference: uv resolves forward past the pin's own
-    requirement, and pip's `--upgrade` declines to install an older version than
-    the one already there. So the pin replaces the upgrade request rather than
-    qualifying it, and `--force` becomes unconditional on the uv path, where
-    installing over an existing tool is otherwise refused.
+    Exact-version plans support the explicit Memory package install action. They
+    replace the ordinary upgrade request and force the installer so the matching
+    optional distribution is applied even when core is already satisfied.
     """
 
     executable = python_executable or sys.executable
@@ -958,9 +811,7 @@ def build_upgrade_plan(
     package_spec = (
         pinned_package_spec(
             version,
-            python_executable=executable,
-            package_name=package_name,
-            memory_package=include_memory,
+            package_name=package_name or PACKAGE_NAME,
         )
         if version
         else (package_spec or get_upgrade_package_spec())
@@ -1005,32 +856,15 @@ def build_upgrade_plan(
     command = [executable, "-m", "pip", "install"]
     if not version:
         command.append("--upgrade")
-    # Neither a pin nor `--upgrade` makes pip act; metadata does, and a rollback
-    # is what makes metadata stop describing the code. So the command forces
-    # whenever the version being asked for is not already the version on disk --
-    # measured here, never read off the metadata that is the thing in doubt.
-    #
-    # A pinned plan always forces: it IS the rollback, running on a machine where
-    # `avibe-os` was just installed over `vibe-remote`, so `pip install
-    # vibe-remote==<old>` reads as already satisfied, pip does nothing, and the
-    # supervisor starts the failed generation again and reports success. The uv
-    # branch above has always forced a pinned install; this branch quietly did
-    # not. A forward plan forces only once that has happened -- the leftover
-    # `avibe-os==3.0.11` metadata would otherwise make the next upgrade a no-op
-    # too, silently, with a person watching it report success.
+    # pip decides whether to act from metadata. Exact installs always force so a
+    # matching optional package is applied even when core is already satisfied;
+    # forward installs force only when published provider metadata disagrees with
+    # the running files.
     if version or not installed_metadata_describes_running_code():
         command.append("--force-reinstall")
     command.append(package_spec)
     if pinned_memory_spec:
         command.append(pinned_memory_spec)
-    cleanup_command = None
-    cleanup_after_command = False
-    if version and not include_memory and memory_package_installed():
-        cleanup_command = [executable, "-m", "pip", "uninstall", "--yes", MEMORY_PACKAGE_NAME]
-        try:
-            cleanup_after_command = Version(version) >= _MEMORY_SPLIT_MIN_VERSION
-        except InvalidVersion:
-            pass
     preflight_command = None
     # Preflight only when the optional package shape is part of the operation.
     # Core-only forward installs retain the origin/dev synchronous behavior: the
@@ -1059,7 +893,7 @@ def build_upgrade_plan(
         if pinned_memory_spec:
             preflight_command.append(pinned_memory_spec)
             preflight_fallback_command.append(pinned_memory_spec)
-    elif include_memory or cleanup_command is not None:
+    elif include_memory:
         preflight_command = [
             executable,
             "-m",
@@ -1077,8 +911,6 @@ def build_upgrade_plan(
         method="pip",
         preflight_command=preflight_command,
         preflight_fallback_command=preflight_fallback_command,
-        cleanup_command=cleanup_command,
-        cleanup_after_command=cleanup_after_command,
     )
 
 def get_safe_cwd() -> str:


### PR DESCRIPTION
## Summary
- align Memory documentation and agent guidance with the completed optional in-process, forward-only package contract
- delete verified dead rollback-era upgrade planner surfaces while preserving forward install, preflight, and normal restart behavior
- add executable `MEMORY-INDEP-025` coverage for structured terminal failure, no compensating package mutation, and a later successful retry

Requires #1774, merged at the exact base `8033662faec6dd4e925e83ed81c9b8ceb7ed7a1b`.

## Evidence
- Unit: `tests/test_upgrade_flow.py` (88 passed)
- Contract: Memory distribution forward-only release contract (1 passed)
- Scenario: `MEMORY-INDEP-025` plus Memory independence package-shape scenarios (12 passed)
- Restart: `tests/test_restart_supervisor.py` (26 passed)
- Static: Ruff, `py_compile`, Markdown/YAML parsing, unique scenario IDs, and `git diff --check` passed
- Packaged smoke: deferred to exact-head CI because the generated Show Runtime manifest/artifacts are absent locally

## Known By Design
- `vibe/runtime.py` launcher remains: production service and UI spawn paths consume it.
- `build_upgrade_plan(..., memory_package=...)` remains: production explicit Memory installation and target-interpreter planning consume it.
- Memory Runtime manifest/hash/fetch/verify/backup availability safeguards remain and are distinct from retired installed-package rollback machinery.
- `storage/backups.py`, release workflows, UI behavior, persisted state, and service lifecycle are unchanged.

## Residual Manual Checks
- No Incus or local Avibe restart was run, per scope. Exact-head GitHub CI owns packaged smoke and lint.