### PR TITLE
fix(model-hub): align agent connection anchors

### DIFF
--- a/docs/plans/model-hub-ui-spec.md
+++ b/docs/plans/model-hub-ui-spec.md
@@ -1944,7 +1944,7 @@ Other limits `[derived]`:
 | Many sources (> 6) | The upstream module grows with every source; the enclosing settings route pane scrolls, so the head, groups and footer remain in one reading flow. |
 | Many backends (> 3) | The gateway module grows with every backend; the enclosing settings route pane scrolls and no nested gateway scrollbar appears. |
 | Zero supply relations | The wire layer renders nothing — no placeholder path. |
-| Wires | Generated from the supply-relation set, never hand-placed; the frame's four paths are an instance of that generator, not a fixed asset. Every path leaves its Source at the right-edge midpoint, and every relation targeting the same Agent lands at that Agent card's shared left-edge midpoint while remaining a distinct curve. The SVG follows the natural-height `cols` track and remains clipped before the legend and following page sections. |
+| Wires | Generated from the supply-relation set, never hand-placed; the frame's four paths are an instance of that generator, not a fixed asset. Every path leaves its Source at the shared right-edge midpoint, and every relation targeting the same Agent lands at that Agent card's shared left-edge midpoint while remaining a distinct curve. One neutral marker represents each shared Source or Agent anchor, so relation ordering cannot hide or recolor either endpoint. The SVG follows the natural-height `cols` track and remains clipped before the legend and following page sections. |
 
 ---
 

--- a/docs/plans/model-hub-ui-spec.md
+++ b/docs/plans/model-hub-ui-spec.md
@@ -1944,7 +1944,7 @@ Other limits `[derived]`:
 | Many sources (> 6) | The upstream module grows with every source; the enclosing settings route pane scrolls, so the head, groups and footer remain in one reading flow. |
 | Many backends (> 3) | The gateway module grows with every backend; the enclosing settings route pane scrolls and no nested gateway scrollbar appears. |
 | Zero supply relations | The wire layer renders nothing — no placeholder path. |
-| Wires | Generated from the supply-relation set, never hand-placed; the frame's four paths are an instance of that generator, not a fixed asset. The SVG follows the natural-height `cols` track and remains clipped before the legend and following page sections. |
+| Wires | Generated from the supply-relation set, never hand-placed; the frame's four paths are an instance of that generator, not a fixed asset. Every path leaves its Source at the right-edge midpoint, and every relation targeting the same Agent lands at that Agent card's shared left-edge midpoint while remaining a distinct curve. The SVG follows the natural-height `cols` track and remains clipped before the legend and following page sections. |
 
 ---
 

--- a/docs/plans/model-hub-ui-spec.md
+++ b/docs/plans/model-hub-ui-spec.md
@@ -1072,7 +1072,7 @@ sections. §1.8 states the direct-only body condition.
 | Run pill | Engine liveness | `runtime-dependency.schema.json` → `status.health` `[contract]` | see the mapping below | see the mapping below |
 | Tabs ×3 | Section switch | — | yes | 来源与网关 / 用量 / 日志; the active one gets the mint underline |
 | Upstream module | Source inventory + info icon | `GET /api/models/sources` `[spec]` | info icon and rows: yes | Tooltip: `upstream.info`; open 06 for that source |
-| Dispatch rail | That upstream feeds gateway | derived, decorative | no | — |
+| Wire corridor | Routing space between Sources and Agents; it draws no independent axis | derived, decorative | no | — |
 | Gateway module | One group per backend, each with model rows + info icon | per-backend supply + chains `[spec]` | info icon, rows, collapse, 「调整优先级」, mode switch | Tooltip: `gateway.info`; open 02 / expand / open 03 for **that backend** / open 10's confirm |
 | Legend | Colour → meaning | static; kept in bijection with the inks the page draws | no | — |
 
@@ -1745,7 +1745,7 @@ dispatch arbitrates → each backend's models resolve to these sources today.
 | `uf3re` detail | account label, or `host/path · masked key` — **and every field it can draw is nullable, so the line is specified by omission, exactly as §0.9 and §1.6 rule the same hole** `[contract]`. `account_label`, `base_url` and `masked_credential` are each `["string","null"]` in `source.schema.json`, so a segment with no value is dropped, never rendered empty and never left behind a dangling `·`; `base_url: null` is the vendor's official endpoint (§0.9's `{{host}}`) and is not synthesized into a hostname (§1.6). When nothing is left the whole line is omitted rather than filled — a subscription that reports no account label is the common case, and the card still identifies itself from four required fields (icon and pill by `kind`, name by `display_name`, state by `state`). Repeating the kind pill or the card's own name here would be the only alternative, and it would say nothing the card has not already said | source | no | — |
 | `YcOFo` status | which Hub-mode backends have this source configured into a route — `adopted_by` (§1.0) | the complete server-derived Source projection, never a computation over chains (D-28) | no | — |
 | `wmROQ` / `Xitl7` footer buttons | Add subscription / Add API key | — | yes | 添加订阅 opens frame 13; its selected vendor opens 04. 添加 API Key opens 05 |
-| `f8w6Xp` + `pnYa0` rail | dispatch happens between the columns | decorative | no | — |
+| `f8w6Xp` + `pnYa0` wire corridor | the relations cross between the columns without an independent axis | decorative | no | — |
 | `GLylJ` backend group | backend tile, name, model count, head buttons, and one `{{mode}} · {{health}}` line. For an open menu the count is the explicit selected count, never the number of models available from Sources | per-backend mode + supply health | head: buttons only | OpenCode's **Manage models** opens its model-menu dialog; other actions are registered below |
 | `ehGRK` / `bGsC7` 「调整优先级」 | — | — | yes | Open 03 **for that backend** |
 | OpenCode 「管理模型」 `[derived]` | — | `menu.checked` plus the server-owned eligible Source inventory | yes | Open the OpenCode model-menu dialog; the same action remains available in the empty row area |
@@ -1753,7 +1753,7 @@ dispatch arbitrates → each backend's models resolve to these sources today.
 | `z02Ep` / `gbrq2` 「切到直连」 | — | backend on the gateway | yes | That backend leaves the gateway immediately — **no confirm** (D-30) |
 | `Exx0a` model row | model id (mono 12), a chain chip, current-source text; `legend.unavailable` occupies that text slot when the page-grain row has no runnable hop | `AgentSupply.model_supply[].has_runnable_hop`; per-model AgentChain and its `current` member | yes | Open 02 for `(backend, model)` |
 | `ZM1pm` collapse row | `还有 N 个型号` | count of hidden rows | yes | Expand in place |
-| `FZUYI` wire layer | one path per supply relation + endpoint dots | derived supply set | no | — |
+| `FZUYI` wire layer | one path per supply relation + endpoint dots; no central axis | derived supply set | Source and Agent cards highlight their connected paths on hover or focus | — |
 | `ftWgW` legend info icon | the legend's note — **the string is measured from the frame, not specified here** (§0.2) | static | hover, focus **and** activation — the same three §1.0's title icon carries | Tooltip, the note standing as the icon's accessible description |
 
 **The 当前 lines are a third read, and the page does not wait on it** `[contract]`. Every
@@ -1944,7 +1944,7 @@ Other limits `[derived]`:
 | Many sources (> 6) | The upstream module grows with every source; the enclosing settings route pane scrolls, so the head, groups and footer remain in one reading flow. |
 | Many backends (> 3) | The gateway module grows with every backend; the enclosing settings route pane scrolls and no nested gateway scrollbar appears. |
 | Zero supply relations | The wire layer renders nothing — no placeholder path. |
-| Wires | Generated from the supply-relation set, never hand-placed; the frame's four paths are an instance of that generator, not a fixed asset. Every path leaves its Source at the shared right-edge midpoint, and every relation targeting the same Agent lands at that Agent card's shared left-edge midpoint while remaining a distinct curve. One neutral marker represents each shared Source or Agent anchor, so relation ordering cannot hide or recolor either endpoint. The SVG follows the natural-height `cols` track and remains clipped before the legend and following page sections. |
+| Wires | Generated from the supply-relation set, never hand-placed; the frame's four paths are an instance of that generator, not a fixed asset. Every path leaves its Source at the shared right-edge midpoint, and every relation targeting the same Agent lands at that Agent card's shared left-edge midpoint while remaining a distinct curve. One neutral marker represents each shared Source or Agent anchor, so relation ordering cannot hide or recolor either endpoint. Paths rest at low opacity; hovering or focusing a Source or Agent restores full opacity only for its connected paths. The corridor draws no independent central axis. The SVG follows the natural-height `cols` track and remains clipped before the legend and following page sections. |
 
 ---
 

--- a/ui/src/components/settings/models/SupplyGraph.test.tsx
+++ b/ui/src/components/settings/models/SupplyGraph.test.tsx
@@ -85,5 +85,14 @@ describe('SupplyGraph', () => {
       'M 30 15 C 60 15, 60 50, 90 50',
       'M 30 35 C 60 35, 60 50, 90 50',
     ]);
+    const anchorCoordinates = () => Array.from(view.container.querySelectorAll<SVGCircleElement>('.model-hub-wire-node--shared-anchor'))
+      .map((anchor) => `${anchor.getAttribute('cx')}:${anchor.getAttribute('cy')}`)
+      .sort();
+    expect(anchorCoordinates()).toEqual(['30:15', '30:35', '90:50']);
+    expect(view.container.querySelectorAll('.model-hub-wire-node--gateway, .model-hub-wire-node--connected_unused')).toHaveLength(0);
+
+    view.rerender(<Fixture relations={[secondRelation, relation]} />);
+    await waitFor(() => expect(anchorCoordinates()).toEqual(['30:15', '30:35', '90:50']));
+    expect(view.container.querySelectorAll('.model-hub-wire-node--gateway, .model-hub-wire-node--connected_unused')).toHaveLength(0);
   });
 });

--- a/ui/src/components/settings/models/SupplyGraph.test.tsx
+++ b/ui/src/components/settings/models/SupplyGraph.test.tsx
@@ -121,11 +121,12 @@ describe('SupplyGraph', () => {
     fireEvent.pointerOver(view.container.querySelector('[data-source-id="src_a"]') as Element);
     await waitFor(() => expect(highlighted()).toEqual([true, false, true]));
 
-    fireEvent.pointerOut(view.container.querySelector('[data-source-id="src_a"]') as Element, { relatedTarget: view.container });
-    await waitFor(() => expect(highlighted()).toEqual([false, false, false]));
-
     fireEvent.focusIn(view.container.querySelector('[data-agent-backend="claude"]') as Element);
+    await waitFor(() => expect(highlighted()).toEqual([true, true, true]));
+
+    fireEvent.pointerOut(view.container.querySelector('[data-source-id="src_a"]') as Element, { relatedTarget: view.container });
     await waitFor(() => expect(highlighted()).toEqual([true, true, false]));
+
     fireEvent.focusOut(view.container.querySelector('[data-agent-backend="claude"]') as Element, { relatedTarget: view.container });
     await waitFor(() => expect(highlighted()).toEqual([false, false, false]));
   });

--- a/ui/src/components/settings/models/SupplyGraph.test.tsx
+++ b/ui/src/components/settings/models/SupplyGraph.test.tsx
@@ -7,6 +7,7 @@ import { SupplyGraph } from './SupplyGraph';
 import type { SupplyRelation } from './supplyRelations';
 
 const relation: SupplyRelation = { sourceId: 'src_a', backend: 'claude', kind: 'gateway' };
+const secondRelation: SupplyRelation = { sourceId: 'src_b', backend: 'claude', kind: 'connected_unused' };
 
 const rect = (left: number, top: number, width: number, height: number): DOMRect => ({
   x: left,
@@ -20,13 +21,14 @@ const rect = (left: number, top: number, width: number, height: number): DOMRect
   toJSON: () => ({}),
 });
 
-const Fixture: React.FC = () => {
+const Fixture: React.FC<{ relations?: SupplyRelation[] }> = ({ relations = [relation] }) => {
   const ref = React.useRef<HTMLDivElement>(null);
   return (
     <div ref={ref} data-testid="graph-root">
       <div data-source-id="src_a" />
+      <div data-source-id="src_b" />
       <div data-agent-backend="claude" />
-      <SupplyGraph containerRef={ref} relations={[relation]} />
+      <SupplyGraph containerRef={ref} relations={relations} />
     </div>
   );
 };
@@ -61,5 +63,27 @@ describe('SupplyGraph', () => {
     fireEvent.scroll(view.container.querySelector('[data-source-id="src_a"]') as Element);
 
     await waitFor(() => expect(path.getAttribute('d')).toContain('M 30 35'));
+  });
+
+  it('lands every relation for an agent on the agent card midpoint', async () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function bounds() {
+      if (this.dataset.testid === 'graph-root') return rect(0, 0, 120, 100);
+      if (this.dataset.sourceId === 'src_a') return rect(10, 10, 20, 10);
+      if (this.dataset.sourceId === 'src_b') return rect(10, 30, 20, 10);
+      if (this.dataset.agentBackend === 'claude') return rect(90, 40, 20, 20);
+      return rect(0, 0, 0, 0);
+    });
+
+    const view = render(<Fixture relations={[relation, secondRelation]} />);
+    const paths = await waitFor(() => {
+      const elements = Array.from(view.container.querySelectorAll<SVGPathElement>('.model-hub-wire'));
+      expect(elements).toHaveLength(2);
+      return elements;
+    });
+
+    expect(paths.map((path) => path.getAttribute('d'))).toEqual([
+      'M 30 15 C 60 15, 60 50, 90 50',
+      'M 30 35 C 60 35, 60 50, 90 50',
+    ]);
   });
 });

--- a/ui/src/components/settings/models/SupplyGraph.test.tsx
+++ b/ui/src/components/settings/models/SupplyGraph.test.tsx
@@ -8,6 +8,7 @@ import type { SupplyRelation } from './supplyRelations';
 
 const relation: SupplyRelation = { sourceId: 'src_a', backend: 'claude', kind: 'gateway' };
 const secondRelation: SupplyRelation = { sourceId: 'src_b', backend: 'claude', kind: 'connected_unused' };
+const codexRelation: SupplyRelation = { sourceId: 'src_a', backend: 'codex', kind: 'gateway' };
 
 const rect = (left: number, top: number, width: number, height: number): DOMRect => ({
   x: left,
@@ -28,6 +29,7 @@ const Fixture: React.FC<{ relations?: SupplyRelation[] }> = ({ relations = [rela
       <div data-source-id="src_a" />
       <div data-source-id="src_b" />
       <div data-agent-backend="claude" />
+      <div data-agent-backend="codex" />
       <SupplyGraph containerRef={ref} relations={relations} />
     </div>
   );
@@ -57,6 +59,7 @@ describe('SupplyGraph', () => {
     const svg = view.container.querySelector('svg');
     expect(svg?.classList.contains('overflow-hidden')).toBe(true);
     expect(svg?.classList.contains('overflow-visible')).toBe(false);
+    expect(svg?.querySelector('.model-hub-rail-line')).toBeNull();
     expect(path.getAttribute('d')).toContain('M 30 15');
 
     sourceTop = 30;
@@ -94,5 +97,36 @@ describe('SupplyGraph', () => {
     view.rerender(<Fixture relations={[secondRelation, relation]} />);
     await waitFor(() => expect(anchorCoordinates()).toEqual(['30:15', '30:35', '90:50']));
     expect(view.container.querySelectorAll('.model-hub-wire-node--gateway, .model-hub-wire-node--connected_unused')).toHaveLength(0);
+  });
+
+  it('highlights only relations connected to the hovered or focused endpoint', async () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function bounds() {
+      if (this.dataset.testid === 'graph-root') return rect(0, 0, 120, 120);
+      if (this.dataset.sourceId === 'src_a') return rect(10, 10, 20, 10);
+      if (this.dataset.sourceId === 'src_b') return rect(10, 30, 20, 10);
+      if (this.dataset.agentBackend === 'claude') return rect(90, 40, 20, 20);
+      if (this.dataset.agentBackend === 'codex') return rect(90, 80, 20, 20);
+      return rect(0, 0, 0, 0);
+    });
+
+    const view = render(<Fixture relations={[relation, secondRelation, codexRelation]} />);
+    const paths = await waitFor(() => {
+      const elements = Array.from(view.container.querySelectorAll<SVGPathElement>('.model-hub-wire'));
+      expect(elements).toHaveLength(3);
+      return elements;
+    });
+    const highlighted = () => paths.map((path) => path.classList.contains('model-hub-wire--highlighted'));
+    expect(highlighted()).toEqual([false, false, false]);
+
+    fireEvent.pointerOver(view.container.querySelector('[data-source-id="src_a"]') as Element);
+    await waitFor(() => expect(highlighted()).toEqual([true, false, true]));
+
+    fireEvent.pointerOut(view.container.querySelector('[data-source-id="src_a"]') as Element, { relatedTarget: view.container });
+    await waitFor(() => expect(highlighted()).toEqual([false, false, false]));
+
+    fireEvent.focusIn(view.container.querySelector('[data-agent-backend="claude"]') as Element);
+    await waitFor(() => expect(highlighted()).toEqual([true, true, false]));
+    fireEvent.focusOut(view.container.querySelector('[data-agent-backend="claude"]') as Element, { relatedTarget: view.container });
+    await waitFor(() => expect(highlighted()).toEqual([false, false, false]));
   });
 });

--- a/ui/src/components/settings/models/SupplyGraph.tsx
+++ b/ui/src/components/settings/models/SupplyGraph.tsx
@@ -13,11 +13,29 @@ type DrawnRelation = SupplyRelation & {
   endY: number;
 };
 
+type HighlightedEndpoint =
+  | { kind: 'source'; id: string }
+  | { kind: 'agent'; id: string };
+
+const endpointFromTarget = (target: EventTarget | null, container: HTMLElement): HighlightedEndpoint | null => {
+  if (!(target instanceof Element)) return null;
+  const source = target.closest<HTMLElement>('[data-source-id]');
+  if (source && container.contains(source) && source.dataset.sourceId) return { kind: 'source', id: source.dataset.sourceId };
+  const agent = target.closest<HTMLElement>('[data-agent-backend]');
+  if (agent && container.contains(agent) && agent.dataset.agentBackend) return { kind: 'agent', id: agent.dataset.agentBackend };
+  return null;
+};
+
+const sameEndpoint = (left: HighlightedEndpoint | null, right: HighlightedEndpoint | null): boolean =>
+  left?.kind === right?.kind && left?.id === right?.id;
+
 export const SupplyGraph: React.FC<{
   containerRef: React.RefObject<HTMLDivElement | null>;
   relations: SupplyRelation[];
 }> = ({ containerRef, relations }) => {
-  const [drawing, setDrawing] = React.useState<{ width: number; height: number; railX: number; wires: DrawnRelation[] } | null>(null);
+  const [drawing, setDrawing] = React.useState<{ width: number; height: number; wires: DrawnRelation[] } | null>(null);
+  const [hoveredEndpoint, setHoveredEndpoint] = React.useState<HighlightedEndpoint | null>(null);
+  const [focusedEndpoint, setFocusedEndpoint] = React.useState<HighlightedEndpoint | null>(null);
 
   React.useEffect(() => {
     const container = containerRef.current;
@@ -38,8 +56,7 @@ export const SupplyGraph: React.FC<{
         const railX = startX + (endX - startX) / 2;
         wires.push({ ...relation, startX, startY, endX, endY, path: `M ${startX} ${startY} C ${railX} ${startY}, ${railX} ${endY}, ${endX} ${endY}` });
       }
-      const railX = wires.length > 0 ? wires.reduce((sum, wire) => sum + (wire.startX + wire.endX) / 2, 0) / wires.length : 0;
-      setDrawing({ width: root.width, height: root.height, railX, wires });
+      setDrawing({ width: root.width, height: root.height, wires });
     };
     measure();
     const resize = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(measure);
@@ -53,18 +70,56 @@ export const SupplyGraph: React.FC<{
     };
   }, [containerRef, relations]);
 
+  React.useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return undefined;
+    const handlePointerOver = (event: PointerEvent) => setHoveredEndpoint(endpointFromTarget(event.target, container));
+    const handlePointerOut = (event: PointerEvent) => {
+      const previous = endpointFromTarget(event.target, container);
+      const next = endpointFromTarget(event.relatedTarget, container);
+      if (previous && !sameEndpoint(previous, next)) setHoveredEndpoint(next);
+    };
+    const handlePointerLeave = () => setHoveredEndpoint(null);
+    const handleFocusIn = (event: FocusEvent) => setFocusedEndpoint(endpointFromTarget(event.target, container));
+    const handleFocusOut = (event: FocusEvent) => {
+      const previous = endpointFromTarget(event.target, container);
+      const next = endpointFromTarget(event.relatedTarget, container);
+      if (previous && !sameEndpoint(previous, next)) setFocusedEndpoint(next);
+    };
+    container.addEventListener('pointerover', handlePointerOver);
+    container.addEventListener('pointerout', handlePointerOut);
+    container.addEventListener('pointerleave', handlePointerLeave);
+    container.addEventListener('focusin', handleFocusIn);
+    container.addEventListener('focusout', handleFocusOut);
+    return () => {
+      container.removeEventListener('pointerover', handlePointerOver);
+      container.removeEventListener('pointerout', handlePointerOut);
+      container.removeEventListener('pointerleave', handlePointerLeave);
+      container.removeEventListener('focusin', handleFocusIn);
+      container.removeEventListener('focusout', handleFocusOut);
+    };
+  }, [containerRef]);
+
   if (!drawing || drawing.wires.length === 0) return null;
-  const yValues = drawing.wires.flatMap((wire) => [wire.startY, wire.endY]);
+  const highlightedEndpoint = hoveredEndpoint ?? focusedEndpoint;
   const sourceAnchors = Array.from(new Map(drawing.wires.map((wire) => [wire.sourceId, wire])).values());
   const agentAnchors = Array.from(new Map(drawing.wires.map((wire) => [wire.backend, wire])).values());
   return (
     <svg aria-hidden="true" className="pointer-events-none absolute inset-0 z-10 hidden size-full overflow-hidden xl:block" viewBox={`0 0 ${drawing.width} ${drawing.height}`} preserveAspectRatio="none">
-      <line className="model-hub-rail-line" x1={drawing.railX} x2={drawing.railX} y1={Math.min(...yValues)} y2={Math.max(...yValues)} />
-      {drawing.wires.map((wire) => (
-        <g key={`${wire.sourceId}:${wire.backend}`}>
-          <path className={`model-hub-wire model-hub-wire--${wire.kind}`} d={wire.path} />
-        </g>
-      ))}
+      {drawing.wires.map((wire) => {
+        const highlighted = highlightedEndpoint?.kind === 'source'
+          ? highlightedEndpoint.id === wire.sourceId
+          : highlightedEndpoint?.kind === 'agent' && highlightedEndpoint.id === wire.backend;
+        return (
+          <path
+            key={`${wire.sourceId}:${wire.backend}`}
+            className={cn(`model-hub-wire model-hub-wire--${wire.kind}`, highlighted && 'model-hub-wire--highlighted')}
+            data-wire-source-id={wire.sourceId}
+            data-wire-agent-backend={wire.backend}
+            d={wire.path}
+          />
+        );
+      })}
       {sourceAnchors.map((anchor) => (
         <circle key={anchor.sourceId} className="model-hub-wire-node model-hub-wire-node--shared-anchor" cx={anchor.startX} cy={anchor.startY} />
       ))}

--- a/ui/src/components/settings/models/SupplyGraph.tsx
+++ b/ui/src/components/settings/models/SupplyGraph.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
 import { ModelHubInfoHint } from './ModelHubInfoHint';
-import type { AgentBackend } from './types';
 import type { SupplyRelation, SupplyRelationKind } from './supplyRelations';
 
 type DrawnRelation = SupplyRelation & {
@@ -25,8 +24,6 @@ export const SupplyGraph: React.FC<{
     if (!container) return undefined;
     const measure = () => {
       const root = container.getBoundingClientRect();
-      const byBackend = new Map<AgentBackend, SupplyRelation[]>();
-      for (const relation of relations) byBackend.set(relation.backend, [...(byBackend.get(relation.backend) ?? []), relation]);
       const wires: DrawnRelation[] = [];
       for (const relation of relations) {
         const source = Array.from(container.querySelectorAll<HTMLElement>('[data-source-id]')).find((element) => element.dataset.sourceId === relation.sourceId);
@@ -34,12 +31,10 @@ export const SupplyGraph: React.FC<{
         if (!source || !backend) continue;
         const sourceBounds = source.getBoundingClientRect();
         const backendBounds = backend.getBoundingClientRect();
-        const siblings = byBackend.get(relation.backend) ?? [];
-        const backendIndex = siblings.findIndex((candidate) => candidate.sourceId === relation.sourceId);
         const startX = sourceBounds.right - root.left;
         const startY = sourceBounds.top - root.top + sourceBounds.height / 2;
         const endX = backendBounds.left - root.left;
-        const endY = backendBounds.top - root.top + backendBounds.height * ((backendIndex + 1) / (siblings.length + 1));
+        const endY = backendBounds.top - root.top + backendBounds.height / 2;
         const railX = startX + (endX - startX) / 2;
         wires.push({ ...relation, startX, startY, endX, endY, path: `M ${startX} ${startY} C ${railX} ${startY}, ${railX} ${endY}, ${endX} ${endY}` });
       }

--- a/ui/src/components/settings/models/SupplyGraph.tsx
+++ b/ui/src/components/settings/models/SupplyGraph.tsx
@@ -55,15 +55,21 @@ export const SupplyGraph: React.FC<{
 
   if (!drawing || drawing.wires.length === 0) return null;
   const yValues = drawing.wires.flatMap((wire) => [wire.startY, wire.endY]);
+  const sourceAnchors = Array.from(new Map(drawing.wires.map((wire) => [wire.sourceId, wire])).values());
+  const agentAnchors = Array.from(new Map(drawing.wires.map((wire) => [wire.backend, wire])).values());
   return (
     <svg aria-hidden="true" className="pointer-events-none absolute inset-0 z-10 hidden size-full overflow-hidden xl:block" viewBox={`0 0 ${drawing.width} ${drawing.height}`} preserveAspectRatio="none">
       <line className="model-hub-rail-line" x1={drawing.railX} x2={drawing.railX} y1={Math.min(...yValues)} y2={Math.max(...yValues)} />
       {drawing.wires.map((wire) => (
         <g key={`${wire.sourceId}:${wire.backend}`}>
           <path className={`model-hub-wire model-hub-wire--${wire.kind}`} d={wire.path} />
-          <circle className={`model-hub-wire-node model-hub-wire-node--${wire.kind}`} cx={wire.startX} cy={wire.startY} />
-          <circle className={`model-hub-wire-node model-hub-wire-node--${wire.kind}`} cx={wire.endX} cy={wire.endY} />
         </g>
+      ))}
+      {sourceAnchors.map((anchor) => (
+        <circle key={anchor.sourceId} className="model-hub-wire-node model-hub-wire-node--shared-anchor" cx={anchor.startX} cy={anchor.startY} />
+      ))}
+      {agentAnchors.map((anchor) => (
+        <circle key={anchor.backend} className="model-hub-wire-node model-hub-wire-node--shared-anchor" cx={anchor.endX} cy={anchor.endY} />
       ))}
     </svg>
   );

--- a/ui/src/components/settings/models/SupplyGraph.tsx
+++ b/ui/src/components/settings/models/SupplyGraph.tsx
@@ -101,15 +101,14 @@ export const SupplyGraph: React.FC<{
   }, [containerRef]);
 
   if (!drawing || drawing.wires.length === 0) return null;
-  const highlightedEndpoint = hoveredEndpoint ?? focusedEndpoint;
   const sourceAnchors = Array.from(new Map(drawing.wires.map((wire) => [wire.sourceId, wire])).values());
   const agentAnchors = Array.from(new Map(drawing.wires.map((wire) => [wire.backend, wire])).values());
   return (
     <svg aria-hidden="true" className="pointer-events-none absolute inset-0 z-10 hidden size-full overflow-hidden xl:block" viewBox={`0 0 ${drawing.width} ${drawing.height}`} preserveAspectRatio="none">
       {drawing.wires.map((wire) => {
-        const highlighted = highlightedEndpoint?.kind === 'source'
-          ? highlightedEndpoint.id === wire.sourceId
-          : highlightedEndpoint?.kind === 'agent' && highlightedEndpoint.id === wire.backend;
+        const highlighted = [hoveredEndpoint, focusedEndpoint].some((endpoint) => endpoint?.kind === 'source'
+          ? endpoint.id === wire.sourceId
+          : endpoint?.kind === 'agent' && endpoint.id === wire.backend);
         return (
           <path
             key={`${wire.sourceId}:${wire.backend}`}

--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -1814,8 +1814,14 @@
 
 .model-hub-wire {
   fill: none;
+  opacity: 0.24;
   stroke-linecap: round;
   stroke-linejoin: round;
+  transition: opacity 120ms ease;
+}
+
+.model-hub-wire--highlighted {
+  opacity: 1;
 }
 
 .model-hub-wire--native {
@@ -1854,11 +1860,6 @@
   fill: var(--background);
   stroke: var(--model-hub-ink-73);
   stroke-width: var(--model-hub-wire-node-stroke);
-}
-
-.model-hub-rail-line {
-  stroke: color-mix(in srgb, var(--mint) 20%, transparent);
-  stroke-width: 2px;
 }
 
 .model-hub-legend {

--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -345,6 +345,7 @@
   --model-hub-wire-active-width: 1.75px;
   --model-hub-wire-muted-width: 1px;
   --model-hub-wire-node: 7px;
+  --model-hub-wire-node-stroke: 1.25px;
   --model-hub-footer-action-height: 30px;
   --model-hub-footer-action-radius: 7px;
   --model-hub-footer-action-font-size: 11.5px;
@@ -1849,15 +1850,11 @@
   r: calc(var(--model-hub-wire-node) / 2);
 }
 
-.model-hub-wire-node--native { fill: var(--cyan); }
-.model-hub-wire-node--gateway { fill: var(--mint); }
-.model-hub-wire-node--connected_unused {
+.model-hub-wire-node--shared-anchor {
   fill: var(--background);
-  stroke: color-mix(in srgb, var(--foreground) 15%, transparent);
-  stroke-width: 1.25px;
+  stroke: var(--model-hub-ink-73);
+  stroke-width: var(--model-hub-wire-node-stroke);
 }
-.model-hub-wire-node--takeover { fill: var(--violet); }
-.model-hub-wire-node--unavailable { fill: var(--gold); }
 
 .model-hub-rail-line {
   stroke: color-mix(in srgb, var(--mint) 20%, transparent);

--- a/ui/src/components/workbench/Composer.shortcut.test.tsx
+++ b/ui/src/components/workbench/Composer.shortcut.test.tsx
@@ -189,6 +189,7 @@ describe('Composer voice shortcut', () => {
 
     fireEvent.keyDown(outside, { code: 'KeyZ', altKey: true });
     await waitFor(() => expect(voiceMocks.getUserMedia).toHaveBeenCalledOnce());
+    await screen.findByRole('button', { name: en.chat.compose.stopRecording });
     expect(document.activeElement).toBe(outside);
 
     fireEvent.keyDown(outside, { code: 'KeyZ', altKey: true });
@@ -206,6 +207,7 @@ describe('Composer voice shortcut', () => {
 
     fireEvent.keyDown(outside, { code: 'KeyZ', altKey: true });
     await waitFor(() => expect(voiceMocks.getUserMedia).toHaveBeenCalledOnce());
+    await screen.findByRole('button', { name: en.chat.compose.stopRecording });
     view.rerender(composerView('gated-shortcut-session', { shortcutStartEnabled: false }));
 
     fireEvent.keyDown(foreground, { code: 'KeyZ', altKey: true });


### PR DESCRIPTION
## Summary

- land every upstream relation for the same Agent at the Agent card's shared left-edge midpoint
- render relation wires at low opacity by default and highlight only the paths connected to the hovered or focused Source or Agent
- remove the independent central axis while retaining distinct curves and order-independent shared endpoint markers
- lock the geometry and interaction with focused regression tests and update the Model Hub UI specification
- stabilize the existing Composer shortcut test by waiting for recording readiness before sending the finish shortcut

## Affected scenarios

Presentation-only connector geometry and interaction on `/settings/models`; routing data and behavior are unchanged. The Composer change is test-only and closes a full-suite timing race exposed by CI.

## Verification

- `npm test -- src/components/settings/models/SettingsModelsPage.render.test.tsx src/components/settings/models/SupplyGraph.test.tsx src/components/settings/models/modelHubStylePolicy.test.ts` (56 tests)
- `npm test -- src/components/workbench/Composer.shortcut.test.tsx` (9 tests)
- `npm test` (262 files, 3359 tests)
- `npm run build`
- `npm run lint`
- `npm run validate:theme`
- real local regression data verified in Chrome at 1470x1400 for default, Source-hover, and Agent-hover states

## Residual risk

None identified. Product behavior changes are limited to presentation and delegated hover/focus state inside the Model Hub graph container; the unrelated Composer adjustment only synchronizes its test with observable recording readiness.

## Dependencies

None.
