### PR TITLE
fix(install): launch from the installer-resolved path

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Claude Code, Codex, OpenCode are incredible. But:
 **One command turns your own machine into the home your AI partner lives in.** You drive the *official* Claude Code, Codex, and OpenCode — from a browser or any chat app — while your code and keys stay on your machine, and avibe.bot never sees your data.
 
 ```bash
-curl -fsSL https://avibe.bot/install.sh | bash && vibe
+curl -fsSL https://avibe.bot/install.sh | bash -s -- --launch
 ```
 
 The browser opens, you follow a short wizard, and your machine becomes an Agent OS you can reach from anywhere.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Claude Code, Codex, OpenCode are incredible. But:
 **One command turns your own machine into the home your AI partner lives in.** You drive the *official* Claude Code, Codex, and OpenCode — from a browser or any chat app — while your code and keys stay on your machine, and avibe.bot never sees your data.
 
 ```bash
-curl -fsSL https://avibe.bot/install.sh | bash -s -- --launch
+bash -o pipefail -c 'curl -fsSL https://avibe.bot/install.sh | bash -s -- --launch'
 ```
 
 The browser opens, you follow a short wizard, and your machine becomes an Agent OS you can reach from anywhere.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -41,7 +41,7 @@ Claude Code、Codex、OpenCode 都很能打。但是：
 **一条命令，把你自己的机器变成 AI 伙伴的家。** 你驱动的是*官方*的 Claude Code、Codex、OpenCode——从浏览器或任意聊天软件——而代码与密钥都留在你的机器上，avibe.bot 也看不到你的数据。
 
 ```bash
-curl -fsSL https://avibe.bot/install.sh | bash -s -- --launch
+bash -o pipefail -c 'curl -fsSL https://avibe.bot/install.sh | bash -s -- --launch'
 ```
 
 浏览器自动打开，跟着简短向导走完，你的机器就成了一个随处可达的 Agent OS。

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -41,7 +41,7 @@ Claude Code、Codex、OpenCode 都很能打。但是：
 **一条命令，把你自己的机器变成 AI 伙伴的家。** 你驱动的是*官方*的 Claude Code、Codex、OpenCode——从浏览器或任意聊天软件——而代码与密钥都留在你的机器上，avibe.bot 也看不到你的数据。
 
 ```bash
-curl -fsSL https://avibe.bot/install.sh | bash && vibe
+curl -fsSL https://avibe.bot/install.sh | bash -s -- --launch
 ```
 
 浏览器自动打开，跟着简短向导走完，你的机器就成了一个随处可达的 Agent OS。

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Avibe Installation Script
-# Usage: curl -fsSL https://avibe.bot/install.sh | bash -s -- --launch
+# Usage: bash -o pipefail -c 'curl -fsSL https://avibe.bot/install.sh | bash -s -- --launch'
 #
 # Prerequisites: None! uv will be installed automatically and manages Python for you.
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Avibe Installation Script
-# Usage: curl -fsSL https://avibe.bot/install.sh | bash
+# Usage: curl -fsSL https://avibe.bot/install.sh | bash -s -- --launch
 #
 # Prerequisites: None! uv will be installed automatically and manages Python for you.
 
@@ -20,6 +20,8 @@ NODE_MINIMUM_REQUIREMENT="20.19+ or 22.12+"
 VIBE_BIN_PATH=""
 VIBE_TOOL_BIN_DIR=""
 VIBE_CANDIDATE_BIN_PATH=""
+LAUNCH_AFTER_INSTALL=""
+AVIBE_LAUNCHED=""
 ORIGINAL_PATH="$PATH"
 if [ -n "${AVIBE_HOME:-}" ]; then
     AVIBE_RUNTIME_HOME="${AVIBE_HOME/#\~/$HOME}"
@@ -728,6 +730,22 @@ pair_remote_access() {
     success "Avibe service started"
 }
 
+launch_vibe() {
+    if [ "${LAUNCH_AFTER_INSTALL:-}" != "1" ] || [ "${REMOTE_ACCESS_PAIRED:-}" = "1" ]; then
+        return 0
+    fi
+
+    local vibe_cmd="${VIBE_BIN_PATH:-}"
+    if [ -z "$vibe_cmd" ] || [ ! -x "$vibe_cmd" ]; then
+        error "Cannot launch Avibe because the verified vibe command is not available."
+    fi
+
+    info "Launching Avibe with $vibe_cmd..."
+    "$vibe_cmd"
+    AVIBE_LAUNCHED="1"
+    success "Avibe launched"
+}
+
 print_uninstall_commands() {
     echo "  avibe_home=\"\${AVIBE_HOME:-\$HOME/.avibe}\""
     echo '  avibe_home="${avibe_home/#\~/$HOME}"'
@@ -781,7 +799,20 @@ print_next_steps() {
         return
     fi
 
-    if is_vibe_immediately_available; then
+    if [ "${AVIBE_LAUNCHED:-}" = "1" ]; then
+        if is_vibe_immediately_available; then
+            echo "  1. Finish setup in the browser"
+            echo "  2. Choose your chat platform and agent backend"
+            echo "  3. Enable a channel or DM and send your first task"
+            echo "  4. Optional: run 'vibe remote' to open the Web UI from another device"
+        else
+            echo "  1. Finish setup in the browser"
+            echo "  2. Run 'export PATH=\"${vibe_dir}:\$PATH\"' for future terminal commands"
+            echo "  3. Choose your chat platform and agent backend"
+            echo "  4. Enable a channel or DM and send your first task"
+            echo "  5. Optional: run 'vibe remote' to open the Web UI from another device"
+        fi
+    elif is_vibe_immediately_available; then
         echo "  1. Run 'vibe' to open the setup wizard"
         echo "  2. Choose your chat platform and agent backend"
         echo "  3. Enable a channel or DM and send your first task"
@@ -817,6 +848,14 @@ main() {
     print_banner
     REMOTE_ACCESS_PAIRING_KEY="${AVIBE_PAIRING_KEY:-}"
     unset AVIBE_PAIRING_KEY
+
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            --launch) LAUNCH_AFTER_INSTALL="1" ;;
+            *) error "Unsupported installer option: $arg" ;;
+        esac
+    done
     
     local os
     os=$(detect_os)
@@ -854,6 +893,10 @@ main() {
     # verified absolute vibe path, not PATH, so it works even when the installer
     # put the command into a fallback tool bin directory.
     pair_remote_access
+
+    # The public pipe-to-shell flow cannot update its parent shell's PATH.
+    # Launch through the verified absolute path while this process still owns it.
+    launch_vibe
     
     # Done
     print_next_steps

--- a/tests/e2e/test_install_command.py
+++ b/tests/e2e/test_install_command.py
@@ -14,6 +14,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BASE_IMAGE = os.environ.get("VIBE_INSTALL_TEST_IMAGE", "debian:trixie-slim")
+PUBLIC_INSTALL_COMMAND = "curl -fsSL https://avibe.bot/install.sh | bash -s -- --launch"
 
 
 def _resolve_install_wheel(fixtures_dir: Path) -> Path:
@@ -48,21 +49,40 @@ def _docker_available() -> bool:
 
 
 @pytest.mark.integration
-def test_install_command_starts_vibe_in_fresh_container():
+def test_install_command_starts_vibe_for_new_user_without_local_bin_on_path():
+    for readme in (REPO_ROOT / "README.md", REPO_ROOT / "README_ZH.md"):
+        assert PUBLIC_INSTALL_COMMAND in readme.read_text(encoding="utf-8")
+
     if not _docker_available():
         pytest.skip("Docker is not available")
 
     with tempfile.TemporaryDirectory(prefix="vibe-install-fixtures-") as tmpdir:
         fixtures_dir = Path(tmpdir)
         wheel_path = _resolve_install_wheel(fixtures_dir)
+        fixtures_dir.chmod(0o755)
+        wheel_path.chmod(0o644)
 
         container_name = f"vibe-install-smoke-{os.getpid()}"
+        local_install_command = PUBLIC_INSTALL_COMMAND.replace(
+            "curl -fsSL https://avibe.bot/install.sh",
+            "cat /work/install.sh",
+        )
         command = (
             "apt-get update >/dev/null && "
-            "apt-get install -y --no-install-recommends curl ca-certificates bash procps >/dev/null && "
-            f"cat /work/install.sh | env VIBE_INSTALL_SKIP_SHOW_RUNTIME=1 AVIBE_INSTALL_PACKAGE_SPEC=/fixtures/{wheel_path.name} bash && "
-            "vibe version && "
-            "vibe && sleep 2 && vibe status"
+            "apt-get install -y --no-install-recommends curl ca-certificates bash procps passwd >/dev/null && "
+            "useradd -m -s /bin/bash installer && "
+            "su - installer -s /bin/bash -c '"
+            "set -euo pipefail; "
+            "export PATH=/usr/bin:/bin; "
+            "export VIBE_INSTALL_SKIP_NODE=1; "
+            "export VIBE_INSTALL_SKIP_SHOW_RUNTIME=1; "
+            f"export AVIBE_INSTALL_PACKAGE_SPEC=/fixtures/{wheel_path.name}; "
+            f"{local_install_command}; "
+            "test \"$PATH\" = /usr/bin:/bin; "
+            "! command -v vibe; "
+            "/home/installer/.local/bin/vibe version; "
+            "sleep 2; "
+            "/home/installer/.local/bin/vibe status'"
         )
 
         try:
@@ -92,8 +112,10 @@ def test_install_command_starts_vibe_in_fresh_container():
             subprocess.run(["docker", "rm", "-f", container_name], capture_output=True)
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "Installing vibe command into" in result.stdout
+    assert "Installing vibe command into /home/installer/.local/bin" in result.stdout
     assert "avibe-os installed successfully (from custom package spec)" in result.stdout
+    assert "Launching Avibe with /home/installer/.local/bin/vibe" in result.stdout
+    assert "Avibe launched" in result.stdout
     assert "avibe-os " in result.stdout
     assert "Web UI:" in result.stdout
     assert '"running": true' in result.stdout

--- a/tests/e2e/test_install_command.py
+++ b/tests/e2e/test_install_command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -14,7 +15,9 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BASE_IMAGE = os.environ.get("VIBE_INSTALL_TEST_IMAGE", "debian:trixie-slim")
-PUBLIC_INSTALL_COMMAND = "curl -fsSL https://avibe.bot/install.sh | bash -s -- --launch"
+PUBLIC_INSTALL_COMMAND = (
+    "bash -o pipefail -c 'curl -fsSL https://avibe.bot/install.sh | bash -s -- --launch'"
+)
 
 
 def _resolve_install_wheel(fixtures_dir: Path) -> Path:
@@ -67,22 +70,24 @@ def test_install_command_starts_vibe_for_new_user_without_local_bin_on_path():
             "curl -fsSL https://avibe.bot/install.sh",
             "cat /work/install.sh",
         )
-        command = (
-            "apt-get update >/dev/null && "
-            "apt-get install -y --no-install-recommends curl ca-certificates bash procps passwd >/dev/null && "
-            "useradd -m -s /bin/bash installer && "
-            "su - installer -s /bin/bash -c '"
+        install_as_user = (
             "set -euo pipefail; "
             "export PATH=/usr/bin:/bin; "
             "export VIBE_INSTALL_SKIP_NODE=1; "
             "export VIBE_INSTALL_SKIP_SHOW_RUNTIME=1; "
             f"export AVIBE_INSTALL_PACKAGE_SPEC=/fixtures/{wheel_path.name}; "
             f"{local_install_command}; "
-            "test \"$PATH\" = /usr/bin:/bin; "
+            'test "$PATH" = /usr/bin:/bin; '
             "! command -v vibe; "
             "/home/installer/.local/bin/vibe version; "
             "sleep 2; "
-            "/home/installer/.local/bin/vibe status'"
+            "/home/installer/.local/bin/vibe status"
+        )
+        command = (
+            "apt-get update >/dev/null && "
+            "apt-get install -y --no-install-recommends curl ca-certificates bash procps passwd >/dev/null && "
+            "useradd -m -s /bin/bash installer && "
+            f"su - installer -s /bin/bash -c {shlex.quote(install_as_user)}"
         )
 
         try:

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -141,6 +141,9 @@ def _write_fake_uv(path: Path, uv_log: Path) -> None:
             fi
             printf 'start\\n' >> "${{VIBE_TEST_CALL_LOG:-/dev/null}}"
             echo "Web UI:"
+        elif [ "$#" -eq 0 ]; then
+            printf 'launch\\n' >> "${{VIBE_TEST_CALL_LOG:-/dev/null}}"
+            echo "Web UI:"
         else
             echo "started"
         fi
@@ -485,6 +488,41 @@ def test_install_script_pairs_and_starts_with_verified_vibe_path(tmp_path):
         "remote pair vrp_test --backend-url https://avibe.bot",
         "start",
     ]
+
+
+def test_pipe_to_shell_launch_uses_verified_vibe_path(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    uv_bin = tmp_path / "uv-bin"
+    uv_bin.mkdir()
+    call_log = tmp_path / "vibe-calls.log"
+    uv_log = tmp_path / "uv-tool-bin-dir.txt"
+
+    _write_fake_uv(uv_bin / "uv", uv_log)
+    uv_bin.chmod(0o555)
+
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["PATH"] = os.pathsep.join([str(uv_bin), "/usr/bin", "/bin"])
+    env["VIBE_INSTALL_SKIP_NODE"] = "1"
+    env["VIBE_INSTALL_SKIP_SHOW_RUNTIME"] = "1"
+    env["VIBE_TEST_CALL_LOG"] = str(call_log)
+
+    install_result = _run(
+        f'cat "{INSTALL_SCRIPT}" | bash -s -- --launch',
+        cwd=tmp_path,
+        env=env,
+    )
+    version_result = _vibe_version(env, cwd=tmp_path)
+    uv_bin.chmod(0o755)
+
+    expected_vibe = home_dir / ".local" / "bin" / "vibe"
+    assert install_result.returncode == 0, install_result.stdout + install_result.stderr
+    assert f"Launching Avibe with {expected_vibe}" in install_result.stdout
+    assert "Avibe launched" in install_result.stdout
+    assert install_result.stdout.index("Avibe launched") < install_result.stdout.index("Installation complete!")
+    assert call_log.read_text(encoding="utf-8").splitlines() == ["launch"]
+    assert version_result.returncode != 0
 
 
 def test_install_script_stops_when_remote_pair_cannot_start_tunnel(tmp_path):

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -10,6 +10,9 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 INSTALL_SCRIPT = REPO_ROOT / "install.sh"
 INSTALL_POWERSHELL = REPO_ROOT / "install.ps1"
+PUBLIC_INSTALL_COMMAND = (
+    "bash -o pipefail -c 'curl -fsSL https://avibe.bot/install.sh | bash -s -- --launch'"
+)
 
 
 def _write_executable(path: Path, content: str) -> None:
@@ -548,6 +551,13 @@ def test_pipe_to_shell_launch_uses_verified_vibe_path(tmp_path):
     uv_log = tmp_path / "uv-tool-bin-dir.txt"
 
     _write_fake_uv(uv_bin / "uv", uv_log)
+    _write_executable(
+        uv_bin / "curl",
+        """\
+        #!/usr/bin/env bash
+        cat "$VIBE_TEST_INSTALL_SCRIPT"
+        """,
+    )
     uv_bin.chmod(0o555)
 
     env = os.environ.copy()
@@ -555,13 +565,13 @@ def test_pipe_to_shell_launch_uses_verified_vibe_path(tmp_path):
     env["PATH"] = os.pathsep.join([str(uv_bin), "/usr/bin", "/bin"])
     env["VIBE_INSTALL_SKIP_NODE"] = "1"
     env["VIBE_INSTALL_SKIP_SHOW_RUNTIME"] = "1"
+    env["VIBE_TEST_INSTALL_SCRIPT"] = str(INSTALL_SCRIPT)
     env["VIBE_TEST_CALL_LOG"] = str(call_log)
 
-    install_result = _run(
-        f'cat "{INSTALL_SCRIPT}" | bash -s -- --launch',
-        cwd=tmp_path,
-        env=env,
-    )
+    for readme in (REPO_ROOT / "README.md", REPO_ROOT / "README_ZH.md"):
+        assert PUBLIC_INSTALL_COMMAND in readme.read_text(encoding="utf-8")
+
+    install_result = _run(PUBLIC_INSTALL_COMMAND, cwd=tmp_path, env=env)
     version_result = _vibe_version(env, cwd=tmp_path)
     uv_bin.chmod(0o755)
 
@@ -572,6 +582,27 @@ def test_pipe_to_shell_launch_uses_verified_vibe_path(tmp_path):
     assert install_result.stdout.index("Avibe launched") < install_result.stdout.index("Installation complete!")
     assert call_log.read_text(encoding="utf-8").splitlines() == ["launch"]
     assert version_result.returncode != 0
+
+
+def test_public_install_command_propagates_download_failure(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(
+        fake_bin / "curl",
+        """\
+        #!/usr/bin/env bash
+        exit 22
+        """,
+    )
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path / "home")
+    env["PATH"] = os.pathsep.join([str(fake_bin), "/usr/bin", "/bin"])
+
+    result = _run(PUBLIC_INSTALL_COMMAND, cwd=tmp_path, env=env)
+
+    assert result.returncode == 22, result.stdout + result.stderr
+    assert not (tmp_path / "home" / ".local" / "bin" / "vibe").exists()
 
 
 def test_install_script_stops_when_remote_pair_cannot_start_tunnel(tmp_path):


### PR DESCRIPTION
## Summary

- make the public Linux one-line command request launch inside the piped installer
- launch through the installer's verified absolute `vibe` path, so a fresh user's unchanged parent-shell `PATH` is not part of the launch contract
- report installation complete only after the requested launch succeeds, while preserving the PATH guidance needed for later terminal commands
- run the container contract as an unprivileged new user whose initial `PATH` excludes `$HOME/.local/bin`

Closes #1778.

## Evidence

- Unit: `tests/test_install_script.py` (33 passed)
- Contract: English and Chinese README commands are asserted by the Linux install E2E test; the same test runs install plus launch in one unchanged parent shell
- Scenario catalog: no install scenario ID exists
- Runtime: clean Ubuntu 24.04 arm64 Incus user reproduced exit 127 before the change; a second clean user completed the patched pipe-to-shell command with exit 0, unchanged `/usr/bin:/bin` parent PATH, and `vibe status` reporting `running: true`
- Static checks: Ruff, `bash -n install.sh`, and `git diff --check` passed
- Residual: the Docker-backed E2E is committed for CI; Docker was unavailable on the macOS development host

## Scope

- No dependency on another PR
- Does not change upgrade generation detection or the compatibility model tracked by #1779
