### PR TITLE
fix(memory): bound disabled cleanup waits

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -81,6 +81,7 @@ logger = logging.getLogger(__name__)
 
 _RUNTIME_WORK_SHUTDOWN_GRACE_SECONDS = 10.0
 _MEMORY_SHUTDOWN_BUDGET_SECONDS = 15.0
+_DISABLED_MEMORY_CLEANUP_WAIT_SECONDS = 1.0
 
 
 def _load_memory_capture_types() -> tuple[type, type, type]:
@@ -751,7 +752,25 @@ class Controller:
     async def _await_disabled_memory_cleanup(self) -> None:
         cleanup_task = getattr(self, "_memory_disabled_cleanup_task", None)
         if cleanup_task is not None and not cleanup_task.done():
-            await asyncio.shield(cleanup_task)
+            wait_seconds = max(
+                0.0,
+                float(
+                    getattr(
+                        self,
+                        "_memory_disabled_cleanup_wait_seconds",
+                        _DISABLED_MEMORY_CLEANUP_WAIT_SECONDS,
+                    )
+                ),
+            )
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(cleanup_task),
+                    timeout=wait_seconds,
+                )
+            except TimeoutError as exc:
+                raise MemoryStoreUnavailableError(
+                    "Disabled Memory cleanup is still in progress"
+                ) from exc
 
     def _start_memory_capture_adapter(self, runtime: "MemoryRuntime") -> bool:
         """Bind every capture task to the Controller-owned event loop."""

--- a/core/controller.py
+++ b/core/controller.py
@@ -767,7 +767,7 @@ class Controller:
                     asyncio.shield(cleanup_task),
                     timeout=wait_seconds,
                 )
-            except TimeoutError as exc:
+            except asyncio.TimeoutError as exc:
                 raise MemoryStoreUnavailableError(
                     "Disabled Memory cleanup is still in progress"
                 ) from exc

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -1049,6 +1049,12 @@ def create_app(
 
         try:
             result = await controller.wake_memory()
+        except MemoryStoreUnavailableError:
+            result = {
+                "ok": False,
+                "state": "degraded",
+                "error": "memory_store_unavailable",
+            }
         except (MemoryImplementationUnavailableError, MemoryImplementationIncompatibleError) as exc:
             result = {"ok": False, "state": "degraded", "error": _memory_implementation_error_code(exc)}
         except Exception:

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -1447,6 +1447,34 @@ def test_memory_wake_uses_non_destructive_runtime_operation() -> None:
     runtime.wake.assert_awaited_once_with()
 
 
+def test_memory_wake_preserves_store_unavailable_outcome() -> None:
+    controller = _build_controller_double()
+    controller.wake_memory = AsyncMock(
+        side_effect=MemoryStoreUnavailableError(
+            "Disabled Memory cleanup is still in progress"
+        )
+    )
+    app = internal_server.create_app(controller, memory_ui_secret="test-secret")
+
+    async def _exercise() -> httpx.Response:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://test",
+        ) as client:
+            return await client.post("/internal/memory/wake", json={})
+
+    response = asyncio.run(_exercise())
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "ok": False,
+        "state": "degraded",
+        "error": "memory_store_unavailable",
+    }
+    controller.wake_memory.assert_awaited_once_with()
+
+
 def test_reconcile_memory_hot_applies_the_persisted_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_memory_disabled_isolation.py
+++ b/tests/test_memory_disabled_isolation.py
@@ -606,6 +606,49 @@ async def test_disabled_cleanup_pending_projects_degraded_status(
         await cleanup_task
 
 
+@pytest.mark.asyncio
+async def test_enabled_operation_bounds_disabled_cleanup_wait_and_remains_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cleanup_started = asyncio.Event()
+    cleanup_release = asyncio.Event()
+
+    async def reconcile_orphans() -> None:
+        cleanup_started.set()
+        await cleanup_release.wait()
+        record_path.unlink()
+
+    controller, cleanup_task, record_path = await _start_disabled_cleanup(
+        monkeypatch,
+        reconcile_orphans,
+    )
+    await cleanup_started.wait()
+    controller.config.memory = replace(controller.config.memory, enabled=True)
+    controller._memory_disabled_cleanup_wait_seconds = 0.01
+
+    class _Runtime:
+        async def wake(self) -> dict[str, object]:
+            return {"ok": True, "state": "running"}
+
+    controller.memory_runtime = _Runtime()
+
+    try:
+        with pytest.raises(
+            MemoryStoreUnavailableError,
+            match="Disabled Memory cleanup is still in progress",
+        ):
+            await asyncio.wait_for(controller.wake_memory(), timeout=0.1)
+        assert cleanup_task.done() is False
+        assert cleanup_task.cancelled() is False
+
+        cleanup_release.set()
+        await cleanup_task
+        assert await controller.wake_memory() == {"ok": True, "state": "running"}
+    finally:
+        cleanup_release.set()
+        await cleanup_task
+
+
 @pytest.mark.parametrize(
     ("outcome", "expected_state"),
     [("failure", "degraded"), ("retained", "degraded"), ("released", "disabled")],

--- a/tests/test_memory_disabled_isolation.py
+++ b/tests/test_memory_disabled_isolation.py
@@ -638,6 +638,30 @@ async def test_enabled_operation_bounds_disabled_cleanup_wait_and_remains_retrya
             match="Disabled Memory cleanup is still in progress",
         ):
             await asyncio.wait_for(controller.wake_memory(), timeout=0.1)
+
+        class _Python310AsyncioTimeoutError(Exception):
+            pass
+
+        async def raise_python310_timeout(
+            _future: object,
+            *,
+            timeout: float,
+        ) -> None:
+            assert timeout == 0.01
+            raise _Python310AsyncioTimeoutError
+
+        with monkeypatch.context() as python310:
+            python310.setattr(
+                asyncio,
+                "TimeoutError",
+                _Python310AsyncioTimeoutError,
+            )
+            python310.setattr(asyncio, "wait_for", raise_python310_timeout)
+            with pytest.raises(
+                MemoryStoreUnavailableError,
+                match="Disabled Memory cleanup is still in progress",
+            ):
+                await controller.wake_memory()
         assert cleanup_task.done() is False
         assert cleanup_task.cancelled() is False
 


### PR DESCRIPTION
## Summary

- bound explicit Memory operations waiting on an older disabled EverOS cleanup
- keep the cleanup task shielded and running after a caller reaches its wait budget
- preserve fail-closed behavior and prove the same operation succeeds after cleanup settles

## Scope

- Affected scenario IDs: none; this is a focused controller lifecycle contract correction
- No Memory capture, package identity, release workflow, migration, rollback, Gate5, Incus, or local service changes

## Evidence

- Unit/contract: `219 passed, 1 skipped` across disabled isolation, Memory wake, and internal routes
- Static: Ruff and `git diff --check` clean
- Scenario: existing disabled-isolation scenarios remain unchanged
- Residual manual checks: none; no local Avibe restart was performed

## Known By Design

- A timed-out caller receives the existing fail-closed `memory_store_unavailable` transport outcome
- The cleanup task is not cancelled or replayed; callers can retry after it settles
