### PR TITLE
fix(ui): preserve Settings overlay in production router

### DIFF
--- a/ui/src/components/settings/SettingsOverlayNavigationBoundary.tsx
+++ b/ui/src/components/settings/SettingsOverlayNavigationBoundary.tsx
@@ -1,17 +1,17 @@
 import { useContext, useMemo } from 'react';
 import type { ReactNode } from 'react';
 import {
-  parsePath,
+  resolvePath,
+  UNSAFE_DataRouterContext as DataRouterContext,
   UNSAFE_NavigationContext as NavigationContext,
   useLocation,
 } from 'react-router-dom';
-import type { Navigator, To } from 'react-router-dom';
+import type { Navigator, RouterNavigateOptions, To } from 'react-router-dom';
 
 import { settingsOverlayNavigationState } from '@/lib/settingsOverlay';
 
 const destinationPathname = (to: To, fallback: string): string => {
-  const pathname = typeof to === 'string' ? parsePath(to).pathname : to.pathname;
-  return pathname ?? fallback;
+  return resolvePath(to, fallback).pathname;
 };
 
 export const SettingsOverlayNavigationBoundary = ({
@@ -23,6 +23,7 @@ export const SettingsOverlayNavigationBoundary = ({
 }) => {
   const location = useLocation();
   const navigation = useContext(NavigationContext);
+  const dataNavigation = useContext(DataRouterContext);
   // Every Settings-bound navigation carries one durable origin. This is the
   // ownership point for all links, redirects, and programmatic navigation.
   const navigator = useMemo<Navigator>(() => ({
@@ -52,10 +53,43 @@ export const SettingsOverlayNavigationBoundary = ({
     () => ({ ...navigation, navigator }),
     [navigation, navigator],
   );
+  // Data routers bypass NavigationContext and call router.navigate directly.
+  // Keep the same state owner in both router modes so production and tests
+  // cannot disagree about whether Settings has a background location.
+  const scopedDataNavigation = useMemo(() => {
+    if (!dataNavigation) return null;
+    const router = Object.create(dataNavigation.router) as typeof dataNavigation.router;
+    router.navigate = ((
+      to: number | To | null,
+      options?: RouterNavigateOptions,
+    ): Promise<void> => {
+      if (typeof to === 'number' || to === null) {
+        return typeof to === 'number'
+          ? dataNavigation.router.navigate(to)
+          : dataNavigation.router.navigate(to, options);
+      }
+      return dataNavigation.router.navigate(to, {
+        ...options,
+        state: settingsOverlayNavigationState({
+          destinationPathname: destinationPathname(to, location.pathname),
+          desktop,
+          source: location,
+          targetState: options?.state,
+        }),
+      });
+    }) as typeof dataNavigation.router.navigate;
+    return { ...dataNavigation, router };
+  }, [dataNavigation, desktop, location]);
+
+  const content = scopedDataNavigation ? (
+    <DataRouterContext.Provider value={scopedDataNavigation}>
+      {children}
+    </DataRouterContext.Provider>
+  ) : children;
 
   return (
     <NavigationContext.Provider value={scopedNavigation}>
-      {children}
+      {content}
     </NavigationContext.Provider>
   );
 };

--- a/ui/src/components/settings/SettingsOverlayRouteSurface.test.tsx
+++ b/ui/src/components/settings/SettingsOverlayRouteSurface.test.tsx
@@ -10,7 +10,9 @@ import {
   Navigate,
   Outlet,
   Route,
+  RouterProvider,
   Routes,
+  createMemoryRouter,
   useLocation,
   useNavigate,
 } from 'react-router-dom';
@@ -162,6 +164,27 @@ afterEach(() => {
 });
 
 describe('SettingsOverlayRouteSurface', () => {
+  it('preserves the Chat route with a data router', async () => {
+    const user = userEvent.setup();
+    const router = createMemoryRouter([
+      { path: '*', element: <Harness desktop /> },
+    ], {
+      initialEntries: ['/chat/ses_1'],
+    });
+    render(<RouterProvider router={router} />);
+
+    await user.click(screen.getByRole('link', { name: 'shell-settings' }));
+
+    expect(screen.getByRole('dialog', { name: 'nav.settings' })).toBeTruthy();
+    await user.click(screen.getByRole('button', { name: 'close-settings' }));
+    expect(screen.getByTestId('chat-location').textContent).toBe('/chat/ses_1');
+
+    await user.click(screen.getByRole('link', { name: 'shell-settings' }));
+    expect(screen.getByRole('dialog', { name: 'nav.settings' })).toBeTruthy();
+    await user.click(screen.getByRole('button', { name: 'shell-settings' }));
+    expect(screen.getByTestId('chat-location').textContent).toBe('/chat/ses_1');
+  });
+
   it('keeps the background route mounted across Settings navigation and close', async () => {
     const user = userEvent.setup();
     const view = render(
@@ -253,9 +276,9 @@ describe('SettingsOverlayRouteSurface', () => {
 
     await user.click(screen.getByRole('link', { name: 'shell-settings' }));
     expect(screen.getByRole('dialog', { name: 'nav.settings' })).toBeTruthy();
-    const backdrop = document.querySelector<HTMLElement>('[data-dialog-surface-backdrop="true"]');
-    expect(backdrop).not.toBeNull();
-    await user.click(backdrop!);
+    expect(document.body.style.pointerEvents).not.toBe('none');
+    expect(document.querySelector('[data-dialog-surface-backdrop="true"]')).toBeNull();
+    await user.click(screen.getByRole('button', { name: 'shell-settings' }));
 
     await waitFor(() => expect(document.querySelector('[data-settings-overlay="true"]')).toBeNull());
     expect(screen.getByTestId('chat-location').textContent).toBe('/chat/ses_1');

--- a/ui/src/components/settings/SettingsOverlayRouteSurface.tsx
+++ b/ui/src/components/settings/SettingsOverlayRouteSurface.tsx
@@ -66,6 +66,7 @@ export const SettingsOverlayRouteSurface = ({
       {settingsSurfaceOpen ? (
         <Dialog
           open
+          modal={false}
           onOpenChange={(open) => {
             if (!open) closeSettingsOverlay(navigate, origin);
           }}
@@ -74,6 +75,15 @@ export const SettingsOverlayRouteSurface = ({
             <DialogSurfaceContent
               data-settings-overlay="true"
               aria-describedby={undefined}
+              onInteractOutside={(event) => {
+                const target = event.target;
+                if (
+                  target instanceof Element
+                  && target.closest('[data-settings-toggle="true"]')
+                ) {
+                  event.preventDefault();
+                }
+              }}
               onCloseAutoFocus={(event) => {
                 event.preventDefault();
                 window.requestAnimationFrame(() => {


### PR DESCRIPTION
## Summary

- preserve the current Chat location when desktop Settings is opened through the production data router
- keep the persistent Settings toggle interactive while the route-sized panel is open
- close through either the panel button or the persistent toggle without remounting the background route

## Root Cause

The first implementation wrapped only React Router's declarative navigation context. Production uses a data router, whose `useNavigate` calls `DataRouterContext.router.navigate` directly, so Settings never received the background-location state outside the old `MemoryRouter` tests. The modal dialog also disabled pointer interaction with the persistent sidebar toggle.

This change keeps one Settings navigation-state owner across both router modes and makes only the background route inert while leaving the persistent sidebar usable.

## Evidence

- full UI suite: 267 files, 3,385 tests passed
- focused Settings/navigation suite: 35 tests passed
- lint baseline gate passed
- production UI build passed
- real Chrome against the existing local Incus data: both close paths returned to the exact original Chat URL with the Chat surface still mounted

## Scenario Catalog

No existing scenario ID covers this route-overlay interaction.

## Dependencies

None.

## Known By Design

Direct Settings URLs remain primary pages because they have no background route to preserve.
