### PR TITLE
fix(model-hub): show mapped model in route rows

### DIFF
--- a/docs/plans/model-hub-ui-spec.md
+++ b/docs/plans/model-hub-ui-spec.md
@@ -964,8 +964,9 @@ a different key.
 | `{{vendor}}` | The upstream vendor's product name, as the user chose it. | Always present | `addSub.title`, `addSub.paste.title.code`, `addSub.paste.title.callbackUrl`, `adopt.effects.1` |
 | `{{host}}` | The source's host, as entered, without scheme or path. | **Absent when the source has no entered host** `[contract]`: `base_url` is `api_key`-kind only, null there means the vendor's official endpoint, and a subscription may not carry one at all. §1.6 states what the one string that interpolates it renders instead. | `sourceDetail.summary` |
 | `{{source}}` | A source's display name. | Always present | `gateway.row.current`, `gateway.row.currentTakeover`, `guard.title.editSource`, `guard.title.refetch`, `guard.title.removeModel`, `guard.title.removeSource`, `guard.title.replaceKey`, `sourceDetail.edit.title`, `upstream.repair.reauthConfirm.title` |
-| `{{model}}` | A model's display id, as the source reports it. | Always present | `guard.title.removeModel`, server-owned `models.launch.route_unconfigured` |
+| `{{model}}` | A model's display id, as the source reports it. | Always present | `gateway.row.current`, `gateway.row.currentTakeover`, `guard.title.removeModel`, server-owned `models.launch.route_unconfigured` |
 | `{{models}}` | Several model ids, joined by `、` / `,` — the ids that left the discovered slice on one fetch. Ids as the source reported them, never display names, because the row that carried a display name is the row that is gone. | Always present in the one key that carries it: `sourceDetail.refetch.removed` renders only when at least one id was removed, which is the same branch guarantee that keeps its `{{count}}` off zero. | `sourceDetail.refetch.removed` |
+| `{{mapping}}` | The complete localized source-to-upstream-model phrase produced by `gateway.row.current` or `gateway.row.currentTakeover`. | Always present | `routeDialog.openWithMapping` |
 | `{{n}}` | A hop's 1-based position in the configured order. | Always present | `guard.hop.position`, `guard.hop.position.removeSource` |
 | `{{menuModel}}` | A protected **menu** model's id — from the held Route identity or `SupplyGap.model_id`. It is its own slot rather than a second use of `{{model}}` because the two name different things and the guard turns on the difference: `{{model}}` is an id a source reports, and `model-hub.md` says 「the protected identifier is always the menu model, never a hop's upstream `model_id`」. | Always present | `guard.gap.subject`, `guard.title.saveRoute`, `route.title` |
 | `{{agents}}` | The enabled named Vibe Agents that pinned this menu model, by name, joined by `、` / `,` — `SupplyGap.agents` `[contract]`. | Always present in the one key that carries it: `SupplyGap.agents` 「is present and may be empty」, and an empty one renders no line at all, which is `model-hub.md`'s 「names affected Agents **when any exist**」 read as a branch rather than as an empty list. | `guard.gap.agents` |
@@ -1477,8 +1478,8 @@ unable to outlive its surface, which is the cheaper answer wherever it is availa
 | `gateway.fail.switchToDirect` `[derived]` | 没能切回直连 | The switch back to direct did not go through |
 | `gateway.retry` `[derived]` | 重试 | Retry |
 | `gateway.group.emptyModels` `[derived]` | 这个后端没有可用型号 | This backend has no models |
-| `gateway.row.current` | 来自 {{source}} | From: {{source}} |
-| `gateway.row.currentTakeover` | 来自 {{source}}(接管) | From: {{source}} (takeover) |
+| `gateway.row.current` | {{source}} → {{model}} | {{source}} → {{model}} |
+| `gateway.row.currentTakeover` | {{source}} → {{model}}（已自动切换） | {{source}} → {{model}} (Taken over) |
 | `models.launch.route_unconfigured` `[contract]` | 模型 {{model}} 尚未配置路由。请前往 Models 配置。 | Model {{model}} has no configured route. Open Models to configure one. |
 | `gateway.moreModels_one` | 还有 {{count}} 个型号 | {{count}} more model |
 | `gateway.moreModels_other` | 还有 {{count}} 个型号 | {{count}} more models |

--- a/ui/src/components/settings/models/AgentCard.test.tsx
+++ b/ui/src/components/settings/models/AgentCard.test.tsx
@@ -86,7 +86,46 @@ describe('AgentCard', () => {
     const key = modelChainKey('claude', 'claude-opus-4-6');
     render(<I18nextProvider i18n={i18n}><AgentCard agents={[hubAgent]} sources={[source('src_a', 'Primary'), source('src_b', 'Backup')]} chains={{ [key]: readyRegion({ contract_version: 6, backend: 'claude', model_id: 'claude-opus-4-6', current: { source_id: 'src_b', model_id: 'claude-opus-4-6' }, chain: [{ source_id: 'src_a', model_id: 'claude-opus-4-6', channel: 'hub', health: 'cooldown', runnable: false, reason: null, retry_at: '2099-01-01T00:00:00Z' }, { source_id: 'src_b', model_id: 'claude-opus-4-6', channel: 'hub', health: 'healthy', runnable: true, reason: null, retry_at: null }], supply_state: 'ok' }) }} pendingBackends={new Set()} switchFailures={new Set()} connectingBackend={null} onConnectHub={vi.fn()} onSwitchDirect={vi.fn()} onOpenOrder={vi.fn()} onOpenRoute={vi.fn()} onProbeSettled={vi.fn()} /></I18nextProvider>);
     expect(screen.getByText(/Backup/)).toBeTruthy();
-    expect(screen.getByText(/takeover/i)).toBeTruthy();
+    expect(screen.getByTitle('Backup → claude-opus-4-6 (Taken over)')).toBeTruthy();
+  });
+
+  it.each([
+    ['en', 'Gateway', 'Backup source → routed-opus'],
+    ['zh', '网关', 'Backup source → routed-opus'],
+  ] as const)('renders the %s mode label beside the exact source-to-model mapping', (lng, modeCopy, title) => {
+    const key = modelChainKey('claude', 'claude-opus-4-6');
+    render(
+      <I18nextProvider i18n={localeInstance(lng)}>
+        <AgentCard
+          agents={[hubAgent]}
+          sources={[source('src_b', 'Backup source')]}
+          chains={{
+            [key]: readyRegion({
+              contract_version: 6,
+              backend: 'claude',
+              model_id: 'claude-opus-4-6',
+              current: { source_id: 'src_b', model_id: 'routed-opus' },
+              chain: [{ source_id: 'src_b', model_id: 'routed-opus', channel: 'hub', health: 'healthy', runnable: true, reason: null, retry_at: null }],
+              supply_state: 'ok',
+            }),
+          }}
+          pendingBackends={new Set()}
+          switchFailures={new Set()}
+          connectingBackend={null}
+          onConnectHub={vi.fn()}
+          onSwitchDirect={vi.fn()}
+          onOpenOrder={vi.fn()}
+          onOpenRoute={vi.fn()}
+          onProbeSettled={vi.fn()}
+        />
+      </I18nextProvider>,
+    );
+
+    const mapping = screen.getByTitle(title);
+    expect(mapping.parentElement?.textContent).toContain(modeCopy);
+    expect(mapping.querySelector('[data-route-source]')?.textContent).toBe('Backup source');
+    expect(mapping.querySelector('[data-route-upstream-model]')?.textContent).toBe('routed-opus');
+    expect(mapping.querySelector('.lucide-arrow-right')).toBeTruthy();
   });
 
   it('does not call a later current hop takeover unless the head is unavailable for cooldown', () => {

--- a/ui/src/components/settings/models/AgentCard.test.tsx
+++ b/ui/src/components/settings/models/AgentCard.test.tsx
@@ -82,17 +82,21 @@ describe('AgentCard', () => {
     expect(screen.getByText(copy)).toBeTruthy();
   });
 
-  it('derives takeover from the exact current hop', () => {
+  it.each([
+    ['en', 'Backup → claude-opus-4-6 (Taken over)', 'Open claude-opus-4-6 route chain · Backup → claude-opus-4-6 (Taken over)'],
+    ['zh', 'Backup → claude-opus-4-6（已自动切换）', '打开 claude-opus-4-6 的路由 · Backup → claude-opus-4-6（已自动切换）'],
+  ] as const)('derives and announces takeover from the exact current hop in %s', (lng, mappingCopy, accessibleName) => {
     const key = modelChainKey('claude', 'claude-opus-4-6');
-    render(<I18nextProvider i18n={i18n}><AgentCard agents={[hubAgent]} sources={[source('src_a', 'Primary'), source('src_b', 'Backup')]} chains={{ [key]: readyRegion({ contract_version: 6, backend: 'claude', model_id: 'claude-opus-4-6', current: { source_id: 'src_b', model_id: 'claude-opus-4-6' }, chain: [{ source_id: 'src_a', model_id: 'claude-opus-4-6', channel: 'hub', health: 'cooldown', runnable: false, reason: null, retry_at: '2099-01-01T00:00:00Z' }, { source_id: 'src_b', model_id: 'claude-opus-4-6', channel: 'hub', health: 'healthy', runnable: true, reason: null, retry_at: null }], supply_state: 'ok' }) }} pendingBackends={new Set()} switchFailures={new Set()} connectingBackend={null} onConnectHub={vi.fn()} onSwitchDirect={vi.fn()} onOpenOrder={vi.fn()} onOpenRoute={vi.fn()} onProbeSettled={vi.fn()} /></I18nextProvider>);
+    render(<I18nextProvider i18n={localeInstance(lng)}><AgentCard agents={[hubAgent]} sources={[source('src_a', 'Primary'), source('src_b', 'Backup')]} chains={{ [key]: readyRegion({ contract_version: 6, backend: 'claude', model_id: 'claude-opus-4-6', current: { source_id: 'src_b', model_id: 'claude-opus-4-6' }, chain: [{ source_id: 'src_a', model_id: 'claude-opus-4-6', channel: 'hub', health: 'cooldown', runnable: false, reason: null, retry_at: '2099-01-01T00:00:00Z' }, { source_id: 'src_b', model_id: 'claude-opus-4-6', channel: 'hub', health: 'healthy', runnable: true, reason: null, retry_at: null }], supply_state: 'ok' }) }} pendingBackends={new Set()} switchFailures={new Set()} connectingBackend={null} onConnectHub={vi.fn()} onSwitchDirect={vi.fn()} onOpenOrder={vi.fn()} onOpenRoute={vi.fn()} onProbeSettled={vi.fn()} /></I18nextProvider>);
     expect(screen.getByText(/Backup/)).toBeTruthy();
-    expect(screen.getByTitle('Backup → claude-opus-4-6 (Taken over)')).toBeTruthy();
+    expect(screen.getByTitle(mappingCopy)).toBeTruthy();
+    expect(screen.getByRole('button', { name: accessibleName })).toBeTruthy();
   });
 
   it.each([
-    ['en', 'Gateway', 'Backup source → routed-opus'],
-    ['zh', '网关', 'Backup source → routed-opus'],
-  ] as const)('renders the %s mode label beside the exact source-to-model mapping', (lng, modeCopy, title) => {
+    ['en', 'Gateway', 'Backup source → routed-opus', 'Open claude-opus-4-6 route chain · Backup source → routed-opus'],
+    ['zh', '网关', 'Backup source → routed-opus', '打开 claude-opus-4-6 的路由 · Backup source → routed-opus'],
+  ] as const)('renders and announces the %s source-to-model mapping', (lng, modeCopy, mappingCopy, accessibleName) => {
     const key = modelChainKey('claude', 'claude-opus-4-6');
     render(
       <I18nextProvider i18n={localeInstance(lng)}>
@@ -121,11 +125,11 @@ describe('AgentCard', () => {
       </I18nextProvider>,
     );
 
-    const mapping = screen.getByTitle(title);
+    const routeButton = screen.getByRole('button', { name: accessibleName });
+    const mapping = screen.getByTitle(mappingCopy);
+    expect(routeButton.contains(mapping)).toBe(true);
     expect(mapping.parentElement?.textContent).toContain(modeCopy);
-    expect(mapping.querySelector('[data-route-source]')?.textContent).toBe('Backup source');
-    expect(mapping.querySelector('[data-route-upstream-model]')?.textContent).toBe('routed-opus');
-    expect(mapping.querySelector('.lucide-arrow-right')).toBeTruthy();
+    expect(mapping.textContent).toBe(mappingCopy);
   });
 
   it('does not call a later current hop takeover unless the head is unavailable for cooldown', () => {

--- a/ui/src/components/settings/models/AgentCard.tsx
+++ b/ui/src/components/settings/models/AgentCard.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ArrowDownUp, ArrowRight, Check, ChevronDown, ChevronRight, ChevronUp, PlugZap, Power, RefreshCw, Route } from 'lucide-react';
+import { ArrowDownUp, Check, ChevronDown, ChevronRight, ChevronUp, PlugZap, Power, RefreshCw, Route } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { Badge } from '@/components/ui/badge';
@@ -55,15 +55,21 @@ const ModelRow: React.FC<{
   const currentCopy = supplyState === 'paused'
     ? t('settings.models.legend.unavailable') as string
     : resolved
-      ? `${currentSource} → ${current.model_id}${takeover ? ` (${t('settings.models.takeover.chip')})` : ''}`
+      ? t(takeover ? 'settings.models.gateway.row.currentTakeover' : 'settings.models.gateway.row.current', {
+        source: currentSource,
+        model: current.model_id,
+      }) as string
       : '—';
+  const openRouteLabel = resolved && supplyState !== 'paused'
+    ? t('settings.models.routeDialog.openWithMapping', { model: modelId, mapping: currentCopy }) as string
+    : t('settings.models.routeDialog.open', { model: modelId }) as string;
   return (
     <button
       type="button"
       data-route-backend={agent.backend}
       data-route-model={modelId}
       onClick={(event) => onOpenRoute(agent, modelId, event.currentTarget)}
-      aria-label={t('settings.models.routeDialog.open', { model: modelId }) as string}
+      aria-label={openRouteLabel}
       className="model-hub-model-row flex h-9 w-full min-w-0 items-center gap-2.5 overflow-hidden rounded-md border border-border px-3 text-left"
     >
       <span className="flex min-w-0 flex-1 items-center justify-between gap-2.5">
@@ -72,14 +78,11 @@ const ModelRow: React.FC<{
           <span className="model-hub-pill model-hub-model-mode-chip shrink-0 border border-border text-muted">{mode}</span>
           {resolved && supplyState !== 'paused' ? (
             <span
-              className={cn('model-hub-model-current flex min-w-0 flex-1 items-center justify-end gap-1.5 text-right text-[10.5px]', takeover && 'model-hub-model-current--takeover')}
+              className={cn('model-hub-model-current min-w-0 flex-1 truncate text-right text-[10.5px]', takeover && 'model-hub-model-current--takeover')}
               title={currentCopy}
               data-route-mapping
             >
-              <span className="min-w-0 truncate" data-route-source>{currentSource}</span>
-              <ArrowRight className="size-3 shrink-0" aria-hidden="true" />
-              <span className="min-w-0 truncate font-mono" data-route-upstream-model>{current.model_id}</span>
-              {takeover ? <span className="hidden shrink-0 sm:inline">({t('settings.models.takeover.chip')})</span> : null}
+              {currentCopy}
             </span>
           ) : (
             <span className={cn('model-hub-model-current min-w-0 flex-1 truncate text-right text-[10.5px]', supplyState === 'paused' && 'model-hub-ink-gold')} title={currentCopy}>{currentCopy}</span>

--- a/ui/src/components/settings/models/AgentCard.tsx
+++ b/ui/src/components/settings/models/AgentCard.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ArrowDownUp, Check, ChevronDown, ChevronRight, ChevronUp, PlugZap, Power, RefreshCw, Route } from 'lucide-react';
+import { ArrowDownUp, ArrowRight, Check, ChevronDown, ChevronRight, ChevronUp, PlugZap, Power, RefreshCw, Route } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { Badge } from '@/components/ui/badge';
@@ -51,10 +51,11 @@ const ModelRow: React.FC<{
       ? t('settings.models.legend.native') as string
       : t('settings.models.gateway.group.mode.gateway') as string
     : '—';
+  const currentSource = resolved ? sourceName(sources, current.source_id) : '';
   const currentCopy = supplyState === 'paused'
     ? t('settings.models.legend.unavailable') as string
     : resolved
-      ? t(takeover ? 'settings.models.gateway.row.currentTakeover' : 'settings.models.gateway.row.current', { source: sourceName(sources, current.source_id) }) as string
+      ? `${currentSource} → ${current.model_id}${takeover ? ` (${t('settings.models.takeover.chip')})` : ''}`
       : '—';
   return (
     <button
@@ -66,8 +67,24 @@ const ModelRow: React.FC<{
       className="model-hub-model-row flex h-9 w-full min-w-0 items-center gap-2.5 overflow-hidden rounded-md border border-border px-3 text-left"
     >
       <span className="flex min-w-0 flex-1 items-center justify-between gap-2.5">
-        <span className="flex min-w-0 flex-1 items-center gap-[7px]"><span className="min-w-0 flex-1 truncate font-mono text-[12px] font-medium text-foreground" title={modelId}>{modelId}</span><span className="model-hub-pill model-hub-model-mode-chip border border-border text-muted">{mode}</span></span>
-        <span className={cn('model-hub-model-current min-w-0 flex-1 truncate text-right text-[10.5px]', supplyState === 'paused' ? 'model-hub-ink-gold' : takeover && 'model-hub-model-current--takeover')} title={currentCopy}>{currentCopy}</span>
+        <span className="min-w-0 flex-1 truncate font-mono text-[12px] font-medium text-foreground" title={modelId}>{modelId}</span>
+        <span className="flex min-w-0 flex-1 items-center justify-end gap-[7px]">
+          <span className="model-hub-pill model-hub-model-mode-chip shrink-0 border border-border text-muted">{mode}</span>
+          {resolved && supplyState !== 'paused' ? (
+            <span
+              className={cn('model-hub-model-current flex min-w-0 flex-1 items-center justify-end gap-1.5 text-right text-[10.5px]', takeover && 'model-hub-model-current--takeover')}
+              title={currentCopy}
+              data-route-mapping
+            >
+              <span className="min-w-0 truncate" data-route-source>{currentSource}</span>
+              <ArrowRight className="size-3 shrink-0" aria-hidden="true" />
+              <span className="min-w-0 truncate font-mono" data-route-upstream-model>{current.model_id}</span>
+              {takeover ? <span className="hidden shrink-0 sm:inline">({t('settings.models.takeover.chip')})</span> : null}
+            </span>
+          ) : (
+            <span className={cn('model-hub-model-current min-w-0 flex-1 truncate text-right text-[10.5px]', supplyState === 'paused' && 'model-hub-ink-gold')} title={currentCopy}>{currentCopy}</span>
+          )}
+        </span>
       </span>
       <ChevronRight className="model-hub-overview-chevron size-[15px] shrink-0" aria-hidden="true" />
     </button>

--- a/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
@@ -85,6 +85,9 @@ const takeoverChain: AgentChain = {
   supply_state: 'ok',
 };
 
+const takeoverMappingTitle = /Replacement source → gpt-5\.6-sol \((?:Taken over|已自动切换)\)/i;
+const headMappingTitle = /^Paused source → gpt-5\.6-sol$/i;
+
 const usageSummary: UsageSummary = {
   window_days: 30,
   from_day: '2026-07-20',
@@ -790,7 +793,7 @@ describe('SettingsModelsPage surface branches', () => {
 
     expect(await screen.findByText(/^1 takeover active$|^1 处已自动切换$/i)).toBeTruthy();
     expect(screen.getByText(/^Taken over$|^已自动切换$/i)).toBeTruthy();
-    expect(screen.getByText(/From: Replacement source \(takeover\)|来自 Replacement source（接管）/i)).toBeTruthy();
+    expect(screen.getByTitle(takeoverMappingTitle)).toBeTruthy();
   });
 
   it('[MH-OVERVIEW-001] reads overview chains once per backend and keeps exact reads for the route dialog', async () => {
@@ -1079,7 +1082,7 @@ describe('SettingsModelsPage surface branches', () => {
 
     expect(screen.queryByRole('button', { name: /route chain|路由链/i })).toBeNull();
     expect(screen.queryByText(/^Taken over$|^已自动切换$/i)).toBeNull();
-    expect(screen.queryByText(/From: Replacement source \(takeover\)|来自 Replacement source（接管）/i)).toBeNull();
+    expect(screen.queryByTitle(takeoverMappingTitle)).toBeNull();
   });
 
   it('cannot let a pre-save chain read overwrite the committed route echo', async () => {
@@ -1119,15 +1122,15 @@ describe('SettingsModelsPage surface branches', () => {
     await userEvent.click(removeButtons[1]);
     await userEvent.click(screen.getByRole('button', { name: /^Save$|^保存$/i }));
     await userEvent.click((await screen.findByText(/^Done$|^完成$/i)).closest('button') as HTMLButtonElement);
-    expect(await screen.findByText(/^From: Paused source$|^来自 Paused source$/i)).toBeTruthy();
+    expect(await screen.findByTitle(headMappingTitle)).toBeTruthy();
 
     await act(async () => {
       pendingOldChain.resolve(takeoverChain);
       await pendingOldChain.promise;
     });
 
-    expect(screen.getByText(/^From: Paused source$|^来自 Paused source$/i)).toBeTruthy();
-    expect(screen.queryByText(/From: Replacement source \(takeover\)|来自 Replacement source（接管）/i)).toBeNull();
+    expect(screen.getByTitle(headMappingTitle)).toBeTruthy();
+    expect(screen.queryByTitle(takeoverMappingTitle)).toBeNull();
   });
 
   it('installs a removed backend before the committed route closes and applies PF-1', async () => {
@@ -1238,14 +1241,14 @@ describe('SettingsModelsPage surface branches', () => {
       </ToastProvider>,
     );
 
-    expect(await screen.findByText(/From: Replacement source \(takeover\)|来自 Replacement source（接管）/i)).toBeTruthy();
+    expect(await screen.findByTitle(takeoverMappingTitle)).toBeTruthy();
     await userEvent.click(screen.getByText('Paused source').closest('button') as HTMLButtonElement);
     await userEvent.click(await screen.findByRole('button', { name: /^Refetch$|^重新拉取$/i }));
 
     await waitFor(() => expect(agentRead).toHaveBeenCalledTimes(2));
     await closeSourceDetails();
     expect(await screen.findByText(/Could not read this backend's supply|没有读到后端列表/i)).toBeTruthy();
-    expect(screen.queryByText(/From: Replacement source \(takeover\)|来自 Replacement source（接管）/i)).toBeNull();
+    expect(screen.queryByTitle(takeoverMappingTitle)).toBeNull();
     expect(screen.getAllByText('—').length).toBeGreaterThan(0);
   });
 
@@ -1269,14 +1272,14 @@ describe('SettingsModelsPage surface branches', () => {
       </ToastProvider>,
     );
 
-    expect(await screen.findByText(/From: Replacement source \(takeover\)|来自 Replacement source（接管）/i)).toBeTruthy();
+    expect(await screen.findByTitle(takeoverMappingTitle)).toBeTruthy();
     await userEvent.click(screen.getByText('Paused source').closest('button') as HTMLButtonElement);
     await userEvent.click(await screen.findByRole('button', { name: /^Refetch$|^重新拉取$/i }));
 
     await waitFor(() => expect(runtimeRead).toHaveBeenCalledTimes(2));
     await closeSourceDetails();
     expect(await screen.findByText(/^Gateway status unavailable$|^模型网关状态不可用$/i)).toBeTruthy();
-    expect(screen.queryByText(/From: Replacement source \(takeover\)|来自 Replacement source（接管）/i)).toBeNull();
+    expect(screen.queryByTitle(takeoverMappingTitle)).toBeNull();
     expect(screen.queryByText(/^Taken over$|^已自动切换$/i)).toBeNull();
     expect(screen.getAllByText('—').length).toBeGreaterThan(0);
   });

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -913,6 +913,10 @@
           "none": "No usable source",
           "unread": "Could not read this backend's supply · the gateway itself is fine"
         },
+        "row": {
+          "current": "{{source}} → {{model}}",
+          "currentTakeover": "{{source}} → {{model}} (Taken over)"
+        },
         "group": {
           "subtitle": {
             "direct": "{{mode}}",
@@ -1194,6 +1198,7 @@
       "routeDialog": {
         "title": "{{menuModel}} · Route chain",
         "open": "Open {{model}} route chain",
+        "openWithMapping": "Open {{model}} route chain · {{mapping}}",
         "label": "Route chain for this model",
         "section": "Route chain for this model",
         "removeHop": "Remove hop",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -913,10 +913,6 @@
           "none": "No usable source",
           "unread": "Could not read this backend's supply · the gateway itself is fine"
         },
-        "row": {
-          "current": "From: {{source}}",
-          "currentTakeover": "From: {{source}} (takeover)"
-        },
         "group": {
           "subtitle": {
             "direct": "{{mode}}",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -913,6 +913,10 @@
           "none": "没有可用供应商",
           "unread": "路由状态暂时不可用 · 模型网关本身正常"
         },
+        "row": {
+          "current": "{{source}} → {{model}}",
+          "currentTakeover": "{{source}} → {{model}}（已自动切换）"
+        },
         "group": {
           "subtitle": {
             "direct": "{{mode}}",
@@ -1194,6 +1198,7 @@
       "routeDialog": {
         "title": "{{menuModel}} · 路由",
         "open": "打开 {{model}} 的路由",
+        "openWithMapping": "打开 {{model}} 的路由 · {{mapping}}",
         "label": "这个模型的路由",
         "section": "这个模型的路由",
         "removeHop": "移除这个路由项",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -913,10 +913,6 @@
           "none": "没有可用供应商",
           "unread": "路由状态暂时不可用 · 模型网关本身正常"
         },
-        "row": {
-          "current": "当前使用 {{source}}",
-          "currentTakeover": "当前使用 {{source}}（已自动切换）"
-        },
         "group": {
           "subtitle": {
             "direct": "{{mode}}",


### PR DESCRIPTION
## Summary

- group the existing Gateway mode label with the resolved route mapping
- show the exact runtime-selected upstream model as `source -> model`
- let each locale own the complete mapping order and punctuation while keeping the full value available to assistive technology

## Acceptance evidence

- Scenario: `MH-OVERVIEW-001`
- Unit: bilingual `AgentCard` coverage verifies ordinary and takeover mappings, including the exact route-button accessible name
- Model Hub UI suite: 69 files, 947 tests passed
- Production UI build: passed
- Contract: no backend or persisted configuration contract changed; the row renders the existing runtime `current.source_name` and `current.model_id`

## Dependencies

- None

## Known by design

- The localized route mapping truncates as one unit in narrow rows; its full value remains available in the tooltip and route-button accessible name.
- Browser-level visual verification remains pending because the in-app Browser bridge was unavailable in this session; focused DOM tests cover the exact rendered and accessible mapping.
