### PR TITLE
feat(upgrade): converge Memory from a preview release's own wheels

### DIFF
--- a/docs/plans/preview-install-convergence.md
+++ b/docs/plans/preview-install-convergence.md
@@ -1,0 +1,145 @@
+# Preview Install Convergence
+
+> Status: implemented (scenario MEMORY-INDEP-027)
+>
+> Scope: a `gh-v*` preview install or preview-to-preview upgrade is one
+> copyable `uv tool install` command for the core wheel; the Memory companion
+> converges automatically afterward. No CLI surface changes. The official
+> `v*` / PyPI publication and upgrade contract is untouched.
+>
+> Replaces the earlier `memory-preview-bundle` and `preview-upgrade` drafts.
+> Deliberately dropped from those drafts: bundle manifest asset, digest
+> pipeline, GitHub API discovery, new CLI flags, and Web UI channel control.
+
+## Problem
+
+A `gh-v*` release attaches the `avibe-os` and `avibe-memory` wheels as GitHub
+Release assets and publishes nothing to PyPI. Installing a preview therefore
+means assembling `uv tool install <core-url> --with <memory-url> --force` from
+two long asset URLs, and the operator must remember the Memory wheel even when
+Memory is already installed. Installing only the core is worse than
+inconvenient: the post-ready Memory package repair treats the rc version as
+published, pins `avibe-memory==<rc>` against PyPI where it does not exist, and
+burns its bounded three-attempt budget on installs that can never succeed.
+
+## Design
+
+The single user action, for first install and for every preview-to-preview
+upgrade, is the one command printed in the `gh-v*` release notes:
+
+```bash
+uv tool install https://github.com/avibe-bot/avibe/releases/download/<tag>/avibe_os-<version>-py3-none-any.whl --force
+```
+
+`uv tool install --force` rebuilds the tool environment from that single spec,
+so the previously installed `avibe-memory` is dropped — intentionally. After
+the service restarts and reaches readiness, the **existing** reconciler
+(`reconcile_memory_package_on_startup` → `_prepare_memory_package_job`)
+observes that Memory is required and the companion is missing or
+version-mismatched, and repairs it. The only change is where the repair points
+its package specs when the running version is a preview.
+
+### Preview-aware repair specs
+
+When the running version is a clean PEP 440 prerelease (`is_prerelease`, not a
+dev release, no local segment), the repair plan's two specs are derived — not
+discovered — from the fixed release convention:
+
+- tag: `gh-v<version>` (the normalized running version)
+- core: `https://github.com/avibe-bot/avibe/releases/download/gh-v<version>/avibe_os-<version>-py3-none-any.whl`
+- memory: `https://github.com/avibe-bot/avibe/releases/download/gh-v<version>/avibe_memory-<version>-py3-none-any.whl`
+
+No GitHub API call is made; the URLs are pure functions of the running
+version. Non-prerelease versions keep today's exact PyPI pins. Dev and local
+versions keep today's refusal (`memory_package_unpublished_build`).
+
+The wheel filename embeds the normalized version, so tag and filename
+derivation share one normalization; the released artifacts' reciprocal exact
+pins (`avibe-os==X ⇄ avibe-memory==X` in published METADATA) remain the
+pairing integrity gate — uv fails resolution if the pair does not match.
+
+### Plan builder extension
+
+`build_upgrade_plan` gains two optional parameters honored only in
+exact-version mode: `core_spec` and `memory_spec`. When set, they replace the
+`avibe-os==<version>` / `avibe-memory==<version>` pins in the install and
+preflight commands. Defaults are `None`, and every existing call site passes
+neither, so all current plans — stable CLI upgrade, stable Web upgrade, stable
+repair — are byte-identical to today. Exact-version semantics (install into
+the current tool dir, `--force`, no `--upgrade`, service-scope restart) are
+unchanged.
+
+### Surfaces that benefit without changes
+
+- the automatic startup reconciler;
+- the manual "install memory-package" job on the Web UI Dependencies page
+  (same `_prepare_memory_package_job` implementation);
+- the bounded three-attempt budget, shared upgrade lock, integrity
+  verification, and `memory-package-repair` service restart, all reused as-is.
+
+## Behavior
+
+| Situation | Result |
+| --- | --- |
+| preview core installed, Memory enabled or previously installed | repair installs the exact-version wheel pair from the GitHub release, then service restart |
+| preview core installed, Memory disabled and absent | reconciler skips; zero download, zero install |
+| preview release or asset missing (404), network failure | structured `memory_package_install_failed`; attempt budget consumed; stays repairable from the Dependencies page |
+| dev / local / source build | refused before any network access, as today |
+| stable version running | exact PyPI pins, byte-identical to today |
+| preview → newer preview | same single `uv tool install` command from the new tag's notes |
+| preview → stable | ordinary `vibe upgrade` once PyPI has a newer official version; the stable path carries Memory automatically |
+
+## Official upgrade path — invariants
+
+This change must not alter any official `v*` behavior:
+
+1. `vibe upgrade` (CLI) and Web `do_upgrade` never pass the new parameters;
+   their plans are unchanged for every input.
+2. The stable repair/reconcile branch is selected by `is_prerelease == False`
+   and keeps today's exact PyPI pins.
+3. `publish.yml`, PyPI ordering (Memory before core), and release asset
+   contracts are untouched.
+4. Regression tests assert the stable plan shapes byte-for-byte (extending the
+   existing exact-plan contract test in `tests/test_upgrade_flow.py`).
+
+## Failure and security bounds
+
+- Fixed repository, HTTPS only, derived URLs; no redirect-following logic of
+  our own — uv performs the download inside the existing install step.
+- All failures surface through the existing structured repair results; no new
+  failure lifecycle, no rollback, no reservation, no quarantine.
+- Error output follows the existing truncation and never adds credentials or
+  URLs beyond what the install command already contains.
+
+## Testing
+
+- URL/tag derivation unit tests: rc/a/b versions, normalization, dev/local
+  refusal, stable versions bypass;
+- plan-shape tests: `core_spec`/`memory_spec` rendering in uv and pip exact
+  plans and their preflights; omitted parameters produce today's commands
+  byte-for-byte;
+- repair tests: prerelease running version produces derived URL specs;
+  attempt budget, lock, and restart behavior unchanged; 404-style install
+  failure yields the existing structured result;
+- reconciler tests: required+missing converges, disabled skips, mismatch at a
+  preview version converges to the running version's pair.
+
+## Delivery
+
+One PR: derivation helper + `core_spec`/`memory_spec` + preview branch in
+`_prepare_memory_package_job` + tests. No publish workflow asset changes.
+
+### As shipped
+
+- `preview_release_specs` in `vibe/upgrade.py` derives the pair, and
+  `build_upgrade_plan` renders `memory_spec` as the PEP 508 direct reference
+  `avibe-memory @ <url>` so every installer still reads it as a named
+  distribution rather than an anonymous artifact.
+- Sources without an exact `version` raise `ValueError` instead of being
+  ignored. A forward upgrade resolves the newest release and has no known pair
+  to name, so a silently dropped spec would read as applied — this is a
+  decision beyond the original draft, and the invariant-1 tests assert it.
+- The optional `gh-v*` release-notes template line is **not** in this PR. The
+  notes are produced by the shared `release_ai.yml` generator, which also
+  writes official `v*` notes, so changing it would put invariant 3 at risk for
+  a text-only convenience. It stays a separate workflow-side change.

--- a/docs/plans/preview-install-convergence.md
+++ b/docs/plans/preview-install-convergence.md
@@ -39,24 +39,37 @@ observes that Memory is required and the companion is missing or
 version-mismatched, and repairs it. The only change is where the repair points
 its package specs when the running version is a preview.
 
-### Preview-aware repair specs
+### Origin-aware repair specs
 
-When the running version is a clean PEP 440 prerelease (`is_prerelease`, not a
-dev release, no local segment), the repair plan's two specs are derived — not
-discovered — from the fixed release convention:
+**The version string cannot decide this.** `publish.yml` triggers on `v*` and
+accepts official `vX.Y.ZrcN` tags, publishing both packages to PyPI. Such a
+build carries a version indistinguishable from a `gh-v*` build of the same
+number, so treating every clean prerelease as GitHub-only would point the
+official one at a `gh-vX.Y.ZrcN` tag that was never created — reproducing the
+exact 404-and-burn-the-budget failure this plan exists to fix, one version
+class over.
 
-- tag: `gh-v<version>` (the normalized running version)
-- core: `https://github.com/avibe-bot/avibe/releases/download/gh-v<version>/avibe_os-<version>-py3-none-any.whl`
-- memory: `https://github.com/avibe-bot/avibe/releases/download/gh-v<version>/avibe_memory-<version>-py3-none-any.whl`
+The installer already recorded the answer. PEP 610 requires a
+`direct_url.json` in the installed `.dist-info` whenever a distribution came
+from somewhere other than an index, so:
 
-No GitHub API call is made; the URLs are pure functions of the running
-version. Non-prerelease versions keep today's exact PyPI pins. Dev and local
-versions keep today's refusal (`memory_package_unpublished_build`).
+- **no record** → resolved by name from an index → keep today's exact PyPI
+  pins. This covers every PyPI install, official prereleases included.
+- **record naming a release asset of this repository** → repair from that same
+  release: the core spec is the recorded URL itself, and the memory spec is its
+  sibling in the same release directory.
+- **any other record** (a local file, another repository, a directory or VCS
+  install) → keep index pins, i.e. today's behavior.
 
-The wheel filename embeds the normalized version, so tag and filename
-derivation share one normalization; the released artifacts' reciprocal exact
-pins (`avibe-os==X ⇄ avibe-memory==X` in published METADATA) remain the
-pairing integrity gate — uv fails resolution if the pair does not match.
+No GitHub API call is made, and no tag is derived from a convention: the pair
+comes from the release the running copy demonstrably came from. The recorded
+URL must name the exact running version, so a stale or mismatched record cannot
+drive the repair to a different pair. Dev and local versions keep today's
+refusal (`memory_package_unpublished_build`).
+
+The released artifacts' reciprocal exact pins (`avibe-os==X ⇄ avibe-memory==X`
+in published METADATA) remain the pairing integrity gate — uv fails resolution
+if the pair does not match.
 
 ### Plan builder extension
 
@@ -85,7 +98,7 @@ unchanged.
 | preview core installed, Memory disabled and absent | reconciler skips; zero download, zero install |
 | preview release or asset missing (404), network failure | structured `memory_package_install_failed`; attempt budget consumed; stays repairable from the Dependencies page |
 | dev / local / source build | refused before any network access, as today |
-| stable version running | exact PyPI pins, byte-identical to today |
+| installed from an index (any version, official `vX.Y.ZrcN` included) | exact PyPI pins, byte-identical to today |
 | preview → newer preview | same single `uv tool install` command from the new tag's notes |
 | preview → stable | ordinary `vibe upgrade` once PyPI has a newer official version; the stable path carries Memory automatically |
 
@@ -95,8 +108,10 @@ This change must not alter any official `v*` behavior:
 
 1. `vibe upgrade` (CLI) and Web `do_upgrade` never pass the new parameters;
    their plans are unchanged for every input.
-2. The stable repair/reconcile branch is selected by `is_prerelease == False`
-   and keeps today's exact PyPI pins.
+2. The repair branch is selected by publication channel, not version shape: an
+   install with no PEP 610 origin record came from an index and keeps today's
+   exact PyPI pins. This is what makes an official `vX.Y.ZrcN` PyPI prerelease
+   safe, and it is the reason the selector is not `is_prerelease`.
 3. `publish.yml`, PyPI ordering (Memory before core), and release asset
    contracts are untouched.
 4. Regression tests assert the stable plan shapes byte-for-byte (extending the
@@ -131,10 +146,14 @@ One PR: derivation helper + `core_spec`/`memory_spec` + preview branch in
 
 ### As shipped
 
-- `preview_release_specs` in `vibe/upgrade.py` derives the pair, and
-  `build_upgrade_plan` renders `memory_spec` as the PEP 508 direct reference
-  `avibe-memory @ <url>` so every installer still reads it as a named
-  distribution rather than an anonymous artifact.
+- `release_asset_specs` in `vibe/upgrade.py` reads the PEP 610 origin and
+  returns the pair, and `build_upgrade_plan` renders `memory_spec` as the PEP
+  508 direct reference `avibe-memory @ <url>` so every installer still reads it
+  as a named distribution rather than an anonymous artifact.
+- The first draft keyed this on `is_prerelease`. Codex review of PR #1806
+  caught that `publish.yml` publishes official `vX.Y.ZrcN` tags to PyPI, so the
+  basis moved from version shape to recorded install origin — which is the
+  thing actually being asked about, and cannot be wrong about a channel.
 - Sources without an exact `version` raise `ValueError` instead of being
   ignored. A forward upgrade resolves the newest release and has no known pair
   to name, so a silently dropped spec would read as applied — this is a

--- a/tests/scenarios/memory_independence/catalog.yaml
+++ b/tests/scenarios/memory_independence/catalog.yaml
@@ -158,3 +158,9 @@ scenarios:
     kind: compatibility
     layer: scenario
     test: tests/e2e/test_upgrade_command.py::test_memory_indep_026_upgrade_command_bridges_released_3_0_13_generation
+  - id: MEMORY-INDEP-027
+    name: A core-only preview install converges to the Memory companion published by its own release
+    status: covered
+    kind: compatibility
+    layer: scenario
+    test: tests/test_local_deps.py::test_memory_indep_027_preview_repair_installs_the_release_that_published_it

--- a/tests/scenarios/memory_independence/test_memory_independence_catalog.py
+++ b/tests/scenarios/memory_independence/test_memory_independence_catalog.py
@@ -44,6 +44,22 @@ def test_memory_indep_021_catalog_points_to_executable_import_fence() -> None:
     assert "test_memory_indep_021_status_import_fence" in test_source
 
 
+def test_memory_indep_027_catalog_points_to_preview_release_convergence() -> None:
+    catalog = yaml.safe_load(
+        (ROOT / "tests/scenarios/memory_independence/catalog.yaml").read_text()
+    )
+    scenario = next(
+        item for item in catalog["scenarios"] if item["id"] == "MEMORY-INDEP-027"
+    )
+
+    assert scenario["status"] == "covered"
+    assert scenario["test"].endswith(
+        "test_memory_indep_027_preview_repair_installs_the_release_that_published_it"
+    )
+    test_source = (ROOT / "tests/test_local_deps.py").read_text()
+    assert "test_memory_indep_027_preview_repair_installs_the_release_that_published_it" in test_source
+
+
 def test_memory_indep_026_catalog_points_to_released_first_hop_upgrade() -> None:
     catalog = yaml.safe_load(
         (ROOT / "tests/scenarios/memory_independence/catalog.yaml").read_text()

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -2400,34 +2400,36 @@ def test_memory_package_server_admission_rejects_nonrepairable_rows(
     }
 
 
-#: Where each kind of running version is published, and therefore which install
-#: sources its repair has to name. A preview release is served by its own
-#: GitHub release and by no index, so pinning it by name would resolve against
-#: a PyPI that never had it.
-PUBLISHED_VERSION_SOURCES = {
-    "final": ("3.0.14", None, None),
-    "preview": (
-        "3.0.14rc8",
-        "https://github.com/avibe-bot/avibe/releases/download/gh-v3.0.14rc8/avibe_os-3.0.14rc8-py3-none-any.whl",
-        (
-            "https://github.com/avibe-bot/avibe/releases/download/gh-v3.0.14rc8/"
-            "avibe_memory-3.0.14rc8-py3-none-any.whl"
-        ),
-    ),
+#: One running version, published two ways. `publish.yml` accepts official
+#: `vX.Y.ZrcN` tags and publishes them to PyPI, while a `gh-v*` build of the
+#: identical version is on no index at all — so the version string cannot pick
+#: the repair sources and only the recorded install origin can. Both rows use
+#: the same version deliberately.
+REPAIR_VERSION = "3.0.14rc8"
+RELEASE_CORE_URL = f"https://github.com/avibe-bot/avibe/releases/download/gh-v{REPAIR_VERSION}/avibe_os-{REPAIR_VERSION}-py3-none-any.whl"
+RELEASE_MEMORY_URL = (
+    f"https://github.com/avibe-bot/avibe/releases/download/gh-v{REPAIR_VERSION}/"
+    f"avibe_memory-{REPAIR_VERSION}-py3-none-any.whl"
+)
+INSTALL_ORIGIN_SOURCES = {
+    "index install": (None, None, None),
+    "release asset install": (RELEASE_CORE_URL, RELEASE_CORE_URL, RELEASE_MEMORY_URL),
 }
 
 
 @pytest.mark.parametrize(
-    ("current_version", "core_spec", "memory_spec"),
-    list(PUBLISHED_VERSION_SOURCES.values()),
-    ids=list(PUBLISHED_VERSION_SOURCES),
+    ("origin", "core_spec", "memory_spec"),
+    list(INSTALL_ORIGIN_SOURCES.values()),
+    ids=list(INSTALL_ORIGIN_SOURCES),
 )
-def test_memory_package_dependency_job_targets_the_running_version_wherever_it_is_published(
+def test_memory_package_dependency_job_targets_the_running_version_wherever_it_came_from(
     monkeypatch,
-    current_version: str,
+    origin: str | None,
     core_spec: str | None,
     memory_spec: str | None,
 ) -> None:
+    current_version = REPAIR_VERSION
+    monkeypatch.setattr("vibe.upgrade._recorded_install_origin", lambda _package: origin)
     plan = SimpleNamespace(
         command=["repair"],
         activation=None,
@@ -2527,8 +2529,9 @@ def test_memory_indep_027_preview_repair_installs_the_release_that_published_it(
     matters is the command an installer would actually run.
     """
 
-    current_version = "3.0.14rc8"
+    current_version = REPAIR_VERSION
     calls: dict[str, object] = {}
+    monkeypatch.setattr("vibe.upgrade._recorded_install_origin", lambda _package: RELEASE_CORE_URL)
     monkeypatch.setattr(api, "_memory_package_repair_rejection", lambda **_kwargs: None)
     monkeypatch.setattr(api, "_published_running_version", lambda: current_version)
     monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/bin/vibe")

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -2400,7 +2400,34 @@ def test_memory_package_server_admission_rejects_nonrepairable_rows(
     }
 
 
-def test_memory_package_dependency_job_uses_existing_pinned_plan(monkeypatch) -> None:
+#: Where each kind of running version is published, and therefore which install
+#: sources its repair has to name. A preview release is served by its own
+#: GitHub release and by no index, so pinning it by name would resolve against
+#: a PyPI that never had it.
+PUBLISHED_VERSION_SOURCES = {
+    "final": ("3.0.14", None, None),
+    "preview": (
+        "3.0.14rc8",
+        "https://github.com/avibe-bot/avibe/releases/download/gh-v3.0.14rc8/avibe_os-3.0.14rc8-py3-none-any.whl",
+        (
+            "https://github.com/avibe-bot/avibe/releases/download/gh-v3.0.14rc8/"
+            "avibe_memory-3.0.14rc8-py3-none-any.whl"
+        ),
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    ("current_version", "core_spec", "memory_spec"),
+    list(PUBLISHED_VERSION_SOURCES.values()),
+    ids=list(PUBLISHED_VERSION_SOURCES),
+)
+def test_memory_package_dependency_job_targets_the_running_version_wherever_it_is_published(
+    monkeypatch,
+    current_version: str,
+    core_spec: str | None,
+    memory_spec: str | None,
+) -> None:
     plan = SimpleNamespace(
         command=["repair"],
         activation=None,
@@ -2410,7 +2437,7 @@ def test_memory_package_dependency_job_uses_existing_pinned_plan(monkeypatch) ->
     calls: dict[str, object] = {}
     lock_events: list[str] = []
     monkeypatch.setattr(api, "_memory_package_repair_rejection", lambda **_kwargs: None)
-    monkeypatch.setattr(api, "_published_running_version", lambda: "3.0.14")
+    monkeypatch.setattr(api, "_published_running_version", lambda: current_version)
     monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/bin/vibe")
     monkeypatch.setattr(api, "get_safe_cwd", lambda: "/safe")
     monkeypatch.setattr(api, "restart_is_pending", lambda: False)
@@ -2456,11 +2483,13 @@ def test_memory_package_dependency_job_uses_existing_pinned_plan(monkeypatch) ->
     assert result["ok"] is True
     assert result["message"] == "memory_package_ready"
     assert calls["plan"] == {
-        "version": "3.0.14",
+        "version": current_version,
         "package_name": api.PACKAGE_NAME,
         "memory_package": True,
-        "memory_version": "3.0.14",
+        "memory_version": current_version,
         "vibe_path": "/bin/vibe",
+        "core_spec": core_spec,
+        "memory_spec": memory_spec,
     }
     assert calls["execute"] == (
         plan,
@@ -2482,10 +2511,67 @@ def test_memory_package_dependency_job_uses_existing_pinned_plan(monkeypatch) ->
     assert result["restart"] == {"job_id": "restart"}
     assert lock_events == ["entered", "build", "execute", "restart", "exited"]
     record_result.assert_called_once_with(
-        "3.0.14",
+        current_version,
         result="restart_scheduled",
         reason=None,
     )
+
+
+def test_memory_indep_027_preview_repair_installs_the_release_that_published_it(
+    monkeypatch,
+) -> None:
+    """MEMORY-INDEP-027: a core-only preview install converges from its own release.
+
+    A `gh-v*` release publishes the wheel pair as release assets and nothing to
+    an index, so this builds the real plan rather than a recorded call: what
+    matters is the command an installer would actually run.
+    """
+
+    current_version = "3.0.14rc8"
+    calls: dict[str, object] = {}
+    monkeypatch.setattr(api, "_memory_package_repair_rejection", lambda **_kwargs: None)
+    monkeypatch.setattr(api, "_published_running_version", lambda: current_version)
+    monkeypatch.setattr(api, "get_running_vibe_path", lambda: "/bin/vibe")
+    monkeypatch.setattr(api, "get_safe_cwd", lambda: "/safe")
+    monkeypatch.setattr(api, "restart_is_pending", lambda: False)
+    monkeypatch.setattr(api, "_memory_package_restart_retry_required", lambda _version: False)
+    monkeypatch.setattr(api, "_record_memory_package_repair_result", Mock())
+    monkeypatch.setattr(api, "atomic_upgrade_lock", nullcontext)
+    monkeypatch.setattr(api, "schedule_restart", lambda **_kwargs: {"job_id": "restart"})
+    monkeypatch.setattr(
+        api,
+        "verify_python_environment",
+        lambda _python: SimpleNamespace(ok=True, detail="ok"),
+    )
+    # Resolve to the pip installer so the plan is built from this interpreter
+    # without consulting any uv tool environment on the host.
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **_kwargs: None)
+
+    def execute_plan(plan, **_kwargs):
+        calls["plan"] = plan
+        return subprocess.CompletedProcess(plan.command, 0, stdout="installed", stderr="")
+
+    monkeypatch.setattr(api, "execute_upgrade_plan", execute_plan)
+
+    result = api._prepare_memory_package_job(automatic=True)
+
+    assert result["ok"] is True
+    assert result["restarting"] is True
+    plan = calls["plan"]
+    release = f"https://github.com/avibe-bot/avibe/releases/download/gh-v{current_version}/"
+    commands = [
+        command
+        for command in (plan.command, plan.preflight_command, plan.preflight_fallback_command)
+        if command
+    ]
+    assert len(commands) >= 2, "the repair resolves the pair before it installs it"
+    for command in commands:
+        assert f"{release}avibe_os-{current_version}-py3-none-any.whl" in command
+        assert f"avibe-memory @ {release}avibe_memory-{current_version}-py3-none-any.whl" in command
+        # An index pin here is the bug: PyPI never served this version, so the
+        # install fails and spends one of the bounded repair attempts.
+        assert f"{api.PACKAGE_NAME}=={current_version}" not in command
+        assert f"{api.MEMORY_PACKAGE_NAME}=={current_version}" not in command
 
 
 def test_memory_package_dependency_job_fails_closed_when_restart_cannot_be_scheduled(

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 from contextlib import nullcontext
+import json
 import os
 import stat
 import subprocess
@@ -16,6 +17,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from vibe import api, cli, runtime
+from vibe import upgrade as vibe_upgrade
 from vibe.runtime import ServiceLauncher
 from vibe.upgrade import (
     AtomicActivation,
@@ -36,7 +38,7 @@ from vibe.upgrade import (
     get_running_vibe_path,
     get_safe_cwd,
     pinned_package_spec,
-    preview_release_specs,
+    release_asset_specs,
     execute_upgrade_plan,
     restart_is_pending,
 )
@@ -1029,39 +1031,105 @@ PREVIEW_MEMORY_URL = (
 )
 
 
-def test_preview_release_specs_name_one_release_of_the_running_version():
-    assert preview_release_specs(PREVIEW_VERSION) == (PREVIEW_CORE_URL, PREVIEW_MEMORY_URL)
+def _installed_from(monkeypatch, origin: str | None) -> None:
+    """Record where the installer says this copy of core came from."""
+
+    monkeypatch.setattr("vibe.upgrade._recorded_install_origin", lambda _package: origin)
+
+
+def test_the_companion_comes_from_the_release_core_was_installed_from(monkeypatch):
+    _installed_from(monkeypatch, PREVIEW_CORE_URL)
+
+    assert release_asset_specs(PREVIEW_VERSION) == (PREVIEW_CORE_URL, PREVIEW_MEMORY_URL)
+
+
+def test_an_official_prerelease_on_pypi_keeps_its_index_pins(monkeypatch):
+    # `publish.yml` accepts official `vX.Y.ZrcN` tags and publishes them to
+    # PyPI. Such a build carries a version indistinguishable from a `gh-v*`
+    # one, so only its origin can say that `gh-v3.0.16rc1` was never created.
+    _installed_from(monkeypatch, None)
+
+    assert release_asset_specs(PREVIEW_VERSION) is None
 
 
 @pytest.mark.parametrize(
     "spelling",
     ["3.0.16rc1", "3.0.16RC1", "3.0.16-rc-1", "v3.0.16rc1", "3.0.16.rc.1"],
 )
-def test_one_normalization_spells_the_tag_and_both_filenames(spelling):
-    # The release names its tag and its assets after the same normalized
-    # version, so any disagreement between the two derivations is a 404.
-    specs = preview_release_specs(spelling)
-    assert specs is not None
-    assert {url.split("/download/")[1].split("/")[0] for url in specs} == {"gh-v3.0.16rc1"}
-    assert all(url.endswith("-3.0.16rc1-py3-none-any.whl") for url in specs)
+def test_one_normalization_matches_the_origin_and_names_the_companion(monkeypatch, spelling):
+    # The recorded URL spells the version the way a wheel filename does, so the
+    # match against the running version must normalize both the same way.
+    _installed_from(monkeypatch, PREVIEW_CORE_URL)
+
+    assert release_asset_specs(spelling) == (PREVIEW_CORE_URL, PREVIEW_MEMORY_URL)
 
 
 @pytest.mark.parametrize(
-    "version",
+    ("origin", "version"),
     [
-        "3.0.16",  # a final release: the index serves it
-        "3.1",
-        "3.0.16.post1",
-        "3.0.16.dev0",  # names this tree, not any release
-        "3.0.16rc1.dev2",
-        "3.0.16rc1+g1234567",
-        "3.0.16+local",
-        "",
-        "not-a-version",
+        # An index install records no origin at all: it is repairable by name.
+        (None, PREVIEW_VERSION),
+        ("", PREVIEW_VERSION),
+        # Somewhere that is not a release asset of this repository.
+        ("https://example.com/gh-v3.0.16rc1/avibe_os-3.0.16rc1-py3-none-any.whl", PREVIEW_VERSION),
+        ("https://github.com/other/repo/releases/download/gh-v3.0.16rc1/avibe_os-3.0.16rc1-py3-none-any.whl", PREVIEW_VERSION),
+        ("file:///tmp/avibe_os-3.0.16rc1-py3-none-any.whl", PREVIEW_VERSION),
+        ("https://github.com/avibe-bot/avibe/releases/download/avibe_os-3.0.16rc1-py3-none-any.whl", PREVIEW_VERSION),
+        (
+            "https://github.com/avibe-bot/avibe/releases/download/gh-v3.0.16rc1/nested/avibe_os-3.0.16rc1-py3-none-any.whl",
+            PREVIEW_VERSION,
+        ),
+        (
+            "https://github.com/avibe-bot/avibe/releases/download/../gh-v3.0.16rc1/avibe_os-3.0.16rc1-py3-none-any.whl",
+            PREVIEW_VERSION,
+        ),
+        # The recorded asset names a different distribution or version than the
+        # one being repaired, so it cannot say where this pair lives.
+        (PREVIEW_MEMORY_URL, PREVIEW_VERSION),
+        (PREVIEW_CORE_URL, "3.0.16rc2"),
+        (PREVIEW_CORE_URL, "3.0.16"),
+        (PREVIEW_CORE_URL, ""),
+        (PREVIEW_CORE_URL, "not-a-version"),
     ],
 )
-def test_preview_release_specs_refuse_a_version_no_preview_release_serves(version):
-    assert preview_release_specs(version) is None
+def test_an_origin_that_cannot_name_this_pair_keeps_index_pins(monkeypatch, origin, version):
+    _installed_from(monkeypatch, origin)
+
+    assert release_asset_specs(version) is None
+
+
+def test_a_missing_or_unreadable_origin_record_reads_as_an_index_install(monkeypatch):
+    class _Distribution:
+        def __init__(self, recorded):
+            self._recorded = recorded
+
+        def read_text(self, _name):
+            return self._recorded
+
+    recorded_values = [None, "", "not json", "[]", "{}", '{"url": 7}']
+    for recorded in recorded_values:
+        monkeypatch.setattr(
+            "importlib.metadata.distribution",
+            lambda _name, recorded=recorded: _Distribution(recorded),
+        )
+        assert vibe_upgrade._recorded_install_origin("avibe-os") is None, recorded
+
+    def _raise(_name):
+        raise RuntimeError("metadata is unreadable")
+
+    monkeypatch.setattr("importlib.metadata.distribution", _raise)
+    assert vibe_upgrade._recorded_install_origin("avibe-os") is None
+
+
+def test_a_recorded_origin_is_read_from_the_installers_own_pep_610_record(monkeypatch):
+    class _Distribution:
+        def read_text(self, name):
+            assert name == "direct_url.json"
+            return json.dumps({"url": PREVIEW_CORE_URL, "archive_info": {}})
+
+    monkeypatch.setattr("importlib.metadata.distribution", lambda _name: _Distribution())
+
+    assert vibe_upgrade._recorded_install_origin("avibe-os") == PREVIEW_CORE_URL
 
 
 def test_an_exact_plan_installs_the_named_sources_instead_of_index_pins(monkeypatch):

--- a/tests/test_upgrade_flow.py
+++ b/tests/test_upgrade_flow.py
@@ -20,6 +20,7 @@ from vibe.runtime import ServiceLauncher
 from vibe.upgrade import (
     AtomicActivation,
     MemoryRequirementUnreadableError,
+    PIP_DOWNLOAD_DEST_PLACEHOLDER,
     UpgradePlan,
     build_upgrade_plan,
     configured_memory_enabled,
@@ -35,6 +36,7 @@ from vibe.upgrade import (
     get_running_vibe_path,
     get_safe_cwd,
     pinned_package_spec,
+    preview_release_specs,
     execute_upgrade_plan,
     restart_is_pending,
 )
@@ -949,6 +951,200 @@ def test_an_exact_plan_never_asks_for_an_upgrade_and_always_forces_the_install(m
     for plan in (uv_plan, pip_plan):
         assert "--upgrade" not in plan.command
         assert FORCES_THE_INSTALL[plan.method] in plan.command
+
+
+def test_an_exact_memory_plan_names_both_index_pins_when_no_source_is_given(monkeypatch):
+    # The repair reaches an index by default. A caller that names no install
+    # source gets exactly the pins it got before install sources existed.
+    monkeypatch.setattr("vibe.upgrade.os.path.exists", lambda path: True)
+    monkeypatch.setattr("vibe.upgrade.os.access", lambda path, mode: True)
+
+    uv_plan = build_upgrade_plan(
+        python_executable="/tmp/.local/share/uv/tools/avibe-os/bin/python",
+        uv_path="/usr/local/bin/uv",
+        vibe_path="/custom/bin/vibe",
+        base_env={"PATH": "/usr/bin"},
+        version="3.0.10",
+        package_name="avibe-os",
+        memory_package=True,
+        memory_version="3.0.10",
+    )
+    assert uv_plan.command == [
+        "/usr/local/bin/uv",
+        "tool",
+        "install",
+        "avibe-os==3.0.10",
+        "--with",
+        "avibe-memory==3.0.10",
+        "--force",
+    ]
+    assert uv_plan.preflight_command == [
+        "/usr/local/bin/uv",
+        "pip",
+        "install",
+        "--dry-run",
+        "--python",
+        "/tmp/.local/share/uv/tools/avibe-os/bin/python",
+        "avibe-os==3.0.10",
+        "avibe-memory==3.0.10",
+    ]
+
+    pip_plan = build_upgrade_plan(
+        python_executable="/usr/bin/python3",
+        uv_path=None,
+        base_env={"PATH": "/usr/bin"},
+        version="3.0.10",
+        package_name="avibe-os",
+        memory_package=True,
+        memory_version="3.0.10",
+    )
+    assert pip_plan.command == [
+        "/usr/bin/python3",
+        "-m",
+        "pip",
+        "install",
+        "--force-reinstall",
+        "avibe-os==3.0.10",
+        "avibe-memory==3.0.10",
+    ]
+    assert pip_plan.preflight_command == [
+        "/usr/bin/python3",
+        "-m",
+        "pip",
+        "download",
+        "--dest",
+        PIP_DOWNLOAD_DEST_PLACEHOLDER,
+        "--no-deps",
+        "avibe-os==3.0.10",
+        "avibe-memory==3.0.10",
+    ]
+
+
+PREVIEW_VERSION = "3.0.16rc1"
+PREVIEW_CORE_URL = (
+    "https://github.com/avibe-bot/avibe/releases/download/gh-v3.0.16rc1/avibe_os-3.0.16rc1-py3-none-any.whl"
+)
+PREVIEW_MEMORY_URL = (
+    "https://github.com/avibe-bot/avibe/releases/download/gh-v3.0.16rc1/avibe_memory-3.0.16rc1-py3-none-any.whl"
+)
+
+
+def test_preview_release_specs_name_one_release_of_the_running_version():
+    assert preview_release_specs(PREVIEW_VERSION) == (PREVIEW_CORE_URL, PREVIEW_MEMORY_URL)
+
+
+@pytest.mark.parametrize(
+    "spelling",
+    ["3.0.16rc1", "3.0.16RC1", "3.0.16-rc-1", "v3.0.16rc1", "3.0.16.rc.1"],
+)
+def test_one_normalization_spells_the_tag_and_both_filenames(spelling):
+    # The release names its tag and its assets after the same normalized
+    # version, so any disagreement between the two derivations is a 404.
+    specs = preview_release_specs(spelling)
+    assert specs is not None
+    assert {url.split("/download/")[1].split("/")[0] for url in specs} == {"gh-v3.0.16rc1"}
+    assert all(url.endswith("-3.0.16rc1-py3-none-any.whl") for url in specs)
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "3.0.16",  # a final release: the index serves it
+        "3.1",
+        "3.0.16.post1",
+        "3.0.16.dev0",  # names this tree, not any release
+        "3.0.16rc1.dev2",
+        "3.0.16rc1+g1234567",
+        "3.0.16+local",
+        "",
+        "not-a-version",
+    ],
+)
+def test_preview_release_specs_refuse_a_version_no_preview_release_serves(version):
+    assert preview_release_specs(version) is None
+
+
+def test_an_exact_plan_installs_the_named_sources_instead_of_index_pins(monkeypatch):
+    monkeypatch.setattr("vibe.upgrade.os.path.exists", lambda path: True)
+    monkeypatch.setattr("vibe.upgrade.os.access", lambda path, mode: True)
+
+    shared = {
+        "base_env": {"PATH": "/usr/bin"},
+        "version": PREVIEW_VERSION,
+        "package_name": "avibe-os",
+        "memory_package": True,
+        "memory_version": PREVIEW_VERSION,
+        "core_spec": PREVIEW_CORE_URL,
+        "memory_spec": PREVIEW_MEMORY_URL,
+    }
+    uv_plan = build_upgrade_plan(
+        python_executable="/tmp/.local/share/uv/tools/avibe-os/bin/python",
+        uv_path="/usr/local/bin/uv",
+        vibe_path="/custom/bin/vibe",
+        **shared,
+    )
+    assert uv_plan.command == [
+        "/usr/local/bin/uv",
+        "tool",
+        "install",
+        PREVIEW_CORE_URL,
+        "--with",
+        f"avibe-memory @ {PREVIEW_MEMORY_URL}",
+        "--force",
+    ]
+    pip_plan = build_upgrade_plan(python_executable="/usr/bin/python3", uv_path=None, **shared)
+    assert pip_plan.command == [
+        "/usr/bin/python3",
+        "-m",
+        "pip",
+        "install",
+        "--force-reinstall",
+        PREVIEW_CORE_URL,
+        f"avibe-memory @ {PREVIEW_MEMORY_URL}",
+    ]
+
+    # Every command an installer runs has to reach the release. A pin left in
+    # any one of them resolves against an index that never served this version,
+    # which is the failure the sources exist to remove.
+    for plan in (uv_plan, pip_plan):
+        commands = [
+            command
+            for command in (plan.command, plan.preflight_command, plan.preflight_fallback_command)
+            if command
+        ]
+        assert len(commands) >= 2, "an exact Memory plan resolves before it installs"
+        for command in commands:
+            assert PREVIEW_CORE_URL in command
+            assert f"avibe-memory @ {PREVIEW_MEMORY_URL}" in command
+            assert f"avibe-os=={PREVIEW_VERSION}" not in command
+            assert f"avibe-memory=={PREVIEW_VERSION}" not in command
+        assert "--upgrade" not in plan.command
+        assert FORCES_THE_INSTALL[plan.method] in plan.command
+
+
+def test_a_forward_upgrade_keeps_index_pins_and_admits_no_install_source(monkeypatch):
+    # A forward upgrade resolves whichever release is newest, so there is no
+    # known release to name. Ignoring a source here would report an install
+    # from the release that never happened.
+    monkeypatch.setattr("vibe.upgrade.find_uv_binary", lambda **kwargs: None)
+    forward = {
+        "python_executable": "/usr/bin/python3",
+        "base_env": {"PATH": "/usr/bin"},
+        "memory_enabled": True,
+        "package_spec": "avibe-os==3.1.0",
+    }
+
+    plan = build_upgrade_plan(**forward)
+    assert "avibe-os[memory]==3.1.0" in plan.command
+    assert "avibe-memory==3.1.0" in plan.command
+
+    for sources in (
+        {"core_spec": PREVIEW_CORE_URL},
+        {"memory_spec": PREVIEW_MEMORY_URL},
+        {"core_spec": PREVIEW_CORE_URL, "memory_spec": PREVIEW_MEMORY_URL},
+    ):
+        with pytest.raises(ValueError):
+            build_upgrade_plan(**forward, **sources)
 
 
 def _metadata_records(monkeypatch, distribution: str, version: str) -> None:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -81,7 +81,7 @@ from vibe.upgrade import (
     get_running_vibe_path,
     get_safe_cwd,
     launcher_is_current_process,
-    preview_release_specs,
+    release_asset_specs,
     restart_is_pending,
     should_skip_show_runtime_prepare,
     UPGRADE_INSTALL_TIMEOUT_SECONDS,
@@ -9512,20 +9512,21 @@ def _prepare_memory_package_job(*, automatic: bool = False) -> dict:
             if restart_only:
                 result = {"ok": True}
             else:
-                # A preview release publishes its pair as release assets and
+                # A GitHub-only release publishes its pair as release assets and
                 # nothing to an index, so pinning it by name would resolve
                 # against a PyPI that never served this version and spend an
-                # attempt on an install that cannot succeed. Any other running
-                # version has no such assets and keeps its index pins.
-                preview_specs = preview_release_specs(current_version)
+                # attempt on an install that cannot succeed. This asks where
+                # core actually came from; an index install answers `None` and
+                # keeps its pins.
+                asset_specs = release_asset_specs(current_version)
                 plan = build_upgrade_plan(
                     version=current_version,
                     package_name=PACKAGE_NAME,
                     memory_package=True,
                     memory_version=current_version,
                     vibe_path=current_vibe_path,
-                    core_spec=preview_specs[0] if preview_specs else None,
-                    memory_spec=preview_specs[1] if preview_specs else None,
+                    core_spec=asset_specs[0] if asset_specs else None,
+                    memory_spec=asset_specs[1] if asset_specs else None,
                 )
                 if plan.preflight_error:
                     return {

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -81,6 +81,7 @@ from vibe.upgrade import (
     get_running_vibe_path,
     get_safe_cwd,
     launcher_is_current_process,
+    preview_release_specs,
     restart_is_pending,
     should_skip_show_runtime_prepare,
     UPGRADE_INSTALL_TIMEOUT_SECONDS,
@@ -9511,12 +9512,20 @@ def _prepare_memory_package_job(*, automatic: bool = False) -> dict:
             if restart_only:
                 result = {"ok": True}
             else:
+                # A preview release publishes its pair as release assets and
+                # nothing to an index, so pinning it by name would resolve
+                # against a PyPI that never served this version and spend an
+                # attempt on an install that cannot succeed. Any other running
+                # version has no such assets and keeps its index pins.
+                preview_specs = preview_release_specs(current_version)
                 plan = build_upgrade_plan(
                     version=current_version,
                     package_name=PACKAGE_NAME,
                     memory_package=True,
                     memory_version=current_version,
                     vibe_path=current_vibe_path,
+                    core_spec=preview_specs[0] if preview_specs else None,
+                    memory_spec=preview_specs[1] if preview_specs else None,
                 )
                 if plan.preflight_error:
                     return {

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -25,6 +25,7 @@ from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import (
     InvalidSdistFilename,
     InvalidWheelFilename,
+    canonicalize_name,
     parse_sdist_filename,
     parse_wheel_filename,
 )
@@ -54,6 +55,13 @@ LEGACY_PACKAGE_NAME = LEGACY_CORE_PACKAGE_NAME
 MEMORY_PACKAGE_NAME = SHAPE_MEMORY_PACKAGE_NAME
 MEMORY_EXTRA_NAME = "memory"
 PIP_DOWNLOAD_DEST_PLACEHOLDER = "{avibe-pip-download-destination}"
+# GitHub-only pre-releases publish their wheels as release assets and nothing to
+# PyPI, so a preview install can only be repaired from the release itself. The
+# tag and asset names are a fixed convention (see AGENTS.md "Release Notes"),
+# which makes the download URLs a pure function of the running version — no
+# GitHub API discovery, no manifest asset, nothing to fall out of date.
+PREVIEW_RELEASE_TAG_PREFIX = "gh-v"
+PREVIEW_RELEASE_DOWNLOAD_BASE_URL = "https://github.com/avibe-bot/avibe/releases/download"
 DEFAULT_UPDATE_METADATA_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
 CURRENT_VIBE_EXECUTABLE_ENV = "VIBE_CURRENT_EXECUTABLE"
 SHOW_RUNTIME_SKIP_ENV = "VIBE_INSTALL_SKIP_SHOW_RUNTIME"
@@ -1269,6 +1277,43 @@ def _memory_target_version(package_spec: str, target_version: str | None) -> str
     return _published_version(str(version))
 
 
+def _wheel_distribution(package_name: str) -> str:
+    """Spell one distribution name the way a wheel filename does."""
+
+    return canonicalize_name(package_name).replace("-", "_")
+
+
+def preview_release_specs(version: str) -> tuple[str, str] | None:
+    """Where a preview version's own wheels live, or `None` if it has none.
+
+    A pre-release is published to a `gh-v*` GitHub release and to no index, so
+    pinning it by name resolves against a PyPI that never served it. This
+    returns the `(core, memory)` asset URLs derived from the release
+    convention instead.
+
+    Only a clean pre-release qualifies. A dev or local version names this tree
+    rather than any release — `_names_a_published_release` already refuses it,
+    and deriving a URL for one would invent a release that was never built. A
+    final version keeps its index pins.
+
+    The tag and both filenames are rendered from one normalized version, so
+    they cannot disagree about how a version is spelled.
+    """
+
+    try:
+        parsed = Version(version)
+    except InvalidVersion:
+        return None
+    if not parsed.is_prerelease or parsed.is_devrelease or parsed.local is not None:
+        return None
+    normalized = str(parsed)
+    release = f"{PREVIEW_RELEASE_DOWNLOAD_BASE_URL}/{PREVIEW_RELEASE_TAG_PREFIX}{normalized}"
+    return (
+        f"{release}/{_wheel_distribution(PACKAGE_NAME)}-{normalized}-py3-none-any.whl",
+        f"{release}/{_wheel_distribution(MEMORY_PACKAGE_NAME)}-{normalized}-py3-none-any.whl",
+    )
+
+
 def pinned_package_spec(
     version: str,
     *,
@@ -1303,13 +1348,26 @@ def build_upgrade_plan(
     memory_package: bool | None = None,
     memory_version: str | None = None,
     package_spec: str | None = None,
+    core_spec: str | None = None,
+    memory_spec: str | None = None,
 ) -> UpgradePlan:
     """How to install avibe: the newest release, or `version` exactly.
 
     Exact-version plans support the explicit Memory package install action. They
     replace the ordinary upgrade request and force the installer so the matching
     optional distribution is applied even when core is already satisfied.
+
+    `core_spec` and `memory_spec` name where to fetch that exact pair when it
+    was never published to an index — a preview release's own wheel URLs. They
+    replace the two pins and change nothing else, so the resulting plan is the
+    same operation against a different source. A forward upgrade resolves the
+    newest release rather than a known one and has no such source to name, so
+    passing either without `version` is rejected instead of ignored: a spec that
+    silently does nothing would read as applied.
     """
+
+    if (core_spec or memory_spec) and not version:
+        raise ValueError("Explicit install sources require an exact target version")
 
     executable = python_executable or sys.executable
     # A caller targeting another interpreter (for example a test-owned venv)
@@ -1323,9 +1381,12 @@ def build_upgrade_plan(
         else bool(memory_enabled or memory_package_installed())
     )
     package_spec = (
-        pinned_package_spec(
-            version,
-            package_name=package_name or PACKAGE_NAME,
+        (
+            core_spec
+            or pinned_package_spec(
+                version,
+                package_name=package_name or PACKAGE_NAME,
+            )
         )
         if version
         else (package_spec or get_upgrade_package_spec())
@@ -1338,7 +1399,14 @@ def build_upgrade_plan(
     if not version and include_memory and f"[{MEMORY_EXTRA_NAME}]" not in package_spec:
         package_spec = _with_memory_extra(package_spec)
     memory_target = memory_version if version else target_version
-    pinned_memory_spec = f"{MEMORY_PACKAGE_NAME}=={memory_target}" if include_memory and memory_target else None
+    # The URL form stays a named requirement so every installer still reads it
+    # as "this distribution, from here" rather than as an anonymous artifact.
+    pinned_memory_spec = None
+    if include_memory:
+        if memory_spec:
+            pinned_memory_spec = f"{MEMORY_PACKAGE_NAME} @ {memory_spec}"
+        elif memory_target:
+            pinned_memory_spec = f"{MEMORY_PACKAGE_NAME}=={memory_target}"
 
     if is_uv_tool_install(executable) and uv_binary:
         env = dict(base_env or os.environ)

--- a/vibe/upgrade.py
+++ b/vibe/upgrade.py
@@ -55,13 +55,13 @@ LEGACY_PACKAGE_NAME = LEGACY_CORE_PACKAGE_NAME
 MEMORY_PACKAGE_NAME = SHAPE_MEMORY_PACKAGE_NAME
 MEMORY_EXTRA_NAME = "memory"
 PIP_DOWNLOAD_DEST_PLACEHOLDER = "{avibe-pip-download-destination}"
-# GitHub-only pre-releases publish their wheels as release assets and nothing to
-# PyPI, so a preview install can only be repaired from the release itself. The
-# tag and asset names are a fixed convention (see AGENTS.md "Release Notes"),
-# which makes the download URLs a pure function of the running version — no
-# GitHub API discovery, no manifest asset, nothing to fall out of date.
-PREVIEW_RELEASE_TAG_PREFIX = "gh-v"
-PREVIEW_RELEASE_DOWNLOAD_BASE_URL = "https://github.com/avibe-bot/avibe/releases/download"
+# A GitHub-only pre-release publishes its wheels as release assets and nothing
+# to PyPI, so an install taken from one can only be repaired from that same
+# release. Which release that is comes from the installer's own PEP 610 record,
+# never from the version string: `publish.yml` accepts official `vX.Y.ZrcN`
+# tags and publishes them to PyPI, so a pre-release version says nothing about
+# where its wheels live.
+RELEASE_DOWNLOAD_BASE_URL = "https://github.com/avibe-bot/avibe/releases/download"
 DEFAULT_UPDATE_METADATA_URL = f"https://pypi.org/pypi/{PACKAGE_NAME}/json"
 CURRENT_VIBE_EXECUTABLE_ENV = "VIBE_CURRENT_EXECUTABLE"
 SHOW_RUNTIME_SKIP_ENV = "VIBE_INSTALL_SKIP_SHOW_RUNTIME"
@@ -1283,34 +1283,75 @@ def _wheel_distribution(package_name: str) -> str:
     return canonicalize_name(package_name).replace("-", "_")
 
 
-def preview_release_specs(version: str) -> tuple[str, str] | None:
-    """Where a preview version's own wheels live, or `None` if it has none.
+def _recorded_install_origin(package_name: str) -> str | None:
+    """The URL an installed distribution was taken from, per PEP 610.
 
-    A pre-release is published to a `gh-v*` GitHub release and to no index, so
-    pinning it by name resolves against a PyPI that never served it. This
-    returns the `(core, memory)` asset URLs derived from the release
-    convention instead.
-
-    Only a clean pre-release qualifies. A dev or local version names this tree
-    rather than any release — `_names_a_published_release` already refuses it,
-    and deriving a URL for one would invent a release that was never built. A
-    final version keeps its index pins.
-
-    The tag and both filenames are rendered from one normalized version, so
-    they cannot disagree about how a version is spelled.
+    Installers write `direct_url.json` only when the distribution came from
+    somewhere other than an index, so its absence is itself the answer: this
+    copy was resolved by name and can be repaired the same way.
     """
 
     try:
-        parsed = Version(version)
+        from importlib.metadata import PackageNotFoundError, distribution
+
+        recorded = distribution(package_name).read_text("direct_url.json")
+    except PackageNotFoundError:
+        return None
+    except Exception:
+        logger.warning("Could not read %s install origin; assuming an index install", package_name, exc_info=True)
+        return None
+    if not recorded:
+        return None
+    try:
+        url = json.loads(recorded).get("url")
+    except (ValueError, AttributeError):
+        return None
+    return url if isinstance(url, str) else None
+
+
+def release_asset_specs(version: str) -> tuple[str, str] | None:
+    """The wheel pair this install came from, or `None` if an index serves it.
+
+    A version string cannot answer this. `publish.yml` accepts official
+    `vX.Y.ZrcN` tags and publishes them to PyPI, so a pre-release may well be
+    on an index, while a `gh-v*` build carrying the identical version is on no
+    index at all. Treating every pre-release as GitHub-only would point the
+    official one at a tag that was never created.
+
+    The installer already recorded the answer. When core came from a release
+    asset of this repository, the pair is repaired from that same release —
+    the one it demonstrably came from, rather than one derived from a naming
+    convention. Every other origin, an index install included, returns `None`
+    and keeps its index pins.
+
+    The recorded URL must name this exact running version, so a stale or
+    mismatched record cannot drive the repair to a different pair.
+    """
+
+    origin = _recorded_install_origin(PACKAGE_NAME)
+    if not origin:
+        return None
+    try:
+        normalized = str(Version(version))
     except InvalidVersion:
         return None
-    if not parsed.is_prerelease or parsed.is_devrelease or parsed.local is not None:
+    prefix = f"{RELEASE_DOWNLOAD_BASE_URL}/"
+    if not origin.startswith(prefix):
         return None
-    normalized = str(parsed)
-    release = f"{PREVIEW_RELEASE_DOWNLOAD_BASE_URL}/{PREVIEW_RELEASE_TAG_PREFIX}{normalized}"
+    # Exactly one tag segment and one filename: anything else is not an asset of
+    # this repository's releases, whatever it may resemble.
+    segments = origin[len(prefix) :].split("/")
+    if len(segments) != 2:
+        return None
+    tag, asset = segments
+    if not tag or tag in {".", ".."}:
+        return None
+    if asset != f"{_wheel_distribution(PACKAGE_NAME)}-{normalized}-py3-none-any.whl":
+        return None
+    # One release directory, so the companion cannot come from another release.
     return (
-        f"{release}/{_wheel_distribution(PACKAGE_NAME)}-{normalized}-py3-none-any.whl",
-        f"{release}/{_wheel_distribution(MEMORY_PACKAGE_NAME)}-{normalized}-py3-none-any.whl",
+        origin,
+        f"{prefix}{tag}/{_wheel_distribution(MEMORY_PACKAGE_NAME)}-{normalized}-py3-none-any.whl",
     )
 
 


### PR DESCRIPTION
Fixes #1805.

## Capability

**A core-only `gh-v*` preview install converges to its Memory companion.**

A GitHub-only pre-release publishes the `avibe-os` / `avibe-memory` wheel pair
as release assets and nothing to PyPI. The post-ready Memory package repair
(`_prepare_memory_package_job`) treated the running version as published, so it
pinned `avibe-os==<version>` / `avibe-memory==<version>` against an index that
never served it. Every attempt failed on resolution, and the bounded
three-attempt repair budget was spent on installs that could not succeed — a
preview install never converged, and the Dependencies page was left holding a
version-mismatch it could not repair.

Now the repair asks where this copy of core actually came from, and repairs the
pair from that same place.

## Change

- `vibe/upgrade.py`: `_recorded_install_origin(package)` reads the installed
  distribution's PEP 610 `direct_url.json`. Installers write that file only
  when a distribution came from somewhere other than an index, so its absence
  is itself the answer.
- `vibe/upgrade.py`: `release_asset_specs(version)` returns the `(core, memory)`
  pair when core's recorded origin is a release asset of this repository, and
  `None` for every other origin — an index install included. The core spec is
  the recorded URL itself; the memory spec is its sibling in that same release
  directory, so the two cannot come from different releases. The recorded URL
  must name the exact running version, so a stale or mismatched record cannot
  drive the repair to a different pair. No GitHub API call, no tag derived from
  a naming convention.
- `vibe/upgrade.py`: `build_upgrade_plan` accepts `core_spec` / `memory_spec`,
  honored only in exact-version mode. The Memory one renders as the PEP 508
  direct reference `avibe-memory @ <url>` so every installer still reads it as
  a named distribution rather than an anonymous artifact. Passing either
  without an exact `version` raises `ValueError` — a forward upgrade resolves
  the newest release and has no known pair to name, so a silently dropped spec
  would read as applied.
- `vibe/api.py`: the repair job passes whatever `release_asset_specs` returns.

Dev and local versions keep today's refusal
(`memory_package_unpublished_build`).

Everything else is reused as-is: the bounded attempt budget, the shared
`atomic_upgrade_lock`, environment verification, the structured failure
results, and the `memory-package-repair` service restart.

## Why not the version string

The first head keyed this on `is_prerelease`. Codex review caught that
`publish.yml` triggers on `v*` and explicitly accepts official `vX.Y.ZrcN`
tags, publishing both packages to PyPI. Such a build carries a version
indistinguishable from a `gh-v*` build of the same number, so classifying every
clean PEP 440 pre-release as GitHub-only would point the official one at a
`gh-vX.Y.ZrcN` tag that was never created — reproducing this PR's own bug one
version class over.

A PEP 440 version does not encode a publication channel, so the fix moved to
the thing that does: the origin the installer recorded. That closes the class
rather than special-casing `v*rcN`, and it is why the selector is not
`is_prerelease`.

## Official `v*` / PyPI path is unchanged

1. `vibe upgrade` (CLI) and Web `do_upgrade` never pass the new parameters;
   their plans are unchanged for every input.
2. The repair branch is selected by publication channel, not version shape. An
   install with no PEP 610 origin record was resolved by name from an index and
   keeps today's exact PyPI pins — official `vX.Y.ZrcN` prereleases included.
3. `publish.yml`, PyPI ordering, and release asset contracts are untouched.
4. A preview install does not leak into later forward upgrades:
   `get_upgrade_package_spec()` is env-driven and defaults to the bare package
   name, so `preview → stable` is an ordinary `vibe upgrade`.

Asserted, not just claimed: `test_an_exact_memory_plan_names_both_index_pins_when_no_source_is_given`
pins the byte-exact uv and pip install + preflight commands for the exact
Memory plan with the new parameters omitted, and
`test_a_forward_upgrade_keeps_index_pins_and_admits_no_install_source` does the
same for forward mode plus the three rejection cases. The pre-existing
exact-plan contract test never enabled Memory, so this closes that gap rather
than assuming it.

## Scenario IDs

- **MEMORY-INDEP-027** (new) — *A core-only preview install converges to the
  Memory companion published by its own release.*
  `tests/test_local_deps.py::test_memory_indep_027_preview_repair_installs_the_release_that_published_it`

## Evidence layers

- **unit** — origin reading and pair derivation: a missing, empty, non-JSON,
  non-object, url-less, wrongly-typed, or unreadable record all read as an
  index install; the record is read from `direct_url.json` by that exact name;
  one normalization drives both the origin match and the companion filename
  across `3.0.16rc1` / `3.0.16RC1` / `3.0.16-rc-1` / `v3.0.16rc1` /
  `3.0.16.rc.1`; and 13 origin/version pairs that cannot name this pair (other
  host, other repository, `file://`, missing tag segment, nested extra segment,
  `..` traversal, the memory URL as core's origin, version mismatch, final
  version, unparseable version) keep index pins.
- **contract** — exact uv and pip command lists for the sourced exact plan, the
  unsourced exact plan, and the forward plan; plus an invariant loop asserting
  every non-`None` command (install, preflight, preflight fallback) carries the
  URLs and carries no index pin, keeps `--force`, and never gains `--upgrade`.
- **scenario** — MEMORY-INDEP-027 builds the **real** plan through
  `_prepare_memory_package_job` (only the installer execution, restart, and
  host lookups are stubbed) and asserts the commands an installer would
  actually run. The repair-path test is parametrized over the two install
  origins **at one identical running version** against one expectation for the
  lock sequence, execute call, restart, and recorded result — so the
  budget/lock/restart behavior is proven the same for both, and the version can
  no longer be what distinguishes them.
- Mutation-checked: reintroducing the reviewed defect (classify by
  `is_prerelease`, derive a `gh-v*` tag) fails 12 tests, including the
  index-install repair case — so the coverage catches exactly the finding.
- Local: `tests/test_upgrade_flow.py`, `tests/test_local_deps.py`,
  `tests/scenarios/memory_independence/` — 326 passed. `ruff check` clean on
  all changed files.
- **Residual manual check** — a real `gh-v*` preview install on a machine,
  confirming the wheel pair downloads and the service restarts. Not run: it
  requires publishing a preview release. The URL shape was verified against the
  existing `gh-v3.0.14rc8` release, whose assets are exactly
  `avibe_os-3.0.14rc8-py3-none-any.whl` and
  `avibe_memory-3.0.14rc8-py3-none-any.whl`, and uv was empirically confirmed
  to write `direct_url.json` for a URL install.

## Known by design

- **No GitHub API discovery.** The pair comes from the release the running copy
  demonstrably came from, so there is nothing to look up. If a release's assets
  are ever removed, preview repair fails loudly (404 → existing structured
  failure) rather than silently.
- **Absence of a PEP 610 record is treated as an index install.** That is what
  PEP 610 says it means, and it is also the safe direction: the failure mode is
  keeping today's exact PyPI pins, which is precisely current behavior.
- **Pairing integrity stays with the published wheels.** The released
  artifacts carry reciprocal exact pins (`avibe-os==X` ⇄ `avibe-memory==X` in
  built METADATA, via `hatch_exact_peer.py`), so uv/pip fails resolution if the
  two URLs ever name a mismatched pair. This PR adds no second integrity check
  that could disagree with that one.
- **Issue item 3 (release-notes install command) is deliberately not here.**
  `gh-v*` notes are produced by the shared `release_ai.yml` generator, which
  also writes official `v*` notes; changing it for a text-only convenience
  would put the "official path untouched" invariant at risk. It belongs in a
  separate workflow-side change.
