### PR TITLE
fix(upgrade): bridge v3.0.13 generation installs

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -415,7 +415,10 @@ function Invoke-UvToolInstallAttempt {
     }
     $runtimeHome = Resolve-InstallPath $runtimeHome
     $generationRoot = Join-Path (Join-Path $runtimeHome "runtime\install-generations") ([Guid]::NewGuid().ToString("N"))
-    $generationTools = Join-Path $generationRoot "tools"
+    # 3.0.13 identifies uv-managed installs from the executable's /uv/tools/
+    # path. Keep that released contract in every generation so the old binary
+    # can hand the first upgrade to uv instead of falling through to pip.
+    $generationTools = Join-Path $generationRoot "uv\tools"
     $generationBin = Join-Path $generationRoot "bin"
     $stableBin = Get-StableBinDirectory
     $stableLauncher = Join-Path $stableBin "vibe.exe"

--- a/install.sh
+++ b/install.sh
@@ -421,7 +421,10 @@ uv_tool_install() {
     # durable generation and activate its launcher only after uv exits
     # successfully, so an interrupted copy cannot damage the active install.
     local generation_root="$AVIBE_RUNTIME_HOME/runtime/install-generations/$(date +%s)-$$-${RANDOM}"
-    local generation_tools="$generation_root/tools"
+    # 3.0.13 identifies uv-managed installs from the executable's /uv/tools/
+    # path. Keep that released contract in every generation so the old binary
+    # can hand the first upgrade to uv instead of falling through to pip.
+    local generation_tools="$generation_root/uv/tools"
     local generation_bin="$generation_root/bin"
     local stable_bin_dir="${VIBE_TOOL_BIN_DIR:-$HOME/.local/bin}"
     local previous_target=""

--- a/tests/e2e/test_upgrade_command.py
+++ b/tests/e2e/test_upgrade_command.py
@@ -1,13 +1,15 @@
-"""Docker smoke test for release-style upgrade flow using a built wheel."""
+"""Docker regression for upgrading the released 3.0.13 wheel to a built wheel."""
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import shutil
 import subprocess
 import sys
 import tempfile
+import urllib.request
 from pathlib import Path
 
 import pytest
@@ -15,7 +17,11 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BASE_IMAGE = os.environ.get("VIBE_UPGRADE_TEST_IMAGE", "debian:trixie-slim")
-INITIAL_RELEASE_VERSION = "9998.0.0"
+INITIAL_RELEASE_VERSION = "3.0.13"
+INITIAL_RELEASE_WHEEL_URL = (
+    "https://github.com/avibe-bot/avibe/releases/download/v3.0.13/avibe_os-3.0.13-py3-none-any.whl"
+)
+INITIAL_RELEASE_WHEEL_SHA256 = "994adbfd23228ea387f0479db8a4efe0ef121847bd04efa550486203a6b03542"
 TEST_RELEASE_VERSION = "9999.0.0"
 
 
@@ -48,14 +54,29 @@ def _build_test_wheel(fixtures_dir: Path, version: str) -> Path:
     return wheel_path
 
 
+def _released_initial_wheel(fixtures_dir: Path) -> Path:
+    wheel_path = fixtures_dir / f"avibe_os-{INITIAL_RELEASE_VERSION}-py3-none-any.whl"
+    local_wheel = os.environ.get("VIBE_UPGRADE_INITIAL_WHEEL")
+    if local_wheel:
+        shutil.copy2(local_wheel, wheel_path)
+    else:
+        request = urllib.request.Request(INITIAL_RELEASE_WHEEL_URL, headers={"User-Agent": "avibe-upgrade-test"})
+        with urllib.request.urlopen(request, timeout=120) as response, wheel_path.open("wb") as destination:
+            shutil.copyfileobj(response, destination)
+
+    digest = hashlib.sha256(wheel_path.read_bytes()).hexdigest()
+    assert digest == INITIAL_RELEASE_WHEEL_SHA256, f"Unexpected {INITIAL_RELEASE_VERSION} wheel digest: {digest}"
+    return wheel_path
+
+
 @pytest.mark.integration
-def test_upgrade_command_uses_built_release_artifact():
+def test_upgrade_command_bridges_released_3_0_13_generation():
     if not _docker_available():
         pytest.skip("Docker is not available")
 
     with tempfile.TemporaryDirectory(prefix="vibe-upgrade-fixtures-") as tmpdir:
         fixtures_dir = Path(tmpdir)
-        initial_wheel_path = _build_test_wheel(fixtures_dir, INITIAL_RELEASE_VERSION)
+        initial_wheel_path = _released_initial_wheel(fixtures_dir)
         wheel_path = _build_test_wheel(fixtures_dir, TEST_RELEASE_VERSION)
 
         metadata_path = fixtures_dir / "metadata.json"
@@ -68,10 +89,13 @@ def test_upgrade_command_uses_built_release_artifact():
                 "apt-get install -y --no-install-recommends curl ca-certificates bash procps >/dev/null",
                 "curl -LsSf https://astral.sh/uv/install.sh | sh",
                 'export PATH="$HOME/.local/bin:$PATH"',
-                f"uv tool install /fixtures/{initial_wheel_path.name} --force",
-                'ln -sf "$HOME/.local/bin/vibe" /usr/local/bin/vibe',
-                'export PATH="/usr/local/bin:/usr/bin:/bin"',
+                "VIBE_INSTALL_SKIP_NODE=1 VIBE_INSTALL_SKIP_SHOW_RUNTIME=1 "
+                f"AVIBE_INSTALL_PACKAGE_SPEC=/fixtures/{initial_wheel_path.name} bash /work/install.sh",
+                'export PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin"',
+                'initial_vibe="$(readlink -f "$HOME/.local/bin/vibe")"',
+                'printf "%s\\n" "$initial_vibe" | grep "/uv/tools/"',
                 "vibe version",
+                'printf "preserved\\n" > "$HOME/.avibe/upgrade-state-marker"',
                 "AVIBE_UPDATE_METADATA_URL=file:///fixtures/metadata.json "
                 f"VIBE_INSTALL_SKIP_SHOW_RUNTIME=1 AVIBE_UPGRADE_PACKAGE_SPEC=/fixtures/{wheel_path.name} vibe check-update",
                 "AVIBE_UPDATE_METADATA_URL=file:///fixtures/metadata.json "
@@ -79,6 +103,8 @@ def test_upgrade_command_uses_built_release_artifact():
                 "hash -r",
                 'printf "launcher=%s\n" "$(command -v vibe)"',
                 "vibe version",
+                'test -x "$initial_vibe"',
+                'test "$(cat "$HOME/.avibe/upgrade-state-marker")" = "preserved"',
                 "AVIBE_UPDATE_METADATA_URL=file:///fixtures/metadata.json vibe check-update",
                 "vibe",
                 "sleep 2",
@@ -116,7 +142,7 @@ def test_upgrade_command_uses_built_release_artifact():
     assert f"avibe-os {INITIAL_RELEASE_VERSION}" in result.stdout
     assert "New version available: 9999.0.0" in result.stdout
     assert "Upgrade successful!" in result.stdout
-    assert "launcher=/usr/local/bin/vibe" in result.stdout
+    assert "launcher=/root/.local/bin/vibe" in result.stdout
     assert f"avibe-os {TEST_RELEASE_VERSION}" in result.stdout
     assert "You are using the latest version." in result.stdout
     assert '"running": true' in result.stdout

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -36,6 +36,7 @@ def _write_fake_uv(path: Path, uv_log: Path) -> None:
         set -euo pipefail
 
         printf '%s' "${{UV_TOOL_BIN_DIR:-}}" > "{uv_log}"
+        printf '%s' "${{UV_TOOL_DIR:-}}" > "{uv_log}.tools"
 
         if [ -n "${{AVIBE_PAIRING_KEY:-}}" ]; then
             printf 'uv leaked key\\n' >> "${{VIBE_TEST_CALL_LOG:-/dev/null}}"
@@ -257,10 +258,14 @@ def _vibe_version(env: dict[str, str], *, cwd: Path = REPO_ROOT) -> subprocess.C
 
 
 def _assert_staged_uv_bin(uv_log: Path, home_dir: Path) -> None:
-    staged = Path(uv_log.read_text(encoding="utf-8"))
-    assert staged.is_absolute()
-    assert staged.name == "bin"
-    assert staged.parent.parent == home_dir / ".avibe" / "runtime" / "install-generations"
+    staged_bin = Path(uv_log.read_text(encoding="utf-8"))
+    staged_tools = Path(f"{uv_log}.tools").read_text(encoding="utf-8")
+    generation_root = home_dir / ".avibe" / "runtime" / "install-generations"
+
+    assert staged_bin.is_absolute()
+    assert staged_bin.name == "bin"
+    assert staged_bin.parent.parent == generation_root
+    assert Path(staged_tools) == staged_bin.parent / "uv" / "tools"
 
 
 def test_install_script_keeps_vibe_available_on_current_path(tmp_path):
@@ -411,6 +416,50 @@ def test_install_script_uses_the_current_owner_for_a_legacy_candidate(tmp_path):
     assert second.returncode == 0, second.stdout + second.stderr
     assert Path(owner_log.read_text(encoding="utf-8")).samefile(first_owner)
     assert (path_dir / "vibe").resolve() != first_owner
+
+
+def test_install_script_recovers_an_existing_3_0_13_generation(tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    path_dir = tmp_path / "path-bin"
+    path_dir.mkdir()
+    uv_log = tmp_path / "uv-tool-bin-dir.txt"
+    _write_fake_uv(path_dir / "uv", uv_log)
+
+    old_generation = home_dir / ".avibe" / "runtime" / "install-generations" / "3.0.13"
+    old_vibe = old_generation / "tools" / "avibe-os" / "bin" / "vibe"
+    old_vibe.parent.mkdir(parents=True)
+    _write_executable(
+        old_vibe,
+        """\
+        #!/usr/bin/env bash
+        if [ "${1:-}" = "version" ]; then
+            echo "avibe-os 3.0.13"
+            exit 0
+        fi
+        exit 2
+        """,
+    )
+    generation_launcher = old_generation / "bin" / "vibe"
+    generation_launcher.parent.mkdir(parents=True)
+    generation_launcher.symlink_to(old_vibe)
+    stable_launcher = path_dir / "vibe"
+    stable_launcher.symlink_to(generation_launcher)
+    state_marker = home_dir / ".avibe" / "state-preserved"
+    state_marker.write_text("preserved\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["PATH"] = os.pathsep.join([str(path_dir), "/usr/bin", "/bin"])
+    env["VIBE_TEST_REQUIRE_SOURCE_GENERATION"] = "1"
+
+    result = _install(env)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert stable_launcher.resolve() != old_vibe
+    assert old_vibe.exists()
+    assert state_marker.read_text(encoding="utf-8") == "preserved\n"
+    _assert_staged_uv_bin(uv_log, home_dir)
 
 
 def test_install_script_keeps_active_launcher_when_uv_install_fails(tmp_path):
@@ -674,6 +723,7 @@ def test_windows_installer_honors_configured_tool_bin_and_cross_volume_copy_fall
     assert "function Get-StableBinDirectory" in powershell
     assert "function Resolve-InstallPath" in powershell
     assert "function Get-LauncherState" in powershell
+    assert '$generationTools = Join-Path $generationRoot "uv\\tools"' in powershell
     assert "Get-Content -LiteralPath $marker" not in powershell
     assert "function Get-GenerationPath" not in powershell
     assert '$expanded.StartsWith("~\\")' in powershell

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -827,14 +827,15 @@ def test_restart_state_with_a_non_object_shape_is_not_pending(monkeypatch, tmp_p
     assert not restart_is_pending()
 
 
-def test_doctor_resolves_hardlinked_atomic_generation(monkeypatch, tmp_path):
+@pytest.mark.parametrize("tools_path", [Path("uv/tools"), Path("tools")], ids=["bridged", "legacy"])
+def test_doctor_resolves_hardlinked_atomic_generation(monkeypatch, tmp_path, tools_path):
     from vibe import upgrade
 
     root = tmp_path / "home" / "runtime" / "install-generations"
     generation = root / "old"
     launcher_source = generation / "bin" / "vibe.exe"
     launcher = tmp_path / ".local" / "bin" / "vibe.exe"
-    site_packages = generation / "tools" / "avibe-os" / "lib" / "python3.12" / "site-packages"
+    site_packages = generation / tools_path / "avibe-os" / "lib" / "python3.12" / "site-packages"
     launcher_source.parent.mkdir(parents=True)
     site_packages.mkdir(parents=True)
     launcher.parent.mkdir(parents=True)

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -131,8 +131,10 @@ def test_build_upgrade_plan_stages_uv_install_for_a_stable_launcher(monkeypatch,
     assert plan.activation is not None
     assert plan.activation.launcher == launcher
     assert plan.env is not None
-    assert plan.env["UV_TOOL_DIR"].startswith(str(tmp_path / "home" / "runtime" / "install-generations"))
-    assert plan.env["UV_TOOL_BIN_DIR"].startswith(str(tmp_path / "home" / "runtime" / "install-generations"))
+    tool_dir = Path(plan.env["UV_TOOL_DIR"])
+    bin_dir = Path(plan.env["UV_TOOL_BIN_DIR"])
+    assert tool_dir == bin_dir.parent / "uv" / "tools"
+    assert bin_dir.parent.parent == tmp_path / "home" / "runtime" / "install-generations"
 
 
 def test_build_upgrade_plan_refuses_uv_install_without_activation_point(monkeypatch):

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -12112,8 +12112,9 @@ def _uv_tool_site_packages_for_vibe(vibe_path: Path) -> list[Path]:
     generation_root = atomic_uv_install_root().expanduser().resolve()
     generation = _launcher_generation(vibe_path, generation_root)
     if generation:
-        for package_name in UV_TOOL_PACKAGE_NAMES:
-            add_tool_root(generation / "tools" / package_name)
+        for tools_dir in (generation / "uv" / "tools", generation / "tools"):
+            for package_name in UV_TOOL_PACKAGE_NAMES:
+                add_tool_root(tools_dir / package_name)
 
     parts = vibe_path.parts
     try:

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -217,7 +217,10 @@ def launcher_is_current_process(launcher: Path | str) -> bool:
 
 def _staged_uv_environment(vibe_path: str | None) -> tuple[Path, Path, AtomicActivation | None]:
     generation = atomic_uv_install_root() / uuid4().hex
-    tools_dir = generation / "tools"
+    # 3.0.13 only recognizes uv installs whose interpreter path contains
+    # /uv/tools/. Generations must retain that released handoff contract so an
+    # immutable 3.0.13 process can choose uv for its first product upgrade.
+    tools_dir = generation / "uv" / "tools"
     bin_dir = generation / "bin"
     if not vibe_path:
         return tools_dir, bin_dir, None
@@ -245,7 +248,7 @@ def _candidate_python(candidate_launcher: Path) -> Path | None:
     with contextlib.suppress(OSError, RuntimeError, ValueError):
         generation = _generation_for_path(candidate_launcher, atomic_uv_install_root())
         if generation is not None:
-            roots.append(generation / "tools")
+            roots.extend((generation / "uv" / "tools", generation / "tools"))
     names = ("python.exe", "python3.exe", "python3", "python") if os.name == "nt" else ("python3", "python")
     for root in roots:
         for name in names:


### PR DESCRIPTION
## Summary

- preserve the released v3.0.13 uv-install detector contract by placing generation tool environments under `uv/tools`
- use the same generation layout in the shell installer, PowerShell installer, and in-product upgrade staging while retaining lookup support for the old `tools` layout
- cover both fresh v3.0.13 generation upgrades and state-preserving recovery of installations already created with the incompatible layout
- make the release-style upgrade regression start from the official v3.0.13 wheel, pinned by SHA-256

## Root Cause

The v3.0.13 upgrade initiator recognizes uv installations only when its running Python path contains `/uv/tools/`. The generation installer introduced a `<generation>/tools/...` environment instead, so the immutable v3.0.13 process selected `python -m pip`; that environment intentionally has no pip.

New generations now retain the old detector's path contract. This lets the released v3.0.13 process select uv and complete the first handoff without modifying the old binary or injecting pip.

## Existing Install Recovery

Once a release containing this fix is available, an affected v3.0.13 user can rerun the normal installer. The protocol-aware candidate adopts the stable launcher, preserves `$AVIBE_HOME`, and retains the previous generation for rollback. The installer test covers this legacy-layout recovery explicitly.

## Validation

- `125 passed` across `tests/test_upgrade_flow.py` and `tests/test_install_script.py`
- Ruff passed for all changed Python files
- `bash -n install.sh` passed
- local Ubuntu 24.04 arm64 Incus reproduced the original public-installer failure from v3.0.13 (`No module named pip`)
- the fixed installer then installed the official v3.0.13 wheel into a bridged generation; the unmodified v3.0.13 CLI upgraded it to the current-head wheel and restarted the live service from PID 20165 to PID 20502
- the restarted API reported 3.0.14, the config digest remained unchanged, state/backend markers remained present, and the v3.0.13 generation remained executable as the recorded rollback target
- the already-affected public-install layout was separately recovered by the fixed installer; its state marker and old generation were retained
- the worktree Incus regression service remained healthy after the compatibility run

This intentionally does not change the README one-line command or post-install launch/reporting behavior tracked by #1778.

Closes #1779
