### PR TITLE
refactor(memory): simplify runtime lifecycle

### DIFF
--- a/avibe_memory/admission.py
+++ b/avibe_memory/admission.py
@@ -40,8 +40,6 @@ class PrincipalDirectory(Protocol):
 
     def principal_for_user_key(self, user_key: str) -> str: ...
 
-    def project_for_workdir(self, workdir: str) -> str: ...
-
 
 class UserBindingDirectory(Protocol):
     """Answers whether an IM user is bound to this install and still enabled."""

--- a/avibe_memory/everos.py
+++ b/avibe_memory/everos.py
@@ -263,6 +263,7 @@ class EverOSPort:
         multimodal_model: str | None = None,
         multimodal_api_key: str | None = None,
         processing_health_check: Callable[[], Awaitable[bool]] | None = None,
+        runtime_active: Callable[[], bool] | None = None,
         sidecar_timeout_seconds: float = _SIDECAR_TIMEOUT_SECONDS,
         add_timeout_seconds: float = _ADD_TIMEOUT_SECONDS,
         flush_timeout_seconds: float = _FLUSH_TIMEOUT_SECONDS,
@@ -287,6 +288,7 @@ class EverOSPort:
         self._multimodal_model = _optional_string(multimodal_model)
         self._multimodal_api_key = _optional_string(multimodal_api_key)
         self._processing_health_check = processing_health_check
+        self._runtime_active = runtime_active or (lambda: True)
         self._sidecar_timeout_seconds = _positive_timeout(sidecar_timeout_seconds, _SIDECAR_TIMEOUT_SECONDS)
         self._add_timeout_seconds = _positive_timeout(add_timeout_seconds, _ADD_TIMEOUT_SECONDS)
         self._flush_timeout_seconds = _positive_timeout(flush_timeout_seconds, _FLUSH_TIMEOUT_SECONDS)
@@ -430,6 +432,13 @@ class EverOSPort:
         timeout_seconds: float | None = None,
     ) -> tuple[int, bytes | None]:
         """Return the HTTP verdict even when its bounded body is unusable."""
+
+        try:
+            runtime_active = bool(self._runtime_active())
+        except Exception:
+            runtime_active = False
+        if not runtime_active:
+            raise MemoryProviderSystemFailure("memory_operation_in_progress")
 
         started = time.monotonic()
         transport = httpx.AsyncHTTPTransport(uds=str(self._socket_path))

--- a/avibe_memory/module.py
+++ b/avibe_memory/module.py
@@ -204,7 +204,6 @@ class MemoryModule:
             tuple[str, str, str], _CaptureReservation
         ] = {}
         self._invalid_capture_admission_lock = asyncio.Lock()
-        self._retired = False
         attachments_available = False
         self._attachment_store: AttachmentPinStore | None = None
         try:
@@ -227,7 +226,6 @@ class MemoryModule:
             store=store,
             provider=provider,
             enabled=self._is_enabled,
-            runtime_active=self._runtime_active,
             processing_event=processing_event,
             attachment_store=self._attachment_store,
             ambiguous_stop_reap=ambiguous_stop_reap,
@@ -240,18 +238,6 @@ class MemoryModule:
         """Whether new attachment captures can enter the volatile writer."""
 
         return self._writer.attachments_enabled
-
-    @property
-    def retired(self) -> bool:
-        """Whether this captured module has been permanently tombstoned."""
-
-        return self._retired
-
-    def retire(self) -> None:
-        """Permanently close this module to stale callers before root deletion."""
-
-        self._retired = True
-        self._writer.retire()
 
     @asynccontextmanager
     async def lifecycle(self) -> AsyncIterator[None]:
@@ -360,12 +346,10 @@ class MemoryModule:
     ) -> CaptureReceipt:
         """Validate and persist one source capture without touching the provider."""
 
-        if self._retired or not self._owns_runtime():
+        if not self._owns_runtime():
             return CaptureSkipped(reason="memory_operation_in_progress")
         if not self._is_enabled():
             return CaptureSkipped(reason="memory_disabled")
-        if self._retired or not self._owns_runtime():
-            return CaptureSkipped(reason="memory_operation_in_progress")
 
         reservation = capacity_reservation
         if reservation is None:
@@ -532,12 +516,10 @@ class MemoryModule:
         capacity_reservation: WriterReservation,
     ) -> CaptureReceipt:
         async with self._root_lifecycle_lock():
-            if self._retired or not self._owns_runtime():
+            if not self._owns_runtime():
                 return CaptureSkipped(reason="memory_operation_in_progress")
             if not self._is_enabled():
                 return CaptureSkipped(reason="memory_disabled")
-            if self._retired or not self._owns_runtime():
-                return CaptureSkipped(reason="memory_operation_in_progress")
             if not isinstance(request, CaptureRequest):
                 return await self._skipped_with_missed("memory_invalid_input")
 
@@ -846,7 +828,7 @@ class MemoryModule:
         if len(query_bytes) > MAX_QUERY_BYTES:
             return OperationFailed(error="memory_input_too_large")
 
-        if self._retired:
+        if not self._owns_runtime():
             return OperationFailed(error="memory_operation_in_progress")
 
         agentic_started = (
@@ -1102,7 +1084,7 @@ class MemoryModule:
             return OperationFailed(error="memory_access_denied")
         if not is_new_stored_memory_project_id(project_id):
             return OperationFailed(error="memory_access_denied")
-        if self._retired:
+        if not self._owns_runtime():
             return OperationFailed(error="memory_operation_in_progress")
 
         async with self._lifecycle_lock:
@@ -1191,7 +1173,7 @@ class MemoryModule:
 
             return result
 
-        if self._retired:
+        if not self._owns_runtime():
             yield unavailable("memory_operation_in_progress")
             return
         remaining = deadline - monotonic()
@@ -1207,7 +1189,7 @@ class MemoryModule:
             yield unavailable("memory_provider_timeout")
             return
         try:
-            if self._retired:
+            if not self._owns_runtime():
                 yield unavailable("memory_operation_in_progress")
                 return
             try:
@@ -1250,7 +1232,7 @@ class MemoryModule:
             or origin not in ("user", "agent")
         ):
             return OperationFailed(error="memory_invalid_input")
-        if self._retired:
+        if not self._owns_runtime():
             return OperationFailed(error="memory_operation_in_progress")
         return None
 
@@ -1581,7 +1563,7 @@ class MemoryModule:
         return _utf8_bytes("\0".join((value.name, value.uri, value.ext))) is not None
 
     def _is_enabled(self) -> bool:
-        if self._retired:
+        if not self._owns_runtime():
             return False
         try:
             value = self._enabled_source() if callable(self._enabled_source) else self._enabled_source

--- a/avibe_memory/module.py
+++ b/avibe_memory/module.py
@@ -173,6 +173,7 @@ class MemoryModule:
         disk_free_bytes: Callable[[], int] | None = None,
         provider_root: Path | None = None,
         provider_root_owner: ProviderRoot | None = None,
+        runtime_active: Callable[[], bool] | None = None,
         processing_event: Callable[..., Awaitable[bool]] | None = None,
         ambiguous_stop_reap: Callable[[], Awaitable[bool] | bool] | None = None,
         writer: BestEffortMemoryWriter | None = None,
@@ -190,6 +191,7 @@ class MemoryModule:
         )
         self._provider_root = provider_root or (self._effective_home / "memory" / "everos-root")
         self._provider_root_key = os.path.abspath(os.fspath(self._provider_root))
+        self._runtime_active = runtime_active or (lambda: True)
         self.provider_root = provider_root_owner or ProviderRoot(
             self._provider_root,
             effective_home=self._effective_home,
@@ -225,6 +227,7 @@ class MemoryModule:
             store=store,
             provider=provider,
             enabled=self._is_enabled,
+            runtime_active=self._runtime_active,
             processing_event=processing_event,
             attachment_store=self._attachment_store,
             ambiguous_stop_reap=ambiguous_stop_reap,
@@ -248,7 +251,7 @@ class MemoryModule:
         """Permanently close this module to stale callers before root deletion."""
 
         self._retired = True
-        self._writer.pause_intake()
+        self._writer.retire()
 
     @asynccontextmanager
     async def lifecycle(self) -> AsyncIterator[None]:
@@ -357,11 +360,11 @@ class MemoryModule:
     ) -> CaptureReceipt:
         """Validate and persist one source capture without touching the provider."""
 
-        if self._retired:
+        if self._retired or not self._owns_runtime():
             return CaptureSkipped(reason="memory_operation_in_progress")
         if not self._is_enabled():
             return CaptureSkipped(reason="memory_disabled")
-        if self._retired:
+        if self._retired or not self._owns_runtime():
             return CaptureSkipped(reason="memory_operation_in_progress")
 
         reservation = capacity_reservation
@@ -529,11 +532,11 @@ class MemoryModule:
         capacity_reservation: WriterReservation,
     ) -> CaptureReceipt:
         async with self._root_lifecycle_lock():
-            if self._retired:
+            if self._retired or not self._owns_runtime():
                 return CaptureSkipped(reason="memory_operation_in_progress")
             if not self._is_enabled():
                 return CaptureSkipped(reason="memory_disabled")
-            if self._retired:
+            if self._retired or not self._owns_runtime():
                 return CaptureSkipped(reason="memory_operation_in_progress")
             if not isinstance(request, CaptureRequest):
                 return await self._skipped_with_missed("memory_invalid_input")
@@ -561,6 +564,12 @@ class MemoryModule:
                 source_lease=source_lease,
                 capacity_reservation=capacity_reservation,
             )
+
+    def _owns_runtime(self) -> bool:
+        try:
+            return bool(self._runtime_active())
+        except Exception:
+            return False
 
     def _capture_lock_for_request(self, request: object) -> asyncio.Lock:
         if not isinstance(request, CaptureRequest):

--- a/avibe_memory/runtime.py
+++ b/avibe_memory/runtime.py
@@ -15,6 +15,7 @@ import stat
 import threading
 import time
 import weakref
+from itertools import count
 from concurrent.futures import CancelledError as FutureCancelledError
 from concurrent.futures import Future as ThreadFuture
 from concurrent.futures import TimeoutError as FutureTimeoutError
@@ -124,50 +125,23 @@ ARTIFACT_ACTIVATION_TIMEOUT_SECONDS = 90.0
 MEMORY_CAPTURE_CLOSE_TIMEOUT_SECONDS = 3.0
 MEMORY_LOCAL_CLOSE_TIMEOUT_SECONDS = 5.0
 MEMORY_PROVIDER_CLOSE_TIMEOUT_SECONDS = 7.0
+MEMORY_CLOSE_TIMEOUT_SECONDS = 15.0
 _MEMORY_LIST_CURSOR_VERSION = 3
 _MEMORY_LIST_PROVIDER_PAGE_SIZE = 20
 _MEMORY_LIST_PROVIDER_MAX_PAGE = 1_000_000
 _MEMORY_LIST_AGGREGATE_TIMEOUT_SECONDS = 20.0
 _WAKE_LEASE_RETRY_DELAYS_SECONDS = (0.0, 0.25, 0.5, 1.0, 2.0)
+_ATTACHMENT_CONFIG_EPOCHS = count(1)
+_RUNTIME_ROOTS_LOCK = threading.Lock()
+_RUNTIME_ROOTS: weakref.WeakValueDictionary[str, MemoryRuntime] = (
+    weakref.WeakValueDictionary()
+)
 
 
-class _RuntimeRootAuthority:
-    """One process-local, revocable claim on an exact provider root."""
-
-    _lock = threading.Lock()
-    _owners: dict[str, "_RuntimeRootAuthority"] = {}
-
-    def __init__(self, provider_root: Path) -> None:
-        self._key = os.path.normcase(os.path.abspath(os.fspath(provider_root)))
-        self._revoked = False
-        with self._lock:
-            if self._key in self._owners:
-                raise MemoryRuntimeBusyError(
-                    "Memory provider root is already owned by a live runtime"
-                )
-            self._owners[self._key] = self
-
-    def active(self) -> bool:
-        with self._lock:
-            return (
-                not self._revoked
-                and self._owners.get(self._key) is self
-            )
-
-    def revoke(self) -> None:
-        with self._lock:
-            self._revoked = True
-
-    def release(self) -> None:
-        with self._lock:
-            if self._owners.get(self._key) is self:
-                self._owners.pop(self._key, None)
-            self._revoked = True
-
-    @property
-    def released(self) -> bool:
-        with self._lock:
-            return self._owners.get(self._key) is not self
+class _RuntimeRootOwnership:
+    def __init__(self, owner: MemoryRuntime) -> None:
+        self.owner = owner
+        self.close_proved = False
 
 
 @asynccontextmanager
@@ -186,6 +160,7 @@ async def _concurrent_episode_lists(
 
 @dataclass(frozen=True, slots=True)
 class _ProcessingRuntimeSnapshot:
+    attachment_config_epoch: int
     transition_active: bool
     enabled: bool
     store_available: bool
@@ -222,7 +197,8 @@ class _ProcessingRuntimeSnapshot:
 
     def same_lifecycle(self, other: _ProcessingRuntimeSnapshot) -> bool:
         return (
-            self.transition_active == other.transition_active
+            self.attachment_config_epoch == other.attachment_config_epoch
+            and self.transition_active == other.transition_active
             and self.enabled == other.enabled
             and self.store_available == other.store_available
             and self.closing == other.closing
@@ -317,6 +293,7 @@ def create_memory_runtime(
     is_enabled_user: Callable[[str, str], bool] | None = None,
     lifecycle_snapshot_matches: Callable[[str, object], bool] | None = None,
     acquire_lifecycle_admission: Callable[[str], Awaitable[object]] | None = None,
+    _root_ownership: _RuntimeRootOwnership | None = None,
 ) -> MemoryRuntime:
     """Construct Memory without allowing store failures to stop Avibe.
 
@@ -335,6 +312,7 @@ def create_memory_runtime(
         is_enabled_user=is_enabled_user,
         lifecycle_snapshot_matches=lifecycle_snapshot_matches,
         acquire_lifecycle_admission=acquire_lifecycle_admission,
+        _root_ownership=_root_ownership,
     )
 
 
@@ -355,6 +333,7 @@ class MemoryRuntime:
         is_enabled_user: Callable[[str, str], bool] | None = None,
         lifecycle_snapshot_matches: Callable[[str, object], bool] | None = None,
         acquire_lifecycle_admission: Callable[[str], Awaitable[object]] | None = None,
+        _root_ownership: _RuntimeRootOwnership | None = None,
     ) -> None:
         self._config = config
         self._wake_config = deepcopy(config)
@@ -362,8 +341,19 @@ class MemoryRuntime:
             effective_home or paths.get_vibe_remote_dir()
         )
         self._effective_home = self._filesystem_root.physical_home
-        self._runtime_authority = _RuntimeRootAuthority(self._provider_root)
-        construction_guard = weakref.finalize(self, self._runtime_authority.release)
+        self._root_key = os.path.normcase(os.path.abspath(os.fspath(self._provider_root)))
+        self._pending_root_ownership = _root_ownership
+        self._reset_root_ownership: _RuntimeRootOwnership | None = None
+        with _RUNTIME_ROOTS_LOCK:
+            owner = _RUNTIME_ROOTS.get(self._root_key)
+            if _root_ownership is None:
+                if owner is not None:
+                    raise MemoryRuntimeBusyError(
+                        "Memory provider root is already owned by a live runtime"
+                    )
+                _RUNTIME_ROOTS[self._root_key] = self
+            elif owner is not _root_ownership.owner or not _root_ownership.close_proved:
+                raise MemoryRuntimeBusyError("Memory provider root ownership changed")
         self._artifact_manager: MemoryArtifactPort = artifact_manager or get_memory_artifact_manager()
         self._provider_root_owner = ProviderRoot(
             self._provider_root,
@@ -384,8 +374,9 @@ class MemoryRuntime:
         # enter an EverOSPort only inside the owned child probe/sidecar.
         self._provider = EverOSPort(
             self._socket_path,
-            runtime_active=self._runtime_authority.active,
+            runtime_active=self._runtime_active,
         )
+        self._attachment_config_epoch = next(_ATTACHMENT_CONFIG_EPOCHS)
         self._runtime_error: str | None = None
         self._released_ownership_blocked = False
         self._needs_repair_reason: str | None = (
@@ -396,10 +387,12 @@ class MemoryRuntime:
         self._reconcile_lock = asyncio.Lock()
         self._wake_task: asyncio.Task[dict[str, Any]] | None = None
         self._artifact_activation_task: asyncio.Task[None] | None = None
+        self._artifact_install_task: asyncio.Task[dict[str, Any]] | None = None
         self._closing = False
         self._activation_loop: asyncio.AbstractEventLoop | None = None
         self._artifact_installing = False
         self._close_task: asyncio.Task[None] | None = None
+        self._close_phase_tasks: dict[str, asyncio.Task[None]] = {}
         self._store: MemoryStore | None = None
         self._module: MemoryModule | None = None
         self._store_error: Exception | None = None
@@ -417,7 +410,6 @@ class MemoryRuntime:
             self._processing_record_port()
         )
         self._open_store(store)
-        construction_guard.detach()
 
     def _open_store(self, store: MemoryStore | None = None) -> bool:
         """Open the local store and build the module, absorbing any failure.
@@ -439,7 +431,7 @@ class MemoryRuntime:
                 enabled=lambda: self._config.enabled,
                 provider_root=self._provider_root,
                 provider_root_owner=self._provider_root_owner,
-                runtime_active=self._runtime_authority.active,
+                runtime_active=self._runtime_active,
                 processing_event=self._processing_event,
                 ambiguous_stop_reap=self._settle_ambiguous_provider_outcome,
                 effective_home=self._effective_home,
@@ -541,16 +533,27 @@ class MemoryRuntime:
 
         return self._module is not None and not self._closing
 
+    @property
+    def closing(self) -> bool:
+        return self._closing
+
+    def _runtime_active(self) -> bool:
+        with _RUNTIME_ROOTS_LOCK:
+            return not self._closing and _RUNTIME_ROOTS.get(self._root_key) is self
+
     def _require_lifecycle_work(self) -> None:
-        if self._closing or not self._runtime_authority.active():
+        if self._closing or not self._runtime_active():
             raise MemoryRuntimeBusyError("Memory runtime authority was revoked")
+
+    def _replace_provider(self, provider: EverOSPort) -> None:
+        self._provider = provider
+        self._attachment_config_epoch = next(_ATTACHMENT_CONFIG_EPOCHS)
+        self.module.replace_provider(provider)
 
     async def _lifecycle_checkpoint(
         self,
         operation: Coroutine[Any, Any, _LifecycleResult],
     ) -> _LifecycleResult:
-        """Run one awaited boundary only while this runtime owns its root."""
-
         try:
             self._require_lifecycle_work()
         except BaseException:
@@ -590,22 +593,29 @@ class MemoryRuntime:
         if self._module is not None:
             self._module.pause_claims()
 
-    async def settle_after_data_loss(self) -> None:
-        """Rotate data authority after the owned process has stopped.
+    def _proved_root_ownership(self, candidate: object) -> _RuntimeRootOwnership:
+        ownership = self._reset_root_ownership
+        with _RUNTIME_ROOTS_LOCK:
+            if (
+                candidate is not ownership
+                or ownership is None
+                or ownership.owner is not self
+                or not ownership.close_proved
+                or _RUNTIME_ROOTS.get(self._root_key) is not self
+            ):
+                raise MemoryRuntimeBusyError("Memory provider root ownership changed")
+        return ownership
 
-        Stable scope identity and the project catalog stay in place. The
-        Controller calls this only inside its destructive operation lease.
-        """
-
-        if not self._runtime_authority.released or self._store is None:
+    async def settle_after_data_loss(self, root_ownership: object) -> None:
+        if self._store is None:
             raise RuntimeError("Memory runtime must be closed before data settlement")
+        self._proved_root_ownership(root_ownership)
         await asyncio.to_thread(self._store.settle_after_data_loss)
 
-    def reset_mutable_data(self) -> MemoryDataResetResult:
+    def reset_mutable_data(self, root_ownership: object) -> MemoryDataResetResult:
         """Reset the fixed mutable roots pinned by this runtime."""
 
-        if not self._runtime_authority.released:
-            raise RuntimeError("Memory runtime must be closed before data reset")
+        self._proved_root_ownership(root_ownership)
         return reset_memory_data_roots(self._effective_home)
 
     @property
@@ -614,9 +624,14 @@ class MemoryRuntime:
 
         return self._effective_home
 
-    def replacement(self, config: MemoryConfig) -> MemoryRuntime:
+    def replacement(
+        self,
+        config: MemoryConfig,
+        root_ownership: object,
+    ) -> MemoryRuntime:
         """Construct the next aggregate without exposing owned dependencies."""
 
+        ownership = self._proved_root_ownership(root_ownership)
         return create_memory_runtime(
             config,
             artifact_manager=self._artifact_manager,
@@ -628,15 +643,42 @@ class MemoryRuntime:
             is_enabled_user=self._is_enabled_user,
             lifecycle_snapshot_matches=self._lifecycle_snapshot_matches,
             acquire_lifecycle_admission=self._acquire_lifecycle_admission,
+            _root_ownership=ownership,
         )
 
-    def begin_close(self) -> None:
-        """Synchronously revoke provider-root publication before host detachment."""
+    def begin_root_ownership_handoff(self) -> object:
+        self.begin_close()
+        if self._reset_root_ownership is None:
+            with _RUNTIME_ROOTS_LOCK:
+                if _RUNTIME_ROOTS.get(self._root_key) is not self:
+                    raise MemoryRuntimeBusyError("Memory provider root ownership changed")
+                self._reset_root_ownership = _RuntimeRootOwnership(self)
+        return self._reset_root_ownership
 
+    def accept_root_ownership(self) -> None:
+        ownership = self._pending_root_ownership
+        if ownership is None:
+            return
+        with _RUNTIME_ROOTS_LOCK:
+            if (
+                _RUNTIME_ROOTS.get(self._root_key) is not ownership.owner
+                or not ownership.close_proved
+            ):
+                raise MemoryRuntimeBusyError("Memory provider root ownership changed")
+            _RUNTIME_ROOTS[self._root_key] = self
+        self._pending_root_ownership = None
+
+    def release_root_ownership(self, root_ownership: object) -> None:
+        self._proved_root_ownership(root_ownership)
+        with _RUNTIME_ROOTS_LOCK:
+            if _RUNTIME_ROOTS.get(self._root_key) is not self:
+                raise MemoryRuntimeBusyError("Memory provider root ownership changed")
+            _RUNTIME_ROOTS.pop(self._root_key, None)
+
+    def begin_close(self) -> None:
         if self._closing:
             return
         self._closing = True
-        self._runtime_authority.revoke()
         self._supervisor.begin_close()
         self._activation_loop = None
         adapter = self._capture_adapter
@@ -745,6 +787,7 @@ class MemoryRuntime:
     def _processing_runtime_snapshot(self) -> _ProcessingRuntimeSnapshot:
         module = self._module
         return _ProcessingRuntimeSnapshot(
+            attachment_config_epoch=self._attachment_config_epoch,
             transition_active=self._reconcile_lock.locked(),
             enabled=self._config.enabled,
             store_available=module is not None,
@@ -752,7 +795,6 @@ class MemoryRuntime:
             supervisor=self._supervisor.status,
             runtime_error=self._runtime_error,
         )
-
 
     def _configure_insight_reader(self, config: MemoryConfig) -> None:
         if self._insight_reader_override is not None:
@@ -883,11 +925,10 @@ class MemoryRuntime:
         self.module.pause_claims()
         self._config = config
         self._configure_insight_reader(config)
-        self._provider = EverOSPort(
+        self._replace_provider(EverOSPort(
             self._socket_path,
-            runtime_active=self._runtime_authority.active,
-        )
-        self.module.replace_provider(self._provider)
+            runtime_active=self._runtime_active,
+        ))
         await self._lifecycle_checkpoint(self._close_writer())
         await self._lifecycle_checkpoint(self._supervisor.stop())
         self._runtime_error = None
@@ -959,11 +1000,10 @@ class MemoryRuntime:
             self._config = deepcopy(config)
             self._wake_config = deepcopy(config)
             self._configure_insight_reader(config)
-            self._provider = EverOSPort(
+            self._replace_provider(EverOSPort(
                 self._socket_path,
-                runtime_active=self._runtime_authority.active,
-            )
-            self.module.replace_provider(self._provider)
+                runtime_active=self._runtime_active,
+            ))
             self._runtime_error = "memory_capability_unavailable"
             return {
                 "ok": True,
@@ -1013,7 +1053,7 @@ class MemoryRuntime:
         candidate_provider = EverOSPort(
             self._socket_path,
             processing_health_check=self._processing_healthy,
-            runtime_active=self._runtime_authority.active,
+            runtime_active=self._runtime_active,
         )
         python = await self._lifecycle_checkpoint(
             asyncio.to_thread(self._artifact_manager.resolve_python)
@@ -1064,8 +1104,7 @@ class MemoryRuntime:
 
         self._config = config
         self._configure_insight_reader(config)
-        self._provider = candidate_provider
-        self.module.replace_provider(self._provider)
+        self._replace_provider(candidate_provider)
         try:
             meta = await self._lifecycle_checkpoint(
                 asyncio.to_thread(self._store.ensure_meta)
@@ -1299,7 +1338,7 @@ class MemoryRuntime:
             or not self._module.attachment_intake_enabled
         ):
             return None
-        return id(self._provider)
+        return self._attachment_config_epoch
 
     async def failure_log_payload(
         self,
@@ -2017,25 +2056,35 @@ class MemoryRuntime:
         async with self.module.lifecycle():
             return await run_blocking(operation)
 
-    async def install_artifact(self) -> dict[str, Any]:
+    async def install_artifact(
+        self,
+        *,
+        operation_lease_held: bool = False,
+    ) -> dict[str, Any]:
         """Install or repair the admitted EverOS artifact."""
 
         lease = MemoryOperationLease(self._effective_home)
+        lease_acquired = operation_lease_held
         try:
-            await run_blocking(lease.acquire)
+            self._require_lifecycle_work()
+            if not operation_lease_held:
+                await run_blocking(lease.acquire)
+                lease_acquired = True
             return await self._install_artifact_with_lease()
-        except MemoryOperationBusy:
+        except (MemoryOperationBusy, MemoryRuntimeBusyError):
             return {
                 "ok": False,
                 "reason": "memory_operation_in_progress",
                 "download_error": None,
             }
         finally:
-            await run_blocking(lease.release)
+            if not operation_lease_held and lease_acquired:
+                await run_blocking(lease.release)
 
     async def _install_artifact_with_lease(self) -> dict[str, Any]:
         self._activation_loop = asyncio.get_running_loop()
         async with self._reconcile_lock:
+            self._require_lifecycle_work()
             if self._artifact_installing:
                 return {
                     "ok": False,
@@ -2050,9 +2099,23 @@ class MemoryRuntime:
                 }
             self._artifact_installing = True
 
+        install = asyncio.create_task(
+            run_blocking(self._artifact_manager.ensure, force=True),
+            name="memory-artifact-install",
+        )
+        self._artifact_install_task = install
+        install.add_done_callback(self._finish_artifact_install)
         try:
-            payload = await run_blocking(self._artifact_manager.ensure, force=True)
-        except asyncio.CancelledError:
+            payload = await asyncio.shield(install)
+            self._require_lifecycle_work()
+        except asyncio.CancelledError as cancellation:
+            while not install.done():
+                try:
+                    await asyncio.shield(install)
+                except (asyncio.CancelledError, Exception):
+                    pass
+            raise cancellation
+        except MemoryRuntimeBusyError:
             raise
         except Exception:
             logger.exception("Memory artifact install failed")
@@ -2061,10 +2124,6 @@ class MemoryRuntime:
                 "reason": "memory_runtime_install_failed",
                 "download_error": None,
             }
-        finally:
-            async with self._reconcile_lock:
-                self._artifact_installing = False
-
         if not isinstance(payload, dict):
             return {
                 "ok": False,
@@ -2078,6 +2137,10 @@ class MemoryRuntime:
             "reason": reason if isinstance(reason, str) else None,
             "download_error": download_error if isinstance(download_error, dict) else None,
         }
+
+    def _finish_artifact_install(self, task: asyncio.Task[dict[str, Any]]) -> None:
+        if self._artifact_install_task is task:
+            self._artifact_installing = False
 
     async def wake(
         self,
@@ -2265,6 +2328,7 @@ class MemoryRuntime:
         return await self.wake()
 
     async def preflight(self, config: MemoryConfig | None = None) -> dict[str, Any]:
+        self._require_lifecycle_work()
         candidate = deepcopy(config or self._config)
         processing = candidate.runtime_processing()
         provider = EverOSPort(
@@ -2296,8 +2360,9 @@ class MemoryRuntime:
                 if processing.multimodal
                 else None
             ),
+            runtime_active=self._runtime_active,
         )
-        return (await provider.preflight()).payload()
+        return (await self._lifecycle_checkpoint(provider.preflight())).payload()
 
     async def _wake_locked(self) -> dict[str, Any]:
         """Wake the admitted sidecar while preserving the existing data root."""
@@ -2357,12 +2422,11 @@ class MemoryRuntime:
 
             self._config = replay
             self._configure_insight_reader(replay)
-            self._provider = EverOSPort(
+            self._replace_provider(EverOSPort(
                 self._socket_path,
                 processing_health_check=self._processing_healthy,
-                runtime_active=self._runtime_authority.active,
-            )
-            self.module.replace_provider(self._provider)
+                runtime_active=self._runtime_active,
+            ))
             try:
                 meta = await self._lifecycle_checkpoint(
                     asyncio.to_thread(self._store.ensure_meta)
@@ -2434,56 +2498,58 @@ class MemoryRuntime:
             self._resume_writer()
             return {"ok": True, "state": "running"}
 
-    async def close(self) -> None:
-        """Bound local cleanup and prove the owned EverOS process stopped."""
-
+    async def close(
+        self,
+        *,
+        timeout_seconds: float = MEMORY_CLOSE_TIMEOUT_SECONDS,
+        root_ownership: object | None = None,
+    ) -> None:
+        if root_ownership is not None and root_ownership is not self._reset_root_ownership:
+            raise MemoryRuntimeBusyError("Memory provider root ownership changed")
         self.begin_close()
-        if self._close_task is None:
-            self._close_task = asyncio.create_task(
-                self._close_once(),
+        task = self._close_task
+        if task is None or task.done() and (
+            task.cancelled() or task.exception() is not None
+        ):
+            task = asyncio.create_task(
+                self._close_once(max(0.0, timeout_seconds)),
                 name="memory-runtime-close",
             )
-        cancellation = await self._join_shutdown_task(self._close_task)
-        error = self._close_task.exception()
-        if cancellation is not None:
-            if error is not None:
-                logger.error("Memory close failed during cancellation: %s", error)
-            raise cancellation
-        if error is not None:
-            raise error
+            self._close_task = task
+        await asyncio.shield(task)
 
-    async def _close_once(self) -> None:
-        local_proved = True
+    async def _close_once(self, timeout_seconds: float) -> None:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout_seconds
         phases = (
-            (
-                self._cancel_capture_tasks(),
-                MEMORY_CAPTURE_CLOSE_TIMEOUT_SECONDS,
-                "capture cancellation",
-            ),
-            (
-                self._close_local_runtime(),
-                MEMORY_LOCAL_CLOSE_TIMEOUT_SECONDS,
-                "local cleanup",
-            ),
+            (self._cancel_capture_tasks, MEMORY_CAPTURE_CLOSE_TIMEOUT_SECONDS, "capture cancellation"),
+            (self._close_local_runtime, MEMORY_LOCAL_CLOSE_TIMEOUT_SECONDS, "local cleanup"),
+            (self._supervisor.close, MEMORY_PROVIDER_CLOSE_TIMEOUT_SECONDS, "provider stop"),
         )
-        for operation, timeout_seconds, label in phases:
-            proved = await self._run_bounded_close_phase(
+        remaining_weight = sum(weight for _operation, weight, _label in phases)
+        failures: list[str] = []
+        for operation, weight, label in phases:
+            remaining = max(0.0, deadline - loop.time())
+            if not await self._run_bounded_close_phase(
                 operation,
-                timeout_seconds=timeout_seconds,
+                timeout_seconds=remaining * weight / remaining_weight,
                 label=label,
-            )
-            local_proved = proved and local_proved
+            ):
+                failures.append(label)
+            remaining_weight -= weight
+        if failures:
+            raise RuntimeError(f"Memory {failures[-1]} did not prove completion")
         self._artifact_manager.set_activation_coordinator(None)
-        provider_proved = await self._run_bounded_close_phase(
-            self._supervisor.close(),
-            timeout_seconds=MEMORY_PROVIDER_CLOSE_TIMEOUT_SECONDS,
-            label="provider stop",
-        )
-        if not provider_proved:
-            raise RuntimeError("Memory provider stop did not prove completion")
-        if not local_proved:
-            raise RuntimeError("Memory local cleanup did not prove completion")
-        self._runtime_authority.release()
+        ownership = self._reset_root_ownership
+        if ownership is None:
+            with _RUNTIME_ROOTS_LOCK:
+                if _RUNTIME_ROOTS.get(self._root_key) is self:
+                    _RUNTIME_ROOTS.pop(self._root_key, None)
+        else:
+            with _RUNTIME_ROOTS_LOCK:
+                if _RUNTIME_ROOTS.get(self._root_key) is not self:
+                    raise MemoryRuntimeBusyError("Memory provider root ownership changed")
+                ownership.close_proved = True
 
     async def _cancel_capture_tasks(self) -> None:
         cancel_capture = getattr(
@@ -2496,12 +2562,18 @@ class MemoryRuntime:
 
     async def _run_bounded_close_phase(
         self,
-        operation: Awaitable[None],
+        operation: Callable[[], Awaitable[None]],
         *,
         timeout_seconds: float,
         label: str,
     ) -> bool:
-        task = asyncio.create_task(operation, name=f"memory-close-{label}")
+        task = self._close_phase_tasks.get(label)
+        if task is None or (
+            task.done() and (task.cancelled() or task.exception() is not None)
+        ):
+            task = asyncio.create_task(operation(), name=f"memory-close-{label}")
+            self._close_phase_tasks[label] = task
+            await asyncio.sleep(0)
         done, _pending = await asyncio.wait({task}, timeout=timeout_seconds)
         if task not in done:
             logger.error(
@@ -2509,78 +2581,47 @@ class MemoryRuntime:
                 label,
                 timeout_seconds,
             )
-            task.add_done_callback(self._log_late_close)
             task.cancel()
             return False
-        if task.cancelled():
-            logger.error("Memory %s was cancelled during close", label)
-            return False
-        error = task.exception()
-        if error is not None:
+        try:
+            task.result()
+        except BaseException:
             logger.error(
                 "Memory %s failed during close",
                 label,
-                exc_info=(type(error), error, error.__traceback__),
+                exc_info=True,
             )
             return False
         return True
 
-    @staticmethod
-    def _log_late_close(task: asyncio.Task[None]) -> None:
-        if task.cancelled():
-            return
-        error = task.exception()
-        if error is not None:
-            logger.error(
-                "%s failed after its close budget",
-                task.get_name(),
-                exc_info=(type(error), error, error.__traceback__),
-            )
-
-    @staticmethod
-    async def _join_shutdown_task(
-        task: asyncio.Task[Any],
-    ) -> asyncio.CancelledError | None:
-        """Join one shutdown-owned task without abandoning it on cancellation."""
-
-        cancellation: asyncio.CancelledError | None = None
-        current = asyncio.current_task()
-        while not task.done():
-            try:
-                await asyncio.shield(task)
-            except asyncio.CancelledError as error:
-                if current is not None and current.cancelling():
-                    cancellation = cancellation or error
-            except BaseException:
-                break
-        return cancellation
-
     async def _close_local_runtime(self) -> None:
-        """Settle local tasks without deciding provider-root ownership."""
-
-        wake = self._wake_task
-        if wake is not None and wake is not asyncio.current_task():
-            if not wake.done():
-                wake.cancel()
-            try:
-                await asyncio.shield(wake)
-            except (Exception, asyncio.CancelledError):
-                pass
-        for task in (self._artifact_activation_task,):
-            if task is None or task is asyncio.current_task():
-                continue
-            try:
-                await asyncio.shield(task)
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                pass
+        await self._join_close_task(self._artifact_install_task)
+        await self._join_close_task(self._wake_task, cancel=True)
+        await self._join_close_task(self._artifact_activation_task)
         if self._module is not None:
             self._module.pause_claims()
             async with self._module.provider_root_lifecycle():
                 if not await self._module.quiesce_claims_for_destructive_reset():
                     raise RuntimeError("Memory writer did not quiesce during close")
                 await self._module.close_writer()
+
+    @staticmethod
+    async def _join_close_task(
+        task: asyncio.Task[Any] | None,
+        *,
+        cancel: bool = False,
+    ) -> None:
+        if task is None or task is asyncio.current_task():
+            return
+        if cancel and not task.done():
+            task.cancel()
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            if (current := asyncio.current_task()) is not None and current.cancelling():
+                raise
+        except Exception:
+            pass
 
     def _active_provider_root_metadata(self) -> ProviderRootMetadata:
         provider_root_format = (
@@ -2604,8 +2645,6 @@ class MemoryRuntime:
         meta: object,
         active_metadata: ProviderRootMetadata,
     ) -> None:
-        """Reject a launch after this runtime's root authority was revoked."""
-
         self._require_lifecycle_work()
         self._provider_root_owner.require_owned(meta, active_metadata)
 

--- a/avibe_memory/runtime.py
+++ b/avibe_memory/runtime.py
@@ -794,9 +794,20 @@ class MemoryRuntime:
         )
 
     async def _processing_record_operator(self, user_key: str) -> str:
-        if not self.available:
+        return await self.resolve_principal_for_user_key(user_key)
+
+    async def _run_local_observation(
+        self,
+        operation: Callable[[], _LifecycleResult],
+    ) -> _LifecycleResult:
+        module = self._module
+        if module is None:
             raise self._unavailable()
-        return await run_blocking(self._store.principal_for_user_key, user_key)
+        async with module.lifecycle():
+            if self._module is not module:
+                raise self._unavailable()
+            self._require_lifecycle_work()
+            return await run_blocking(operation)
 
     def _processing_runtime_snapshot(self) -> _ProcessingRuntimeSnapshot:
         module = self._module
@@ -1241,7 +1252,7 @@ class MemoryRuntime:
         reader = self._insight_reader
         if reader is None:
             raise self._unavailable()
-        observation = await run_blocking(reader.source_observation)
+        observation = await self._run_local_observation(reader.source_observation)
         after = self._processing_runtime_snapshot()
         current_reason = after.local_observation_reason(maintenance_reason)
         if not after.same_lifecycle(before) or current_reason is not None:
@@ -1262,16 +1273,21 @@ class MemoryRuntime:
         observation: MaintenanceObservation,
     ) -> MaintenanceResult:
         del operator_ref
+        reason = self._processing_runtime_snapshot().local_observation_reason(
+            observation.block_reason
+        )
         data_exists = True
-        if self.available:
+        if reason is None:
             try:
-                data_exists = await asyncio.to_thread(self._provider_data_exists_strict)
+                data_exists = await self._run_local_observation(
+                    self._provider_data_exists_strict
+                )
             except Exception:
-                data_exists = True
+                reason = "busy"
         return MaintenanceResult(
             data_exists=data_exists,
-            can_delete_data=observation.can_delete_data,
-            error=observation.block_reason,
+            can_delete_data=observation.can_delete_data and reason is None,
+            error=reason,
         )
 
     async def processing_record_payload(
@@ -1396,10 +1412,10 @@ class MemoryRuntime:
             raise self._unavailable()
         return self._store.principal_for_user_key(user_key)
 
-    def project_for_workdir(self, workdir: str) -> str:
-        if not self.available:
-            raise self._unavailable()
-        return self._store.project_for_workdir(workdir)
+    async def resolve_principal_for_user_key(self, user_key: str) -> str:
+        return await self._run_local_observation(
+            lambda: self._store.principal_for_user_key(user_key)
+        )
 
     def offer_barrier(self, raw_session_id: str) -> str:
         """Offer a non-blocking provider barrier for lifecycle transitions."""
@@ -1468,7 +1484,7 @@ class MemoryRuntime:
         ):
             return {"status": "failed", "error": "memory_invalid_input"}
         try:
-            projects = await run_blocking(self.list_memory_projects, principal_id)
+            projects = await self.list_memory_projects(principal_id)
         except Exception:
             return {"status": "failed", "error": "memory_store_unavailable"}
         if not projects:
@@ -1902,10 +1918,10 @@ class MemoryRuntime:
             },
         )
 
-    def list_memory_projects(self, principal_id: str) -> tuple[str, ...]:
-        if not self.available:
-            return (DEFAULT_MEMORY_PROJECT_ID,)
-        return self._store.list_memory_projects(principal_id)
+    async def list_memory_projects(self, principal_id: str) -> tuple[str, ...]:
+        return await self._run_local_observation(
+            lambda: self._store.list_memory_projects(principal_id)
+        )
 
     async def search_payload(
         self,
@@ -1952,7 +1968,7 @@ class MemoryRuntime:
         if policy.mode == "agentic" or policy.include_current_session:
             return OperationFailed(error="memory_invalid_input")
         deadline = time.monotonic() + 20.0
-        projects = await run_blocking(self.list_memory_projects, principal_id)
+        projects = await self.list_memory_projects(principal_id)
         if not projects:
             projects = (DEFAULT_MEMORY_PROJECT_ID,)
         collected: list[MemoryItem] = []
@@ -2067,8 +2083,7 @@ class MemoryRuntime:
         self,
         operation: Callable[[], dict[str, Any]],
     ) -> dict[str, Any]:
-        async with self.module.lifecycle():
-            return await run_blocking(operation)
+        return await self._run_local_observation(operation)
 
     async def install_artifact(
         self,

--- a/avibe_memory/runtime.py
+++ b/avibe_memory/runtime.py
@@ -113,6 +113,7 @@ from vibe.memory_contract import MemoryRuntimeBusyError, MemoryStoreUnavailableE
 logger = logging.getLogger(__name__)
 
 MEMORY_RUNTIME_PROTOCOL_VERSION = 1
+MEMORY_RUNTIME_LIFECYCLE_CONTRACT = 1
 
 ProcessingEvent = Callable[
     [Literal["fault", "recovered"], Literal["credential", "engine"] | None, str, int],

--- a/avibe_memory/runtime.py
+++ b/avibe_memory/runtime.py
@@ -12,7 +12,9 @@ import logging
 import os
 import sqlite3
 import stat
+import threading
 import time
+import weakref
 from concurrent.futures import CancelledError as FutureCancelledError
 from concurrent.futures import Future as ThreadFuture
 from concurrent.futures import TimeoutError as FutureTimeoutError
@@ -118,11 +120,66 @@ ProcessingEvent = Callable[
 
 
 ARTIFACT_ACTIVATION_TIMEOUT_SECONDS = 90.0
+MEMORY_CAPTURE_CLOSE_TIMEOUT_SECONDS = 3.0
+MEMORY_LOCAL_CLOSE_TIMEOUT_SECONDS = 5.0
+MEMORY_PROVIDER_CLOSE_TIMEOUT_SECONDS = 7.0
 _MEMORY_LIST_CURSOR_VERSION = 3
 _MEMORY_LIST_PROVIDER_PAGE_SIZE = 20
 _MEMORY_LIST_PROVIDER_MAX_PAGE = 1_000_000
 _MEMORY_LIST_AGGREGATE_TIMEOUT_SECONDS = 20.0
 _WAKE_LEASE_RETRY_DELAYS_SECONDS = (0.0, 0.25, 0.5, 1.0, 2.0)
+
+
+class MemoryRuntimeRootBusyError(RuntimeError):
+    """Another live Memory runtime still owns this provider root."""
+
+
+class _RuntimeRootAuthority:
+    """One process-local, revocable claim on an exact provider root."""
+
+    _lock = threading.Lock()
+    _owners: dict[str, "_RuntimeRootAuthority"] = {}
+
+    def __init__(self, key: str) -> None:
+        self._key = key
+        self._active = True
+        self._released = False
+
+    @classmethod
+    def acquire(cls, provider_root: Path) -> "_RuntimeRootAuthority":
+        key = os.path.normcase(os.path.abspath(os.fspath(provider_root)))
+        with cls._lock:
+            if key in cls._owners:
+                raise MemoryRuntimeRootBusyError(
+                    "Memory provider root is already owned by a live runtime"
+                )
+            authority = cls(key)
+            cls._owners[key] = authority
+            return authority
+
+    def active(self) -> bool:
+        with self._lock:
+            return (
+                self._active
+                and not self._released
+                and self._owners.get(self._key) is self
+            )
+
+    def revoke(self) -> None:
+        with self._lock:
+            self._active = False
+
+    def release(self) -> None:
+        with self._lock:
+            if self._owners.get(self._key) is self:
+                self._owners.pop(self._key, None)
+            self._active = False
+            self._released = True
+
+    @property
+    def released(self) -> bool:
+        with self._lock:
+            return self._released
 
 
 @asynccontextmanager
@@ -348,6 +405,8 @@ class MemoryRuntime:
             effective_home or paths.get_vibe_remote_dir()
         )
         self._effective_home = self._filesystem_root.physical_home
+        self._runtime_authority = _RuntimeRootAuthority.acquire(self._provider_root)
+        construction_guard = weakref.finalize(self, self._runtime_authority.release)
         self._artifact_manager: MemoryArtifactPort = artifact_manager or get_memory_artifact_manager()
         self._provider_root_owner = ProviderRoot(
             self._provider_root,
@@ -366,7 +425,10 @@ class MemoryRuntime:
         self._compose_capture_adapter(None)
         # The controller-side port only talks to the private UDS. Credentials
         # enter an EverOSPort only inside the owned child probe/sidecar.
-        self._provider = EverOSPort(self._socket_path)
+        self._provider = EverOSPort(
+            self._socket_path,
+            runtime_active=self._runtime_authority.active,
+        )
         self._runtime_error: str | None = None
         self._released_ownership_blocked = False
         self._needs_repair_reason: str | None = (
@@ -382,7 +444,8 @@ class MemoryRuntime:
         self._activation_loop: asyncio.AbstractEventLoop | None = None
         self._artifact_installing = False
         self._retired = False
-        self._closed = False
+        self._close_task: asyncio.Task[None] | None = None
+        self._provider_close_task: asyncio.Task[None] | None = None
         self._store: MemoryStore | None = None
         self._module: MemoryModule | None = None
         self._store_error: Exception | None = None
@@ -400,6 +463,7 @@ class MemoryRuntime:
             self._processing_record_port()
         )
         self._open_store(store)
+        construction_guard.detach()
 
     def _open_store(self, store: MemoryStore | None = None) -> bool:
         """Open the local store and build the module, absorbing any failure.
@@ -421,6 +485,7 @@ class MemoryRuntime:
                 enabled=lambda: self._config.enabled,
                 provider_root=self._provider_root,
                 provider_root_owner=self._provider_root_owner,
+                runtime_active=self._runtime_authority.active,
                 processing_event=self._processing_event,
                 ambiguous_stop_reap=self._settle_ambiguous_provider_outcome,
                 effective_home=self._effective_home,
@@ -559,14 +624,14 @@ class MemoryRuntime:
         Controller calls this only inside its destructive operation lease.
         """
 
-        if not self._closed or self._store is None:
+        if not self._runtime_authority.released or self._store is None:
             raise RuntimeError("Memory runtime must be closed before data settlement")
         await asyncio.to_thread(self._store.settle_after_data_loss)
 
     def reset_mutable_data(self) -> MemoryDataResetResult:
         """Reset the fixed mutable roots pinned by this runtime."""
 
-        if not self._closed:
+        if not self._runtime_authority.released:
             raise RuntimeError("Memory runtime must be closed before data reset")
         return reset_memory_data_roots(self._effective_home)
 
@@ -575,12 +640,6 @@ class MemoryRuntime:
         """Whether this aggregate has been permanently retired."""
 
         return self._retired
-
-    @property
-    def closed(self) -> bool:
-        """Whether the last close attempt completed all cleanup steps."""
-
-        return self._closed
 
     @property
     def effective_home(self) -> Path:
@@ -608,8 +667,23 @@ class MemoryRuntime:
         """Tombstone this aggregate and its module before mutable roots die."""
 
         self._retired = True
+        self.begin_close()
+
+    def begin_close(self) -> None:
+        """Synchronously revoke provider-root publication before host detachment."""
+
+        if self._closing:
+            return
         self._closing = True
+        self._runtime_authority.revoke()
         self._supervisor.begin_close()
+        adapter = self._capture_adapter
+        quiesce = getattr(adapter, "quiesce_memory_capture_tasks", None)
+        if callable(quiesce):
+            quiesce()
+        cancel_nowait = getattr(adapter, "cancel_memory_capture_tasks_nowait", None)
+        if callable(cancel_nowait):
+            cancel_nowait()
         if self._module is not None:
             self._module.retire()
         self._advance_lifecycle_revision()
@@ -867,7 +941,10 @@ class MemoryRuntime:
         self.module.pause_claims()
         self._config = config
         self._configure_insight_reader(config)
-        self._provider = EverOSPort(self._socket_path)
+        self._provider = EverOSPort(
+            self._socket_path,
+            runtime_active=self._runtime_authority.active,
+        )
         self.module.replace_provider(self._provider)
         await self._close_writer()
         await self._supervisor.stop()
@@ -939,7 +1016,10 @@ class MemoryRuntime:
             self._config = deepcopy(config)
             self._wake_config = deepcopy(config)
             self._configure_insight_reader(config)
-            self._provider = EverOSPort(self._socket_path)
+            self._provider = EverOSPort(
+                self._socket_path,
+                runtime_active=self._runtime_authority.active,
+            )
             self.module.replace_provider(self._provider)
             self._runtime_error = "memory_capability_unavailable"
             return {
@@ -984,6 +1064,7 @@ class MemoryRuntime:
         candidate_provider = EverOSPort(
             self._socket_path,
             processing_health_check=self._processing_healthy,
+            runtime_active=self._runtime_authority.active,
         )
         python = await asyncio.to_thread(self._artifact_manager.resolve_python)
         if python is None:
@@ -2284,6 +2365,7 @@ class MemoryRuntime:
             self._provider = EverOSPort(
                 self._socket_path,
                 processing_health_check=self._processing_healthy,
+                runtime_active=self._runtime_authority.active,
             )
             self.module.replace_provider(self._provider)
             try:
@@ -2346,39 +2428,18 @@ class MemoryRuntime:
             return {"ok": True, "state": "running"}
 
     async def close(self) -> None:
-        self._closing = True
-        self._supervisor.begin_close()
-        self._activation_loop = None
-        self._advance_lifecycle_revision()
+        """Bound local cleanup and prove the owned EverOS process stopped."""
 
-        adapter = self._capture_adapter
-        quiesce = getattr(adapter, "quiesce_memory_capture_tasks", None)
-        if callable(quiesce):
-            quiesce()
-        cancel_capture = getattr(adapter, "cancel_memory_capture_tasks", None)
-        if callable(cancel_capture):
-            await cancel_capture()
-
-        cancellation: asyncio.CancelledError | None = None
-        wake = self._wake_task
-        if wake is not None and wake is not asyncio.current_task():
-            if not wake.done():
-                wake.cancel()
-            cancellation = await self._join_shutdown_task(wake)
-            try:
-                wake.result()
-            except (Exception, asyncio.CancelledError):
-                pass
-
-        cleanup = asyncio.create_task(
-            self._close_owned_runtime(),
-            name="memory-runtime-close",
-        )
-        cleanup_cancellation = await self._join_shutdown_task(cleanup)
-        cancellation = cancellation or cleanup_cancellation
+        self.begin_close()
+        if self._close_task is None:
+            self._close_task = asyncio.create_task(
+                self._close_once(),
+                name="memory-runtime-close",
+            )
+        cancellation = await self._join_shutdown_task(self._close_task)
         cleanup_error: BaseException | None = None
         try:
-            cleanup.result()
+            self._close_task.result()
         except BaseException as error:
             cleanup_error = error
         if cancellation is not None:
@@ -2390,6 +2451,106 @@ class MemoryRuntime:
             raise cancellation
         if cleanup_error is not None:
             raise cleanup_error
+
+    async def _close_once(self) -> None:
+        local_failures: list[str] = []
+        if not await self._run_bounded_close_phase(
+            self._cancel_capture_tasks(),
+            timeout_seconds=MEMORY_CAPTURE_CLOSE_TIMEOUT_SECONDS,
+            label="capture cancellation",
+        ):
+            local_failures.append("capture cancellation")
+        if not await self._run_bounded_close_phase(
+            self._close_local_runtime(),
+            timeout_seconds=MEMORY_LOCAL_CLOSE_TIMEOUT_SECONDS,
+            label="local cleanup",
+        ):
+            local_failures.append("local cleanup")
+
+        await self._close_provider_root()
+        self._artifact_manager.set_activation_coordinator(None)
+        self._advance_lifecycle_revision()
+        if local_failures:
+            logger.warning(
+                "Memory runtime crossed its provider stop boundary after bounded %s",
+                " and ".join(local_failures),
+            )
+
+    async def _cancel_capture_tasks(self) -> None:
+        cancel_capture = getattr(
+            self._capture_adapter,
+            "cancel_memory_capture_tasks",
+            None,
+        )
+        if callable(cancel_capture):
+            await cancel_capture()
+
+    async def _run_bounded_close_phase(
+        self,
+        operation: Awaitable[None],
+        *,
+        timeout_seconds: float,
+        label: str,
+    ) -> bool:
+        task = asyncio.create_task(operation, name=f"memory-close-{label}")
+        done, _pending = await asyncio.wait({task}, timeout=timeout_seconds)
+        if task not in done:
+            logger.error(
+                "Memory %s exceeded its %.3fs close budget",
+                label,
+                timeout_seconds,
+            )
+            task.add_done_callback(
+                lambda settled: self._log_late_close_phase(settled, label)
+            )
+            task.cancel()
+            return False
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            logger.error("Memory %s was cancelled during close", label)
+            return False
+        except Exception:
+            logger.exception("Memory %s failed during close", label)
+            return False
+        return True
+
+    @staticmethod
+    def _log_late_close_phase(task: asyncio.Task[None], label: str) -> None:
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            logger.error("Memory %s failed after its close budget", label, exc_info=True)
+
+    async def _close_provider_root(self) -> None:
+        if self._provider_close_task is None:
+            self._provider_close_task = asyncio.create_task(
+                self._supervisor.close(),
+                name="memory-provider-root-close",
+            )
+            self._provider_close_task.add_done_callback(
+                self._release_root_after_provider_close
+            )
+        done, _pending = await asyncio.wait(
+            {self._provider_close_task},
+            timeout=MEMORY_PROVIDER_CLOSE_TIMEOUT_SECONDS,
+        )
+        if self._provider_close_task not in done:
+            raise TimeoutError(
+                "Memory provider stop did not complete within its close budget"
+            )
+        self._provider_close_task.result()
+
+    def _release_root_after_provider_close(self, task: asyncio.Task[None]) -> None:
+        if task.cancelled():
+            return
+        try:
+            task.result()
+        except Exception:
+            return
+        self._runtime_authority.release()
 
     @staticmethod
     async def _join_shutdown_task(
@@ -2409,10 +2570,18 @@ class MemoryRuntime:
                 break
         return cancellation
 
-    async def _close_owned_runtime(self) -> None:
-        """Finish ordinary shutdown after runtime ownership is released."""
+    async def _close_local_runtime(self) -> None:
+        """Settle local tasks without deciding provider-root ownership."""
 
         cleanup_error: BaseException | None = None
+        wake = self._wake_task
+        if wake is not None and wake is not asyncio.current_task():
+            if not wake.done():
+                wake.cancel()
+            try:
+                await asyncio.shield(wake)
+            except (Exception, asyncio.CancelledError):
+                pass
         for task in (self._artifact_activation_task,):
             if task is None or task is asyncio.current_task():
                 continue
@@ -2440,15 +2609,8 @@ class MemoryRuntime:
                     await self._module.close_writer()
                 except BaseException as error:
                     cleanup_error = cleanup_error or error
-        try:
-            await self._supervisor.close()
-        except BaseException as error:
-            cleanup_error = cleanup_error or error
-        self._artifact_manager.set_activation_coordinator(None)
         if cleanup_error is not None:
             raise cleanup_error
-        self._closed = True
-        self._advance_lifecycle_revision()
 
     def _active_provider_root_metadata(self) -> ProviderRootMetadata:
         provider_root_format = (

--- a/avibe_memory/runtime.py
+++ b/avibe_memory/runtime.py
@@ -2068,7 +2068,10 @@ class MemoryRuntime:
         try:
             self._require_lifecycle_work()
             if not operation_lease_held:
-                await run_blocking(lease.acquire)
+                await run_blocking(
+                    lease.acquire,
+                    on_cancel_result=lambda _result: lease.release(),
+                )
                 lease_acquired = True
             return await self._install_artifact_with_lease()
         except (MemoryOperationBusy, MemoryRuntimeBusyError):

--- a/avibe_memory/runtime.py
+++ b/avibe_memory/runtime.py
@@ -107,7 +107,7 @@ from avibe_memory.types import (
     memory_item_payload,
     memory_list_page_payload,
 )
-from vibe.memory_contract import MemoryStoreUnavailableError
+from vibe.memory_contract import MemoryRuntimeBusyError, MemoryStoreUnavailableError
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +130,7 @@ _MEMORY_LIST_AGGREGATE_TIMEOUT_SECONDS = 20.0
 _WAKE_LEASE_RETRY_DELAYS_SECONDS = (0.0, 0.25, 0.5, 1.0, 2.0)
 
 
-class MemoryRuntimeRootBusyError(RuntimeError):
+class MemoryRuntimeRootBusyError(MemoryRuntimeBusyError):
     """Another live Memory runtime still owns this provider root."""
 
 
@@ -587,6 +587,19 @@ class MemoryRuntime:
 
         return self._module is not None and not self._retired
 
+    def _accepts_lifecycle_work(self) -> bool:
+        """Return whether this runtime may still mutate its provider root."""
+
+        return (
+            not self._closing
+            and not self._retired
+            and self._runtime_authority.active()
+        )
+
+    @staticmethod
+    def _lifecycle_busy_result() -> dict[str, Any]:
+        return {"ok": False, "error": "memory_operation_in_progress"}
+
     @property
     def needs_repair(self) -> bool:
         """Whether local mutable data is known unusable or incompatible."""
@@ -870,6 +883,8 @@ class MemoryRuntime:
         """Best-effort compatibility cleanup for ordinary non-destructive flows."""
 
         async with self._reconcile_lock:
+            if not self._accepts_lifecycle_work():
+                return False
             was_blocked = self._released_ownership_blocked
             try:
                 required_no_follow_flag()
@@ -879,6 +894,8 @@ class MemoryRuntime:
                 self._runtime_error = "memory_sidecar_unavailable"
                 return False
             reconciled = await self._supervisor.reconcile_orphans()
+            if not self._accepts_lifecycle_work():
+                return False
             if not reconciled and self._supervisor.status.retains_configuration:
                 # The current supervisor-owned child is not released ownership.
                 reconciled = True
@@ -892,8 +909,8 @@ class MemoryRuntime:
     async def reconcile(self, config: MemoryConfig) -> dict[str, Any]:
         """Apply persisted config without restarting the Avibe service."""
 
-        if self._retired:
-            return {"ok": False, "error": "memory_operation_in_progress"}
+        if not self._accepts_lifecycle_work():
+            return self._lifecycle_busy_result()
         return await self._reconcile(config)
 
     async def _reconcile(self, config: MemoryConfig) -> dict[str, Any]:
@@ -903,18 +920,25 @@ class MemoryRuntime:
         # sidecar is exactly the boot that may face one from the run before it.
         # Takes and releases the reconcile lock itself; the lock this method
         # acquires later is a separate, sequential acquisition.
-        if not await self._reconcile_released_ownership():
+        reconciled = await self._reconcile_released_ownership()
+        if not self._accepts_lifecycle_work():
+            return self._lifecycle_busy_result()
+        if not reconciled:
             return {
                 "ok": False,
                 "state": "needs_repair" if self.needs_repair else "degraded",
                 "error": "memory_sidecar_unavailable",
             }
         if not self.available:
+            if not self._accepts_lifecycle_work():
+                return self._lifecycle_busy_result()
             # A transient store failure must not close Memory forever: every
             # reconciliation is another chance to open it.
             self._config = config
             if not config.enabled:
                 async with self._reconcile_lock:
+                    if not self._accepts_lifecycle_work():
+                        return self._lifecycle_busy_result()
                     self._wake_config = deepcopy(config)
                     return {"ok": True, "state": "disabled"}
             if not self._open_store():
@@ -926,18 +950,24 @@ class MemoryRuntime:
                 }
             self.start_capture_adapter()
         async with self._reconcile_lock:
+            if not self._accepts_lifecycle_work():
+                return self._lifecycle_busy_result()
             self._activation_loop = asyncio.get_running_loop()
             if self._artifact_installing:
                 return {"ok": False, "error": "memory_runtime_install_failed"}
             async with self.module.lifecycle():
+                if not self._accepts_lifecycle_work():
+                    return self._lifecycle_busy_result()
                 result = await self._reconcile_locked(config)
-                if result.get("ok") is True:
+                if result.get("ok") is True and self._accepts_lifecycle_work():
                     self._wake_config = deepcopy(config)
                 return result
 
     async def _disable_locked(self, config: MemoryConfig) -> dict[str, Any]:
         """Stop every active Memory component without consulting maintenance state."""
 
+        if not self._accepts_lifecycle_work():
+            return self._lifecycle_busy_result()
         self.module.pause_claims()
         self._config = config
         self._configure_insight_reader(config)
@@ -947,7 +977,11 @@ class MemoryRuntime:
         )
         self.module.replace_provider(self._provider)
         await self._close_writer()
+        if not self._accepts_lifecycle_work():
+            return self._lifecycle_busy_result()
         await self._supervisor.stop()
+        if not self._accepts_lifecycle_work():
+            return self._lifecycle_busy_result()
         self._runtime_error = None
         return {"ok": True, "state": "disabled"}
 
@@ -961,6 +995,8 @@ class MemoryRuntime:
     ) -> dict[str, Any]:
         """Reconcile while both controller and module lifecycle locks are held."""
 
+        if not self._accepts_lifecycle_work():
+            return self._lifecycle_busy_result()
         if self.needs_repair:
             if not config.enabled:
                 result = await self._disable_locked(config)
@@ -976,7 +1012,11 @@ class MemoryRuntime:
                 }
             self.module.pause_claims()
             await self._close_writer()
+            if not self._accepts_lifecycle_work():
+                return self._lifecycle_busy_result()
             await self._supervisor.stop()
+            if not self._accepts_lifecycle_work():
+                return self._lifecycle_busy_result()
             self._config = deepcopy(config)
             self._wake_config = deepcopy(config)
             self._runtime_error = self._needs_repair_reason
@@ -996,7 +1036,11 @@ class MemoryRuntime:
         if cloud_identity_changed:
             self.module.pause_claims()
             await self._close_writer()
+            if not self._accepts_lifecycle_work():
+                return self._lifecycle_busy_result()
             await self._supervisor.stop()
+            if not self._accepts_lifecycle_work():
+                return self._lifecycle_busy_result()
             self._config = deepcopy(config)
             self._wake_config = deepcopy(config)
             self._runtime_error = "memory_loss_confirmation_required"
@@ -1012,7 +1056,11 @@ class MemoryRuntime:
             # keep queuing while claims and the old sidecar stay fenced.
             self.module.pause_claims()
             await self._close_writer()
+            if not self._accepts_lifecycle_work():
+                return self._lifecycle_busy_result()
             await self._supervisor.stop()
+            if not self._accepts_lifecycle_work():
+                return self._lifecycle_busy_result()
             self._config = deepcopy(config)
             self._wake_config = deepcopy(config)
             self._configure_insight_reader(config)
@@ -1037,16 +1085,27 @@ class MemoryRuntime:
         if embedding_changed:
             # Fence and join volatile writer work before inspecting provider
             # state, so no old-embedding call can cross this boundary.
-            if not await self.module.quiesce_claims():
+            quiesced = await self.module.quiesce_claims()
+            if not self._accepts_lifecycle_work():
+                return self._lifecycle_busy_result()
+            if not quiesced:
                 if resume_claims_on_failure:
                     self._defer_wake_until_writer_closed()
                 self._runtime_error = "memory_loss_confirmation_required"
                 return {"ok": False, "state": "degraded", "error": self._runtime_error}
             claims_paused = True
-            if not await self._embedding_change_is_admissible(self._config, config):
+            admissible = await self._embedding_change_is_admissible(
+                self._config,
+                config,
+            )
+            if not self._accepts_lifecycle_work():
+                return self._lifecycle_busy_result()
+            if not admissible:
                 restored = False
                 if resume_claims_on_failure:
                     restored = await self._restore_provisional_claims(previous_config)
+                    if not self._accepts_lifecycle_work():
+                        return self._lifecycle_busy_result()
                 if not restored:
                     self._runtime_error = "memory_loss_confirmation_required"
                 return {
@@ -1067,8 +1126,12 @@ class MemoryRuntime:
             runtime_active=self._runtime_authority.active,
         )
         python = await asyncio.to_thread(self._artifact_manager.resolve_python)
+        if not self._accepts_lifecycle_work():
+            return self._lifecycle_busy_result()
         if python is None:
             error = _runtime_error_for_status(await asyncio.to_thread(self._artifact_manager.status))
+            if not self._accepts_lifecycle_work():
+                return self._lifecycle_busy_result()
             if not self._supervisor.status.retains_configuration:
                 # No retained supervisor can run now or relaunch with the prior
                 # settings, including one that exhausted its wake budget.
@@ -1078,25 +1141,39 @@ class MemoryRuntime:
                 self._runtime_error = error
             if claims_paused and resume_claims_on_failure:
                 await self._restore_provisional_claims(previous_config)
+                if not self._accepts_lifecycle_work():
+                    return self._lifecycle_busy_result()
             return {"ok": False, "error": error}
-        if not await self._probe_processing(python, config):
+        processing_ready = await self._probe_processing(python, config)
+        if not self._accepts_lifecycle_work():
+            return self._lifecycle_busy_result()
+        if not processing_ready:
             error = "memory_processing_failed"
             if not self._supervisor.status.running:
                 self._runtime_error = error
             if claims_paused and resume_claims_on_failure:
                 await self._restore_provisional_claims(previous_config)
+                if not self._accepts_lifecycle_work():
+                    return self._lifecycle_busy_result()
             return {"ok": False, "error": error}
 
         # Every enabled reconciliation receives a fresh process. Endpoint,
         # model, and key changes belong exclusively in its allowlisted child
         # environment and must never leave an old sidecar running.
-        if not claims_paused and not await self.module.quiesce_claims():
+        quiesced = claims_paused or await self.module.quiesce_claims()
+        if not self._accepts_lifecycle_work():
+            return self._lifecycle_busy_result()
+        if not quiesced:
             if resume_claims_on_failure:
                 self._defer_wake_until_writer_closed()
             self._runtime_error = "memory_runtime_busy"
             return {"ok": False, "state": "degraded", "error": self._runtime_error}
         await self._close_writer()
+        if not self._accepts_lifecycle_work():
+            return self._lifecycle_busy_result()
         await self._supervisor.stop()
+        if not self._accepts_lifecycle_work():
+            return self._lifecycle_busy_result()
 
         self._config = config
         self._configure_insight_reader(config)
@@ -1104,12 +1181,16 @@ class MemoryRuntime:
         self.module.replace_provider(self._provider)
         try:
             meta = await asyncio.to_thread(self._store.ensure_meta)
+            if not self._accepts_lifecycle_work():
+                return self._lifecycle_busy_result()
             active_metadata = self._active_provider_root_metadata()
             await run_blocking(
                 self._provider_root_owner.ensure,
                 meta,
                 active_metadata,
             )
+            if not self._accepts_lifecycle_work():
+                return self._lifecycle_busy_result()
         except Exception as exc:
             if _local_data_failure_requires_repair(exc):
                 self._needs_repair_reason = "memory_local_data_unusable"
@@ -1122,17 +1203,21 @@ class MemoryRuntime:
             return {"ok": False, "state": state, "error": self._runtime_error}
 
         settings = _process_settings(config)
+        if not self._accepts_lifecycle_work():
+            return self._lifecycle_busy_result()
         try:
             started = await self._supervisor.wake(
                 python,
                 settings,
-                provider_root_guard=lambda: self._provider_root_owner.require_owned(
+                provider_root_guard=lambda: self._require_current_provider_root(
                     meta,
                     active_metadata,
                 ),
             )
         except BaseException:
             raise
+        if not self._accepts_lifecycle_work():
+            return self._lifecycle_busy_result()
         if not started:
             self._runtime_error = "memory_sidecar_unavailable"
             return {"ok": False, "state": "degraded", "error": self._runtime_error}
@@ -2628,6 +2713,17 @@ class MemoryRuntime:
                 }
             ),
         )
+
+    def _require_current_provider_root(
+        self,
+        meta: object,
+        active_metadata: ProviderRootMetadata,
+    ) -> None:
+        """Reject a launch after this runtime's root authority was revoked."""
+
+        if not self._accepts_lifecycle_work():
+            raise ProviderRootError("Memory runtime authority was revoked")
+        self._provider_root_owner.require_owned(meta, active_metadata)
 
     def _coordinate_artifact_activation(
         self,

--- a/avibe_memory/runtime.py
+++ b/avibe_memory/runtime.py
@@ -2547,7 +2547,12 @@ class MemoryRuntime:
                 name="memory-runtime-close",
             )
             self._close_task = task
-        await asyncio.shield(task)
+            await asyncio.shield(task)
+            return
+        await asyncio.wait_for(
+            asyncio.shield(task),
+            timeout=max(0.0, timeout_seconds),
+        )
 
     async def _close_once(self, timeout_seconds: float) -> None:
         loop = asyncio.get_running_loop()

--- a/avibe_memory/runtime.py
+++ b/avibe_memory/runtime.py
@@ -355,62 +355,68 @@ class MemoryRuntime:
                 _RUNTIME_ROOTS[self._root_key] = self
             elif owner is not _root_ownership.owner or not _root_ownership.close_proved:
                 raise MemoryRuntimeBusyError("Memory provider root ownership changed")
-        self._artifact_manager: MemoryArtifactPort = artifact_manager or get_memory_artifact_manager()
-        self._provider_root_owner = ProviderRoot(
-            self._provider_root,
-            effective_home=self._effective_home,
-        )
-        self._supervisor_factory: EverOSSupervisorFactory = (
-            supervisor_factory or EverOSSupervisor
-        )
-        self._processing_event = processing_event
-        self._on_config_settled = on_config_settled
-        self._is_enabled_user = is_enabled_user
-        self._lifecycle_snapshot_matches = lifecycle_snapshot_matches
-        self._acquire_lifecycle_admission = acquire_lifecycle_admission
-        self._capture_adapter: MemoryCaptureAdapter = DisabledMemoryAdapter()
-        self._capture_task_factory: Callable[..., asyncio.Task[Any]] | None = None
-        self._compose_capture_adapter(None)
-        # The controller-side port only talks to the private UDS. Credentials
-        # enter an EverOSPort only inside the owned child probe/sidecar.
-        self._provider = EverOSPort(
-            self._socket_path,
-            runtime_active=self._runtime_active,
-        )
-        self._attachment_config_epoch = next(_ATTACHMENT_CONFIG_EPOCHS)
-        self._runtime_error: str | None = None
-        self._released_ownership_blocked = False
-        self._needs_repair_reason: str | None = (
-            "memory_legacy_recovery_required"
-            if config.legacy_needs_repair
-            else None
-        )
-        self._reconcile_lock = asyncio.Lock()
-        self._wake_task: asyncio.Task[dict[str, Any]] | None = None
-        self._artifact_activation_task: asyncio.Task[None] | None = None
-        self._artifact_install_task: asyncio.Task[dict[str, Any]] | None = None
-        self._closing = False
-        self._activation_loop: asyncio.AbstractEventLoop | None = None
-        self._artifact_installing = False
-        self._close_task: asyncio.Task[None] | None = None
-        self._close_phase_tasks: dict[str, asyncio.Task[None]] = {}
-        self._store: MemoryStore | None = None
-        self._module: MemoryModule | None = None
-        self._store_error: Exception | None = None
-        self._insight_reader_override = insight_reader
-        self._insight_reader: MemoryInsightReader | None = None
-        self._supervisor = self._supervisor_factory(
-            provider_root=self._provider_root,
-            effective_home=self._effective_home,
-            socket_path=self._socket_path,
-            on_ready=self._current_sidecar_ready,
-            on_unavailable=self._current_sidecar_unavailable,
-            on_recover=self._recover_current_sidecar,
-        )
-        self._processing_record = MemoryProcessingRecord(
-            self._processing_record_port()
-        )
-        self._open_store(store)
+        try:
+            self._artifact_manager: MemoryArtifactPort = artifact_manager or get_memory_artifact_manager()
+            self._provider_root_owner = ProviderRoot(
+                self._provider_root,
+                effective_home=self._effective_home,
+            )
+            self._supervisor_factory: EverOSSupervisorFactory = (
+                supervisor_factory or EverOSSupervisor
+            )
+            self._processing_event = processing_event
+            self._on_config_settled = on_config_settled
+            self._is_enabled_user = is_enabled_user
+            self._lifecycle_snapshot_matches = lifecycle_snapshot_matches
+            self._acquire_lifecycle_admission = acquire_lifecycle_admission
+            self._capture_adapter: MemoryCaptureAdapter = DisabledMemoryAdapter()
+            self._capture_task_factory: Callable[..., asyncio.Task[Any]] | None = None
+            self._compose_capture_adapter(None)
+            # The controller-side port only talks to the private UDS. Credentials
+            # enter an EverOSPort only inside the owned child probe/sidecar.
+            self._provider = EverOSPort(
+                self._socket_path,
+                runtime_active=self._runtime_active,
+            )
+            self._attachment_config_epoch = next(_ATTACHMENT_CONFIG_EPOCHS)
+            self._runtime_error: str | None = None
+            self._released_ownership_blocked = False
+            self._needs_repair_reason: str | None = (
+                "memory_legacy_recovery_required"
+                if config.legacy_needs_repair
+                else None
+            )
+            self._reconcile_lock = asyncio.Lock()
+            self._wake_task: asyncio.Task[dict[str, Any]] | None = None
+            self._artifact_activation_task: asyncio.Task[None] | None = None
+            self._artifact_install_task: asyncio.Task[dict[str, Any]] | None = None
+            self._closing = False
+            self._activation_loop: asyncio.AbstractEventLoop | None = None
+            self._artifact_installing = False
+            self._close_task: asyncio.Task[None] | None = None
+            self._close_phase_tasks: dict[str, asyncio.Task[None]] = {}
+            self._store: MemoryStore | None = None
+            self._module: MemoryModule | None = None
+            self._store_error: Exception | None = None
+            self._insight_reader_override = insight_reader
+            self._insight_reader: MemoryInsightReader | None = None
+            self._supervisor = self._supervisor_factory(
+                provider_root=self._provider_root,
+                effective_home=self._effective_home,
+                socket_path=self._socket_path,
+                on_ready=self._current_sidecar_ready,
+                on_unavailable=self._current_sidecar_unavailable,
+                on_recover=self._recover_current_sidecar,
+            )
+            self._processing_record = MemoryProcessingRecord(
+                self._processing_record_port()
+            )
+            self._open_store(store)
+        except BaseException:
+            with _RUNTIME_ROOTS_LOCK:
+                if _RUNTIME_ROOTS.get(self._root_key) is self:
+                    _RUNTIME_ROOTS.pop(self._root_key, None)
+            raise
 
     def _open_store(self, store: MemoryStore | None = None) -> bool:
         """Open the local store and build the module, absorbing any failure.
@@ -2611,7 +2617,7 @@ class MemoryRuntime:
         await self._join_close_task(self._artifact_activation_task)
         if self._module is not None:
             self._module.pause_claims()
-            async with self._module.provider_root_lifecycle():
+            async with self._module.destructive_lifecycle():
                 if not await self._module.quiesce_claims_for_destructive_reset():
                     raise RuntimeError("Memory writer did not quiesce during close")
                 await self._module.close_writer()

--- a/avibe_memory/runtime.py
+++ b/avibe_memory/runtime.py
@@ -666,6 +666,7 @@ class MemoryRuntime:
             ):
                 raise MemoryRuntimeBusyError("Memory provider root ownership changed")
             _RUNTIME_ROOTS[self._root_key] = self
+            ownership.owner._reset_root_ownership = None
         self._pending_root_ownership = None
 
     def release_root_ownership(self, root_ownership: object) -> None:
@@ -674,6 +675,12 @@ class MemoryRuntime:
             if _RUNTIME_ROOTS.get(self._root_key) is not self:
                 raise MemoryRuntimeBusyError("Memory provider root ownership changed")
             _RUNTIME_ROOTS.pop(self._root_key, None)
+            self._reset_root_ownership = None
+
+    def release_retained_root_ownership(self) -> None:
+        ownership = self._reset_root_ownership
+        if ownership is not None:
+            self.release_root_ownership(ownership)
 
     def begin_close(self) -> None:
         if self._closing:

--- a/avibe_memory/runtime.py
+++ b/avibe_memory/runtime.py
@@ -18,12 +18,12 @@ import weakref
 from concurrent.futures import CancelledError as FutureCancelledError
 from concurrent.futures import Future as ThreadFuture
 from concurrent.futures import TimeoutError as FutureTimeoutError
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Iterable, Mapping
 from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TypeVar
 
 from config import paths
 from config.v2_config import (
@@ -117,6 +117,7 @@ ProcessingEvent = Callable[
     [Literal["fault", "recovered"], Literal["credential", "engine"] | None, str, int],
     Awaitable[bool],
 ]
+_LifecycleResult = TypeVar("_LifecycleResult")
 
 
 ARTIFACT_ACTIVATION_TIMEOUT_SECONDS = 90.0
@@ -130,56 +131,43 @@ _MEMORY_LIST_AGGREGATE_TIMEOUT_SECONDS = 20.0
 _WAKE_LEASE_RETRY_DELAYS_SECONDS = (0.0, 0.25, 0.5, 1.0, 2.0)
 
 
-class MemoryRuntimeRootBusyError(MemoryRuntimeBusyError):
-    """Another live Memory runtime still owns this provider root."""
-
-
 class _RuntimeRootAuthority:
     """One process-local, revocable claim on an exact provider root."""
 
     _lock = threading.Lock()
     _owners: dict[str, "_RuntimeRootAuthority"] = {}
 
-    def __init__(self, key: str) -> None:
-        self._key = key
-        self._active = True
-        self._released = False
-
-    @classmethod
-    def acquire(cls, provider_root: Path) -> "_RuntimeRootAuthority":
-        key = os.path.normcase(os.path.abspath(os.fspath(provider_root)))
-        with cls._lock:
-            if key in cls._owners:
-                raise MemoryRuntimeRootBusyError(
+    def __init__(self, provider_root: Path) -> None:
+        self._key = os.path.normcase(os.path.abspath(os.fspath(provider_root)))
+        self._revoked = False
+        with self._lock:
+            if self._key in self._owners:
+                raise MemoryRuntimeBusyError(
                     "Memory provider root is already owned by a live runtime"
                 )
-            authority = cls(key)
-            cls._owners[key] = authority
-            return authority
+            self._owners[self._key] = self
 
     def active(self) -> bool:
         with self._lock:
             return (
-                self._active
-                and not self._released
+                not self._revoked
                 and self._owners.get(self._key) is self
             )
 
     def revoke(self) -> None:
         with self._lock:
-            self._active = False
+            self._revoked = True
 
     def release(self) -> None:
         with self._lock:
             if self._owners.get(self._key) is self:
                 self._owners.pop(self._key, None)
-            self._active = False
-            self._released = True
+            self._revoked = True
 
     @property
     def released(self) -> bool:
         with self._lock:
-            return self._released
+            return self._owners.get(self._key) is not self
 
 
 @asynccontextmanager
@@ -198,11 +186,9 @@ async def _concurrent_episode_lists(
 
 @dataclass(frozen=True, slots=True)
 class _ProcessingRuntimeSnapshot:
-    revision: int
     transition_active: bool
     enabled: bool
     store_available: bool
-    retired: bool
     closing: bool
     supervisor: EverOSSupervisorStatus
     runtime_error: str | None
@@ -214,7 +200,7 @@ class _ProcessingRuntimeSnapshot:
             return "memory_sidecar_unavailable"
         if maintenance_reason is not None:
             return maintenance_reason
-        if self.retired or self.transition_active or self.closing:
+        if self.transition_active or self.closing:
             return "busy"
         if not self.supervisor.running:
             return self.runtime_error or "memory_sidecar_unavailable"
@@ -230,48 +216,19 @@ class _ProcessingRuntimeSnapshot:
             return "memory_store_unavailable"
         if maintenance_reason is not None:
             return maintenance_reason
-        if self.retired or self.transition_active or self.closing:
+        if self.transition_active or self.closing:
             return "busy"
         return None
 
     def same_lifecycle(self, other: _ProcessingRuntimeSnapshot) -> bool:
         return (
-            self.revision == other.revision
-            and self.transition_active == other.transition_active
+            self.transition_active == other.transition_active
             and self.enabled == other.enabled
             and self.store_available == other.store_available
-            and self.retired == other.retired
             and self.closing == other.closing
             and self.supervisor == other.supervisor
             and self.runtime_error == other.runtime_error
         )
-
-
-class _LifecycleGenerationLock:
-    """Publish reconcile transitions without making health readers wait."""
-
-    def __init__(self, on_transition: Callable[[], None]) -> None:
-        self._lock = asyncio.Lock()
-        self._on_transition = on_transition
-
-    async def acquire(self) -> bool:
-        acquired = await self._lock.acquire()
-        self._on_transition()
-        return acquired
-
-    def release(self) -> None:
-        self._lock.release()
-        self._on_transition()
-
-    def locked(self) -> bool:
-        return self._lock.locked()
-
-    async def __aenter__(self) -> _LifecycleGenerationLock:
-        await self.acquire()
-        return self
-
-    async def __aexit__(self, *_exc: object) -> None:
-        self.release()
 
 
 def _source_observation_payload(source: SourceObservation) -> dict[str, Any]:
@@ -405,7 +362,7 @@ class MemoryRuntime:
             effective_home or paths.get_vibe_remote_dir()
         )
         self._effective_home = self._filesystem_root.physical_home
-        self._runtime_authority = _RuntimeRootAuthority.acquire(self._provider_root)
+        self._runtime_authority = _RuntimeRootAuthority(self._provider_root)
         construction_guard = weakref.finalize(self, self._runtime_authority.release)
         self._artifact_manager: MemoryArtifactPort = artifact_manager or get_memory_artifact_manager()
         self._provider_root_owner = ProviderRoot(
@@ -436,16 +393,13 @@ class MemoryRuntime:
             if config.legacy_needs_repair
             else None
         )
-        self._lifecycle_revision = 0
-        self._reconcile_lock = _LifecycleGenerationLock(self._advance_lifecycle_revision)
+        self._reconcile_lock = asyncio.Lock()
         self._wake_task: asyncio.Task[dict[str, Any]] | None = None
         self._artifact_activation_task: asyncio.Task[None] | None = None
         self._closing = False
         self._activation_loop: asyncio.AbstractEventLoop | None = None
         self._artifact_installing = False
-        self._retired = False
         self._close_task: asyncio.Task[None] | None = None
-        self._provider_close_task: asyncio.Task[None] | None = None
         self._store: MemoryStore | None = None
         self._module: MemoryModule | None = None
         self._store_error: Exception | None = None
@@ -585,20 +539,26 @@ class MemoryRuntime:
     def available(self) -> bool:
         """Whether the local store opened. False keeps every read closed."""
 
-        return self._module is not None and not self._retired
+        return self._module is not None and not self._closing
 
-    def _accepts_lifecycle_work(self) -> bool:
-        """Return whether this runtime may still mutate its provider root."""
+    def _require_lifecycle_work(self) -> None:
+        if self._closing or not self._runtime_authority.active():
+            raise MemoryRuntimeBusyError("Memory runtime authority was revoked")
 
-        return (
-            not self._closing
-            and not self._retired
-            and self._runtime_authority.active()
-        )
+    async def _lifecycle_checkpoint(
+        self,
+        operation: Coroutine[Any, Any, _LifecycleResult],
+    ) -> _LifecycleResult:
+        """Run one awaited boundary only while this runtime owns its root."""
 
-    @staticmethod
-    def _lifecycle_busy_result() -> dict[str, Any]:
-        return {"ok": False, "error": "memory_operation_in_progress"}
+        try:
+            self._require_lifecycle_work()
+        except BaseException:
+            operation.close()
+            raise
+        result = await operation
+        self._require_lifecycle_work()
+        return result
 
     @property
     def needs_repair(self) -> bool:
@@ -649,12 +609,6 @@ class MemoryRuntime:
         return reset_memory_data_roots(self._effective_home)
 
     @property
-    def retired(self) -> bool:
-        """Whether this aggregate has been permanently retired."""
-
-        return self._retired
-
-    @property
     def effective_home(self) -> Path:
         """Return the pinned home used by this aggregate's mutable state."""
 
@@ -676,12 +630,6 @@ class MemoryRuntime:
             acquire_lifecycle_admission=self._acquire_lifecycle_admission,
         )
 
-    def retire(self) -> None:
-        """Tombstone this aggregate and its module before mutable roots die."""
-
-        self._retired = True
-        self.begin_close()
-
     def begin_close(self) -> None:
         """Synchronously revoke provider-root publication before host detachment."""
 
@@ -690,6 +638,7 @@ class MemoryRuntime:
         self._closing = True
         self._runtime_authority.revoke()
         self._supervisor.begin_close()
+        self._activation_loop = None
         adapter = self._capture_adapter
         quiesce = getattr(adapter, "quiesce_memory_capture_tasks", None)
         if callable(quiesce):
@@ -697,9 +646,6 @@ class MemoryRuntime:
         cancel_nowait = getattr(adapter, "cancel_memory_capture_tasks_nowait", None)
         if callable(cancel_nowait):
             cancel_nowait()
-        if self._module is not None:
-            self._module.retire()
-        self._advance_lifecycle_revision()
 
     def artifact_admitted(self) -> bool:
         """Return whether the pinned artifact is valid for a reset admission."""
@@ -713,29 +659,6 @@ class MemoryRuntime:
             )
         except Exception:
             return False
-
-    async def activate_fresh(self, config: MemoryConfig) -> dict[str, Any]:
-        """Activate a newly constructed aggregate without re-reading old intent."""
-
-        if self._retired:
-            return {"ok": False, "error": "memory_operation_in_progress"}
-        if not self.available:
-            return {"ok": False, "error": "memory_store_unavailable"}
-        self._activation_loop = asyncio.get_running_loop()
-        self.module.pause_claims()
-        async with self._reconcile_lock:
-            async with self.module.lifecycle():
-                result = await self._reconcile_locked(
-                    config,
-                    claims_already_paused=True,
-                    skip_embedding_guard=True,
-                    resume_claims_on_failure=False,
-                )
-                if result.get("ok") is True:
-                    # Fresh runtimes start fenced while the child is proved;
-                    # settled recovery must leave ordinary capture admission open.
-                    self.module.resume_claims()
-                return result
 
     @property
     def module(self) -> MemoryModule | _UnavailableMemoryModule:
@@ -819,17 +742,12 @@ class MemoryRuntime:
             raise self._unavailable()
         return await run_blocking(self._store.principal_for_user_key, user_key)
 
-    def _advance_lifecycle_revision(self) -> None:
-        self._lifecycle_revision += 1
-
     def _processing_runtime_snapshot(self) -> _ProcessingRuntimeSnapshot:
         module = self._module
         return _ProcessingRuntimeSnapshot(
-            revision=self._lifecycle_revision,
             transition_active=self._reconcile_lock.locked(),
             enabled=self._config.enabled,
             store_available=module is not None,
-            retired=bool(module and module.retired),
             closing=self._closing,
             supervisor=self._supervisor.status,
             runtime_error=self._runtime_error,
@@ -883,8 +801,7 @@ class MemoryRuntime:
         """Best-effort compatibility cleanup for ordinary non-destructive flows."""
 
         async with self._reconcile_lock:
-            if not self._accepts_lifecycle_work():
-                return False
+            self._require_lifecycle_work()
             was_blocked = self._released_ownership_blocked
             try:
                 required_no_follow_flag()
@@ -893,9 +810,9 @@ class MemoryRuntime:
                 self._released_ownership_blocked = True
                 self._runtime_error = "memory_sidecar_unavailable"
                 return False
-            reconciled = await self._supervisor.reconcile_orphans()
-            if not self._accepts_lifecycle_work():
-                return False
+            reconciled = await self._lifecycle_checkpoint(
+                self._supervisor.reconcile_orphans()
+            )
             if not reconciled and self._supervisor.status.retains_configuration:
                 # The current supervisor-owned child is not released ownership.
                 reconciled = True
@@ -909,9 +826,11 @@ class MemoryRuntime:
     async def reconcile(self, config: MemoryConfig) -> dict[str, Any]:
         """Apply persisted config without restarting the Avibe service."""
 
-        if not self._accepts_lifecycle_work():
-            return self._lifecycle_busy_result()
-        return await self._reconcile(config)
+        try:
+            self._require_lifecycle_work()
+            return await self._reconcile(config)
+        except MemoryRuntimeBusyError:
+            return {"ok": False, "error": "memory_operation_in_progress"}
 
     async def _reconcile(self, config: MemoryConfig) -> dict[str, Any]:
         """Run one reconciliation owned by the public lifecycle operation."""
@@ -921,8 +840,6 @@ class MemoryRuntime:
         # Takes and releases the reconcile lock itself; the lock this method
         # acquires later is a separate, sequential acquisition.
         reconciled = await self._reconcile_released_ownership()
-        if not self._accepts_lifecycle_work():
-            return self._lifecycle_busy_result()
         if not reconciled:
             return {
                 "ok": False,
@@ -930,15 +847,12 @@ class MemoryRuntime:
                 "error": "memory_sidecar_unavailable",
             }
         if not self.available:
-            if not self._accepts_lifecycle_work():
-                return self._lifecycle_busy_result()
             # A transient store failure must not close Memory forever: every
             # reconciliation is another chance to open it.
             self._config = config
             if not config.enabled:
                 async with self._reconcile_lock:
-                    if not self._accepts_lifecycle_work():
-                        return self._lifecycle_busy_result()
+                    self._require_lifecycle_work()
                     self._wake_config = deepcopy(config)
                     return {"ok": True, "state": "disabled"}
             if not self._open_store():
@@ -950,24 +864,22 @@ class MemoryRuntime:
                 }
             self.start_capture_adapter()
         async with self._reconcile_lock:
-            if not self._accepts_lifecycle_work():
-                return self._lifecycle_busy_result()
+            self._require_lifecycle_work()
             self._activation_loop = asyncio.get_running_loop()
             if self._artifact_installing:
                 return {"ok": False, "error": "memory_runtime_install_failed"}
             async with self.module.lifecycle():
-                if not self._accepts_lifecycle_work():
-                    return self._lifecycle_busy_result()
+                self._require_lifecycle_work()
                 result = await self._reconcile_locked(config)
-                if result.get("ok") is True and self._accepts_lifecycle_work():
+                if result.get("ok") is True:
+                    self._require_lifecycle_work()
                     self._wake_config = deepcopy(config)
                 return result
 
     async def _disable_locked(self, config: MemoryConfig) -> dict[str, Any]:
         """Stop every active Memory component without consulting maintenance state."""
 
-        if not self._accepts_lifecycle_work():
-            return self._lifecycle_busy_result()
+        self._require_lifecycle_work()
         self.module.pause_claims()
         self._config = config
         self._configure_insight_reader(config)
@@ -976,12 +888,8 @@ class MemoryRuntime:
             runtime_active=self._runtime_authority.active,
         )
         self.module.replace_provider(self._provider)
-        await self._close_writer()
-        if not self._accepts_lifecycle_work():
-            return self._lifecycle_busy_result()
-        await self._supervisor.stop()
-        if not self._accepts_lifecycle_work():
-            return self._lifecycle_busy_result()
+        await self._lifecycle_checkpoint(self._close_writer())
+        await self._lifecycle_checkpoint(self._supervisor.stop())
         self._runtime_error = None
         return {"ok": True, "state": "disabled"}
 
@@ -995,8 +903,7 @@ class MemoryRuntime:
     ) -> dict[str, Any]:
         """Reconcile while both controller and module lifecycle locks are held."""
 
-        if not self._accepts_lifecycle_work():
-            return self._lifecycle_busy_result()
+        self._require_lifecycle_work()
         if self.needs_repair:
             if not config.enabled:
                 result = await self._disable_locked(config)
@@ -1011,12 +918,8 @@ class MemoryRuntime:
                     "error": reason,
                 }
             self.module.pause_claims()
-            await self._close_writer()
-            if not self._accepts_lifecycle_work():
-                return self._lifecycle_busy_result()
-            await self._supervisor.stop()
-            if not self._accepts_lifecycle_work():
-                return self._lifecycle_busy_result()
+            await self._lifecycle_checkpoint(self._close_writer())
+            await self._lifecycle_checkpoint(self._supervisor.stop())
             self._config = deepcopy(config)
             self._wake_config = deepcopy(config)
             self._runtime_error = self._needs_repair_reason
@@ -1035,12 +938,8 @@ class MemoryRuntime:
         )
         if cloud_identity_changed:
             self.module.pause_claims()
-            await self._close_writer()
-            if not self._accepts_lifecycle_work():
-                return self._lifecycle_busy_result()
-            await self._supervisor.stop()
-            if not self._accepts_lifecycle_work():
-                return self._lifecycle_busy_result()
+            await self._lifecycle_checkpoint(self._close_writer())
+            await self._lifecycle_checkpoint(self._supervisor.stop())
             self._config = deepcopy(config)
             self._wake_config = deepcopy(config)
             self._runtime_error = "memory_loss_confirmation_required"
@@ -1055,12 +954,8 @@ class MemoryRuntime:
             # a pause, never a fallback to saved custom providers. Capture can
             # keep queuing while claims and the old sidecar stay fenced.
             self.module.pause_claims()
-            await self._close_writer()
-            if not self._accepts_lifecycle_work():
-                return self._lifecycle_busy_result()
-            await self._supervisor.stop()
-            if not self._accepts_lifecycle_work():
-                return self._lifecycle_busy_result()
+            await self._lifecycle_checkpoint(self._close_writer())
+            await self._lifecycle_checkpoint(self._supervisor.stop())
             self._config = deepcopy(config)
             self._wake_config = deepcopy(config)
             self._configure_insight_reader(config)
@@ -1085,27 +980,22 @@ class MemoryRuntime:
         if embedding_changed:
             # Fence and join volatile writer work before inspecting provider
             # state, so no old-embedding call can cross this boundary.
-            quiesced = await self.module.quiesce_claims()
-            if not self._accepts_lifecycle_work():
-                return self._lifecycle_busy_result()
+            quiesced = await self._lifecycle_checkpoint(self.module.quiesce_claims())
             if not quiesced:
                 if resume_claims_on_failure:
                     self._defer_wake_until_writer_closed()
                 self._runtime_error = "memory_loss_confirmation_required"
                 return {"ok": False, "state": "degraded", "error": self._runtime_error}
             claims_paused = True
-            admissible = await self._embedding_change_is_admissible(
-                self._config,
-                config,
+            admissible = await self._lifecycle_checkpoint(
+                self._embedding_change_is_admissible(self._config, config)
             )
-            if not self._accepts_lifecycle_work():
-                return self._lifecycle_busy_result()
             if not admissible:
                 restored = False
                 if resume_claims_on_failure:
-                    restored = await self._restore_provisional_claims(previous_config)
-                    if not self._accepts_lifecycle_work():
-                        return self._lifecycle_busy_result()
+                    restored = await self._lifecycle_checkpoint(
+                        self._restore_provisional_claims(previous_config)
+                    )
                 if not restored:
                     self._runtime_error = "memory_loss_confirmation_required"
                 return {
@@ -1125,13 +1015,14 @@ class MemoryRuntime:
             processing_health_check=self._processing_healthy,
             runtime_active=self._runtime_authority.active,
         )
-        python = await asyncio.to_thread(self._artifact_manager.resolve_python)
-        if not self._accepts_lifecycle_work():
-            return self._lifecycle_busy_result()
+        python = await self._lifecycle_checkpoint(
+            asyncio.to_thread(self._artifact_manager.resolve_python)
+        )
         if python is None:
-            error = _runtime_error_for_status(await asyncio.to_thread(self._artifact_manager.status))
-            if not self._accepts_lifecycle_work():
-                return self._lifecycle_busy_result()
+            status = await self._lifecycle_checkpoint(
+                asyncio.to_thread(self._artifact_manager.status)
+            )
+            error = _runtime_error_for_status(status)
             if not self._supervisor.status.retains_configuration:
                 # No retained supervisor can run now or relaunch with the prior
                 # settings, including one that exhausted its wake budget.
@@ -1140,57 +1031,55 @@ class MemoryRuntime:
                 self._config = config
                 self._runtime_error = error
             if claims_paused and resume_claims_on_failure:
-                await self._restore_provisional_claims(previous_config)
-                if not self._accepts_lifecycle_work():
-                    return self._lifecycle_busy_result()
+                await self._lifecycle_checkpoint(
+                    self._restore_provisional_claims(previous_config)
+                )
             return {"ok": False, "error": error}
-        processing_ready = await self._probe_processing(python, config)
-        if not self._accepts_lifecycle_work():
-            return self._lifecycle_busy_result()
+        processing_ready = await self._lifecycle_checkpoint(
+            self._probe_processing(python, config)
+        )
         if not processing_ready:
             error = "memory_processing_failed"
             if not self._supervisor.status.running:
                 self._runtime_error = error
             if claims_paused and resume_claims_on_failure:
-                await self._restore_provisional_claims(previous_config)
-                if not self._accepts_lifecycle_work():
-                    return self._lifecycle_busy_result()
+                await self._lifecycle_checkpoint(
+                    self._restore_provisional_claims(previous_config)
+                )
             return {"ok": False, "error": error}
 
         # Every enabled reconciliation receives a fresh process. Endpoint,
         # model, and key changes belong exclusively in its allowlisted child
         # environment and must never leave an old sidecar running.
-        quiesced = claims_paused or await self.module.quiesce_claims()
-        if not self._accepts_lifecycle_work():
-            return self._lifecycle_busy_result()
+        quiesced = claims_paused or await self._lifecycle_checkpoint(
+            self.module.quiesce_claims()
+        )
         if not quiesced:
             if resume_claims_on_failure:
                 self._defer_wake_until_writer_closed()
             self._runtime_error = "memory_runtime_busy"
             return {"ok": False, "state": "degraded", "error": self._runtime_error}
-        await self._close_writer()
-        if not self._accepts_lifecycle_work():
-            return self._lifecycle_busy_result()
-        await self._supervisor.stop()
-        if not self._accepts_lifecycle_work():
-            return self._lifecycle_busy_result()
+        await self._lifecycle_checkpoint(self._close_writer())
+        await self._lifecycle_checkpoint(self._supervisor.stop())
 
         self._config = config
         self._configure_insight_reader(config)
         self._provider = candidate_provider
         self.module.replace_provider(self._provider)
         try:
-            meta = await asyncio.to_thread(self._store.ensure_meta)
-            if not self._accepts_lifecycle_work():
-                return self._lifecycle_busy_result()
-            active_metadata = self._active_provider_root_metadata()
-            await run_blocking(
-                self._provider_root_owner.ensure,
-                meta,
-                active_metadata,
+            meta = await self._lifecycle_checkpoint(
+                asyncio.to_thread(self._store.ensure_meta)
             )
-            if not self._accepts_lifecycle_work():
-                return self._lifecycle_busy_result()
+            active_metadata = self._active_provider_root_metadata()
+            await self._lifecycle_checkpoint(
+                run_blocking(
+                    self._provider_root_owner.ensure,
+                    meta,
+                    active_metadata,
+                )
+            )
+        except MemoryRuntimeBusyError:
+            raise
         except Exception as exc:
             if _local_data_failure_requires_repair(exc):
                 self._needs_repair_reason = "memory_local_data_unusable"
@@ -1203,10 +1092,8 @@ class MemoryRuntime:
             return {"ok": False, "state": state, "error": self._runtime_error}
 
         settings = _process_settings(config)
-        if not self._accepts_lifecycle_work():
-            return self._lifecycle_busy_result()
-        try:
-            started = await self._supervisor.wake(
+        started = await self._lifecycle_checkpoint(
+            self._supervisor.wake(
                 python,
                 settings,
                 provider_root_guard=lambda: self._require_current_provider_root(
@@ -1214,10 +1101,7 @@ class MemoryRuntime:
                     active_metadata,
                 ),
             )
-        except BaseException:
-            raise
-        if not self._accepts_lifecycle_work():
-            return self._lifecycle_busy_result()
+        )
         if not started:
             self._runtime_error = "memory_sidecar_unavailable"
             return {"ok": False, "state": "degraded", "error": self._runtime_error}
@@ -1415,7 +1299,7 @@ class MemoryRuntime:
             or not self._module.attachment_intake_enabled
         ):
             return None
-        return self._lifecycle_revision
+        return id(self._provider)
 
     async def failure_log_payload(
         self,
@@ -2202,7 +2086,7 @@ class MemoryRuntime:
     ) -> dict[str, Any]:
         """Validate the artifact and non-destructively wake the existing root."""
 
-        if self._closing or self._retired:
+        if self._closing:
             return {
                 "ok": False,
                 "state": self.runtime_state(),
@@ -2215,16 +2099,13 @@ class MemoryRuntime:
                 for delay_seconds in _WAKE_LEASE_RETRY_DELAYS_SECONDS:
                     if delay_seconds:
                         await asyncio.sleep(delay_seconds)
-                    if self._closing or self._retired:
-                        return {
-                            "ok": False,
-                            "state": self.runtime_state(),
-                            "error": "memory_operation_in_progress",
-                        }
+                    self._require_lifecycle_work()
                     try:
-                        await run_blocking(
-                            lease.acquire,
-                            on_cancel_result=lambda _result: lease.release(),
+                        await self._lifecycle_checkpoint(
+                            run_blocking(
+                                lease.acquire,
+                                on_cancel_result=lambda _result: lease.release(),
+                            )
                         )
                     except MemoryOperationBusy:
                         continue
@@ -2250,13 +2131,16 @@ class MemoryRuntime:
                 self._wake_config.enabled
                 and not self.available
                 and not self.needs_repair
-                and not await run_blocking(self._open_store)
             ):
-                return {
-                    "ok": False,
-                    "state": "needs_repair" if self.needs_repair else "degraded",
-                    "error": self._runtime_error or "memory_store_unavailable",
-                }
+                opened = await self._lifecycle_checkpoint(
+                    run_blocking(self._open_store)
+                )
+                if not opened:
+                    return {
+                        "ok": False,
+                        "state": "needs_repair" if self.needs_repair else "degraded",
+                        "error": self._runtime_error or "memory_store_unavailable",
+                    }
             self.start_capture_adapter()
             if self.needs_repair:
                 return {
@@ -2270,26 +2154,37 @@ class MemoryRuntime:
                     "state": "disabled",
                     "error": "memory_disabled",
                 }
-            if not await run_blocking(self.artifact_admitted):
+            artifact_admitted = await self._lifecycle_checkpoint(
+                run_blocking(self.artifact_admitted)
+            )
+            if not artifact_admitted:
                 if self.available:
                     async with self._reconcile_lock, self.module.lifecycle():
+                        self._require_lifecycle_work()
                         self.module.pause_claims()
-                        if not await self.module.quiesce_claims(timeout_seconds=5.0):
+                        quiesced = await self._lifecycle_checkpoint(
+                            self.module.quiesce_claims(timeout_seconds=5.0)
+                        )
+                        if not quiesced:
                             return {
                                 "ok": False,
                                 "state": "degraded",
                                 "error": "memory_runtime_busy",
                             }
-                        await self._close_writer()
+                        await self._lifecycle_checkpoint(self._close_writer())
                         try:
-                            await self._supervisor.stop()
+                            await self._lifecycle_checkpoint(self._supervisor.stop())
+                        except MemoryRuntimeBusyError:
+                            raise
                         except Exception:
                             return {
                                 "ok": False,
                                 "state": "degraded",
                                 "error": "memory_wake_failed",
                             }
-                installed = await self._install_artifact_with_lease()
+                installed = await self._lifecycle_checkpoint(
+                    self._install_artifact_with_lease()
+                )
                 if installed.get("ok") is not True:
                     self._runtime_error = str(
                         installed.get("reason") or "memory_wake_failed"
@@ -2307,7 +2202,14 @@ class MemoryRuntime:
                         "error": self._runtime_error,
                     }
             async with self._reconcile_lock:
+                self._require_lifecycle_work()
                 return await self._wake_locked()
+        except MemoryRuntimeBusyError:
+            return {
+                "ok": False,
+                "state": self.runtime_state(),
+                "error": "memory_operation_in_progress",
+            }
         except MemoryOperationBusy:
             return {"ok": False, "error": "memory_operation_in_progress"}
         except Exception as exc:
@@ -2338,7 +2240,7 @@ class MemoryRuntime:
     def _current_sidecar_unavailable(self) -> None:
         """Project supervisor-owned crash state into Memory policy."""
 
-        if self._closing or self._retired or self.needs_repair:
+        if self._closing or self.needs_repair:
             return
         self.module.pause_claims()
         self._runtime_error = "memory_sidecar_unavailable"
@@ -2400,8 +2302,7 @@ class MemoryRuntime:
     async def _wake_locked(self) -> dict[str, Any]:
         """Wake the admitted sidecar while preserving the existing data root."""
 
-        if self._closing or self._retired:
-            return {"ok": False, "error": "memory_operation_in_progress"}
+        self._require_lifecycle_work()
         if self.needs_repair:
             return {
                 "ok": False,
@@ -2421,17 +2322,24 @@ class MemoryRuntime:
         replay = deepcopy(self._wake_config)
         if not replay.enabled:
             return {"ok": False, "state": "disabled", "error": "memory_disabled"}
-        python = await asyncio.to_thread(self._artifact_manager.resolve_python)
+        python = await self._lifecycle_checkpoint(
+            asyncio.to_thread(self._artifact_manager.resolve_python)
+        )
         if python is None:
             self._runtime_error = "memory_wake_failed"
             return {"ok": False, "state": "degraded", "error": self._runtime_error}
 
         async with self.module.lifecycle():
+            self._require_lifecycle_work()
             self.module.pause_claims()
             try:
-                quiesced = await self.module.quiesce_claims(timeout_seconds=5.0)
+                quiesced = await self._lifecycle_checkpoint(
+                    self.module.quiesce_claims(timeout_seconds=5.0)
+                )
                 if quiesced:
-                    await self._close_writer()
+                    await self._lifecycle_checkpoint(self._close_writer())
+            except MemoryRuntimeBusyError:
+                raise
             except Exception:
                 quiesced = False
             if not quiesced:
@@ -2439,7 +2347,9 @@ class MemoryRuntime:
                 return {"ok": False, "state": "degraded", "error": self._runtime_error}
 
             try:
-                await self._supervisor.stop()
+                await self._lifecycle_checkpoint(self._supervisor.stop())
+            except MemoryRuntimeBusyError:
+                raise
             except Exception:
                 logger.exception("Memory wake could not prove the old sidecar stopped")
                 self._runtime_error = "memory_wake_failed"
@@ -2454,13 +2364,19 @@ class MemoryRuntime:
             )
             self.module.replace_provider(self._provider)
             try:
-                meta = await asyncio.to_thread(self._store.ensure_meta)
-                active_metadata = self._active_provider_root_metadata()
-                await run_blocking(
-                    self._provider_root_owner.ensure,
-                    meta,
-                    active_metadata,
+                meta = await self._lifecycle_checkpoint(
+                    asyncio.to_thread(self._store.ensure_meta)
                 )
+                active_metadata = self._active_provider_root_metadata()
+                await self._lifecycle_checkpoint(
+                    run_blocking(
+                        self._provider_root_owner.ensure,
+                        meta,
+                        active_metadata,
+                    )
+                )
+            except MemoryRuntimeBusyError:
+                raise
             except Exception as exc:
                 if _local_data_failure_requires_repair(exc):
                     self._needs_repair_reason = "memory_local_data_unusable"
@@ -2472,14 +2388,18 @@ class MemoryRuntime:
                 return {"ok": False, "state": state, "error": self._runtime_error}
 
             try:
-                started = await self._supervisor.wake(
-                    python,
-                    _process_settings(replay),
-                    provider_root_guard=lambda: self._provider_root_owner.require_owned(
-                        meta,
-                        active_metadata,
-                    ),
+                started = await self._lifecycle_checkpoint(
+                    self._supervisor.wake(
+                        python,
+                        _process_settings(replay),
+                        provider_root_guard=lambda: self._require_current_provider_root(
+                            meta,
+                            active_metadata,
+                        ),
+                    )
                 )
+            except MemoryRuntimeBusyError:
+                raise
             except Exception as exc:
                 self._runtime_error = _degraded_runtime_reason(
                     exc,
@@ -2494,8 +2414,9 @@ class MemoryRuntime:
             for delay in (0.0, 0.25, 0.5, 1.0):
                 if delay:
                     await asyncio.sleep(delay)
+                    self._require_lifecycle_work()
                 try:
-                    await self._provider.health_snapshot()
+                    await self._lifecycle_checkpoint(self._provider.health_snapshot())
                     readiness_error = None
                     break
                 except MemoryProviderFailure as failure:
@@ -2508,6 +2429,7 @@ class MemoryRuntime:
                 return {"ok": False, "state": "degraded", "error": readiness_error}
 
             self._runtime_error = None
+            self._require_lifecycle_work()
             self.module.resume_claims()
             self._resume_writer()
             return {"ok": True, "state": "running"}
@@ -2522,44 +2444,46 @@ class MemoryRuntime:
                 name="memory-runtime-close",
             )
         cancellation = await self._join_shutdown_task(self._close_task)
-        cleanup_error: BaseException | None = None
-        try:
-            self._close_task.result()
-        except BaseException as error:
-            cleanup_error = error
+        error = self._close_task.exception()
         if cancellation is not None:
-            if cleanup_error is not None:
-                logger.error(
-                    "Memory runtime cleanup failed while close was cancelled: %s",
-                    cleanup_error,
-                )
+            if error is not None:
+                logger.error("Memory close failed during cancellation: %s", error)
             raise cancellation
-        if cleanup_error is not None:
-            raise cleanup_error
+        if error is not None:
+            raise error
 
     async def _close_once(self) -> None:
-        local_failures: list[str] = []
-        if not await self._run_bounded_close_phase(
-            self._cancel_capture_tasks(),
-            timeout_seconds=MEMORY_CAPTURE_CLOSE_TIMEOUT_SECONDS,
-            label="capture cancellation",
-        ):
-            local_failures.append("capture cancellation")
-        if not await self._run_bounded_close_phase(
-            self._close_local_runtime(),
-            timeout_seconds=MEMORY_LOCAL_CLOSE_TIMEOUT_SECONDS,
-            label="local cleanup",
-        ):
-            local_failures.append("local cleanup")
-
-        await self._close_provider_root()
-        self._artifact_manager.set_activation_coordinator(None)
-        self._advance_lifecycle_revision()
-        if local_failures:
-            logger.warning(
-                "Memory runtime crossed its provider stop boundary after bounded %s",
-                " and ".join(local_failures),
+        local_proved = True
+        phases = (
+            (
+                self._cancel_capture_tasks(),
+                MEMORY_CAPTURE_CLOSE_TIMEOUT_SECONDS,
+                "capture cancellation",
+            ),
+            (
+                self._close_local_runtime(),
+                MEMORY_LOCAL_CLOSE_TIMEOUT_SECONDS,
+                "local cleanup",
+            ),
+        )
+        for operation, timeout_seconds, label in phases:
+            proved = await self._run_bounded_close_phase(
+                operation,
+                timeout_seconds=timeout_seconds,
+                label=label,
             )
+            local_proved = proved and local_proved
+        self._artifact_manager.set_activation_coordinator(None)
+        provider_proved = await self._run_bounded_close_phase(
+            self._supervisor.close(),
+            timeout_seconds=MEMORY_PROVIDER_CLOSE_TIMEOUT_SECONDS,
+            label="provider stop",
+        )
+        if not provider_proved:
+            raise RuntimeError("Memory provider stop did not prove completion")
+        if not local_proved:
+            raise RuntimeError("Memory local cleanup did not prove completion")
+        self._runtime_authority.release()
 
     async def _cancel_capture_tasks(self) -> None:
         cancel_capture = getattr(
@@ -2585,57 +2509,33 @@ class MemoryRuntime:
                 label,
                 timeout_seconds,
             )
-            task.add_done_callback(
-                lambda settled: self._log_late_close_phase(settled, label)
-            )
+            task.add_done_callback(self._log_late_close)
             task.cancel()
             return False
-        try:
-            task.result()
-        except asyncio.CancelledError:
+        if task.cancelled():
             logger.error("Memory %s was cancelled during close", label)
             return False
-        except Exception:
-            logger.exception("Memory %s failed during close", label)
+        error = task.exception()
+        if error is not None:
+            logger.error(
+                "Memory %s failed during close",
+                label,
+                exc_info=(type(error), error, error.__traceback__),
+            )
             return False
         return True
 
     @staticmethod
-    def _log_late_close_phase(task: asyncio.Task[None], label: str) -> None:
-        try:
-            task.result()
-        except asyncio.CancelledError:
-            return
-        except Exception:
-            logger.error("Memory %s failed after its close budget", label, exc_info=True)
-
-    async def _close_provider_root(self) -> None:
-        if self._provider_close_task is None:
-            self._provider_close_task = asyncio.create_task(
-                self._supervisor.close(),
-                name="memory-provider-root-close",
-            )
-            self._provider_close_task.add_done_callback(
-                self._release_root_after_provider_close
-            )
-        done, _pending = await asyncio.wait(
-            {self._provider_close_task},
-            timeout=MEMORY_PROVIDER_CLOSE_TIMEOUT_SECONDS,
-        )
-        if self._provider_close_task not in done:
-            raise TimeoutError(
-                "Memory provider stop did not complete within its close budget"
-            )
-        self._provider_close_task.result()
-
-    def _release_root_after_provider_close(self, task: asyncio.Task[None]) -> None:
+    def _log_late_close(task: asyncio.Task[None]) -> None:
         if task.cancelled():
             return
-        try:
-            task.result()
-        except Exception:
-            return
-        self._runtime_authority.release()
+        error = task.exception()
+        if error is not None:
+            logger.error(
+                "%s failed after its close budget",
+                task.get_name(),
+                exc_info=(type(error), error, error.__traceback__),
+            )
 
     @staticmethod
     async def _join_shutdown_task(
@@ -2658,7 +2558,6 @@ class MemoryRuntime:
     async def _close_local_runtime(self) -> None:
         """Settle local tasks without deciding provider-root ownership."""
 
-        cleanup_error: BaseException | None = None
         wake = self._wake_task
         if wake is not None and wake is not asyncio.current_task():
             if not wake.done():
@@ -2678,24 +2577,10 @@ class MemoryRuntime:
                 pass
         if self._module is not None:
             self._module.pause_claims()
-            try:
-                await self._close_writer()
-            except BaseException as error:
-                cleanup_error = error
             async with self._module.provider_root_lifecycle():
-                try:
-                    if (
-                        self._retired
-                        and not await self._module.quiesce_claims_for_destructive_reset()
-                    ):
-                        raise RuntimeError(
-                            "Memory writer did not quiesce during retired close"
-                        )
-                    await self._module.close_writer()
-                except BaseException as error:
-                    cleanup_error = cleanup_error or error
-        if cleanup_error is not None:
-            raise cleanup_error
+                if not await self._module.quiesce_claims_for_destructive_reset():
+                    raise RuntimeError("Memory writer did not quiesce during close")
+                await self._module.close_writer()
 
     def _active_provider_root_metadata(self) -> ProviderRootMetadata:
         provider_root_format = (
@@ -2721,8 +2606,7 @@ class MemoryRuntime:
     ) -> None:
         """Reject a launch after this runtime's root authority was revoked."""
 
-        if not self._accepts_lifecycle_work():
-            raise ProviderRootError("Memory runtime authority was revoked")
+        self._require_lifecycle_work()
         self._provider_root_owner.require_owned(meta, active_metadata)
 
     def _coordinate_artifact_activation(
@@ -2922,7 +2806,7 @@ class MemoryRuntime:
         """Prove old ownership ended and reuse the settled runtime when requested."""
 
         await self._supervisor.stop()
-        if recover and not self._closing and not self._retired:
+        if recover and not self._closing:
             self._defer_wake_until_writer_closed()
         return True
 

--- a/avibe_memory/runtime.py
+++ b/avibe_memory/runtime.py
@@ -2196,15 +2196,14 @@ class MemoryRuntime:
                         await asyncio.sleep(delay_seconds)
                     self._require_lifecycle_work()
                     try:
-                        await self._lifecycle_checkpoint(
-                            run_blocking(
-                                lease.acquire,
-                                on_cancel_result=lambda _result: lease.release(),
-                            )
+                        await run_blocking(
+                            lease.acquire,
+                            on_cancel_result=lambda _result: lease.release(),
                         )
                     except MemoryOperationBusy:
                         continue
                     lease_acquired = True
+                    self._require_lifecycle_work()
                     break
                 if not lease_acquired:
                     self._runtime_error = "memory_operation_in_progress"

--- a/avibe_memory/store.py
+++ b/avibe_memory/store.py
@@ -230,10 +230,6 @@ class MemoryStore:
         with self._transaction() as conn:
             return derive_principal_id(self._ensure_meta(conn).scope_key, user_key)
 
-    def project_for_workdir(self, workdir: str) -> str:
-        with self._transaction() as conn:
-            return derive_project_id(self._ensure_meta(conn).scope_key, workdir)
-
     def source_message_digest(self, source_message_id: str) -> str:
         if not isinstance(source_message_id, str) or not source_message_id or "\x00" in source_message_id:
             raise ValueError("invalid Memory source message")

--- a/avibe_memory/supervisor.py
+++ b/avibe_memory/supervisor.py
@@ -36,7 +36,6 @@ class EverOSSupervisorStatus:
 
     state: Literal["stopped", "starting", "running", "degraded", "closed"]
     retains_configuration: bool
-    epoch: int
 
     @property
     def running(self) -> bool:
@@ -155,7 +154,6 @@ class EverOSSupervisor:
         return EverOSSupervisorStatus(
             state=state,
             retains_configuration=retains_configuration,
-            epoch=self._epoch,
         )
 
     def begin_close(self) -> None:

--- a/avibe_memory/supervisor.py
+++ b/avibe_memory/supervisor.py
@@ -36,6 +36,7 @@ class EverOSSupervisorStatus:
 
     state: Literal["stopped", "starting", "running", "degraded", "closed"]
     retains_configuration: bool
+    epoch: int
 
     @property
     def running(self) -> bool:
@@ -154,6 +155,7 @@ class EverOSSupervisor:
         return EverOSSupervisorStatus(
             state=state,
             retains_configuration=retains_configuration,
+            epoch=self._epoch,
         )
 
     def begin_close(self) -> None:

--- a/avibe_memory/writer.py
+++ b/avibe_memory/writer.py
@@ -118,6 +118,7 @@ class BestEffortMemoryWriter:
         store: MemoryStore,
         provider: MemoryProviderPort,
         enabled: Callable[[], bool],
+        runtime_active: Callable[[], bool] | None = None,
         attachment_store: AttachmentPinStore | None = None,
         ambiguous_stop_reap: AmbiguousStop | None = None,
         now: Callable[[], datetime] | None = None,
@@ -127,6 +128,7 @@ class BestEffortMemoryWriter:
         self._store = store
         self._provider = provider
         self._enabled = enabled
+        self._runtime_active = runtime_active or (lambda: True)
         self._attachment_store = attachment_store
         self._ambiguous_stop_reap = ambiguous_stop_reap
         self._now = now or (lambda: datetime.now(timezone.utc))
@@ -147,6 +149,7 @@ class BestEffortMemoryWriter:
         self._closed = False
         self._unavailable = False
         self._attachments_disabled = False
+        self._retired = False
         self.dropped = 0
 
     @property
@@ -179,6 +182,18 @@ class BestEffortMemoryWriter:
     def pause_intake(self) -> None:
         self._intake_paused = True
 
+    def retire(self) -> None:
+        """Permanently revoke this writer before its runtime is detached."""
+
+        self._retired = True
+        self._intake_paused = True
+
+    def _owns_runtime(self) -> bool:
+        try:
+            return not self._retired and bool(self._runtime_active())
+        except Exception:
+            return False
+
     def resume_intake(self) -> None:
         # ``_closed`` independently fences a settling cleanup. Clearing the
         # pause records recovery intent without reopening that old work early.
@@ -209,6 +224,8 @@ class BestEffortMemoryWriter:
     ) -> WriterReservation | Literal["full", "disabled", "unavailable"]:
         """Claim capacity before deferred capture work performs I/O."""
 
+        if not self._owns_runtime():
+            return "disabled"
         if self._unavailable:
             return "unavailable"
         if self._closed or self._intake_paused or not self._enabled():
@@ -230,6 +247,9 @@ class BestEffortMemoryWriter:
             or not reservation.active
             or reservation.digest is not None
         ):
+            return "disabled"
+        if not self._owns_runtime():
+            reservation.abandon()
             return "disabled"
         if self._unavailable:
             reservation.abandon()
@@ -263,6 +283,8 @@ class BestEffortMemoryWriter:
             or reservation.digest is None
             or admission.outcome != "accepted"
         ):
+            return "disabled"
+        if not self._owns_runtime():
             return "disabled"
         if self._unavailable:
             return "unavailable"
@@ -305,6 +327,7 @@ class BestEffortMemoryWriter:
             or self._closed
             or self._intake_paused
             or self._unavailable
+            or not self._owns_runtime()
             or not self._enabled()
         ):
             return "disabled"
@@ -323,7 +346,7 @@ class BestEffortMemoryWriter:
         return "queued"
 
     async def quiesce(self, *, timeout_seconds: float = 30.0) -> bool:
-        """Join current generation admissions for authority-changing transitions."""
+        """Join current admissions for authority-changing transitions."""
 
         self.pause_intake()
         loop = asyncio.get_running_loop()
@@ -464,6 +487,9 @@ class BestEffortMemoryWriter:
                 self._queued_items = max(0, self._queued_items - 1)
 
     async def _deliver(self, item: _CaptureItem) -> None:
+        if not self._owns_runtime():
+            await self._cleanup_item(item)
+            return
         capture = item.capture
         attachments = capture.attachments
         if item.bundle is not None and self._attachment_store is not None:
@@ -488,6 +514,9 @@ class BestEffortMemoryWriter:
         )
         attempt = 0
         while attempt < MAX_ATTEMPTS:
+            if not self._owns_runtime():
+                await self._cleanup_item(item)
+                return
             attempt += 1
             self._active_provider_calls += 1
             try:
@@ -524,6 +553,10 @@ class BestEffortMemoryWriter:
             finally:
                 self._active_provider_calls = max(0, self._active_provider_calls - 1)
 
+            if not self._owns_runtime():
+                await self._cleanup_item(item)
+                return
+
             if (
                 isinstance(result, AddAck)
                 and result.status in {"accumulated", "extracted"}
@@ -552,6 +585,9 @@ class BestEffortMemoryWriter:
             return
 
     async def _success(self, item: _CaptureItem, *, extracted: bool) -> None:
+        if not self._owns_runtime():
+            await self._cleanup_item(item)
+            return
         try:
             await run_blocking(self._store.mark_capture_success)
         except Exception:
@@ -576,6 +612,9 @@ class BestEffortMemoryWriter:
         await self._cleanup_item(item)
 
     async def _terminal_failure(self, item: _CaptureItem, error: str) -> None:
+        if not self._owns_runtime():
+            await self._cleanup_item(item)
+            return
         try:
             await run_blocking(self._store.set_last_error, error)
         except Exception:
@@ -626,6 +665,9 @@ class BestEffortMemoryWriter:
                 continue
             result: FlushResult | None = None
             for attempt in range(1, MAX_ATTEMPTS + 1):
+                if not self._owns_runtime():
+                    self._pending.pop(key, None)
+                    return
                 self._active_provider_calls += 1
                 try:
                     result = await self._provider.flush(ref)
@@ -706,6 +748,8 @@ class BestEffortMemoryWriter:
             return
 
     async def _ambiguous_outcome(self, _error: str, *, recover: bool = True) -> None:
+        if not self._owns_runtime():
+            return
         self._unavailable = True
         self._intake_paused = True
         self._pending.clear()

--- a/avibe_memory/writer.py
+++ b/avibe_memory/writer.py
@@ -118,7 +118,6 @@ class BestEffortMemoryWriter:
         store: MemoryStore,
         provider: MemoryProviderPort,
         enabled: Callable[[], bool],
-        runtime_active: Callable[[], bool] | None = None,
         attachment_store: AttachmentPinStore | None = None,
         ambiguous_stop_reap: AmbiguousStop | None = None,
         now: Callable[[], datetime] | None = None,
@@ -128,7 +127,6 @@ class BestEffortMemoryWriter:
         self._store = store
         self._provider = provider
         self._enabled = enabled
-        self._runtime_active = runtime_active or (lambda: True)
         self._attachment_store = attachment_store
         self._ambiguous_stop_reap = ambiguous_stop_reap
         self._now = now or (lambda: datetime.now(timezone.utc))
@@ -149,7 +147,6 @@ class BestEffortMemoryWriter:
         self._closed = False
         self._unavailable = False
         self._attachments_disabled = False
-        self._retired = False
         self.dropped = 0
 
     @property
@@ -182,18 +179,6 @@ class BestEffortMemoryWriter:
     def pause_intake(self) -> None:
         self._intake_paused = True
 
-    def retire(self) -> None:
-        """Permanently revoke this writer before its runtime is detached."""
-
-        self._retired = True
-        self._intake_paused = True
-
-    def _owns_runtime(self) -> bool:
-        try:
-            return not self._retired and bool(self._runtime_active())
-        except Exception:
-            return False
-
     def resume_intake(self) -> None:
         # ``_closed`` independently fences a settling cleanup. Clearing the
         # pause records recovery intent without reopening that old work early.
@@ -224,8 +209,6 @@ class BestEffortMemoryWriter:
     ) -> WriterReservation | Literal["full", "disabled", "unavailable"]:
         """Claim capacity before deferred capture work performs I/O."""
 
-        if not self._owns_runtime():
-            return "disabled"
         if self._unavailable:
             return "unavailable"
         if self._closed or self._intake_paused or not self._enabled():
@@ -247,9 +230,6 @@ class BestEffortMemoryWriter:
             or not reservation.active
             or reservation.digest is not None
         ):
-            return "disabled"
-        if not self._owns_runtime():
-            reservation.abandon()
             return "disabled"
         if self._unavailable:
             reservation.abandon()
@@ -283,8 +263,6 @@ class BestEffortMemoryWriter:
             or reservation.digest is None
             or admission.outcome != "accepted"
         ):
-            return "disabled"
-        if not self._owns_runtime():
             return "disabled"
         if self._unavailable:
             return "unavailable"
@@ -327,7 +305,6 @@ class BestEffortMemoryWriter:
             or self._closed
             or self._intake_paused
             or self._unavailable
-            or not self._owns_runtime()
             or not self._enabled()
         ):
             return "disabled"
@@ -487,7 +464,7 @@ class BestEffortMemoryWriter:
                 self._queued_items = max(0, self._queued_items - 1)
 
     async def _deliver(self, item: _CaptureItem) -> None:
-        if not self._owns_runtime():
+        if not self._enabled():
             await self._cleanup_item(item)
             return
         capture = item.capture
@@ -514,7 +491,7 @@ class BestEffortMemoryWriter:
         )
         attempt = 0
         while attempt < MAX_ATTEMPTS:
-            if not self._owns_runtime():
+            if not self._enabled():
                 await self._cleanup_item(item)
                 return
             attempt += 1
@@ -553,7 +530,7 @@ class BestEffortMemoryWriter:
             finally:
                 self._active_provider_calls = max(0, self._active_provider_calls - 1)
 
-            if not self._owns_runtime():
+            if not self._enabled():
                 await self._cleanup_item(item)
                 return
 
@@ -585,7 +562,7 @@ class BestEffortMemoryWriter:
             return
 
     async def _success(self, item: _CaptureItem, *, extracted: bool) -> None:
-        if not self._owns_runtime():
+        if not self._enabled():
             await self._cleanup_item(item)
             return
         try:
@@ -612,7 +589,7 @@ class BestEffortMemoryWriter:
         await self._cleanup_item(item)
 
     async def _terminal_failure(self, item: _CaptureItem, error: str) -> None:
-        if not self._owns_runtime():
+        if not self._enabled():
             await self._cleanup_item(item)
             return
         try:
@@ -665,7 +642,7 @@ class BestEffortMemoryWriter:
                 continue
             result: FlushResult | None = None
             for attempt in range(1, MAX_ATTEMPTS + 1):
-                if not self._owns_runtime():
+                if not self._enabled():
                     self._pending.pop(key, None)
                     return
                 self._active_provider_calls += 1
@@ -748,7 +725,7 @@ class BestEffortMemoryWriter:
             return
 
     async def _ambiguous_outcome(self, _error: str, *, recover: bool = True) -> None:
-        if not self._owns_runtime():
+        if not self._enabled():
             return
         self._unavailable = True
         self._intake_paused = True

--- a/avibe_memory/writer.py
+++ b/avibe_memory/writer.py
@@ -530,10 +530,6 @@ class BestEffortMemoryWriter:
             finally:
                 self._active_provider_calls = max(0, self._active_provider_calls - 1)
 
-            if not self._enabled():
-                await self._cleanup_item(item)
-                return
-
             if (
                 isinstance(result, AddAck)
                 and result.status in {"accumulated", "extracted"}

--- a/core/controller.py
+++ b/core/controller.py
@@ -67,6 +67,7 @@ from vibe.i18n import get_supported_languages, t as i18n_t
 from vibe.memory_contract import (
     MemoryPluginIncompatibleError,
     MemoryPluginUnavailableError,
+    MemoryRuntimeBusyError,
     MemoryStoreUnavailableError,
 )
 from vibe.runtime import mark_service_instance_started
@@ -834,6 +835,8 @@ class Controller:
             return await runtime.preflight(memory_config)
         try:
             runtime = self._create_memory_runtime(memory_config)
+        except MemoryRuntimeBusyError:
+            return {"ok": False, "error": "memory_operation_in_progress"}
         except (MemoryPluginUnavailableError, MemoryPluginIncompatibleError) as exc:
             self._memory_plugin_error = exc
             raise
@@ -857,6 +860,12 @@ class Controller:
                 self.config.memory,
                 allow_disabled=True,
             )
+        except MemoryRuntimeBusyError:
+            return {
+                "ok": False,
+                "reason": "memory_operation_in_progress",
+                "download_error": None,
+            }
         except (MemoryPluginUnavailableError, MemoryPluginIncompatibleError) as exc:
             self._memory_plugin_error = exc
             raise
@@ -887,6 +896,8 @@ class Controller:
         if created:
             try:
                 runtime = self._create_memory_runtime(memory_config)
+            except MemoryRuntimeBusyError:
+                return {"ok": False, "error": "memory_operation_in_progress"}
             except (
                 MemoryPluginUnavailableError,
                 MemoryPluginIncompatibleError,
@@ -1624,6 +1635,22 @@ class Controller:
                     reason="operation_lock_failed",
                 )
 
+            async def close_reset_runtime() -> dict[str, Any] | None:
+                runtime.begin_close()
+                try:
+                    await runtime.close()
+                except BaseException:
+                    logger.exception("Memory data reset could not close the owned runtime")
+                    runtime.mark_needs_repair(f"memory_{operation}_failed")
+                    failure = unchanged_memory_data_result(
+                        runtime.effective_home,
+                        operation=operation,
+                        reason="runtime_termination_unproved",
+                    )
+                    failure["state"] = "needs_repair"
+                    return failure
+                return None
+
             try:
                 if getattr(runtime, "_artifact_installing", False):
                     return {
@@ -1644,6 +1671,16 @@ class Controller:
                         reason="sidecar_termination_unproved",
                     )
 
+                if attached:
+                    detached = await self._detach_memory_runtime(runtime)
+                    if detached is not runtime:
+                        return {
+                            "ok": False,
+                            "operation": operation,
+                            "error": "memory_operation_in_progress",
+                            "result": "unchanged",
+                        }
+
                 target = replace(
                     deepcopy(target_config or self.config.memory),
                     legacy_needs_repair=False,
@@ -1663,6 +1700,8 @@ class Controller:
                         )
                     ).memory
                 except MemoryConfigStaleWrite:
+                    if failure := await close_reset_runtime():
+                        return failure
                     return {
                         "ok": False,
                         "operation": operation,
@@ -1673,6 +1712,8 @@ class Controller:
                     logger.exception(
                         "Memory data reset could not persist its repair fence"
                     )
+                    if failure := await close_reset_runtime():
+                        return failure
                     return unchanged_memory_data_result(
                         runtime.effective_home,
                         operation=operation,
@@ -1687,28 +1728,7 @@ class Controller:
                         return target
                     return replace(current, legacy_needs_repair=False)
 
-                if attached:
-                    detached = await self._detach_memory_runtime(runtime)
-                    if detached is not runtime:
-                        return {
-                            "ok": False,
-                            "operation": operation,
-                            "error": "memory_operation_in_progress",
-                            "result": "unchanged",
-                        }
-                else:
-                    runtime.begin_close()
-                try:
-                    await runtime.close()
-                except BaseException:
-                    logger.exception("Memory data reset could not close the owned runtime")
-                    runtime.mark_needs_repair(f"memory_{operation}_failed")
-                    failure = unchanged_memory_data_result(
-                        runtime.effective_home,
-                        operation=operation,
-                        reason="runtime_termination_unproved",
-                    )
-                    failure["state"] = "needs_repair"
+                if failure := await close_reset_runtime():
                     return failure
                 try:
                     await runtime.settle_after_data_loss()

--- a/core/controller.py
+++ b/core/controller.py
@@ -1714,6 +1714,13 @@ class Controller:
             logger.error("Memory runtime close failed during shutdown", exc_info=True)
 
     async def _close_memory_runtime_for_shutdown(self, *, timeout_seconds: float) -> None:
+        if any(
+            not task.done()
+            for task in getattr(self, "_memory_destructive_tasks", ())
+        ):
+            raise MemoryRuntimeBusyError(
+                "Memory destructive operation is still active"
+            )
         runtime = await self._detach_memory_runtime()
         if runtime is not None:
             await runtime.close(timeout_seconds=timeout_seconds)

--- a/core/controller.py
+++ b/core/controller.py
@@ -810,6 +810,28 @@ class Controller:
             self.memory_module = None
             return current
 
+    async def _activate_memory_replacement(
+        self,
+        previous: "MemoryRuntime",
+        config: MemoryConfig,
+    ) -> tuple["MemoryRuntime", dict[str, Any]]:
+        """Attach one successor after the previous runtime proved closed."""
+
+        fresh = previous.replacement(config)
+        try:
+            await self._attach_memory_runtime(fresh, capture_enabled=True)
+        except BaseException:
+            fresh.begin_close()
+            try:
+                await fresh.close()
+            except Exception:
+                logger.warning(
+                    "Unattached Memory replacement did not close cleanly",
+                    exc_info=True,
+                )
+            raise
+        return fresh, await fresh.wake(operation_lease_held=True)
+
     async def _memory_runtime_for_operation(self) -> "MemoryRuntime":
         """Snapshot the enabled runtime without retaining a host lifecycle lease."""
 
@@ -821,7 +843,7 @@ class Controller:
             plugin_error = getattr(self, "_memory_plugin_error", None)
             if runtime is None and plugin_error is not None:
                 raise plugin_error
-        if runtime is None or getattr(runtime, "retired", False):
+        if runtime is None:
             raise MemoryStoreUnavailableError("Memory runtime is unavailable")
         return runtime
 
@@ -953,7 +975,7 @@ class Controller:
             if plugin_error is not None:
                 raise plugin_error
             runtime = getattr(self, "memory_runtime", None)
-            if runtime is None or getattr(runtime, "retired", False):
+            if runtime is None:
                 return CaptureSkipped(reason="memory_operation_in_progress")
             if not runtime.available:
                 return CaptureSkipped(reason="memory_store_unavailable")
@@ -1454,7 +1476,7 @@ class Controller:
     @asynccontextmanager
     async def _memory_runtime_for_data_reset(
         self,
-    ) -> AsyncIterator[tuple["MemoryRuntime", bool]]:
+    ) -> AsyncIterator[tuple["MemoryRuntime" | None, bool]]:
         """Provide the current runtime or an unpublished disabled-mode runtime."""
 
         await self._await_disabled_memory_cleanup()
@@ -1462,10 +1484,14 @@ class Controller:
             runtime = getattr(self, "memory_runtime", None)
         attached = runtime is not None
         if runtime is None:
-            runtime = self._create_memory_runtime(
-                self.config.memory,
-                allow_disabled=True,
-            )
+            try:
+                runtime = self._create_memory_runtime(
+                    self.config.memory,
+                    allow_disabled=True,
+                )
+            except MemoryRuntimeBusyError:
+                yield None, False
+                return
         try:
             yield runtime, attached
         finally:
@@ -1609,6 +1635,14 @@ class Controller:
                 unchanged_memory_data_result,
             )
 
+            if runtime is None:
+                return {
+                    "ok": False,
+                    "operation": operation,
+                    "error": "memory_operation_in_progress",
+                    "result": "unchanged",
+                }
+
             if operation == "repair" and not runtime.needs_repair:
                 return {
                     "ok": False,
@@ -1650,6 +1684,47 @@ class Controller:
                     failure["state"] = "needs_repair"
                     return failure
                 return None
+
+            async def restore_after_fence_failure(
+                failure: dict[str, Any],
+            ) -> dict[str, Any]:
+                try:
+                    live_config = (await run_blocking(V2Config.load)).memory
+                except Exception:
+                    logger.exception(
+                        "Memory could not reload configuration after reset fencing failed"
+                    )
+                    failure.update(state="degraded", result="runtime_restore_failed")
+                    return failure
+                self.config.memory = live_config
+                if not live_config.enabled:
+                    failure["state"] = "disabled"
+                    return failure
+                try:
+                    _fresh, activation = await self._activate_memory_replacement(
+                        runtime,
+                        live_config,
+                    )
+                except MemoryRuntimeBusyError:
+                    failure.update(
+                        state="degraded",
+                        error="memory_operation_in_progress",
+                        result="runtime_restore_failed",
+                    )
+                    return failure
+                except Exception:
+                    logger.exception(
+                        "Memory could not restore its enabled runtime after fencing failed"
+                    )
+                    failure.update(state="degraded", result="runtime_restore_failed")
+                    return failure
+                failure["state"] = str(activation.get("state") or "degraded")
+                if activation.get("ok") is not True:
+                    failure.update(
+                        error=activation.get("error", failure.get("error")),
+                        result="runtime_restore_failed",
+                    )
+                return failure
 
             try:
                 if getattr(runtime, "_artifact_installing", False):
@@ -1702,22 +1777,24 @@ class Controller:
                 except MemoryConfigStaleWrite:
                     if failure := await close_reset_runtime():
                         return failure
-                    return {
+                    return await restore_after_fence_failure({
                         "ok": False,
                         "operation": operation,
                         "error": "memory_operation_in_progress",
                         "result": "unchanged",
-                    }
+                    })
                 except Exception:
                     logger.exception(
                         "Memory data reset could not persist its repair fence"
                     )
                     if failure := await close_reset_runtime():
                         return failure
-                    return unchanged_memory_data_result(
-                        runtime.effective_home,
-                        operation=operation,
-                        reason="config_persist_failed",
+                    return await restore_after_fence_failure(
+                        unchanged_memory_data_result(
+                            runtime.effective_home,
+                            operation=operation,
+                            reason="config_persist_failed",
+                        )
                     )
                 self.config.memory = fenced_config
 
@@ -1786,13 +1863,11 @@ class Controller:
                     self.config.memory = live_config
                     fallback_state = "disabled"
                     if live_config.enabled:
-                        fallback = runtime.replacement(live_config)
-                        await self._attach_memory_runtime(
-                            fallback,
-                            capture_enabled=True,
-                        )
-                        fallback_activation = await fallback.wake(
-                            operation_lease_held=True
+                        _fallback, fallback_activation = (
+                            await self._activate_memory_replacement(
+                                runtime,
+                                live_config,
+                            )
                         )
                         fallback_state = str(
                             fallback_activation.get("state") or "degraded"
@@ -1821,9 +1896,10 @@ class Controller:
                         "result": "completed",
                         **deletion_payload,
                     }
-                fresh = runtime.replacement(target)
-                await self._attach_memory_runtime(fresh, capture_enabled=True)
-                activation = await fresh.wake(operation_lease_held=True)
+                fresh, activation = await self._activate_memory_replacement(
+                    runtime,
+                    target,
+                )
                 if activation.get("ok") is not True:
                     state = activation.get("state")
                     if state == "needs_repair" and not fresh.needs_repair:

--- a/core/controller.py
+++ b/core/controller.py
@@ -1239,7 +1239,7 @@ class Controller:
             verified_user_key=verified_user_key
         )
 
-    def _memory_scope_for_runtime(
+    async def _memory_scope_for_runtime(
         self,
         runtime: "MemoryRuntime",
         *,
@@ -1251,7 +1251,7 @@ class Controller:
         try:
             if verified_user_key is not None:
                 scope = (
-                    runtime.principal_for_user_key(verified_user_key),
+                    await runtime.resolve_principal_for_user_key(verified_user_key),
                     self.default_memory_project_id(),
                 )
             else:
@@ -1281,10 +1281,7 @@ class Controller:
         if project_id is None or project_id == default_project_id:
             return scope
         try:
-            catalog = await run_blocking(
-                runtime.list_memory_projects,
-                principal_id,
-            )
+            catalog = await runtime.list_memory_projects(principal_id)
         except Exception as exc:
             raise MemoryStoreUnavailableError(
                 "Memory store is unavailable"
@@ -1300,7 +1297,7 @@ class Controller:
         cli_scope: tuple[str, str] | None,
     ) -> dict[str, Any]:
         runtime = await self._memory_runtime_for_operation()
-        scope = self._memory_scope_for_runtime(
+        scope = await self._memory_scope_for_runtime(
             runtime,
             verified_user_key=verified_user_key,
             cli_scope=cli_scope,
@@ -1317,7 +1314,7 @@ class Controller:
         cli_scope: tuple[str, str] | None,
     ) -> dict[str, Any]:
         runtime = await self._memory_runtime_for_operation()
-        scope = self._memory_scope_for_runtime(
+        scope = await self._memory_scope_for_runtime(
             runtime,
             verified_user_key=verified_user_key,
             cli_scope=cli_scope,
@@ -1338,7 +1335,7 @@ class Controller:
         cli_scope: tuple[str, str] | None,
     ) -> dict[str, Any]:
         runtime = await self._memory_runtime_for_operation()
-        scope = self._memory_scope_for_runtime(
+        scope = await self._memory_scope_for_runtime(
             runtime,
             verified_user_key=verified_user_key,
             cli_scope=cli_scope,
@@ -1358,16 +1355,13 @@ class Controller:
         )
 
         runtime = await self._memory_runtime_for_operation()
-        principal_id, _project_id = self._memory_scope_for_runtime(
+        principal_id, _project_id = await self._memory_scope_for_runtime(
             runtime,
             verified_user_key=verified_user_key,
             cli_scope=cli_scope,
         )
         try:
-            catalogued = await run_blocking(
-                runtime.list_memory_projects,
-                principal_id,
-            )
+            catalogued = await runtime.list_memory_projects(principal_id)
         except Exception as exc:
             raise MemoryStoreUnavailableError(
                 "Memory store is unavailable"
@@ -1395,7 +1389,7 @@ class Controller:
         from vibe.memory_project_ids import DEFAULT_MEMORY_PROJECT_ID
 
         runtime = await self._memory_runtime_for_operation()
-        scope = self._memory_scope_for_runtime(
+        scope = await self._memory_scope_for_runtime(
             runtime,
             verified_user_key=verified_user_key,
             cli_scope=cli_scope,
@@ -1427,7 +1421,7 @@ class Controller:
         )
 
         runtime = await self._memory_runtime_for_operation()
-        principal_id, default_project_id = self._memory_scope_for_runtime(
+        principal_id, default_project_id = await self._memory_scope_for_runtime(
             runtime,
             verified_user_key=verified_user_key,
             cli_scope=cli_scope,

--- a/core/controller.py
+++ b/core/controller.py
@@ -10,7 +10,7 @@ import threading
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from copy import deepcopy
-from dataclasses import dataclass, replace
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Dict, Any
 from config import paths
@@ -67,7 +67,6 @@ from vibe.i18n import get_supported_languages, t as i18n_t
 from vibe.memory_contract import (
     MemoryPluginIncompatibleError,
     MemoryPluginUnavailableError,
-    MemoryRuntimeCloseUnprovedError,
     MemoryStoreUnavailableError,
 )
 from vibe.runtime import mark_service_instance_started
@@ -89,12 +88,6 @@ def _load_memory_capture_types() -> tuple[type, type, type]:
     from avibe_memory import CaptureAccepted, CaptureRequest, CaptureSkipped
 
     return CaptureAccepted, CaptureRequest, CaptureSkipped
-@dataclass(frozen=True, slots=True)
-class _MemoryRuntimeLease:
-    runtime: "MemoryRuntime"
-    temporary: bool
-
-
 def _memory_reconfigure_changes_identity(
     expected_config: MemoryConfig,
     candidate_config: MemoryConfig,
@@ -391,13 +384,6 @@ class Controller:
         self._memory_disabled_cleanup_task: Optional[asyncio.Task] = None
         self._memory_disabled_cleanup_unproved = False
         self._memory_replacement_gate = asyncio.Lock()
-        self._memory_runtime_lease_condition = asyncio.Condition(
-            self._memory_replacement_gate
-        )
-        self._memory_runtime_lease_count = 0
-        self._memory_runtime_leases_blocked = False
-        self._memory_runtime_temporary = False
-        self._memory_runtime_temporary_config: MemoryConfig | None = None
         self._memory_destructive_tasks: set[asyncio.Task[dict[str, Any]]] = set()
         self._memory_destructive_quiescing = False
 
@@ -526,7 +512,6 @@ class Controller:
         self.memory_runtime = None
         self.memory_module = None
         self._memory_plugin_error: MemoryPluginUnavailableError | MemoryPluginIncompatibleError | None = None
-        self._memory_runtime_generation = 0
         if memory_config.enabled:
             try:
                 self.memory_runtime = self._create_memory_runtime(memory_config)
@@ -536,7 +521,6 @@ class Controller:
             else:
                 self.memory_module = self.memory_runtime.module
                 self.memory_adapter = self.memory_runtime.capture_adapter
-                self._memory_runtime_generation = 1
         self._migrate_discord_guild_scope_from_config()
 
         # Migrate legacy per-channel language into global config
@@ -768,46 +752,6 @@ class Controller:
         if cleanup_task is not None and not cleanup_task.done():
             await asyncio.shield(cleanup_task)
 
-    def _memory_runtime_condition(self) -> asyncio.Condition:
-        """Return the lease condition bound to the replacement gate."""
-
-        condition = getattr(self, "_memory_runtime_lease_condition", None)
-        if condition is None:
-            condition = asyncio.Condition(self._memory_replacement_lock())
-            self._memory_runtime_lease_condition = condition
-        return condition
-
-    async def _drain_memory_runtime_leases_locked(
-        self,
-        runtime: "MemoryRuntime",
-    ) -> None:
-        """Wait for all references to one fenced runtime to leave."""
-
-        condition = self._memory_runtime_condition()
-        while (
-            getattr(self, "memory_runtime", None) is runtime
-            and getattr(self, "_memory_runtime_lease_count", 0) > 0
-        ):
-            await condition.wait()
-
-    @asynccontextmanager
-    async def _mutate_memory_runtime(self) -> AsyncIterator[None]:
-        """Fence new leases and drain existing ones before runtime mutation."""
-
-        condition = self._memory_runtime_condition()
-        async with condition:
-            while getattr(self, "_memory_runtime_leases_blocked", False):
-                await condition.wait()
-            self._memory_runtime_leases_blocked = True
-            try:
-                runtime = getattr(self, "memory_runtime", None)
-                if runtime is not None:
-                    await self._drain_memory_runtime_leases_locked(runtime)
-                yield
-            finally:
-                self._memory_runtime_leases_blocked = False
-                condition.notify_all()
-
     def _start_memory_capture_adapter(self, runtime: "MemoryRuntime") -> bool:
         """Bind every capture task to the Controller-owned event loop."""
 
@@ -821,255 +765,168 @@ class Controller:
             return False
         return runtime.start_capture_adapter(task_factory=loop.create_task)
 
-    def _attach_memory_runtime_locked(
+    async def _attach_memory_runtime(
         self,
         runtime: "MemoryRuntime",
         *,
         capture_enabled: bool,
-        temporary: bool = False,
     ) -> None:
-        """Attach the sole runtime while the replacement gate is held."""
+        """Publish one fully constructed runtime with a short pointer swap."""
 
-        gate = self._memory_replacement_lock()
-        if not gate.locked():
-            raise RuntimeError("Memory runtime attachment requires the replacement lock")
-        current = getattr(self, "memory_runtime", None)
-        if current not in (None, runtime):
-            raise RuntimeError("A different Memory runtime is already owned")
-        if current is None:
-            if getattr(self, "_memory_runtime_lease_count", 0) != 0:
-                raise RuntimeError("Cannot attach Memory while runtime leases remain")
-            self._memory_runtime_generation = (
-                getattr(self, "_memory_runtime_generation", 0) + 1
+        async with self._memory_replacement_lock():
+            current = getattr(self, "memory_runtime", None)
+            if current not in (None, runtime):
+                raise RuntimeError("A different Memory runtime is already owned")
+            self.memory_runtime = runtime
+            self.memory_module = runtime.module
+            self._memory_plugin_error = None
+            if capture_enabled:
+                self._start_memory_capture_adapter(runtime)
+            self.memory_adapter = (
+                runtime.capture_adapter
+                if capture_enabled
+                else DisabledMemoryAdapter()
             )
-            self._memory_runtime_temporary = temporary
-        self.memory_runtime = runtime
-        self.memory_module = runtime.module
-        self._memory_plugin_error = None
-        if capture_enabled:
-            self.memory_adapter = runtime.capture_adapter
-            self._start_memory_capture_adapter(runtime)
-        else:
+
+    async def _detach_memory_runtime(
+        self,
+        runtime: "MemoryRuntime" | None = None,
+        *,
+        disabled_config: MemoryConfig | None = None,
+    ) -> "MemoryRuntime" | None:
+        """Publish Disabled first, revoke the old runtime, then drop pointers."""
+
+        async with self._memory_replacement_lock():
+            current = getattr(self, "memory_runtime", None)
+            if runtime is not None and current is not runtime:
+                return None
             self.memory_adapter = DisabledMemoryAdapter()
+            if disabled_config is not None:
+                self.config.memory = disabled_config
+            if current is not None:
+                current.begin_close()
+            self.memory_runtime = None
+            self.memory_module = None
+            return current
 
-    def _clear_memory_runtime_locked(self, runtime: "MemoryRuntime") -> None:
-        """Release a runtime only after its close proof is visible."""
+    async def _memory_runtime_for_operation(self) -> "MemoryRuntime":
+        """Snapshot the enabled runtime without retaining a host lifecycle lease."""
 
-        gate = self._memory_replacement_lock()
-        if not gate.locked():
-            raise RuntimeError("Memory runtime release requires the replacement lock")
-        if getattr(self, "memory_runtime", None) is not runtime:
-            raise RuntimeError("Cannot release a Memory runtime the Controller does not own")
-        if getattr(runtime, "closed", False) is not True:
-            raise MemoryRuntimeCloseUnprovedError(
-                "Memory runtime close returned without a closed proof"
-            )
-        if getattr(self, "_memory_runtime_lease_count", 0) != 0:
-            raise RuntimeError("Cannot release Memory while runtime leases remain")
-        adapter = getattr(self, "memory_adapter", None)
-        quiesce = getattr(adapter, "quiesce_memory_capture_tasks", None)
-        if callable(quiesce):
-            quiesce()
-        cancel = getattr(adapter, "cancel_memory_capture_tasks_nowait", None)
-        if callable(cancel):
-            cancel()
-        self.memory_runtime = None
-        self.memory_module = None
-        self.memory_adapter = DisabledMemoryAdapter()
-        self._memory_runtime_temporary = False
-        self._memory_runtime_temporary_config = None
-        self._memory_runtime_generation = (
-            getattr(self, "_memory_runtime_generation", 0) + 1
-        )
-
-    async def _close_memory_runtime_locked(
-        self,
-        runtime: "MemoryRuntime",
-        *,
-        retire: bool,
-    ) -> None:
-        """Fence, close, prove, then release one Controller-owned runtime."""
-
-        gate = self._memory_replacement_lock()
-        if not gate.locked() or getattr(self, "memory_runtime", None) is not runtime:
-            raise RuntimeError("Memory runtime close requires locked Controller ownership")
-        await self._drain_memory_runtime_leases_locked(runtime)
-        if retire:
-            retire_runtime = getattr(runtime, "retire", None)
-            if callable(retire_runtime) and not getattr(runtime, "retired", False):
-                retire_runtime()
-        try:
-            await runtime.close()
-        except BaseException:
-            retire_runtime = getattr(runtime, "retire", None)
-            if callable(retire_runtime) and not getattr(runtime, "retired", False):
-                retire_runtime()
-            raise
-        self._clear_memory_runtime_locked(runtime)
-
-    @asynccontextmanager
-    async def _borrow_memory_runtime(
-        self,
-        memory_config: MemoryConfig | None = None,
-        *,
-        allow_disabled: bool = False,
-        retry_plugin_error: bool = False,
-    ) -> AsyncIterator[_MemoryRuntimeLease]:
-        """Lease the sole runtime for one non-destructive explicit operation."""
-
-        selected_config = memory_config or self.config.memory
-        if not selected_config.enabled and not allow_disabled:
-            raise MemoryStoreUnavailableError("Memory is disabled")
         await self._await_disabled_memory_cleanup()
-        condition = self._memory_runtime_condition()
-        async with condition:
-            while True:
-                while getattr(self, "_memory_runtime_leases_blocked", False):
-                    await condition.wait()
-                runtime = getattr(self, "memory_runtime", None)
-                if (
-                    memory_config is None
-                    and not self.config.memory.enabled
-                    and not allow_disabled
-                ):
-                    raise MemoryStoreUnavailableError("Memory is disabled")
-                if runtime is not None and getattr(runtime, "retired", False):
-                    raise MemoryRuntimeCloseUnprovedError(
-                        "Memory runtime remains fenced after an unproved close"
-                    )
-                if not (
-                    runtime is not None
-                    and getattr(self, "_memory_runtime_temporary", False)
-                    and getattr(self, "_memory_runtime_temporary_config", None)
-                    != selected_config
-                ):
-                    break
-                await condition.wait()
-            temporary = runtime is None
-            if temporary:
-                plugin_error = getattr(self, "_memory_plugin_error", None)
-                if plugin_error is not None and not retry_plugin_error:
-                    raise plugin_error
-                try:
-                    runtime = self._create_memory_runtime(
-                        selected_config,
-                        allow_disabled=allow_disabled,
-                    )
-                except (
-                    MemoryPluginUnavailableError,
-                    MemoryPluginIncompatibleError,
-                ) as exc:
-                    self._memory_plugin_error = exc
-                    raise
-                self._attach_memory_runtime_locked(
-                    runtime,
-                    capture_enabled=bool(self.config.memory.enabled),
-                    temporary=True,
-                )
-                self._memory_runtime_temporary_config = selected_config
-            self._memory_runtime_lease_count = (
-                getattr(self, "_memory_runtime_lease_count", 0) + 1
-            )
-            lease = _MemoryRuntimeLease(
-                runtime=runtime,
-                temporary=bool(getattr(self, "_memory_runtime_temporary", False)),
-            )
-        try:
-            yield lease
-        finally:
-            condition = self._memory_runtime_condition()
-            async with condition:
-                if getattr(self, "memory_runtime", None) is not runtime:
-                    raise RuntimeError("Memory runtime ownership changed during a lease")
-                lease_count = getattr(self, "_memory_runtime_lease_count", 0)
-                if lease_count <= 0:
-                    raise RuntimeError("Memory runtime lease count underflow")
-                self._memory_runtime_lease_count = lease_count - 1
-                condition.notify_all()
-                if (
-                    self._memory_runtime_lease_count == 0
-                    and getattr(self, "_memory_runtime_temporary", False)
-                ):
-                    acquired_fence = not getattr(
-                        self,
-                        "_memory_runtime_leases_blocked",
-                        False,
-                    )
-                    if acquired_fence:
-                        self._memory_runtime_leases_blocked = True
-                    try:
-                        await self._close_memory_runtime_locked(
-                            runtime,
-                            retire=True,
-                        )
-                    finally:
-                        if acquired_fence:
-                            self._memory_runtime_leases_blocked = False
-                        condition.notify_all()
+        async with self._memory_replacement_lock():
+            if not self.config.memory.enabled:
+                raise MemoryStoreUnavailableError("Memory is disabled")
+            runtime = getattr(self, "memory_runtime", None)
+            plugin_error = getattr(self, "_memory_plugin_error", None)
+            if runtime is None and plugin_error is not None:
+                raise plugin_error
+        if runtime is None or getattr(runtime, "retired", False):
+            raise MemoryStoreUnavailableError("Memory runtime is unavailable")
+        return runtime
 
     async def preflight_memory(self, memory_config: MemoryConfig) -> dict[str, Any]:
         """Preflight a candidate without activating capture on a disabled host."""
 
-        async with self._borrow_memory_runtime(
-            memory_config,
-            retry_plugin_error=True,
-        ) as lease:
-            return await lease.runtime.preflight(memory_config)
+        await self._await_disabled_memory_cleanup()
+        async with self._memory_replacement_lock():
+            runtime = getattr(self, "memory_runtime", None)
+        if runtime is not None:
+            return await runtime.preflight(memory_config)
+        try:
+            runtime = self._create_memory_runtime(memory_config)
+        except (MemoryPluginUnavailableError, MemoryPluginIncompatibleError) as exc:
+            self._memory_plugin_error = exc
+            raise
+        self._memory_plugin_error = None
+        try:
+            return await runtime.preflight(memory_config)
+        finally:
+            runtime.begin_close()
+            await runtime.close()
 
     async def install_memory_runtime(self) -> dict[str, Any]:
         """Install the managed artifact through Controller runtime ownership."""
 
-        async with self._borrow_memory_runtime(
-            allow_disabled=True,
-            retry_plugin_error=True,
-        ) as lease:
-            return await lease.runtime.install_artifact()
+        await self._await_disabled_memory_cleanup()
+        async with self._memory_replacement_lock():
+            runtime = getattr(self, "memory_runtime", None)
+        if runtime is not None:
+            return await runtime.install_artifact()
+        try:
+            runtime = self._create_memory_runtime(
+                self.config.memory,
+                allow_disabled=True,
+            )
+        except (MemoryPluginUnavailableError, MemoryPluginIncompatibleError) as exc:
+            self._memory_plugin_error = exc
+            raise
+        self._memory_plugin_error = None
+        try:
+            return await runtime.install_artifact()
+        finally:
+            runtime.begin_close()
+            await runtime.close()
 
     async def reconcile_memory(self, memory_config: MemoryConfig) -> dict[str, Any]:
         """Hot-apply persisted Memory settings without destructive fallback."""
 
         await self._await_disabled_memory_cleanup()
-        async with self._mutate_memory_runtime():
+        async with self._memory_replacement_lock():
             runtime = getattr(self, "memory_runtime", None)
-            if runtime is not None and getattr(runtime, "retired", False):
-                raise MemoryRuntimeCloseUnprovedError(
-                    "Memory runtime remains fenced after an unproved close"
-                )
-            if runtime is None:
-                if not memory_config.enabled:
-                    self.memory_adapter = DisabledMemoryAdapter()
-                    self.memory_module = None
-                    self.config.memory = memory_config
-                    self._recheck_disabled_memory_cleanup_locked()
-                    return {"ok": True, "state": "disabled"}
+        if not memory_config.enabled:
+            runtime = await self._detach_memory_runtime(
+                runtime,
+                disabled_config=memory_config,
+            )
+            if runtime is not None:
+                await runtime.close()
+            await self._recheck_disabled_memory_cleanup()
+            return {"ok": True, "state": "disabled"}
+
+        created = runtime is None
+        if created:
+            try:
                 runtime = self._create_memory_runtime(memory_config)
-                self._attach_memory_runtime_locked(runtime, capture_enabled=True)
+            except (
+                MemoryPluginUnavailableError,
+                MemoryPluginIncompatibleError,
+            ) as exc:
+                self._memory_plugin_error = exc
+                raise
+            try:
+                await self._attach_memory_runtime(runtime, capture_enabled=False)
+            except BaseException:
+                runtime.begin_close()
+                await runtime.close()
+                raise
+        try:
             result = await runtime.reconcile(memory_config)
-            self.memory_module = runtime.module
-            if result.get("ok") is True:
-                self.config.memory = memory_config
-                if not memory_config.enabled:
-                    adapter = getattr(self, "memory_adapter", None)
-                    quiesce = getattr(adapter, "quiesce_memory_capture_tasks", None)
-                    if callable(quiesce):
-                        quiesce()
-                    cancel_capture = getattr(
-                        adapter,
-                        "cancel_memory_capture_tasks",
-                        None,
-                    )
-                    if callable(cancel_capture):
-                        await cancel_capture()
-                    self.memory_adapter = DisabledMemoryAdapter()
-                    await self._close_memory_runtime_locked(runtime, retire=False)
-                    self._recheck_disabled_memory_cleanup_locked()
-                else:
-                    self.memory_adapter = runtime.capture_adapter
-                    self._start_memory_capture_adapter(runtime)
+            async with self._memory_replacement_lock():
+                still_owned = getattr(self, "memory_runtime", None) is runtime
+                current_enabled = bool(self.config.memory.enabled)
+                if still_owned:
+                    self.memory_module = runtime.module
+                    if result.get("ok") is True:
+                        self.config.memory = memory_config
+                        if created:
+                            self._start_memory_capture_adapter(runtime)
+                        self.memory_adapter = runtime.capture_adapter
+            if result.get("ok") is True and not still_owned:
+                return {
+                    "ok": False,
+                    "state": "degraded" if current_enabled else "disabled",
+                    "error": "memory_operation_in_progress",
+                }
             return result
+        except BaseException:
+            if created:
+                detached = await self._detach_memory_runtime(runtime)
+                if detached is runtime:
+                    await runtime.close()
+            raise
 
     async def capture_memory(self, request: CaptureRequest) -> CaptureReceipt:
-        """Capture through the replacement gate so stale modules cannot write."""
+        """Snapshot the current module before offering one volatile capture."""
 
         if not self.config.memory.enabled:
             return DisabledCaptureReceipt()
@@ -1080,22 +937,17 @@ class Controller:
             _load_memory_capture_types()
         )
         del _CaptureAccepted, _CaptureRequest
-        observed_generation = getattr(self, "_memory_runtime_generation", 0)
         async with self._memory_replacement_lock():
             plugin_error = getattr(self, "_memory_plugin_error", None)
             if plugin_error is not None:
                 raise plugin_error
-            if (
-                getattr(self, "_memory_runtime_generation", 0)
-                != observed_generation
-            ):
-                return CaptureSkipped(reason="memory_operation_in_progress")
             runtime = getattr(self, "memory_runtime", None)
             if runtime is None or getattr(runtime, "retired", False):
                 return CaptureSkipped(reason="memory_operation_in_progress")
             if not runtime.available:
                 return CaptureSkipped(reason="memory_store_unavailable")
-            return await runtime.module.capture(request)
+            module = runtime.module
+        return await module.capture(request)
 
     def _disabled_memory_source_payload(
         self,
@@ -1141,7 +993,7 @@ class Controller:
         }
 
     def _disabled_memory_status_payload_locked(self) -> dict[str, Any]:
-        """Project Controller-owned disabled state while its condition is held."""
+        """Project Controller-owned disabled state while its pointer lock is held."""
 
         cleanup_task = getattr(self, "_memory_disabled_cleanup_task", None)
         return self._disabled_memory_status_payload(
@@ -1185,15 +1037,14 @@ class Controller:
     async def memory_status_payload(self) -> dict[str, Any]:
         """Project disabled status without loading or touching Memory state."""
 
-        condition = self._memory_runtime_condition()
-        async with condition:
+        async with self._memory_replacement_lock():
             if not self.config.memory.enabled:
                 return self._disabled_memory_status_payload_locked()
         try:
-            async with self._borrow_memory_runtime() as lease:
-                return await lease.runtime.status_payload()
+            runtime = await self._memory_runtime_for_operation()
+            return await runtime.status_payload()
         except MemoryStoreUnavailableError:
-            async with condition:
+            async with self._memory_replacement_lock():
                 if not self.config.memory.enabled:
                     return self._disabled_memory_status_payload_locked()
             raise
@@ -1209,8 +1060,8 @@ class Controller:
                     "error": "memory_legacy_recovery_required",
                 }
             return {"ok": False, "state": "disabled", "error": "memory_disabled"}
-        async with self._borrow_memory_runtime() as lease:
-            return await lease.runtime.wake()
+        runtime = await self._memory_runtime_for_operation()
+        return await runtime.wake()
 
     async def memory_processing_record_payload(
         self,
@@ -1219,20 +1070,20 @@ class Controller:
     ) -> dict[str, Any]:
         if not self.config.memory.enabled:
             return self._disabled_memory_processing_record_payload()
-        async with self._borrow_memory_runtime() as lease:
-            return await lease.runtime.processing_record_payload(
-                verified_user_key=verified_user_key
-            )
+        runtime = await self._memory_runtime_for_operation()
+        return await runtime.processing_record_payload(
+            verified_user_key=verified_user_key
+        )
 
     async def memory_failure_log_payload(
         self,
         *,
         verified_user_key: str | None,
     ) -> dict[str, Any]:
-        async with self._borrow_memory_runtime() as lease:
-            return await lease.runtime.failure_log_payload(
-                verified_user_key=verified_user_key
-            )
+        runtime = await self._memory_runtime_for_operation()
+        return await runtime.failure_log_payload(
+            verified_user_key=verified_user_key
+        )
 
     async def memory_maintenance_payload(
         self,
@@ -1241,10 +1092,10 @@ class Controller:
     ) -> dict[str, Any]:
         if not self.config.memory.enabled:
             return self._disabled_memory_maintenance_payload()
-        async with self._borrow_memory_runtime() as lease:
-            return await lease.runtime.maintenance_payload(
-                verified_user_key=verified_user_key
-            )
+        runtime = await self._memory_runtime_for_operation()
+        return await runtime.maintenance_payload(
+            verified_user_key=verified_user_key
+        )
 
     def _memory_scope_for_runtime(
         self,
@@ -1306,13 +1157,13 @@ class Controller:
         verified_user_key: str | None,
         cli_scope: tuple[str, str] | None,
     ) -> dict[str, Any]:
-        async with self._borrow_memory_runtime() as lease:
-            scope = self._memory_scope_for_runtime(
-                lease.runtime,
-                verified_user_key=verified_user_key,
-                cli_scope=cli_scope,
-            )
-            return await lease.runtime.profile_payload(*scope)
+        runtime = await self._memory_runtime_for_operation()
+        scope = self._memory_scope_for_runtime(
+            runtime,
+            verified_user_key=verified_user_key,
+            cli_scope=cli_scope,
+        )
+        return await runtime.profile_payload(*scope)
 
     async def memory_processing_record_entries_payload(
         self,
@@ -1323,22 +1174,18 @@ class Controller:
         verified_user_key: str | None,
         cli_scope: tuple[str, str] | None,
     ) -> dict[str, Any]:
-        async with self._borrow_memory_runtime() as lease:
-            scope = self._memory_scope_for_runtime(
-                lease.runtime,
-                verified_user_key=verified_user_key,
-                cli_scope=cli_scope,
-            )
-            scope = await self._memory_scope_for_project(
-                lease.runtime,
-                scope,
-                project_id,
-            )
-            return await lease.runtime.processing_record_entries_payload(
-                *scope,
-                cursor,
-                limit,
-            )
+        runtime = await self._memory_runtime_for_operation()
+        scope = self._memory_scope_for_runtime(
+            runtime,
+            verified_user_key=verified_user_key,
+            cli_scope=cli_scope,
+        )
+        scope = await self._memory_scope_for_project(runtime, scope, project_id)
+        return await runtime.processing_record_entries_payload(
+            *scope,
+            cursor,
+            limit,
+        )
 
     async def memory_processing_record_entry_payload(
         self,
@@ -1348,21 +1195,14 @@ class Controller:
         verified_user_key: str | None,
         cli_scope: tuple[str, str] | None,
     ) -> dict[str, Any]:
-        async with self._borrow_memory_runtime() as lease:
-            scope = self._memory_scope_for_runtime(
-                lease.runtime,
-                verified_user_key=verified_user_key,
-                cli_scope=cli_scope,
-            )
-            scope = await self._memory_scope_for_project(
-                lease.runtime,
-                scope,
-                project_id,
-            )
-            return await lease.runtime.processing_record_entry_payload(
-                *scope,
-                memcell_id,
-            )
+        runtime = await self._memory_runtime_for_operation()
+        scope = self._memory_scope_for_runtime(
+            runtime,
+            verified_user_key=verified_user_key,
+            cli_scope=cli_scope,
+        )
+        scope = await self._memory_scope_for_project(runtime, scope, project_id)
+        return await runtime.processing_record_entry_payload(*scope, memcell_id)
 
     async def memory_projects_payload(
         self,
@@ -1375,32 +1215,30 @@ class Controller:
             MEMORY_SEARCH_ALL_PROJECTS,
         )
 
-        async with self._borrow_memory_runtime() as lease:
-            principal_id, _project_id = self._memory_scope_for_runtime(
-                lease.runtime,
-                verified_user_key=verified_user_key,
-                cli_scope=cli_scope,
+        runtime = await self._memory_runtime_for_operation()
+        principal_id, _project_id = self._memory_scope_for_runtime(
+            runtime,
+            verified_user_key=verified_user_key,
+            cli_scope=cli_scope,
+        )
+        try:
+            catalogued = await run_blocking(
+                runtime.list_memory_projects,
+                principal_id,
             )
-            try:
-                catalogued = await run_blocking(
-                    lease.runtime.list_memory_projects,
-                    principal_id,
-                )
-            except Exception as exc:
-                raise MemoryStoreUnavailableError(
-                    "Memory store is unavailable"
-                ) from exc
-            named = [
-                item for item in catalogued if item != DEFAULT_MEMORY_PROJECT_ID
-            ]
-            return {
-                "status": "ok",
-                "projects": [
-                    {"id": DEFAULT_MEMORY_PROJECT_ID, "kind": "default"},
-                    *[{"id": item, "kind": "named"} for item in named],
-                    {"id": MEMORY_SEARCH_ALL_PROJECTS, "kind": "all"},
-                ],
-            }
+        except Exception as exc:
+            raise MemoryStoreUnavailableError(
+                "Memory store is unavailable"
+            ) from exc
+        named = [item for item in catalogued if item != DEFAULT_MEMORY_PROJECT_ID]
+        return {
+            "status": "ok",
+            "projects": [
+                {"id": DEFAULT_MEMORY_PROJECT_ID, "kind": "default"},
+                *[{"id": item, "kind": "named"} for item in named],
+                {"id": MEMORY_SEARCH_ALL_PROJECTS, "kind": "all"},
+            ],
+        }
 
     async def memory_search_payload(
         self,
@@ -1414,25 +1252,21 @@ class Controller:
     ) -> dict[str, Any]:
         from vibe.memory_project_ids import DEFAULT_MEMORY_PROJECT_ID
 
-        async with self._borrow_memory_runtime() as lease:
-            scope = self._memory_scope_for_runtime(
-                lease.runtime,
-                verified_user_key=verified_user_key,
-                cli_scope=cli_scope,
-            )
-            if project_id not in {DEFAULT_MEMORY_PROJECT_ID, "all"}:
-                await self._memory_scope_for_project(
-                    lease.runtime,
-                    scope,
-                    project_id,
-                )
-            return await lease.runtime.search_payload(
-                query,
-                policy,
-                scope[0],
-                project_id,
-                current_session_id=current_session_id,
-            )
+        runtime = await self._memory_runtime_for_operation()
+        scope = self._memory_scope_for_runtime(
+            runtime,
+            verified_user_key=verified_user_key,
+            cli_scope=cli_scope,
+        )
+        if project_id not in {DEFAULT_MEMORY_PROJECT_ID, "all"}:
+            await self._memory_scope_for_project(runtime, scope, project_id)
+        return await runtime.search_payload(
+            query,
+            policy,
+            scope[0],
+            project_id,
+            current_session_id=current_session_id,
+        )
 
     async def memory_list_payload(
         self,
@@ -1450,38 +1284,38 @@ class Controller:
             MEMORY_SEARCH_ALL_PROJECTS,
         )
 
-        async with self._borrow_memory_runtime() as lease:
-            principal_id, default_project_id = self._memory_scope_for_runtime(
-                lease.runtime,
-                verified_user_key=verified_user_key,
-                cli_scope=cli_scope,
-            )
-            del default_project_id
-            origin_options = {"origin": origin} if origin is not None else {}
-            if project_id == MEMORY_SEARCH_ALL_PROJECTS:
-                return await lease.runtime.list_all_episodes_payload(
-                    principal_id,
-                    cursor=cursor,
-                    limit=limit,
-                    **origin_options,
-                )
-            if project_id != DEFAULT_MEMORY_PROJECT_ID:
-                if getattr(lease.runtime, "available", True) is False:
-                    raise MemoryStoreUnavailableError(
-                        "Memory store is unavailable"
-                    )
-                await self._memory_scope_for_project(
-                    lease.runtime,
-                    (principal_id, DEFAULT_MEMORY_PROJECT_ID),
-                    project_id,
-                )
-            return await lease.runtime.list_episodes_payload(
+        runtime = await self._memory_runtime_for_operation()
+        principal_id, default_project_id = self._memory_scope_for_runtime(
+            runtime,
+            verified_user_key=verified_user_key,
+            cli_scope=cli_scope,
+        )
+        del default_project_id
+        origin_options = {"origin": origin} if origin is not None else {}
+        if project_id == MEMORY_SEARCH_ALL_PROJECTS:
+            return await runtime.list_all_episodes_payload(
                 principal_id,
-                project_id,
-                page=page,
-                page_size=limit,
+                cursor=cursor,
+                limit=limit,
                 **origin_options,
             )
+        if project_id != DEFAULT_MEMORY_PROJECT_ID:
+            if getattr(runtime, "available", True) is False:
+                raise MemoryStoreUnavailableError(
+                    "Memory store is unavailable"
+                )
+            await self._memory_scope_for_project(
+                runtime,
+                (principal_id, DEFAULT_MEMORY_PROJECT_ID),
+                project_id,
+            )
+        return await runtime.list_episodes_payload(
+            principal_id,
+            project_id,
+            page=page,
+            page_size=limit,
+            **origin_options,
+        )
 
     async def repair_memory(self, *, confirm_loss: bool) -> dict[str, Any]:
         """Reset unusable local data, then prove native EverOS readiness."""
@@ -1583,38 +1417,6 @@ class Controller:
         finally:
             transactions.discard(transaction)
 
-    @asynccontextmanager
-    async def _destructive_memory_runtime(self) -> AsyncIterator["MemoryRuntime"]:
-        """Own temporary runtime cleanup inside one destructive transaction."""
-
-        await self._await_disabled_memory_cleanup()
-        async with self._mutate_memory_runtime():
-            runtime = getattr(self, "memory_runtime", None)
-            if runtime is not None and getattr(runtime, "retired", False):
-                raise MemoryRuntimeCloseUnprovedError(
-                    "Memory runtime remains fenced after an unproved close"
-                )
-            temporary = runtime is None
-            if temporary:
-                runtime = self._create_memory_runtime(
-                    self.config.memory,
-                    allow_disabled=True,
-                )
-                self._attach_memory_runtime_locked(
-                    runtime,
-                    capture_enabled=bool(self.config.memory.enabled),
-                    temporary=True,
-                )
-            try:
-                yield runtime
-            finally:
-                if (
-                    temporary
-                    and getattr(self, "memory_runtime", None) is runtime
-                    and not getattr(runtime, "retired", False)
-                ):
-                    await self._close_memory_runtime_locked(runtime, retire=True)
-
     async def _join_memory_destructive_transactions(self) -> None:
         """Stop admission and settle accepted data-loss operations before shutdown."""
 
@@ -1637,6 +1439,34 @@ class Controller:
                 "Memory destructive transaction failed while shutdown joined it",
                 exc_info=(type(errors[0]), errors[0], errors[0].__traceback__),
             )
+
+    @asynccontextmanager
+    async def _memory_runtime_for_data_reset(
+        self,
+    ) -> AsyncIterator[tuple["MemoryRuntime", bool]]:
+        """Provide the current runtime or an unpublished disabled-mode runtime."""
+
+        await self._await_disabled_memory_cleanup()
+        async with self._memory_replacement_lock():
+            runtime = getattr(self, "memory_runtime", None)
+        attached = runtime is not None
+        if runtime is None:
+            runtime = self._create_memory_runtime(
+                self.config.memory,
+                allow_disabled=True,
+            )
+        try:
+            yield runtime, attached
+        finally:
+            if not attached:
+                runtime.begin_close()
+                try:
+                    await runtime.close()
+                except Exception:
+                    logger.warning(
+                        "Unpublished Memory reset runtime did not close cleanly",
+                        exc_info=True,
+                    )
 
     async def _cancel_memory_reconcile_task(self) -> None:
         task = getattr(self, "_memory_reconcile_task", None)
@@ -1696,14 +1526,9 @@ class Controller:
         if getattr(self, "_memory_reconcile_task", None) is not None:
             stages.append(("startup reconciliation", self._cancel_memory_reconcile_task))
 
-        cancel_capture = getattr(adapter, "cancel_memory_capture_tasks", None)
-        if callable(cancel_capture):
-            stages.append(("capture cancellation", cancel_capture))
         stages.append(
             ("destructive-operation settlement", self._join_memory_destructive_transactions)
         )
-
-        stages.append(("runtime close", self._close_memory_runtime_for_shutdown))
 
         budget = max(
             0.0,
@@ -1717,21 +1542,13 @@ class Controller:
         )
         loop = asyncio.get_running_loop()
         deadline = loop.time() + budget
-        runtime_close_safe = True
         for index, (label, operation) in enumerate(stages):
-            if label == "runtime close" and not runtime_close_safe:
-                self._shutdown_tainted = True
-                logger.error(
-                    "Skipping Memory runtime close because an earlier shutdown stage did not settle"
-                )
-                continue
             remaining = max(0.0, deadline - loop.time())
             stage_budget = remaining / (len(stages) - index)
             task = asyncio.create_task(operation(), name=f"memory-shutdown-{index}")
             done, _pending = await asyncio.wait({task}, timeout=stage_budget)
             if task not in done:
                 self._shutdown_tainted = True
-                runtime_close_safe = False
                 logger.error(
                     "Memory %s exceeded its %.3fs shutdown budget slice",
                     label,
@@ -1750,21 +1567,23 @@ class Controller:
                 task.result()
             except asyncio.CancelledError:
                 self._shutdown_tainted = True
-                runtime_close_safe = False
                 logger.error("Memory %s was cancelled during shutdown", label)
             except Exception:
                 self._shutdown_tainted = True
-                runtime_close_safe = False
                 logger.error("Memory %s failed during shutdown", label, exc_info=True)
 
-    async def _close_memory_runtime_for_shutdown(self) -> None:
-        """Close the currently owned runtime through the replacement gate."""
+        try:
+            await self._close_memory_runtime_for_shutdown()
+        except Exception:
+            self._shutdown_tainted = True
+            logger.error("Memory runtime close failed during shutdown", exc_info=True)
 
-        async with self._mutate_memory_runtime():
-            runtime = getattr(self, "memory_runtime", None)
-            if runtime is None:
-                return
-            await self._close_memory_runtime_locked(runtime, retire=False)
+    async def _close_memory_runtime_for_shutdown(self) -> None:
+        """Detach the current runtime, then run its bounded close boundary."""
+
+        runtime = await self._detach_memory_runtime()
+        if runtime is not None:
+            await runtime.close()
 
     async def _reset_memory_data_transaction(
         self,
@@ -1773,7 +1592,8 @@ class Controller:
         target_config: MemoryConfig | None = None,
         expected_config: MemoryConfig | None = None,
     ) -> dict[str, Any]:
-        async with self._destructive_memory_runtime() as runtime:
+        async with self._memory_runtime_for_data_reset() as runtime_context:
+            runtime, attached = runtime_context
             from avibe_memory.data_reset import (
                 unchanged_memory_data_result,
             )
@@ -1867,7 +1687,17 @@ class Controller:
                         return target
                     return replace(current, legacy_needs_repair=False)
 
-                runtime.retire()
+                if attached:
+                    detached = await self._detach_memory_runtime(runtime)
+                    if detached is not runtime:
+                        return {
+                            "ok": False,
+                            "operation": operation,
+                            "error": "memory_operation_in_progress",
+                            "result": "unchanged",
+                        }
+                else:
+                    runtime.begin_close()
                 try:
                     await runtime.close()
                 except BaseException:
@@ -1880,17 +1710,6 @@ class Controller:
                     )
                     failure["state"] = "needs_repair"
                     return failure
-                if not runtime.closed:
-                    runtime.mark_needs_repair(f"memory_{operation}_failed")
-                    failure = unchanged_memory_data_result(
-                        runtime.effective_home,
-                        operation=operation,
-                        reason="runtime_termination_unproved",
-                    )
-                    failure["state"] = "needs_repair"
-                    return failure
-                self._clear_memory_runtime_locked(runtime)
-
                 try:
                     await runtime.settle_after_data_loss()
                 except Exception:
@@ -1913,7 +1732,7 @@ class Controller:
                 if deletion.data_remaining:
                     if fenced_config.enabled:
                         failed = runtime.replacement(fenced_config)
-                        self._attach_memory_runtime_locked(
+                        await self._attach_memory_runtime(
                             failed,
                             capture_enabled=True,
                         )
@@ -1948,7 +1767,7 @@ class Controller:
                     fallback_state = "disabled"
                     if live_config.enabled:
                         fallback = runtime.replacement(live_config)
-                        self._attach_memory_runtime_locked(
+                        await self._attach_memory_runtime(
                             fallback,
                             capture_enabled=True,
                         )
@@ -1983,7 +1802,7 @@ class Controller:
                         **deletion_payload,
                     }
                 fresh = runtime.replacement(target)
-                self._attach_memory_runtime_locked(fresh, capture_enabled=True)
+                await self._attach_memory_runtime(fresh, capture_enabled=True)
                 activation = await fresh.wake(operation_lease_held=True)
                 if activation.get("ok") is not True:
                     state = activation.get("state")
@@ -2446,23 +2265,28 @@ class Controller:
         except OSError:
             return False
 
-    def _recheck_disabled_memory_cleanup_locked(self) -> None:
-        """Clear a stale cleanup fence only after released ownership is absent."""
+    async def _recheck_disabled_memory_cleanup(self) -> None:
+        """Clear a stale cleanup fence after checking ownership off-lock."""
 
-        if not self._memory_replacement_lock().locked():
-            raise RuntimeError("Memory cleanup recheck requires the replacement lock")
         if not getattr(self, "_memory_disabled_cleanup_unproved", False):
             return
         memory_dir = paths.get_vibe_remote_dir() / "memory"
-        self._memory_disabled_cleanup_unproved = (
-            self._disabled_memory_ownership_exists(memory_dir)
+        ownership_exists = await asyncio.to_thread(
+            self._disabled_memory_ownership_exists,
+            memory_dir,
         )
+        async with self._memory_replacement_lock():
+            self._memory_disabled_cleanup_unproved = ownership_exists
 
     async def _schedule_disabled_memory_cleanup(self) -> None:
         """Reap older owned Memory children only when a record exists."""
 
-        condition = self._memory_runtime_condition()
-        async with condition:
+        memory_dir = paths.get_vibe_remote_dir() / "memory"
+        ownership_exists = await asyncio.to_thread(
+            self._disabled_memory_ownership_exists,
+            memory_dir,
+        )
+        async with self._memory_replacement_lock():
             if not isinstance(
                 getattr(self, "memory_adapter", None),
                 DisabledMemoryAdapter,
@@ -2471,8 +2295,7 @@ class Controller:
             task = getattr(self, "_memory_disabled_cleanup_task", None)
             if task is not None and not task.done():
                 return
-            memory_dir = paths.get_vibe_remote_dir() / "memory"
-            if not self._disabled_memory_ownership_exists(memory_dir):
+            if not ownership_exists:
                 return
             self._memory_disabled_cleanup_unproved = True
             self._memory_disabled_cleanup_task = asyncio.create_task(
@@ -2483,14 +2306,17 @@ class Controller:
     async def _cleanup_disabled_memory_process(self, memory_dir: Path) -> None:
         """Lazily load the proven-ownership reaper after service readiness."""
 
-        condition = self._memory_runtime_condition()
-        async with condition:
+        ownership_exists = await asyncio.to_thread(
+            self._disabled_memory_ownership_exists,
+            memory_dir,
+        )
+        async with self._memory_replacement_lock():
             if not isinstance(
                 getattr(self, "memory_adapter", None),
                 DisabledMemoryAdapter,
             ) or getattr(self, "memory_runtime", None) is not None:
                 return
-            if not self._disabled_memory_ownership_exists(memory_dir):
+            if not ownership_exists:
                 self._memory_disabled_cleanup_unproved = False
                 return
             self._memory_disabled_cleanup_unproved = True
@@ -2504,21 +2330,23 @@ class Controller:
             )
             await reconciler.reconcile_orphans()
         except asyncio.CancelledError:
-            async with condition:
+            async with self._memory_replacement_lock():
                 self._memory_disabled_cleanup_unproved = True
             raise
         except Exception:
-            async with condition:
+            async with self._memory_replacement_lock():
                 self._memory_disabled_cleanup_unproved = True
             logger.warning(
                 "Disabled Memory could not clean up an older owned EverOS process",
                 exc_info=True,
             )
         else:
-            async with condition:
-                self._memory_disabled_cleanup_unproved = (
-                    self._disabled_memory_ownership_exists(memory_dir)
-                )
+            ownership_exists = await asyncio.to_thread(
+                self._disabled_memory_ownership_exists,
+                memory_dir,
+            )
+            async with self._memory_replacement_lock():
+                self._memory_disabled_cleanup_unproved = ownership_exists
 
     def _run_im_runtime(self) -> None:
         try:

--- a/core/controller.py
+++ b/core/controller.py
@@ -772,7 +772,10 @@ class Controller:
     ) -> MemoryOperationLease | None:
         lease = MemoryOperationLease(effective_home)
         try:
-            await run_blocking(lease.acquire)
+            await run_blocking(
+                lease.acquire,
+                on_cancel_result=lambda _result: lease.release(),
+            )
         except MemoryOperationBusy:
             return None
         return lease
@@ -817,6 +820,55 @@ class Controller:
                     self.memory_runtime = runtime
                     self.memory_module = None
             raise
+
+    async def _settle_retained_memory_runtime(
+        self,
+        runtime: "MemoryRuntime",
+    ) -> bool:
+        async with self._memory_replacement_lock():
+            if getattr(self, "memory_runtime", None) is not runtime:
+                return False
+        try:
+            await runtime.close()
+        except Exception:
+            return False
+        return await self._clear_memory_runtime(runtime)
+
+    @asynccontextmanager
+    async def _memory_mutation_runtime(
+        self,
+        memory_config: MemoryConfig,
+        *,
+        allow_disabled: bool = False,
+    ) -> AsyncIterator[tuple["MemoryRuntime" | None, bool]]:
+        async with self._memory_replacement_lock():
+            runtime = getattr(self, "memory_runtime", None)
+        async with self._memory_operation(
+            getattr(runtime, "effective_home", None)
+        ) as lease:
+            if lease is None:
+                yield None, False
+                return
+            async with self._memory_replacement_lock():
+                if getattr(self, "memory_runtime", None) is not runtime:
+                    yield None, False
+                    return
+            if runtime is not None and bool(getattr(runtime, "closing", False)):
+                if not await self._settle_retained_memory_runtime(runtime):
+                    yield None, False
+                    return
+                runtime = None
+            created = runtime is None
+            if created:
+                try:
+                    runtime = self._retry_memory_runtime(
+                        memory_config,
+                        allow_disabled=allow_disabled,
+                    )
+                except MemoryRuntimeBusyError:
+                    yield None, False
+                    return
+            yield runtime, created
 
     async def _attach_memory_runtime(
         self,
@@ -917,22 +969,10 @@ class Controller:
     async def preflight_memory(self, memory_config: MemoryConfig) -> dict[str, Any]:
         """Preflight a candidate without activating capture on a disabled host."""
 
-        async with self._memory_replacement_lock():
-            runtime = getattr(self, "memory_runtime", None)
-        created = runtime is None
-        async with self._memory_operation(
-            getattr(runtime, "effective_home", None)
-        ) as lease:
-            if lease is None:
+        async with self._memory_mutation_runtime(memory_config) as runtime_context:
+            runtime, created = runtime_context
+            if runtime is None:
                 return {"ok": False, "error": "memory_operation_in_progress"}
-            async with self._memory_replacement_lock():
-                if getattr(self, "memory_runtime", None) is not runtime:
-                    return {"ok": False, "error": "memory_operation_in_progress"}
-            if created:
-                try:
-                    runtime = self._retry_memory_runtime(memory_config)
-                except MemoryRuntimeBusyError:
-                    return {"ok": False, "error": "memory_operation_in_progress"}
             try:
                 return await runtime.preflight(memory_config)
             except MemoryRuntimeBusyError:
@@ -944,30 +984,12 @@ class Controller:
     async def install_memory_runtime(self) -> dict[str, Any]:
         """Install the managed artifact through Controller runtime ownership."""
 
-        async with self._memory_replacement_lock():
-            runtime = getattr(self, "memory_runtime", None)
-        if runtime is not None:
-            return await runtime.install_artifact()
-        async with self._memory_operation() as lease:
-            if lease is None:
-                return {
-                    "ok": False,
-                    "reason": "memory_operation_in_progress",
-                    "download_error": None,
-                }
-            async with self._memory_replacement_lock():
-                if getattr(self, "memory_runtime", None) is not None:
-                    return {
-                        "ok": False,
-                        "reason": "memory_operation_in_progress",
-                        "download_error": None,
-                    }
-            try:
-                runtime = self._retry_memory_runtime(
-                    self.config.memory,
-                    allow_disabled=True,
-                )
-            except MemoryRuntimeBusyError:
+        async with self._memory_mutation_runtime(
+            self.config.memory,
+            allow_disabled=True,
+        ) as runtime_context:
+            runtime, created = runtime_context
+            if runtime is None:
                 return {
                     "ok": False,
                     "reason": "memory_operation_in_progress",
@@ -976,36 +998,38 @@ class Controller:
             try:
                 return await runtime.install_artifact(operation_lease_held=True)
             finally:
-                await self._close_unpublished_memory_runtime(runtime)
+                if created:
+                    await self._close_unpublished_memory_runtime(runtime)
 
     async def reconcile_memory(self, memory_config: MemoryConfig) -> dict[str, Any]:
         """Hot-apply persisted Memory settings without destructive fallback."""
 
-        async with self._memory_replacement_lock():
-            runtime = getattr(self, "memory_runtime", None)
         if not memory_config.enabled:
+            busy = {
+                "ok": False,
+                "state": "disabled",
+                "error": "memory_operation_in_progress",
+            }
             runtime = await self._detach_memory_runtime(
-                runtime,
                 disabled_config=memory_config,
             )
-            if runtime is not None:
-                await runtime.close()
-                await self._clear_memory_runtime(runtime)
+            async with self._memory_operation(
+                getattr(runtime, "effective_home", None)
+            ) as lease:
+                if lease is None:
+                    return busy
+                if runtime is not None and not await self._settle_retained_memory_runtime(
+                    runtime
+                ):
+                    return busy
             await self._recheck_disabled_memory_cleanup()
             return {"ok": True, "state": "disabled"}
 
-        created = runtime is None
-        if created:
-            async with self._memory_operation() as lease:
-                if lease is None:
-                    return {"ok": False, "error": "memory_operation_in_progress"}
-                async with self._memory_replacement_lock():
-                    if getattr(self, "memory_runtime", None) is not None:
-                        return {"ok": False, "error": "memory_operation_in_progress"}
-                try:
-                    runtime = self._retry_memory_runtime(memory_config)
-                except MemoryRuntimeBusyError:
-                    return {"ok": False, "error": "memory_operation_in_progress"}
+        async with self._memory_mutation_runtime(memory_config) as runtime_context:
+            runtime, created = runtime_context
+            if runtime is None:
+                return {"ok": False, "error": "memory_operation_in_progress"}
+            if created:
                 try:
                     await self._attach_memory_runtime(runtime, capture_enabled=False)
                 except BaseException:
@@ -1560,41 +1584,19 @@ class Controller:
     async def _memory_runtime_for_data_reset(
         self,
     ) -> AsyncIterator[tuple["MemoryRuntime" | None, bool]]:
-        async with self._memory_replacement_lock():
-            runtime = getattr(self, "memory_runtime", None)
-        if runtime is None:
-            async with self._memory_operation() as lease:
-                if lease is None:
-                    yield None, False
-                    return
-                async with self._memory_replacement_lock():
-                    if getattr(self, "memory_runtime", None) is not None:
-                        yield None, False
-                        return
-                try:
-                    runtime = self._retry_memory_runtime(
-                        self.config.memory,
-                        allow_disabled=True,
-                    )
-                except MemoryRuntimeBusyError:
-                    yield None, False
-                    return
-                try:
-                    yield runtime, False
-                finally:
-                    if not bool(getattr(runtime, "closing", False)):
-                        await self._close_unpublished_memory_runtime(runtime)
-            return
-        async with self._memory_operation(runtime.effective_home) as lease:
-            if lease is None:
+        async with self._memory_mutation_runtime(
+            self.config.memory,
+            allow_disabled=True,
+        ) as runtime_context:
+            runtime, created = runtime_context
+            if runtime is None:
                 yield None, False
                 return
-            async with self._memory_replacement_lock():
-                ownership_changed = getattr(self, "memory_runtime", None) is not runtime
-            if ownership_changed:
-                yield None, False
-                return
-            yield runtime, True
+            try:
+                yield runtime, not created
+            finally:
+                if created and not bool(getattr(runtime, "closing", False)):
+                    await self._close_unpublished_memory_runtime(runtime)
 
     async def _cancel_memory_reconcile_task(self) -> None:
         task = getattr(self, "_memory_reconcile_task", None)

--- a/core/controller.py
+++ b/core/controller.py
@@ -766,18 +766,74 @@ class Controller:
             return False
         return runtime.start_capture_adapter(task_factory=loop.create_task)
 
+    async def _try_memory_operation_lease(
+        self,
+        effective_home: Path | None = None,
+    ) -> MemoryOperationLease | None:
+        lease = MemoryOperationLease(effective_home)
+        try:
+            await run_blocking(lease.acquire)
+        except MemoryOperationBusy:
+            return None
+        return lease
+
+    @asynccontextmanager
+    async def _memory_operation(self, effective_home: Path | None = None):
+        lease = await self._try_memory_operation_lease(effective_home)
+        try:
+            yield lease
+        finally:
+            if lease is not None:
+                await run_blocking(lease.release)
+
+    def _retry_memory_runtime(
+        self,
+        memory_config: MemoryConfig,
+        *,
+        allow_disabled: bool = False,
+    ) -> "MemoryRuntime":
+        try:
+            runtime = self._create_memory_runtime(
+                memory_config,
+                **({"allow_disabled": True} if allow_disabled else {}),
+            )
+        except (MemoryPluginUnavailableError, MemoryPluginIncompatibleError) as exc:
+            self._memory_plugin_error = exc
+            raise
+        self._memory_plugin_error = None
+        return runtime
+
+    async def _close_unpublished_memory_runtime(
+        self,
+        runtime: "MemoryRuntime",
+    ) -> None:
+        runtime.begin_close()
+        try:
+            await runtime.close()
+        except BaseException:
+            async with self._memory_replacement_lock():
+                if getattr(self, "memory_runtime", None) is None:
+                    self.memory_adapter = DisabledMemoryAdapter()
+                    self.memory_runtime = runtime
+                    self.memory_module = None
+            raise
+
     async def _attach_memory_runtime(
         self,
         runtime: "MemoryRuntime",
         *,
         capture_enabled: bool,
+        previous: "MemoryRuntime" | None = None,
     ) -> None:
-        """Publish one fully constructed runtime with a short pointer swap."""
-
         async with self._memory_replacement_lock():
             current = getattr(self, "memory_runtime", None)
-            if current not in (None, runtime):
+            if (
+                previous is None and current is not None and current is not runtime
+            ) or previous is not None and current is not previous:
                 raise RuntimeError("A different Memory runtime is already owned")
+            accept_ownership = getattr(runtime, "accept_root_ownership", None)
+            if callable(accept_ownership):
+                accept_ownership()
             self.memory_runtime = runtime
             self.memory_module = runtime.module
             self._memory_plugin_error = None
@@ -795,8 +851,6 @@ class Controller:
         *,
         disabled_config: MemoryConfig | None = None,
     ) -> "MemoryRuntime" | None:
-        """Publish Disabled first, revoke the old runtime, then drop pointers."""
-
         async with self._memory_replacement_lock():
             current = getattr(self, "memory_runtime", None)
             if runtime is not None and current is not runtime:
@@ -806,35 +860,48 @@ class Controller:
                 self.config.memory = disabled_config
             if current is not None:
                 current.begin_close()
-            self.memory_runtime = None
             self.memory_module = None
             return current
+
+    async def _clear_memory_runtime(self, runtime: "MemoryRuntime") -> bool:
+        async with self._memory_replacement_lock():
+            if getattr(self, "memory_runtime", None) is not runtime:
+                return False
+            self.memory_runtime = None
+            self.memory_module = None
+            return True
+
+    async def _retire_memory_runtime_for_reset(
+        self,
+        runtime: "MemoryRuntime",
+        *,
+        allow_unpublished: bool,
+    ) -> object | None:
+        async with self._memory_replacement_lock():
+            current = getattr(self, "memory_runtime", None)
+            if current is not runtime and not (allow_unpublished and current is None):
+                return None
+            self.memory_adapter = DisabledMemoryAdapter()
+            ownership = runtime.begin_root_ownership_handoff()
+            self.memory_runtime = runtime
+            self.memory_module = None
+            return ownership
 
     async def _activate_memory_replacement(
         self,
         previous: "MemoryRuntime",
         config: MemoryConfig,
+        root_ownership: object,
     ) -> tuple["MemoryRuntime", dict[str, Any]]:
-        """Attach one successor after the previous runtime proved closed."""
-
-        fresh = previous.replacement(config)
-        try:
-            await self._attach_memory_runtime(fresh, capture_enabled=True)
-        except BaseException:
-            fresh.begin_close()
-            try:
-                await fresh.close()
-            except Exception:
-                logger.warning(
-                    "Unattached Memory replacement did not close cleanly",
-                    exc_info=True,
-                )
-            raise
+        fresh = previous.replacement(config, root_ownership)
+        await self._attach_memory_runtime(
+            fresh,
+            capture_enabled=True,
+            previous=previous,
+        )
         return fresh, await fresh.wake(operation_lease_held=True)
 
     async def _memory_runtime_for_operation(self) -> "MemoryRuntime":
-        """Snapshot the enabled runtime without retaining a host lifecycle lease."""
-
         await self._await_disabled_memory_cleanup()
         async with self._memory_replacement_lock():
             if not self.config.memory.enabled:
@@ -850,58 +917,70 @@ class Controller:
     async def preflight_memory(self, memory_config: MemoryConfig) -> dict[str, Any]:
         """Preflight a candidate without activating capture on a disabled host."""
 
-        await self._await_disabled_memory_cleanup()
         async with self._memory_replacement_lock():
             runtime = getattr(self, "memory_runtime", None)
-        if runtime is not None:
-            return await runtime.preflight(memory_config)
-        try:
-            runtime = self._create_memory_runtime(memory_config)
-        except MemoryRuntimeBusyError:
-            return {"ok": False, "error": "memory_operation_in_progress"}
-        except (MemoryPluginUnavailableError, MemoryPluginIncompatibleError) as exc:
-            self._memory_plugin_error = exc
-            raise
-        self._memory_plugin_error = None
-        try:
-            return await runtime.preflight(memory_config)
-        finally:
-            runtime.begin_close()
-            await runtime.close()
+        created = runtime is None
+        async with self._memory_operation(
+            getattr(runtime, "effective_home", None)
+        ) as lease:
+            if lease is None:
+                return {"ok": False, "error": "memory_operation_in_progress"}
+            async with self._memory_replacement_lock():
+                if getattr(self, "memory_runtime", None) is not runtime:
+                    return {"ok": False, "error": "memory_operation_in_progress"}
+            if created:
+                try:
+                    runtime = self._retry_memory_runtime(memory_config)
+                except MemoryRuntimeBusyError:
+                    return {"ok": False, "error": "memory_operation_in_progress"}
+            try:
+                return await runtime.preflight(memory_config)
+            except MemoryRuntimeBusyError:
+                return {"ok": False, "error": "memory_operation_in_progress"}
+            finally:
+                if created:
+                    await self._close_unpublished_memory_runtime(runtime)
 
     async def install_memory_runtime(self) -> dict[str, Any]:
         """Install the managed artifact through Controller runtime ownership."""
 
-        await self._await_disabled_memory_cleanup()
         async with self._memory_replacement_lock():
             runtime = getattr(self, "memory_runtime", None)
         if runtime is not None:
             return await runtime.install_artifact()
-        try:
-            runtime = self._create_memory_runtime(
-                self.config.memory,
-                allow_disabled=True,
-            )
-        except MemoryRuntimeBusyError:
-            return {
-                "ok": False,
-                "reason": "memory_operation_in_progress",
-                "download_error": None,
-            }
-        except (MemoryPluginUnavailableError, MemoryPluginIncompatibleError) as exc:
-            self._memory_plugin_error = exc
-            raise
-        self._memory_plugin_error = None
-        try:
-            return await runtime.install_artifact()
-        finally:
-            runtime.begin_close()
-            await runtime.close()
+        async with self._memory_operation() as lease:
+            if lease is None:
+                return {
+                    "ok": False,
+                    "reason": "memory_operation_in_progress",
+                    "download_error": None,
+                }
+            async with self._memory_replacement_lock():
+                if getattr(self, "memory_runtime", None) is not None:
+                    return {
+                        "ok": False,
+                        "reason": "memory_operation_in_progress",
+                        "download_error": None,
+                    }
+            try:
+                runtime = self._retry_memory_runtime(
+                    self.config.memory,
+                    allow_disabled=True,
+                )
+            except MemoryRuntimeBusyError:
+                return {
+                    "ok": False,
+                    "reason": "memory_operation_in_progress",
+                    "download_error": None,
+                }
+            try:
+                return await runtime.install_artifact(operation_lease_held=True)
+            finally:
+                await self._close_unpublished_memory_runtime(runtime)
 
     async def reconcile_memory(self, memory_config: MemoryConfig) -> dict[str, Any]:
         """Hot-apply persisted Memory settings without destructive fallback."""
 
-        await self._await_disabled_memory_cleanup()
         async with self._memory_replacement_lock():
             runtime = getattr(self, "memory_runtime", None)
         if not memory_config.enabled:
@@ -911,40 +990,43 @@ class Controller:
             )
             if runtime is not None:
                 await runtime.close()
+                await self._clear_memory_runtime(runtime)
             await self._recheck_disabled_memory_cleanup()
             return {"ok": True, "state": "disabled"}
 
         created = runtime is None
         if created:
-            try:
-                runtime = self._create_memory_runtime(memory_config)
-            except MemoryRuntimeBusyError:
-                return {"ok": False, "error": "memory_operation_in_progress"}
-            except (
-                MemoryPluginUnavailableError,
-                MemoryPluginIncompatibleError,
-            ) as exc:
-                self._memory_plugin_error = exc
-                raise
-            try:
-                await self._attach_memory_runtime(runtime, capture_enabled=False)
-            except BaseException:
-                runtime.begin_close()
-                await runtime.close()
-                raise
+            async with self._memory_operation() as lease:
+                if lease is None:
+                    return {"ok": False, "error": "memory_operation_in_progress"}
+                async with self._memory_replacement_lock():
+                    if getattr(self, "memory_runtime", None) is not None:
+                        return {"ok": False, "error": "memory_operation_in_progress"}
+                try:
+                    runtime = self._retry_memory_runtime(memory_config)
+                except MemoryRuntimeBusyError:
+                    return {"ok": False, "error": "memory_operation_in_progress"}
+                try:
+                    await self._attach_memory_runtime(runtime, capture_enabled=False)
+                except BaseException:
+                    await self._close_unpublished_memory_runtime(runtime)
+                    raise
         try:
             result = await runtime.reconcile(memory_config)
             async with self._memory_replacement_lock():
                 still_owned = getattr(self, "memory_runtime", None) is runtime
                 current_enabled = bool(self.config.memory.enabled)
-                if still_owned:
+                publishable = (
+                    still_owned
+                    and not bool(getattr(runtime, "closing", False))
+                )
+                if publishable:
                     self.memory_module = runtime.module
                     if result.get("ok") is True:
                         self.config.memory = memory_config
-                        if created:
-                            self._start_memory_capture_adapter(runtime)
+                        self._start_memory_capture_adapter(runtime)
                         self.memory_adapter = runtime.capture_adapter
-            if result.get("ok") is True and not still_owned:
+            if result.get("ok") is True and not publishable:
                 return {
                     "ok": False,
                     "state": "degraded" if current_enabled else "disabled",
@@ -956,6 +1038,7 @@ class Controller:
                 detached = await self._detach_memory_runtime(runtime)
                 if detached is runtime:
                     await runtime.close()
+                    await self._clear_memory_runtime(runtime)
             raise
 
     async def capture_memory(self, request: CaptureRequest) -> CaptureReceipt:
@@ -1477,33 +1560,41 @@ class Controller:
     async def _memory_runtime_for_data_reset(
         self,
     ) -> AsyncIterator[tuple["MemoryRuntime" | None, bool]]:
-        """Provide the current runtime or an unpublished disabled-mode runtime."""
-
-        await self._await_disabled_memory_cleanup()
         async with self._memory_replacement_lock():
             runtime = getattr(self, "memory_runtime", None)
-        attached = runtime is not None
         if runtime is None:
-            try:
-                runtime = self._create_memory_runtime(
-                    self.config.memory,
-                    allow_disabled=True,
-                )
-            except MemoryRuntimeBusyError:
+            async with self._memory_operation() as lease:
+                if lease is None:
+                    yield None, False
+                    return
+                async with self._memory_replacement_lock():
+                    if getattr(self, "memory_runtime", None) is not None:
+                        yield None, False
+                        return
+                try:
+                    runtime = self._retry_memory_runtime(
+                        self.config.memory,
+                        allow_disabled=True,
+                    )
+                except MemoryRuntimeBusyError:
+                    yield None, False
+                    return
+                try:
+                    yield runtime, False
+                finally:
+                    if not bool(getattr(runtime, "closing", False)):
+                        await self._close_unpublished_memory_runtime(runtime)
+            return
+        async with self._memory_operation(runtime.effective_home) as lease:
+            if lease is None:
                 yield None, False
                 return
-        try:
-            yield runtime, attached
-        finally:
-            if not attached:
-                runtime.begin_close()
-                try:
-                    await runtime.close()
-                except Exception:
-                    logger.warning(
-                        "Unpublished Memory reset runtime did not close cleanly",
-                        exc_info=True,
-                    )
+            async with self._memory_replacement_lock():
+                ownership_changed = getattr(self, "memory_runtime", None) is not runtime
+            if ownership_changed:
+                yield None, False
+                return
+            yield runtime, True
 
     async def _cancel_memory_reconcile_task(self) -> None:
         task = getattr(self, "_memory_reconcile_task", None)
@@ -1581,7 +1672,7 @@ class Controller:
         deadline = loop.time() + budget
         for index, (label, operation) in enumerate(stages):
             remaining = max(0.0, deadline - loop.time())
-            stage_budget = remaining / (len(stages) - index)
+            stage_budget = remaining / (len(stages) - index + 1)
             task = asyncio.create_task(operation(), name=f"memory-shutdown-{index}")
             done, _pending = await asyncio.wait({task}, timeout=stage_budget)
             if task not in done:
@@ -1610,17 +1701,18 @@ class Controller:
                 logger.error("Memory %s failed during shutdown", label, exc_info=True)
 
         try:
-            await self._close_memory_runtime_for_shutdown()
+            await self._close_memory_runtime_for_shutdown(
+                timeout_seconds=max(0.0, deadline - loop.time())
+            )
         except Exception:
             self._shutdown_tainted = True
             logger.error("Memory runtime close failed during shutdown", exc_info=True)
 
-    async def _close_memory_runtime_for_shutdown(self) -> None:
-        """Detach the current runtime, then run its bounded close boundary."""
-
+    async def _close_memory_runtime_for_shutdown(self, *, timeout_seconds: float) -> None:
         runtime = await self._detach_memory_runtime()
         if runtime is not None:
-            await runtime.close()
+            await runtime.close(timeout_seconds=timeout_seconds)
+            await self._clear_memory_runtime(runtime)
 
     async def _reset_memory_data_transaction(
         self,
@@ -1631,9 +1723,7 @@ class Controller:
     ) -> dict[str, Any]:
         async with self._memory_runtime_for_data_reset() as runtime_context:
             runtime, attached = runtime_context
-            from avibe_memory.data_reset import (
-                unchanged_memory_data_result,
-            )
+            from avibe_memory.data_reset import unchanged_memory_data_result
 
             if runtime is None:
                 return {
@@ -1651,28 +1741,46 @@ class Controller:
                     "result": "unchanged",
                 }
 
-            lease = MemoryOperationLease(runtime.effective_home)
-            try:
-                await run_blocking(lease.acquire)
-            except MemoryOperationBusy:
+            if getattr(runtime, "_artifact_installing", False):
                 return {
                     "ok": False,
                     "operation": operation,
                     "error": "memory_operation_in_progress",
                     "result": "unchanged",
                 }
-            except Exception:
-                logger.exception("Memory data reset could not acquire operation lease")
-                return unchanged_memory_data_result(
-                    runtime.effective_home,
-                    operation=operation,
-                    reason="operation_lock_failed",
-                )
+            if not bool(getattr(runtime, "closing", False)):
+                try:
+                    await runtime.prepare_data_reset()
+                except Exception:
+                    logger.exception(
+                        "Memory data reset could not prove recorded sidecar ownership ended"
+                    )
+                    return unchanged_memory_data_result(
+                        runtime.effective_home,
+                        operation=operation,
+                        reason="sidecar_termination_unproved",
+                    )
+
+            root_ownership = await self._retire_memory_runtime_for_reset(
+                runtime,
+                allow_unpublished=not attached,
+            )
+            if root_ownership is None:
+                return {
+                    "ok": False,
+                    "operation": operation,
+                    "error": "memory_operation_in_progress",
+                    "result": "unchanged",
+                }
+
+            target = replace(
+                deepcopy(target_config or self.config.memory),
+                legacy_needs_repair=False,
+            )
 
             async def close_reset_runtime() -> dict[str, Any] | None:
-                runtime.begin_close()
                 try:
-                    await runtime.close()
+                    await runtime.close(root_ownership=root_ownership)
                 except BaseException:
                     logger.exception("Memory data reset could not close the owned runtime")
                     runtime.mark_needs_repair(f"memory_{operation}_failed")
@@ -1685,6 +1793,21 @@ class Controller:
                     return failure
                 return None
 
+            async def release_disabled() -> None:
+                runtime.release_root_ownership(root_ownership)
+                await self._clear_memory_runtime(runtime)
+
+            async def publish(config: MemoryConfig):
+                self.config.memory = config
+                if config.enabled:
+                    return await self._activate_memory_replacement(
+                        runtime,
+                        config,
+                        root_ownership,
+                    )
+                await release_disabled()
+                return None, {"ok": True, "state": "disabled"}
+
             async def restore_after_fence_failure(
                 failure: dict[str, Any],
             ) -> dict[str, Any]:
@@ -1696,15 +1819,8 @@ class Controller:
                     )
                     failure.update(state="degraded", result="runtime_restore_failed")
                     return failure
-                self.config.memory = live_config
-                if not live_config.enabled:
-                    failure["state"] = "disabled"
-                    return failure
                 try:
-                    _fresh, activation = await self._activate_memory_replacement(
-                        runtime,
-                        live_config,
-                    )
+                    _fresh, activation = await publish(live_config)
                 except MemoryRuntimeBusyError:
                     failure.update(
                         state="degraded",
@@ -1726,203 +1842,146 @@ class Controller:
                     )
                 return failure
 
+            def persist_reset_fence(current: MemoryConfig) -> MemoryConfig:
+                if operation == "reconfigure":
+                    if expected_config is None or current != expected_config:
+                        raise MemoryConfigStaleWrite("memory candidate changed")
+                return replace(current, legacy_needs_repair=True)
+
             try:
-                if getattr(runtime, "_artifact_installing", False):
-                    return {
-                        "ok": False,
-                        "operation": operation,
-                        "error": "memory_operation_in_progress",
-                        "result": "unchanged",
-                    }
-                try:
-                    await runtime.prepare_data_reset()
-                except Exception:
-                    logger.exception(
-                        "Memory data reset could not prove recorded sidecar ownership ended"
+                fenced_config = (
+                    await run_blocking(
+                        atomic_update_memory,
+                        persist_reset_fence,
                     )
-                    return unchanged_memory_data_result(
-                        runtime.effective_home,
-                        operation=operation,
-                        reason="sidecar_termination_unproved",
-                    )
-
-                if attached:
-                    detached = await self._detach_memory_runtime(runtime)
-                    if detached is not runtime:
-                        return {
-                            "ok": False,
-                            "operation": operation,
-                            "error": "memory_operation_in_progress",
-                            "result": "unchanged",
-                        }
-
-                target = replace(
-                    deepcopy(target_config or self.config.memory),
-                    legacy_needs_repair=False,
-                )
-
-                def persist_reset_fence(current: MemoryConfig) -> MemoryConfig:
-                    if operation == "reconfigure":
-                        if expected_config is None or current != expected_config:
-                            raise MemoryConfigStaleWrite("memory candidate changed")
-                    return replace(current, legacy_needs_repair=True)
-
-                try:
-                    fenced_config = (
-                        await run_blocking(
-                            atomic_update_memory,
-                            persist_reset_fence,
-                        )
-                    ).memory
-                except MemoryConfigStaleWrite:
-                    if failure := await close_reset_runtime():
-                        return failure
-                    return await restore_after_fence_failure({
-                        "ok": False,
-                        "operation": operation,
-                        "error": "memory_operation_in_progress",
-                        "result": "unchanged",
-                    })
-                except Exception:
+                ).memory
+            except Exception as exc:
+                stale = isinstance(exc, MemoryConfigStaleWrite)
+                if not stale:
                     logger.exception(
                         "Memory data reset could not persist its repair fence"
                     )
-                    if failure := await close_reset_runtime():
-                        return failure
-                    return await restore_after_fence_failure(
-                        unchanged_memory_data_result(
-                            runtime.effective_home,
-                            operation=operation,
-                            reason="config_persist_failed",
-                        )
-                    )
-                self.config.memory = fenced_config
-
-                def persist_confirmed_config(current: MemoryConfig) -> MemoryConfig:
-                    if operation == "reconfigure":
-                        if current != fenced_config:
-                            raise MemoryConfigStaleWrite("memory candidate changed")
-                        return target
-                    return replace(current, legacy_needs_repair=False)
-
                 if failure := await close_reset_runtime():
                     return failure
-                try:
-                    await runtime.settle_after_data_loss()
-                except Exception:
-                    logger.exception(
-                        "Memory data reset could not preserve and rotate stable identity"
-                    )
-                    runtime.mark_needs_repair(f"memory_{operation}_failed")
+                if stale:
+                    failure = {
+                        "ok": False,
+                        "operation": operation,
+                        "error": "memory_operation_in_progress",
+                        "result": "unchanged",
+                    }
+                else:
                     failure = unchanged_memory_data_result(
                         runtime.effective_home,
                         operation=operation,
-                        reason="identity_settlement_failed",
+                        reason="config_persist_failed",
                     )
-                    failure["state"] = "needs_repair"
-                    return failure
+                return await restore_after_fence_failure(failure)
+            self.config.memory = fenced_config
 
-                deletion = await run_blocking(
-                    runtime.reset_mutable_data,
+            def persist_confirmed_config(current: MemoryConfig) -> MemoryConfig:
+                if operation == "reconfigure":
+                    if current != fenced_config:
+                        raise MemoryConfigStaleWrite("memory candidate changed")
+                    return target
+                return replace(current, legacy_needs_repair=False)
+
+            if failure := await close_reset_runtime():
+                return failure
+            try:
+                await runtime.settle_after_data_loss(root_ownership)
+            except Exception:
+                logger.exception(
+                    "Memory data reset could not preserve and rotate stable identity"
                 )
-                deletion_payload = deletion.payload()
-                if deletion.data_remaining:
-                    if fenced_config.enabled:
-                        failed = runtime.replacement(fenced_config)
-                        await self._attach_memory_runtime(
-                            failed,
-                            capture_enabled=True,
-                        )
-                    return {
-                        "ok": False,
-                        "operation": operation,
-                        "state": "needs_repair",
-                        "error": f"memory_{operation}_failed",
-                        "result": "partial",
-                        **deletion_payload,
-                    }
+                runtime.mark_needs_repair(f"memory_{operation}_failed")
+                failure = unchanged_memory_data_result(
+                    runtime.effective_home,
+                    operation=operation,
+                    reason="identity_settlement_failed",
+                )
+                failure["state"] = "needs_repair"
+                return failure
 
+            deletion = await run_blocking(
+                runtime.reset_mutable_data,
+                root_ownership,
+            )
+            deletion_payload = deletion.payload()
+            if deletion.data_remaining:
+                await publish(fenced_config)
+                return {
+                    "ok": False,
+                    "operation": operation,
+                    "state": "needs_repair",
+                    "error": f"memory_{operation}_failed",
+                    "result": "partial",
+                    **deletion_payload,
+                }
+
+            try:
+                persisted = await run_blocking(
+                    atomic_update_memory,
+                    persist_confirmed_config,
+                )
+            except Exception as exc:
+                stale = isinstance(exc, MemoryConfigStaleWrite)
+                if not stale:
+                    logger.exception(
+                        "Memory data reset deleted data but could not persist configuration"
+                    )
                 try:
-                    persisted = await run_blocking(
-                        atomic_update_memory,
-                        persist_confirmed_config,
+                    live_config = (await run_blocking(V2Config.load)).memory
+                except Exception:
+                    logger.exception(
+                        "Memory data reset could not reload configuration after deletion"
                     )
-                except Exception as exc:
-                    stale = isinstance(exc, MemoryConfigStaleWrite)
-                    if not stale:
-                        logger.exception(
-                            "Memory data reset deleted data but could not persist configuration"
-                        )
-                    try:
-                        live_config = (await run_blocking(V2Config.load)).memory
-                    except Exception:
-                        logger.exception(
-                            "Memory data reset could not reload configuration after deletion"
-                        )
-                        live_config = deepcopy(expected_config or self.config.memory)
-                    self.config.memory = live_config
-                    fallback_state = "disabled"
-                    if live_config.enabled:
-                        _fallback, fallback_activation = (
-                            await self._activate_memory_replacement(
-                                runtime,
-                                live_config,
-                            )
-                        )
-                        fallback_state = str(
-                            fallback_activation.get("state") or "degraded"
-                        )
-                    return {
-                        "ok": False,
-                        "operation": operation,
-                        "state": fallback_state,
-                        "error": (
-                            "memory_operation_in_progress"
-                            if stale
-                            else f"memory_{operation}_failed"
-                        ),
-                        "result": "deleted_config_not_applied",
-                        **deletion_payload,
-                    }
+                    live_config = deepcopy(expected_config or self.config.memory)
+                _fresh, fallback = await publish(live_config)
+                return {
+                    "ok": False,
+                    "operation": operation,
+                    "state": str(fallback.get("state") or "degraded"),
+                    "error": (
+                        "memory_operation_in_progress"
+                        if stale
+                        else f"memory_{operation}_failed"
+                    ),
+                    "result": "deleted_config_not_applied",
+                    **deletion_payload,
+                }
 
-                target = persisted.memory
-                self.config.memory = target
-
-                if not target.enabled:
-                    return {
-                        "ok": True,
-                        "operation": operation,
-                        "state": "disabled",
-                        "result": "completed",
-                        **deletion_payload,
-                    }
-                fresh, activation = await self._activate_memory_replacement(
-                    runtime,
-                    target,
-                )
-                if activation.get("ok") is not True:
-                    state = activation.get("state")
-                    if state == "needs_repair" and not fresh.needs_repair:
-                        fresh.mark_needs_repair(
-                            str(activation.get("error") or f"memory_{operation}_failed")
-                        )
-                    return {
-                        "ok": False,
-                        "operation": operation,
-                        "state": "needs_repair" if fresh.needs_repair else "degraded",
-                        "error": activation.get("error", f"memory_{operation}_failed"),
-                        "result": "deleted_readiness_failed",
-                        **deletion_payload,
-                    }
+            target = persisted.memory
+            fresh, activation = await publish(target)
+            if fresh is None:
                 return {
                     "ok": True,
                     "operation": operation,
-                    "state": "running",
+                    "state": "disabled",
                     "result": "completed",
                     **deletion_payload,
                 }
-            finally:
-                await run_blocking(lease.release)
+            if activation.get("ok") is not True:
+                state = activation.get("state")
+                if state == "needs_repair" and not fresh.needs_repair:
+                    fresh.mark_needs_repair(
+                        str(activation.get("error") or f"memory_{operation}_failed")
+                    )
+                return {
+                    "ok": False,
+                    "operation": operation,
+                    "state": "needs_repair" if fresh.needs_repair else "degraded",
+                    "error": activation.get("error", f"memory_{operation}_failed"),
+                    "result": "deleted_readiness_failed",
+                    **deletion_payload,
+                }
+            return {
+                "ok": True,
+                "operation": operation,
+                "state": "running",
+                "result": "completed",
+                **deletion_payload,
+            }
 
     def _memory_replacement_lock(self) -> asyncio.Lock:
         """Lazily provide the gate for lightweight Controller test doubles."""
@@ -2362,8 +2421,6 @@ class Controller:
             return False
 
     async def _recheck_disabled_memory_cleanup(self) -> None:
-        """Clear a stale cleanup fence after checking ownership off-lock."""
-
         if not getattr(self, "_memory_disabled_cleanup_unproved", False):
             return
         memory_dir = paths.get_vibe_remote_dir() / "memory"
@@ -2400,49 +2457,52 @@ class Controller:
             )
 
     async def _cleanup_disabled_memory_process(self, memory_dir: Path) -> None:
-        """Lazily load the proven-ownership reaper after service readiness."""
-
-        ownership_exists = await asyncio.to_thread(
-            self._disabled_memory_ownership_exists,
-            memory_dir,
-        )
-        async with self._memory_replacement_lock():
-            if not isinstance(
-                getattr(self, "memory_adapter", None),
-                DisabledMemoryAdapter,
-            ) or getattr(self, "memory_runtime", None) is not None:
+        async with self._memory_operation() as lease:
+            if lease is None:
+                async with self._memory_replacement_lock():
+                    self._memory_disabled_cleanup_unproved = True
                 return
-            if not ownership_exists:
-                self._memory_disabled_cleanup_unproved = False
-                return
-            self._memory_disabled_cleanup_unproved = True
-
-        try:
-            from avibe_memory.process import ReleasedEverOSOrphanReconciler
-
-            reconciler = ReleasedEverOSOrphanReconciler(
-                provider_root=memory_dir / "everos-root",
-                effective_home=paths.get_vibe_remote_dir(),
-            )
-            await reconciler.reconcile_orphans()
-        except asyncio.CancelledError:
-            async with self._memory_replacement_lock():
-                self._memory_disabled_cleanup_unproved = True
-            raise
-        except Exception:
-            async with self._memory_replacement_lock():
-                self._memory_disabled_cleanup_unproved = True
-            logger.warning(
-                "Disabled Memory could not clean up an older owned EverOS process",
-                exc_info=True,
-            )
-        else:
             ownership_exists = await asyncio.to_thread(
                 self._disabled_memory_ownership_exists,
                 memory_dir,
             )
             async with self._memory_replacement_lock():
-                self._memory_disabled_cleanup_unproved = ownership_exists
+                if not isinstance(
+                    getattr(self, "memory_adapter", None),
+                    DisabledMemoryAdapter,
+                ) or getattr(self, "memory_runtime", None) is not None:
+                    return
+                if not ownership_exists:
+                    self._memory_disabled_cleanup_unproved = False
+                    return
+                self._memory_disabled_cleanup_unproved = True
+
+            try:
+                from avibe_memory.process import ReleasedEverOSOrphanReconciler
+
+                reconciler = ReleasedEverOSOrphanReconciler(
+                    provider_root=memory_dir / "everos-root",
+                    effective_home=paths.get_vibe_remote_dir(),
+                )
+                await reconciler.reconcile_orphans()
+            except asyncio.CancelledError:
+                async with self._memory_replacement_lock():
+                    self._memory_disabled_cleanup_unproved = True
+                raise
+            except Exception:
+                async with self._memory_replacement_lock():
+                    self._memory_disabled_cleanup_unproved = True
+                logger.warning(
+                    "Disabled Memory could not clean up an older owned EverOS process",
+                    exc_info=True,
+                )
+            else:
+                ownership_exists = await asyncio.to_thread(
+                    self._disabled_memory_ownership_exists,
+                    memory_dir,
+                )
+                async with self._memory_replacement_lock():
+                    self._memory_disabled_cleanup_unproved = ownership_exists
 
     def _run_im_runtime(self) -> None:
         try:

--- a/core/controller.py
+++ b/core/controller.py
@@ -1722,10 +1722,28 @@ class Controller:
             raise MemoryRuntimeBusyError(
                 "Memory destructive operation is still active"
             )
-        runtime = await self._detach_memory_runtime()
-        if runtime is not None:
-            await runtime.close(timeout_seconds=timeout_seconds)
-            await self._clear_memory_runtime(runtime)
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + max(0.0, timeout_seconds)
+        async with self._memory_replacement_lock():
+            runtime = getattr(self, "memory_runtime", None)
+        effective_home = getattr(runtime, "effective_home", None)
+        lease = await self._try_memory_operation_lease(effective_home)
+        while lease is None and loop.time() < deadline:
+            await asyncio.sleep(min(0.01, deadline - loop.time()))
+            lease = await self._try_memory_operation_lease(effective_home)
+        if lease is None:
+            raise MemoryRuntimeBusyError(
+                "Memory operation is still active during shutdown"
+            )
+        try:
+            runtime = await self._detach_memory_runtime()
+            if runtime is not None:
+                await runtime.close(
+                    timeout_seconds=max(0.0, deadline - loop.time())
+                )
+                await self._clear_memory_runtime(runtime)
+        finally:
+            await run_blocking(lease.release)
 
     async def _reset_memory_data_transaction(
         self,
@@ -1738,13 +1756,14 @@ class Controller:
             runtime, attached = runtime_context
             from avibe_memory.data_reset import unchanged_memory_data_result
 
+            busy = {
+                "ok": False,
+                "operation": operation,
+                "error": "memory_operation_in_progress",
+                "result": "unchanged",
+            }
             if runtime is None:
-                return {
-                    "ok": False,
-                    "operation": operation,
-                    "error": "memory_operation_in_progress",
-                    "result": "unchanged",
-                }
+                return busy
 
             if operation == "repair" and not runtime.needs_repair:
                 return {
@@ -1755,12 +1774,7 @@ class Controller:
                 }
 
             if getattr(runtime, "_artifact_installing", False):
-                return {
-                    "ok": False,
-                    "operation": operation,
-                    "error": "memory_operation_in_progress",
-                    "result": "unchanged",
-                }
+                return busy
             if not bool(getattr(runtime, "closing", False)):
                 try:
                     await runtime.prepare_data_reset()
@@ -1774,17 +1788,16 @@ class Controller:
                         reason="sidecar_termination_unproved",
                     )
 
-            root_ownership = await self._retire_memory_runtime_for_reset(
-                runtime,
-                allow_unpublished=not attached,
-            )
+            try:
+                root_ownership = await self._retire_memory_runtime_for_reset(
+                    runtime,
+                    allow_unpublished=not attached,
+                )
+            except MemoryRuntimeBusyError:
+                await self._settle_retained_memory_runtime(runtime)
+                return busy
             if root_ownership is None:
-                return {
-                    "ok": False,
-                    "operation": operation,
-                    "error": "memory_operation_in_progress",
-                    "result": "unchanged",
-                }
+                return busy
 
             target = replace(
                 deepcopy(target_config or self.config.memory),
@@ -1877,12 +1890,7 @@ class Controller:
                 if failure := await close_reset_runtime():
                     return failure
                 if stale:
-                    failure = {
-                        "ok": False,
-                        "operation": operation,
-                        "error": "memory_operation_in_progress",
-                        "result": "unchanged",
-                    }
+                    failure = busy
                 else:
                     failure = unchanged_memory_data_result(
                         runtime.effective_home,

--- a/core/controller.py
+++ b/core/controller.py
@@ -830,6 +830,7 @@ class Controller:
                 return False
         try:
             await runtime.close()
+            runtime.release_retained_root_ownership()
         except Exception:
             return False
         return await self._clear_memory_runtime(runtime)
@@ -840,6 +841,7 @@ class Controller:
         memory_config: MemoryConfig,
         *,
         allow_disabled: bool = False,
+        settle_closing: bool = True,
     ) -> AsyncIterator[tuple["MemoryRuntime" | None, bool]]:
         async with self._memory_replacement_lock():
             runtime = getattr(self, "memory_runtime", None)
@@ -853,7 +855,7 @@ class Controller:
                 if getattr(self, "memory_runtime", None) is not runtime:
                     yield None, False
                     return
-            if runtime is not None and bool(getattr(runtime, "closing", False)):
+            if settle_closing and runtime is not None and bool(getattr(runtime, "closing", False)):
                 if not await self._settle_retained_memory_runtime(runtime):
                     yield None, False
                     return
@@ -1587,6 +1589,7 @@ class Controller:
         async with self._memory_mutation_runtime(
             self.config.memory,
             allow_disabled=True,
+            settle_closing=False,
         ) as runtime_context:
             runtime, created = runtime_context
             if runtime is None:

--- a/core/controller.py
+++ b/core/controller.py
@@ -1044,35 +1044,35 @@ class Controller:
                 except BaseException:
                     await self._close_unpublished_memory_runtime(runtime)
                     raise
-        try:
-            result = await runtime.reconcile(memory_config)
-            async with self._memory_replacement_lock():
-                still_owned = getattr(self, "memory_runtime", None) is runtime
-                current_enabled = bool(self.config.memory.enabled)
-                publishable = (
-                    still_owned
-                    and not bool(getattr(runtime, "closing", False))
-                )
-                if publishable:
-                    self.memory_module = runtime.module
-                    if result.get("ok") is True:
-                        self.config.memory = memory_config
-                        self._start_memory_capture_adapter(runtime)
-                        self.memory_adapter = runtime.capture_adapter
-            if result.get("ok") is True and not publishable:
-                return {
-                    "ok": False,
-                    "state": "degraded" if current_enabled else "disabled",
-                    "error": "memory_operation_in_progress",
-                }
-            return result
-        except BaseException:
-            if created:
-                detached = await self._detach_memory_runtime(runtime)
-                if detached is runtime:
-                    await runtime.close()
-                    await self._clear_memory_runtime(runtime)
-            raise
+            try:
+                result = await runtime.reconcile(memory_config)
+                async with self._memory_replacement_lock():
+                    still_owned = getattr(self, "memory_runtime", None) is runtime
+                    current_enabled = bool(self.config.memory.enabled)
+                    publishable = (
+                        still_owned
+                        and not bool(getattr(runtime, "closing", False))
+                    )
+                    if publishable:
+                        self.memory_module = runtime.module
+                        if result.get("ok") is True:
+                            self.config.memory = memory_config
+                            self._start_memory_capture_adapter(runtime)
+                            self.memory_adapter = runtime.capture_adapter
+                if result.get("ok") is True and not publishable:
+                    return {
+                        "ok": False,
+                        "state": "degraded" if current_enabled else "disabled",
+                        "error": "memory_operation_in_progress",
+                    }
+                return result
+            except BaseException:
+                if created:
+                    detached = await self._detach_memory_runtime(runtime)
+                    if detached is runtime:
+                        await runtime.close()
+                        await self._clear_memory_runtime(runtime)
+                raise
 
     async def capture_memory(self, request: CaptureRequest) -> CaptureReceipt:
         """Snapshot the current module before offering one volatile capture."""

--- a/core/controller.py
+++ b/core/controller.py
@@ -1012,14 +1012,21 @@ class Controller:
                 "state": "disabled",
                 "error": "memory_operation_in_progress",
             }
-            runtime = await self._detach_memory_runtime(
-                disabled_config=memory_config,
-            )
+            async with self._memory_replacement_lock():
+                runtime = getattr(self, "memory_runtime", None)
             async with self._memory_operation(
                 getattr(runtime, "effective_home", None)
             ) as lease:
                 if lease is None:
                     return busy
+                async with self._memory_replacement_lock():
+                    if getattr(self, "memory_runtime", None) is not runtime:
+                        return busy
+                    self.memory_adapter = DisabledMemoryAdapter()
+                    self.config.memory = memory_config
+                    if runtime is not None:
+                        runtime.begin_close()
+                    self.memory_module = None
                 if runtime is not None and not await self._settle_retained_memory_runtime(
                     runtime
                 ):

--- a/core/memory_loader.py
+++ b/core/memory_loader.py
@@ -15,11 +15,13 @@ from vibe.memory_contract import (
 
 MEMORY_RUNTIME_ENTRYPOINT = "avibe_memory.runtime"
 MEMORY_RUNTIME_PROTOCOL_VERSION = 1
+MEMORY_RUNTIME_LIFECYCLE_CONTRACT = 1
 # Host-owned transport bound used by the list route. Keeping this here lets
 # disabled/failing plugin paths validate cursors without importing the optional
 # implementation module.
 MEMORY_LIST_CURSOR_MAX_BYTES = 8192
 _PROTOCOL_ATTR = "MEMORY_RUNTIME_PROTOCOL_VERSION"
+_LIFECYCLE_ATTR = "MEMORY_RUNTIME_LIFECYCLE_CONTRACT"
 
 
 def _resolve_memory_runtime_factory() -> Callable[..., Any]:
@@ -33,6 +35,7 @@ def _resolve_memory_runtime_factory() -> Callable[..., Any]:
         ) from exc
     try:
         protocol_version = getattr(implementation, _PROTOCOL_ATTR, None)
+        lifecycle_contract = getattr(implementation, _LIFECYCLE_ATTR, None)
         factory = getattr(implementation, "create_memory_runtime", None)
     except Exception as exc:
         raise MemoryPluginUnavailableError(
@@ -41,6 +44,10 @@ def _resolve_memory_runtime_factory() -> Callable[..., Any]:
     if protocol_version != MEMORY_RUNTIME_PROTOCOL_VERSION:
         raise MemoryPluginIncompatibleError(
             "Memory implementation protocol is incompatible"
+        )
+    if lifecycle_contract != MEMORY_RUNTIME_LIFECYCLE_CONTRACT:
+        raise MemoryPluginIncompatibleError(
+            "Memory implementation lifecycle contract is incompatible"
         )
     if not callable(factory):
         raise MemoryPluginUnavailableError(
@@ -64,7 +71,7 @@ def load_memory_runtime(
     """Load and construct the fixed Memory runtime for an enabled snapshot.
 
     This module intentionally imports no implementation module at import time.
-    The entrypoint, protocol comparison, and constructor are deliberately fixed
+    The entrypoint, compatibility contracts, and constructor are deliberately fixed
     so a missing/broken optional implementation cannot affect core startup.
     """
 

--- a/core/memory_loader.py
+++ b/core/memory_loader.py
@@ -9,6 +9,7 @@ from typing import Any
 from vibe.memory_contract import (
     MemoryPluginIncompatibleError,
     MemoryPluginUnavailableError,
+    MemoryRuntimeBusyError,
 )
 
 
@@ -72,6 +73,8 @@ def load_memory_runtime(
     factory = _resolve_memory_runtime_factory()
     try:
         runtime = factory(config, **runtime_kwargs)
+    except MemoryRuntimeBusyError:
+        raise
     except Exception as exc:
         raise MemoryPluginUnavailableError(
             "Memory implementation could not be constructed"

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -288,7 +288,7 @@ capture data.
 
 Lifecycle offers and barriers are non-blocking. `/new`, archive, runtime
 replacement, and shutdown never wait for capture delivery. Work still preparing
-or belonging to a stale authority generation may be missed or invalidated.
+after its runtime authority is revoked may be missed or invalidated.
 Shutdown and replacement intentionally drop volatile work.
 
 The writer gives add and flush operations at most three attempts, and retries

--- a/docs/MEMORY_ZH.md
+++ b/docs/MEMORY_ZH.md
@@ -150,7 +150,7 @@ Call Log，记录可以不完整或丢失。包含 `memory.diagnostics.log_provi
 提供方 I/O 的情况下丢弃。
 
 生命周期 offer 和 barrier 都不会阻塞。`/new`、归档、运行时替换和关机不会等待捕获
-投递；仍在准备中或属于旧 authority generation 的捕获可能丢失或失效。替换和关机
+投递；运行时 authority 被撤销后仍在准备的捕获可能丢失或失效。替换和关机
 会主动丢弃进程内易失工作。
 
 add/flush 最多尝试三次，只有明确证明在提供方执行前失败时才重试。可能已经提交的

--- a/tests/scenarios/memory_list/test_memory_list_scenarios.py
+++ b/tests/scenarios/memory_list/test_memory_list_scenarios.py
@@ -103,7 +103,7 @@ def test_captured_processed_episodes_list_through_cli_with_exact_page_boundary(
     asyncio.run(_capture_and_process())
     runtime = object.__new__(MemoryRuntime)
     runtime._module = module
-    runtime._retired = False
+    runtime._closing = False
     monkeypatch.setenv(AVIBE_SESSION_ID_ENV, "ses-memory-list-scenario")
 
     def list_sync(*, project, page, limit, caller_session_id):
@@ -193,7 +193,7 @@ def test_settings_can_browse_agent_episodes_without_crossing_owner_scopes(
         await module.wait_writer_idle_for_tests()
         runtime = object.__new__(MemoryRuntime)
         runtime._module = module
-        runtime._retired = False
+        runtime._closing = False
         return (
             await runtime.list_episodes_payload(
                 PRINCIPAL,

--- a/tests/test_controller_dispatch_loop.py
+++ b/tests/test_controller_dispatch_loop.py
@@ -372,7 +372,11 @@ def test_cleanup_sync_stops_watch_service_on_stopped_loop() -> None:
         def __init__(self) -> None:
             self.closed = False
 
+        def begin_close(self) -> None:
+            memory_adapter.quiesce_memory_capture_tasks()
+
         async def close(self) -> None:
+            await memory_adapter.cancel_memory_capture_tasks()
             assert stopped["capture"] is True
             self.closed = True
             stopped["runtime"] = True
@@ -394,7 +398,8 @@ def test_cleanup_sync_stops_watch_service_on_stopped_loop() -> None:
     controller.runtime_work_supervisor = _Supervisor("supervisor")
     controller.watch_service = _WatchStopper("watch")
     controller.runtime_command_watcher = _Stopper("runtime")
-    controller.memory_adapter = _MemoryAdapter()
+    memory_adapter = _MemoryAdapter()
+    controller.memory_adapter = memory_adapter
     memory_runtime = _MemoryRuntime()
     controller.memory_runtime = memory_runtime
 
@@ -870,6 +875,9 @@ def test_cleanup_sync_cancels_memory_reconcile_before_closing_runtime() -> None:
     controller._join_memory_destructive_transactions = join_destructive_transactions
 
     class _MemoryRuntime:
+        def begin_close(self) -> None:
+            assert reconcile_task.cancelled()
+
         async def close(self) -> None:
             assert reconcile_task.cancelled()
             assert cleanup_order == ["destructive-transactions"]

--- a/tests/test_controller_dispatch_loop.py
+++ b/tests/test_controller_dispatch_loop.py
@@ -375,7 +375,7 @@ def test_cleanup_sync_stops_watch_service_on_stopped_loop() -> None:
         def begin_close(self) -> None:
             memory_adapter.quiesce_memory_capture_tasks()
 
-        async def close(self) -> None:
+        async def close(self, **_kwargs: object) -> None:
             await memory_adapter.cancel_memory_capture_tasks()
             assert stopped["capture"] is True
             self.closed = True
@@ -878,7 +878,7 @@ def test_cleanup_sync_cancels_memory_reconcile_before_closing_runtime() -> None:
         def begin_close(self) -> None:
             assert reconcile_task.cancelled()
 
-        async def close(self) -> None:
+        async def close(self, **_kwargs: object) -> None:
             assert reconcile_task.cancelled()
             assert cleanup_order == ["destructive-transactions"]
             cleanup_order.append("runtime")

--- a/tests/test_controller_memory_data_reset.py
+++ b/tests/test_controller_memory_data_reset.py
@@ -30,17 +30,17 @@ class _Runtime:
         home: Path,
         *,
         needs_repair: bool = False,
-        close_proved: bool = True,
+        close_error: bool = False,
         wake_result: dict[str, object] | None = None,
     ) -> None:
         self.effective_home = home
         self.needs_repair = needs_repair
-        self.closed = False
+        self.close_completed = False
         self.retired = False
         self.module = object()
         self.capture_adapter = DisabledMemoryAdapter()
         self._artifact_installing = False
-        self._close_proved = close_proved
+        self._close_error = close_error
         self._wake_result = wake_result or {"ok": True, "state": "running"}
         self.events: list[str] = []
         self.marked_reason: str | None = None
@@ -63,12 +63,19 @@ class _Runtime:
         )
 
     def retire(self) -> None:
+        self.begin_close()
+
+    def begin_close(self) -> None:
+        if self.retired:
+            return
         self.events.append("retire")
         self.retired = True
 
     async def close(self) -> None:
         self.events.append("close")
-        self.closed = self._close_proved
+        if self._close_error:
+            raise RuntimeError("close failed")
+        self.close_completed = True
 
     async def wake(self, *, operation_lease_held: bool) -> dict[str, object]:
         assert operation_lease_held is True
@@ -76,11 +83,11 @@ class _Runtime:
         return self._wake_result
 
     async def settle_after_data_loss(self) -> None:
-        assert self.closed is True
+        assert self.close_completed is True
         self.events.append("settle")
 
     def reset_mutable_data(self):
-        assert self.closed is True
+        assert self.close_completed is True
         self.events.append("delete")
         return reset_memory_data_roots(self.effective_home)
 
@@ -123,7 +130,7 @@ async def test_reset_reaches_plugin_boundary_before_importing_reset_helpers(
         raise MemoryPluginUnavailableError("implementation missing")
         yield
 
-    controller._destructive_memory_runtime = unavailable_runtime
+    controller._memory_runtime_for_data_reset = unavailable_runtime
     real_import = builtins.__import__
 
     def block_reset_helper(name, *args, **kwargs):
@@ -243,14 +250,14 @@ async def test_repair_stops_owned_runtime_before_delete_and_proves_native_readin
 
 
 @pytest.mark.asyncio
-async def test_repair_deletes_nothing_when_termination_is_unproved(
+async def test_repair_deletes_nothing_when_runtime_close_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """MEMORY-REPAIR-203: failed termination proof grants no deletion."""
+    """MEMORY-REPAIR-203: failed runtime close grants no deletion."""
 
     _roots(tmp_path)
-    runtime = _Runtime(tmp_path, needs_repair=True, close_proved=False)
+    runtime = _Runtime(tmp_path, needs_repair=True, close_error=True)
     controller = _controller(runtime)
     _persist(monkeypatch, controller)
     result = await controller.repair_memory(confirm_loss=True)
@@ -386,73 +393,6 @@ async def test_delete_data_lazily_constructs_runtime_after_disabled_restart(
     assert controller.memory_module is None
     assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
     assert runtime.replacement_configs == []
-
-
-@pytest.mark.asyncio
-async def test_disable_vs_delete_race_closes_temporary_runtime_on_early_return(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A queued delete decides temporary ownership only after taking the gate."""
-
-    old_runtime = _Runtime(tmp_path)
-    controller = _controller(old_runtime)
-    controller.memory_adapter = None
-    controller._memory_reconcile_task = None
-    temporary = _Runtime(tmp_path)
-    created: list[MemoryConfig] = []
-
-    def create_memory_runtime(
-        config: MemoryConfig,
-        **_kwargs: object,
-    ) -> _Runtime:
-        created.append(config)
-        return temporary
-
-    class _BusyLease:
-        def __init__(self, _home: Path) -> None:
-            pass
-
-        def acquire(self) -> None:
-            from config.memory_operation_lock import MemoryOperationBusy
-
-            raise MemoryOperationBusy("busy")
-
-        def release(self) -> None:
-            raise AssertionError("an unacquired lease must not be released")
-
-    monkeypatch.setattr(controller, "_create_memory_runtime", create_memory_runtime)
-    monkeypatch.setattr("core.controller.MemoryOperationLease", _BusyLease)
-
-    gate = controller._memory_replacement_lock()
-    await gate.acquire()
-    operation = asyncio.create_task(
-        controller.delete_memory_data(confirm_loss=True)
-    )
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
-
-    disabled = MemoryConfig(enabled=False)
-    controller.config.memory = disabled
-    controller.memory_runtime = None
-    controller.memory_module = None
-    controller.memory_adapter = DisabledMemoryAdapter()
-    gate.release()
-
-    result = await operation
-
-    assert result == {
-        "ok": False,
-        "operation": "delete_data",
-        "error": "memory_operation_in_progress",
-        "result": "unchanged",
-    }
-    assert created == [disabled]
-    assert temporary.events == ["retire", "close"]
-    assert temporary.closed is True
-    assert controller.memory_runtime is None
-    assert controller.memory_module is None
-    assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
 
 
 @pytest.mark.asyncio

--- a/tests/test_controller_memory_data_reset.py
+++ b/tests/test_controller_memory_data_reset.py
@@ -21,7 +21,7 @@ from config.v2_config import (
 from core.controller import Controller
 from avibe_memory.data_reset import reset_memory_data_roots
 from core.memory_adapter import DisabledMemoryAdapter
-from vibe.memory_contract import MemoryPluginUnavailableError
+from vibe.memory_contract import MemoryPluginUnavailableError, MemoryRuntimeBusyError
 
 
 class _Runtime:
@@ -36,7 +36,7 @@ class _Runtime:
         self.effective_home = home
         self.needs_repair = needs_repair
         self.close_completed = False
-        self.retired = False
+        self.closing = False
         self.module = object()
         self.capture_adapter = DisabledMemoryAdapter()
         self._artifact_installing = False
@@ -62,14 +62,11 @@ class _Runtime:
             needs_repair=config.legacy_needs_repair,
         )
 
-    def retire(self) -> None:
-        self.begin_close()
-
     def begin_close(self) -> None:
-        if self.retired:
+        if self.closing:
             return
-        self.events.append("retire")
-        self.retired = True
+        self.closing = True
+        self.events.append("begin_close")
 
     async def close(self) -> None:
         self.events.append("close")
@@ -244,7 +241,7 @@ async def test_repair_stops_owned_runtime_before_delete_and_proves_native_readin
 
     assert result["ok"] is True
     assert result["state"] == "running"
-    assert events == ["reap", "retire", "close", "settle", "delete"]
+    assert events == ["reap", "begin_close", "close", "settle", "delete"]
     assert fresh.events == ["wake"]
     assert controller.memory_runtime is fresh
 
@@ -267,6 +264,7 @@ async def test_repair_deletes_nothing_when_runtime_close_fails(
     assert result["state"] == "needs_repair"
     assert result["data_deleted"] is False
     assert "delete" not in runtime.events
+    assert runtime.replacement_configs == []
     assert runtime.marked_reason == "memory_repair_failed"
     assert (tmp_path / "memory").is_dir()
 
@@ -519,12 +517,16 @@ async def test_reconfigure_accepts_scope_release_acknowledgement(
     ]
 
 
+@pytest.mark.parametrize("write_failure", ("stale", "error"))
 @pytest.mark.asyncio
-async def test_reconfigure_rejects_a_stale_memory_snapshot(
+async def test_reconfigure_fence_failure_restores_exact_enabled_runtime(
+    write_failure: str,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     runtime = _Runtime(tmp_path)
+    fresh = _Runtime(tmp_path)
+    runtime.replacement_runtime = fresh
     controller = _controller(runtime)
     expected = controller.config.memory
     target = MemoryConfig(enabled=True)
@@ -535,10 +537,16 @@ async def test_reconfigure_rejects_a_stale_memory_snapshot(
     )
 
     def update(transform):
+        if write_failure == "error":
+            raise OSError("write failed")
         concurrent = MemoryConfig(enabled=False)
         return SimpleNamespace(memory=transform(concurrent))
 
     monkeypatch.setattr("core.controller.atomic_update_memory", update)
+    monkeypatch.setattr(
+        "core.controller.V2Config.load",
+        classmethod(lambda cls: SimpleNamespace(memory=expected)),
+    )
 
     result = await controller.reconfigure_memory(
         target,
@@ -546,13 +554,39 @@ async def test_reconfigure_rejects_a_stale_memory_snapshot(
         confirm_loss=True,
     )
 
-    assert result == {
+    assert result["ok"] is False
+    assert result["error"] == (
+        "memory_operation_in_progress"
+        if write_failure == "stale"
+        else "memory_reconfigure_failed"
+    )
+    assert result["state"] == "running"
+    assert runtime.events == ["reap", "begin_close", "close"]
+    assert runtime.replacement_configs == [expected]
+    assert fresh.events == ["wake"]
+    assert controller.memory_runtime is fresh
+
+
+@pytest.mark.asyncio
+async def test_disabled_reset_root_contention_returns_busy() -> None:
+    controller = Controller.__new__(Controller)
+    controller.config = SimpleNamespace(memory=MemoryConfig(enabled=False))
+    controller.memory_runtime = None
+    controller.memory_module = None
+    controller.memory_adapter = DisabledMemoryAdapter()
+    controller._memory_disabled_cleanup_task = None
+
+    def busy(*_args, **_kwargs):
+        raise MemoryRuntimeBusyError("provider root busy")
+
+    controller._create_memory_runtime = busy
+
+    assert await controller.delete_memory_data(confirm_loss=True) == {
         "ok": False,
-        "operation": "reconfigure",
+        "operation": "delete_data",
         "error": "memory_operation_in_progress",
         "result": "unchanged",
     }
-    assert runtime.events == ["reap", "retire", "close"]
 
 
 @pytest.mark.asyncio
@@ -686,7 +720,7 @@ async def test_cancelled_reset_joins_deletion_before_releasing_exclusion(
         await task
     assert lease_events == ["acquire", "release"]
     assert controller._memory_destructive_tasks == set()
-    assert runtime.events == ["reap", "retire", "close", "settle", "delete"]
+    assert runtime.events == ["reap", "begin_close", "close", "settle", "delete"]
     assert controller.memory_runtime is None
     assert controller.memory_module is None
     assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)

--- a/tests/test_controller_memory_data_reset.py
+++ b/tests/test_controller_memory_data_reset.py
@@ -18,6 +18,7 @@ from config.v2_config import (
     MemoryEndpointConfig,
     MemoryProcessingConfig,
 )
+from config.memory_operation_lock import MemoryOperationLease
 from core.controller import Controller
 from avibe_memory.data_reset import reset_memory_data_roots
 from core.memory_adapter import DisabledMemoryAdapter
@@ -722,7 +723,7 @@ async def test_reconfigure_does_not_overwrite_a_change_racing_with_deletion(
 
 
 @pytest.mark.asyncio
-async def test_cancelled_reset_joins_deletion_before_releasing_exclusion(
+async def test_reset_disable_and_cancellation_retain_owner_until_settlement(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -730,21 +731,10 @@ async def test_cancelled_reset_joins_deletion_before_releasing_exclusion(
     runtime = _Runtime(tmp_path)
     fresh = _Runtime(tmp_path)
     runtime.replacement_runtime = fresh
-    controller = _controller(runtime, enabled=False)
+    controller = _controller(runtime)
     _persist(monkeypatch, controller)
     deletion_started = threading.Event()
     allow_deletion_to_finish = threading.Event()
-    lease_events: list[str] = []
-
-    class Lease:
-        def __init__(self, _home: Path) -> None:
-            pass
-
-        def acquire(self) -> None:
-            lease_events.append("acquire")
-
-        def release(self) -> None:
-            lease_events.append("release")
 
     def blocking_reset(_root_ownership: object):
         runtime.events.append("delete")
@@ -753,26 +743,36 @@ async def test_cancelled_reset_joins_deletion_before_releasing_exclusion(
         return reset_memory_data_roots(tmp_path)
 
     runtime.reset_mutable_data = blocking_reset
-    monkeypatch.setattr("core.controller.MemoryOperationLease", Lease)
     task = asyncio.create_task(controller.delete_memory_data(confirm_loss=True))
     assert await asyncio.to_thread(deletion_started.wait, 2)
+    disabled = MemoryConfig(enabled=False)
+    assert await controller.reconcile_memory(disabled) == {
+        "ok": False,
+        "state": "disabled",
+        "error": "memory_operation_in_progress",
+    }
+    assert controller.memory_runtime is runtime
+    assert controller.config.memory == disabled
     task.cancel()
     await asyncio.sleep(0.05)
 
     assert task.done() is False
-    assert lease_events == ["acquire"]
     assert len(controller._memory_destructive_tasks) == 1
 
     allow_deletion_to_finish.set()
     with pytest.raises(asyncio.CancelledError):
         await task
-    assert lease_events == ["acquire", "release"]
+    lease = MemoryOperationLease(tmp_path)
+    lease.acquire()
+    lease.release()
     assert controller._memory_destructive_tasks == set()
     assert runtime.events == ["reap", "begin_close", "close", "settle", "delete"]
     assert controller.memory_runtime is None
     assert controller.memory_module is None
+    assert controller.config.memory == disabled
     assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
     assert runtime.replacement_configs == []
+    assert runtime.root_released is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_controller_memory_data_reset.py
+++ b/tests/test_controller_memory_data_reset.py
@@ -552,7 +552,44 @@ async def test_reconfigure_rejects_a_stale_memory_snapshot(
         "error": "memory_operation_in_progress",
         "result": "unchanged",
     }
+    assert runtime.events == ["reap", "retire", "close"]
+
+
+@pytest.mark.asyncio
+async def test_reset_lost_runtime_writes_no_fence_and_leaves_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _Runtime(tmp_path)
+    replacement = _Runtime(tmp_path)
+    controller = _controller(runtime)
+    replacement_adapter = object()
+
+    async def lose_expected_runtime() -> None:
+        runtime.events.append("reap")
+        controller.memory_runtime = replacement
+        controller.memory_module = replacement.module
+        controller.memory_adapter = replacement_adapter
+
+    runtime.prepare_data_reset = lose_expected_runtime
+    monkeypatch.setattr(
+        "core.controller.atomic_update_memory",
+        lambda _transform: pytest.fail("lost ownership must not persist a fence"),
+    )
+
+    result = await controller.delete_memory_data(confirm_loss=True)
+
+    assert result == {
+        "ok": False,
+        "operation": "delete_data",
+        "error": "memory_operation_in_progress",
+        "result": "unchanged",
+    }
     assert runtime.events == ["reap"]
+    assert replacement.events == []
+    assert controller.memory_runtime is replacement
+    assert controller.memory_module is replacement.module
+    assert controller.memory_adapter is replacement_adapter
 
 
 @pytest.mark.asyncio

--- a/tests/test_controller_memory_data_reset.py
+++ b/tests/test_controller_memory_data_reset.py
@@ -712,6 +712,7 @@ async def test_reset_disable_and_cancellation_retain_owner_until_settlement(
     fresh = _Runtime(tmp_path)
     runtime.replacement_runtime = fresh
     controller = _controller(runtime)
+    enabled = controller.config.memory
     _persist(monkeypatch, controller)
     deletion_started = threading.Event()
     allow_deletion_to_finish = threading.Event()
@@ -731,8 +732,7 @@ async def test_reset_disable_and_cancellation_retain_owner_until_settlement(
         "state": "disabled",
         "error": "memory_operation_in_progress",
     }
-    assert controller.memory_runtime is runtime
-    assert controller.config.memory == disabled
+    assert controller.config.memory == enabled
     task.cancel()
     await asyncio.sleep(0.05)
 
@@ -747,12 +747,12 @@ async def test_reset_disable_and_cancellation_retain_owner_until_settlement(
     lease.release()
     assert controller._memory_destructive_tasks == set()
     assert runtime.events == ["reap", "begin_close", "close", "settle", "delete"]
-    assert controller.memory_runtime is None
-    assert controller.memory_module is None
-    assert controller.config.memory == disabled
-    assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
-    assert runtime.replacement_configs == []
-    assert runtime.root_released is True
+    assert controller.memory_runtime is fresh
+    assert controller.memory_module is fresh.module
+    assert controller.config.memory == enabled
+    assert controller.memory_adapter is fresh.capture_adapter
+    assert runtime.replacement_configs == [enabled]
+    assert runtime.root_released is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_controller_memory_data_reset.py
+++ b/tests/test_controller_memory_data_reset.py
@@ -22,7 +22,7 @@ from config.memory_operation_lock import MemoryOperationLease
 from core.controller import Controller
 from avibe_memory.data_reset import reset_memory_data_roots
 from core.memory_adapter import DisabledMemoryAdapter
-from vibe.memory_contract import MemoryPluginUnavailableError
+from vibe.memory_contract import MemoryPluginUnavailableError, MemoryRuntimeBusyError
 
 
 class _Runtime:
@@ -80,6 +80,9 @@ class _Runtime:
 
     def begin_root_ownership_handoff(self) -> object:
         self.begin_close()
+        if self._fail_stage == "handoff":
+            self._fail_stage = None
+            raise MemoryRuntimeBusyError("Memory provider root ownership changed")
         self.root_handoffs.append(self.root_ownership)
         return self.root_ownership
 
@@ -252,14 +255,14 @@ async def test_repair_requires_exact_loss_and_repair_authority(
     assert runtime.events == []
 
 
-@pytest.mark.parametrize("failure_stage", (None, "close", "settle", "delete"))
+@pytest.mark.parametrize("failure_stage", (None, "handoff", "close", "settle", "delete"))
 @pytest.mark.asyncio
 async def test_repair_reuses_retained_owner_until_reset_proves(
     failure_stage: str | None,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """MEMORY-REPAIR-202/203: failed reset phases retain one retryable owner."""
+    """MEMORY-REPAIR-202/203: failed reset phases retain or recover one owner."""
 
     _roots(tmp_path)
     runtime = _Runtime(
@@ -267,6 +270,8 @@ async def test_repair_reuses_retained_owner_until_reset_proves(
         needs_repair=True,
         fail_stage=failure_stage,
     )
+    if failure_stage == "handoff":
+        runtime.closing = True
     fresh = _Runtime(tmp_path)
     runtime.replacement_runtime = fresh
     controller = _controller(runtime)
@@ -278,19 +283,26 @@ async def test_repair_reuses_retained_owner_until_reset_proves(
         first = await controller.repair_memory(confirm_loss=True)
         if failure_stage is None:
             result = first
+        elif failure_stage == "handoff":
+            assert first["error"] == "memory_operation_in_progress"
         else:
             assert first["ok"] is False
             assert first["state"] == "needs_repair"
     if failure_stage is not None:
-        assert controller.memory_runtime is runtime
-        assert runtime.root_released is False
+        if failure_stage == "handoff":
+            assert controller.memory_runtime is None
+            assert runtime.root_released is True
+            controller._create_memory_runtime = lambda *_args, **_kwargs: runtime
+        else:
+            assert controller.memory_runtime is runtime
+            assert runtime.root_released is False
         assert fresh.events == []
         result = await controller.repair_memory(confirm_loss=True)
 
     assert result["ok"] is True
     assert result["state"] == "running"
     assert all(token is runtime.root_ownership for token in runtime.root_handoffs)
-    assert len(runtime.root_handoffs) == (1 if failure_stage is None else 2)
+    assert len(runtime.root_handoffs) == (1 if failure_stage in {None, "handoff"} else 2)
     assert fresh.events == ["wake"]
     assert controller.memory_runtime is fresh
 

--- a/tests/test_controller_memory_data_reset.py
+++ b/tests/test_controller_memory_data_reset.py
@@ -21,7 +21,7 @@ from config.v2_config import (
 from core.controller import Controller
 from avibe_memory.data_reset import reset_memory_data_roots
 from core.memory_adapter import DisabledMemoryAdapter
-from vibe.memory_contract import MemoryPluginUnavailableError, MemoryRuntimeBusyError
+from vibe.memory_contract import MemoryPluginUnavailableError
 
 
 class _Runtime:
@@ -46,6 +46,8 @@ class _Runtime:
         self.marked_reason: str | None = None
         self.replacement_runtime: _Runtime | None = None
         self.replacement_configs: list[MemoryConfig] = []
+        self.root_ownership = object()
+        self.root_released = False
 
     async def prepare_data_reset(self) -> None:
         self.events.append("reap")
@@ -53,7 +55,8 @@ class _Runtime:
     def start_capture_adapter(self, **_options: object) -> bool:
         return True
 
-    def replacement(self, config: MemoryConfig) -> _Runtime:
+    def replacement(self, config: MemoryConfig, root_ownership: object) -> _Runtime:
+        assert root_ownership is self.root_ownership
         self.replacement_configs.append(config)
         if self.replacement_runtime is not None:
             return self.replacement_runtime
@@ -68,7 +71,22 @@ class _Runtime:
         self.closing = True
         self.events.append("begin_close")
 
-    async def close(self) -> None:
+    def begin_root_ownership_handoff(self) -> object:
+        self.begin_close()
+        return self.root_ownership
+
+    def accept_root_ownership(self) -> None:
+        return None
+
+    async def close(
+        self,
+        *,
+        root_ownership: object | None = None,
+        timeout_seconds: float | None = None,
+    ) -> None:
+        del timeout_seconds
+        if root_ownership is not None:
+            assert root_ownership is self.root_ownership
         self.events.append("close")
         if self._close_error:
             raise RuntimeError("close failed")
@@ -79,24 +97,30 @@ class _Runtime:
         self.events.append("wake")
         return self._wake_result
 
-    async def settle_after_data_loss(self) -> None:
+    async def settle_after_data_loss(self, root_ownership: object) -> None:
+        assert root_ownership is self.root_ownership
         assert self.close_completed is True
         self.events.append("settle")
 
-    def reset_mutable_data(self):
+    def reset_mutable_data(self, root_ownership: object):
+        assert root_ownership is self.root_ownership
         assert self.close_completed is True
         self.events.append("delete")
         return reset_memory_data_roots(self.effective_home)
+
+    def release_root_ownership(self, root_ownership: object) -> None:
+        assert root_ownership is self.root_ownership
+        self.root_released = True
 
     def mark_needs_repair(self, reason: str) -> None:
         self.marked_reason = reason
         self.needs_repair = True
 
 
-def _controller(runtime: _Runtime, *, enabled: bool = True) -> Controller:
+def _controller(runtime: _Runtime | None, *, enabled: bool = True) -> Controller:
     controller = Controller.__new__(Controller)
     controller.memory_runtime = runtime
-    controller.memory_module = runtime.module
+    controller.memory_module = runtime.module if runtime is not None else None
     controller.config = SimpleNamespace(memory=MemoryConfig(enabled=enabled))
     return controller
 
@@ -568,25 +592,49 @@ async def test_reconfigure_fence_failure_restores_exact_enabled_runtime(
 
 
 @pytest.mark.asyncio
-async def test_disabled_reset_root_contention_returns_busy() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = SimpleNamespace(memory=MemoryConfig(enabled=False))
-    controller.memory_runtime = None
-    controller.memory_module = None
+async def test_unpublished_reset_blocks_concurrent_enable_before_construction(
+    tmp_path: Path,
+) -> None:
+    controller = _controller(None, enabled=False)
     controller.memory_adapter = DisabledMemoryAdapter()
-    controller._memory_disabled_cleanup_task = None
+    controller._memory_plugin_error = None
+    runtime = _Runtime(tmp_path)
+    reset_started = asyncio.Event()
+    reset_release = asyncio.Event()
+    lease = threading.Lock()
+    construction_calls: list[object] = []
 
-    def busy(*_args, **_kwargs):
-        raise MemoryRuntimeBusyError("provider root busy")
+    async def try_lease(_effective_home=None):
+        if not lease.acquire(blocking=False):
+            return None
+        return SimpleNamespace(release=lease.release)
 
-    controller._create_memory_runtime = busy
+    async def prepare_data_reset() -> None:
+        reset_started.set()
+        await reset_release.wait()
 
-    assert await controller.delete_memory_data(confirm_loss=True) == {
+    runtime.prepare_data_reset = prepare_data_reset
+    controller._try_memory_operation_lease = try_lease
+    controller._create_memory_runtime = lambda config, **_kwargs: (
+        construction_calls.append(config) or runtime
+    )
+    reset = asyncio.create_task(
+        controller._reset_memory_data_transaction(operation="delete_data")
+    )
+    await reset_started.wait()
+
+    assert await controller.reconcile_memory(MemoryConfig(enabled=True)) == {
         "ok": False,
-        "operation": "delete_data",
         "error": "memory_operation_in_progress",
-        "result": "unchanged",
     }
+    assert construction_calls == [controller.config.memory]
+    assert controller.memory_runtime is None
+
+    reset.cancel()
+    reset_release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await reset
+    assert runtime.close_completed is True
 
 
 @pytest.mark.asyncio
@@ -698,7 +746,7 @@ async def test_cancelled_reset_joins_deletion_before_releasing_exclusion(
         def release(self) -> None:
             lease_events.append("release")
 
-    def blocking_reset():
+    def blocking_reset(_root_ownership: object):
         runtime.events.append("delete")
         deletion_started.set()
         allow_deletion_to_finish.wait(timeout=5)

--- a/tests/test_controller_memory_data_reset.py
+++ b/tests/test_controller_memory_data_reset.py
@@ -31,7 +31,7 @@ class _Runtime:
         home: Path,
         *,
         needs_repair: bool = False,
-        close_error: bool = False,
+        fail_stage: str | None = None,
         wake_result: dict[str, object] | None = None,
     ) -> None:
         self.effective_home = home
@@ -41,17 +41,23 @@ class _Runtime:
         self.module = object()
         self.capture_adapter = DisabledMemoryAdapter()
         self._artifact_installing = False
-        self._close_error = close_error
+        self._fail_stage = fail_stage
         self._wake_result = wake_result or {"ok": True, "state": "running"}
         self.events: list[str] = []
         self.marked_reason: str | None = None
         self.replacement_runtime: _Runtime | None = None
         self.replacement_configs: list[MemoryConfig] = []
         self.root_ownership = object()
+        self.root_handoffs: list[object] = []
         self.root_released = False
 
     async def prepare_data_reset(self) -> None:
         self.events.append("reap")
+
+    def _fail_once(self, stage: str) -> None:
+        if self._fail_stage == stage:
+            self._fail_stage = None
+            raise RuntimeError(f"{stage} failed")
 
     def start_capture_adapter(self, **_options: object) -> bool:
         return True
@@ -74,6 +80,7 @@ class _Runtime:
 
     def begin_root_ownership_handoff(self) -> object:
         self.begin_close()
+        self.root_handoffs.append(self.root_ownership)
         return self.root_ownership
 
     def accept_root_ownership(self) -> None:
@@ -89,8 +96,7 @@ class _Runtime:
         if root_ownership is not None:
             assert root_ownership is self.root_ownership
         self.events.append("close")
-        if self._close_error:
-            raise RuntimeError("close failed")
+        self._fail_once("close")
         self.close_completed = True
 
     async def wake(self, *, operation_lease_held: bool) -> dict[str, object]:
@@ -101,16 +107,21 @@ class _Runtime:
     async def settle_after_data_loss(self, root_ownership: object) -> None:
         assert root_ownership is self.root_ownership
         assert self.close_completed is True
+        self._fail_once("settle")
         self.events.append("settle")
 
     def reset_mutable_data(self, root_ownership: object):
         assert root_ownership is self.root_ownership
         assert self.close_completed is True
+        self._fail_once("delete")
         self.events.append("delete")
         return reset_memory_data_roots(self.effective_home)
 
     def release_root_ownership(self, root_ownership: object) -> None:
         assert root_ownership is self.root_ownership
+        self.root_released = True
+
+    def release_retained_root_ownership(self) -> None:
         self.root_released = True
 
     def mark_needs_repair(self, reason: str) -> None:
@@ -216,82 +227,72 @@ def test_reset_memory_data_roots_fails_closed_on_special_entry(tmp_path: Path) -
     assert stat.S_ISFIFO(os.lstat(unsafe).st_mode)
 
 
+@pytest.mark.parametrize(
+    ("needs_repair", "confirm_loss", "error"),
+    (
+        (True, False, "memory_loss_confirmation_required"),
+        (False, True, "memory_repair_not_required"),
+    ),
+)
 @pytest.mark.asyncio
-async def test_repair_requires_exact_loss_confirmation(tmp_path: Path) -> None:
-    """MEMORY-REPAIR-201: Repair requires exact accepted-loss authority."""
+async def test_repair_requires_exact_loss_and_repair_authority(
+    needs_repair: bool,
+    confirm_loss: bool,
+    error: str,
+    tmp_path: Path,
+) -> None:
+    """MEMORY-REPAIR-201: Repair requires loss and needs-repair authority."""
 
-    runtime = _Runtime(tmp_path, needs_repair=True)
+    runtime = _Runtime(tmp_path, needs_repair=needs_repair)
     controller = _controller(runtime)
 
-    result = await controller.repair_memory(confirm_loss=False)
+    result = await controller.repair_memory(confirm_loss=confirm_loss)
 
-    assert result == {
-        "ok": False,
-        "operation": "repair",
-        "error": "memory_loss_confirmation_required",
-        "result": "unchanged",
-    }
+    assert result["error"] == error
     assert runtime.events == []
 
 
+@pytest.mark.parametrize("failure_stage", (None, "close", "settle", "delete"))
 @pytest.mark.asyncio
-async def test_repair_is_not_offered_for_degraded_runtime(tmp_path: Path) -> None:
-    """MEMORY-REPAIR-201: degraded state grants no Repair authority."""
-
-    runtime = _Runtime(tmp_path, needs_repair=False)
-    controller = _controller(runtime)
-
-    result = await controller.repair_memory(confirm_loss=True)
-
-    assert result["error"] == "memory_repair_not_required"
-    assert runtime.events == []
-
-
-@pytest.mark.asyncio
-async def test_repair_stops_owned_runtime_before_delete_and_proves_native_readiness(
+async def test_repair_reuses_retained_owner_until_reset_proves(
+    failure_stage: str | None,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """MEMORY-REPAIR-202: Repair proves stop, reset, and native readiness."""
+    """MEMORY-REPAIR-202/203: failed reset phases retain one retryable owner."""
 
     _roots(tmp_path)
-    runtime = _Runtime(tmp_path, needs_repair=True)
+    runtime = _Runtime(
+        tmp_path,
+        needs_repair=True,
+        fail_stage=failure_stage,
+    )
     fresh = _Runtime(tmp_path)
     runtime.replacement_runtime = fresh
     controller = _controller(runtime)
     _persist(monkeypatch, controller)
-    events = runtime.events
-
-    result = await controller.repair_memory(confirm_loss=True)
+    if failure_stage == "delete":
+        with pytest.raises(RuntimeError, match="delete failed"):
+            await controller.repair_memory(confirm_loss=True)
+    else:
+        first = await controller.repair_memory(confirm_loss=True)
+        if failure_stage is None:
+            result = first
+        else:
+            assert first["ok"] is False
+            assert first["state"] == "needs_repair"
+    if failure_stage is not None:
+        assert controller.memory_runtime is runtime
+        assert runtime.root_released is False
+        assert fresh.events == []
+        result = await controller.repair_memory(confirm_loss=True)
 
     assert result["ok"] is True
     assert result["state"] == "running"
-    assert events == ["reap", "begin_close", "close", "settle", "delete"]
+    assert all(token is runtime.root_ownership for token in runtime.root_handoffs)
+    assert len(runtime.root_handoffs) == (1 if failure_stage is None else 2)
     assert fresh.events == ["wake"]
     assert controller.memory_runtime is fresh
-
-
-@pytest.mark.asyncio
-async def test_repair_deletes_nothing_when_runtime_close_fails(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """MEMORY-REPAIR-203: failed runtime close grants no deletion."""
-
-    _roots(tmp_path)
-    runtime = _Runtime(tmp_path, needs_repair=True, close_error=True)
-    controller = _controller(runtime)
-    _persist(monkeypatch, controller)
-    result = await controller.repair_memory(confirm_loss=True)
-
-    assert result["ok"] is False
-    assert result["reason"] == "runtime_termination_unproved"
-    assert result["state"] == "needs_repair"
-    assert result["data_deleted"] is False
-    assert "delete" not in runtime.events
-    assert runtime.replacement_configs == []
-    assert runtime.marked_reason == "memory_repair_failed"
-    assert (tmp_path / "memory").is_dir()
 
 
 @pytest.mark.asyncio
@@ -359,28 +360,6 @@ async def test_local_post_reset_wake_failure_remains_needs_repair(
 
 
 @pytest.mark.asyncio
-async def test_delete_data_has_distinct_intent_but_reuses_reset(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """MEMORY-DELETE-DATA-001: explicit deletion uses the shared reset."""
-
-    _roots(tmp_path)
-    runtime = _Runtime(tmp_path)
-    fresh = _Runtime(tmp_path)
-    runtime.replacement_runtime = fresh
-    controller = _controller(runtime, enabled=False)
-    _persist(monkeypatch, controller)
-    result = await controller.delete_memory_data(confirm_loss=True)
-
-    assert result["ok"] is True
-    assert result["operation"] == "delete_data"
-    assert result["state"] == "disabled"
-    assert result["data_deleted"] is True
-    assert fresh.events == []
-
-
-@pytest.mark.asyncio
 async def test_delete_data_lazily_constructs_runtime_after_disabled_restart(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -408,6 +387,7 @@ async def test_delete_data_lazily_constructs_runtime_after_disabled_restart(
     result = await controller.delete_memory_data(confirm_loss=True)
 
     assert result["ok"] is True
+    assert result["operation"] == "delete_data"
     assert result["state"] == "disabled"
     assert result["data_deleted"] is True
     assert created == [controller.config.memory]

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -372,22 +372,13 @@ def _build_controller_double(handler=None):
     controller._memory_disabled_cleanup_task = None
     controller._memory_disabled_cleanup_unproved = False
     controller._memory_replacement_gate = None
-    controller._memory_runtime_lease_condition = None
-    controller._memory_runtime_lease_count = 0
-    controller._memory_runtime_leases_blocked = False
-    controller._memory_runtime_temporary = False
-    controller._memory_runtime_generation = 0
     controller.default_memory_project_id.return_value = "default"
     for method_name in (
         "_memory_replacement_lock",
-        "_memory_runtime_condition",
-        "_drain_memory_runtime_leases_locked",
-        "_mutate_memory_runtime",
         "_await_disabled_memory_cleanup",
-        "_attach_memory_runtime_locked",
-        "_clear_memory_runtime_locked",
-        "_close_memory_runtime_locked",
-        "_borrow_memory_runtime",
+        "_attach_memory_runtime",
+        "_detach_memory_runtime",
+        "_memory_runtime_for_operation",
         "_disabled_memory_source_payload",
         "_disabled_memory_status_payload",
         "_disabled_memory_status_payload_locked",
@@ -2000,8 +1991,8 @@ def test_native_processing_record_routes_authorize_the_selected_project() -> Non
     assert runtime.list_memory_projects.call_count == 3
 
 
-def test_memory_remember_route_rejects_capture_queued_across_runtime_replacement() -> None:
-    """The production CLI route cannot repopulate the fresh reset aggregate."""
+def test_memory_remember_route_does_not_hold_pointer_lock_during_capture() -> None:
+    """Long capture work runs after the Controller pointer snapshot."""
 
     from core.controller import Controller
     from avibe_memory import CaptureAccepted
@@ -2010,21 +2001,23 @@ def test_memory_remember_route_rejects_capture_queued_across_runtime_replacement
     class Module:
         def __init__(self) -> None:
             self.calls = 0
+            self.started = asyncio.Event()
+            self.release = asyncio.Event()
 
         async def capture(self, _request):  # noqa: ANN001, ANN202
+            assert controller._memory_replacement_lock().locked() is False
             self.calls += 1
+            self.started.set()
+            await self.release.wait()
             return CaptureAccepted()
 
-    old_module = Module()
-    fresh_module = Module()
-    old_runtime = SimpleNamespace(retired=False, available=True, module=old_module)
-    fresh_runtime = SimpleNamespace(retired=False, available=True, module=fresh_module)
+    module = Module()
+    runtime = SimpleNamespace(retired=False, available=True, module=module)
     controller = Controller.__new__(Controller)
     controller.config = SimpleNamespace(
         memory=SimpleNamespace(enabled=True),
     )
-    controller.memory_runtime = old_runtime
-    controller._memory_runtime_generation = 1
+    controller.memory_runtime = runtime
     controller.memory_scope_for_cli_session = lambda _session_id: (
         "u-" + "1" * 32,
         "p-" + "2" * 32,
@@ -2032,8 +2025,6 @@ def test_memory_remember_route_rejects_capture_queued_across_runtime_replacement
     app = internal_server.create_app(controller)
 
     async def _exercise() -> httpx.Response:
-        gate = controller._memory_replacement_lock()
-        await gate.acquire()
         transport = httpx.ASGITransport(app=app)
         async with httpx.AsyncClient(
             transport=transport,
@@ -2046,25 +2037,18 @@ def test_memory_remember_route_rejects_capture_queued_across_runtime_replacement
                     headers={CALLER_SESSION_HEADER: "session-1"},
                 )
             )
-            for _ in range(20):
-                await asyncio.sleep(0)
-                if getattr(gate, "_waiters", None):
-                    break
-            assert getattr(gate, "_waiters", None)
-            controller.memory_runtime = fresh_runtime
-            controller._memory_runtime_generation += 1
-            gate.release()
+            await module.started.wait()
+            async with asyncio.timeout(0.1):
+                async with controller._memory_replacement_lock():
+                    assert controller.memory_runtime is runtime
+            module.release.set()
             return await request
 
     response = asyncio.run(_exercise())
 
     assert response.status_code == 200
-    assert response.json() == {
-        "status": "skipped",
-        "reason": "memory_operation_in_progress",
-    }
-    assert old_module.calls == 0
-    assert fresh_module.calls == 0
+    assert response.json() == {"status": "accepted"}
+    assert module.calls == 1
 
 
 # ---------------------------------------------------------------------

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -2012,7 +2012,7 @@ def test_memory_remember_route_does_not_hold_pointer_lock_during_capture() -> No
             return CaptureAccepted()
 
     module = Module()
-    runtime = SimpleNamespace(retired=False, available=True, module=module)
+    runtime = SimpleNamespace(available=True, module=module)
     controller = Controller.__new__(Controller)
     controller.config = SimpleNamespace(
         memory=SimpleNamespace(enabled=True),

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -1067,7 +1067,7 @@ def test_memory_list_binds_cli_session_and_uses_exact_provider_page() -> None:
     from vibe.memory_http_headers import CALLER_SESSION_HEADER
 
     runtime = SimpleNamespace(
-        list_memory_projects=Mock(return_value=("default", "notes")),
+        list_memory_projects=AsyncMock(return_value=("default", "notes")),
         list_episodes_payload=AsyncMock(
             return_value={"status": "ok", "items": [], "page": 2}
         ),
@@ -1094,7 +1094,7 @@ def test_memory_list_binds_cli_session_and_uses_exact_provider_page() -> None:
     assert response.status_code == 200
     assert response.json() == {"status": "ok", "items": [], "page": 2}
     controller.memory_scope_for_cli_session.assert_called_once_with("ses-memory-list")
-    runtime.list_memory_projects.assert_called_once_with(
+    runtime.list_memory_projects.assert_awaited_once_with(
         "u-11111111111111111111111111111111"
     )
     runtime.list_episodes_payload.assert_awaited_once_with(
@@ -1110,7 +1110,7 @@ def test_memory_list_reports_unavailable_store_before_named_project_validation()
 
     runtime = SimpleNamespace(
         available=False,
-        list_memory_projects=Mock(return_value=("default",)),
+        list_memory_projects=AsyncMock(return_value=("default",)),
         list_episodes_payload=AsyncMock(),
     )
     controller = _build_controller_double()
@@ -1137,7 +1137,7 @@ def test_memory_list_reports_unavailable_store_before_named_project_validation()
         "status": "failed",
         "error": "memory_store_unavailable",
     }
-    runtime.list_memory_projects.assert_not_called()
+    runtime.list_memory_projects.assert_not_awaited()
     runtime.list_episodes_payload.assert_not_awaited()
 
 
@@ -1183,7 +1183,7 @@ def test_memory_list_all_is_available_only_to_signed_ui_principal() -> None:
 
     secret = "test-memory-ui-secret"
     runtime = SimpleNamespace(
-        principal_for_user_key=Mock(
+        resolve_principal_for_user_key=AsyncMock(
             return_value="u-22222222222222222222222222222222"
         ),
         list_all_episodes_payload=AsyncMock(
@@ -1227,7 +1227,7 @@ def test_memory_list_all_is_available_only_to_signed_ui_principal() -> None:
 
     assert response.status_code == 200
     assert response.json()["next_cursor"] == "next-token"
-    runtime.principal_for_user_key.assert_called_once_with(user_key)
+    runtime.resolve_principal_for_user_key.assert_awaited_once_with(user_key)
     runtime.list_all_episodes_payload.assert_awaited_once_with(
         "u-22222222222222222222222222222222",
         cursor="cursor-token",
@@ -1278,7 +1278,7 @@ def test_memory_list_rejects_invalid_aggregate_cursor_at_controller_boundary() -
 
     secret = "test-memory-ui-secret"
     runtime = SimpleNamespace(
-        principal_for_user_key=Mock(
+        resolve_principal_for_user_key=AsyncMock(
             return_value="u-22222222222222222222222222222222"
         ),
         list_all_episodes_payload=AsyncMock(
@@ -1324,7 +1324,7 @@ def test_memory_list_rejects_surrogate_aggregate_cursor_at_controller_boundary()
 
     secret = "test-memory-ui-secret"
     runtime = SimpleNamespace(
-        principal_for_user_key=Mock(
+        resolve_principal_for_user_key=AsyncMock(
             return_value="u-22222222222222222222222222222222"
         ),
         list_all_episodes_payload=AsyncMock(),
@@ -1374,7 +1374,7 @@ def test_memory_list_accepts_maximum_aggregate_cursor_transport_bound(monkeypatc
     secret = "test-memory-ui-secret"
     cursor = "a" * MEMORY_LIST_CURSOR_MAX_BYTES
     runtime = SimpleNamespace(
-        principal_for_user_key=Mock(
+        resolve_principal_for_user_key=AsyncMock(
             return_value="u-22222222222222222222222222222222"
         ),
         list_all_episodes_payload=AsyncMock(
@@ -1929,8 +1929,8 @@ def test_native_processing_record_routes_authorize_the_selected_project() -> Non
 
     principal_id = "u-11111111111111111111111111111111"
     runtime = SimpleNamespace(
-        principal_for_user_key=Mock(return_value=principal_id),
-        list_memory_projects=Mock(return_value=("default", "notes")),
+        resolve_principal_for_user_key=AsyncMock(return_value=principal_id),
+        list_memory_projects=AsyncMock(return_value=("default", "notes")),
         processing_record_entries_payload=AsyncMock(
             return_value={"status": "ok", "entries": [], "next_cursor": None}
         ),
@@ -1988,7 +1988,7 @@ def test_native_processing_record_routes_authorize_the_selected_project() -> Non
     runtime.processing_record_entry_payload.assert_awaited_once_with(
         principal_id, "notes", "mc_1"
     )
-    assert runtime.list_memory_projects.call_count == 3
+    assert runtime.list_memory_projects.await_count == 3
 
 
 def test_memory_remember_route_does_not_hold_pointer_lock_during_capture() -> None:

--- a/tests/test_memory_adapter.py
+++ b/tests/test_memory_adapter.py
@@ -118,10 +118,6 @@ class _Principals:
             raise AssertionError("offer reached SQLite/store principal derivation")
         return PRINCIPAL
 
-    def project_for_workdir(self, _workdir: str) -> str:
-        raise AssertionError("capture must not derive a project from workdir")
-
-
 class _Bindings:
     def __init__(self, forbidden: bool = False, enabled: bool = True) -> None:
         self.forbidden = forbidden

--- a/tests/test_memory_admission.py
+++ b/tests/test_memory_admission.py
@@ -50,12 +50,6 @@ class _Principals:
         self.keys.append(user_key)
         return PRINCIPAL
 
-    def project_for_workdir(self, workdir: str) -> str:
-        if self.raises:
-            raise RuntimeError("memory store unavailable")
-        return PROJECT
-
-
 class _Bindings:
     def __init__(self, *, enabled: bool = True, raises: bool = False) -> None:
         self.enabled = enabled

--- a/tests/test_memory_disabled_isolation.py
+++ b/tests/test_memory_disabled_isolation.py
@@ -22,7 +22,6 @@ from core.memory_adapter import DisabledMemoryAdapter, TurnAccepted
 from vibe.memory_contract import (
     MemoryPluginIncompatibleError,
     MemoryPluginUnavailableError,
-    MemoryRuntimeCloseUnprovedError,
     MemoryStoreUnavailableError,
 )
 
@@ -684,8 +683,12 @@ async def test_memory_reconcile_lazily_enters_and_leaves_enabled_runtime(
             }
 
         async def close(self) -> None:
-            assert capture_stopped.is_set()
+            await self.capture_adapter.cancel_memory_capture_tasks()
             self.closed = True
+
+        def begin_close(self) -> None:
+            self.capture_adapter.quiesce_memory_capture_tasks()
+            self.capture_adapter.cancel_memory_capture_tasks_nowait()
 
     runtime = _Runtime()
 
@@ -756,7 +759,7 @@ async def test_memory_reconcile_lazily_enters_and_leaves_enabled_runtime(
 
 
 @pytest.mark.asyncio
-async def test_disabled_preflight_uses_one_temporary_runtime() -> None:
+async def test_disabled_preflight_uses_one_unpublished_runtime() -> None:
     controller = Controller.__new__(Controller)
     controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
     controller.memory_adapter = DisabledMemoryAdapter()
@@ -777,6 +780,9 @@ async def test_disabled_preflight_uses_one_temporary_runtime() -> None:
 
         async def close(self) -> None:
             self.closed = True
+
+        def begin_close(self) -> None:
+            return None
 
     runtime = _Runtime()
     controller._create_memory_runtime = lambda config, **_kwargs: runtime
@@ -819,6 +825,9 @@ async def test_explicit_recovery_retries_after_cached_plugin_failure(
 
         async def close(self) -> None:
             self.closed = True
+
+        def begin_close(self) -> None:
+            return None
 
     runtime = _Runtime()
     controller._create_memory_runtime = lambda config, **_kwargs: runtime
@@ -885,7 +894,7 @@ async def test_explicit_recovery_caches_typed_retry_failure() -> None:
 
 
 @pytest.mark.asyncio
-async def test_disabled_install_owns_runtime_until_successful_close() -> None:
+async def test_disabled_install_keeps_runtime_unpublished_until_close() -> None:
     controller = Controller.__new__(Controller)
     controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
     controller.memory_adapter = DisabledMemoryAdapter()
@@ -902,13 +911,13 @@ async def test_disabled_install_owns_runtime_until_successful_close() -> None:
             self.retired = False
 
         async def install_artifact(self) -> dict[str, object]:
-            assert controller.memory_runtime is self
+            assert controller.memory_runtime is None
             events.append("install")
             return {"ok": True}
 
-        def retire(self) -> None:
+        def begin_close(self) -> None:
             self.retired = True
-            events.append("retire")
+            events.append("begin-close")
 
         async def close(self) -> None:
             events.append("close")
@@ -924,7 +933,7 @@ async def test_disabled_install_owns_runtime_until_successful_close() -> None:
 
     assert await controller.install_memory_runtime() == {"ok": True}
     assert loader_flags == [True]
-    assert events == ["install", "retire", "close"]
+    assert events == ["install", "begin-close", "close"]
     assert controller.memory_runtime is None
     assert controller.memory_module is None
     assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
@@ -961,6 +970,9 @@ async def test_cancelled_install_does_not_cancel_shared_disabled_cleanup() -> No
         async def close(self) -> None:
             self.closed = True
 
+        def begin_close(self) -> None:
+            return None
+
     cleanup_task = asyncio.create_task(cleanup())
     controller._memory_disabled_cleanup_task = cleanup_task
     controller._create_memory_runtime = (
@@ -985,181 +997,40 @@ async def test_cancelled_install_does_not_cancel_shared_disabled_cleanup() -> No
 
 
 @pytest.mark.asyncio
-async def test_temporary_close_failure_retains_fenced_controller_ownership() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller.memory_module = None
-    controller._memory_reconcile_task = None
-    created: list[object] = []
-
-    class _Runtime:
-        def __init__(self) -> None:
-            self.module = object()
-            self.closed = False
-            self.retired = False
-
-        async def install_artifact(self) -> dict[str, object]:
-            assert controller.memory_runtime is self
-            return {"ok": True}
-
-        def retire(self) -> None:
-            self.retired = True
-
-        async def close(self) -> None:
-            raise RuntimeError("close failed")
-
-    runtime = _Runtime()
-
-    def create(config, **_kwargs):
-        created.append(config)
-        return runtime
-
-    controller._create_memory_runtime = create
-
-    with pytest.raises(RuntimeError, match="close failed"):
-        await controller.install_memory_runtime()
-
-    assert created == [controller.config.memory]
-    assert runtime.retired is True
-    assert controller.memory_runtime is runtime
-    assert controller.memory_module is runtime.module
-    assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
-
-    with pytest.raises(RuntimeError, match="remains fenced"):
-        await controller.install_memory_runtime()
-    assert created == [controller.config.memory]
-    assert controller.memory_runtime is runtime
-
-
-@pytest.mark.asyncio
-async def test_disabled_status_reports_retained_fenced_runtime_truthfully() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_module = object()
-    controller._memory_reconcile_task = None
-    controller._memory_disabled_cleanup_task = None
-
-    runtime = types.SimpleNamespace(
-        module=controller.memory_module,
-        closed=False,
-        retired=True,
-    )
-    controller.memory_runtime = runtime
-    controller._create_memory_runtime = lambda _config, **_kwargs: pytest.fail(
-        "disabled status must not construct Memory"
-    )
-
-    status = await controller.memory_status_payload()
-
-    assert status["state"] == "degraded"
-    assert status["reason"] == "memory_runtime_busy"
-    assert status["source"]["reason"] == "memory_runtime_busy"
-    assert controller.memory_runtime is runtime
-
-
-@pytest.mark.asyncio
-async def test_temporary_close_without_closed_proof_retains_ownership() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller.memory_module = None
-    controller._memory_reconcile_task = None
-
-    class _Runtime:
-        def __init__(self) -> None:
-            self.module = object()
-            self.closed = False
-            self.retired = False
-
-        async def preflight(self, _config) -> dict[str, object]:
-            return {"ok": True}
-
-        def retire(self) -> None:
-            self.retired = True
-
-        async def close(self) -> None:
-            return None
-
-    runtime = _Runtime()
-    controller._create_memory_runtime = lambda _config, **_kwargs: runtime
-
-    with pytest.raises(RuntimeError, match="closed proof"):
-        await controller.preflight_memory(
-            replace(controller.config.memory, enabled=True)
-        )
-
-    assert runtime.retired is True
-    assert runtime.closed is False
-    assert controller.memory_runtime is runtime
-    assert controller.memory_module is runtime.module
-    assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
-
-
-@pytest.mark.asyncio
-async def test_disable_close_failure_fences_rollback_and_destructive_reuse() -> None:
+async def test_disable_publishes_disabled_before_failed_close() -> None:
     enabled = replace(_disabled_app_config().memory, enabled=True)
     disabled = replace(enabled, enabled=False)
     controller = Controller.__new__(Controller)
     controller.config = types.SimpleNamespace(memory=enabled)
-    controller.memory_adapter = None
-    controller.memory_module = None
+    original_adapter = object()
+    controller.memory_adapter = original_adapter
     controller._memory_reconcile_task = None
     controller._memory_disabled_cleanup_task = None
-    created: list[object] = []
 
     class _Runtime:
         def __init__(self) -> None:
             self.module = object()
-            self.closed = False
             self.retired = False
-            self.reconciled: list[object] = []
 
-        async def reconcile(self, config) -> dict[str, object]:
-            self.reconciled.append(config)
-            return {
-                "ok": True,
-                "state": "running" if config.enabled else "disabled",
-            }
+        def begin_close(self) -> None:
+            assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
+            self.retired = True
 
         async def close(self) -> None:
             raise RuntimeError("close failed")
-
-        def retire(self) -> None:
-            self.retired = True
 
     runtime = _Runtime()
     controller.memory_runtime = runtime
     controller.memory_module = runtime.module
 
-    def create(config, **_kwargs):
-        created.append(config)
-        raise AssertionError("rollback must not construct a second runtime")
-
-    controller._create_memory_runtime = create
-
     with pytest.raises(RuntimeError, match="close failed"):
         await controller.reconcile_memory(disabled)
 
     assert controller.config.memory == disabled
-    assert controller.memory_runtime is runtime
-    assert controller.memory_module is runtime.module
+    assert controller.memory_runtime is None
+    assert controller.memory_module is None
     assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
     assert runtime.retired is True
-
-    with pytest.raises(MemoryRuntimeCloseUnprovedError, match="fenced"):
-        await controller.reconcile_memory(enabled)
-    with pytest.raises(MemoryRuntimeCloseUnprovedError, match="fenced"):
-        async with controller._destructive_memory_runtime():
-            pytest.fail("destructive operations must not reuse a closing runtime")
-
-    assert runtime.reconciled == [disabled]
-    assert created == []
-    assert controller.memory_runtime is runtime
-    assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
 
 
 @pytest.mark.asyncio
@@ -1289,7 +1160,6 @@ async def test_plugin_failure_rechecked_after_blocked_capture_lock() -> None:
     controller.config = types.SimpleNamespace(memory=types.SimpleNamespace(enabled=True))
     controller._memory_plugin_error = None
     controller.memory_runtime = None
-    controller._memory_runtime_generation = 1
     request = CaptureRequest(
         source_message_id="message-1",
         session_id="session-1",
@@ -1373,7 +1243,7 @@ async def test_enabled_status_does_not_wait_for_startup_wake() -> None:
 
 
 @pytest.mark.asyncio
-async def test_enabled_status_reprojects_when_disabled_before_borrow() -> None:
+async def test_enabled_status_reprojects_when_disabled_before_snapshot() -> None:
     enabled = replace(_disabled_app_config().memory, enabled=True)
     disabled = replace(enabled, enabled=False)
     controller = Controller.__new__(Controller)
@@ -1383,24 +1253,23 @@ async def test_enabled_status_reprojects_when_disabled_before_borrow() -> None:
     controller.memory_module = None
     controller._memory_reconcile_task = None
     controller._memory_disabled_cleanup_task = None
-    borrow_started = asyncio.Event()
-    borrow_release = asyncio.Event()
+    snapshot_started = asyncio.Event()
+    snapshot_release = asyncio.Event()
 
     async def await_cleanup() -> None:
-        borrow_started.set()
-        await borrow_release.wait()
+        snapshot_started.set()
+        await snapshot_release.wait()
 
     controller._await_disabled_memory_cleanup = await_cleanup
     controller._create_memory_runtime = lambda _config, **_kwargs: pytest.fail(
         "status must re-project disabled state before constructing Memory"
     )
     status_task = asyncio.create_task(controller.memory_status_payload())
-    await borrow_started.wait()
+    await snapshot_started.wait()
 
-    condition = controller._memory_runtime_condition()
-    async with condition:
+    async with controller._memory_replacement_lock():
         controller.config.memory = disabled
-    borrow_release.set()
+    snapshot_release.set()
 
     status = await status_task
 
@@ -1408,67 +1277,6 @@ async def test_enabled_status_reprojects_when_disabled_before_borrow() -> None:
     assert status["state"] == "disabled"
     assert status["reason"] is None
     assert status["source"]["reason"] == "memory_disabled"
-
-
-@pytest.mark.asyncio
-async def test_enabled_status_reprojects_after_failed_disable_close() -> None:
-    enabled = replace(_disabled_app_config().memory, enabled=True)
-    disabled = replace(enabled, enabled=False)
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=enabled)
-    controller.memory_adapter = None
-    controller._memory_disabled_cleanup_task = None
-    status_waiting = asyncio.Event()
-    status_release = asyncio.Event()
-
-    class _Runtime:
-        def __init__(self) -> None:
-            self.module = object()
-            self.closed = False
-            self.retired = False
-
-        async def status_payload(self) -> dict[str, object]:
-            pytest.fail("status must re-project before reading a retired runtime")
-
-        async def reconcile(self, config) -> dict[str, object]:
-            return {"ok": True, "state": "disabled"}
-
-        async def close(self) -> None:
-            raise RuntimeError("close failed")
-
-        def retire(self) -> None:
-            self.retired = True
-
-    runtime = _Runtime()
-    controller.memory_runtime = runtime
-    controller.memory_module = runtime.module
-
-    async def hold_status_before_borrow() -> None:
-        status_waiting.set()
-        await status_release.wait()
-
-    controller._await_disabled_memory_cleanup = hold_status_before_borrow
-    status_task = asyncio.create_task(controller.memory_status_payload())
-    await status_waiting.wait()
-
-    async def cleanup_ready() -> None:
-        return None
-
-    controller._await_disabled_memory_cleanup = cleanup_ready
-    try:
-        with pytest.raises(RuntimeError, match="close failed"):
-            await controller.reconcile_memory(disabled)
-    finally:
-        status_release.set()
-
-    status = await status_task
-
-    assert runtime.retired is True
-    assert controller.memory_runtime is runtime
-    assert status["status"] == "ok"
-    assert status["state"] == "degraded"
-    assert status["reason"] == "memory_runtime_busy"
-    assert status["source"]["reason"] == "memory_runtime_busy"
 
 
 @pytest.mark.asyncio
@@ -1523,7 +1331,7 @@ async def test_concurrent_enabled_memory_reads_overlap() -> None:
 
 
 @pytest.mark.asyncio
-async def test_disable_waits_for_outstanding_read_lease_then_closes_once() -> None:
+async def test_disable_does_not_wait_for_long_runtime_read() -> None:
     enabled = replace(_disabled_app_config().memory, enabled=True)
     disabled = replace(enabled, enabled=False)
     controller = Controller.__new__(Controller)
@@ -1537,162 +1345,142 @@ async def test_disable_waits_for_outstanding_read_lease_then_closes_once() -> No
     class _Runtime:
         def __init__(self) -> None:
             self.module = object()
-            self.closed = False
             self.retired = False
             self.close_calls = 0
 
         async def status_payload(self) -> dict[str, object]:
+            assert controller._memory_replacement_lock().locked() is False
             read_started.set()
             await read_release.wait()
             return {"status": "ok", "state": "running"}
 
-        async def reconcile(self, config) -> dict[str, object]:
-            return {"ok": True, "state": "running" if config.enabled else "disabled"}
+        def begin_close(self) -> None:
+            self.retired = True
 
         async def close(self) -> None:
             self.close_calls += 1
-            self.closed = True
 
     runtime = _Runtime()
     controller.memory_runtime = runtime
     controller.memory_module = runtime.module
     status = asyncio.create_task(controller.memory_status_payload())
     await read_started.wait()
-    disable = asyncio.create_task(controller.reconcile_memory(disabled))
+    assert await asyncio.wait_for(
+        controller.reconcile_memory(disabled),
+        timeout=0.1,
+    ) == {"ok": True, "state": "disabled"}
 
-    try:
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        assert controller._memory_replacement_lock().locked() is False
-        assert disable.done() is False
-        assert runtime.close_calls == 0
-    finally:
-        read_release.set()
-
-    assert await status == {"status": "ok", "state": "running"}
-    assert await disable == {"ok": True, "state": "disabled"}
     assert runtime.close_calls == 1
     assert controller.memory_runtime is None
+    assert controller._memory_replacement_lock().locked() is False
+    read_release.set()
+    assert await status == {"status": "ok", "state": "running"}
 
 
 @pytest.mark.asyncio
-async def test_concurrent_temporary_borrows_share_runtime_until_final_release() -> None:
+async def test_reconcile_provider_work_does_not_hold_pointer_lock() -> None:
+    enabled = replace(_disabled_app_config().memory, enabled=True)
+    candidate = replace(enabled)
     controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
+    controller.config = types.SimpleNamespace(memory=enabled)
+    controller.memory_adapter = None
+    controller._memory_disabled_cleanup_task = None
+    reconcile_started = asyncio.Event()
+    reconcile_release = asyncio.Event()
+
+    class _Runtime:
+        module = object()
+        retired = False
+        capture_adapter = object()
+
+        async def reconcile(self, config) -> dict[str, object]:
+            assert config is candidate
+            assert controller._memory_replacement_lock().locked() is False
+            reconcile_started.set()
+            await reconcile_release.wait()
+            return {"ok": True, "state": "running"}
+
+    runtime = _Runtime()
+    controller.memory_runtime = runtime
+    controller.memory_module = runtime.module
+    reconcile = asyncio.create_task(controller.reconcile_memory(candidate))
+    await reconcile_started.wait()
+
+    async with asyncio.timeout(0.1):
+        async with controller._memory_replacement_lock():
+            assert controller.memory_runtime is runtime
+
+    reconcile_release.set()
+    assert await reconcile == {"ok": True, "state": "running"}
+    assert controller.config.memory is candidate
+
+
+@pytest.mark.asyncio
+async def test_disable_revokes_unpublished_enable_before_it_can_publish() -> None:
+    disabled = _disabled_app_config().memory
+    enabled = replace(disabled, enabled=True)
+    controller = Controller.__new__(Controller)
+    controller.config = types.SimpleNamespace(memory=disabled)
     controller.memory_adapter = DisabledMemoryAdapter()
     controller.memory_runtime = None
     controller.memory_module = None
-    controller._memory_reconcile_task = None
     controller._memory_disabled_cleanup_task = None
-    candidate = replace(controller.config.memory, enabled=True)
-    started = 0
-    release = asyncio.Event()
-    created: list[object] = []
+    reconcile_started = asyncio.Event()
+    reconcile_release = asyncio.Event()
+
+    async def no_cleanup() -> None:
+        return None
+
+    controller._await_disabled_memory_cleanup = no_cleanup
+    controller._recheck_disabled_memory_cleanup = no_cleanup
 
     class _Runtime:
+        module = object()
+        capture_adapter = object()
+        retired = False
+
         def __init__(self) -> None:
-            self.module = object()
-            self.closed = False
-            self.retired = False
             self.close_calls = 0
 
-        async def preflight(self, config) -> dict[str, object]:
-            nonlocal started
-            assert config is candidate
+        async def reconcile(self, config) -> dict[str, object]:
+            assert config is enabled
             assert controller.memory_runtime is self
-            started += 1
-            await release.wait()
-            return {"ok": True}
+            assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
+            assert controller._memory_replacement_lock().locked() is False
+            reconcile_started.set()
+            await reconcile_release.wait()
+            return {"ok": True, "state": "running"}
 
-        def retire(self) -> None:
+        def begin_close(self) -> None:
+            assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
             self.retired = True
 
         async def close(self) -> None:
             self.close_calls += 1
-            self.closed = True
 
-    def create_runtime(_config, **_kwargs) -> _Runtime:
-        runtime = _Runtime()
-        created.append(runtime)
-        return runtime
+    runtime = _Runtime()
+    controller._create_memory_runtime = lambda _config: runtime
+    reconcile = asyncio.create_task(controller.reconcile_memory(enabled))
+    await reconcile_started.wait()
 
-    controller._create_memory_runtime = create_runtime
-    first = asyncio.create_task(controller.preflight_memory(candidate))
-    second = asyncio.create_task(controller.preflight_memory(candidate))
-
-    try:
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        assert started == 2
-        assert len(created) == 1
-        assert created[0].close_calls == 0
-    finally:
-        release.set()
-
-    assert await asyncio.gather(first, second) == [{"ok": True}, {"ok": True}]
-    assert created[0].close_calls == 1
+    assert await controller.reconcile_memory(disabled) == {
+        "ok": True,
+        "state": "disabled",
+    }
     assert controller.memory_runtime is None
+    assert controller.config.memory is disabled
+    assert runtime.retired is True
+    assert runtime.close_calls == 1
+
+    reconcile_release.set()
+    assert await reconcile == {
+        "ok": False,
+        "state": "disabled",
+        "error": "memory_operation_in_progress",
+    }
+    assert controller.memory_runtime is None
+    assert controller.config.memory is disabled
     assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
-
-
-@pytest.mark.asyncio
-async def test_temporary_borrows_do_not_share_different_configs() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller.memory_module = None
-    controller._memory_reconcile_task = None
-    controller._memory_disabled_cleanup_task = None
-    candidate = replace(controller.config.memory, enabled=True)
-    candidate_started = asyncio.Event()
-    candidate_release = asyncio.Event()
-    install_started = asyncio.Event()
-    created: list[object] = []
-
-    class _Runtime:
-        def __init__(self, config) -> None:
-            self.config = config
-            self.module = object()
-            self.closed = False
-            self.retired = False
-
-        async def preflight(self, config) -> dict[str, object]:
-            assert self.config == candidate
-            assert config == candidate
-            candidate_started.set()
-            await candidate_release.wait()
-            return {"ok": True}
-
-        async def install_artifact(self) -> dict[str, object]:
-            assert self.config == controller.config.memory
-            install_started.set()
-            return {"ok": True}
-
-        def retire(self) -> None:
-            self.retired = True
-
-        async def close(self) -> None:
-            self.closed = True
-
-    def create_runtime(config, **_kwargs) -> _Runtime:
-        created.append(config)
-        return _Runtime(config)
-
-    controller._create_memory_runtime = create_runtime
-    preflight = asyncio.create_task(controller.preflight_memory(candidate))
-    await candidate_started.wait()
-    install = asyncio.create_task(controller.install_memory_runtime())
-    await asyncio.sleep(0)
-
-    assert install_started.is_set() is False
-    assert created == [candidate]
-
-    candidate_release.set()
-    assert await preflight == {"ok": True}
-    assert await install == {"ok": True}
-    assert created == [candidate, controller.config.memory]
-    assert controller.memory_runtime is None
 
 
 @pytest.mark.asyncio
@@ -1703,28 +1491,19 @@ async def test_memory_indep_015_shutdown_bounds_all_memory_stages_under_one_budg
     controller._shutdown_tainted = False
     controller._memory_destructive_quiescing = False
 
-    release = asyncio.Event()
     started: list[str] = []
-    cancelled: list[str] = []
-
-    async def stubborn_stage(name: str) -> None:
-        started.append(name)
-        try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            cancelled.append(name)
-            await release.wait()
 
     class _MemoryAdapter:
         def quiesce_memory_capture_tasks(self) -> None:
             started.append("capture-registration")
 
-        async def cancel_memory_capture_tasks(self) -> None:
-            started.append("capture")
-
     class _MemoryRuntime:
+        def begin_close(self) -> None:
+            assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
+            started.append("runtime-revoke")
+
         async def close(self) -> None:
-            await stubborn_stage("runtime")
+            started.append("runtime")
 
     controller.memory_adapter = _MemoryAdapter()
     controller.memory_runtime = _MemoryRuntime()
@@ -1734,7 +1513,6 @@ async def test_memory_indep_015_shutdown_bounds_all_memory_stages_under_one_budg
 
     controller._join_memory_destructive_transactions = join_destructive_transactions
 
-    before = set(asyncio.all_tasks())
     started_at = time.monotonic()
     await controller._shutdown_memory_stack()
     elapsed = time.monotonic() - started_at
@@ -1742,21 +1520,15 @@ async def test_memory_indep_015_shutdown_bounds_all_memory_stages_under_one_budg
     assert elapsed < 0.2
     assert started == [
         "capture-registration",
-        "capture",
         "destructive",
+        "runtime-revoke",
         "runtime",
     ]
-    assert cancelled == ["runtime"]
-    assert controller._shutdown_tainted is True
-
-    release.set()
-    leftovers = set(asyncio.all_tasks()).difference(before)
-    if leftovers:
-        await asyncio.gather(*leftovers, return_exceptions=True)
+    assert controller._shutdown_tainted is False
 
 
 @pytest.mark.asyncio
-async def test_shutdown_does_not_close_runtime_over_live_destructive_transaction() -> None:
+async def test_shutdown_attempts_runtime_close_after_destructive_timeout() -> None:
     controller = Controller.__new__(Controller)
     controller._memory_reconcile_task = None
     controller._memory_shutdown_budget_seconds = 0.04
@@ -1778,6 +1550,9 @@ async def test_shutdown_does_not_close_runtime_over_live_destructive_transaction
         def __init__(self) -> None:
             self.closed = False
 
+        def begin_close(self) -> None:
+            return None
+
         async def close(self) -> None:
             self.closed = True
 
@@ -1789,7 +1564,8 @@ async def test_shutdown_does_not_close_runtime_over_live_destructive_transaction
 
     assert time.monotonic() - started_at < 0.2
     assert destructive.done() is False
-    assert runtime.closed is False
+    assert runtime.closed is True
+    assert controller.memory_runtime is None
     assert controller._shutdown_tainted is True
 
     release.set()

--- a/tests/test_memory_disabled_isolation.py
+++ b/tests/test_memory_disabled_isolation.py
@@ -877,7 +877,7 @@ async def test_cached_plugin_failure_only_retries_for_explicit_recovery(
 
 @pytest.mark.parametrize("ordering", ("reaper-first", "enable-first"))
 @pytest.mark.asyncio
-async def test_disabled_reaper_and_enable_share_root_mutation_gate(
+async def test_disabled_reaper_enable_and_shutdown_share_root_mutation_gate(
     ordering: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -931,6 +931,12 @@ async def test_disabled_reaper_and_enable_share_root_mutation_gate(
         def start_capture_adapter(self, **_kwargs) -> bool:
             return True
 
+        def begin_close(self) -> None:
+            self.closing = True
+
+        async def close(self, **_options: object) -> None:
+            return None
+
     runtime = _Runtime()
 
     def create_runtime(_config, **_kwargs):
@@ -966,9 +972,16 @@ async def test_disabled_reaper_and_enable_share_root_mutation_gate(
         await attach_started.wait()
         await controller._cleanup_disabled_memory_process(memory_dir)
         assert reaper_calls == 0
+        shutdown = asyncio.create_task(
+            controller._close_memory_runtime_for_shutdown(timeout_seconds=0.5)
+        )
+        await asyncio.sleep(0.02)
+        assert shutdown.done() is False
+        assert controller.memory_runtime is None
         attach_release.set()
         assert await reconcile == {"ok": True, "state": "running"}
-        assert controller.memory_runtime is runtime
+        await shutdown
+        assert controller.memory_runtime is None
 
     assert controller._memory_replacement_lock().locked() is False
 

--- a/tests/test_memory_disabled_isolation.py
+++ b/tests/test_memory_disabled_isolation.py
@@ -1292,6 +1292,8 @@ async def test_memory_indep_015_shutdown_uses_one_budget_after_stage_timeout() -
 
     async def transaction() -> dict[str, object]:
         await release.wait()
+        assert controller.memory_runtime is runtime
+        assert runtime.closed is False
         return {"ok": True}
 
     destructive = asyncio.create_task(transaction())
@@ -1316,11 +1318,14 @@ async def test_memory_indep_015_shutdown_uses_one_budget_after_stage_timeout() -
 
     assert time.monotonic() - started_at < 0.2
     assert destructive.done() is False
-    assert runtime.closed is True
-    assert controller.memory_runtime is None
+    assert runtime.closed is False
+    assert controller.memory_runtime is runtime
     assert controller._shutdown_tainted is True
-    assert 0.0 <= close_deadlines[0] <= controller._memory_shutdown_budget_seconds
+    assert close_deadlines == []
 
     release.set()
     await destructive
-    await asyncio.sleep(0)
+    await controller._shutdown_memory_stack()
+    assert runtime.closed is True
+    assert controller.memory_runtime is None
+    assert 0.0 <= close_deadlines[0] <= controller._memory_shutdown_budget_seconds

--- a/tests/test_memory_disabled_isolation.py
+++ b/tests/test_memory_disabled_isolation.py
@@ -1188,6 +1188,9 @@ async def test_reconcile_provider_work_does_not_hold_pointer_lock() -> None:
             await reconcile_release.wait()
             return {"ok": True, "state": "running"}
 
+        async def preflight(self, _config) -> dict[str, object]:
+            pytest.fail("preflight overlapped enabled reconciliation")
+
     runtime = _Runtime()
     controller.memory_runtime = runtime
     controller.memory_module = runtime.module
@@ -1197,63 +1200,15 @@ async def test_reconcile_provider_work_does_not_hold_pointer_lock() -> None:
     async with asyncio.timeout(0.1):
         async with controller._memory_replacement_lock():
             assert controller.memory_runtime is runtime
+    assert await controller.preflight_memory(candidate) == {
+        "ok": False,
+        "error": "memory_operation_in_progress",
+    }
 
     reconcile_release.set()
     assert await reconcile == {"ok": True, "state": "running"}
     assert controller.config.memory is candidate
     assert runtime.capture_starts == 1
-
-
-@pytest.mark.asyncio
-async def test_disable_revokes_unpublished_enable_before_it_can_publish() -> None:
-    disabled = _disabled_app_config().memory
-    enabled = replace(disabled, enabled=True)
-    controller = _controller_with_memory(disabled)
-    reconcile_started = asyncio.Event()
-    reconcile_release = asyncio.Event()
-
-    class _Runtime(_NoRetainedRootOwnership):
-        module = object()
-        capture_adapter = object()
-
-        def __init__(self) -> None:
-            self.close_calls = 0
-
-        async def reconcile(self, config) -> dict[str, object]:
-            assert config is enabled
-            assert controller.memory_runtime is self
-            assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
-            assert controller._memory_replacement_lock().locked() is False
-            reconcile_started.set()
-            await reconcile_release.wait()
-            return {"ok": True, "state": "running"}
-
-        def begin_close(self) -> None:
-            assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
-
-        async def close(self) -> None:
-            self.close_calls += 1
-
-    runtime = _Runtime()
-    controller._create_memory_runtime = lambda _config: runtime
-    reconcile = asyncio.create_task(controller.reconcile_memory(enabled))
-    await reconcile_started.wait()
-
-    assert await controller.reconcile_memory(disabled) == {
-        "ok": True,
-        "state": "disabled",
-    }
-    assert runtime.close_calls == 1
-
-    reconcile_release.set()
-    assert await reconcile == {
-        "ok": False,
-        "state": "disabled",
-        "error": "memory_operation_in_progress",
-    }
-    assert controller.memory_runtime is None
-    assert controller.config.memory is disabled
-    assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_disabled_isolation.py
+++ b/tests/test_memory_disabled_isolation.py
@@ -759,43 +759,6 @@ async def test_memory_reconcile_lazily_enters_and_leaves_enabled_runtime(
     assert controller._memory_disabled_cleanup_unproved is False
 
 
-@pytest.mark.asyncio
-async def test_disabled_preflight_uses_one_unpublished_runtime() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller.memory_module = None
-    controller._memory_reconcile_task = None
-    candidate = replace(controller.config.memory, enabled=True)
-    calls: list[object] = []
-
-    class _Runtime:
-        def __init__(self) -> None:
-            self.module = object()
-            self.closed = False
-
-        async def preflight(self, config) -> dict[str, object]:
-            calls.append(config)
-            return {"ok": True}
-
-        async def close(self) -> None:
-            self.closed = True
-
-        def begin_close(self) -> None:
-            return None
-
-    runtime = _Runtime()
-    controller._create_memory_runtime = lambda config, **_kwargs: runtime
-
-    assert await controller.preflight_memory(candidate) == {"ok": True}
-    assert calls == [candidate]
-    assert runtime.closed is True
-    assert controller.memory_runtime is None
-    assert controller.memory_module is None
-    assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
-
-
 @pytest.mark.parametrize("overlap", ("preflight", "install"))
 @pytest.mark.asyncio
 async def test_overlapping_unpublished_operations_return_busy(
@@ -885,7 +848,6 @@ async def test_explicit_recovery_retries_after_cached_plugin_failure(
     class _Runtime:
         module = object()
         closed = False
-        retired = False
 
         async def preflight(self, config) -> dict[str, object]:
             calls.append(("preflight", config))
@@ -980,7 +942,6 @@ async def test_disabled_install_keeps_runtime_unpublished_until_close() -> None:
         def __init__(self) -> None:
             self.module = object()
             self.closed = False
-            self.retired = False
 
         async def install_artifact(self) -> dict[str, object]:
             assert controller.memory_runtime is None
@@ -988,7 +949,6 @@ async def test_disabled_install_keeps_runtime_unpublished_until_close() -> None:
             return {"ok": True}
 
         def begin_close(self) -> None:
-            self.retired = True
             events.append("begin-close")
 
         async def close(self) -> None:
@@ -1031,13 +991,9 @@ async def test_cancelled_install_does_not_cancel_shared_disabled_cleanup() -> No
         def __init__(self) -> None:
             self.module = object()
             self.closed = False
-            self.retired = False
 
         async def install_artifact(self) -> dict[str, object]:
             return {"ok": True}
-
-        def retire(self) -> None:
-            self.retired = True
 
         async def close(self) -> None:
             self.closed = True
@@ -1082,11 +1038,9 @@ async def test_disable_publishes_disabled_before_failed_close() -> None:
     class _Runtime:
         def __init__(self) -> None:
             self.module = object()
-            self.retired = False
 
         def begin_close(self) -> None:
             assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
-            self.retired = True
 
         async def close(self) -> None:
             raise RuntimeError("close failed")
@@ -1102,7 +1056,6 @@ async def test_disable_publishes_disabled_before_failed_close() -> None:
     assert controller.memory_runtime is None
     assert controller.memory_module is None
     assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
-    assert runtime.retired is True
 
 
 @pytest.mark.asyncio
@@ -1295,7 +1248,6 @@ async def test_enabled_status_does_not_wait_for_startup_wake() -> None:
     class _Runtime:
         module = object()
         closed = False
-        retired = False
 
         async def status_payload(self) -> dict[str, object]:
             return {"status": "ok", "state": "starting"}
@@ -1315,94 +1267,6 @@ async def test_enabled_status_does_not_wait_for_startup_wake() -> None:
 
 
 @pytest.mark.asyncio
-async def test_enabled_status_reprojects_when_disabled_before_snapshot() -> None:
-    enabled = replace(_disabled_app_config().memory, enabled=True)
-    disabled = replace(enabled, enabled=False)
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=enabled)
-    controller.memory_adapter = None
-    controller.memory_runtime = None
-    controller.memory_module = None
-    controller._memory_reconcile_task = None
-    controller._memory_disabled_cleanup_task = None
-    snapshot_started = asyncio.Event()
-    snapshot_release = asyncio.Event()
-
-    async def await_cleanup() -> None:
-        snapshot_started.set()
-        await snapshot_release.wait()
-
-    controller._await_disabled_memory_cleanup = await_cleanup
-    controller._create_memory_runtime = lambda _config, **_kwargs: pytest.fail(
-        "status must re-project disabled state before constructing Memory"
-    )
-    status_task = asyncio.create_task(controller.memory_status_payload())
-    await snapshot_started.wait()
-
-    async with controller._memory_replacement_lock():
-        controller.config.memory = disabled
-    snapshot_release.set()
-
-    status = await status_task
-
-    assert status["status"] == "ok"
-    assert status["state"] == "disabled"
-    assert status["reason"] is None
-    assert status["source"]["reason"] == "memory_disabled"
-
-
-@pytest.mark.asyncio
-async def test_concurrent_enabled_memory_reads_overlap() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(
-        memory=replace(_disabled_app_config().memory, enabled=True)
-    )
-    controller.memory_adapter = None
-    controller._memory_reconcile_task = None
-    controller._memory_disabled_cleanup_task = None
-    started: set[str] = set()
-    release = asyncio.Event()
-
-    class _Runtime:
-        module = object()
-        closed = False
-        retired = False
-
-        async def status_payload(self) -> dict[str, object]:
-            started.add("status")
-            await release.wait()
-            return {"status": "ok", "state": "running"}
-
-        async def processing_record_payload(
-            self,
-            *,
-            verified_user_key: str | None,
-        ) -> dict[str, object]:
-            assert verified_user_key == "user-1"
-            started.add("processing")
-            await release.wait()
-            return {"status": "ok"}
-
-    runtime = _Runtime()
-    controller.memory_runtime = runtime
-    controller.memory_module = runtime.module
-    status = asyncio.create_task(controller.memory_status_payload())
-    processing = asyncio.create_task(
-        controller.memory_processing_record_payload(
-            verified_user_key="user-1",
-        )
-    )
-
-    try:
-        await asyncio.sleep(0)
-        await asyncio.sleep(0)
-        assert started == {"status", "processing"}
-    finally:
-        release.set()
-        await asyncio.gather(status, processing)
-
-
-@pytest.mark.asyncio
 async def test_disable_does_not_wait_for_long_runtime_read() -> None:
     enabled = replace(_disabled_app_config().memory, enabled=True)
     disabled = replace(enabled, enabled=False)
@@ -1417,7 +1281,6 @@ async def test_disable_does_not_wait_for_long_runtime_read() -> None:
     class _Runtime:
         def __init__(self) -> None:
             self.module = object()
-            self.retired = False
             self.close_calls = 0
 
         async def status_payload(self) -> dict[str, object]:
@@ -1427,7 +1290,7 @@ async def test_disable_does_not_wait_for_long_runtime_read() -> None:
             return {"status": "ok", "state": "running"}
 
         def begin_close(self) -> None:
-            self.retired = True
+            return None
 
         async def close(self) -> None:
             self.close_calls += 1
@@ -1462,7 +1325,6 @@ async def test_reconcile_provider_work_does_not_hold_pointer_lock() -> None:
 
     class _Runtime:
         module = object()
-        retired = False
         capture_adapter = object()
 
         async def reconcile(self, config) -> dict[str, object]:
@@ -1509,7 +1371,6 @@ async def test_disable_revokes_unpublished_enable_before_it_can_publish() -> Non
     class _Runtime:
         module = object()
         capture_adapter = object()
-        retired = False
 
         def __init__(self) -> None:
             self.close_calls = 0
@@ -1525,7 +1386,6 @@ async def test_disable_revokes_unpublished_enable_before_it_can_publish() -> Non
 
         def begin_close(self) -> None:
             assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
-            self.retired = True
 
         async def close(self) -> None:
             self.close_calls += 1
@@ -1541,7 +1401,6 @@ async def test_disable_revokes_unpublished_enable_before_it_can_publish() -> Non
     }
     assert controller.memory_runtime is None
     assert controller.config.memory is disabled
-    assert runtime.retired is True
     assert runtime.close_calls == 1
 
     reconcile_release.set()

--- a/tests/test_memory_disabled_isolation.py
+++ b/tests/test_memory_disabled_isolation.py
@@ -18,7 +18,7 @@ from config.v2_compat import to_app_config
 from config.v2_config import V2Config
 from core.controller import Controller
 from avibe_memory import CaptureRequest, CaptureSkipped
-from core.memory_adapter import DisabledMemoryAdapter, TurnAccepted
+from core.memory_adapter import DisabledMemoryAdapter
 from vibe.memory_contract import (
     MemoryPluginIncompatibleError,
     MemoryPluginUnavailableError,
@@ -636,11 +636,16 @@ async def test_disabled_cleanup_terminal_status_tracks_ownership(
     )
 
 
+@pytest.mark.parametrize("active_operation", ("preflight", "install"))
 @pytest.mark.asyncio
-async def test_memory_reconcile_lazily_enters_and_leaves_enabled_runtime() -> None:
+async def test_memory_reconcile_lazily_enters_and_leaves_enabled_runtime(
+    active_operation: str,
+) -> None:
     controller = _controller_with_memory()
     enabled = replace(controller.config.memory, enabled=True)
     offers: list[object] = []
+    operation_started = asyncio.Event()
+    operation_release = asyncio.Event()
 
     class _CaptureAdapter:
         def offer(self, event: object) -> None:
@@ -652,6 +657,7 @@ async def test_memory_reconcile_lazily_enters_and_leaves_enabled_runtime() -> No
             self.available = True
             self.closed = False
             self.capture_adapter = _CaptureAdapter()
+            self.begin_close_calls = 0
 
         def start_capture_adapter(self, **_options: object) -> bool:
             return True
@@ -659,11 +665,20 @@ async def test_memory_reconcile_lazily_enters_and_leaves_enabled_runtime() -> No
         async def reconcile(self, _config) -> dict[str, object]:
             return {"ok": True, "state": "running"}
 
+        async def preflight(self, _config) -> dict[str, object]:
+            operation_started.set()
+            await operation_release.wait()
+            return {"ok": True}
+
+        async def install_artifact(self, **_options: object) -> dict[str, object]:
+            return await self.preflight(enabled)
+
         async def close(self) -> None:
             self.closed = True
 
         def begin_close(self) -> None:
             assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
+            self.begin_close_calls += 1
 
     runtime = _Runtime()
     controller._create_memory_runtime = lambda _config: runtime
@@ -676,22 +691,30 @@ async def test_memory_reconcile_lazily_enters_and_leaves_enabled_runtime() -> No
     assert controller.memory_adapter is runtime.capture_adapter
     assert controller.config.memory.enabled is True
 
-    event = TurnAccepted(
-        platform="slack",
-        user_id="user-1",
-        message_id="native-1",
-        session_id="session-1",
-        text="remember this",
-        files=(),
-        is_dm=True,
-        is_ordinary_text=True,
-        is_ordinary_attachment=False,
-        lifecycle_snapshot=0,
-    )
+    event = object()
     controller.memory_adapter.offer(event)
     assert offers == [event]
 
+    operation = asyncio.create_task(
+        controller.preflight_memory(enabled)
+        if active_operation == "preflight"
+        else controller.install_memory_runtime()
+    )
+    await operation_started.wait()
+
     disabled = replace(enabled, enabled=False)
+    assert await controller.reconcile_memory(disabled) == {
+        "ok": False,
+        "state": "disabled",
+        "error": "memory_operation_in_progress",
+    }
+    assert controller.config.memory is enabled
+    assert controller.memory_runtime is runtime
+    assert controller.memory_adapter is runtime.capture_adapter
+    assert runtime.begin_close_calls == 0
+
+    operation_release.set()
+    assert await operation == {"ok": True}
     assert await controller.reconcile_memory(disabled) == {
         "ok": True,
         "state": "disabled",
@@ -701,7 +724,6 @@ async def test_memory_reconcile_lazily_enters_and_leaves_enabled_runtime() -> No
     assert controller.memory_module is None
     assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
     assert controller.config.memory.enabled is False
-    assert controller._memory_disabled_cleanup_unproved is False
 
 
 @pytest.mark.parametrize("overlap", ("preflight", "install"))
@@ -1139,49 +1161,6 @@ async def test_enabled_status_does_not_wait_for_startup_wake() -> None:
     finally:
         wake_release.set()
         await controller._memory_reconcile_task
-
-
-@pytest.mark.asyncio
-async def test_disable_does_not_wait_for_long_runtime_read() -> None:
-    enabled = replace(_disabled_app_config().memory, enabled=True)
-    disabled = replace(enabled, enabled=False)
-    controller = _controller_with_memory(enabled)
-    controller.memory_adapter = None
-    read_started = asyncio.Event()
-    read_release = asyncio.Event()
-
-    class _Runtime(_NoRetainedRootOwnership):
-        def __init__(self) -> None:
-            self.module = object()
-            self.close_calls = 0
-
-        async def status_payload(self) -> dict[str, object]:
-            assert controller._memory_replacement_lock().locked() is False
-            read_started.set()
-            await read_release.wait()
-            return {"status": "ok", "state": "running"}
-
-        def begin_close(self) -> None:
-            return None
-
-        async def close(self) -> None:
-            self.close_calls += 1
-
-    runtime = _Runtime()
-    controller.memory_runtime = runtime
-    controller.memory_module = runtime.module
-    status = asyncio.create_task(controller.memory_status_payload())
-    await read_started.wait()
-    assert await asyncio.wait_for(
-        controller.reconcile_memory(disabled),
-        timeout=0.1,
-    ) == {"ok": True, "state": "disabled"}
-
-    assert runtime.close_calls == 1
-    assert controller.memory_runtime is None
-    assert controller._memory_replacement_lock().locked() is False
-    read_release.set()
-    assert await status == {"status": "ok", "state": "running"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_disabled_isolation.py
+++ b/tests/test_memory_disabled_isolation.py
@@ -22,6 +22,7 @@ from core.memory_adapter import DisabledMemoryAdapter, TurnAccepted
 from vibe.memory_contract import (
     MemoryPluginIncompatibleError,
     MemoryPluginUnavailableError,
+    MemoryRuntimeBusyError,
     MemoryStoreUnavailableError,
 )
 
@@ -793,6 +794,77 @@ async def test_disabled_preflight_uses_one_unpublished_runtime() -> None:
     assert controller.memory_runtime is None
     assert controller.memory_module is None
     assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
+
+
+@pytest.mark.parametrize("overlap", ("preflight", "install"))
+@pytest.mark.asyncio
+async def test_overlapping_unpublished_operations_return_busy(
+    overlap: str,
+) -> None:
+    controller = Controller.__new__(Controller)
+    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
+    controller.memory_adapter = DisabledMemoryAdapter()
+    controller.memory_runtime = None
+    controller.memory_module = None
+    controller._memory_reconcile_task = None
+    controller._memory_disabled_cleanup_task = None
+    controller._memory_plugin_error = None
+    candidate = replace(controller.config.memory, enabled=True)
+    preflight_started = asyncio.Event()
+    preflight_release = asyncio.Event()
+    construction_attempts = 0
+
+    class _Runtime:
+        module = object()
+
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def preflight(self, config) -> dict[str, object]:
+            assert config is candidate
+            preflight_started.set()
+            await preflight_release.wait()
+            return {"ok": True}
+
+        def begin_close(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            self.closed = True
+
+    runtime = _Runtime()
+
+    def create_runtime(_config, **_kwargs):
+        nonlocal construction_attempts
+        construction_attempts += 1
+        if construction_attempts == 1:
+            return runtime
+        raise MemoryRuntimeBusyError("provider root busy")
+
+    controller._create_memory_runtime = create_runtime
+    first = asyncio.create_task(controller.preflight_memory(candidate))
+    await preflight_started.wait()
+
+    if overlap == "preflight":
+        busy = await controller.preflight_memory(candidate)
+        assert busy == {"ok": False, "error": "memory_operation_in_progress"}
+    else:
+        busy = await controller.install_memory_runtime()
+        assert busy == {
+            "ok": False,
+            "reason": "memory_operation_in_progress",
+            "download_error": None,
+        }
+
+    assert construction_attempts == 2
+    assert controller.memory_runtime is None
+    assert controller.memory_module is None
+    assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
+    assert controller._memory_plugin_error is None
+
+    preflight_release.set()
+    assert await first == {"ok": True}
+    assert runtime.closed is True
 
 
 @pytest.mark.parametrize("operation", ("preflight", "install"))

--- a/tests/test_memory_disabled_isolation.py
+++ b/tests/test_memory_disabled_isolation.py
@@ -29,6 +29,11 @@ from vibe.memory_contract import (
 ROOT = Path(__file__).resolve().parents[1]
 
 
+class _NoRetainedRootOwnership:
+    def release_retained_root_ownership(self) -> None:
+        return None
+
+
 def _disabled_app_config():
     return to_app_config(
         V2Config.from_payload(
@@ -641,7 +646,7 @@ async def test_memory_reconcile_lazily_enters_and_leaves_enabled_runtime() -> No
         def offer(self, event: object) -> None:
             offers.append(event)
 
-    class _Runtime:
+    class _Runtime(_NoRetainedRootOwnership):
         def __init__(self) -> None:
             self.module = object()
             self.available = True
@@ -781,7 +786,7 @@ async def test_cached_plugin_failure_only_retries_for_explicit_recovery(
     assert raised.value is failure
     events: list[str] = []
 
-    class _Runtime:
+    class _Runtime(_NoRetainedRootOwnership):
         def __init__(self, label: str, *, fail_close: bool = False) -> None:
             self.label = label
             self.module = object()
@@ -959,6 +964,7 @@ async def test_disable_publishes_disabled_before_failed_close() -> None:
             self.module = object()
             self.fail_close = True
             self.close_calls = 0
+            self.root_released = False
 
         def begin_close(self) -> None:
             assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
@@ -967,6 +973,9 @@ async def test_disable_publishes_disabled_before_failed_close() -> None:
             self.close_calls += 1
             if self.fail_close:
                 raise RuntimeError("close failed")
+
+        def release_retained_root_ownership(self) -> None:
+            self.root_released = True
 
     runtime = _Runtime()
     controller.memory_runtime = runtime
@@ -989,6 +998,7 @@ async def test_disable_publishes_disabled_before_failed_close() -> None:
         "state": "disabled",
     }
     assert runtime.close_calls == 2
+    assert runtime.root_released is True
     assert controller.memory_runtime is None
 
 
@@ -1140,7 +1150,7 @@ async def test_disable_does_not_wait_for_long_runtime_read() -> None:
     read_started = asyncio.Event()
     read_release = asyncio.Event()
 
-    class _Runtime:
+    class _Runtime(_NoRetainedRootOwnership):
         def __init__(self) -> None:
             self.module = object()
             self.close_calls = 0
@@ -1223,7 +1233,7 @@ async def test_disable_revokes_unpublished_enable_before_it_can_publish() -> Non
     reconcile_started = asyncio.Event()
     reconcile_release = asyncio.Event()
 
-    class _Runtime:
+    class _Runtime(_NoRetainedRootOwnership):
         module = object()
         capture_adapter = object()
 

--- a/tests/test_memory_disabled_isolation.py
+++ b/tests/test_memory_disabled_isolation.py
@@ -758,53 +758,11 @@ async def test_overlapping_unpublished_operations_return_busy(
     assert runtime.closed is True
 
 
-@pytest.mark.parametrize("operation", ("preflight", "install"))
+@pytest.mark.parametrize("recovery", ("preflight", "install"))
 @pytest.mark.asyncio
-async def test_explicit_recovery_retries_after_cached_plugin_failure(
-    operation: str,
+async def test_cached_plugin_failure_only_retries_for_explicit_recovery(
+    recovery: str,
 ) -> None:
-    controller = _controller_with_memory()
-    controller._memory_plugin_error = MemoryPluginUnavailableError("startup failed")
-    candidate = replace(controller.config.memory, enabled=True)
-    calls: list[tuple[str, object]] = []
-
-    class _Runtime:
-        module = object()
-        closed = False
-
-        async def preflight(self, config) -> dict[str, object]:
-            calls.append(("preflight", config))
-            return {"ok": True}
-
-        async def install_artifact(self, **_options: object) -> dict[str, object]:
-            calls.append(("install", controller.config.memory))
-            return {"ok": True}
-
-        async def close(self) -> None:
-            self.closed = True
-
-        def begin_close(self) -> None:
-            return None
-
-    runtime = _Runtime()
-    controller._create_memory_runtime = lambda config, **_kwargs: runtime
-
-    if operation == "preflight":
-        result = await controller.preflight_memory(candidate)
-        expected_calls = [("preflight", candidate)]
-    else:
-        result = await controller.install_memory_runtime()
-        expected_calls = [("install", controller.config.memory)]
-
-    assert result == {"ok": True}
-    assert calls == expected_calls
-    assert runtime.closed is True
-    assert controller._memory_plugin_error is None
-    assert controller.memory_runtime is None
-
-
-@pytest.mark.asyncio
-async def test_cached_plugin_failure_only_retries_for_explicit_recovery() -> None:
     controller = _controller_with_memory(
         replace(_disabled_app_config().memory, enabled=True)
     )
@@ -821,57 +779,73 @@ async def test_cached_plugin_failure_only_retries_for_explicit_recovery() -> Non
         )
 
     assert raised.value is failure
+    events: list[str] = []
+
+    class _Runtime:
+        def __init__(self, label: str, *, fail_close: bool = False) -> None:
+            self.label = label
+            self.module = object()
+            self.closing = False
+            self.fail_close = fail_close
+
+        async def install_artifact(self, **_options: object) -> dict[str, object]:
+            assert controller.memory_runtime is None
+            events.append(f"{self.label}:install")
+            return {"ok": True}
+
+        async def preflight(self, _config: object) -> dict[str, object]:
+            events.append(f"{self.label}:preflight")
+            return {"ok": True}
+
+        def begin_close(self) -> None:
+            self.closing = True
+            events.append(f"{self.label}:begin-close")
+
+        async def close(self) -> None:
+            events.append(f"{self.label}:close")
+            if self.fail_close:
+                self.fail_close = False
+                raise RuntimeError("close failed")
+
+    retained = _Runtime("retained", fail_close=True)
+    fresh = _Runtime("fresh")
+    runtimes = iter((retained, fresh))
+    controller._create_memory_runtime = lambda *_args, **_kwargs: next(runtimes)
+
+    with pytest.raises(RuntimeError, match="close failed"):
+        await controller.install_memory_runtime()
+    assert controller.memory_runtime is retained
+    assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
+
+    if recovery == "preflight":
+        result = await controller.preflight_memory(controller.config.memory)
+    else:
+        result = await controller.install_memory_runtime()
+    assert result == {"ok": True}
+    assert events == [
+        "retained:install",
+        "retained:begin-close",
+        "retained:close",
+        "retained:close",
+        f"fresh:{recovery}",
+        "fresh:begin-close",
+        "fresh:close",
+    ]
+    assert controller.memory_runtime is None
+    assert controller.memory_module is None
+    assert controller._memory_plugin_error is None
+    assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
+
     retry_failure = MemoryPluginIncompatibleError("still incompatible")
 
     def fail_retry(_config, **_kwargs):
         raise retry_failure
 
     controller._create_memory_runtime = fail_retry
-
     with pytest.raises(MemoryPluginIncompatibleError) as raised:
         await controller.preflight_memory(controller.config.memory)
-
     assert raised.value is retry_failure
     assert controller._memory_plugin_error is retry_failure
-
-
-@pytest.mark.asyncio
-async def test_disabled_install_keeps_runtime_unpublished_until_close() -> None:
-    controller = _controller_with_memory()
-    events: list[str] = []
-    loader_flags: list[bool] = []
-
-    class _Runtime:
-        def __init__(self) -> None:
-            self.module = object()
-            self.closed = False
-
-        async def install_artifact(self, **_options: object) -> dict[str, object]:
-            assert controller.memory_runtime is None
-            events.append("install")
-            return {"ok": True}
-
-        def begin_close(self) -> None:
-            events.append("begin-close")
-
-        async def close(self) -> None:
-            events.append("close")
-            self.closed = True
-
-    runtime = _Runtime()
-
-    def create_runtime(config, **kwargs):
-        loader_flags.append(bool(kwargs["allow_disabled"]))
-        return runtime
-
-    controller._create_memory_runtime = create_runtime
-
-    assert await controller.install_memory_runtime() == {"ok": True}
-    assert loader_flags == [True]
-    assert events == ["install", "begin-close", "close"]
-    assert controller.memory_runtime is None
-    assert controller.memory_module is None
-    assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
 
 
 @pytest.mark.parametrize("ordering", ("reaper-first", "enable-first"))
@@ -998,8 +972,11 @@ async def test_disable_publishes_disabled_before_failed_close() -> None:
     controller.memory_runtime = runtime
     controller.memory_module = runtime.module
 
-    with pytest.raises(RuntimeError, match="close failed"):
-        await controller.reconcile_memory(disabled)
+    assert await controller.reconcile_memory(disabled) == {
+        "ok": False,
+        "state": "disabled",
+        "error": "memory_operation_in_progress",
+    }
 
     assert controller.config.memory == disabled
     assert controller.memory_runtime is runtime

--- a/tests/test_memory_disabled_isolation.py
+++ b/tests/test_memory_disabled_isolation.py
@@ -22,7 +22,6 @@ from core.memory_adapter import DisabledMemoryAdapter, TurnAccepted
 from vibe.memory_contract import (
     MemoryPluginIncompatibleError,
     MemoryPluginUnavailableError,
-    MemoryRuntimeBusyError,
     MemoryStoreUnavailableError,
 )
 
@@ -47,6 +46,33 @@ def _disabled_app_config():
                 "setup_completed": True,
             }
         )
+    )
+
+
+def _controller_with_memory(memory=None) -> Controller:
+    controller = Controller.__new__(Controller)
+    controller.config = types.SimpleNamespace(
+        memory=memory or _disabled_app_config().memory
+    )
+    controller.memory_adapter = DisabledMemoryAdapter()
+    controller.memory_runtime = None
+    controller.memory_module = None
+    controller._memory_reconcile_task = None
+    controller._memory_disabled_cleanup_task = None
+    controller._memory_disabled_cleanup_unproved = False
+    controller._memory_plugin_error = None
+    return controller
+
+
+def _capture_request() -> CaptureRequest:
+    return CaptureRequest(
+        source_message_id="message-1",
+        session_id="session-1",
+        principal_id="u-11111111111111111111111111111111",
+        project_id="default",
+        provenance="agent",
+        text="remember this",
+        occurred_at_ms=1,
     )
 
 
@@ -116,11 +142,7 @@ async def _start_disabled_cleanup(
     process_module.ReleasedEverOSOrphanReconciler = _Reconciler
     monkeypatch.setitem(sys.modules, "avibe_memory.process", process_module)
 
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller._memory_disabled_cleanup_task = None
+    controller = _controller_with_memory()
     await controller._schedule_disabled_memory_cleanup()
     cleanup_task = controller._memory_disabled_cleanup_task
     assert cleanup_task is not None
@@ -534,10 +556,7 @@ async def test_disabled_cleanup_reaps_only_preexisting_everos_ownership(
     process_module.ReleasedEverOSOrphanReconciler = _Reconciler
     monkeypatch.setitem(sys.modules, "avibe_memory.process", process_module)
 
-    controller = Controller.__new__(Controller)
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller._memory_disabled_cleanup_task = None
+    controller = _controller_with_memory()
 
     await controller._schedule_disabled_memory_cleanup()
 
@@ -582,37 +601,20 @@ async def test_disabled_cleanup_pending_projects_degraded_status(
         await cleanup_task
 
 
-@pytest.mark.asyncio
-async def test_disabled_cleanup_failure_remains_degraded(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    async def reconcile_orphans() -> None:
-        raise RuntimeError("cleanup failed")
-
-    controller, cleanup_task, _record_path = await _start_disabled_cleanup(
-        monkeypatch,
-        reconcile_orphans,
-    )
-    await cleanup_task
-
-    status = await controller.memory_status_payload()
-
-    assert status["state"] == "degraded"
-    assert status["reason"] == "memory_runtime_busy"
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("remove_ownership", "expected_state"),
-    [(False, "degraded"), (True, "disabled")],
+    ("outcome", "expected_state"),
+    [("failure", "degraded"), ("retained", "degraded"), ("released", "disabled")],
 )
-async def test_disabled_cleanup_success_rechecks_released_ownership(
+@pytest.mark.asyncio
+async def test_disabled_cleanup_terminal_status_tracks_ownership(
     monkeypatch: pytest.MonkeyPatch,
-    remove_ownership: bool,
+    outcome: str,
     expected_state: str,
 ) -> None:
     async def reconcile_orphans() -> None:
-        if remove_ownership:
+        if outcome == "failure":
+            raise RuntimeError("cleanup failed")
+        if outcome == "released":
             record_path.unlink()
 
     controller, cleanup_task, record_path = await _start_disabled_cleanup(
@@ -630,121 +632,59 @@ async def test_disabled_cleanup_success_rechecks_released_ownership(
 
 
 @pytest.mark.asyncio
-async def test_memory_reconcile_lazily_enters_and_leaves_enabled_runtime(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    created: list[object] = []
-    capture_started = asyncio.Event()
-    capture_stopped = asyncio.Event()
+async def test_memory_reconcile_lazily_enters_and_leaves_enabled_runtime() -> None:
+    controller = _controller_with_memory()
+    enabled = replace(controller.config.memory, enabled=True)
+    offers: list[object] = []
+
+    class _CaptureAdapter:
+        def offer(self, event: object) -> None:
+            offers.append(event)
 
     class _Runtime:
         def __init__(self) -> None:
             self.module = object()
             self.available = True
             self.closed = False
-            self.capture_adapter = self._CaptureAdapter()
-
-        class _CaptureAdapter:
-            def __init__(self) -> None:
-                self.task: asyncio.Task[None] | None = None
-
-            def start(self) -> bool:
-                return True
-
-            def offer(self, _event: object) -> None:
-                async def capture() -> None:
-                    capture_started.set()
-                    try:
-                        await asyncio.Event().wait()
-                    finally:
-                        capture_stopped.set()
-
-                self.task = asyncio.create_task(capture())
-
-            def quiesce_memory_capture_tasks(self) -> None:
-                return None
-
-            async def cancel_memory_capture_tasks(self) -> None:
-                if self.task is None:
-                    return
-                self.task.cancel()
-                await asyncio.gather(self.task, return_exceptions=True)
-
-            def cancel_memory_capture_tasks_nowait(self) -> None:
-                if self.task is not None:
-                    self.task.cancel()
+            self.capture_adapter = _CaptureAdapter()
 
         def start_capture_adapter(self, **_options: object) -> bool:
-            return self.capture_adapter.start()
+            return True
 
-        async def reconcile(self, config) -> dict[str, object]:
-            return {
-                "ok": True,
-                "state": "running" if config.enabled else "disabled",
-            }
+        async def reconcile(self, _config) -> dict[str, object]:
+            return {"ok": True, "state": "running"}
 
         async def close(self) -> None:
-            await self.capture_adapter.cancel_memory_capture_tasks()
             self.closed = True
 
         def begin_close(self) -> None:
-            self.capture_adapter.quiesce_memory_capture_tasks()
-            self.capture_adapter.cancel_memory_capture_tasks_nowait()
+            assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
 
     runtime = _Runtime()
-
-    def create_memory_runtime(config, **_kwargs):
-        created.append(config)
-        return runtime
-
-    runtime_module = types.ModuleType("avibe_memory.runtime")
-    runtime_module.MEMORY_RUNTIME_PROTOCOL_VERSION = 1
-    runtime_module.create_memory_runtime = create_memory_runtime
-    monkeypatch.setitem(sys.modules, "avibe_memory.runtime", runtime_module)
-
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller.memory_module = None
-    controller._memory_disabled_cleanup_unproved = True
-    controller.settings_manager = types.SimpleNamespace(
-        is_enabled_user=lambda *_args, **_kwargs: True
-    )
-    controller.session_turns = types.SimpleNamespace(
-        session_lifecycle_snapshot_matches=lambda *_args: True,
-        acquire_lifecycle_admission=lambda *_args: asyncio.sleep(
-            0,
-            result=types.SimpleNamespace(release=lambda: None),
-        ),
-    )
-
-    enabled = replace(controller.config.memory, enabled=True)
+    controller._create_memory_runtime = lambda _config: runtime
     assert await controller.reconcile_memory(enabled) == {
         "ok": True,
         "state": "running",
     }
-    assert created == [enabled]
     assert controller.memory_runtime is runtime
     assert controller.memory_module is runtime.module
     assert controller.memory_adapter is runtime.capture_adapter
     assert controller.config.memory.enabled is True
 
-    controller.memory_adapter.offer(
-        TurnAccepted(
-            platform="slack",
-            user_id="user-1",
-            message_id="native-1",
-            session_id="session-1",
-            text="remember this",
-            files=(),
-            is_dm=True,
-            is_ordinary_text=True,
-            is_ordinary_attachment=False,
-            lifecycle_snapshot=0,
-        )
+    event = TurnAccepted(
+        platform="slack",
+        user_id="user-1",
+        message_id="native-1",
+        session_id="session-1",
+        text="remember this",
+        files=(),
+        is_dm=True,
+        is_ordinary_text=True,
+        is_ordinary_attachment=False,
+        lifecycle_snapshot=0,
     )
-    await capture_started.wait()
+    controller.memory_adapter.offer(event)
+    assert offers == [event]
 
     disabled = replace(enabled, enabled=False)
     assert await controller.reconcile_memory(disabled) == {
@@ -764,18 +704,11 @@ async def test_memory_reconcile_lazily_enters_and_leaves_enabled_runtime(
 async def test_overlapping_unpublished_operations_return_busy(
     overlap: str,
 ) -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller.memory_module = None
-    controller._memory_reconcile_task = None
-    controller._memory_disabled_cleanup_task = None
-    controller._memory_plugin_error = None
+    controller = _controller_with_memory()
     candidate = replace(controller.config.memory, enabled=True)
     preflight_started = asyncio.Event()
     preflight_release = asyncio.Event()
-    construction_attempts = 0
+    construction_attempts: list[object] = []
 
     class _Runtime:
         module = object()
@@ -797,12 +730,9 @@ async def test_overlapping_unpublished_operations_return_busy(
 
     runtime = _Runtime()
 
-    def create_runtime(_config, **_kwargs):
-        nonlocal construction_attempts
-        construction_attempts += 1
-        if construction_attempts == 1:
-            return runtime
-        raise MemoryRuntimeBusyError("provider root busy")
+    def create_runtime(config, **_kwargs):
+        construction_attempts.append(config)
+        return runtime
 
     controller._create_memory_runtime = create_runtime
     first = asyncio.create_task(controller.preflight_memory(candidate))
@@ -819,11 +749,9 @@ async def test_overlapping_unpublished_operations_return_busy(
             "download_error": None,
         }
 
-    assert construction_attempts == 2
+    assert construction_attempts == [candidate]
     assert controller.memory_runtime is None
-    assert controller.memory_module is None
     assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
-    assert controller._memory_plugin_error is None
 
     preflight_release.set()
     assert await first == {"ok": True}
@@ -835,12 +763,7 @@ async def test_overlapping_unpublished_operations_return_busy(
 async def test_explicit_recovery_retries_after_cached_plugin_failure(
     operation: str,
 ) -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller.memory_module = None
-    controller._memory_reconcile_task = None
+    controller = _controller_with_memory()
     controller._memory_plugin_error = MemoryPluginUnavailableError("startup failed")
     candidate = replace(controller.config.memory, enabled=True)
     calls: list[tuple[str, object]] = []
@@ -853,7 +776,7 @@ async def test_explicit_recovery_retries_after_cached_plugin_failure(
             calls.append(("preflight", config))
             return {"ok": True}
 
-        async def install_artifact(self) -> dict[str, object]:
+        async def install_artifact(self, **_options: object) -> dict[str, object]:
             calls.append(("install", controller.config.memory))
             return {"ok": True}
 
@@ -881,13 +804,10 @@ async def test_explicit_recovery_retries_after_cached_plugin_failure(
 
 
 @pytest.mark.asyncio
-async def test_ordinary_memory_read_keeps_cached_plugin_failure_without_retry() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(
-        memory=replace(_disabled_app_config().memory, enabled=True)
+async def test_cached_plugin_failure_only_retries_for_explicit_recovery() -> None:
+    controller = _controller_with_memory(
+        replace(_disabled_app_config().memory, enabled=True)
     )
-    controller.memory_runtime = None
-    controller._memory_reconcile_task = None
     failure = MemoryPluginUnavailableError("startup failed")
     controller._memory_plugin_error = failure
     controller._create_memory_runtime = lambda *_args, **_kwargs: pytest.fail(
@@ -901,27 +821,15 @@ async def test_ordinary_memory_read_keeps_cached_plugin_failure_without_retry() 
         )
 
     assert raised.value is failure
-
-
-@pytest.mark.asyncio
-async def test_explicit_recovery_caches_typed_retry_failure() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller.memory_module = None
-    controller._memory_reconcile_task = None
-    controller._memory_plugin_error = MemoryPluginUnavailableError("startup failed")
-    candidate = replace(controller.config.memory, enabled=True)
     retry_failure = MemoryPluginIncompatibleError("still incompatible")
 
-    def create_runtime(_config, **_kwargs):
+    def fail_retry(_config, **_kwargs):
         raise retry_failure
 
-    controller._create_memory_runtime = create_runtime
+    controller._create_memory_runtime = fail_retry
 
     with pytest.raises(MemoryPluginIncompatibleError) as raised:
-        await controller.preflight_memory(candidate)
+        await controller.preflight_memory(controller.config.memory)
 
     assert raised.value is retry_failure
     assert controller._memory_plugin_error is retry_failure
@@ -929,12 +837,7 @@ async def test_explicit_recovery_caches_typed_retry_failure() -> None:
 
 @pytest.mark.asyncio
 async def test_disabled_install_keeps_runtime_unpublished_until_close() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller.memory_module = None
-    controller._memory_reconcile_task = None
+    controller = _controller_with_memory()
     events: list[str] = []
     loader_flags: list[bool] = []
 
@@ -943,7 +846,7 @@ async def test_disabled_install_keeps_runtime_unpublished_until_close() -> None:
             self.module = object()
             self.closed = False
 
-        async def install_artifact(self) -> dict[str, object]:
+        async def install_artifact(self, **_options: object) -> dict[str, object]:
             assert controller.memory_runtime is None
             events.append("install")
             return {"ok": True}
@@ -971,79 +874,125 @@ async def test_disabled_install_keeps_runtime_unpublished_until_close() -> None:
     assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
 
 
+@pytest.mark.parametrize("ordering", ("reaper-first", "enable-first"))
 @pytest.mark.asyncio
-async def test_cancelled_install_does_not_cancel_shared_disabled_cleanup() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller.memory_module = None
-    controller._memory_reconcile_task = None
-    cleanup_started = asyncio.Event()
-    cleanup_release = asyncio.Event()
-    created: list[object] = []
+async def test_disabled_reaper_and_enable_share_root_mutation_gate(
+    ordering: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = _controller_with_memory()
+    controller._memory_disabled_cleanup_unproved = True
+    enabled = replace(controller.config.memory, enabled=True)
+    lease_held = False
+    reaper_started = asyncio.Event()
+    reaper_release = asyncio.Event()
+    attach_started = asyncio.Event()
+    attach_release = asyncio.Event()
+    reaper_calls = 0
+    construction_calls = 0
 
-    async def cleanup() -> None:
-        cleanup_started.set()
-        await cleanup_release.wait()
+    class _Lease:
+        def release(self) -> None:
+            nonlocal lease_held
+            lease_held = False
+
+    async def try_lease(_effective_home=None):
+        nonlocal lease_held
+        if lease_held:
+            return None
+        lease_held = True
+        return _Lease()
+
+    class _Reconciler:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        async def reconcile_orphans(self) -> None:
+            nonlocal reaper_calls
+            reaper_calls += 1
+            reaper_started.set()
+            await reaper_release.wait()
+
+    process_module = types.ModuleType("avibe_memory.process")
+    process_module.ReleasedEverOSOrphanReconciler = _Reconciler
+    monkeypatch.setitem(sys.modules, "avibe_memory.process", process_module)
+    controller._try_memory_operation_lease = try_lease
+    controller._disabled_memory_ownership_exists = lambda _path: True
 
     class _Runtime:
-        def __init__(self) -> None:
-            self.module = object()
-            self.closed = False
+        module = object()
+        capture_adapter = object()
+        closing = False
 
-        async def install_artifact(self) -> dict[str, object]:
-            return {"ok": True}
+        async def reconcile(self, _config) -> dict[str, object]:
+            return {"ok": True, "state": "running"}
 
-        async def close(self) -> None:
-            self.closed = True
+        def start_capture_adapter(self, **_kwargs) -> bool:
+            return True
 
-        def begin_close(self) -> None:
-            return None
+    runtime = _Runtime()
 
-    cleanup_task = asyncio.create_task(cleanup())
-    controller._memory_disabled_cleanup_task = cleanup_task
-    controller._create_memory_runtime = (
-        lambda config, **_kwargs: created.append(config) or _Runtime()
-    )
+    def create_runtime(_config, **_kwargs):
+        nonlocal construction_calls
+        construction_calls += 1
+        return runtime
 
-    first = asyncio.create_task(controller.install_memory_runtime())
-    await cleanup_started.wait()
-    first.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await first
+    controller._create_memory_runtime = create_runtime
+    memory_dir = Path("unused-memory-root")
 
-    assert cleanup_task.done() is False
-    second = asyncio.create_task(controller.install_memory_runtime())
-    await asyncio.sleep(0)
-    assert created == []
+    if ordering == "reaper-first":
+        cleanup = asyncio.create_task(
+            controller._cleanup_disabled_memory_process(memory_dir)
+        )
+        await reaper_started.wait()
+        assert await controller.reconcile_memory(enabled) == {
+            "ok": False,
+            "error": "memory_operation_in_progress",
+        }
+        assert construction_calls == 0
+        reaper_release.set()
+        await cleanup
+    else:
+        attach = controller._attach_memory_runtime
 
-    cleanup_release.set()
-    assert await second == {"ok": True}
-    assert cleanup_task.done() is True
-    assert created == [controller.config.memory]
+        async def blocked_attach(*args, **kwargs) -> None:
+            attach_started.set()
+            await attach_release.wait()
+            await attach(*args, **kwargs)
+
+        controller._attach_memory_runtime = blocked_attach
+        reconcile = asyncio.create_task(controller.reconcile_memory(enabled))
+        await attach_started.wait()
+        await controller._cleanup_disabled_memory_process(memory_dir)
+        assert reaper_calls == 0
+        attach_release.set()
+        assert await reconcile == {"ok": True, "state": "running"}
+        assert controller.memory_runtime is runtime
+
+    assert controller._memory_replacement_lock().locked() is False
 
 
 @pytest.mark.asyncio
 async def test_disable_publishes_disabled_before_failed_close() -> None:
     enabled = replace(_disabled_app_config().memory, enabled=True)
     disabled = replace(enabled, enabled=False)
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=enabled)
+    controller = _controller_with_memory(enabled)
     original_adapter = object()
     controller.memory_adapter = original_adapter
-    controller._memory_reconcile_task = None
-    controller._memory_disabled_cleanup_task = None
 
     class _Runtime:
         def __init__(self) -> None:
             self.module = object()
+            self.fail_close = True
+            self.close_calls = 0
 
         def begin_close(self) -> None:
             assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
 
-        async def close(self) -> None:
-            raise RuntimeError("close failed")
+        async def close(self, **_options: object) -> None:
+            self.close_calls += 1
+            if self.fail_close:
+                raise RuntimeError("close failed")
 
     runtime = _Runtime()
     controller.memory_runtime = runtime
@@ -1053,67 +1002,56 @@ async def test_disable_publishes_disabled_before_failed_close() -> None:
         await controller.reconcile_memory(disabled)
 
     assert controller.config.memory == disabled
-    assert controller.memory_runtime is None
+    assert controller.memory_runtime is runtime
     assert controller.memory_module is None
     assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
 
+    runtime.fail_close = False
+    assert await controller.reconcile_memory(disabled) == {
+        "ok": True,
+        "state": "disabled",
+    }
+    assert runtime.close_calls == 2
+    assert controller.memory_runtime is None
 
+
+@pytest.mark.parametrize(
+    ("cleanup_unproved", "expected_state", "expected_reason", "source_reason"),
+    [
+        (False, "needs_repair", "memory_legacy_recovery_required", "memory_disabled"),
+        (True, "degraded", "memory_runtime_busy", "memory_runtime_busy"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_disabled_status_preserves_legacy_repair_fence_without_runtime() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(
-        memory=replace(
+async def test_disabled_status_projects_repair_and_cleanup_fences(
+    cleanup_unproved: bool,
+    expected_state: str,
+    expected_reason: str,
+    source_reason: str,
+) -> None:
+    controller = _controller_with_memory(
+        replace(
             _disabled_app_config().memory,
             legacy_needs_repair=True,
         )
     )
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller.memory_module = None
+    controller._memory_disabled_cleanup_unproved = cleanup_unproved
 
     status = await controller.memory_status_payload()
 
-    assert status["state"] == "needs_repair"
-    assert status["reason"] == "memory_legacy_recovery_required"
-    assert status["source"]["reason"] == "memory_disabled"
+    assert status["state"] == expected_state
+    assert status["reason"] == expected_reason
+    assert status["source"]["reason"] == source_reason
 
 
 @pytest.mark.asyncio
-async def test_disabled_cleanup_fence_precedes_legacy_repair_projection() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(
-        memory=replace(
-            _disabled_app_config().memory,
-            legacy_needs_repair=True,
-        )
-    )
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller.memory_module = None
-    controller._memory_disabled_cleanup_task = None
-    controller._memory_disabled_cleanup_unproved = True
-
-    status = await controller.memory_status_payload()
-
-    assert status["state"] == "degraded"
-    assert status["reason"] == "memory_runtime_busy"
-    assert status["source"]["reason"] == "memory_runtime_busy"
-
-
-@pytest.mark.asyncio
-async def test_disabled_dashboard_reads_do_not_construct_runtime() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller.memory_module = None
-    controller._memory_reconcile_task = None
-    controller._memory_disabled_cleanup_task = None
+async def test_disabled_operations_do_not_construct_runtime() -> None:
+    controller = _controller_with_memory()
     factory_calls: list[object] = []
 
     def create_runtime(config, **_kwargs):
         factory_calls.append(config)
-        raise AssertionError("disabled dashboard reads must not construct Memory")
+        raise AssertionError("disabled operations must not construct Memory")
 
     controller._create_memory_runtime = create_runtime
 
@@ -1147,53 +1085,28 @@ async def test_disabled_dashboard_reads_do_not_construct_runtime() -> None:
         "data_exists": True,
         "can_delete_data": True,
     }
-    assert factory_calls == []
-
-
-@pytest.mark.asyncio
-async def test_disabled_wake_and_remember_are_host_derived_without_runtime() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller.memory_module = None
-    controller._create_memory_runtime = lambda _config, **_kwargs: pytest.fail(
-        "disabled outcomes must not construct Memory"
-    )
-
     assert await controller.wake_memory() == {
         "ok": False,
         "state": "disabled",
         "error": "memory_disabled",
     }
     assert await controller.capture_memory(
-        CaptureRequest(
-            source_message_id="message-1",
-            session_id="session-1",
-            principal_id="u-11111111111111111111111111111111",
-            project_id="default",
-            provenance="agent",
-            text="remember this",
-            occurred_at_ms=1,
-        )
+        _capture_request()
     ) == CaptureSkipped(reason="memory_disabled")
+    with pytest.raises(MemoryStoreUnavailableError, match="Memory is disabled"):
+        await controller.memory_projects_payload(
+            verified_user_key=None,
+            cli_scope=("u-11111111111111111111111111111111", "default"),
+        )
+    assert factory_calls == []
 
 
 @pytest.mark.asyncio
 async def test_plugin_failure_rechecked_after_blocked_capture_lock() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=types.SimpleNamespace(enabled=True))
-    controller._memory_plugin_error = None
-    controller.memory_runtime = None
-    request = CaptureRequest(
-        source_message_id="message-1",
-        session_id="session-1",
-        principal_id="u-11111111111111111111111111111111",
-        project_id="default",
-        provenance="agent",
-        text="remember this",
-        occurred_at_ms=1,
+    controller = _controller_with_memory(
+        replace(_disabled_app_config().memory, enabled=True)
     )
+    request = _capture_request()
 
     gate = controller._memory_replacement_lock()
     await gate.acquire()
@@ -1208,36 +1121,11 @@ async def test_plugin_failure_rechecked_after_blocked_capture_lock() -> None:
 
 
 @pytest.mark.asyncio
-async def test_disabled_store_backed_read_is_gated_before_runtime_construction() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=_disabled_app_config().memory)
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller.memory_module = None
-    controller._memory_reconcile_task = None
-
-    controller._create_memory_runtime = lambda _config, **_kwargs: pytest.fail(
-        "disabled reads must not construct Memory"
-    )
-
-    with pytest.raises(MemoryStoreUnavailableError, match="Memory is disabled"):
-        await controller.memory_projects_payload(
-            verified_user_key=None,
-            cli_scope=("u-11111111111111111111111111111111", "default"),
-        )
-
-    assert controller.memory_runtime is None
-    assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
-
-
-@pytest.mark.asyncio
 async def test_enabled_status_does_not_wait_for_startup_wake() -> None:
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(
-        memory=replace(_disabled_app_config().memory, enabled=True)
+    controller = _controller_with_memory(
+        replace(_disabled_app_config().memory, enabled=True)
     )
     controller.memory_adapter = None
-    controller._memory_disabled_cleanup_task = None
     wake_release = asyncio.Event()
 
     async def startup_wake() -> None:
@@ -1270,11 +1158,8 @@ async def test_enabled_status_does_not_wait_for_startup_wake() -> None:
 async def test_disable_does_not_wait_for_long_runtime_read() -> None:
     enabled = replace(_disabled_app_config().memory, enabled=True)
     disabled = replace(enabled, enabled=False)
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=enabled)
+    controller = _controller_with_memory(enabled)
     controller.memory_adapter = None
-    controller._memory_reconcile_task = None
-    controller._memory_disabled_cleanup_task = None
     read_started = asyncio.Event()
     read_release = asyncio.Event()
 
@@ -1316,16 +1201,19 @@ async def test_disable_does_not_wait_for_long_runtime_read() -> None:
 async def test_reconcile_provider_work_does_not_hold_pointer_lock() -> None:
     enabled = replace(_disabled_app_config().memory, enabled=True)
     candidate = replace(enabled)
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=enabled)
+    controller = _controller_with_memory(enabled)
     controller.memory_adapter = None
-    controller._memory_disabled_cleanup_task = None
     reconcile_started = asyncio.Event()
     reconcile_release = asyncio.Event()
 
     class _Runtime:
         module = object()
         capture_adapter = object()
+        capture_starts = 0
+
+        def start_capture_adapter(self, **_options: object) -> bool:
+            self.capture_starts += 1
+            return True
 
         async def reconcile(self, config) -> dict[str, object]:
             assert config is candidate
@@ -1347,26 +1235,16 @@ async def test_reconcile_provider_work_does_not_hold_pointer_lock() -> None:
     reconcile_release.set()
     assert await reconcile == {"ok": True, "state": "running"}
     assert controller.config.memory is candidate
+    assert runtime.capture_starts == 1
 
 
 @pytest.mark.asyncio
 async def test_disable_revokes_unpublished_enable_before_it_can_publish() -> None:
     disabled = _disabled_app_config().memory
     enabled = replace(disabled, enabled=True)
-    controller = Controller.__new__(Controller)
-    controller.config = types.SimpleNamespace(memory=disabled)
-    controller.memory_adapter = DisabledMemoryAdapter()
-    controller.memory_runtime = None
-    controller.memory_module = None
-    controller._memory_disabled_cleanup_task = None
+    controller = _controller_with_memory(disabled)
     reconcile_started = asyncio.Event()
     reconcile_release = asyncio.Event()
-
-    async def no_cleanup() -> None:
-        return None
-
-    controller._await_disabled_memory_cleanup = no_cleanup
-    controller._recheck_disabled_memory_cleanup = no_cleanup
 
     class _Runtime:
         module = object()
@@ -1399,8 +1277,6 @@ async def test_disable_revokes_unpublished_enable_before_it_can_publish() -> Non
         "ok": True,
         "state": "disabled",
     }
-    assert controller.memory_runtime is None
-    assert controller.config.memory is disabled
     assert runtime.close_calls == 1
 
     reconcile_release.set()
@@ -1415,51 +1291,7 @@ async def test_disable_revokes_unpublished_enable_before_it_can_publish() -> Non
 
 
 @pytest.mark.asyncio
-async def test_memory_indep_015_shutdown_bounds_all_memory_stages_under_one_budget() -> None:
-    controller = Controller.__new__(Controller)
-    controller._memory_reconcile_task = None
-    controller._memory_shutdown_budget_seconds = 0.06
-    controller._shutdown_tainted = False
-    controller._memory_destructive_quiescing = False
-
-    started: list[str] = []
-
-    class _MemoryAdapter:
-        def quiesce_memory_capture_tasks(self) -> None:
-            started.append("capture-registration")
-
-    class _MemoryRuntime:
-        def begin_close(self) -> None:
-            assert isinstance(controller.memory_adapter, DisabledMemoryAdapter)
-            started.append("runtime-revoke")
-
-        async def close(self) -> None:
-            started.append("runtime")
-
-    controller.memory_adapter = _MemoryAdapter()
-    controller.memory_runtime = _MemoryRuntime()
-
-    async def join_destructive_transactions() -> None:
-        started.append("destructive")
-
-    controller._join_memory_destructive_transactions = join_destructive_transactions
-
-    started_at = time.monotonic()
-    await controller._shutdown_memory_stack()
-    elapsed = time.monotonic() - started_at
-
-    assert elapsed < 0.2
-    assert started == [
-        "capture-registration",
-        "destructive",
-        "runtime-revoke",
-        "runtime",
-    ]
-    assert controller._shutdown_tainted is False
-
-
-@pytest.mark.asyncio
-async def test_shutdown_attempts_runtime_close_after_destructive_timeout() -> None:
+async def test_memory_indep_015_shutdown_uses_one_budget_after_stage_timeout() -> None:
     controller = Controller.__new__(Controller)
     controller._memory_reconcile_task = None
     controller._memory_shutdown_budget_seconds = 0.04
@@ -1469,6 +1301,7 @@ async def test_shutdown_attempts_runtime_close_after_destructive_timeout() -> No
         quiesce_memory_capture_tasks=lambda: None,
     )
     release = asyncio.Event()
+    close_deadlines: list[float] = []
 
     async def transaction() -> dict[str, object]:
         await release.wait()
@@ -1484,8 +1317,9 @@ async def test_shutdown_attempts_runtime_close_after_destructive_timeout() -> No
         def begin_close(self) -> None:
             return None
 
-        async def close(self) -> None:
+        async def close(self, **options: object) -> None:
             self.closed = True
+            close_deadlines.append(float(options["timeout_seconds"]))
 
     runtime = _MemoryRuntime()
     controller.memory_runtime = runtime
@@ -1498,6 +1332,7 @@ async def test_shutdown_attempts_runtime_close_after_destructive_timeout() -> No
     assert runtime.closed is True
     assert controller.memory_runtime is None
     assert controller._shutdown_tainted is True
+    assert 0.0 <= close_deadlines[0] <= controller._memory_shutdown_budget_seconds
 
     release.set()
     await destructive

--- a/tests/test_memory_loader.py
+++ b/tests/test_memory_loader.py
@@ -35,21 +35,10 @@ def test_disabled_loader_never_imports_optional_implementation(monkeypatch: pyte
     importer.assert_not_called()
 
 
-def test_loader_maps_missing_implementation_to_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
-    import core.memory_loader
-
-    monkeypatch.setattr(
-        core.memory_loader.importlib,
-        "import_module",
-        Mock(side_effect=ModuleNotFoundError("optional package missing")),
-    )
-
-    with pytest.raises(MemoryPluginUnavailableError):
-        load_memory_runtime(_config())
-
-
-def test_entrypoint_probe_maps_missing_implementation_to_unavailable(
+@pytest.mark.parametrize("probe_only", (False, True))
+def test_loader_and_probe_map_missing_implementation_to_unavailable(
     monkeypatch: pytest.MonkeyPatch,
+    probe_only: bool,
 ) -> None:
     import core.memory_loader
 
@@ -60,7 +49,10 @@ def test_entrypoint_probe_maps_missing_implementation_to_unavailable(
     )
 
     with pytest.raises(MemoryPluginUnavailableError):
-        probe_memory_runtime_entrypoint()
+        if probe_only:
+            probe_memory_runtime_entrypoint()
+        else:
+            load_memory_runtime(_config())
 
 
 @pytest.mark.parametrize(
@@ -188,26 +180,18 @@ def test_loader_preserves_runtime_root_busy(monkeypatch: pytest.MonkeyPatch) -> 
     assert raised.value is busy
 
 
-def test_loader_constructs_fixed_protocol_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
-    import core.memory_loader
-
-    async def close() -> None:
-        return None
-
-    runtime = SimpleNamespace(module=object(), available=True, close=close)
-    factory = Mock(return_value=runtime)
-    monkeypatch.setattr(
-        core.memory_loader.importlib,
-        "import_module",
-        Mock(return_value=_implementation(factory)),
-    )
-
-    assert load_memory_runtime(_config(), marker="tested") is runtime
-    factory.assert_called_once_with(_config(), marker="tested")
-
-
-def test_disabled_loader_allows_explicit_maintenance_runtime(
+@pytest.mark.parametrize(
+    ("config", "loader_kwargs", "factory_kwargs"),
+    (
+        (_config(), {"marker": "tested"}, {"marker": "tested"}),
+        (_config(False), {"allow_disabled": True}, {}),
+    ),
+)
+def test_loader_constructs_declared_runtime(
     monkeypatch: pytest.MonkeyPatch,
+    config: SimpleNamespace,
+    loader_kwargs: dict[str, object],
+    factory_kwargs: dict[str, object],
 ) -> None:
     import core.memory_loader
 
@@ -222,9 +206,8 @@ def test_disabled_loader_allows_explicit_maintenance_runtime(
         Mock(return_value=_implementation(factory)),
     )
 
-    config = _config(False)
-    assert load_memory_runtime(config, allow_disabled=True) is runtime
-    factory.assert_called_once_with(config)
+    assert load_memory_runtime(config, **loader_kwargs) is runtime
+    factory.assert_called_once_with(config, **factory_kwargs)
 
 
 def test_loader_rejects_incomplete_runtime_contract(

--- a/tests/test_memory_loader.py
+++ b/tests/test_memory_loader.py
@@ -9,6 +9,7 @@ from core.memory_loader import load_memory_runtime, probe_memory_runtime_entrypo
 from vibe.memory_contract import (
     MemoryPluginIncompatibleError,
     MemoryPluginUnavailableError,
+    MemoryRuntimeBusyError,
 )
 
 
@@ -172,6 +173,27 @@ def test_loader_maps_constructor_failure_to_unavailable(monkeypatch: pytest.Monk
 
     with pytest.raises(MemoryPluginUnavailableError):
         load_memory_runtime(_config())
+
+
+def test_loader_preserves_runtime_root_busy(monkeypatch: pytest.MonkeyPatch) -> None:
+    import core.memory_loader
+
+    busy = MemoryRuntimeBusyError("provider root busy")
+    monkeypatch.setattr(
+        core.memory_loader.importlib,
+        "import_module",
+        Mock(
+            return_value=SimpleNamespace(
+                MEMORY_RUNTIME_PROTOCOL_VERSION=1,
+                create_memory_runtime=Mock(side_effect=busy),
+            )
+        ),
+    )
+
+    with pytest.raises(MemoryRuntimeBusyError) as raised:
+        load_memory_runtime(_config())
+
+    assert raised.value is busy
 
 
 def test_loader_constructs_fixed_protocol_runtime(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_memory_loader.py
+++ b/tests/test_memory_loader.py
@@ -17,6 +17,14 @@ def _config(enabled: bool = True) -> SimpleNamespace:
     return SimpleNamespace(enabled=enabled)
 
 
+def _implementation(factory: object) -> SimpleNamespace:
+    return SimpleNamespace(
+        MEMORY_RUNTIME_PROTOCOL_VERSION=1,
+        MEMORY_RUNTIME_LIFECYCLE_CONTRACT=1,
+        create_memory_runtime=factory,
+    )
+
+
 def test_disabled_loader_never_imports_optional_implementation(monkeypatch: pytest.MonkeyPatch) -> None:
     import core.memory_loader
 
@@ -55,37 +63,36 @@ def test_entrypoint_probe_maps_missing_implementation_to_unavailable(
         probe_memory_runtime_entrypoint()
 
 
-def test_loader_rejects_protocol_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
-    import core.memory_loader
-
-    monkeypatch.setattr(
-        core.memory_loader.importlib,
-        "import_module",
-        Mock(return_value=SimpleNamespace(MEMORY_RUNTIME_PROTOCOL_VERSION=99)),
-    )
-
-    with pytest.raises(MemoryPluginIncompatibleError):
-        load_memory_runtime(_config())
-
-
-def test_entrypoint_probe_rejects_protocol_mismatch(
+@pytest.mark.parametrize(
+    ("attribute", "value"),
+    (
+        ("MEMORY_RUNTIME_PROTOCOL_VERSION", 99),
+        ("MEMORY_RUNTIME_LIFECYCLE_CONTRACT", None),
+        ("MEMORY_RUNTIME_LIFECYCLE_CONTRACT", 99),
+    ),
+)
+def test_entrypoint_probe_rejects_legacy_or_incompatible_contract(
     monkeypatch: pytest.MonkeyPatch,
+    attribute: str,
+    value: int | None,
 ) -> None:
     import core.memory_loader
 
+    factory = Mock()
+    implementation = _implementation(factory)
+    if value is None:
+        delattr(implementation, attribute)
+    else:
+        setattr(implementation, attribute, value)
     monkeypatch.setattr(
         core.memory_loader.importlib,
         "import_module",
-        Mock(
-            return_value=SimpleNamespace(
-                MEMORY_RUNTIME_PROTOCOL_VERSION=99,
-                create_memory_runtime=Mock(),
-            )
-        ),
+        Mock(return_value=implementation),
     )
 
     with pytest.raises(MemoryPluginIncompatibleError):
         probe_memory_runtime_entrypoint()
+    factory.assert_not_called()
 
 
 @pytest.mark.parametrize("factory", (None, object()))
@@ -98,12 +105,7 @@ def test_entrypoint_probe_rejects_missing_or_noncallable_factory(
     monkeypatch.setattr(
         core.memory_loader.importlib,
         "import_module",
-        Mock(
-            return_value=SimpleNamespace(
-                MEMORY_RUNTIME_PROTOCOL_VERSION=1,
-                create_memory_runtime=factory,
-            )
-        ),
+        Mock(return_value=_implementation(factory)),
     )
 
     with pytest.raises(MemoryPluginUnavailableError):
@@ -119,12 +121,7 @@ def test_entrypoint_probe_validates_contract_without_constructing_runtime(
     monkeypatch.setattr(
         core.memory_loader.importlib,
         "import_module",
-        Mock(
-            return_value=SimpleNamespace(
-                MEMORY_RUNTIME_PROTOCOL_VERSION=1,
-                create_memory_runtime=factory,
-            )
-        ),
+        Mock(return_value=_implementation(factory)),
     )
 
     assert probe_memory_runtime_entrypoint() is None
@@ -132,7 +129,12 @@ def test_entrypoint_probe_validates_contract_without_constructing_runtime(
 
 
 @pytest.mark.parametrize(
-    "attribute", ("MEMORY_RUNTIME_PROTOCOL_VERSION", "create_memory_runtime")
+    "attribute",
+    (
+        "MEMORY_RUNTIME_PROTOCOL_VERSION",
+        "MEMORY_RUNTIME_LIFECYCLE_CONTRACT",
+        "create_memory_runtime",
+    ),
 )
 def test_loader_translates_implementation_attribute_probe_failure(
     monkeypatch: pytest.MonkeyPatch,
@@ -163,12 +165,7 @@ def test_loader_maps_constructor_failure_to_unavailable(monkeypatch: pytest.Monk
     monkeypatch.setattr(
         core.memory_loader.importlib,
         "import_module",
-        Mock(
-            return_value=SimpleNamespace(
-                MEMORY_RUNTIME_PROTOCOL_VERSION=1,
-                create_memory_runtime=factory,
-            )
-        ),
+        Mock(return_value=_implementation(factory)),
     )
 
     with pytest.raises(MemoryPluginUnavailableError):
@@ -182,12 +179,7 @@ def test_loader_preserves_runtime_root_busy(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(
         core.memory_loader.importlib,
         "import_module",
-        Mock(
-            return_value=SimpleNamespace(
-                MEMORY_RUNTIME_PROTOCOL_VERSION=1,
-                create_memory_runtime=Mock(side_effect=busy),
-            )
-        ),
+        Mock(return_value=_implementation(Mock(side_effect=busy))),
     )
 
     with pytest.raises(MemoryRuntimeBusyError) as raised:
@@ -207,12 +199,7 @@ def test_loader_constructs_fixed_protocol_runtime(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(
         core.memory_loader.importlib,
         "import_module",
-        Mock(
-            return_value=SimpleNamespace(
-                MEMORY_RUNTIME_PROTOCOL_VERSION=1,
-                create_memory_runtime=factory,
-            )
-        ),
+        Mock(return_value=_implementation(factory)),
     )
 
     assert load_memory_runtime(_config(), marker="tested") is runtime
@@ -232,12 +219,7 @@ def test_disabled_loader_allows_explicit_maintenance_runtime(
     monkeypatch.setattr(
         core.memory_loader.importlib,
         "import_module",
-        Mock(
-            return_value=SimpleNamespace(
-                MEMORY_RUNTIME_PROTOCOL_VERSION=1,
-                create_memory_runtime=factory,
-            )
-        ),
+        Mock(return_value=_implementation(factory)),
     )
 
     config = _config(False)
@@ -253,12 +235,7 @@ def test_loader_rejects_incomplete_runtime_contract(
     monkeypatch.setattr(
         core.memory_loader.importlib,
         "import_module",
-        Mock(
-            return_value=SimpleNamespace(
-                MEMORY_RUNTIME_PROTOCOL_VERSION=1,
-                create_memory_runtime=Mock(return_value=SimpleNamespace()),
-            )
-        ),
+        Mock(return_value=_implementation(Mock(return_value=SimpleNamespace()))),
     )
 
     with pytest.raises(MemoryPluginIncompatibleError):
@@ -278,12 +255,7 @@ def test_loader_maps_runtime_contract_probe_failure_to_incompatible(
     monkeypatch.setattr(
         core.memory_loader.importlib,
         "import_module",
-        Mock(
-            return_value=SimpleNamespace(
-                MEMORY_RUNTIME_PROTOCOL_VERSION=1,
-                create_memory_runtime=Mock(return_value=_BrokenRuntime()),
-            )
-        ),
+        Mock(return_value=_implementation(Mock(return_value=_BrokenRuntime()))),
     )
 
     with pytest.raises(MemoryPluginIncompatibleError):

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -83,7 +83,10 @@ async def test_reset_handoff_holds_root_until_exact_successor_accepts(
 
     await replacement.close()
     final = _runtime(tmp_path)
-    await final.close()
+    final_ownership = final.begin_root_ownership_handoff()
+    await final.close(root_ownership=final_ownership)
+    final.release_retained_root_ownership()
+    await _runtime(tmp_path).close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -223,7 +223,7 @@ async def test_runtime_close_timeouts_still_attempt_everos_stop(
 
 
 @pytest.mark.asyncio
-async def test_blocked_artifact_install_keeps_root_until_close_retry(
+async def test_blocked_artifact_install_keeps_root_across_cached_close_deadline(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -241,9 +241,12 @@ async def test_blocked_artifact_install_keeps_root_until_close_retry(
     install = asyncio.create_task(runtime.install_artifact())
     assert await asyncio.to_thread(install_started.wait, 1.0)
 
-    runtime.begin_close()
-    with pytest.raises(RuntimeError, match="local cleanup"):
+    close = asyncio.create_task(runtime.close(timeout_seconds=1.0))
+    while "local cleanup" not in runtime._close_phase_tasks:
+        await asyncio.sleep(0)
+    with pytest.raises(TimeoutError):
         await runtime.close(timeout_seconds=0.03)
+    assert close.done() is False
     with pytest.raises(MemoryRuntimeBusyError):
         _runtime(tmp_path)
 
@@ -253,7 +256,7 @@ async def test_blocked_artifact_install_keeps_root_until_close_retry(
         "reason": "memory_operation_in_progress",
         "download_error": None,
     }
-    await runtime.close(timeout_seconds=1.0)
+    await close
     replacement = _runtime(tmp_path)
     await replacement.close()
 

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -137,6 +137,75 @@ async def test_failed_provider_stop_prevents_second_runtime(
 
 
 @pytest.mark.asyncio
+async def test_revoked_reconcile_stops_before_provider_root_side_effects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _runtime(tmp_path)
+    probe_started = asyncio.Event()
+    probe_release = asyncio.Event()
+    side_effects: list[str] = []
+
+    async def ownership_reconciled() -> bool:
+        return True
+
+    async def delayed_probe(_python: Path, _config: MemoryConfig) -> bool:
+        probe_started.set()
+        await probe_release.wait()
+        return True
+
+    async def unexpected_async(name: str, *_args, **_kwargs):
+        side_effects.append(name)
+        pytest.fail(f"revoked reconciliation reached {name}")
+
+    def unexpected_sync(name: str, *_args, **_kwargs):
+        side_effects.append(name)
+        pytest.fail(f"revoked reconciliation reached {name}")
+
+    async def no_op() -> None:
+        return None
+
+    monkeypatch.setattr(runtime, "_reconcile_released_ownership", ownership_reconciled)
+    monkeypatch.setattr(runtime, "_probe_processing", delayed_probe)
+    monkeypatch.setattr(runtime._artifact_manager, "resolve_python", lambda: Path("python"))
+    monkeypatch.setattr(
+        runtime._supervisor,
+        "stop",
+        lambda: unexpected_async("provider stop"),
+    )
+    monkeypatch.setattr(
+        runtime._supervisor,
+        "wake",
+        lambda *_args, **_kwargs: unexpected_async("provider wake"),
+    )
+    monkeypatch.setattr(
+        runtime._store,
+        "ensure_meta",
+        lambda: unexpected_sync("store metadata"),
+    )
+    monkeypatch.setattr(
+        runtime._provider_root_owner,
+        "ensure",
+        lambda *_args: unexpected_sync("provider root ensure"),
+    )
+    monkeypatch.setattr(runtime, "_cancel_capture_tasks", no_op)
+    monkeypatch.setattr(runtime, "_close_local_runtime", no_op)
+    monkeypatch.setattr(runtime._supervisor, "close", no_op)
+
+    reconcile = asyncio.create_task(runtime.reconcile(MemoryConfig(enabled=True)))
+    await probe_started.wait()
+    runtime.begin_close()
+    await runtime.close()
+    probe_release.set()
+
+    assert await reconcile == {
+        "ok": False,
+        "error": "memory_operation_in_progress",
+    }
+    assert side_effects == []
+
+
+@pytest.mark.asyncio
 async def test_environmental_store_failure_defers_durable_repair_fence(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -65,12 +65,28 @@ async def test_session_lifecycle_offers_without_waiting_for_capture(tmp_path: Pa
 async def test_reset_handoff_holds_root_until_exact_successor_accepts(
     tmp_path: Path,
 ) -> None:
+    def fail_supervisor(**_kwargs):
+        raise RuntimeError("supervisor construction failed")
+
+    with pytest.raises(RuntimeError) as retained:
+        MemoryRuntime(
+            MemoryConfig(enabled=True),
+            effective_home=tmp_path,
+            supervisor_factory=fail_supervisor,
+        )
+    assert retained.traceback is not None
     runtime = _runtime(tmp_path)
     with pytest.raises(MemoryRuntimeBusyError):
         _runtime(tmp_path)
-    ownership = runtime.begin_root_ownership_handoff()
-
-    await runtime.close(root_ownership=ownership)
+    async with runtime.module.lifecycle():
+        ownership = runtime.begin_root_ownership_handoff()
+        closing = asyncio.create_task(runtime.close(root_ownership=ownership))
+        while "local cleanup" not in runtime._close_phase_tasks:
+            await asyncio.sleep(0)
+        assert closing.done() is False
+        assert (tmp_path / "memory").exists()
+    await closing
+    assert runtime.reset_mutable_data(ownership).data_deleted is True
     with pytest.raises(MemoryRuntimeBusyError):
         _runtime(tmp_path)
 

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -11,7 +11,11 @@ from avibe_memory.capture_adapter import EnabledMemoryAdapter
 from config.v2_config import MemoryEndpointConfig, MemoryProcessingConfig
 from avibe_memory.everos import ProviderHealthSnapshot
 from avibe_memory.processing_record import RuntimeHealthProjection, SourceObservation
-from avibe_memory.runtime import MemoryConfig, MemoryRuntime
+from avibe_memory.runtime import (
+    MemoryConfig,
+    MemoryRuntime,
+    MemoryRuntimeRootBusyError,
+)
 from avibe_memory.store import MemoryStore
 
 
@@ -60,10 +64,76 @@ async def test_session_lifecycle_offers_without_waiting_for_capture(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_runtime_close_drops_volatile_work(tmp_path: Path) -> None:
+async def test_runtime_close_releases_provider_root_for_one_replacement(
+    tmp_path: Path,
+) -> None:
     runtime = _runtime(tmp_path)
+    with pytest.raises(MemoryRuntimeRootBusyError):
+        _runtime(tmp_path)
+
     await runtime.close()
-    assert runtime.closed
+
+    replacement = _runtime(tmp_path)
+    await replacement.close()
+
+
+@pytest.mark.asyncio
+async def test_runtime_close_timeouts_still_attempt_everos_stop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _runtime(tmp_path)
+    release = asyncio.Event()
+    phases: list[str] = []
+
+    async def stalled_capture() -> None:
+        phases.append("capture")
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await release.wait()
+
+    async def stalled_local_cleanup() -> None:
+        phases.append("local")
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await release.wait()
+
+    async def stop_provider() -> None:
+        phases.append("provider")
+
+    monkeypatch.setattr(runtime, "_cancel_capture_tasks", stalled_capture)
+    monkeypatch.setattr(runtime, "_close_local_runtime", stalled_local_cleanup)
+    monkeypatch.setattr(runtime._supervisor, "close", stop_provider)
+    monkeypatch.setattr(runtime_module, "MEMORY_CAPTURE_CLOSE_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(runtime_module, "MEMORY_LOCAL_CLOSE_TIMEOUT_SECONDS", 0.01)
+
+    await runtime.close()
+
+    assert phases == ["capture", "local", "provider"]
+    replacement = _runtime(tmp_path)
+    await replacement.close()
+    release.set()
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_failed_provider_stop_prevents_second_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _runtime(tmp_path)
+
+    async def fail_stop() -> None:
+        raise RuntimeError("stop failed")
+
+    monkeypatch.setattr(runtime._supervisor, "close", fail_stop)
+
+    with pytest.raises(RuntimeError, match="stop failed"):
+        await runtime.close()
+    with pytest.raises(MemoryRuntimeRootBusyError):
+        _runtime(tmp_path)
 
 
 @pytest.mark.asyncio
@@ -293,7 +363,6 @@ async def test_runtime_close_cancels_pending_automatic_wake(
 
     assert wake.cancelled()
     assert runtime._wake_task is None
-    assert runtime.closed
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -11,7 +11,11 @@ import avibe_memory.runtime as runtime_module
 from avibe_memory.capture_adapter import EnabledMemoryAdapter
 from config.v2_config import MemoryEndpointConfig, MemoryProcessingConfig
 from avibe_memory.everos import ProviderHealthSnapshot
-from avibe_memory.processing_record import RuntimeHealthProjection, SourceObservation
+from avibe_memory.processing_record import (
+    MaintenanceObservation,
+    RuntimeHealthProjection,
+    SourceObservation,
+)
 from avibe_memory.runtime import MemoryConfig, MemoryRuntime
 from avibe_memory.store import MemoryStore
 from vibe.memory_contract import MemoryRuntimeBusyError
@@ -62,8 +66,14 @@ async def test_session_lifecycle_offers_without_waiting_for_capture(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_reset_handoff_holds_root_until_exact_successor_accepts(
+@pytest.mark.parametrize(
+    "read_kind",
+    ("sources", "maintenance", "principal", "projects"),
+)
+async def test_local_reads_hold_reset_and_fail_closed_after_detach(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    read_kind: str,
 ) -> None:
     def fail_supervisor(**_kwargs):
         raise RuntimeError("supervisor construction failed")
@@ -76,32 +86,99 @@ async def test_reset_handoff_holds_root_until_exact_successor_accepts(
         )
     assert retained.traceback is not None
     runtime = _runtime(tmp_path)
-    with pytest.raises(MemoryRuntimeBusyError):
-        _runtime(tmp_path)
-    async with runtime.module.lifecycle():
+
+    observation = MaintenanceObservation(block_reason=None, can_delete_data=True)
+    principal_id = "u-11111111111111111111111111111111"
+    read_call = {
+        "sources": lambda: runtime._processing_record_sources(None),
+        "maintenance": lambda: runtime._processing_record_maintenance(
+            None, observation
+        ),
+        "principal": lambda: runtime.resolve_principal_for_user_key("avibe:local"),
+        "projects": lambda: runtime.list_memory_projects(principal_id),
+    }[read_kind]
+    wake = None
+    if read_kind == "sources":
+        failure = await runtime._processing_record_failure_log(None)
+        assert failure.items == ()
+        assert failure.unavailable_reason == "memory_failure_history_unavailable"
+        wake_entered = asyncio.Event()
+
+        async def pending_wake() -> None:
+            wake_entered.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(runtime, "_wake_after_writer_close", pending_wake)
+        runtime._defer_wake_until_writer_closed()
+        wake = runtime._wake_task
+        assert wake is not None
+        await wake_entered.wait()
+    run_local = runtime._run_local_observation
+    started = threading.Event()
+    release = threading.Event()
+
+    async def blocked(operation):
+        def run():
+            started.set()
+            assert release.wait(timeout=5.0)
+            return operation()
+
+        return await run_local(run)
+
+    monkeypatch.setattr(runtime, "_run_local_observation", blocked)
+    read = asyncio.create_task(read_call())
+
+    try:
+        assert await asyncio.to_thread(started.wait, 1.0)
         ownership = runtime.begin_root_ownership_handoff()
-        closing = asyncio.create_task(runtime.close(root_ownership=ownership))
+
+        async def close_and_reset():
+            await runtime.close(root_ownership=ownership)
+            return runtime.reset_mutable_data(ownership)
+
+        resetting = asyncio.create_task(close_and_reset())
         while "local cleanup" not in runtime._close_phase_tasks:
             await asyncio.sleep(0)
-        assert closing.done() is False
+        assert resetting.done() is False
         assert (tmp_path / "memory").exists()
-    await closing
-    assert runtime.reset_mutable_data(ownership).data_deleted is True
+    finally:
+        release.set()
+    await read
+    assert (await resetting).data_deleted is True
+    if wake is not None:
+        assert wake.cancelled() and runtime._wake_task is None
+    monkeypatch.setattr(runtime, "_run_local_observation", run_local)
+
+    if read_kind in {"sources", "maintenance"}:
+        detached = await read_call()
+    else:
+        with pytest.raises(MemoryRuntimeBusyError):
+            await read_call()
+    if read_kind == "sources":
+        assert {
+            detached.memcells.reason,
+            detached.runs.reason,
+            detached.semantic.reason,
+        } == {"busy"}
+        assert not hasattr(runtime, "log_entries_payload")
+        assert not hasattr(runtime, "_call_log_db_path")
+        failure = await runtime._processing_record_failure_log(None)
+        assert failure.unavailable_reason == "busy"
+    elif read_kind == "maintenance":
+        assert detached.data_exists is True
+        assert detached.can_delete_data is False
+        assert detached.error == "busy"
     with pytest.raises(MemoryRuntimeBusyError):
         _runtime(tmp_path)
 
-    replacement = runtime.replacement(MemoryConfig(enabled=True), ownership)
-    with pytest.raises(MemoryRuntimeBusyError):
-        _runtime(tmp_path)
-    replacement.accept_root_ownership()
-    with pytest.raises(MemoryRuntimeBusyError):
-        _runtime(tmp_path)
-
-    await replacement.close()
-    final = _runtime(tmp_path)
-    final_ownership = final.begin_root_ownership_handoff()
-    await final.close(root_ownership=final_ownership)
-    final.release_retained_root_ownership()
+    if read_kind == "sources":
+        replacement = runtime.replacement(MemoryConfig(enabled=True), ownership)
+        with pytest.raises(MemoryRuntimeBusyError):
+            _runtime(tmp_path)
+        replacement.accept_root_ownership()
+        await replacement.close()
+    else:
+        runtime.release_retained_root_ownership()
     await _runtime(tmp_path).close()
 
 
@@ -447,62 +524,6 @@ async def test_malformed_released_clear_journal_remains_repair_fenced(
     assert runtime.needs_repair is True
     assert runtime.needs_repair_reason == "memory_legacy_recovery_required"
     assert journal.exists()
-    await runtime.close()
-
-
-@pytest.mark.asyncio
-async def test_runtime_close_cancels_pending_automatic_wake(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """MEMORY-INDEP-003: shutdown cancels volatile recovery work."""
-
-    runtime = _runtime(tmp_path)
-    wake_entered = asyncio.Event()
-
-    async def pending_wake() -> None:
-        wake_entered.set()
-        await asyncio.Event().wait()
-
-    monkeypatch.setattr(runtime, "_wake_after_writer_close", pending_wake)
-    runtime._defer_wake_until_writer_closed()
-    wake = runtime._wake_task
-    assert wake is not None
-    await wake_entered.wait()
-
-    await asyncio.wait_for(runtime.close(), timeout=1.0)
-
-    assert wake.cancelled()
-    assert runtime._wake_task is None
-
-
-@pytest.mark.asyncio
-async def test_processing_record_uses_native_sources_without_call_log(tmp_path: Path) -> None:
-    runtime = _runtime(tmp_path)
-
-    projection = await runtime._processing_record_sources(None)
-
-    assert projection.memcells.status == "unavailable"
-    assert projection.runs.status == "unavailable"
-    assert projection.semantic.status == "unavailable"
-    assert not hasattr(runtime, "log_entries_payload")
-    assert not hasattr(runtime, "log_unlinked_calls_payload")
-    assert not hasattr(runtime, "_call_log_db_path")
-    await runtime.close()
-
-
-@pytest.mark.asyncio
-async def test_capture_diagnostics_are_unavailable_without_delivery_history(
-    tmp_path: Path,
-) -> None:
-    """MEMORY-SEARCH-014: absent durable history is unavailable, not empty."""
-
-    runtime = _runtime(tmp_path)
-
-    observation = await runtime._processing_record_failure_log(None)
-
-    assert observation.items == ()
-    assert observation.unavailable_reason == "memory_failure_history_unavailable"
     await runtime.close()
 
 

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -11,12 +11,9 @@ from avibe_memory.capture_adapter import EnabledMemoryAdapter
 from config.v2_config import MemoryEndpointConfig, MemoryProcessingConfig
 from avibe_memory.everos import ProviderHealthSnapshot
 from avibe_memory.processing_record import RuntimeHealthProjection, SourceObservation
-from avibe_memory.runtime import (
-    MemoryConfig,
-    MemoryRuntime,
-    MemoryRuntimeRootBusyError,
-)
+from avibe_memory.runtime import MemoryConfig, MemoryRuntime
 from avibe_memory.store import MemoryStore
+from vibe.memory_contract import MemoryRuntimeBusyError
 
 
 def _runtime(tmp_path: Path) -> MemoryRuntime:
@@ -68,7 +65,7 @@ async def test_runtime_close_releases_provider_root_for_one_replacement(
     tmp_path: Path,
 ) -> None:
     runtime = _runtime(tmp_path)
-    with pytest.raises(MemoryRuntimeRootBusyError):
+    with pytest.raises(MemoryRuntimeBusyError):
         _runtime(tmp_path)
 
     await runtime.close()
@@ -109,50 +106,37 @@ async def test_runtime_close_timeouts_still_attempt_everos_stop(
     monkeypatch.setattr(runtime_module, "MEMORY_CAPTURE_CLOSE_TIMEOUT_SECONDS", 0.01)
     monkeypatch.setattr(runtime_module, "MEMORY_LOCAL_CLOSE_TIMEOUT_SECONDS", 0.01)
 
-    await runtime.close()
+    with pytest.raises(RuntimeError, match="local cleanup"):
+        await runtime.close()
 
     assert phases == ["capture", "local", "provider"]
-    replacement = _runtime(tmp_path)
-    await replacement.close()
+    with pytest.raises(MemoryRuntimeBusyError):
+        _runtime(tmp_path)
     release.set()
     await asyncio.sleep(0)
 
 
+@pytest.mark.parametrize("operation", ("reconcile", "wake"))
 @pytest.mark.asyncio
-async def test_failed_provider_stop_prevents_second_runtime(
+async def test_revoked_lifecycle_stops_before_provider_root_side_effects(
+    operation: str,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     runtime = _runtime(tmp_path)
-
-    async def fail_stop() -> None:
-        raise RuntimeError("stop failed")
-
-    monkeypatch.setattr(runtime._supervisor, "close", fail_stop)
-
-    with pytest.raises(RuntimeError, match="stop failed"):
-        await runtime.close()
-    with pytest.raises(MemoryRuntimeRootBusyError):
-        _runtime(tmp_path)
-
-
-@pytest.mark.asyncio
-async def test_revoked_reconcile_stops_before_provider_root_side_effects(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    runtime = _runtime(tmp_path)
-    probe_started = asyncio.Event()
-    probe_release = asyncio.Event()
+    stop_started = asyncio.Event()
+    stop_release = asyncio.Event()
     side_effects: list[str] = []
 
     async def ownership_reconciled() -> bool:
         return True
 
-    async def delayed_probe(_python: Path, _config: MemoryConfig) -> bool:
-        probe_started.set()
-        await probe_release.wait()
+    async def processing_ready(_python: Path, _config: MemoryConfig) -> bool:
         return True
+
+    async def delayed_stop() -> None:
+        stop_started.set()
+        await stop_release.wait()
 
     async def unexpected_async(name: str, *_args, **_kwargs):
         side_effects.append(name)
@@ -166,13 +150,10 @@ async def test_revoked_reconcile_stops_before_provider_root_side_effects(
         return None
 
     monkeypatch.setattr(runtime, "_reconcile_released_ownership", ownership_reconciled)
-    monkeypatch.setattr(runtime, "_probe_processing", delayed_probe)
+    monkeypatch.setattr(runtime, "_probe_processing", processing_ready)
+    monkeypatch.setattr(runtime, "artifact_admitted", lambda: True)
     monkeypatch.setattr(runtime._artifact_manager, "resolve_python", lambda: Path("python"))
-    monkeypatch.setattr(
-        runtime._supervisor,
-        "stop",
-        lambda: unexpected_async("provider stop"),
-    )
+    monkeypatch.setattr(runtime._supervisor, "stop", delayed_stop)
     monkeypatch.setattr(
         runtime._supervisor,
         "wake",
@@ -192,17 +173,21 @@ async def test_revoked_reconcile_stops_before_provider_root_side_effects(
     monkeypatch.setattr(runtime, "_close_local_runtime", no_op)
     monkeypatch.setattr(runtime._supervisor, "close", no_op)
 
-    reconcile = asyncio.create_task(runtime.reconcile(MemoryConfig(enabled=True)))
-    await probe_started.wait()
+    lifecycle = asyncio.create_task(
+        runtime.reconcile(MemoryConfig(enabled=True))
+        if operation == "reconcile"
+        else runtime.wake(operation_lease_held=True)
+    )
+    await stop_started.wait()
     runtime.begin_close()
-    await runtime.close()
-    probe_release.set()
+    stop_release.set()
 
-    assert await reconcile == {
-        "ok": False,
-        "error": "memory_operation_in_progress",
-    }
+    expected = {"ok": False, "error": "memory_operation_in_progress"}
+    if operation == "wake":
+        expected["state"] = "starting"
+    assert await lifecycle == expected
     assert side_effects == []
+    await runtime.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import sqlite3
+import threading
 from pathlib import Path
 
 import pytest
@@ -61,17 +62,28 @@ async def test_session_lifecycle_offers_without_waiting_for_capture(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_runtime_close_releases_provider_root_for_one_replacement(
+async def test_reset_handoff_holds_root_until_exact_successor_accepts(
     tmp_path: Path,
 ) -> None:
     runtime = _runtime(tmp_path)
     with pytest.raises(MemoryRuntimeBusyError):
         _runtime(tmp_path)
+    ownership = runtime.begin_root_ownership_handoff()
 
-    await runtime.close()
+    await runtime.close(root_ownership=ownership)
+    with pytest.raises(MemoryRuntimeBusyError):
+        _runtime(tmp_path)
 
-    replacement = _runtime(tmp_path)
+    replacement = runtime.replacement(MemoryConfig(enabled=True), ownership)
+    with pytest.raises(MemoryRuntimeBusyError):
+        _runtime(tmp_path)
+    replacement.accept_root_ownership()
+    with pytest.raises(MemoryRuntimeBusyError):
+        _runtime(tmp_path)
+
     await replacement.close()
+    final = _runtime(tmp_path)
+    await final.close()
 
 
 @pytest.mark.asyncio
@@ -83,37 +95,71 @@ async def test_runtime_close_timeouts_still_attempt_everos_stop(
     release = asyncio.Event()
     phases: list[str] = []
 
-    async def stalled_capture() -> None:
-        phases.append("capture")
-        try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            await release.wait()
+    def stalled(label: str):
+        async def wait() -> None:
+            phases.append(label)
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                await release.wait()
 
-    async def stalled_local_cleanup() -> None:
-        phases.append("local")
-        try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            await release.wait()
+        return wait
 
     async def stop_provider() -> None:
         phases.append("provider")
 
-    monkeypatch.setattr(runtime, "_cancel_capture_tasks", stalled_capture)
-    monkeypatch.setattr(runtime, "_close_local_runtime", stalled_local_cleanup)
+    monkeypatch.setattr(runtime, "_cancel_capture_tasks", stalled("capture"))
+    monkeypatch.setattr(runtime, "_close_local_runtime", stalled("local"))
     monkeypatch.setattr(runtime._supervisor, "close", stop_provider)
-    monkeypatch.setattr(runtime_module, "MEMORY_CAPTURE_CLOSE_TIMEOUT_SECONDS", 0.01)
-    monkeypatch.setattr(runtime_module, "MEMORY_LOCAL_CLOSE_TIMEOUT_SECONDS", 0.01)
 
     with pytest.raises(RuntimeError, match="local cleanup"):
-        await runtime.close()
+        await runtime.close(timeout_seconds=0.03)
 
     assert phases == ["capture", "local", "provider"]
     with pytest.raises(MemoryRuntimeBusyError):
         _runtime(tmp_path)
     release.set()
     await asyncio.sleep(0)
+    await runtime.close(timeout_seconds=1.0)
+
+    replacement = _runtime(tmp_path)
+    await replacement.close()
+
+
+@pytest.mark.asyncio
+async def test_blocked_artifact_install_keeps_root_until_close_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _runtime(tmp_path)
+    install_started = threading.Event()
+    install_release = threading.Event()
+
+    def blocked_ensure(*, force: bool) -> dict[str, object]:
+        assert force is True
+        install_started.set()
+        assert install_release.wait(timeout=2.0)
+        return {"ok": True}
+
+    monkeypatch.setattr(runtime._artifact_manager, "ensure", blocked_ensure)
+    install = asyncio.create_task(runtime.install_artifact())
+    assert await asyncio.to_thread(install_started.wait, 1.0)
+
+    runtime.begin_close()
+    with pytest.raises(RuntimeError, match="local cleanup"):
+        await runtime.close(timeout_seconds=0.03)
+    with pytest.raises(MemoryRuntimeBusyError):
+        _runtime(tmp_path)
+
+    install_release.set()
+    assert await install == {
+        "ok": False,
+        "reason": "memory_operation_in_progress",
+        "download_error": None,
+    }
+    await runtime.close(timeout_seconds=1.0)
+    replacement = _runtime(tmp_path)
+    await replacement.close()
 
 
 @pytest.mark.parametrize("operation", ("reconcile", "wake"))
@@ -126,12 +172,8 @@ async def test_revoked_lifecycle_stops_before_provider_root_side_effects(
     runtime = _runtime(tmp_path)
     stop_started = asyncio.Event()
     stop_release = asyncio.Event()
-    side_effects: list[str] = []
 
-    async def ownership_reconciled() -> bool:
-        return True
-
-    async def processing_ready(_python: Path, _config: MemoryConfig) -> bool:
+    async def truthy(*_args) -> bool:
         return True
 
     async def delayed_stop() -> None:
@@ -139,18 +181,16 @@ async def test_revoked_lifecycle_stops_before_provider_root_side_effects(
         await stop_release.wait()
 
     async def unexpected_async(name: str, *_args, **_kwargs):
-        side_effects.append(name)
         pytest.fail(f"revoked reconciliation reached {name}")
 
     def unexpected_sync(name: str, *_args, **_kwargs):
-        side_effects.append(name)
         pytest.fail(f"revoked reconciliation reached {name}")
 
     async def no_op() -> None:
         return None
 
-    monkeypatch.setattr(runtime, "_reconcile_released_ownership", ownership_reconciled)
-    monkeypatch.setattr(runtime, "_probe_processing", processing_ready)
+    monkeypatch.setattr(runtime, "_reconcile_released_ownership", truthy)
+    monkeypatch.setattr(runtime, "_probe_processing", truthy)
     monkeypatch.setattr(runtime, "artifact_admitted", lambda: True)
     monkeypatch.setattr(runtime._artifact_manager, "resolve_python", lambda: Path("python"))
     monkeypatch.setattr(runtime._supervisor, "stop", delayed_stop)
@@ -169,7 +209,6 @@ async def test_revoked_lifecycle_stops_before_provider_root_side_effects(
         "ensure",
         lambda *_args: unexpected_sync("provider root ensure"),
     )
-    monkeypatch.setattr(runtime, "_cancel_capture_tasks", no_op)
     monkeypatch.setattr(runtime, "_close_local_runtime", no_op)
     monkeypatch.setattr(runtime._supervisor, "close", no_op)
 
@@ -186,7 +225,6 @@ async def test_revoked_lifecycle_stops_before_provider_root_side_effects(
     if operation == "wake":
         expected["state"] = "starting"
     assert await lifecycle == expected
-    assert side_effects == []
     await runtime.close()
 
 
@@ -500,6 +538,13 @@ async def test_disabled_attachment_intake_is_unavailable_in_status(
         ),
         effective_home=tmp_path,
     )
+    first_epoch = runtime.attachment_capture_config_generation()
+    assert isinstance(first_epoch, int)
+    runtime._replace_provider(runtime._provider)
+    second_epoch = runtime.attachment_capture_config_generation()
+    assert isinstance(second_epoch, int)
+    assert second_epoch > first_epoch
+
     runtime.module._writer.disable_attachment_intake()
 
     assert (await runtime.status_payload())["attachment_capture"] == {

--- a/tests/test_memory_runtime_factory.py
+++ b/tests/test_memory_runtime_factory.py
@@ -302,7 +302,6 @@ async def test_factory_settles_runtime_tasks_and_sidecar_before_scope_exit(
     assert scheduler_task not in asyncio.all_tasks()
     assert runtime.module._writer._worker_task is None
     assert runtime.module._writer._scheduler_task is None
-    assert runtime.closed is True
 
 
 async def test_factory_continues_teardown_after_a_close_failure(tmp_path: Path) -> None:

--- a/tests/test_memory_slice3.py
+++ b/tests/test_memory_slice3.py
@@ -73,7 +73,6 @@ class _Runtime:
     def __init__(self, module) -> None:
         self.module = module
         self.available = True
-        self.retired = False
         self.attachment_status = "ready"
         self.attachment_generation: int | None = 1
         self.barrier_offers = 0

--- a/tests/test_memory_slice3.py
+++ b/tests/test_memory_slice3.py
@@ -900,11 +900,13 @@ def _reconcile_controller(current: MemoryConfig) -> Controller:
 def test_a_failed_memory_reconciliation_does_not_adopt_the_candidate_config() -> None:
     controller = _reconcile_controller(_memory_config())
 
-    result = asyncio.run(controller.reconcile_memory(_memory_config(enabled=False)))
+    result = asyncio.run(
+        controller.reconcile_memory(_memory_config(llm_model="replacement"))
+    )
 
     assert result["ok"] is False
     assert controller.memory_runtime.calls == 1
-    assert controller.config.memory.enabled is True
+    assert controller.config.memory.processing.llm.model == "chat"
 
 
 def test_controller_adopts_an_independent_settled_memory_snapshot() -> None:

--- a/tests/test_memory_slice3.py
+++ b/tests/test_memory_slice3.py
@@ -83,10 +83,6 @@ class _Runtime:
         suffix = "1" if user_key.endswith("user-1") else "2"
         return f"u-{suffix * 32}"
 
-    def project_for_workdir(self, workdir: str) -> str:
-        assert workdir == "/tmp/project"
-        return PROJECT
-
     async def attachment_capture_status(self) -> str:
         return self.attachment_status
 

--- a/tests/test_memory_wake.py
+++ b/tests/test_memory_wake.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 import avibe_memory.runtime as runtime_module
+import core.controller as controller_module
 from config.v2_config import MemoryConfig, MemoryEndpointConfig, MemoryProcessingConfig
 from avibe_memory.artifact import (
     EVEROS_VERSION,
@@ -23,6 +24,7 @@ from avibe_memory.artifact import (
 from avibe_memory.confined_filesystem import ConfinedFilesystemError
 from avibe_memory.everos import FakeMemoryProvider, ProviderHealthSnapshot
 from config.memory_operation_lock import MemoryOperationBusy
+from core.controller import Controller
 from avibe_memory.process import FakeEverOSProcessFactory
 
 
@@ -287,8 +289,10 @@ async def test_wake_retries_short_operation_lease_contention(
     assert releases == 1
 
 
+@pytest.mark.parametrize("consumer", ("wake", "install", "controller"))
 @pytest.mark.asyncio
-async def test_cancelled_wake_releases_a_completed_lease_acquisition(
+async def test_cancelled_operation_releases_a_completed_lease_acquisition(
+    consumer: str,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     memory_runtime_factory,
@@ -310,8 +314,14 @@ async def test_cancelled_wake_releases_a_completed_lease_acquisition(
             lease_events.append("release")
 
     monkeypatch.setattr(runtime_module, "MemoryOperationLease", Lease)
-    runtime = memory_runtime_factory(_config(), effective_home=tmp_path)
-    task = asyncio.create_task(runtime.wake())
+    monkeypatch.setattr(controller_module, "MemoryOperationLease", Lease)
+    if consumer == "controller":
+        controller = Controller.__new__(Controller)
+        task = asyncio.create_task(controller._try_memory_operation_lease(tmp_path))
+    else:
+        runtime = memory_runtime_factory(_config(), effective_home=tmp_path)
+        operation = runtime.wake if consumer == "wake" else runtime.install_artifact
+        task = asyncio.create_task(operation())
     assert await asyncio.to_thread(acquire_started.wait, 2)
 
     task.cancel()

--- a/tests/test_memory_wake.py
+++ b/tests/test_memory_wake.py
@@ -12,7 +12,6 @@ from pathlib import Path
 import pytest
 
 import avibe_memory.runtime as runtime_module
-import core.controller as controller_module
 from config.v2_config import MemoryConfig, MemoryEndpointConfig, MemoryProcessingConfig
 from avibe_memory.artifact import (
     EVEROS_VERSION,
@@ -24,7 +23,6 @@ from avibe_memory.artifact import (
 from avibe_memory.confined_filesystem import ConfinedFilesystemError
 from avibe_memory.everos import FakeMemoryProvider, ProviderHealthSnapshot
 from config.memory_operation_lock import MemoryOperationBusy
-from core.controller import Controller
 from avibe_memory.process import FakeEverOSProcessFactory
 
 
@@ -314,8 +312,11 @@ async def test_cancelled_operation_releases_a_completed_lease_acquisition(
             lease_events.append("release")
 
     monkeypatch.setattr(runtime_module, "MemoryOperationLease", Lease)
-    monkeypatch.setattr(controller_module, "MemoryOperationLease", Lease)
     if consumer == "controller":
+        import core.controller as controller_module
+        from core.controller import Controller
+
+        monkeypatch.setattr(controller_module, "MemoryOperationLease", Lease)
         controller = Controller.__new__(Controller)
         task = asyncio.create_task(controller._try_memory_operation_lease(tmp_path))
     else:

--- a/tests/test_memory_wake.py
+++ b/tests/test_memory_wake.py
@@ -255,6 +255,8 @@ async def test_wake_retries_short_operation_lease_contention(
     )
     attempts = 0
     releases = 0
+    acquired = threading.Event()
+    finish_acquire = threading.Event()
 
     class Lease:
         def __init__(self, _home: Path) -> None:
@@ -265,6 +267,8 @@ async def test_wake_retries_short_operation_lease_contention(
             attempts += 1
             if attempts < 3:
                 raise MemoryOperationBusy("busy")
+            acquired.set()
+            finish_acquire.wait(timeout=5)
 
         def release(self) -> None:
             nonlocal releases
@@ -280,11 +284,22 @@ async def test_wake_retries_short_operation_lease_contention(
         effective_home=tmp_path,
     )
 
-    result = await runtime.wake()
+    wake = asyncio.create_task(runtime.wake())
+    assert await asyncio.to_thread(acquired.wait, 2)
+    runtime.begin_close()
+    finish_acquire.set()
+    result = await wake
 
-    assert result == {"ok": True, "state": "running"}
-    assert attempts == 3
-    assert releases == 1
+    assert result == {
+        "ok": False,
+        "state": "starting",
+        "error": "memory_operation_in_progress",
+    }
+    assert (attempts, releases) == (3, 1)
+    later = Lease(tmp_path)
+    later.acquire()
+    later.release()
+    assert (attempts, releases) == (4, 2)
 
 
 @pytest.mark.parametrize("consumer", ("wake", "install", "controller"))

--- a/tests/test_memory_writer.py
+++ b/tests/test_memory_writer.py
@@ -179,6 +179,36 @@ async def test_worker_delivers_captures_in_offer_order(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_revoked_runtime_drops_detached_provider_completion(
+    tmp_path: Path,
+) -> None:
+    active = True
+    provider = FakeMemoryProvider()
+    provider_entered = asyncio.Event()
+    provider_release = asyncio.Event()
+    successes: list[str] = []
+
+    async def delayed_add(capture):  # noqa: ANN001, ANN202
+        provider_entered.set()
+        await provider_release.wait()
+        return AddAck(request_id="old-runtime", status="accumulated")
+
+    provider.add = delayed_add
+    writer = _writer(tmp_path, provider, runtime_active=lambda: active)
+    writer._store.mark_capture_success = lambda: successes.append("published")
+    _reserve_and_offer(writer, 0)
+    await provider_entered.wait()
+
+    active = False
+    provider_release.set()
+    await writer.wait_idle_for_tests()
+
+    assert successes == []
+    assert writer._pending == {}
+    assert writer._permits == MAX_WRITER_PERMITS
+
+
+@pytest.mark.asyncio
 async def test_extracted_add_clears_existing_volatile_session_state(tmp_path: Path) -> None:
     provider = FakeMemoryProvider(
         add_results=deque([AddAck(request_id="add-extracted", status="extracted")])

--- a/tests/test_memory_writer.py
+++ b/tests/test_memory_writer.py
@@ -39,10 +39,11 @@ PRINCIPAL = "u-" + "1" * 32
 
 def _writer(tmp_path: Path, provider: FakeMemoryProvider, **kwargs: object) -> BestEffortMemoryWriter:
     store = MemoryStore(tmp_path / "state" / "memory" / "memory.sqlite", effective_home=tmp_path)
+    enabled = kwargs.pop("enabled", lambda: True)
     return BestEffortMemoryWriter(
         store=store,
         provider=provider,
-        enabled=lambda: True,
+        enabled=enabled,
         **kwargs,
     )
 
@@ -194,7 +195,7 @@ async def test_revoked_runtime_drops_detached_provider_completion(
         return AddAck(request_id="old-runtime", status="accumulated")
 
     provider.add = delayed_add
-    writer = _writer(tmp_path, provider, runtime_active=lambda: active)
+    writer = _writer(tmp_path, provider, enabled=lambda: active)
     writer._store.mark_capture_success = lambda: successes.append("published")
     _reserve_and_offer(writer, 0)
     await provider_entered.wait()

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -329,9 +329,6 @@ async def test_hung_memory_capture_does_not_fence_next_turn_or_destructive_ops(
         def principal_for_user_key(self, _user_key: str) -> str:
             return "u-11111111111111111111111111111111"
 
-        def project_for_workdir(self, _workdir: str) -> str:
-            raise AssertionError("capture must use the default project")
-
     module = Module()
     adapter = EnabledMemoryAdapter(
         module=module,

--- a/vibe/memory_contract.py
+++ b/vibe/memory_contract.py
@@ -220,10 +220,6 @@ class MemoryStoreUnavailableError(RuntimeError):
     """The optional Memory store cannot currently serve a host request."""
 
 
-class MemoryRuntimeCloseUnprovedError(RuntimeError):
-    """Controller ownership remains fenced because runtime close was unproved."""
-
-
 class MemoryPluginUnavailableError(RuntimeError):
     """The optional Memory implementation is absent or cannot be constructed."""
 

--- a/vibe/memory_contract.py
+++ b/vibe/memory_contract.py
@@ -220,6 +220,10 @@ class MemoryStoreUnavailableError(RuntimeError):
     """The optional Memory store cannot currently serve a host request."""
 
 
+class MemoryRuntimeBusyError(RuntimeError):
+    """The provider root already belongs to another live Memory runtime."""
+
+
 class MemoryPluginUnavailableError(RuntimeError):
     """The optional Memory implementation is absent or cannot be constructed."""
 


### PR DESCRIPTION
## Summary

- replace the Controller's Memory generation/lease/close-proof lifecycle state machine with a short pointer-swap lock
- publish disabled capture before bounded old-runtime cleanup, always attempting the EverOS stop boundary and blocking replacement when it is unproved
- enforce one runtime per provider root and fence detached writer/sidecar publication at the optional-package boundary
- keep PR #1790 capture admission and scheduled-worker ownership unchanged

## Evidence

- Unit: `1014 passed, 9 skipped` across affected Memory, Controller reset/dispatch, and internal route tests; packaged-upgrade fixture deferred to exact-head CI because the shared local venv intentionally has no `pip`
- Contract: one-runtime-per-root replacement, disabled-first publication, capture/local timeout continuation to EverOS stop, failed-stop replacement refusal, detached writer result fencing, and pointer-lock freedom during provider/capture work
- Scenario: preserved `MEMORY-INDEP-003`, `MEMORY-INDEP-015`, `MEMORY-INDEP-017`, `MEMORY-REPAIR-201`, `MEMORY-REPAIR-202`, `MEMORY-REPAIR-203`, `MEMORY-REPAIR-204`, and `MEMORY-REPAIR-205` evidence
- Static: Ruff passed for every changed Python file; `git diff --check` passed
- Residual manual: none; Incus and local Avibe service actions are explicitly outside PR2 scope

## Scope

No dependency/version/UI identity, packaging, release, migration, rollback, Gate5, Incus, or service-restart changes.
