### PR TITLE
fix(ui): format completed Agent activity duration

### DIFF
--- a/ui/src/components/workbench/AgentActivityGroup.test.tsx
+++ b/ui/src/components/workbench/AgentActivityGroup.test.tsx
@@ -9,7 +9,7 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-import { ActivityCard } from './AgentActivityGroup';
+import { ActivityCard, ActivityChip } from './AgentActivityGroup';
 
 afterEach(() => {
   cleanup();
@@ -62,5 +62,34 @@ describe('ActivityCard display shortcut', () => {
 
     fireEvent.click(close);
     expect(onDisableActivity).toHaveBeenCalledOnce();
+  });
+});
+
+describe('ActivityChip completed duration', () => {
+  it.each([
+    ['collapsed', false],
+    ['expanded', true],
+  ])('uses the long-duration clock while %s', (_state, expanded) => {
+    render(
+      <ActivityChip
+        group={{
+          id: 'completed-turn',
+          anchorMessageId: 'reply',
+          anchorPosition: 'before',
+          open: false,
+          status: 'done',
+          steps: 4,
+          durationMs: (24 + 14) * 3_600_000 + 33 * 60_000 + 11_000,
+          rows: [],
+        }}
+        expanded={expanded}
+        loading={false}
+        onToggle={vi.fn()}
+        showToolCalls
+        onToggleTools={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/1d 14:33:11/)).toBeTruthy();
   });
 });

--- a/ui/src/components/workbench/AgentActivityGroup.tsx
+++ b/ui/src/components/workbench/AgentActivityGroup.tsx
@@ -28,7 +28,6 @@ import { Markdown } from '../ui/markdown';
 import { Dialog, DialogContent } from '../ui/dialog';
 import { copyTextToClipboard } from '../../lib/utils';
 import {
-  activityDurationParts,
   filterActivityRows,
   formatActivityElapsedClock,
   genericChips,
@@ -562,11 +561,8 @@ export const ActivityChip: React.FC<{
   } else if (group.status === 'interrupted') {
     label = t('chat.agentActivity.interrupted', { count: group.steps });
   } else {
-    const parts = activityDurationParts(group.durationMs);
-    const duration = parts
-      ? parts.minutes > 0
-        ? t('chat.agentActivity.durationMin', { minutes: parts.minutes, seconds: parts.seconds })
-        : t('chat.agentActivity.durationSec', { seconds: parts.seconds })
+    const duration = group.durationMs != null && Number.isFinite(group.durationMs) && group.durationMs >= 0
+      ? formatActivityElapsedClock(group.durationMs, t('chat.agentActivity.dayShort'))
       : '';
     label = `${t('chat.agentActivity.label')} · ${stepLabel(t, group.steps)}${duration ? ` · ${duration}` : ''}`;
   }

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -4006,8 +4006,6 @@
       "jumpToLatest": "Jump to latest",
       "loadFailed": "Couldn't load activity detail.",
       "retry": "Retry",
-      "durationMin": "{{minutes}}m {{seconds}}s",
-      "durationSec": "{{seconds}}s",
       "dayShort": "d",
       "empty": "No activity recorded for this turn.",
       "tools": "Tools",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -4006,8 +4006,6 @@
       "jumpToLatest": "跳到最新",
       "loadFailed": "无法加载执行详情。",
       "retry": "重试",
-      "durationMin": "{{minutes}} 分 {{seconds}} 秒",
-      "durationSec": "{{seconds}} 秒",
       "dayShort": "d",
       "empty": "本轮没有执行过程记录。",
       "tools": "工具",

--- a/ui/src/lib/agentActivity.test.ts
+++ b/ui/src/lib/agentActivity.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import type { WorkbenchMessage } from '../context/ApiContext';
 import {
   activityGroupsForForeground,
-  activityDurationParts,
   activityRowFromMessage,
   filterActivityRows,
   formatActivityElapsedClock,
@@ -218,19 +217,6 @@ describe('filterActivityRows (B: eye toggle filters tool rows only)', () => {
   it('never hides assistant rows even with tools off', () => {
     const narrationOnly = rows.filter((r) => r.kind === 'assistant');
     expect(filterActivityRows(narrationOnly, false)).toEqual({ visible: narrationOnly, hiddenTools: 0 });
-  });
-});
-
-describe('activityDurationParts', () => {
-  it('splits into whole-second minutes/seconds (units applied via i18n)', () => {
-    expect(activityDurationParts(45000)).toEqual({ minutes: 0, seconds: 45 });
-    expect(activityDurationParts(83000)).toEqual({ minutes: 1, seconds: 23 });
-    expect(activityDurationParts(600000)).toEqual({ minutes: 10, seconds: 0 });
-  });
-
-  it('returns null for null/negative', () => {
-    expect(activityDurationParts(null)).toBeNull();
-    expect(activityDurationParts(-5)).toBeNull();
   });
 });
 

--- a/ui/src/lib/agentActivity.ts
+++ b/ui/src/lib/agentActivity.ts
@@ -228,18 +228,7 @@ export const toolIconKind = (toolName: string): ToolIconKind => {
   return 'wrench';
 };
 
-// Duration as {minutes, seconds} (null when unavailable). The unit text is applied
-// by the component through i18n (AGENTS.md: no hardcoded user-facing units), so the
-// zh chip renders localized units rather than a hardcoded "1m 23s".
-export const activityDurationParts = (
-  ms: number | null | undefined,
-): { minutes: number; seconds: number } | null => {
-  if (ms == null || !Number.isFinite(ms) || ms < 0) return null;
-  const totalSeconds = Math.round(ms / 1000);
-  return { minutes: Math.floor(totalSeconds / 60), seconds: totalSeconds % 60 };
-};
-
-// Precise elapsed clock for the live activity card. Keep the compact MM:SS
+// Shared duration clock for live and completed activity. Keep the compact MM:SS
 // shape below one hour, then expose hours and days instead of letting minutes
 // grow into an increasingly hard-to-read total.
 export const formatActivityElapsedClock = (ms: number, daySuffix: string): string => {


### PR DESCRIPTION
## Summary

- reuse the Agent activity clock formatter for completed activity
- apply the same MM:SS, HH:MM:SS, and Nd HH:MM:SS display in collapsed and expanded completed states
- remove the superseded localized minute/second formatting path

## Evidence

- Unit/component: focused Vitest suite, 42 tests passed
- UI lint: baseline check passed
- Build: production Vite build passed
- Scenario catalog: no matching scenario ID
- Residual manual check: visual acceptance in a real completed long-running Agent turn is deferred

## Dependencies

- None; #1706 is already merged.
