### PR TITLE
fix(model-hub): translate OpenCode reserved tool names

### DIFF
--- a/core/handlers/model_hub/stream_wire.py
+++ b/core/handlers/model_hub/stream_wire.py
@@ -74,6 +74,20 @@ class SSEFrameTokenizer:
         self._stream_prefix.clear()
         return line_open
 
+    def drain_partial_frame(self) -> bytes:
+        """Return and clear any unterminated bytes in normalized SSE form."""
+
+        if not self._stream_started:
+            pending = bytes(self._stream_prefix)
+        else:
+            pending = b"\n".join((*self._frame_lines, bytes(self._line)))
+        self._line.clear()
+        self._frame_lines.clear()
+        self._frame_size = 0
+        self._after_cr = False
+        self._stream_prefix.clear()
+        return pending
+
     def _finish_line(self, frames: list[bytes]) -> None:
         line = bytes(self._line)
         self._line.clear()

--- a/core/handlers/model_hub/tool_names.py
+++ b/core/handlers/model_hub/tool_names.py
@@ -6,7 +6,7 @@ import json
 from dataclasses import dataclass
 from typing import Any, Mapping
 
-from .stream_wire import SSEFrameTokenizer, parse_sse_frame
+from .stream_wire import SSE_MAX_FRAME_BYTES, SSEFrameTokenizer, parse_sse_frame
 
 
 _OPENCODE_UPSTREAM_TOOL_ALIASES = {
@@ -29,23 +29,25 @@ def translate_opencode_tool_names(request: Mapping[str, Any]) -> ToolNameTransla
     if not isinstance(tools, list):
         return ToolNameTranslation(request=request, response_aliases={})
 
-    names = {
+    names = [
         function.get("name")
         for item in tools
         if isinstance(item, Mapping)
         and isinstance((function := item.get("function")), Mapping)
         and isinstance(function.get("name"), str)
-    }
+    ]
+    occupied_names = {name.casefold() for name in names}
     aliases: dict[str, str] = {}
-    for original, preferred in _OPENCODE_UPSTREAM_TOOL_ALIASES.items():
-        if original not in names:
+    for original in names:
+        preferred = _OPENCODE_UPSTREAM_TOOL_ALIASES.get(original.casefold())
+        if preferred is None or original in aliases:
             continue
         alias = preferred
         suffix = 2
-        while alias in names:
+        while alias.casefold() in occupied_names:
             alias = f"{preferred}_{suffix}"
             suffix += 1
-        names.add(alias)
+        occupied_names.add(alias.casefold())
         aliases[original] = alias
 
     if not aliases:
@@ -84,42 +86,154 @@ def rewrite_buffered_tool_names(payload: bytes, aliases: Mapping[str, str]) -> b
 
 
 class StreamingToolNameRewriter:
-    """Restore aliases in complete SSE frames while retaining bounded parser state."""
+    """Restore aliases across SSE deltas while retaining bounded parser state."""
 
     def __init__(self, aliases: Mapping[str, str]) -> None:
         self._aliases = aliases
         self._tokenizer = SSEFrameTokenizer()
+        self._pending_frames: list[tuple[bytes, dict[str, Any]]] = []
+        self._pending_size = 0
 
     def feed(self, chunk: bytes) -> bytes:
         if not self._aliases:
             return chunk
-        return b"".join(self._rewrite_frame(frame) for frame in self._tokenizer.feed(chunk))
+        output: list[bytes] = []
+        for frame in self._tokenizer.feed(chunk):
+            output.extend(self._consume_frame(frame))
+        return b"".join(output)
 
     def finish(self) -> bytes:
-        return self._tokenizer.drain_partial_frame()
+        if not self._aliases:
+            return self._tokenizer.drain_partial_frame()
+        return b"".join(
+            (*self._flush_pending(rewrite=True), self._tokenizer.drain_partial_frame())
+        )
 
-    def _rewrite_frame(self, frame: bytes) -> bytes:
+    def _consume_frame(self, frame: bytes) -> list[bytes]:
         _event_name, data = parse_sse_frame(frame)
         if data is None or data == b"[DONE]":
-            return frame + b"\n\n"
+            return [*self._flush_pending(rewrite=True), frame + b"\n\n"]
         try:
             decoded = json.loads(data)
         except (UnicodeDecodeError, ValueError):
-            return frame + b"\n\n"
-        if not isinstance(decoded, dict) or not _rewrite_chat_response(decoded, self._aliases):
-            return frame + b"\n\n"
-        rewritten = json.dumps(decoded, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
-        lines: list[bytes] = []
-        inserted = False
-        for line in frame.split(b"\n"):
-            field, separator, _value = line.partition(b":")
-            if separator and field == b"data":
-                if not inserted:
-                    lines.append(b"data: " + rewritten)
-                    inserted = True
+            return [*self._flush_pending(rewrite=True), frame + b"\n\n"]
+        if not isinstance(decoded, dict):
+            return [*self._flush_pending(rewrite=True), frame + b"\n\n"]
+
+        output: list[bytes] = []
+        if len(frame) > SSE_MAX_FRAME_BYTES:
+            return [*self._flush_pending(rewrite=False), frame + b"\n\n"]
+        if self._pending_size + len(frame) > SSE_MAX_FRAME_BYTES:
+            output.extend(self._flush_pending(rewrite=False))
+        self._pending_frames.append((frame, decoded))
+        self._pending_size += len(frame)
+        if self._has_partial_alias():
+            return output
+        output.extend(self._flush_pending(rewrite=True))
+        return output
+
+    def _has_partial_alias(self) -> bool:
+        for assembled, _locations in self._assembled_stream_names().values():
+            if assembled and assembled not in self._aliases and any(
+                alias.startswith(assembled) for alias in self._aliases
+            ):
+                return True
+        return False
+
+    def _assembled_stream_names(
+        self,
+    ) -> dict[tuple[int, str, int], tuple[str, list[tuple[int, dict[str, Any]]]]]:
+        assembled: dict[
+            tuple[int, str, int],
+            tuple[str, list[tuple[int, dict[str, Any]]]],
+        ] = {}
+        for frame_index, (_frame, payload) in enumerate(self._pending_frames):
+            for key, function, fragment in _stream_function_names(payload):
+                current, locations = assembled.get(key, ("", []))
+                assembled[key] = (
+                    current + fragment,
+                    [*locations, (frame_index, function)],
+                )
+        return assembled
+
+    def _flush_pending(self, *, rewrite: bool) -> list[bytes]:
+        if not self._pending_frames:
+            return []
+        changed_frames: set[int] = set()
+        if rewrite:
+            for assembled, locations in self._assembled_stream_names().values():
+                original = self._aliases.get(assembled)
+                if original is None or not locations:
+                    continue
+                first_index, first_function = locations[0]
+                first_function["name"] = original
+                changed_frames.add(first_index)
+                for frame_index, function in locations[1:]:
+                    function.pop("name", None)
+                    changed_frames.add(frame_index)
+
+        output = [
+            _render_sse_frame(frame, payload) if index in changed_frames else frame + b"\n\n"
+            for index, (frame, payload) in enumerate(self._pending_frames)
+        ]
+        self._pending_frames.clear()
+        self._pending_size = 0
+        return output
+
+
+def _render_sse_frame(frame: bytes, decoded: Mapping[str, Any]) -> bytes:
+    rewritten = json.dumps(decoded, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    lines: list[bytes] = []
+    inserted = False
+    for line in frame.split(b"\n"):
+        field, separator, _value = line.partition(b":")
+        if separator and field == b"data":
+            if not inserted:
+                lines.append(b"data: " + rewritten)
+                inserted = True
+            continue
+        lines.append(line)
+    return b"\n".join(lines) + b"\n\n"
+
+
+def _stream_function_names(
+    payload: Mapping[str, Any],
+) -> list[tuple[tuple[int, str, int], dict[str, Any], str]]:
+    names: list[tuple[tuple[int, str, int], dict[str, Any], str]] = []
+    choices = payload.get("choices")
+    if not isinstance(choices, list):
+        return names
+    for choice_position, choice in enumerate(choices):
+        if not isinstance(choice, Mapping):
+            continue
+        choice_index = choice.get("index")
+        if not isinstance(choice_index, int):
+            choice_index = choice_position
+        for envelope_name in ("delta", "message"):
+            envelope = choice.get(envelope_name)
+            if not isinstance(envelope, Mapping):
                 continue
-            lines.append(line)
-        return b"\n".join(lines) + b"\n\n"
+            function_call = envelope.get("function_call")
+            if isinstance(function_call, dict):
+                name = function_call.get("name")
+                if isinstance(name, str):
+                    names.append(((choice_index, "function_call", 0), function_call, name))
+            tool_calls = envelope.get("tool_calls")
+            if not isinstance(tool_calls, list):
+                continue
+            for call_position, call in enumerate(tool_calls):
+                if not isinstance(call, Mapping):
+                    continue
+                call_index = call.get("index")
+                if not isinstance(call_index, int):
+                    call_index = call_position
+                function = call.get("function")
+                if not isinstance(function, dict):
+                    continue
+                name = function.get("name")
+                if isinstance(name, str):
+                    names.append(((choice_index, "tool_calls", call_index), function, name))
+    return names
 
 
 def _rewrite_tool_definition(tool: Mapping[str, Any], aliases: Mapping[str, str]) -> dict[str, Any]:
@@ -133,7 +247,7 @@ def _rewrite_tool_definition(tool: Mapping[str, Any], aliases: Mapping[str, str]
 def _rewrite_message(message: Mapping[str, Any], aliases: Mapping[str, str]) -> dict[str, Any]:
     translated = dict(message)
     name = message.get("name")
-    if isinstance(name, str) and name in aliases:
+    if message.get("role") in {"tool", "function"} and isinstance(name, str) and name in aliases:
         translated["name"] = aliases[name]
     tool_calls = message.get("tool_calls")
     if isinstance(tool_calls, list):

--- a/core/handlers/model_hub/tool_names.py
+++ b/core/handlers/model_hub/tool_names.py
@@ -1,0 +1,196 @@
+"""Bidirectional tool-name compatibility for the OpenCode gateway protocol."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .stream_wire import SSEFrameTokenizer, parse_sse_frame
+
+
+_OPENCODE_UPSTREAM_TOOL_ALIASES = {
+    # Some Anthropic-compatible relays reserve Claude Code's TodoWrite name
+    # case-insensitively and reject OpenCode's otherwise valid definition.
+    "todowrite": "avibe_todo_write",
+}
+
+
+@dataclass(frozen=True)
+class ToolNameTranslation:
+    request: Mapping[str, Any]
+    response_aliases: Mapping[str, str]
+
+
+def translate_opencode_tool_names(request: Mapping[str, Any]) -> ToolNameTranslation:
+    """Alias incompatible definitions and every request-side reference to them."""
+
+    tools = request.get("tools")
+    if not isinstance(tools, list):
+        return ToolNameTranslation(request=request, response_aliases={})
+
+    names = {
+        function.get("name")
+        for item in tools
+        if isinstance(item, Mapping)
+        and isinstance((function := item.get("function")), Mapping)
+        and isinstance(function.get("name"), str)
+    }
+    aliases: dict[str, str] = {}
+    for original, preferred in _OPENCODE_UPSTREAM_TOOL_ALIASES.items():
+        if original not in names:
+            continue
+        alias = preferred
+        suffix = 2
+        while alias in names:
+            alias = f"{preferred}_{suffix}"
+            suffix += 1
+        names.add(alias)
+        aliases[original] = alias
+
+    if not aliases:
+        return ToolNameTranslation(request=request, response_aliases={})
+
+    translated = dict(request)
+    translated["tools"] = [
+        _rewrite_tool_definition(item, aliases) if isinstance(item, Mapping) else item for item in tools
+    ]
+    messages = request.get("messages")
+    if isinstance(messages, list):
+        translated["messages"] = [
+            _rewrite_message(item, aliases) if isinstance(item, Mapping) else item for item in messages
+        ]
+    tool_choice = request.get("tool_choice")
+    if isinstance(tool_choice, Mapping):
+        translated["tool_choice"] = _rewrite_named_function(tool_choice, aliases)
+    return ToolNameTranslation(
+        request=translated,
+        response_aliases={alias: original for original, alias in aliases.items()},
+    )
+
+
+def rewrite_buffered_tool_names(payload: bytes, aliases: Mapping[str, str]) -> bytes:
+    """Restore aliased tool names in one buffered OpenAI Chat response."""
+
+    if not aliases:
+        return payload
+    try:
+        decoded = json.loads(payload)
+    except (UnicodeDecodeError, ValueError):
+        return payload
+    if not isinstance(decoded, dict) or not _rewrite_chat_response(decoded, aliases):
+        return payload
+    return json.dumps(decoded, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+
+class StreamingToolNameRewriter:
+    """Restore aliases in complete SSE frames while retaining bounded parser state."""
+
+    def __init__(self, aliases: Mapping[str, str]) -> None:
+        self._aliases = aliases
+        self._tokenizer = SSEFrameTokenizer()
+
+    def feed(self, chunk: bytes) -> bytes:
+        if not self._aliases:
+            return chunk
+        return b"".join(self._rewrite_frame(frame) for frame in self._tokenizer.feed(chunk))
+
+    def finish(self) -> bytes:
+        return self._tokenizer.drain_partial_frame()
+
+    def _rewrite_frame(self, frame: bytes) -> bytes:
+        _event_name, data = parse_sse_frame(frame)
+        if data is None or data == b"[DONE]":
+            return frame + b"\n\n"
+        try:
+            decoded = json.loads(data)
+        except (UnicodeDecodeError, ValueError):
+            return frame + b"\n\n"
+        if not isinstance(decoded, dict) or not _rewrite_chat_response(decoded, self._aliases):
+            return frame + b"\n\n"
+        rewritten = json.dumps(decoded, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        lines: list[bytes] = []
+        inserted = False
+        for line in frame.split(b"\n"):
+            field, separator, _value = line.partition(b":")
+            if separator and field == b"data":
+                if not inserted:
+                    lines.append(b"data: " + rewritten)
+                    inserted = True
+                continue
+            lines.append(line)
+        return b"\n".join(lines) + b"\n\n"
+
+
+def _rewrite_tool_definition(tool: Mapping[str, Any], aliases: Mapping[str, str]) -> dict[str, Any]:
+    translated = dict(tool)
+    function = tool.get("function")
+    if isinstance(function, Mapping):
+        translated["function"] = _rewrite_name(function, aliases)
+    return translated
+
+
+def _rewrite_message(message: Mapping[str, Any], aliases: Mapping[str, str]) -> dict[str, Any]:
+    translated = dict(message)
+    name = message.get("name")
+    if isinstance(name, str) and name in aliases:
+        translated["name"] = aliases[name]
+    tool_calls = message.get("tool_calls")
+    if isinstance(tool_calls, list):
+        translated["tool_calls"] = [
+            _rewrite_named_function(call, aliases) if isinstance(call, Mapping) else call for call in tool_calls
+        ]
+    function_call = message.get("function_call")
+    if isinstance(function_call, Mapping):
+        translated["function_call"] = _rewrite_name(function_call, aliases)
+    return translated
+
+
+def _rewrite_named_function(value: Mapping[str, Any], aliases: Mapping[str, str]) -> dict[str, Any]:
+    translated = dict(value)
+    function = value.get("function")
+    if isinstance(function, Mapping):
+        translated["function"] = _rewrite_name(function, aliases)
+    return translated
+
+
+def _rewrite_name(value: Mapping[str, Any], aliases: Mapping[str, str]) -> dict[str, Any]:
+    translated = dict(value)
+    name = value.get("name")
+    if isinstance(name, str) and name in aliases:
+        translated["name"] = aliases[name]
+    return translated
+
+
+def _rewrite_chat_response(payload: dict[str, Any], aliases: Mapping[str, str]) -> bool:
+    changed = False
+    choices = payload.get("choices")
+    if not isinstance(choices, list):
+        return False
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        for envelope_name in ("delta", "message"):
+            envelope = choice.get(envelope_name)
+            if not isinstance(envelope, dict):
+                continue
+            function_call = envelope.get("function_call")
+            if isinstance(function_call, dict):
+                name = function_call.get("name")
+                if isinstance(name, str) and name in aliases:
+                    function_call["name"] = aliases[name]
+                    changed = True
+            tool_calls = envelope.get("tool_calls")
+            if not isinstance(tool_calls, list):
+                continue
+            for call in tool_calls:
+                if not isinstance(call, dict):
+                    continue
+                function = call.get("function")
+                if not isinstance(function, dict):
+                    continue
+                name = function.get("name")
+                if isinstance(name, str) and name in aliases:
+                    function["name"] = aliases[name]
+                    changed = True
+    return changed

--- a/core/handlers/model_hub/turn_gateway.py
+++ b/core/handlers/model_hub/turn_gateway.py
@@ -7,9 +7,9 @@ import json
 import logging
 import socket
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextlib import AsyncExitStack, suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Final, Optional
 
@@ -43,6 +43,11 @@ from .stream_wire import (
     observe_protocol_response,
     render_protocol_terminal_event,
     render_protocol_terminal_frame,
+)
+from .tool_names import (
+    StreamingToolNameRewriter,
+    rewrite_buffered_tool_names,
+    translate_opencode_tool_names,
 )
 from .usage import BoundedUsageLedger, UsageWriter
 from .service import (
@@ -115,6 +120,9 @@ class _TurnExecution:
     # the record that this turn has already been metered. A flag would only say
     # the write was started by something whose own death could still take it.
     usage_write: asyncio.Future[None] | None = None
+    # OpenCode owns its public tool names; the gateway may use collision-free
+    # upstream aliases, but those names must never escape back to OpenCode.
+    response_tool_aliases: Mapping[str, str] = field(default_factory=dict)
 
     @property
     def upstream_observation(self) -> ProtocolSSEState | None:
@@ -648,6 +656,10 @@ class ModelHubTurnGateway:
             protocol_headers = {
                 name.lower(): value for name, value in request.headers.items() if name.lower() in _PROTOCOL_HEADERS
             }
+            if backend == "opencode" and _REQUEST_PROTOCOLS[endpoint] == "openai_chat":
+                translation = translate_opencode_tool_names(payload)
+                payload = translation.request
+                execution.response_tool_aliases = translation.response_aliases
             resolved = await self.service.resolve(
                 backend=backend,
                 model_id=resolution_model,
@@ -748,7 +760,10 @@ class ModelHubTurnGateway:
                 )
             return web.Response(
                 status=200,
-                body=bytes(payload),
+                body=rewrite_buffered_tool_names(
+                    bytes(payload),
+                    execution.response_tool_aliases,
+                ),
                 content_type="application/json",
                 headers={"Cache-Control": "no-store", "X-Content-Type-Options": "nosniff"},
             )
@@ -765,12 +780,18 @@ class ModelHubTurnGateway:
         await self._downstream_io(response.prepare(request))
         wire_state = ProtocolSSEState(protocol)
         execution.wire_state = wire_state
+        tool_name_rewriter = StreamingToolNameRewriter(execution.response_tool_aliases)
         async for chunk in handle.stream:
             output_started_before = wire_state.model_output_started
             wire_state.observe(chunk)
             if wire_state.model_output_started and not output_started_before:
                 terminalizer.mark_stream_started()
-            await self._downstream_io(response.write(chunk))
+            rewritten = tool_name_rewriter.feed(chunk)
+            if rewritten:
+                await self._downstream_io(response.write(rewritten))
+        trailing = tool_name_rewriter.finish()
+        if trailing:
+            await self._downstream_io(response.write(trailing))
         execution.completed_at = self._now()
         _outcome, _settlement, rendered = await self._settle_metered_turn(
             execution,

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -41,7 +41,9 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_OPENCODE_PORT = 4096
 DEFAULT_OPENCODE_HOST = "127.0.0.1"
-SERVER_START_TIMEOUT = 15
+# A cold OpenCode process can take more than 15 seconds to load on a busy or
+# freshly provisioned host. This is a startup ceiling, not a request timeout.
+SERVER_START_TIMEOUT = 60
 OPENCODE_LOG_TAIL_BYTES = 2_000_000
 MODEL_HUB_OVERLAY_DRAIN_TIMEOUT_SECONDS = 30.0
 _USE_CURRENT_CALLER_CONTEXT_PATH = object()
@@ -1616,9 +1618,20 @@ class OpenCodeServerManager:
                 self._observe_runtime_generation(self._read_pid_file())
                 logger.info(f"OpenCode server started at {self._base_url}")
                 return
+            if self._process.returncode is not None:
+                break
             await asyncio.sleep(0.5)
 
         exit_code = self._process.returncode
+        if exit_code is None:
+            # A late-starting process must not become a healthy but unmanaged
+            # server after this call reports failure and clears its PID file.
+            await terminate_process_tree(
+                self._process,
+                logger,
+                "OpenCode server after startup timeout",
+                terminate_timeout=5,
+            )
         self._clear_pid_file()
         self._process = None
         self._process_loop = None

--- a/tests/test_model_hub_l3.py
+++ b/tests/test_model_hub_l3.py
@@ -1575,6 +1575,68 @@ def test_authenticated_gateway_validation_failure_is_correlated(
     asyncio.run(exercise())
 
 
+def test_opencode_gateway_round_trips_aliased_tool_names(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        handle = LiveInvokeHandle(
+            _outcome(RawOutcomeKind.SUCCESS, stream_started=True),
+            (
+                b'data: {"choices":[{"delta":{"tool_calls":[{"function":'
+                b'{"name":"avibe_todo_write","arguments":"{}"}}]}}]}\n\n',
+                b"data: [DONE]\n\n",
+            ),
+        )
+        service = _service(
+            tmp_path,
+            sources=[
+                _source(
+                    "src_primary01",
+                    "Anthropic relay",
+                    vendor="custom",
+                    protocol="anthropic",
+                )
+            ],
+            live_handles=[handle],
+        )
+        gateway = ModelHubTurnGateway(service)
+        base_url, token = await gateway.endpoint(
+            "opencode",
+            process_scope="opencode:shared-server",
+        )
+        try:
+            async with aiohttp.ClientSession(trust_env=False) as client:
+                response = await client.post(
+                    f"{base_url}/v1/chat/completions",
+                    json={
+                        "model": "openai/shared-model",
+                        "messages": [{"role": "user", "content": "update the list"}],
+                        "tools": [
+                            {
+                                "type": "function",
+                                "function": {
+                                    "name": "todowrite",
+                                    "parameters": {"type": "object"},
+                                },
+                            }
+                        ],
+                        "stream": True,
+                    },
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+                assert response.status == 200
+                body = await response.read()
+        finally:
+            await gateway.close()
+
+        adapter = service.adapter
+        assert isinstance(adapter, ProbeAdapter)
+        forwarded = adapter.requests[0]
+        assert forwarded["tools"][0]["function"]["name"] == "avibe_todo_write"
+        assert b'"name":"todowrite"' in body
+        assert b'"name":"avibe_todo_write"' not in body
+
+    asyncio.run(exercise())
+
+
 def test_gateway_terminalizer_records_pre_observer_engine_down_before_return(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_model_hub_tool_names.py
+++ b/tests/test_model_hub_tool_names.py
@@ -54,6 +54,26 @@ def test_opencode_tool_name_translation_covers_every_request_reference_without_m
     assert request["messages"][0]["tool_calls"][0]["function"]["name"] == "todowrite"
 
 
+def test_opencode_tool_name_translation_matches_reserved_names_case_insensitively() -> None:
+    request = {
+        "tools": [
+            {"type": "function", "function": {"name": "TodoWrite"}},
+            {"type": "function", "function": {"name": "AVIBE_TODO_WRITE"}},
+        ],
+        "messages": [
+            {"role": "system", "name": "TodoWrite", "content": "participant"},
+            {"role": "function", "name": "TodoWrite", "content": "result"},
+        ],
+    }
+
+    translation = translate_opencode_tool_names(request)
+
+    assert translation.request["tools"][0]["function"]["name"] == "avibe_todo_write_2"
+    assert translation.request["messages"][0]["name"] == "TodoWrite"
+    assert translation.request["messages"][1]["name"] == "avibe_todo_write_2"
+    assert translation.response_aliases == {"avibe_todo_write_2": "TodoWrite"}
+
+
 def test_buffered_chat_response_restores_only_tool_name_fields() -> None:
     payload = json.dumps(
         {
@@ -105,6 +125,32 @@ def test_streaming_chat_response_restores_alias_across_transport_chunks() -> Non
     first_payload = json.loads(payloads[0])
     assert first_payload["choices"][0]["delta"]["tool_calls"][0]["function"]["name"] == "todowrite"
     assert json.loads(payloads[1])["choices"][0]["delta"]["content"] == "avibe_todo_write"
+    assert payloads[2] == b"[DONE]"
+
+
+def test_streaming_chat_response_reassembles_semantic_tool_name_deltas() -> None:
+    first = (
+        b'data: {"choices":[{"index":0,"delta":{"tool_calls":'
+        b'[{"index":2,"function":{"name":"avibe_todo"}}]}}]}\n\n'
+    )
+    second = (
+        b'data: {"choices":[{"index":0,"delta":{"tool_calls":'
+        b'[{"index":2,"function":{"name":"_write","arguments":"{}"}}]}}]}\n\n'
+    )
+    rewriter = StreamingToolNameRewriter({"avibe_todo_write": "todowrite"})
+
+    assert rewriter.feed(first) == b""
+    output = rewriter.feed(second) + rewriter.feed(b"data: [DONE]\n\n")
+
+    frames = SSEFrameTokenizer().feed(output)
+    payloads = [parse_sse_frame(frame)[1] for frame in frames]
+    first_payload = json.loads(payloads[0])
+    second_payload = json.loads(payloads[1])
+    first_function = first_payload["choices"][0]["delta"]["tool_calls"][0]["function"]
+    second_function = second_payload["choices"][0]["delta"]["tool_calls"][0]["function"]
+    assert first_function["name"] == "todowrite"
+    assert "name" not in second_function
+    assert second_function["arguments"] == "{}"
     assert payloads[2] == b"[DONE]"
 
 

--- a/tests/test_model_hub_tool_names.py
+++ b/tests/test_model_hub_tool_names.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+
+from core.handlers.model_hub.stream_wire import SSEFrameTokenizer, parse_sse_frame
+from core.handlers.model_hub.tool_names import (
+    StreamingToolNameRewriter,
+    rewrite_buffered_tool_names,
+    translate_opencode_tool_names,
+)
+
+
+def test_opencode_tool_name_translation_covers_every_request_reference_without_mutation() -> None:
+    request = {
+        "model": "custom/claude-opus",
+        "tools": [
+            {
+                "type": "function",
+                "function": {"name": "todowrite", "parameters": {"type": "object"}},
+            },
+            {
+                "type": "function",
+                "function": {"name": "avibe_todo_write", "parameters": {"type": "object"}},
+            },
+        ],
+        "tool_choice": {"type": "function", "function": {"name": "todowrite"}},
+        "messages": [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {"name": "todowrite", "arguments": "{}"},
+                    }
+                ],
+                "function_call": {"name": "todowrite", "arguments": "{}"},
+            },
+            {"role": "tool", "name": "todowrite", "tool_call_id": "call-1", "content": "ok"},
+        ],
+    }
+
+    translation = translate_opencode_tool_names(request)
+
+    translated = translation.request
+    assert translated["tools"][0]["function"]["name"] == "avibe_todo_write_2"
+    assert translated["tools"][1]["function"]["name"] == "avibe_todo_write"
+    assert translated["tool_choice"]["function"]["name"] == "avibe_todo_write_2"
+    assert translated["messages"][0]["tool_calls"][0]["function"]["name"] == "avibe_todo_write_2"
+    assert translated["messages"][0]["function_call"]["name"] == "avibe_todo_write_2"
+    assert translated["messages"][1]["name"] == "avibe_todo_write_2"
+    assert translation.response_aliases == {"avibe_todo_write_2": "todowrite"}
+    assert request["tools"][0]["function"]["name"] == "todowrite"
+    assert request["messages"][0]["tool_calls"][0]["function"]["name"] == "todowrite"
+
+
+def test_buffered_chat_response_restores_only_tool_name_fields() -> None:
+    payload = json.dumps(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": "avibe_todo_write remains ordinary content",
+                        "tool_calls": [
+                            {
+                                "id": "call-1",
+                                "type": "function",
+                                "function": {"name": "avibe_todo_write", "arguments": "{}"},
+                            }
+                        ],
+                        "function_call": {"name": "avibe_todo_write", "arguments": "{}"},
+                    }
+                }
+            ]
+        }
+    ).encode()
+
+    rewritten = json.loads(rewrite_buffered_tool_names(payload, {"avibe_todo_write": "todowrite"}))
+
+    message = rewritten["choices"][0]["message"]
+    assert message["tool_calls"][0]["function"]["name"] == "todowrite"
+    assert message["function_call"]["name"] == "todowrite"
+    assert message["content"] == "avibe_todo_write remains ordinary content"
+
+
+def test_streaming_chat_response_restores_alias_across_transport_chunks() -> None:
+    first = b'data: {"choices":[{"delta":{"tool_calls":[{"function":{"name":"avibe_todo_write"}}]}}]}\r\n\r\n'
+    second = b'data: {"choices":[{"delta":{"content":"avibe_todo_write"}}]}\n\n'
+    terminal = b"data: [DONE]\n\n"
+    wire = first + second + terminal
+    rewriter = StreamingToolNameRewriter({"avibe_todo_write": "todowrite"})
+
+    output = b"".join(
+        (
+            rewriter.feed(wire[:17]),
+            rewriter.feed(wire[17:71]),
+            rewriter.feed(wire[71:]),
+            rewriter.finish(),
+        )
+    )
+
+    frames = SSEFrameTokenizer().feed(output)
+    payloads = [parse_sse_frame(frame)[1] for frame in frames]
+    assert len(payloads) == 3
+    first_payload = json.loads(payloads[0])
+    assert first_payload["choices"][0]["delta"]["tool_calls"][0]["function"]["name"] == "todowrite"
+    assert json.loads(payloads[1])["choices"][0]["delta"]["content"] == "avibe_todo_write"
+    assert payloads[2] == b"[DONE]"
+
+
+def test_streaming_rewriter_drains_unterminated_wire_bytes_without_loss() -> None:
+    rewriter = StreamingToolNameRewriter({"avibe_todo_write": "todowrite"})
+    partial = b'data: {"choices":[]}'
+
+    assert rewriter.feed(partial) == b""
+    assert rewriter.finish() == partial

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -123,6 +123,39 @@ class _FakeSession:
 
 
 class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
+    async def test_start_server_reaps_a_live_process_after_cold_start_timeout(self):
+        manager = OpenCodeServerManager(binary="opencode", port=4096)
+        process = types.SimpleNamespace(pid=4321, returncode=None)
+        manager._is_healthy = AsyncMock(return_value=False)  # type: ignore[method-assign]
+        manager._write_pid_file = Mock()  # type: ignore[method-assign]
+        manager._clear_pid_file = Mock()  # type: ignore[method-assign]
+        manager._apply_resource_governance = Mock()  # type: ignore[method-assign]
+        terminate = AsyncMock()
+
+        with (
+            patch.object(
+                SERVER_MODULE.asyncio,
+                "create_subprocess_exec",
+                AsyncMock(return_value=process),
+            ),
+            patch.object(SERVER_MODULE.asyncio, "sleep", AsyncMock()),
+            patch.object(SERVER_MODULE.time, "monotonic", side_effect=[0.0, 0.0, 61.0]),
+            patch.object(SERVER_MODULE, "server_environment", return_value={}),
+            patch.object(SERVER_MODULE, "terminate_process_tree", terminate),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "failed to start within 60s"):
+                await manager._start_server()
+
+        terminate.assert_awaited_once_with(
+            process,
+            SERVER_MODULE.logger,
+            "OpenCode server after startup timeout",
+            terminate_timeout=5,
+        )
+        self.assertEqual(manager._clear_pid_file.call_count, 2)
+        self.assertIsNone(manager._process)
+        self.assertIsNone(manager._process_loop)
+
     def test_terminate_instance_sync_stops_unadopted_managed_server(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             pid_file = Path(tmp_dir) / "opencode_server.json"


### PR DESCRIPTION
## Summary

- capability: translate OpenCode tool names that are reserved by an upstream relay, then restore them on the response boundary
- reliability: allow busy-host OpenCode cold starts to finish and terminate a still-live child before reporting a startup timeout
- user-visible change: OpenCode sessions routed to Anthropic-compatible Model Hub sources can start normally with the full built-in tool set, without leaving an unmanaged server after a slow start
- motivation: the live Claude upstream accepts the configured model and minimal probes, but rejects OpenCode's `todowrite` function name with HTTP 400; the first exact-head acceptance also showed that the old 15-second startup ceiling could expire while OpenCode was still loading

## Scenario Coverage

- scenario IDs: OpenCode Model Hub turns through `ai-relay-gpt/gpt-5.6-luna` and `ai-relay-claude/claude-opus-4-8`; cold server startup exceeding the former 15-second ceiling
- unit / contract coverage: case-insensitive collision-safe request rewriting, role-scoped historical references, buffered responses, transport and semantic SSE name fragments, incomplete tails, and live-process cleanup after startup timeout
- scenario coverage: in-process gateway verifies the upstream receives the alias while OpenCode receives its original tool name
- residual manual checks: none; exact reviewed head `7f00970181a8` passed strict live turns through both configured upstream sources

## Validation

- commands run: focused Model Hub, runtime, structure guard, and OpenCode server test suites; Ruff; diff check
- result: 565 passed, 1 xfailed; Ruff passed; diff check passed
- live result: both turns returned the exact agent-only marker, retained an exact one-hop route, and incremented usage on the selected source/model (`17 -> 19` for each source); shared-server provenance failed closed as `attribution_ambiguous` as designed
- cleanup result: the original empty OpenCode menu and routes, exact product-config hash, healthy service, and archived verification sessions were independently confirmed after the run

## Risks / Follow-ups

- risk: response rewriting must remain scoped to OpenCode's OpenAI Chat gateway and only to structured tool-name fields
- risk: a process that exceeds the 60-second startup ceiling is terminated before ownership metadata is cleared, so it cannot later become a healthy unmanaged blocker
- evidence: exact-head deployment was clean, Linux-arm64 Show Runtime was prepared, and the regression service remained healthy after restoring all product state
