### PR TITLE
fix(opencode): unblock Model Hub overlay changes before native start

### DIFF
--- a/core/runtime_ownership.py
+++ b/core/runtime_ownership.py
@@ -126,8 +126,32 @@ class RuntimeTargetOwnershipSnapshot:
         """Whether durable native-effect evidence vetoes transport replacement.
 
         Pre-native Delivery and Turn rows use the adapter's live-turn fence.
-        This gate covers evidence that can outlive that local fence: unknown
-        ownership, active Activity effects, and fallback Runs with a live PID.
+        This gate also preserves an accepted active Turn when the adapter has
+        not independently proved that its native transport is drained.
+        """
+
+        return bool(
+            self.blocks_transport_replacement_after_turn_drain
+            or self.has_active_turn_evidence
+        )
+
+    @property
+    def has_active_turn_evidence(self) -> bool:
+        """Whether durable state still records an accepted native Turn."""
+
+        return any(
+            "turn:active" in session.reasons
+            for session in self.sessions
+        )
+
+    @property
+    def blocks_transport_replacement_after_turn_drain(self) -> bool:
+        """Whether non-Turn native effects survive an adapter-owned drain.
+
+        A backend may use this narrower gate only while holding the lifecycle
+        lock that proves its live requests and native runs are empty. Unknown
+        ownership, Activities, unmatched claimed deliveries, and live fallback
+        processes remain vetoes after that proof.
         """
 
         if self.disposition is SessionRuntimeDisposition.UNKNOWN:
@@ -138,11 +162,11 @@ class RuntimeTargetOwnershipSnapshot:
             return True
         for session in self.sessions:
             session_reasons = set(session.reasons)
-            if "turn:active" in session_reasons:
-                return True
             if (
                 "delivery:claimed" in session_reasons
-                and "turn:starting" not in session_reasons
+                and not {"turn:starting", "turn:active"}.intersection(
+                    session_reasons
+                )
             ):
                 return True
         reasons = self.reasons + tuple(

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -714,9 +714,10 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
         set_retire = getattr(server, "set_runtime_activation_retire", None)
         if callable(set_retire):
             set_retire(
-                lambda force=False: self._retire_server_activation(
+                lambda force=False, native_turns_drained=False: self._retire_server_activation(
                     server,
                     force=force,
+                    native_turns_drained=native_turns_drained,
                 )
             )
         return identity
@@ -726,6 +727,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
         server: OpenCodeServerManager,
         *,
         force: bool = False,
+        native_turns_drained: bool = False,
     ) -> bool:
         registry = getattr(getattr(self, "controller", None), "runtime_activation", None)
         identity = self._server_activation_identity(server)
@@ -738,7 +740,11 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             if force:
                 return True
             snapshots = self.runtime_ownership_snapshots()
-            live_native_turn = server.runtime_has_active_turns()
+            live_native_turn = (
+                False
+                if native_turns_drained
+                else server.runtime_has_active_turns()
+            )
             return bool(
                 snapshots is not None
                 and all(

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -738,10 +738,15 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             if force:
                 return True
             snapshots = self.runtime_ownership_snapshots()
+            live_native_turn = server.runtime_has_active_turns()
             return bool(
                 snapshots is not None
                 and all(
-                    not snapshot.blocks_transport_replacement
+                    not snapshot.blocks_transport_replacement_after_turn_drain
+                    and not (
+                        live_native_turn
+                        and snapshot.has_active_turn_evidence
+                    )
                     for snapshot in snapshots
                 )
             )

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -740,18 +740,13 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             if force:
                 return True
             snapshots = self.runtime_ownership_snapshots()
-            live_native_turn = (
-                False
-                if native_turns_drained
-                else server.runtime_has_active_turns()
-            )
             return bool(
                 snapshots is not None
                 and all(
-                    not snapshot.blocks_transport_replacement_after_turn_drain
-                    and not (
-                        live_native_turn
-                        and snapshot.has_active_turn_evidence
+                    not (
+                        snapshot.blocks_transport_replacement_after_turn_drain
+                        if native_turns_drained
+                        else snapshot.blocks_transport_replacement
                     )
                     for snapshot in snapshots
                 )

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -740,7 +740,10 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             snapshots = self.runtime_ownership_snapshots()
             return bool(
                 snapshots is not None
-                and all(not snapshot.blocks_reclamation for snapshot in snapshots)
+                and all(
+                    not snapshot.blocks_transport_replacement
+                    for snapshot in snapshots
+                )
             )
 
         return bool(registry.retire_if_current(identity, final_predicate))

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -260,12 +260,12 @@ class OpenCodeServerManager:
             object, tuple[Optional[str], Optional[str]]
         ] = {}
         self._model_hub_overlay_drain_timeout_seconds = MODEL_HUB_OVERLAY_DRAIN_TIMEOUT_SECONDS
-        self._runtime_activation_retire: Callable[[bool], bool] | None = None
+        self._runtime_activation_retire: Callable[[bool, bool], bool] | None = None
         self._runtime_generation_token: tuple[int, float | None] | None = None
 
     def set_runtime_activation_retire(
         self,
-        callback: Callable[[bool], bool],
+        callback: Callable[[bool, bool], bool],
     ) -> None:
         self._runtime_activation_retire = callback
 
@@ -286,7 +286,7 @@ class OpenCodeServerManager:
 
     def _retire_runtime_generation_for_replacement(self) -> None:
         retire_activation = self._runtime_activation_retire
-        if callable(retire_activation) and not retire_activation(True):
+        if callable(retire_activation) and not retire_activation(True, False):
             raise RuntimeError(
                 "OpenCode runtime replacement could not retire its activation generation"
             )
@@ -439,9 +439,17 @@ class OpenCodeServerManager:
                 return
             await self._close_http_session_locked()
 
-    async def _restart_for_auth_refresh_locked(self, *, force: bool = False) -> None:
+    async def _restart_for_auth_refresh_locked(
+        self,
+        *,
+        force: bool = False,
+        native_turns_drained: bool = False,
+    ) -> None:
         retire_activation = self._runtime_activation_retire
-        if callable(retire_activation) and not retire_activation(force):
+        if callable(retire_activation) and not retire_activation(
+            force,
+            native_turns_drained,
+        ):
             self._auth_refresh_pending = True
             raise RuntimeError(
                 "OpenCode runtime restart is blocked by a newly admitted owner"
@@ -687,7 +695,9 @@ class OpenCodeServerManager:
                                     logger.info(
                                         "Restarting OpenCode server after Model Hub overlay change"
                                     )
-                                    await self._restart_for_auth_refresh_locked()
+                                    await self._restart_for_auth_refresh_locked(
+                                        native_turns_drained=True,
+                                    )
                                 self._model_hub_overlay_reservations[
                                     transition_owner
                                 ] = (desired_path, desired_hash)

--- a/tests/scenarios/INDEX.yaml
+++ b/tests/scenarios/INDEX.yaml
@@ -120,6 +120,7 @@ capabilities:
       - tests/test_model_hub_l3.py
       - tests/test_model_hub_usage.py
       - tests/test_opencode_server.py
+      - tests/test_runtime_activation.py
       - ui/src/components/settings/models/UsageTab.test.tsx
       - ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
       - ui/src/components/settings/models/RouteChainDialog.test.tsx

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -11,6 +11,7 @@ capability:
     - tests/test_model_hub_l3.py
     - tests/test_model_hub_usage.py
     - tests/test_opencode_server.py
+    - tests/test_runtime_activation.py
     # The user-visible half of metering. A vitest case is the only place these
     # properties can be observed, so the catalog checker resolves both shapes.
     - ui/src/components/settings/models/UsageTab.test.tsx
@@ -164,6 +165,12 @@ scenarios:
     kind: timeout_cancel
     layer: unit
     test: tests/test_model_hub_runtime.py::test_mh_runtime_006_timeout_stops_engine_with_bounded_structured_diagnostics
+  - id: MH-RUNTIME-007
+    name: An OpenCode overlay change retires a pre-native owner without replacing an active native Turn
+    status: covered
+    kind: concurrency
+    layer: unit
+    test: tests/test_runtime_activation.py::test_mh_runtime_007_opencode_overlay_restart_retires_pre_native_start_owner
   - id: MH-USAGE-001
     name: Tokens an upstream reported before the turn ended are still metered
     status: covered

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -166,7 +166,7 @@ scenarios:
     layer: unit
     test: tests/test_model_hub_runtime.py::test_mh_runtime_006_timeout_stops_engine_with_bounded_structured_diagnostics
   - id: MH-RUNTIME-007
-    name: An OpenCode overlay change retires a pre-native owner without replacing an active native Turn
+    name: An OpenCode overlay change retires drained durable owners without replacing an active native Turn
     status: covered
     kind: concurrency
     layer: unit

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -590,7 +590,10 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         events = []
         manager._runtime_generation_token = (111, 1.0)
         manager.set_runtime_activation_retire(
-            lambda force: events.append(("retire", force)) or True
+            lambda force, native_turns_drained: events.append(
+                ("retire", force, native_turns_drained)
+            )
+            or True
         )
         manager._is_healthy = AsyncMock(return_value=False)  # type: ignore[method-assign]
         manager._cleanup_orphaned_managed_server = AsyncMock()  # type: ignore[method-assign]
@@ -606,14 +609,17 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         ):
             await manager.ensure_running()
 
-        self.assertEqual(events, [("retire", True), ("start", True)])
+        self.assertEqual(events, [("retire", True, False), ("start", True)])
 
     async def test_ensure_running_retires_generation_when_adopted_pid_changes(self):
         manager = OpenCodeServerManager(binary="opencode", port=4096)
         retired = []
         manager._runtime_generation_token = (111, 1.0)
         manager.set_runtime_activation_retire(
-            lambda force: retired.append(force) or True
+            lambda force, native_turns_drained: retired.append(
+                (force, native_turns_drained)
+            )
+            or True
         )
         manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
         manager._cleanup_orphaned_managed_server = AsyncMock()  # type: ignore[method-assign]
@@ -632,7 +638,7 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         ):
             await manager.ensure_running()
 
-        self.assertEqual(retired, [True])
+        self.assertEqual(retired, [(True, False)])
         self.assertEqual(manager._runtime_generation_token, (222, 2.0))
 
     async def test_prompt_async_percent_encodes_directory_header(self):
@@ -2658,6 +2664,34 @@ def test_changed_overlay_still_waits_for_active_run_before_restart():
     assert manager._model_hub_overlay_path == str(overlay.path)
     assert manager._model_hub_overlay_hash == overlay.content_hash
     manager._restart_for_auth_refresh_locked.assert_awaited_once()
+
+
+def test_changed_overlay_passes_completed_persisted_drain_to_retirement():
+    manager = OpenCodeServerManager(binary="opencode", port=4096)
+    manager._model_hub_overlay_path = "/tmp/old-overlay.json"
+    manager._model_hub_overlay_hash = "old-hash"
+    manager._model_hub_overlay_drain_timeout_seconds = 0
+    manager._read_pid_file = lambda: {  # type: ignore[method-assign]
+        "pid": 321,
+        "port": 4096,
+        "active_run_sessions": ["sess-stale"],
+    }
+    manager._pid_file_references_current_server = Mock(return_value=True)  # type: ignore[method-assign]
+    manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    manager._restart_for_auth_refresh_locked = AsyncMock()  # type: ignore[method-assign]
+    overlay = types.SimpleNamespace(
+        path=Path("/tmp/new-overlay.json"),
+        content_hash="new-hash",
+        content='{"provider": {}}',
+        provider_id="avibe-model-hub-new",
+    )
+
+    reservation = asyncio.run(manager.configure_model_hub_overlay(overlay))
+    asyncio.run(manager.release_model_hub_overlay_reservation(reservation))
+
+    manager._restart_for_auth_refresh_locked.assert_awaited_once_with(
+        native_turns_drained=True,
+    )
 
 
 def test_mh_runtime_003_pending_overlay_transition_blocks_new_turns_on_the_old_overlay():

--- a/tests/test_runtime_activation.py
+++ b/tests/test_runtime_activation.py
@@ -324,7 +324,7 @@ def test_opencode_overlay_restart_preserves_native_active_owner() -> None:
             self.retire_activation = callback
 
         def runtime_has_active_turns(self) -> bool:
-            return True
+            return False
 
     server = _Server()
     opencode = object.__new__(OpenCodeAgent)
@@ -357,7 +357,7 @@ def test_mh_runtime_007_opencode_overlay_restart_ignores_drained_durable_active_
             self.retire_activation = callback
 
         def runtime_has_active_turns(self) -> bool:
-            return True
+            raise AssertionError("explicit drain must not reread PID turn metadata")
 
     server = _Server()
     opencode = object.__new__(OpenCodeAgent)

--- a/tests/test_runtime_activation.py
+++ b/tests/test_runtime_activation.py
@@ -292,6 +292,9 @@ def test_mh_runtime_007_opencode_overlay_restart_retires_pre_native_start_owner(
         def set_runtime_activation_retire(self, callback) -> None:
             self.retire_activation = callback
 
+        def runtime_has_active_turns(self) -> bool:
+            return False
+
     server = _Server()
     opencode = object.__new__(OpenCodeAgent)
     opencode.controller = SimpleNamespace(runtime_activation=registry)
@@ -299,6 +302,8 @@ def test_mh_runtime_007_opencode_overlay_restart_retires_pre_native_start_owner(
         SimpleNamespace(
             blocks_reclamation=True,
             blocks_transport_replacement=False,
+            blocks_transport_replacement_after_turn_drain=False,
+            has_active_turn_evidence=False,
         ),
     )
 
@@ -318,6 +323,9 @@ def test_opencode_overlay_restart_preserves_native_active_owner() -> None:
         def set_runtime_activation_retire(self, callback) -> None:
             self.retire_activation = callback
 
+        def runtime_has_active_turns(self) -> bool:
+            return True
+
     server = _Server()
     opencode = object.__new__(OpenCodeAgent)
     opencode.controller = SimpleNamespace(runtime_activation=registry)
@@ -325,6 +333,8 @@ def test_opencode_overlay_restart_preserves_native_active_owner() -> None:
         SimpleNamespace(
             blocks_reclamation=True,
             blocks_transport_replacement=True,
+            blocks_transport_replacement_after_turn_drain=False,
+            has_active_turn_evidence=True,
         ),
     )
 
@@ -333,6 +343,39 @@ def test_opencode_overlay_restart_preserves_native_active_owner() -> None:
     assert identity is not None
     assert not server.retire_activation(False)
     assert registry.is_current(identity)
+
+
+def test_mh_runtime_007_opencode_overlay_restart_ignores_drained_durable_active_turn() -> None:
+    """MH-RUNTIME-007: a stale durable Turn cannot outvote the server drain."""
+
+    registry = RuntimeActivationRegistry()
+
+    class _Server:
+        base_url = "http://127.0.0.1:4096"
+
+        def set_runtime_activation_retire(self, callback) -> None:
+            self.retire_activation = callback
+
+        def runtime_has_active_turns(self) -> bool:
+            return False
+
+    server = _Server()
+    opencode = object.__new__(OpenCodeAgent)
+    opencode.controller = SimpleNamespace(runtime_activation=registry)
+    opencode.runtime_ownership_snapshots = lambda: (
+        SimpleNamespace(
+            blocks_reclamation=True,
+            blocks_transport_replacement=True,
+            blocks_transport_replacement_after_turn_drain=False,
+            has_active_turn_evidence=True,
+        ),
+    )
+
+    identity = opencode._attach_server_activation(server)
+
+    assert identity is not None
+    assert server.retire_activation(False)
+    assert not registry.is_current(identity)
 
 
 def test_session_binding_lookup_failure_is_not_resource_absence() -> None:

--- a/tests/test_runtime_activation.py
+++ b/tests/test_runtime_activation.py
@@ -281,6 +281,60 @@ def test_opencode_binding_resolver_returns_pre_prompt_shared_generation() -> Non
     assert registry.is_current(replacement)
 
 
+def test_mh_runtime_007_opencode_overlay_restart_retires_pre_native_start_owner() -> None:
+    """MH-RUNTIME-007: a claimed pre-native Turn cannot block its overlay change."""
+
+    registry = RuntimeActivationRegistry()
+
+    class _Server:
+        base_url = "http://127.0.0.1:4096"
+
+        def set_runtime_activation_retire(self, callback) -> None:
+            self.retire_activation = callback
+
+    server = _Server()
+    opencode = object.__new__(OpenCodeAgent)
+    opencode.controller = SimpleNamespace(runtime_activation=registry)
+    opencode.runtime_ownership_snapshots = lambda: (
+        SimpleNamespace(
+            blocks_reclamation=True,
+            blocks_transport_replacement=False,
+        ),
+    )
+
+    identity = opencode._attach_server_activation(server)
+
+    assert identity is not None
+    assert server.retire_activation(False)
+    assert not registry.is_current(identity)
+
+
+def test_opencode_overlay_restart_preserves_native_active_owner() -> None:
+    registry = RuntimeActivationRegistry()
+
+    class _Server:
+        base_url = "http://127.0.0.1:4096"
+
+        def set_runtime_activation_retire(self, callback) -> None:
+            self.retire_activation = callback
+
+    server = _Server()
+    opencode = object.__new__(OpenCodeAgent)
+    opencode.controller = SimpleNamespace(runtime_activation=registry)
+    opencode.runtime_ownership_snapshots = lambda: (
+        SimpleNamespace(
+            blocks_reclamation=True,
+            blocks_transport_replacement=True,
+        ),
+    )
+
+    identity = opencode._attach_server_activation(server)
+
+    assert identity is not None
+    assert not server.retire_activation(False)
+    assert registry.is_current(identity)
+
+
 def test_session_binding_lookup_failure_is_not_resource_absence() -> None:
     service = object.__new__(AgentService)
     service.agents = {

--- a/tests/test_runtime_activation.py
+++ b/tests/test_runtime_activation.py
@@ -272,7 +272,7 @@ def test_opencode_binding_resolver_returns_pre_prompt_shared_generation() -> Non
             workdir="/other",
         )
 
-    assert server.retire_activation(True)
+    assert server.retire_activation(True, False)
     replacement = opencode.runtime_activation_identity_for_request(SimpleNamespace())
     late_prompt_commit = registry.commit_if_current(identity, lambda: "accepted")
 
@@ -310,7 +310,7 @@ def test_mh_runtime_007_opencode_overlay_restart_retires_pre_native_start_owner(
     identity = opencode._attach_server_activation(server)
 
     assert identity is not None
-    assert server.retire_activation(False)
+    assert server.retire_activation(False, False)
     assert not registry.is_current(identity)
 
 
@@ -341,7 +341,7 @@ def test_opencode_overlay_restart_preserves_native_active_owner() -> None:
     identity = opencode._attach_server_activation(server)
 
     assert identity is not None
-    assert not server.retire_activation(False)
+    assert not server.retire_activation(False, False)
     assert registry.is_current(identity)
 
 
@@ -357,7 +357,7 @@ def test_mh_runtime_007_opencode_overlay_restart_ignores_drained_durable_active_
             self.retire_activation = callback
 
         def runtime_has_active_turns(self) -> bool:
-            return False
+            return True
 
     server = _Server()
     opencode = object.__new__(OpenCodeAgent)
@@ -374,7 +374,7 @@ def test_mh_runtime_007_opencode_overlay_restart_ignores_drained_durable_active_
     identity = opencode._attach_server_activation(server)
 
     assert identity is not None
-    assert server.retire_activation(False)
+    assert server.retire_activation(False, True)
     assert not registry.is_current(identity)
 
 

--- a/tests/test_runtime_ownership.py
+++ b/tests/test_runtime_ownership.py
@@ -606,7 +606,7 @@ def test_snapshot_many_reads_backend_owner_tables_once(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    ("snapshot", "expected", "dead_expected"),
+    ("snapshot", "expected", "drained_expected", "dead_expected"),
     (
         (
             RuntimeTargetOwnershipSnapshot(
@@ -618,6 +618,7 @@ def test_snapshot_many_reads_backend_owner_tables_once(tmp_path: Path) -> None:
                 sessionless_fallback_run_ids=(),
                 disposition=SessionRuntimeDisposition.UNKNOWN,
             ),
+            True,
             True,
             True,
         ),
@@ -633,6 +634,7 @@ def test_snapshot_many_reads_backend_owner_tables_once(tmp_path: Path) -> None:
             ),
             True,
             True,
+            True,
         ),
         (
             RuntimeTargetOwnershipSnapshot(
@@ -645,6 +647,7 @@ def test_snapshot_many_reads_backend_owner_tables_once(tmp_path: Path) -> None:
                 disposition=SessionRuntimeDisposition.ACTIVE,
                 reasons=("run:run-a:active",),
             ),
+            True,
             True,
             False,
         ),
@@ -670,6 +673,7 @@ def test_snapshot_many_reads_backend_owner_tables_once(tmp_path: Path) -> None:
             ),
             False,
             False,
+            False,
         ),
         (
             RuntimeTargetOwnershipSnapshot(
@@ -693,15 +697,18 @@ def test_snapshot_many_reads_backend_owner_tables_once(tmp_path: Path) -> None:
             ),
             True,
             False,
+            False,
         ),
     ),
 )
 def test_transport_replacement_gate_tracks_only_durable_native_effect_owners(
     snapshot: RuntimeTargetOwnershipSnapshot,
     expected: bool,
+    drained_expected: bool,
     dead_expected: bool,
 ) -> None:
     assert snapshot.blocks_transport_replacement is expected
+    assert snapshot.blocks_transport_replacement_after_turn_drain is drained_expected
     assert snapshot.blocks_dead_transport_replacement is dead_expected
 
 


### PR DESCRIPTION
## Summary

- separate ordinary OpenCode runtime refreshes from Model Hub overlay replacement after the native-turn fence has explicitly drained
- allow a stale durable turn claim to stop owning a drained shared-server generation
- continue blocking replacement for ordinary refreshes and for any overlay transition with active native turns or durable native effects

## Root cause

The OpenCode overlay transition used the full runtime reclamation gate. A newly claimed delivery therefore became an owner of the old server generation before its own overlay could be applied, and the turn repeatedly failed before native start with `OpenCode runtime restart is blocked by a newly admitted owner`.

The final design keeps the full ownership gate for ordinary refreshes. Only the Model Hub overlay path, after the server has explicitly proved that its native-turn fence drained, uses the narrower transport-replacement gate. This avoids both the stale-owner deadlock and unsafe retirement during a normal refresh.

## Scenario

- `MH-RUNTIME-007`

## Verification

- Exact head: `0b0157a27a6b4c81cbf6f2c2a9c44655a7eb55d6`, clean deployment metadata
- Unit: `tests/test_runtime_activation.py`, `tests/test_runtime_ownership.py`, and `tests/test_opencode_server.py` (174 passed)
- Scenario catalog: `tests/scenarios/model_hub/test_model_hub_catalog.py` (1 passed)
- Ruff and `git diff --check`: passed
- Exact-head GitHub Actions lint workflow: passed
- Exact-head Codex review: completed with no findings; all review threads resolved
- Local Incus master regression: `avibe-regression.service` active, `/health=ok`, `/status=running`, Linux-arm64 Show Runtime installed from the prepared archive
- Live OpenCode overlay switch under project `proj_d77a4e474dab` completed without restarting Avibe (`MainPID 606778` before and after both turns)
- GPT upstream: session `sesttabqzt597` returned exactly `OPENCODE_PR1785_GPT_OK`; one-hop route was `src_04d906294ece/gpt-5.6-luna`; that exact source/model usage counter increased
- Claude upstream: session `sesv64985wfq4` returned exactly `OPENCODE_PR1785_CLAUDE_OK`; one-hop route was `src_3457a1e5f2b4/claude-opus-4-8`; that exact source/model usage counter increased
- Both successful sessions remain visible for user inspection. The OpenCode menu and both one-hop routes are intentionally retained; failed verification sessions were archived.

The acceptance waiter reached every product assertion and then reported a false failure because it compared the checked-model list as ordered data. The backend canonically returned the same two-model set in a different order; the retained menu, routes, exact replies, usage increments, and service gates were independently read back afterward.
