### PR TITLE
refactor(memory): enforce exact package identity

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,11 +67,15 @@ jobs:
       - name: Build package artifact
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          AVIBE_PACKAGE_CONTRACT_VERSION: 3.0.99rc1
+          SETUPTOOLS_SCM_PRETEND_VERSION: 3.0.99rc1
+          SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_OS: 3.0.99rc1
+          SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_MEMORY: 3.0.99rc1
         run: |
           pip install -e . build pytest
           python scripts/prepare_local_show_runtime_manifest.py
           python -m build --outdir memory-dist packaging/avibe-memory
-          python -m build --wheel
+          python -m build
           AVIBE_CORE_WHEEL="$(ls dist/avibe_os-*.whl)" \
           AVIBE_MEMORY_WHEEL="$(ls memory-dist/avibe_memory-*.whl)" \
             pytest tests/test_memory_distribution.py -v

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,7 +72,7 @@ jobs:
           SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_OS: 3.0.99rc1
           SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_MEMORY: 3.0.99rc1
         run: |
-          pip install -e . build pytest
+          pip install -e . build hatchling hatch-vcs pytest
           python scripts/prepare_local_show_runtime_manifest.py
           python -m build --outdir memory-dist packaging/avibe-memory
           python -m build

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -11,6 +11,7 @@ MANIFEST_WHEEL_PATH = "vibe/show_runtime_manifest.json"
 _VALIDATION = run_path(str(Path(__file__).parent / "scripts" / "show_runtime_manifest_asset.py"))
 validate_manifest_bytes = _VALIDATION["validate_manifest_bytes"]
 validate_manifest_file = _VALIDATION["validate_manifest_file"]
+pin_peer_dependency = run_path(str(Path(__file__).parent / "hatch_exact_peer.py"))["pin_peer_dependency"]
 
 
 class CustomBuildHook(BuildHookInterface):
@@ -22,14 +23,22 @@ class CustomBuildHook(BuildHookInterface):
         validate_manifest_file(Path(self.root) / MANIFEST_SOURCE)
 
     def finalize(self, version: str, build_data: dict, artifact_path: str) -> None:
-        if version == "editable" or self.target_name != "wheel":
+        if version == "editable":
             return
-        with zipfile.ZipFile(artifact_path) as wheel:
+        if self.target_name == "wheel":
+            with zipfile.ZipFile(artifact_path) as wheel:
+                try:
+                    content = wheel.read(MANIFEST_WHEEL_PATH)
+                except KeyError as exc:
+                    raise RuntimeError(f"Built wheel is missing {MANIFEST_WHEEL_PATH}") from exc
             try:
-                content = wheel.read(MANIFEST_WHEEL_PATH)
-            except KeyError as exc:
-                raise RuntimeError(f"Built wheel is missing {MANIFEST_WHEEL_PATH}") from exc
-        try:
-            validate_manifest_bytes(content)
-        except ValueError as exc:
-            raise RuntimeError(f"Built wheel contains an invalid {MANIFEST_WHEEL_PATH}: {exc}") from exc
+                validate_manifest_bytes(content)
+            except ValueError as exc:
+                raise RuntimeError(f"Built wheel contains an invalid {MANIFEST_WHEEL_PATH}: {exc}") from exc
+        pin_peer_dependency(
+            artifact_path,
+            project_name="avibe-os",
+            peer_name="avibe-memory",
+            package_version=self.metadata.version,
+            peer_extra="memory",
+        )

--- a/hatch_exact_peer.py
+++ b/hatch_exact_peer.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import base64
+import csv
+from email import policy
+from email.parser import BytesParser
+import hashlib
+import io
+import os
+from pathlib import Path, PurePosixPath
+import tarfile
+import tempfile
+import zipfile
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
+
+
+_METADATA_POLICY = policy.compat32.clone(linesep="\n", max_line_length=0)
+
+
+def pin_peer_dependency(
+    artifact_path: str,
+    *,
+    project_name: str,
+    peer_name: str,
+    package_version: str,
+    peer_extra: str | None = None,
+) -> None:
+    artifact = Path(artifact_path)
+    normalized_version = _normalize_version(package_version)
+    try:
+        if artifact.suffix == ".whl":
+            _pin_wheel(
+                artifact,
+                project_name=project_name,
+                peer_name=peer_name,
+                package_version=normalized_version,
+                peer_extra=peer_extra,
+            )
+        elif artifact.name.endswith(".tar.gz"):
+            _pin_sdist(
+                artifact,
+                project_name=project_name,
+                peer_name=peer_name,
+                package_version=normalized_version,
+                peer_extra=peer_extra,
+            )
+        else:
+            raise RuntimeError(f"Unsupported publishable artifact for exact peer metadata: {artifact.name}")
+    except Exception:
+        artifact.unlink(missing_ok=True)
+        raise
+
+
+def _normalize_version(value: str) -> str:
+    try:
+        return str(Version(value))
+    except InvalidVersion as exc:
+        raise RuntimeError(f"Cannot pin peer metadata to invalid package version {value!r}") from exc
+
+
+def _pin_metadata(
+    content: bytes,
+    *,
+    project_name: str,
+    peer_name: str,
+    package_version: str,
+    peer_extra: str | None,
+) -> bytes:
+    metadata = BytesParser(policy=policy.compat32).parsebytes(content)
+    metadata_name = metadata.get("Name")
+    metadata_version = metadata.get("Version")
+    if not metadata_name or canonicalize_name(metadata_name) != canonicalize_name(project_name):
+        raise RuntimeError(f"Artifact metadata is not for {project_name}")
+    if not metadata_version or _normalize_version(metadata_version) != package_version:
+        raise RuntimeError(
+            f"{project_name} artifact metadata version {metadata_version!r} does not match built version {package_version}"
+        )
+
+    requirements = metadata.get_all("Requires-Dist") or []
+    parsed: list[Requirement] = []
+    for value in requirements:
+        try:
+            parsed.append(Requirement(value))
+        except InvalidRequirement as exc:
+            raise RuntimeError(f"{project_name} emitted invalid dependency metadata: {value}") from exc
+    peer_indexes = [
+        index
+        for index, requirement in enumerate(parsed)
+        if canonicalize_name(requirement.name) == canonicalize_name(peer_name)
+    ]
+    if len(peer_indexes) != 1:
+        raise RuntimeError(f"{project_name} must declare exactly one {peer_name} dependency")
+
+    peer_index = peer_indexes[0]
+    peer_requirement = parsed[peer_index]
+    if peer_requirement.url or peer_requirement.extras:
+        raise RuntimeError(f"{project_name} cannot exact-pin a URL or extra-qualified {peer_name} dependency")
+    if peer_extra is None:
+        if peer_requirement.marker is not None:
+            raise RuntimeError(f"{project_name} must require {peer_name} without an environment marker")
+    elif peer_requirement.marker is None or not _is_exact_extra_marker(peer_requirement, peer_extra):
+        raise RuntimeError(f"{project_name} must expose {peer_name} only through the {peer_extra!r} extra")
+
+    marker = f"; {peer_requirement.marker}" if peer_requirement.marker is not None else ""
+    requirements[peer_index] = f"{peer_name}=={package_version}{marker}"
+    del metadata["Requires-Dist"]
+    for requirement in requirements:
+        metadata["Requires-Dist"] = requirement
+
+    pinned = metadata.as_bytes(policy=_METADATA_POLICY)
+    _verify_exact_pin(
+        pinned,
+        project_name=project_name,
+        peer_name=peer_name,
+        package_version=package_version,
+        peer_extra=peer_extra,
+    )
+    return pinned
+
+
+def _is_exact_extra_marker(requirement: Requirement, peer_extra: str) -> bool:
+    if requirement.marker is None:
+        return False
+    return requirement.marker.evaluate({"extra": peer_extra}) and not requirement.marker.evaluate(
+        {"extra": f"not-{peer_extra}"}
+    )
+
+
+def _verify_exact_pin(
+    content: bytes,
+    *,
+    project_name: str,
+    peer_name: str,
+    package_version: str,
+    peer_extra: str | None,
+) -> None:
+    metadata = BytesParser(policy=policy.compat32).parsebytes(content)
+    requirements = metadata.get_all("Requires-Dist") or []
+    peers = [
+        Requirement(value)
+        for value in requirements
+        if canonicalize_name(Requirement(value).name) == canonicalize_name(peer_name)
+    ]
+    if len(peers) != 1 or str(peers[0].specifier) != f"=={package_version}":
+        raise RuntimeError(f"{project_name} artifact did not emit the exact {peer_name}=={package_version} contract")
+    if peer_extra is None:
+        marker_matches = peers[0].marker is None
+    else:
+        marker_matches = peers[0].marker is not None and _is_exact_extra_marker(peers[0], peer_extra)
+    if not marker_matches:
+        raise RuntimeError(f"{project_name} artifact emitted the wrong marker for {peer_name}")
+
+
+def _pin_wheel(
+    artifact: Path,
+    *,
+    project_name: str,
+    peer_name: str,
+    package_version: str,
+    peer_extra: str | None,
+) -> None:
+    with zipfile.ZipFile(artifact) as wheel:
+        infos = wheel.infolist()
+        entries = {info.filename: wheel.read(info.filename) for info in infos}
+    if len(entries) != len(infos):
+        raise RuntimeError(f"Wheel contains duplicate paths: {artifact.name}")
+
+    metadata_names = [name for name in entries if name.endswith(".dist-info/METADATA")]
+    record_names = [name for name in entries if name.endswith(".dist-info/RECORD")]
+    if len(metadata_names) != 1 or len(record_names) != 1:
+        raise RuntimeError(f"Wheel must contain one METADATA and one RECORD file: {artifact.name}")
+    metadata_name = metadata_names[0]
+    record_name = record_names[0]
+    if metadata_name.rsplit("/", 1)[0] != record_name.rsplit("/", 1)[0]:
+        raise RuntimeError(f"Wheel METADATA and RECORD identities disagree: {artifact.name}")
+
+    entries[metadata_name] = _pin_metadata(
+        entries[metadata_name],
+        project_name=project_name,
+        peer_name=peer_name,
+        package_version=package_version,
+        peer_extra=peer_extra,
+    )
+    entries[record_name] = _updated_record(
+        entries[record_name], metadata_name=metadata_name, metadata=entries[metadata_name], record_name=record_name
+    )
+
+    temporary = _temporary_artifact_path(artifact)
+    try:
+        with zipfile.ZipFile(temporary, "w") as wheel:
+            for info in infos:
+                wheel.writestr(info, entries[info.filename])
+        os.replace(temporary, artifact)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _updated_record(content: bytes, *, metadata_name: str, metadata: bytes, record_name: str) -> bytes:
+    rows = list(csv.reader(io.StringIO(content.decode("utf-8"))))
+    metadata_rows = [row for row in rows if row and row[0] == metadata_name]
+    record_rows = [row for row in rows if row and row[0] == record_name]
+    if len(metadata_rows) != 1 or len(record_rows) != 1:
+        raise RuntimeError("Wheel RECORD must name METADATA and itself exactly once")
+
+    digest = base64.urlsafe_b64encode(hashlib.sha256(metadata).digest()).rstrip(b"=").decode("ascii")
+    metadata_rows[0][1:] = [f"sha256={digest}", str(len(metadata))]
+    record_rows[0][1:] = ["", ""]
+    output = io.StringIO()
+    csv.writer(output, lineterminator="\n").writerows(rows)
+    return output.getvalue().encode("utf-8")
+
+
+def _pin_sdist(
+    artifact: Path,
+    *,
+    project_name: str,
+    peer_name: str,
+    package_version: str,
+    peer_extra: str | None,
+) -> None:
+    with tarfile.open(artifact, "r:gz") as sdist:
+        pax_headers = dict(sdist.pax_headers)
+        members = sdist.getmembers()
+        entries: list[tuple[tarfile.TarInfo, bytes | None]] = []
+        for member in members:
+            source = sdist.extractfile(member) if member.isfile() else None
+            entries.append((member, source.read() if source is not None else None))
+
+    pkg_info_indexes = [
+        index
+        for index, (member, _content) in enumerate(entries)
+        if member.isfile() and PurePosixPath(member.name).name == "PKG-INFO"
+    ]
+    if len(pkg_info_indexes) != 1:
+        raise RuntimeError(f"Sdist must contain exactly one PKG-INFO file: {artifact.name}")
+    pkg_info_index = pkg_info_indexes[0]
+    member, content = entries[pkg_info_index]
+    if content is None:
+        raise RuntimeError(f"Sdist PKG-INFO is unreadable: {artifact.name}")
+    pinned_content = _pin_metadata(
+        content,
+        project_name=project_name,
+        peer_name=peer_name,
+        package_version=package_version,
+        peer_extra=peer_extra,
+    )
+    member.size = len(pinned_content)
+    entries[pkg_info_index] = (
+        member,
+        pinned_content,
+    )
+
+    temporary = _temporary_artifact_path(artifact)
+    try:
+        with tarfile.open(temporary, "w:gz", format=tarfile.PAX_FORMAT, pax_headers=pax_headers) as sdist:
+            for member, content in entries:
+                sdist.addfile(member, io.BytesIO(content) if content is not None else None)
+        os.replace(temporary, artifact)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _temporary_artifact_path(artifact: Path) -> Path:
+    descriptor, path = tempfile.mkstemp(prefix=f".{artifact.name}.", suffix=".tmp", dir=artifact.parent)
+    os.close(descriptor)
+    return Path(path)

--- a/hatch_exact_peer.py
+++ b/hatch_exact_peer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+from collections.abc import MutableMapping, MutableSequence
 import csv
 from email import policy
 from email.parser import BytesParser
@@ -253,6 +254,27 @@ def _pin_sdist(
         pinned_content,
     )
 
+    pyproject_indexes = [
+        index
+        for index, (member, _content) in enumerate(entries)
+        if member.isfile() and PurePosixPath(member.name).name == "pyproject.toml"
+    ]
+    if len(pyproject_indexes) != 1:
+        raise RuntimeError(f"Sdist must contain exactly one pyproject.toml file: {artifact.name}")
+    pyproject_index = pyproject_indexes[0]
+    member, content = entries[pyproject_index]
+    if content is None:
+        raise RuntimeError(f"Sdist pyproject.toml is unreadable: {artifact.name}")
+    pinned_content = _pin_sdist_build_input(
+        content,
+        project_name=project_name,
+        peer_name=peer_name,
+        package_version=package_version,
+        peer_extra=peer_extra,
+    )
+    member.size = len(pinned_content)
+    entries[pyproject_index] = (member, pinned_content)
+
     temporary = _temporary_artifact_path(artifact)
     try:
         with tarfile.open(temporary, "w:gz", format=tarfile.PAX_FORMAT, pax_headers=pax_headers) as sdist:
@@ -261,6 +283,97 @@ def _pin_sdist(
         os.replace(temporary, artifact)
     finally:
         temporary.unlink(missing_ok=True)
+
+
+def _pin_sdist_build_input(
+    content: bytes,
+    *,
+    project_name: str,
+    peer_name: str,
+    package_version: str,
+    peer_extra: str | None,
+) -> bytes:
+    try:
+        import tomlkit
+
+        document = tomlkit.parse(content.decode("utf-8"))
+    except Exception as exc:
+        raise RuntimeError(f"{project_name} sdist has an invalid pyproject.toml") from exc
+
+    project = document.get("project")
+    if not isinstance(project, MutableMapping):
+        raise RuntimeError(f"{project_name} sdist pyproject.toml has no project table")
+    metadata_name = project.get("name")
+    if not isinstance(metadata_name, str) or canonicalize_name(metadata_name) != canonicalize_name(project_name):
+        raise RuntimeError(f"Sdist build input is not for {project_name}")
+
+    dependencies = _project_peer_dependencies(project, project_name=project_name, peer_extra=peer_extra)
+    peer_index, peer_requirement = _find_peer_requirement(
+        dependencies,
+        project_name=project_name,
+        peer_name=peer_name,
+    )
+    if peer_requirement.url or peer_requirement.extras or peer_requirement.marker is not None:
+        raise RuntimeError(f"{project_name} sdist cannot exact-pin a qualified {peer_name} dependency")
+    dependencies[peer_index] = f"{peer_name}=={package_version}"
+
+    pinned = tomlkit.dumps(document).encode("utf-8")
+    verified = tomlkit.parse(pinned.decode("utf-8"))["project"]
+    verified_dependencies = _project_peer_dependencies(
+        verified,
+        project_name=project_name,
+        peer_extra=peer_extra,
+    )
+    _index, verified_requirement = _find_peer_requirement(
+        verified_dependencies,
+        project_name=project_name,
+        peer_name=peer_name,
+    )
+    if str(verified_requirement.specifier) != f"=={package_version}" or verified_requirement.marker is not None:
+        raise RuntimeError(f"{project_name} sdist build input did not retain the exact {peer_name} pin")
+    return pinned
+
+
+def _project_peer_dependencies(
+    project: MutableMapping,
+    *,
+    project_name: str,
+    peer_extra: str | None,
+) -> MutableSequence:
+    if peer_extra is None:
+        dependencies = project.get("dependencies")
+    else:
+        optional = project.get("optional-dependencies")
+        dependencies = optional.get(peer_extra) if isinstance(optional, MutableMapping) else None
+    if not isinstance(dependencies, MutableSequence):
+        label = "dependencies" if peer_extra is None else f"optional-dependencies.{peer_extra}"
+        raise RuntimeError(f"{project_name} sdist pyproject.toml has no {label} array")
+    return dependencies
+
+
+def _find_peer_requirement(
+    dependencies: MutableSequence,
+    *,
+    project_name: str,
+    peer_name: str,
+) -> tuple[int, Requirement]:
+    parsed: list[Requirement] = []
+    for value in dependencies:
+        if not isinstance(value, str):
+            raise RuntimeError(f"{project_name} sdist emitted a non-string dependency")
+        try:
+            parsed.append(Requirement(value))
+        except InvalidRequirement as exc:
+            raise RuntimeError(f"{project_name} sdist emitted an invalid dependency: {value}") from exc
+    peer_indexes = [
+        index
+        for index, requirement in enumerate(parsed)
+        if canonicalize_name(requirement.name) == canonicalize_name(peer_name)
+    ]
+    if len(peer_indexes) != 1:
+        raise RuntimeError(f"{project_name} sdist must declare exactly one {peer_name} dependency")
+    peer_index = peer_indexes[0]
+    return peer_index, parsed[peer_index]
 
 
 def _temporary_artifact_path(artifact: Path) -> Path:

--- a/packaging/avibe-memory/README.md
+++ b/packaging/avibe-memory/README.md
@@ -7,9 +7,17 @@ Install it through the host extra so the resolver selects a compatible pair:
 pip install "avibe-os[memory]"
 ```
 
-The `3.0.x` package line implements Memory runtime protocol `1` and requires
-`avibe-os>=3.0.14.dev0,<3.1`. The host extra applies the same compatibility
-range to this distribution.
+The `3.0.x` package line implements Memory runtime protocol `1`. Every built
+wheel and sdist requires the peer distribution at exactly the same normalized
+version: `avibe-memory==X` requires `avibe-os==X`, and the `memory` extra on
+`avibe-os==X` requires `avibe-memory==X`. This is the same identity used by the
+Dependencies readiness check.
+
+The source projects retain the `>=3.0.14.dev0,<3.1` compatibility window so a
+source or editable checkout can use an available development peer before that
+exact version is published. The Hatch build hooks replace that development
+range in every publishable artifact and fail the build unless the resulting
+metadata contains the reciprocal exact pin.
 
 ## Distribution contract
 

--- a/packaging/avibe-memory/hatch_build.py
+++ b/packaging/avibe-memory/hatch_build.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
 from pathlib import Path
+from runpy import run_path
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+_ROOT = Path(__file__).resolve().parent
+_HELPER = _ROOT / "hatch_exact_peer.py"
+if not _HELPER.is_file():
+    _HELPER = _ROOT.parents[1] / "hatch_exact_peer.py"
+pin_peer_dependency = run_path(str(_HELPER))["pin_peer_dependency"]
 
 
 class CustomBuildHook(BuildHookInterface):
@@ -19,6 +27,8 @@ class CustomBuildHook(BuildHookInterface):
         }
         if source_root != root:
             sources[source_root / "avibe_memory"] = "avibe_memory"
+        if self.target_name == "sdist":
+            sources[_HELPER] = "hatch_exact_peer.py"
         missing = [str(path) for path in sources if not path.exists()]
         if missing:
             raise RuntimeError(
@@ -26,3 +36,13 @@ class CustomBuildHook(BuildHookInterface):
             )
         force_include = build_data.setdefault("force_include", {})
         force_include.update({str(path): target for path, target in sources.items()})
+
+    def finalize(self, version: str, build_data: dict, artifact_path: str) -> None:
+        if version == "editable":
+            return
+        pin_peer_dependency(
+            artifact_path,
+            project_name="avibe-memory",
+            peer_name="avibe-os",
+            package_version=self.metadata.version,
+        )

--- a/packaging/avibe-memory/pyproject.toml
+++ b/packaging/avibe-memory/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "tomlkit>=0.11.1"]
 build-backend = "hatchling.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "tomlkit>=0.11.1"]
 build-backend = "hatchling.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ include = [
     "modules/**",
     "storage/**",
     "hatch_build.py",
+    "hatch_exact_peer.py",
     "main.py",
     "scripts/prepare_local_show_runtime_manifest.py",
     "scripts/show_runtime_manifest_asset.py",

--- a/tests/test_memory_distribution.py
+++ b/tests/test_memory_distribution.py
@@ -39,6 +39,10 @@ def _project(path: Path) -> dict[str, Any]:
     return tomllib.loads(path.read_text(encoding="utf-8"))["project"]
 
 
+def _build_system(path: Path) -> dict[str, Any]:
+    return tomllib.loads(path.read_text(encoding="utf-8"))["build-system"]
+
+
 def _workflow(name: str) -> dict[str, Any]:
     return yaml.safe_load((WORKFLOW_DIR / name).read_text(encoding="utf-8"))
 
@@ -98,10 +102,10 @@ def _sdist_metadata(wheel: Path, distribution: str) -> Any:
         return Parser().parsestr(metadata.decode("utf-8"))
 
 
-def _sdist_project(wheel: Path, distribution: str) -> dict[str, Any]:
+def _sdist_pyproject(wheel: Path, distribution: str) -> dict[str, Any]:
     sdist = _sdist_path(wheel, distribution)
     with tarfile.open(sdist, "r:gz") as archive:
-        return tomllib.loads(_sdist_member(archive, "pyproject.toml").decode("utf-8"))["project"]
+        return tomllib.loads(_sdist_member(archive, "pyproject.toml").decode("utf-8"))
 
 
 def _sdist_path(wheel: Path, distribution: str) -> Path:
@@ -174,6 +178,12 @@ def test_source_metadata_preserves_the_developer_compatibility_window() -> None:
 
     assert memory_requirement.specifier == COMPATIBILITY
     assert host_requirement.specifier == COMPATIBILITY
+
+
+def test_sdist_rewriter_is_an_explicit_isolated_build_requirement() -> None:
+    for pyproject in (ROOT / "pyproject.toml", MEMORY_PROJECT / "pyproject.toml"):
+        requirement = _requirement(_build_system(pyproject)["requires"], "tomlkit")
+        assert str(requirement.specifier) == ">=0.11.1"
 
 
 def test_pr_artifact_build_uses_an_explicit_prerelease_contract_version() -> None:
@@ -382,8 +392,10 @@ def test_built_distributions_have_independent_contents_and_exact_peer_metadata()
     memory_names, memory_metadata = _wheel_metadata(memory_wheel)
     core_sdist_metadata = _sdist_metadata(core_wheel, "avibe_os")
     memory_sdist_metadata = _sdist_metadata(memory_wheel, "avibe_memory")
-    core_sdist_project = _sdist_project(core_wheel, "avibe_os")
-    memory_sdist_project = _sdist_project(memory_wheel, "avibe_memory")
+    core_sdist_pyproject = _sdist_pyproject(core_wheel, "avibe_os")
+    memory_sdist_pyproject = _sdist_pyproject(memory_wheel, "avibe_memory")
+    core_sdist_project = core_sdist_pyproject["project"]
+    memory_sdist_project = memory_sdist_pyproject["project"]
 
     assert core_metadata["Name"] == "avibe-os"
     assert memory_metadata["Name"] == "avibe-memory"
@@ -432,6 +444,9 @@ def test_built_distributions_have_independent_contents_and_exact_peer_metadata()
     assert core_build_requirement.marker is None
     assert str(memory_build_requirement.specifier) == f"=={memory_version}"
     assert memory_build_requirement.marker is None
+    for pyproject in (core_sdist_pyproject, memory_sdist_pyproject):
+        build_requirement = _requirement(pyproject["build-system"]["requires"], "tomlkit")
+        assert str(build_requirement.specifier) == ">=0.11.1"
 
 
 def test_memory_extra_resolves_and_installs_the_same_version_pair(tmp_path: Path) -> None:

--- a/tests/test_memory_distribution.py
+++ b/tests/test_memory_distribution.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import base64
+import csv
 from email.parser import Parser
+import hashlib
+import io
 import os
 from pathlib import Path
+import site
 import subprocess
 import sys
+import tarfile
 from typing import Any
 import zipfile
 
@@ -15,6 +21,8 @@ from packaging.version import Version
 import pytest
 import yaml
 
+from hatch_exact_peer import pin_peer_dependency
+
 try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
@@ -24,6 +32,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
 ROOT = Path(__file__).resolve().parents[1]
 MEMORY_PROJECT = ROOT / "packaging" / "avibe-memory"
 COMPATIBILITY = SpecifierSet(">=3.0.14.dev0,<3.1")
+PACKAGE_CONTRACT_VERSION = Version("3.0.99rc1")
 WORKFLOW_DIR = ROOT / ".github" / "workflows"
 
 
@@ -71,10 +80,31 @@ def _wheel_metadata(wheel: Path) -> tuple[set[str], Any]:
         names = set(archive.namelist())
         metadata_paths = [name for name in names if name.endswith(".dist-info/METADATA")]
         assert len(metadata_paths) == 1
-        metadata = Parser().parsestr(
-            archive.read(metadata_paths[0]).decode("utf-8")
-        )
+        metadata_content = archive.read(metadata_paths[0])
+        metadata = Parser().parsestr(metadata_content.decode("utf-8"))
+        record_paths = [name for name in names if name.endswith(".dist-info/RECORD")]
+        assert len(record_paths) == 1
+        record = list(csv.reader(io.StringIO(archive.read(record_paths[0]).decode("utf-8"))))
+        metadata_record = [row for row in record if row and row[0] == metadata_paths[0]]
+        assert len(metadata_record) == 1
+        digest = base64.urlsafe_b64encode(hashlib.sha256(metadata_content).digest()).rstrip(b"=").decode("ascii")
+        assert metadata_record[0][1:] == [f"sha256={digest}", str(len(metadata_content))]
     return names, metadata
+
+
+def _sdist_metadata(wheel: Path, distribution: str) -> Any:
+    matches = list(wheel.parent.glob(f"{distribution}-*.tar.gz"))
+    assert len(matches) == 1
+    with tarfile.open(matches[0], "r:gz") as archive:
+        metadata_members = [
+            member
+            for member in archive.getmembers()
+            if member.isfile() and Path(member.name).name == "PKG-INFO"
+        ]
+        assert len(metadata_members) == 1
+        metadata_file = archive.extractfile(metadata_members[0])
+        assert metadata_file is not None
+        return Parser().parsestr(metadata_file.read().decode("utf-8"))
 
 
 def _run(python: Path, *args: str, cwd: Path) -> None:
@@ -90,7 +120,7 @@ def _run(python: Path, *args: str, cwd: Path) -> None:
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_memory_extra_and_distribution_share_one_compatibility_window() -> None:
+def test_source_metadata_preserves_the_developer_compatibility_window() -> None:
     host = _project(ROOT / "pyproject.toml")
     memory = _project(MEMORY_PROJECT / "pyproject.toml")
 
@@ -99,6 +129,43 @@ def test_memory_extra_and_distribution_share_one_compatibility_window() -> None:
 
     assert memory_requirement.specifier == COMPATIBILITY
     assert host_requirement.specifier == COMPATIBILITY
+
+
+def test_pr_artifact_build_uses_an_explicit_prerelease_contract_version() -> None:
+    step = _step(_workflow("lint.yml")["jobs"]["build-linux-artifacts"], "Build package artifact")
+    environment = step["env"]
+
+    assert Version(environment["AVIBE_PACKAGE_CONTRACT_VERSION"]) == PACKAGE_CONTRACT_VERSION
+    assert PACKAGE_CONTRACT_VERSION.is_prerelease
+    assert environment["SETUPTOOLS_SCM_PRETEND_VERSION"] == str(PACKAGE_CONTRACT_VERSION)
+    assert environment["SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_OS"] == str(PACKAGE_CONTRACT_VERSION)
+    assert environment["SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_MEMORY"] == str(PACKAGE_CONTRACT_VERSION)
+    assert "python -m build\n" in step["run"]
+
+
+def test_publishable_metadata_without_the_peer_contract_fails_closed(tmp_path: Path) -> None:
+    wheel = tmp_path / "avibe_os-3.0.99rc1-py3-none-any.whl"
+    dist_info = "avibe_os-3.0.99rc1.dist-info"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr(
+            f"{dist_info}/METADATA",
+            "Metadata-Version: 2.4\nName: avibe-os\nVersion: 3.0.99rc1\n\n",
+        )
+        archive.writestr(
+            f"{dist_info}/RECORD",
+            f"{dist_info}/METADATA,,\n{dist_info}/RECORD,,\n",
+        )
+
+    with pytest.raises(RuntimeError, match="exactly one avibe-memory dependency"):
+        pin_peer_dependency(
+            str(wheel),
+            project_name="avibe-os",
+            peer_name="avibe-memory",
+            package_version="3.0.99rc1",
+            peer_extra="memory",
+        )
+
+    assert not wheel.exists()
 
 
 def test_distribution_release_contract_is_forward_only_and_memory_first() -> None:
@@ -263,11 +330,13 @@ def test_each_trusted_publisher_receives_only_its_distribution(
     assert publish_steps[0]["with"]["skip-existing"] is True
 
 
-def test_built_wheels_have_independent_contents_and_compatible_metadata() -> None:
+def test_built_distributions_have_independent_contents_and_exact_peer_metadata() -> None:
     core_wheel = _wheel_path("AVIBE_CORE_WHEEL")
     memory_wheel = _wheel_path("AVIBE_MEMORY_WHEEL")
     core_names, core_metadata = _wheel_metadata(core_wheel)
     memory_names, memory_metadata = _wheel_metadata(memory_wheel)
+    core_sdist_metadata = _sdist_metadata(core_wheel, "avibe_os")
+    memory_sdist_metadata = _sdist_metadata(memory_wheel, "avibe_memory")
 
     assert core_metadata["Name"] == "avibe-os"
     assert memory_metadata["Name"] == "avibe-memory"
@@ -290,20 +359,83 @@ def test_built_wheels_have_independent_contents_and_compatible_metadata() -> Non
             ROOT / "vibe/memory_runtime_manifest.json"
         ).read_bytes()
 
-    core_requires = core_metadata.get_all("Requires-Dist") or []
-    memory_requires = memory_metadata.get_all("Requires-Dist") or []
-    memory_requirement = _requirement(core_requires, "avibe-memory")
-    host_requirement = _requirement(memory_requires, "avibe-os")
     core_version = Version(core_metadata["Version"])
     memory_version = Version(memory_metadata["Version"])
-
-    assert memory_requirement.specifier == COMPATIBILITY
-    assert memory_requirement.marker is not None
-    assert memory_requirement.marker.evaluate({"extra": "memory"})
-    assert memory_version in memory_requirement.specifier
-    assert host_requirement.specifier == COMPATIBILITY
-    assert core_version in host_requirement.specifier
     assert memory_version == core_version
+    explicit_version = os.environ.get("AVIBE_PACKAGE_CONTRACT_VERSION")
+    if explicit_version is not None:
+        assert core_version == Version(explicit_version) == PACKAGE_CONTRACT_VERSION
+
+    for metadata in (core_metadata, core_sdist_metadata):
+        assert Version(metadata["Version"]) == core_version
+        memory_requirement = _requirement(metadata.get_all("Requires-Dist") or [], "avibe-memory")
+        assert str(memory_requirement.specifier) == f"=={core_version}"
+        assert memory_requirement.marker is not None
+        assert memory_requirement.marker.evaluate({"extra": "memory"})
+        assert not memory_requirement.marker.evaluate({"extra": "not-memory"})
+    for metadata in (memory_metadata, memory_sdist_metadata):
+        assert Version(metadata["Version"]) == memory_version
+        host_requirement = _requirement(metadata.get_all("Requires-Dist") or [], "avibe-os")
+        assert str(host_requirement.specifier) == f"=={memory_version}"
+        assert host_requirement.marker is None
+
+
+def test_memory_extra_resolves_and_installs_the_same_version_pair(tmp_path: Path) -> None:
+    core_wheel = _wheel_path("AVIBE_CORE_WHEEL")
+    memory_wheel = _wheel_path("AVIBE_MEMORY_WHEEL")
+    core_version = Version(_wheel_metadata(core_wheel)[1]["Version"])
+    environment = tmp_path / "same-version-resolver"
+    subprocess.run(
+        [sys.executable, "-m", "venv", str(environment)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    python = environment / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    child_site_packages = subprocess.run(
+        [str(python), "-c", "import sysconfig; print(sysconfig.get_path('purelib'))"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    Path(child_site_packages, "avibe-test-environment.pth").write_text(
+        "".join(f"{path}\n" for path in site.getsitepackages()),
+        encoding="utf-8",
+    )
+    _run(
+        python,
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        "--no-deps",
+        "--force-reinstall",
+        str(core_wheel),
+        cwd=tmp_path,
+    )
+    _run(
+        python,
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        "--no-index",
+        "--find-links",
+        str(core_wheel.parent),
+        "--find-links",
+        str(memory_wheel.parent),
+        f"avibe-os[memory]=={core_version}",
+        cwd=tmp_path,
+    )
+    _run(
+        python,
+        "-c",
+        (
+            "from importlib.metadata import version; "
+            f"assert version('avibe-os') == version('avibe-memory') == {str(core_version)!r}"
+        ),
+        cwd=tmp_path,
+    )
 
 
 @pytest.mark.parametrize("installation", ["core-only", "core+memory"])

--- a/tests/test_memory_distribution.py
+++ b/tests/test_memory_distribution.py
@@ -7,6 +7,7 @@ import hashlib
 import io
 import os
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 import tarfile
@@ -15,7 +16,7 @@ import zipfile
 
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
-from packaging.utils import canonicalize_name
+from packaging.utils import canonicalize_name, parse_wheel_filename
 from packaging.version import Version
 import pytest
 import yaml
@@ -154,6 +155,35 @@ def _parent_site_packages() -> list[Path]:
     ]
     assert paths
     return paths
+
+
+def _provision_build_requirement_wheelhouse(pyprojects: tuple[dict[str, Any], ...], directory: Path) -> None:
+    requirements = sorted(
+        {
+            value
+            for pyproject in pyprojects
+            for value in pyproject["build-system"]["requires"]
+        }
+    )
+    parsed = [Requirement(value) for value in requirements]
+    directory.mkdir()
+    _run(
+        Path(sys.executable),
+        "-m",
+        "pip",
+        "download",
+        "--disable-pip-version-check",
+        "--only-binary=:all:",
+        "--dest",
+        str(directory),
+        *requirements,
+        cwd=directory.parent,
+    )
+
+    wheels = list(directory.glob("*.whl"))
+    assert wheels
+    downloaded_names = {canonicalize_name(parse_wheel_filename(wheel.name)[0]) for wheel in wheels}
+    assert {canonicalize_name(requirement.name) for requirement in parsed} <= downloaded_names
 
 
 def _run(python: Path, *args: str, cwd: Path) -> None:
@@ -512,13 +542,18 @@ def test_memory_extra_resolves_and_installs_from_both_sdists(tmp_path: Path) -> 
     memory_wheel = _wheel_path("AVIBE_MEMORY_WHEEL")
     core_sdist = _sdist_path(core_wheel, "avibe_os")
     memory_sdist = _sdist_path(memory_wheel, "avibe_memory")
+    core_pyproject = _sdist_pyproject(core_wheel, "avibe_os")
+    memory_pyproject = _sdist_pyproject(memory_wheel, "avibe_memory")
     core_version = Version(_sdist_metadata(core_wheel, "avibe_os")["Version"])
     decoy_version = Version("3.0.99rc2")
     assert decoy_version > core_version
 
-    links = tmp_path / "links"
-    links.mkdir()
-    _write_minimal_wheel(links, "avibe-memory", str(decoy_version))
+    package_links = tmp_path / "package-links"
+    package_links.mkdir()
+    shutil.copy2(memory_sdist, package_links / memory_sdist.name)
+    _write_minimal_wheel(package_links, "avibe-memory", str(decoy_version))
+    build_links = tmp_path / "build-links"
+    _provision_build_requirement_wheelhouse((core_pyproject, memory_pyproject), build_links)
 
     environment = tmp_path / "sdist-resolver"
     subprocess.run(
@@ -534,24 +569,28 @@ def test_memory_extra_resolves_and_installs_from_both_sdists(tmp_path: Path) -> 
         capture_output=True,
         text=True,
     ).stdout.strip()
-    Path(child_site_packages, "avibe-test-build-environment.pth").write_text(
+    Path(child_site_packages, "avibe-test-runtime-dependencies.pth").write_text(
         "".join(f"{path}\n" for path in _parent_site_packages()),
         encoding="utf-8",
     )
 
-    _run(
-        python,
+    install_command = [
         "-m",
         "pip",
         "install",
         "--disable-pip-version-check",
-        "--no-build-isolation",
         "--no-index",
         "--find-links",
-        str(memory_sdist.parent),
+        str(package_links),
         "--find-links",
-        str(links),
+        str(build_links),
         f"avibe-os[memory] @ {core_sdist.as_uri()}",
+    ]
+    assert "--no-build-isolation" not in install_command
+    assert install_command.count("--find-links") == 2
+    _run(
+        python,
+        *install_command,
         cwd=tmp_path,
     )
     _run(

--- a/tests/test_memory_distribution.py
+++ b/tests/test_memory_distribution.py
@@ -7,7 +7,6 @@ import hashlib
 import io
 import os
 from pathlib import Path
-import site
 import subprocess
 import sys
 import tarfile
@@ -93,18 +92,64 @@ def _wheel_metadata(wheel: Path) -> tuple[set[str], Any]:
 
 
 def _sdist_metadata(wheel: Path, distribution: str) -> Any:
+    sdist = _sdist_path(wheel, distribution)
+    with tarfile.open(sdist, "r:gz") as archive:
+        metadata = _sdist_member(archive, "PKG-INFO")
+        return Parser().parsestr(metadata.decode("utf-8"))
+
+
+def _sdist_project(wheel: Path, distribution: str) -> dict[str, Any]:
+    sdist = _sdist_path(wheel, distribution)
+    with tarfile.open(sdist, "r:gz") as archive:
+        return tomllib.loads(_sdist_member(archive, "pyproject.toml").decode("utf-8"))["project"]
+
+
+def _sdist_path(wheel: Path, distribution: str) -> Path:
     matches = list(wheel.parent.glob(f"{distribution}-*.tar.gz"))
     assert len(matches) == 1
-    with tarfile.open(matches[0], "r:gz") as archive:
-        metadata_members = [
-            member
-            for member in archive.getmembers()
-            if member.isfile() and Path(member.name).name == "PKG-INFO"
-        ]
-        assert len(metadata_members) == 1
-        metadata_file = archive.extractfile(metadata_members[0])
-        assert metadata_file is not None
-        return Parser().parsestr(metadata_file.read().decode("utf-8"))
+    return matches[0]
+
+
+def _sdist_member(archive: tarfile.TarFile, name: str) -> bytes:
+    matches = [
+        member
+        for member in archive.getmembers()
+        if member.isfile() and Path(member.name).name == name
+    ]
+    assert len(matches) == 1
+    member_file = archive.extractfile(matches[0])
+    assert member_file is not None
+    return member_file.read()
+
+
+def _write_minimal_wheel(directory: Path, distribution: str, version: str) -> Path:
+    normalized = distribution.replace("-", "_")
+    dist_info = f"{normalized}-{version}.dist-info"
+    wheel = directory / f"{normalized}-{version}-py3-none-any.whl"
+    entries = {
+        f"{dist_info}/METADATA": f"Metadata-Version: 2.4\nName: {distribution}\nVersion: {version}\n\n",
+        f"{dist_info}/WHEEL": (
+            "Wheel-Version: 1.0\n"
+            "Generator: avibe-package-contract-test\n"
+            "Root-Is-Purelib: true\n"
+            "Tag: py3-none-any\n\n"
+        ),
+    }
+    entries[f"{dist_info}/RECORD"] = "".join(f"{name},,\n" for name in entries) + f"{dist_info}/RECORD,,\n"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        for name, content in entries.items():
+            archive.writestr(name, content)
+    return wheel
+
+
+def _parent_site_packages() -> list[Path]:
+    paths = [
+        path
+        for value in sys.path
+        if value and (path := Path(value).resolve()).name in {"site-packages", "dist-packages"}
+    ]
+    assert paths
+    return paths
 
 
 def _run(python: Path, *args: str, cwd: Path) -> None:
@@ -337,6 +382,8 @@ def test_built_distributions_have_independent_contents_and_exact_peer_metadata()
     memory_names, memory_metadata = _wheel_metadata(memory_wheel)
     core_sdist_metadata = _sdist_metadata(core_wheel, "avibe_os")
     memory_sdist_metadata = _sdist_metadata(memory_wheel, "avibe_memory")
+    core_sdist_project = _sdist_project(core_wheel, "avibe_os")
+    memory_sdist_project = _sdist_project(memory_wheel, "avibe_memory")
 
     assert core_metadata["Name"] == "avibe-os"
     assert memory_metadata["Name"] == "avibe-memory"
@@ -379,6 +426,13 @@ def test_built_distributions_have_independent_contents_and_exact_peer_metadata()
         assert str(host_requirement.specifier) == f"=={memory_version}"
         assert host_requirement.marker is None
 
+    core_build_requirement = _requirement(core_sdist_project["optional-dependencies"]["memory"], "avibe-memory")
+    memory_build_requirement = _requirement(memory_sdist_project["dependencies"], "avibe-os")
+    assert str(core_build_requirement.specifier) == f"=={core_version}"
+    assert core_build_requirement.marker is None
+    assert str(memory_build_requirement.specifier) == f"=={memory_version}"
+    assert memory_build_requirement.marker is None
+
 
 def test_memory_extra_resolves_and_installs_the_same_version_pair(tmp_path: Path) -> None:
     core_wheel = _wheel_path("AVIBE_CORE_WHEEL")
@@ -399,7 +453,7 @@ def test_memory_extra_resolves_and_installs_the_same_version_pair(tmp_path: Path
         text=True,
     ).stdout.strip()
     Path(child_site_packages, "avibe-test-environment.pth").write_text(
-        "".join(f"{path}\n" for path in site.getsitepackages()),
+        "".join(f"{path}\n" for path in _parent_site_packages()),
         encoding="utf-8",
     )
     _run(
@@ -425,6 +479,64 @@ def test_memory_extra_resolves_and_installs_the_same_version_pair(tmp_path: Path
         "--find-links",
         str(memory_wheel.parent),
         f"avibe-os[memory]=={core_version}",
+        cwd=tmp_path,
+    )
+    _run(
+        python,
+        "-c",
+        (
+            "from importlib.metadata import version; "
+            f"assert version('avibe-os') == version('avibe-memory') == {str(core_version)!r}"
+        ),
+        cwd=tmp_path,
+    )
+
+
+def test_memory_extra_resolves_and_installs_from_both_sdists(tmp_path: Path) -> None:
+    core_wheel = _wheel_path("AVIBE_CORE_WHEEL")
+    memory_wheel = _wheel_path("AVIBE_MEMORY_WHEEL")
+    core_sdist = _sdist_path(core_wheel, "avibe_os")
+    memory_sdist = _sdist_path(memory_wheel, "avibe_memory")
+    core_version = Version(_sdist_metadata(core_wheel, "avibe_os")["Version"])
+    decoy_version = Version("3.0.99rc2")
+    assert decoy_version > core_version
+
+    links = tmp_path / "links"
+    links.mkdir()
+    _write_minimal_wheel(links, "avibe-memory", str(decoy_version))
+
+    environment = tmp_path / "sdist-resolver"
+    subprocess.run(
+        [sys.executable, "-m", "venv", str(environment)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    python = environment / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    child_site_packages = subprocess.run(
+        [str(python), "-c", "import sysconfig; print(sysconfig.get_path('purelib'))"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    Path(child_site_packages, "avibe-test-build-environment.pth").write_text(
+        "".join(f"{path}\n" for path in _parent_site_packages()),
+        encoding="utf-8",
+    )
+
+    _run(
+        python,
+        "-m",
+        "pip",
+        "install",
+        "--disable-pip-version-check",
+        "--no-build-isolation",
+        "--no-index",
+        "--find-links",
+        str(memory_sdist.parent),
+        "--find-links",
+        str(links),
+        f"avibe-os[memory] @ {core_sdist.as_uri()}",
         cwd=tmp_path,
     )
     _run(

--- a/tests/test_memory_upgrade_packaged.py
+++ b/tests/test_memory_upgrade_packaged.py
@@ -1,15 +1,9 @@
 from __future__ import annotations
 
-import base64
-import csv
-import hashlib
-import io
 import os
-import re
 import shutil
 import subprocess
 import sys
-import zipfile
 from pathlib import Path
 
 import pytest
@@ -34,41 +28,8 @@ def _wheel(project: Path, version: str, wheelhouse: Path) -> None:
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def _pin_host_memory_extra(wheel: Path, version: str) -> None:
-    """Give each fixture host release its own target-owned Memory pin."""
-
-    with zipfile.ZipFile(wheel) as archive:
-        entries = {info.filename: archive.read(info.filename) for info in archive.infolist()}
-    metadata_name = next(name for name in entries if name.endswith(".dist-info/METADATA"))
-    record_name = next(name for name in entries if name.endswith(".dist-info/RECORD"))
-    metadata = re.sub(
-        rb"Requires-Dist: avibe-memory[^\r\n]*",
-        f'Requires-Dist: avibe-memory=={version}; extra == "memory"'.encode(),
-        entries[metadata_name],
-    )
-    assert metadata != entries[metadata_name]
-    entries[metadata_name] = metadata
-
-    rows = list(csv.reader(io.StringIO(entries[record_name].decode())))
-    digest = base64.urlsafe_b64encode(hashlib.sha256(metadata).digest()).rstrip(b"=").decode()
-    for row in rows:
-        if row[0] == metadata_name:
-            row[1:] = [f"sha256={digest}", str(len(metadata))]
-        elif row[0] == record_name:
-            row[1:] = ["", ""]
-    record = io.StringIO()
-    csv.writer(record, lineterminator="\n").writerows(rows)
-    entries[record_name] = record.getvalue().encode()
-
-    with zipfile.ZipFile(wheel, "w", compression=zipfile.ZIP_DEFLATED) as archive:
-        for name, payload in entries.items():
-            archive.writestr(name, payload)
-
-
 def _build_release_wheels(version: str, wheelhouse: Path) -> None:
     _wheel(ROOT, version, wheelhouse)
-    host_wheel = next(wheelhouse.glob(f"avibe_os-{version}-*.whl"))
-    _pin_host_memory_extra(host_wheel, version)
     _wheel(ROOT / "packaging" / "avibe-memory", version, wheelhouse)
 
 


### PR DESCRIPTION
## Capability

- Make every built `avibe-os` wheel and sdist require `avibe-memory` at the exact normalized core version when the `memory` extra is selected.
- Make every built `avibe-memory` wheel and sdist require `avibe-os` at the exact normalized Memory version.
- Keep the source-project compatibility windows for source/editable development, while failing closed if a publishable artifact cannot be rewritten and verified as an exact reciprocal pair.

## Evidence

- Unit: fail-closed missing-peer metadata contract; source compatibility-window contract; workflow explicit-prerelease input contract.
- Contract: real `3.0.99rc1` wheel and sdist builds for both distributions; reciprocal exact metadata and wheel `RECORD` verification; same-version resolver/install test; `twine check` for all four artifacts.
- Scenario IDs: none. This packaging-only identity change does not alter a cataloged runtime scenario.
- Packaged regression: all four `tests/test_memory_upgrade_packaged.py` cases pass without the former test-only wheel metadata rewrite.
- Residual manual checks: no actual release, Incus regression, local Avibe restart, or publish operation. Official and `gh-v*` build commands are unchanged and consume the same VCS/pretend version inputs exercised by the artifact contracts.

## Known By Design

- Source `pyproject.toml` declarations retain `>=3.0.14.dev0,<3.1` for editable/developer resolution. Only built wheel/sdist metadata is the publishable exact-version contract.
- The existing Dependencies readiness equality remains the sole installed-package identity check; this PR adds no runtime protocol, reservation, migration, rollback, or lifecycle state.

## Dependency

- Base is exactly `6125f78bf0c63dc4e372a640ad555b33141762c9`, including merged PR #1792.
