### PR TITLE
docs(skills): define managed skills protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,11 @@ Source-of-truth rule:
   contract, require an exact-head Codex review, zero unresolved review threads,
   and passing CI before close-out, apply the review-loop circuit breaker, and
   never merge without explicit owner instruction
+- the fallback change contract names the intended behavior, affected boundaries,
+  and validation evidence; pause patching when one root-cause class appears on
+  two reviewed heads, or after three findings-bearing heads following an
+  architecture or data-model rewrite, then diagnose the whole class before
+  continuing
 - use the `background-watch-hook` skill for managed review and CI waits
 - keep one durable `--forever` combined PR/CI Watch and disable the Watch's per-cycle timeout
 - only an explicit owner decision may make Codex findings advisory for an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,7 +215,7 @@ Source-of-truth rule:
 
 ### PR Delivery
 
-- load and follow the `pr-delivery-loop` skill for every implementation task;
+- load and follow the `pr-delivery-loop` skill for every PR-producing task;
   it owns the detailed procedure, but cannot weaken the baseline below
 - regardless of Skill resolution, use a task branch/worktree, record the change
   contract, require an exact-head Codex review, zero unresolved review threads,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,8 +216,11 @@ Source-of-truth rule:
 ### PR Delivery
 
 - load and follow the `pr-delivery-loop` skill for every implementation task;
-  it is the single source of truth for branch and worktree policy, contracts,
-  review and CI gates, circuit breaking, managed waits, and close-out
+  it owns the detailed procedure, but cannot weaken the baseline below
+- regardless of Skill resolution, use a task branch/worktree, record the change
+  contract, require an exact-head Codex review, zero unresolved review threads,
+  and passing CI before close-out, apply the review-loop circuit breaker, and
+  never merge without explicit owner instruction
 - use the `background-watch-hook` skill for managed review and CI waits
 - keep one durable `--forever` combined PR/CI Watch and disable the Watch's per-cycle timeout
 - only an explicit owner decision may make Codex findings advisory for an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,13 +15,19 @@ Current product shape:
 - multi-backend agent routing across OpenCode, Claude Code, and Codex
 - local Incus-based unified regression environment for real cross-platform verification
 
-Default mindset:
-
-- treat the system as **multi-platform, multi-backend** first
-- prefer root-cause fixes over narrow patches
-- preserve user-visible behavior unless the task explicitly changes product behavior
-
 ## 2. Design Philosophy and Architecture
+
+### Product and Technical Decision-Making
+
+- Start from one coherent user mental model. Avibe absorbs backend and
+  implementation differences; users and agents see only what they need to act.
+- Establish hard constraints before choosing scope. Build the smallest complete
+  solution that works within them, and leave concepts undefined until they have
+  a clear responsibility.
+- Prefer compatibility, permissive adoption, and subtraction. Add validation,
+  metadata, state, or isolation only when it protects a demonstrated outcome.
+- Reuse existing ownership and lifecycle before adding mechanisms. Keep the
+  path simple and stateless, then optimize from measured evidence.
 
 ### Core Rule: Fix at the Highest Appropriate Layer
 
@@ -198,12 +204,6 @@ Source-of-truth rule:
 
 ## 5. Development Workflow
 
-### Branching and Scope
-
-- when starting a new feature or bug fix yourself, branch from the latest `master`
-- if the user already put you on an existing branch/worktree, continue there unless asked to move
-- keep commits small and focused; avoid mixing unrelated changes
-
 ### Planning and Documentation
 
 - if the task is complex or ambiguous, create a short plan before large changes
@@ -213,46 +213,14 @@ Source-of-truth rule:
 - update user documentation alongside user-visible features or changed workflows
 - keep project-specific plans, investigations, and summaries under `docs/`, never in the repo root
 
-### Worktrees
+### PR Delivery
 
-- use git worktree for long-running, parallel, or workspace-blocking efforts
-- if detailed worktree workflow is needed, load the dedicated worktree skill
-
-### Review Loop for PRs
-
-- the rules in this section are the self-sufficient baseline for every PR; use
-  the `pr-delivery-loop` skill for every implementation task to apply the fuller
-  standard for roles, authority, contracts, and close-out
-- open PRs non-draft; draft PRs do not trigger the Codex bot review
-- the GitHub Codex bot is the review gate: after every push confirm a review
-  of the new head starts, comment `@codex review` if none appears, and treat a
-  trigger as accepted only once the bot reacts 👀 to that comment
+- load and follow the `pr-delivery-loop` Skill for every implementation task;
+  it is the single source of truth for branch and worktree policy, contracts,
+  review and CI gates, circuit breaking, managed waits, and close-out
 - only an explicit owner decision may make Codex findings advisory for an
-  architecture/spec-only PR: findings inform owner decision-completeness
-  certification instead of requiring edits until zero findings. This is a
-  per-PR exception; ordinary documentation and every product/test code PR retain
-  the normal exact-head Codex clean/pass, CI, and zero-unresolved-thread gates.
-- a bot pass is either an authenticated Codex-bot issue comment with the pass
-  phrase and exact reviewed commit, or a head-bound Codex-bot `+1` captured as
-  new waiter activity after the prior review was terminal; close-out requires
-  zero unresolved review threads across the entire PR, including earlier and
-  outdated heads, not just a 0-finding latest review
-- after opening a PR, use the `background-watch-hook` skill to keep a
-  review-fix loop running until the review passes; use that skill's bundled PR
-  and Actions waiters rather than hand-rolling one, and create the watch
-  immediately without waiting to be reminded
-- keep one durable `--forever` combined PR/CI Watch for the loop: seed its state
-  once before the first review trigger, let the waiter follow the PR's current
-  head for exact-SHA Actions, disable the Watch's per-cycle timeout, and never
-  rebuild the baseline between rounds
-- PR descriptions must name the changed capability, list affected scenario IDs
-  when a catalog exists, and state which evidence layers were updated: unit,
-  contract, scenario, and residual manual checks
-- do not merge on your own initiative: the orchestrator (or the user) does the
-  final review and merge; an explicit merge instruction from them is carried
-  out directly after a mechanical `mergeStateStatus == CLEAN` check, never by
-  spawning another agent to re-review
-- require the GitHub CI checks to pass before merge
+  architecture/spec-only PR; ordinary documentation and every product or test
+  code PR retain the Skill's normal gates
 
 ### Pre-Push Requirements
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,9 +215,11 @@ Source-of-truth rule:
 
 ### PR Delivery
 
-- load and follow the `pr-delivery-loop` Skill for every implementation task;
+- load and follow the `pr-delivery-loop` skill for every implementation task;
   it is the single source of truth for branch and worktree policy, contracts,
   review and CI gates, circuit breaking, managed waits, and close-out
+- use the `background-watch-hook` skill for managed review and CI waits
+- keep one durable `--forever` combined PR/CI Watch and disable the Watch's per-cycle timeout
 - only an explicit owner decision may make Codex findings advisory for an
   architecture/spec-only PR; ordinary documentation and every product or test
   code PR retain the Skill's normal gates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,7 +215,7 @@ Source-of-truth rule:
 
 ### PR Delivery
 
-- load and follow the `pr-delivery-loop` skill for every PR-producing task;
+- load and follow the `pr-delivery-loop` skill for every implementation task;
   it owns the detailed procedure, but cannot weaken the baseline below
 - regardless of Skill resolution, use a task branch/worktree, record the change
   contract, require an exact-head Codex review, zero unresolved review threads,

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -248,9 +248,10 @@ failing the whole Catalog. The name grammar is the existing Agent Skills
 boundary: 1-64 lowercase ASCII letters, digits, or hyphens; no leading,
 trailing, or consecutive hyphen. This makes every advertised name one literal
 shell token without Avibe-specific quoting or encoding.
-Any failure while constructing optional typed YAML values falls back to the
-same bounded tolerant extraction of `name` and `description`; malformed
-unrelated metadata cannot abort Catalog construction.
+The parser scans only top-level `name` and `description` syntax. It never
+constructs ignored YAML values, expands aliases, or traverses optional nested
+structures; malformed or recursively aliased unrelated metadata therefore
+cannot amplify work or abort Catalog construction.
 
 Catalog parsing and rendering are bounded independently:
 
@@ -439,7 +440,8 @@ Contract details:
 - XML attribute values are escaped.
 - Only the body after the leading frontmatter is emitted.
 - On a successful load, the body is otherwise unchanged: no generated title,
-  indentation, escaping, summary, or rewrite is added. Invalid UTF-8 fails load
+  indentation, escaping, summary, or rewrite is added. Invalid UTF-8 or a C0/C1
+  terminal control other than tab, line feed, or carriage return fails load
   rather than being replaced or re-encoded.
 - A body larger than 256 KiB is not advertised and cannot be loaded. If a file
   grows beyond the limit between discovery and load, load fails with empty
@@ -530,8 +532,10 @@ loops; after a crash or an ambiguously abandoned poll, the last expiry remains
 the bounded cleanup path. Binding-file updates are serialized across processes,
 use a unique same-directory temporary file and atomic replacement, and cleanup
 is guarded by a per-Turn token so an older Turn cannot refresh or remove a newer
-binding for the same native Session. Each new or restored Turn writes its own
-entry. The persisted shape remains readable by
+binding for the same native Session. Each new or restored Turn makes its initial
+publication before entering the active poll loop. A delayed initial publication
+or renewal lost to a newer token stops instead of replacing that newer binding.
+The persisted shape remains readable by
 an already-running OpenCode server that loaded the released plugin: the
 existing `env`, `updated_at`, and `expires_at` fields are unchanged, while the
 cleanup token and Skill roots are additive. This feature leaves the released
@@ -550,9 +554,11 @@ same-Turn load.
 Binding publication and cleanup run outside the controller event loop. A
 restored poll makes three immediate publication attempts. If the binding store
 remains unavailable, Avibe restores result delivery without waiting, then keeps
-retrying for the lifetime of that active poll and resumes expiry renewal after
-publication succeeds. This preserves the durable result path without
-permanently dropping the Turn's shell binding after a transient failure.
+retrying conditionally for the lifetime of that active poll and resumes expiry
+renewal after publication succeeds. An atomic ownership check at the binding
+store permits the write only while no newer Turn owns the native Session. This
+preserves the durable result path without permanently dropping the Turn's shell
+binding after a transient failure or letting recovery overwrite current state.
 
 ### 8.3 Runtime access boundary
 
@@ -873,8 +879,9 @@ Catalogs at runtime.
   validation, and indented continuation lines in a plain description remain
   part of its normalized Catalog value.
 - Valid quoted `name` and `description` mapping keys are accepted, while the
-  tolerant fallback still extracts required fields when unrelated metadata is
-  malformed.
+  tolerant scanner still extracts required fields when unrelated metadata is
+  malformed, deeply nested, or recursively aliased, without constructing those
+  ignored values.
 - Prompt and `vibe skill list` pagination are deterministic for an unchanged
   filesystem, limited to 25 entries, remain within the row budget, and do not
   expose paths or sources. A multibyte-description fixture proves that every
@@ -907,6 +914,9 @@ Catalogs at runtime.
   limit before load produces empty standard output and a non-zero exit.
 - An invalid UTF-8 body may be advertised from its valid frontmatter but load
   produces empty standard output and a non-zero exit without replacement text.
+- A body containing C0/C1 terminal controls other than tab, line feed, or
+  carriage return may be advertised from its valid frontmatter but load fails
+  with empty standard output instead of emitting those bytes.
 - Built-in publication rejects an invalid UTF-8 body, so every published
   built-in that can be advertised is also loadable under the body-encoding
   contract.
@@ -952,8 +962,9 @@ and verify:
   Sessions. When a managed server is adopted across an `AVIBE_HOME` change,
   bind, renew, and unbind operations continue using the absolute binding path
   recorded by that server. Restored polls retain their advertised built-in
-  snapshot and continue retrying a failed binding publication for the poll
-  lifetime; and
+  snapshot and continue conditionally retrying a failed binding publication for
+  the poll lifetime; a newer Turn token makes the delayed retry stop without
+  replacing current state; and
 - a cached Claude client is recreated and resumes the same native Session when
   its bound Skill roots or built-in snapshot change even if page 1 is identical;
   and

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -347,8 +347,8 @@ Catalog. It does not receive:
 
 ### 6.1 System prompt injection
 
-When at least one Skill is available, Avibe injects this block with the
-resolved rows substituted:
+When at least one model-invocable Skill is available, Avibe injects this block
+with the resolved rows substituted:
 
 ```md
 ## Skills
@@ -373,7 +373,20 @@ finding it in a paged Catalog. If more entries exist, append exactly:
 More skills are available. Run `vibe skill list --page 2` to view more.
 ```
 
-When no Skills are available, omit the entire block.
+When resolved Skills exist but every one declares
+`disable-model-invocation: true`, Avibe omits every name and description but
+retains only this exact-name loading guidance:
+
+```md
+## Skills
+
+If the user requests a skill by exact name, run `vibe skill load -- <name>` before proceeding.
+Otherwise, do not guess skill names.
+```
+
+This keeps an explicitly requested manual-only Skill usable without advertising
+it for model selection. When no Skills of either kind resolve, Avibe omits the
+entire block.
 
 ### 6.2 List command
 
@@ -911,6 +924,9 @@ Catalogs at runtime.
   when unrelated metadata is malformed, deeply nested, or recursively aliased.
 - A Skill declaring `disable-model-invocation: true` is absent from every
   Catalog page but remains loadable by an explicitly supplied portable name.
+  When every resolved Skill has that policy, the prompt retains generic
+  exact-name load guidance without exposing any protected name or description;
+  a truly empty resolver still emits no Skill block.
 - Prompt and `vibe skill list` pagination are deterministic for an unchanged
   filesystem, limited to 25 entries, remain within the row budget, and do not
   expose paths or sources. A multibyte-description fixture proves that every

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -125,8 +125,10 @@ When Claude reports enabled plugins through its supported CLI, their standard
 failure omits only plugin roots; it never prevents static discovery or a
 backend Turn.
 
-Native locations are read in place. Avibe does not migrate, rename, annotate,
-or expose their source identity to the agent.
+Native locations are read in place. Avibe does not migrate or rename them, and
+the Catalog never annotates their source. A successful load still includes the
+selected absolute directory because companion files must remain usable; that
+path may naturally identify the native family or scope.
 
 ### 4.4 Reserved root
 
@@ -150,12 +152,14 @@ Candidates are deduplicated by their declared `name`. Lower numbers win:
 Within the same project depth or global scope, family order is:
 
 ```text
-.avibe > .agents > .codex > .claude > .config/OpenCode
+.avibe > .agents > .codex > .claude > OpenCode
 ```
 
-The `.avibe` family slot is reserved in v1. Enabled Claude plugin roots follow
-the static user roots, and Codex `.system` defaults are last. A final stable
-path order breaks any remaining tie. Winners are sorted by name before Catalog
+Here `OpenCode` maps to `.opencode/skills` for project discovery and
+`${XDG_CONFIG_HOME:-$HOME/.config}/opencode/skills` for global discovery. The
+`.avibe` family slot is reserved in v1. Enabled Claude plugin roots follow the
+static user roots, and Codex `.system` defaults are last. A final stable path
+order breaks any remaining tie. Winners are sorted by name before Catalog
 pagination.
 
 The agent sees only each winning `name` and `description`. It never sees source
@@ -268,7 +272,8 @@ Therefore, without restarting Avibe or creating a new Session:
 - installing a Skill makes it available on the next Turn;
 - renaming it or changing its description updates the next Catalog;
 - changing its body updates the next load; and
-- deleting it removes it from the next Catalog and load.
+- deleting the winning candidate promotes the next duplicate by precedence, if
+  one exists; otherwise the name disappears from the next Catalog and load.
 
 `vibe skill list` and `vibe skill load` also resolve from disk on every
 invocation. Backend-bound commands use the same Session working directory,

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -2,50 +2,34 @@
 
 > **Status:** Accepted
 > **Date:** 2026-09-02
-> **Scope:** Runtime discovery, catalog injection, loading, backend isolation,
-> and built-in Skill lifecycle for Claude Code, Codex, and OpenCode
+> **Scope:** Unified Skill discovery, Catalog injection, loading, backend
+> isolation, and built-in lifecycle for Claude Code, Codex, and OpenCode
 
-## 1. Decision
+## 1. Product Decision
 
-Avibe owns one Skill experience across all supported agent backends:
+Avibe owns one Skill experience across every supported backend:
 
-1. Users install a Skill once.
-2. Avibe discovers compatible global, project, backend-native, and built-in
-   locations.
-3. Every backend receives the same resolved Skill Catalog.
-4. An agent loads a Skill through `vibe skill load <name>`.
+1. Users install or keep a Skill in any supported location.
+2. Avibe discovers those locations and resolves one entry per Skill name.
+3. Every backend receives the same name-and-description Catalog.
+4. The agent loads a Skill with `vibe skill load -- <name>`.
 
-The agent sees Skill names and descriptions when choosing a Skill. It sees the
-selected Skill's absolute directory only when loading it, because supporting
-scripts, references, and assets are resolved relative to that directory.
+The agent does not need to know which backend or directory contributed a
+Catalog entry. The selected absolute directory is revealed only when the Skill
+is loaded, so the Skill can use companion scripts, references, and assets.
 
-Avibe's Catalog and load command are the product-level entry points. Backend
-namespaces, source locations, conflict resolution, and compatibility metadata
-are implementation details and are not exposed to the agent.
+Avibe disables backend-native Skill presentation on the backend calls it owns.
+This creates one product-level route, not a filesystem sandbox: an agent that
+already knows a path can still read it with ordinary filesystem tools.
 
-This is product-path isolation, not a filesystem security boundary. An agent
-can still read a known file through ordinary filesystem tools.
+## 2. Why v1 Starts With Skills
 
-## 2. Why Skills First
+Backend prompt files are not yet a portable unit. Their paths, traversal rules,
+and automatic injection differ, and not every backend provides a dependable
+way to disable them. Avibe therefore does not unify `AGENTS.md`, `CLAUDE.md`,
+or global system prompts in v1.
 
-Backend-native prompt files are not uniform:
-
-- their global and project paths differ;
-- their traversal and injection behavior differ; and
-- not every backend provides a reliable way to disable automatic context-file
-  loading.
-
-Avibe therefore does not attempt to unify `AGENTS.md`, `CLAUDE.md`, or global
-system prompts in v1. That work requires a dependable native opt-out first.
-
-Skills have a smaller and already portable unit: a directory containing a
-`SKILL.md`, optionally accompanied by scripts and references. Avibe keeps that
-storage shape and replaces only native discovery and loading in the Avibe
-runtime path.
-
-## 3. Compatibility Boundary
-
-The on-disk unit remains compatible with the Agent Skills convention:
+A Skill already has a compatible storage shape:
 
 ```text
 example-skill/
@@ -55,7 +39,15 @@ example-skill/
 `-- assets/
 ```
 
-Avibe requires only two fields in the leading frontmatter:
+Avibe keeps this shape and replaces only discovery, Catalog presentation, and
+loading in the Avibe runtime path.
+
+## 3. Compatibility Contract
+
+A candidate is a direct child directory containing `SKILL.md`. Nested files
+remain part of that Skill and are not discovered as separate Skills.
+
+The leading frontmatter needs only `name` and `description`:
 
 ```yaml
 ---
@@ -64,121 +56,61 @@ description: Explain when this Skill should be used.
 ---
 ```
 
-The Catalog prompt and `vibe skill load` output are Avibe runtime contracts.
-They are not presented as formats required by the Agent Skills specification.
+Parsing is permissive. Unknown or malformed optional fields do not reject an
+otherwise usable Skill. The name must follow the portable Agent Skills token
+shape: 1-64 lowercase ASCII letters, digits, or hyphens, with no leading,
+trailing, or consecutive hyphen. Descriptions are normalized to one line for
+Catalog display.
 
-Existing Skills are usable by default. There is no Avibe-specific portability
-field, compatibility state, validation state, source namespace, or migration
-requirement. Avibe reuses the portable Agent Skills name grammar rather than
-inventing another identifier format; all other frontmatter remains optional.
+The existing optional `disable-model-invocation: true` field remains
+meaningful. The winning Skill is resolved before this policy is applied: a
+manual-only winner is omitted from Catalogs but remains available through an
+explicit exact-name load. All other optional backend metadata is ignored by
+the portable v1 execution path.
 
-## 4. Discovery
+Invalid or unreadable candidates are omitted independently. Discovery and load
+use bounded input and output so one compatibility directory or file cannot
+make a Turn unbounded. Exact resource ceilings and race-resistant filesystem
+mechanics are implementation safeguards owned by code and tests, not additions
+to the model-facing protocol.
 
-### 4.1 Candidate shape
+## 4. Discovery Sources
 
-A discovery root contributes only direct child Skill directories:
+### 4.1 Avibe built-ins
 
-```text
-<discovery-root>/<skill-directory>/SKILL.md
-```
-
-Avibe does not recursively treat arbitrary nested `SKILL.md` files as separate
-Skills. Directories such as `scripts/`, `references/`, and `assets/` remain
-part of their parent Skill. The only nested container exception is the
-explicit Codex `.system` discovery root in Section 4.4; its direct children
-still follow the same candidate shape.
-
-Compatibility roots accept either a direct child directory or a direct child
-directory symlink. A symlink contributes the resolved target as the directory
-shown by `vibe skill load`; discovery and load revalidate both the alias and
-target identities so replacing either cannot pair one Skill body with another
-directory. Avibe-owned built-in snapshots remain symlink-free.
-
-Avibe opens `SKILL.md` with platform nonblocking semantics, immediately uses
-`fstat` or the platform-equivalent handle query to verify that same open handle
-is a regular file, and performs the bounded parse or load through that handle.
-It performs no potentially blocking read before handle-level type verification.
-A path-level check alone never authorizes a read, so replacing a candidate
-between enumeration and open cannot redirect the checked operation to a FIFO,
-socket, device, directory, broken link, or other non-regular target. Load
-repeats the same open-handle contract.
-
-Discovery and load share one verified-read primitive. It records the open
-file's identity, size, high-resolution modification time, and change/version
-metadata available on the platform before the bounded read, queries the same
-handle afterward, and accepts the bytes only when every recorded value remains
-unchanged. This detects changes observable through the host filesystem; on a
-filesystem whose metadata cannot distinguish a same-size concurrent rewrite,
-consistency is best-effort rather than a locking or immutable-snapshot
-guarantee. Before accepting, it also queries the `SKILL.md` directory entry
-again, relative to the retained directory handle when one is available, and
-requires that path to remain a regular file naming the same file identity as
-the open handle. An observable in-place rewrite, truncation, or atomic path
-replacement during the read therefore omits the candidate during discovery or
-fails load
-with empty standard output. This consistency rule is owned once by the resolver
-rather than reimplemented by Catalog and load call sites.
-
-Backend-bundled or system Skills other than the explicitly listed Codex
-`.system` compatibility root and enabled Claude plugin roots are not discovery
-sources. Avibe does not crawl plugin caches or marketplaces, import
-administrator-only Skills, or treat `.claude/commands` as Skills.
-
-### 4.2 Built-in root
+Built-ins are maintained in the repository at:
 
 ```text
-${AVIBE_HOME:-$HOME/.avibe}/builtin-skills/<snapshot-id>
+skills/<name>/
 ```
 
-This is logical user-facing notation. Implementations resolve it through
-`config.paths.get_vibe_remote_dir()` so a legacy `~/.vibe_remote` home remains
-authoritative when the compatibility migration cannot move it. Each running
-Avibe artifact selects only the version-scoped snapshot derived from its own
-bundled Skill tree. The `builtin-skills` umbrella is not a generic discovery
-root for direct child Skills. The selected snapshot is Avibe-owned runtime
-content, has the highest resolution priority, and contains at most 1,024 total
-direct child entries, each a valid Skill directory, whose bounded frontmatter
-totals at most 8 MiB. Every closing frontmatter delimiter is within the 64 KiB
-per-candidate bound and every body is at most 256 KiB. This keeps every
-published built-in discoverable within the same root, candidate, and byte
-budgets as compatibility inputs.
-
-### 4.3 Project roots
-
-For each directory `D` from the active working directory up to and including
-the first project boundary, Avibe inspects:
+An installed Avibe artifact publishes its complete built-in set beneath:
 
 ```text
-<D>/.agents/skills
-<D>/.codex/skills
-<D>/.claude/skills
-<D>/.opencode/skills
+${AVIBE_HOME:-$HOME/.avibe}/builtin-skills/<runtime-snapshot>/<name>/
 ```
 
-When a Session has a bound Avibe project base, that base is the project
-boundary even if the Session works inside a nested Git checkout. The base is
-snapshotted with the Session when the Session is created, so moving the Session
-to another scope does not change which project-level Skills it sees. This also
-lets a Workbench project whose configured directory has no `.git` marker retain
-project-level Skills when an existing Session works in one of its descendants.
-For a pre-upgrade Session without this snapshot, resolution safely derives the
-current scope workdir when it is an ancestor; a later scope move first persists
-that derived value. If an already-moved legacy row has no recoverable ancestor,
-Avibe does not guess the former project base and uses the standalone boundary
-rules.
-A standalone command has no Avibe project binding and therefore uses the first
-Git root; if neither boundary is found, only its active working directory is
-project scope.
+The runtime snapshot is directly readable by the agent. It is separate from
+user-managed Skills and has the highest resolution priority.
 
-The nearest directory to the active working directory wins within the same
-directory family. Root discovery examines at most 128 directories including
-the active working directory and performs at most 512 project-root probes
-before the existing candidate and byte budgets apply. A bound Avibe project
-base is accepted only when it is an absolute ancestor reachable within those
-128 directories; otherwise it is ignored and the standalone boundary rules
-apply.
+### 4.2 Project compatibility roots
 
-### 4.4 Global roots
+From the active working directory up to the project boundary, Avibe inspects:
+
+```text
+<directory>/.agents/skills
+<directory>/.codex/skills
+<directory>/.claude/skills
+<directory>/.opencode/skills
+```
+
+The nearest matching directory wins. A Workbench Session uses its bound Avibe
+project base as the boundary; a standalone command uses the first Git root, or
+only its current directory when no Git root exists.
+
+### 4.3 Global compatibility roots
+
+Avibe inspects:
 
 ```text
 $HOME/.agents/skills
@@ -188,167 +120,53 @@ ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/skills
 ${CODEX_HOME:-$HOME/.codex}/skills/.system
 ```
 
-Native locations are compatibility inputs. Avibe reads them in place and does
-not migrate, rename, or annotate their Skills. Implementations resolve the
-Claude root through the existing `vibe.claude_config.get_claude_home()` helper
-so discovery and the live Claude backend honor the same override semantics.
-Codex's `.system` directory is an explicit container root rather than a generic
-recursive exception: Avibe inspects only its direct child Skill directories and
-visits it after every user-managed global root, including enabled Claude plugin
-roots. A same-name project or user global Skill therefore wins over the
-Codex-bundled default. The container entry
-counts toward the parent root's raw direct-child enumeration limit, but is not
-a candidate and consumes no frontmatter budget there. Its children are charged
-only when the explicit Codex system root is scanned.
+When Claude reports enabled plugins through its supported CLI, their standard
+`skills` directories are also best-effort compatibility roots. Plugin lookup
+failure omits only plugin roots; it never prevents static discovery or a
+backend Turn.
 
-If `${CLAUDE_CONFIG_DIR}/plugins/installed_plugins.json` exists, Avibe invokes
-the official `<configured-claude-cli> plugin list --json` command in the Turn's
-bound working directory and scans `<installPath>/skills` for each entry whose
-`enabled` field is exactly `true`. The executable is the normalized V2
-`agents.claude.cli_path` used by the live Claude backend, including a custom
-path; standalone commands fall back to the normal Claude executable lookup. It
-does not crawl the installation cache or trust stale registry entries directly.
-Disabled plugins and relative installation paths are omitted. This lookup runs
-on every Avibe-dispatched Turn so installing,
-enabling, disabling, or removing a plugin is reflected without restarting Avibe
-or creating a Session. A missing CLI, non-zero exit, timeout after one second,
-combined standard output and standard error over 1 MiB, invalid UTF-8 or JSON,
-or more than 256 reported entries omits plugin roots without failing the rest
-of discovery. The combined output limit is enforced while both streams are
-drained rather than after either stream has been buffered without a bound.
+Native locations are read in place. Avibe does not migrate, rename, annotate,
+or expose their source identity to the agent.
 
-Enabled Claude plugin roots are compatibility inputs for the shared Avibe
-Catalog, not a Claude-only feature. They are scanned after the four user static
-roots and before Codex's bundled `.system` root, share the compatibility
-aggregate budget, and expose only each portable Skill name and description.
-Their plugin ID, installation path, and source are not shown to the agent.
-
-### 4.5 Reserved root
+### 4.4 Reserved root
 
 ```text
 ${AVIBE_HOME:-$HOME/.avibe}/skills
 ```
 
-This path is reserved for a future user-level Avibe Skill role. In v1 Avibe
-does not scan it, write to it, or assign it any behavior.
+This path is reserved for a future user-level Avibe role. V1 does not scan it,
+write to it, or assign it behavior.
 
-## 5. Parsing and Resolution
+## 5. Resolution and Precedence
 
-### 5.1 Loose frontmatter parsing
+Candidates are deduplicated by their declared `name`. Lower numbers win:
 
-Discovery is deliberately permissive:
+| Priority | Scope or family |
+| --- | --- |
+| 1 | Avibe built-ins |
+| 2 | Project Skills, nearest directory first |
+| 3 | Global Skills |
 
-- extract `name`, `description`, and the optional existing
-  `disable-model-invocation` policy from the leading frontmatter;
-- accept the Skill when `description` is non-empty and `name` follows the
-  portable Agent Skills grammar;
-- ignore every other field;
-- do not reject a Skill because unrelated frontmatter is unknown or malformed;
-- do not require the declared name to match the directory name; and
-- accept quoted or plain managed-field keys and decode standard YAML escapes
-  in quoted keys and required values; and
-- fold plain, quoted, or block `description` continuation lines and whitespace
-  into a single-line Catalog value.
+Within the same project depth or global scope, family order is:
 
-If either required value cannot be extracted, omit that candidate without
-failing the whole Catalog. The name grammar is the existing Agent Skills
-boundary: 1-64 lowercase ASCII letters, digits, or hyphens; no leading,
-trailing, or consecutive hyphen. This makes every advertised name one literal
-shell token without Avibe-specific quoting or encoding.
-For valid YAML, a base loader composes at most 1,024 nodes and 128 alias
-references, then reads only top-level scalar managed fields; it does not run
-typed constructors or recursively materialize aliases. If composition is
-malformed or exceeds either bound, a line scanner extracts only top-level
-managed fields and ignores nested structures. Unrelated metadata therefore
-cannot amplify work beyond the explicit bounds or abort Catalog construction.
+```text
+.avibe > .agents > .codex > .claude > .config/OpenCode
+```
 
-An existing `disable-model-invocation: true` declaration remains manual-only:
-the Skill is omitted from the injected Catalog and `vibe skill list`, but an
-explicit `vibe skill load -- <name>` still resolves it. The field is optional;
-Skills declaring only `name` and `description` remain automatically available.
+The `.avibe` family slot is reserved in v1. Enabled Claude plugin roots follow
+the static user roots, and Codex `.system` defaults are last. A final stable
+path order breaks any remaining tie. Winners are sorted by name before Catalog
+pagination.
 
-Catalog parsing and rendering are bounded independently:
+The agent sees only each winning `name` and `description`. It never sees source
+namespaces, scopes, duplicate candidates, priority details, or compatibility
+status.
 
-- read at most 64 KiB of leading frontmatter, including its delimiters, and
-  omit the candidate if the closing delimiter is not found within that budget;
-- accept a body of at most 256 KiB of encoded bytes, measured from the closing
-  frontmatter delimiter to end of file without reading the body during Catalog
-  discovery;
-- truncate a normalized description beyond 1,024 characters, adding `...`;
-- replace decoded Unicode control characters with spaces before collapsing
-  whitespace, so Catalog output cannot carry terminal control sequences; and
-- render at most 25 entries and 16 KiB of Skill rows per page.
-
-The bounded read happens before decoding or normalizing field values, so a
-large optional field, description, or unterminated frontmatter cannot create
-unbounded per-Turn work. Discovery enumerates at most 1,025 direct child
-entries in any root and omits the entire root if it contains more than 1,024.
-One resolution gives the built-in root and the combined project/global roots
-independent aggregate budgets of 4,096 direct child entries, 1,024 candidate
-Skill directories, and 8 MiB of frontmatter bytes each. A full built-in root
-therefore cannot consume the capacity reserved for user Skills. Within each
-class, roots are visited in precedence order. Before reading frontmatter,
-direct children of each root are sorted by their absolute entry path; declared
-names participate only after parsing. Compatibility entries that resolve to the
-same directory identity are visited once in precedence order and consume one
-candidate and frontmatter slot; each alias remains charged to the direct-child
-budget because it was enumerated. If a root would exceed the remaining
-direct-child budget, Avibe observes at most one entry beyond that remainder,
-omits the whole root, and omits all lower-priority roots. Reaching the candidate
-or frontmatter budget likewise omits remaining lower-priority roots. These
-rules make pre-parse work and omission deterministic without walking the rest
-of an oversized directory. Omission is diagnostic log data, not additional
-prompt content.
-
-These limits do not validate optional frontmatter, require the directory and
-declared name to match, or add compatibility metadata.
-Catalog discovery also does not read the complete body merely to validate its
-encoding. A successful load requires the bounded body to be valid UTF-8; an
-invalid body can appear in the Catalog but load fails with no standard output.
-
-### 5.2 Deduplication
-
-Candidates are deduplicated by their final declared `name`. The winner is
-selected by these rules, in order:
-
-1. Avibe built-ins over project and global Skills.
-2. Project Skills over global Skills.
-3. Within project scope, a directory nearer to the working directory over a
-   more distant directory.
-4. At the same scope and depth, directory-family priority is:
-   `.avibe` > `.agents` > `.codex` > `.claude` > OpenCode > enabled Claude
-   plugins > Codex system.
-5. If every preceding dimension ties, the candidate whose absolute directory
-   path sorts first by Unicode code-point order wins.
-
-The `.avibe` family reserves the highest family slot for future use, but
-`${AVIBE_HOME:-$HOME/.avibe}/skills` is inactive in v1. OpenCode means
-`.opencode` at project scope and `${XDG_CONFIG_HOME:-$HOME/.config}/opencode`
-at global scope. Codex system means the explicit
-`${CODEX_HOME:-$HOME/.codex}/skills/.system` container. Enabled Claude plugin
-roots follow user static roots but precede Codex system defaults, so no bundled
-default shadows an enabled user plugin.
-
-Resolution must be deterministic. After resolution, entries are sorted by
-name for pagination and prompt rendering.
-
-### 5.3 Agent-visible result
-
-The agent receives only each winning Skill's `name` and `description` in the
-Catalog. It does not receive:
-
-- the discovery root or backend source;
-- a namespace or scope label;
-- duplicate candidates;
-- the conflict rule or selected priority; or
-- compatibility or validation status.
-
-## 6. Skill Catalog Contract
+## 6. Skill Catalog Protocol
 
 ### 6.1 System prompt injection
 
-When at least one model-invocable Skill is available, Avibe injects this block
-with the resolved rows substituted:
+When model-invocable Skills exist, Avibe injects this shape:
 
 ```md
 ## Skills
@@ -364,18 +182,15 @@ Use `vibe skill list --page 2` only when more discovery is useful; ordinary task
 - pdf-processing: Extract text, fill forms, and merge PDF files.
 ```
 
-The system prompt contains page 1 only, within the entry and row budgets in
-Section 5.1. The optional subsequent-page guidance is present only when another
-page exists. A user-requested exact name may be loaded directly without first
-finding it in a paged Catalog. If more entries exist, append exactly:
+Page 1 contains at most 25 entries. The optional page-2 guidance appears only
+when another page exists. If more entries exist, append:
 
 ```md
 More skills are available. Run `vibe skill list --page 2` to view more.
 ```
 
-When resolved Skills exist but every one declares
-`disable-model-invocation: true`, Avibe omits every name and description but
-retains only this exact-name loading guidance:
+When only manual-only Skills resolve, Avibe reveals no names or descriptions
+and retains only exact-name guidance:
 
 ```md
 ## Skills
@@ -384,9 +199,7 @@ If the user requests a skill by exact name, run `vibe skill load -- <name>` befo
 Otherwise, do not guess skill names.
 ```
 
-This keeps an explicitly requested manual-only Skill usable without advertising
-it for model selection. When no Skills of either kind resolve, Avibe omits the
-entire block.
+When no Skills resolve, Avibe omits the block.
 
 ### 6.2 List command
 
@@ -395,49 +208,28 @@ vibe skill list
 vibe skill list --page <N>
 ```
 
-The default page is page 1. Each page contains at most 25 entries in the same
-stable name order used by the prompt for the filesystem state observed by that
-invocation. Standard output uses only Catalog rows:
+The default is page 1. Each page contains at most 25 entries in stable name
+order and prints only Catalog rows:
 
 ```text
 - data-analysis: Analyze datasets, generate charts, and create reports.
 - pdf-processing: Extract text, fill forms, and merge PDF files.
 ```
 
-When another page exists, the output ends with the same next-page sentence
-used by the prompt, with the appropriate page number. Paths, sources, scopes,
-and resolution metadata are not printed.
+When another page exists, the output ends with the next-page sentence using
+the appropriate page number. Pagination is live: after changing Skills while
+paging, callers restart at page 1 rather than relying on a hidden snapshot.
 
-Page boundaries are packed from the stable name order under both limits. Page
-`N+1` starts with the first entry after the last row actually emitted on page
-`N`; the 16 KiB limit never skips entries that did not fit an earlier page.
+## 7. Skill Load Protocol
 
-Pagination is deliberately live rather than a cross-command snapshot. If the
-filesystem changes between `list --page` invocations, entries can move between
-pages; after installing, editing, renaming, or deleting a Skill while paging,
-the caller restarts at page 1. V1 does not add a hidden per-Session cursor or
-freeze the Catalog merely to linearize an uncommon concurrent scan. With an
-unchanged filesystem, every invocation produces the same order and page
-boundaries.
-
-## 7. Skill Load Contract
-
-### 7.1 Command
+Both forms are accepted; agent instructions use the second:
 
 ```text
 vibe skill load <name>
 vibe skill load -- <name>
 ```
 
-Both forms are accepted. The second is the canonical form emitted in agent
-instructions; portable names cannot begin with an option prefix, but the
-end-of-options marker keeps the command contract explicit.
-
-The command resolves live global and project roots together with the caller's
-bound Session working directory and built-in snapshot, selects the current
-winner for `name`, and writes this structure to standard output. A bound
-command never derives project scope from the shell command's own current
-directory:
+A successful load writes exactly one wrapper to standard output:
 
 ```xml
 <skill_content name="pdf-processing" directory="/absolute/path/to/pdf-processing">
@@ -445,639 +237,161 @@ SKILL BODY ONLY
 </skill_content>
 ```
 
-Contract details:
+Contract:
 
-- `name` is the resolved Skill name.
+- `name` is the resolved portable Skill name.
 - `directory` is the absolute, agent-accessible directory containing
-  `SKILL.md`. Compatibility candidates whose resolved absolute directory is
-  not valid UTF-8 are omitted; v1 does not invent a second path encoding for
-  model-facing output. After ordinary XML attribute escaping, every Unicode
-  control character in the path is emitted as an ASCII numeric character
-  reference such as `&#xA;`, so the command prints no raw terminal controls and
-  the represented path remains reversible.
-- Load retains an open handle to the selected Skill directory, reads
-  `SKILL.md` relative to that handle, and verifies immediately before output
-  that the reported absolute path still names the same directory identity. If
-  the directory moved, disappeared, or was replaced during load, the command
-  fails instead of pairing one body with another directory.
-- The required frontmatter and bounded body are parsed from one verified
-  `SKILL.md` read after selection. Load confirms that those exact bytes still
-  declare the requested portable name before emitting; it never combines a
-  name retained from an earlier discovery read with newly opened content.
-- XML attribute values are escaped.
-- Only the body after the leading frontmatter is emitted.
-- On a successful load, the body is otherwise unchanged: no generated title,
-  indentation, escaping, summary, or rewrite is added. Invalid UTF-8 or a C0/C1
-  terminal control other than tab, line feed, or carriage return fails load
-  rather than being replaced or re-encoded.
-- A body larger than 256 KiB is not advertised and cannot be loaded. If a file
-  grows beyond the limit between discovery and load, load fails with empty
-  standard output rather than truncating it.
-- Relative references to `scripts/`, `references/`, `assets/`, or other files
-  resolve from `directory`.
-- The directory-identity check covers the load operation; it does not make a
-  mutable user Skill immutable after the command returns. Later edits follow
-  ordinary filesystem semantics and become visible to later reads or loads.
-- There is no protocol/version header, JSON envelope, source label,
-  compatibility state, or file manifest.
+  `SKILL.md`; XML attribute characters are escaped.
+- The payload is only the body after the leading frontmatter.
+- The body is otherwise unchanged. There is no generated title, summary,
+  indentation, JSON envelope, protocol header, source label, or file manifest.
+- Relative references to scripts, references, assets, and other companion
+  files resolve from `directory`.
+- Load resolves the current winner from disk and verifies the selected file
+  still declares the requested name before it emits content.
 
 On failure, standard output is empty, standard error contains a short
 human-readable error, and the process exits non-zero.
 
-The wrapper is XML-like model-facing framing, not an XML document consumed by
-an XML parser. Only its attributes use XML escaping; the Markdown body is an
-opaque, unchanged payload and may itself contain XML-looking text. The wrapper
-does not change instruction precedence. A loaded Skill is tool-level context
-and cannot override Avibe's system prompt, permissions, or safety rules.
+The wrapper is model-facing framing, not a parsed XML document. A loaded Skill
+is tool-level context and cannot override Avibe's system prompt, permissions,
+or safety rules.
 
 ## 8. Freshness and Session Semantics
 
-### 8.1 Avibe-dispatched Turn snapshot
+Immediately before every new Turn that Avibe dispatches, it resolves the live
+Catalog and renders the current system prompt. The existing backend Session is
+retained.
 
-Immediately before each new Turn that Avibe dispatches to a backend, Avibe:
+Therefore, without restarting Avibe or creating a new Session:
 
-1. resolves the Catalog from the current filesystem state;
-2. renders the current system prompt with page 1 of that Catalog; and
-3. dispatches the Turn to the existing backend Session.
+- installing a Skill makes it available on the next Turn;
+- renaming it or changing its description updates the next Catalog;
+- changing its body updates the next load; and
+- deleting it removes it from the next Catalog and load.
 
-This gives an existing Avibe Session newly installed, renamed, edited, or
-removed Skills on its next Avibe-dispatched Turn. No Avibe restart and no new
-Session are required.
+`vibe skill list` and `vibe skill load` also resolve from disk on every
+invocation. Backend-bound commands use the same Session working directory,
+project boundary, compatibility homes, and built-in snapshot that produced the
+Turn's Catalog. Binding is internal runtime state, not prompt text or a command
+argument.
 
-A message steered into a backend Turn that is already active is part of that
-same Turn and does not trigger another Catalog refresh. Changes become visible
-on the next Avibe-dispatched Turn.
+Binding infrastructure is auxiliary to backend execution. If it is temporarily
+unavailable, Avibe keeps the Turn usable and withholds any Catalog whose load
+address it cannot bind; later Turns recover automatically when binding succeeds.
 
-A backend-native continuation that starts without an Avibe dispatch, such as a
-Claude background-tool completion or native wakeup, cannot be intercepted
-before it begins and may use the prompt snapshot already held by that backend
-client. It does not weaken the next Avibe-dispatched Turn guarantee and is not
-part of the v1 freshness contract.
+A message steered into an already active backend Turn is part of that Turn and
+does not cause another refresh. A backend-native continuation that Avibe did
+not dispatch may retain its existing prompt snapshot. Both cases leave the next
+Avibe-dispatched Turn guarantee unchanged.
 
-### 8.2 Live commands
+Previously loaded bodies remain ordinary conversation history. Avibe does not
+rewrite history, invalidate old content, track loaded revisions, or instruct
+the agent to distrust earlier loads.
 
-`vibe skill list` and `vibe skill load` resolve from disk on every invocation.
-Therefore:
+V1 uses no filesystem watcher, change notification, incremental prompt patch,
+or long-lived Catalog cache. Turn-time rendering and live commands are the
+consistency boundaries.
 
-- adding or removing a Skill changes the next command result and next Turn;
-- changing `name` or `description` changes the next Catalog resolution; and
-- changing the body, scripts, or references changes the next load or file
-  read.
+## 9. Backend Isolation
 
-When a backend launches either command, Avibe supplies internal bindings:
-
-- `AVIBE_SKILL_WORKING_DIR` is the absolute working directory from which Avibe
-  rendered that Session's Catalog. Project discovery always starts there, even
-  when the agent runs the command from another directory.
-- `AVIBE_SKILL_PROJECT_BASE`, when present, is the normalized absolute Avibe
-  project base that bounded that Session's Catalog. It lets a command launched
-  by an existing Session discover project Skills between a descendant working
-  directory and a configured non-Git project base. Values outside the bound
-  working directory's ancestor chain are ignored.
-- `AVIBE_BUILTIN_SKILLS_SNAPSHOT_ID` selects the version-scoped built-in snapshot
-  retained by the Avibe process that created that backend runtime, even if an
-  upgrade has since switched the stable `vibe` launcher to another artifact.
-- `AVIBE_BUILTIN_SKILLS_ROOT` is that snapshot's absolute directory. It binds
-  the complete runtime address, so a later launcher or `AVIBE_HOME` change
-  cannot combine the retained snapshot ID with a different Avibe home.
-- `AVIBE_SKILL_HOME`, `AVIBE_SKILL_CODEX_HOME`,
-  `AVIBE_SKILL_CLAUDE_HOME`, and `AVIBE_SKILL_XDG_CONFIG_HOME` are normalized
-  absolute roots resolved by the advertising Avibe process.
-  `AVIBE_SKILL_CLAUDE_CLI_PATH` carries its configured Claude executable for
-  plugin enumeration and load-time re-resolution. A relative
-  `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, or `XDG_CONFIG_HOME` is therefore resolved
-  once at Turn dispatch and cannot select a different compatibility tree merely
-  because the agent launches `vibe skill` from another shell directory.
-
-These values use the existing per-Session shell-environment path for each
-backend: Claude SDK process environment, Codex `shell_environment_policy`, and
-the OpenCode caller-context plugin. They are not prompt text or agent-visible
-command arguments. A standalone command without Avibe bindings uses its own
-current working directory and the snapshot bundled with its own executable.
-
-An OpenCode binding normally lives for the active Avibe-dispatched Turn. Avibe
-renews its released 24-hour expiry throughout active original and restored poll
-loops; after a crash or an ambiguously abandoned poll, the last expiry remains
-the bounded cleanup path. Binding-file updates are serialized across processes,
-use a unique same-directory temporary file and atomic replacement, and cleanup
-is guarded by a per-Turn token so an older Turn cannot refresh or remove a newer
-binding for the same native Session. Each new or restored Turn makes its initial
-publication before entering the active poll loop. A delayed initial publication
-or renewal lost to a newer token stops instead of replacing that newer binding.
-If the initial publication for a new Turn raises, Avibe logs the auxiliary
-failure, starts its binding maintainer in the unbound state, and still sends the
-prompt to OpenCode. The maintainer retries conditionally for the active Turn's
-lifetime; binding-store availability never becomes a prerequisite for backend
-execution.
-The persisted shape remains readable by
-an already-running OpenCode server that loaded the released plugin: the
-existing `env`, `updated_at`, and `expires_at` fields are unchanged, while the
-cleanup token and Skill roots are additive. This feature leaves the released
-plugin source unchanged, so an upgrade can adopt its active server and restore
-polls without requesting a plugin refresh. The adopting process reads the
-binding-file path recorded for that managed server and continues to bind,
-renew, and unbind there until the server is replaced, even when the effective
-`AVIBE_HOME` has changed. A newly started server uses the current runtime path.
-Expired entries are ignored and pruned.
-
-The active-poll record retains the exact built-in snapshot ID and root that the
-Turn's Catalog advertised. A process adopting that poll restores those values,
-not the newer process default, so an overlapping upgrade cannot change a
-same-Turn load.
-
-Binding publication and cleanup run outside the controller event loop. A
-restored poll makes three immediate publication attempts. If the binding store
-remains unavailable, Avibe restores result delivery without waiting, then keeps
-retrying conditionally for the lifetime of that active poll and resumes expiry
-renewal after publication succeeds. An atomic ownership check at the binding
-store permits the write only while no newer Turn owns the native Session. This
-preserves the durable result path without permanently dropping the Turn's shell
-binding after a transient failure or letting recovery overwrite current state.
-
-### 8.3 Runtime access boundary
-
-Workbench resource policies continue to authorize the Skills management API:
-who may install, remove, or inspect packages through the Web surface. They do
-not filter the runtime Catalog or `vibe skill load`. Once a Session can operate
-an agent on the local machine, that agent can use ordinary filesystem tools to
-read known Skill paths, so an environment-backed runtime filter would create a
-false security boundary that the same shell could bypass.
-
-The runtime Catalog is therefore the same resolved local capability set for
-Claude, Codex, and OpenCode. Backend caller bindings select the advertised
-working directory, compatibility roots, and built-in snapshot only. A real
-per-user confidentiality boundary would require a sandboxed command and
-filesystem broker and is outside v1.
-
-### 8.4 Historical context is historical
-
-Avibe does not track which Skills a Session has loaded, attach revisions to
-loaded content, rewrite old conversation history, invalidate prior loads, or
-require a Skill to be reloaded on every Turn.
-
-Once a Skill body has been loaded, it remains historical context just like any
-other file previously read by the agent. The current Catalog describes current
-availability; it does not retroactively change history.
-
-### 8.5 No watcher in v1
-
-There is no filesystem watcher, change notification, incremental system-prompt
-patch, or long-lived per-Session Catalog. Turn-time rendering is already the
-correct consistency boundary, so a second refresh mechanism would add state
-without improving the user-visible contract.
-
-The initial implementation scans the fixed roots within the candidate and byte
-budgets and reads only enough of each `SKILL.md` to extract frontmatter. A
-reference measurement of six roots, 20 Skill files, and 242 KB total input
-completed in about 1 ms median on a warm local filesystem. This is not a
-latency guarantee; it shows that correctness can precede caching. Per-Turn
-discovery runs outside the controller event loop so bounded cold-filesystem
-latency cannot stall unrelated dispatch.
-
-The common path performs no subprocess lookup when Claude has no installed
-plugin registry. When that registry exists, the official plugin-list lookup is
-also live per Turn and has the one-second failure boundary in Section 4.4.
-
-V1 does not cache discovery results. A future parsed-frontmatter cache cannot
-treat file identity, size, or timestamps as proof that content is unchanged: it
-must read and digest the bounded frontmatter on that Turn before reusing a
-parsed value. Any optimization must preserve the same freshness contract.
-
-## 9. Backend Isolation and Prompt Application
-
-Avibe disables native Skill presentation in the call path it controls, then
-applies the same Avibe Catalog to all three backends.
-
-| Backend | Native Skill isolation | Applying a changed Avibe prompt |
+| Backend | Native isolation | Avibe prompt application |
 | --- | --- | --- |
-| Claude Code | Configure the SDK with `skills=[]`. | Build the candidate prompt and complete Skill-binding state every Turn. If either changed, recreate the SDK client and resume the same native session; otherwise reuse the client. |
-| Codex | Set `skills.include_instructions=false`. | Build `developerInstructions` every Turn. Send updated instructions only when they differ, while retaining the same thread/session. |
-| OpenCode | Send `tools.skill=false` in every prompt request without rewriting user permission configuration. | Build and send the current system prompt on every new Turn. |
+| Claude Code | Configure the SDK with `skills=[]`. | Rebuild when the Skill Catalog changes and resume the same native Session. |
+| Codex | Set `skills.include_instructions=false`. | Render `developerInstructions` for each Turn while retaining the same thread. |
+| OpenCode | Send `tools.skill=false` in every prompt request. | Send the current system prompt on every new Turn. |
 
-For OpenCode, `tools.skill=false` is a request parameter, not text appended to
-the system prompt.
+For OpenCode, `tools.skill=false` is a request parameter, not prompt text, and
+Avibe does not rewrite the user's permission configuration.
 
-The v1 isolation boundary intentionally does not block:
+V1 does not block handwritten Codex `$skill` references, backend TUI or slash
+commands Avibe does not call, or ordinary filesystem access. The outcome is
+that Avibe's normal backend calls expose only the Avibe Catalog and load route.
 
-- handwritten Codex `$skill` references;
-- backend TUI or slash-command endpoints that Avibe does not invoke; or
-- ordinary filesystem access to known Skill paths.
+## 10. Built-in Lifecycle
 
-Avibe does not add command deny-lists, directory fingerprints, transport
-rebuilds solely for isolation, or backend-specific compatibility warnings.
-The required product outcome is narrower: through Avibe's normal backend call
-path, the model is not shown the native Skill Catalog and is not offered the
-native Skill tool.
+The bundled `skills/` tree is authoritative for each Avibe artifact. Before
+managed discovery, the artifact publishes a complete, agent-readable runtime
+snapshot. A new version therefore adds new built-ins, replaces changed ones,
+and omits retired ones as one coherent set.
 
-## 10. Built-in Skills
+Publication is atomic and content-addressed so overlapping old and new Avibe
+processes can keep using the snapshot each one advertised. Published snapshots
+are not a user customization surface. V1 does not garbage-collect old
+snapshots, detect later manual tampering, or repair user changes there.
 
-### 10.1 Source and runtime mirror
-
-Built-in Skills are maintained in the source tree at:
-
-```text
-skills/<name>/
-```
-
-Release artifacts must carry that authoritative tree: wheels force-include it
-under a package-owned resource path and sdists include `skills/**`. Runtime
-code resolves the checkout path during development and the packaged resource
-path after installation; it never assumes the repository root exists in a
-wheel environment. Built-in trees contain only directories and regular files;
-release packaging and publication preserve whether each file is executable.
-
-Before the first managed Skill resolution from an installed or upgraded Avibe
-artifact, Avibe publishes a complete runtime snapshot to:
-
-```text
-${AVIBE_HOME:-$HOME/.avibe}/builtin-skills/<snapshot-id>/<name>/
-```
-
-`<snapshot-id>` is lowercase SHA-256 over an unambiguous snapshot-v1 byte
-stream. The stream begins with the ASCII domain separator
-`avibe-builtin-snapshot-v1` followed by NUL. It then contains one record for
-every directory except the source root and every regular file, ordered by the
-UTF-8 bytes of its `/`-separated relative path. A record contains the ASCII byte
-`d` (`0x64`) for a directory or `f` (`0x66`) for a file, the path length as an
-unsigned 64-bit big-endian integer,
-and the path bytes. A file record additionally contains its byte length in the
-same integer encoding, its exact bytes, and one byte holding
-`st_mode & 0o111` where POSIX executable bits exist (zero otherwise). Release
-packaging requires relative paths to be valid UTF-8 in NFC form and every
-built-in `SKILL.md` body to be valid UTF-8. A fixed
-tree-to-digest fixture freezes this encoding without creating a persisted
-manifest. The identifier selects a directory; it is not a runtime integrity
-protocol.
-
-Built-in source paths must be representable without aliases on every supported
-platform. Release packaging rejects absolute or traversal paths, backslashes,
-NUL and every Win32-forbidden control character (`U+0001`-`U+001F`), plus
-every forbidden component character (`<`, `>`, `:`, `"`, `\`, `|`, `?`,
-`*`), drive/UNC prefixes,
-Windows-reserved components, trailing-dot/space names, case-insensitive path
-collisions, and empty directories. It also rejects more than 1,024 built-in
-root entries, any direct child that is not a valid Skill directory, duplicate
-declared Skill names, more than 4,096 directories and regular files across the
-complete tree, more than 32 MiB of regular-file bytes across the complete tree,
-any Skill whose closing frontmatter delimiter exceeds 64 KiB, any body over 256
-KiB, any invalid UTF-8 `SKILL.md` body, or a built-in tree whose bounded
-frontmatter exceeds 8 MiB. The aggregate
-entry traversal is capped while enumerating. Hashing and publication also charge
-the size of each regular file at the point it is opened and bound every read to
-that size, so growth after enumeration cannot exceed the aggregate byte budget.
-
-The runtime directory is deliberately separate from user-managed Skills and
-is directly accessible to the agent so loaded built-ins can use their own
-scripts and references.
-
-### 10.2 Replacement lifecycle
-
-The source tree is authoritative for each Avibe artifact. Each snapshot is a
-complete mirror that Avibe itself never mutates:
-
-- new built-ins are added;
-- changed built-ins are replaced; and
-- built-ins removed from the artifact are absent from its snapshot.
-
-Publication is serialized by a cross-process lock keyed by snapshot digest.
-The next lock holder first removes the one deterministic hidden staging path
-for that digest, reclaiming any partial tree left by an interrupted publisher.
-It then re-enumerates one bounded, fixed entry set and copies only those entries
-into staging; entries created after that enumeration are neither traversed nor
-copied. Each file is reopened without following its final path component,
-charged against the aggregate byte budget, read to its opened size, and rejected
-if it changes during the read. Source and destination descriptors use binary
-mode where the platform distinguishes it, so publication preserves exact bytes
-on Windows as well as POSIX systems. Avibe then validates that staging
-directory, recomputes the canonical snapshot-v1 digest from the completed
-staging tree, and requires it to equal the target `<snapshot-id>` before
-atomically renaming it once into the previously absent digest path. The staged
-digest includes every
-file byte and executable mode, so copied bytes cannot diverge from the name
-under which they are published. A process interruption can leave only that
-undiscoverable, bounded staging directory, and the next attempt safely replaces
-it before retrying. If the digest path already exists,
-concurrent or later publishers reuse that path without
-mutating it. A wrong-type or unreadable path fails safely. Readable external
-changes are unsupported post-publication mutation and may affect later
-Catalog/load results; runtime commands neither validate nor repair the path
-from whichever artifact the stable launcher currently selects.
-
-After publication, list/load does not hash the full snapshot, compare it with a
-package source, or repair it. It reads the selected built-in through the same
-bounded verified-file contract as every other Skill. The snapshot is an
-Avibe-owned lifecycle surface, not a user customization or security boundary;
-direct post-publication mutation is unsupported and may change or omit a later
-Catalog/load result.
-
-Every resolver selects the digest computed from the bundled source of its own
-running artifact. Concurrent old and new Avibe processes therefore use
-different snapshots when their built-ins differ, while identical trees safely
-share one. Other snapshots are not discovery candidates. V1 retains them so a
-running older process and an already loaded Skill directory remain usable;
-garbage collection of unreferenced snapshots is outside this protocol.
-
-Backend runtimes inherit this selected digest as
-`AVIBE_BUILTIN_SKILLS_SNAPSHOT_ID`, so `vibe skill list` and
-`vibe skill load` remain bound to the advertising runtime's built-ins across an
-overlapping upgrade. The digest is validated as an identifier under the
-`builtin-skills` umbrella before use; it cannot select an arbitrary path. A
-newer stable launcher needs only that retained path, not the older package
-source. A missing or unreadable retained snapshot fails safely instead of
-falling back to the newer artifact's built-ins.
+Wheels and source distributions include the authoritative built-in tree and
+preserve companion files and executable script modes. A publication failure
+omits built-ins without substituting a different version's content.
 
 ## 11. Installation Defaults
 
-The default user-level installation target is backend-neutral:
+The default user-level target is backend-neutral:
 
 ```text
 $HOME/.agents/skills/<name>
 ```
 
-An explicitly project-scoped installation targets:
+An explicitly project-scoped install targets:
 
 ```text
 $PROJECT_BASE/.agents/skills/<name>
 ```
 
-`$PROJECT_BASE` is the Git project root when discovery finds it within the
-128-directory ascent bound and the active working directory otherwise. The
-installer and resolver share this bounded project-base rule, so an installed
-project Skill is always in a root that the next Turn scans.
+The Workbench presents one logical installation, not a backend selector. It
+may keep backend-native compatibility links required by existing tooling, but
+Avibe still resolves and presents one Skill. Existing native installs stay in
+place and remain compatibility inputs.
 
-The Workbench exposes one installation, not a backend selector or per-backend
-toggle. New installs invoke askill for Claude Code, Codex, and OpenCode
-together. askill keeps the authoritative directory in the backend-neutral
-`.agents/skills` target and may create its normal backend-native compatibility
-links; native presentation is disabled in Avibe's runtime path, so those links
-do not create three product-level copies.
+Skill editing, adoption, and copy-on-write are outside v1.
 
-Existing backend-native installs remain in place and are discovered as
-compatibility inputs; Avibe does not move or rewrite user files during this
-migration. New backend-neutral installs create all three legacy Workbench
-access-policy identifiers for the one logical `.agents` Skill, and logical
-removal removes all three identifiers and askill-managed links. Existing
-backend-native Skills retain their existing management-policy identities.
-These identifiers govern the management surface only and do not narrow the
-runtime Catalog. The API may continue accepting a
-legacy `backends` field for compatibility, but validates and ignores narrowing
-requests. The UI removes backend filters, chips, install selectors, and
-availability switches.
+## 12. Prompt Slimming
 
-Skill editing, adoption, and copy-on-write are outside v1. This protocol owns
-runtime discovery and loading, while the existing Workbench/askill management
-surface owns installation UI and package operations. That surface must adopt
-these default targets when the runtime implementation lands.
+Managed Skills allow long, conditional operating manuals to leave the always-on
+system prompt. The kernel keeps only identity, interaction contracts,
+permissions, safety boundaries, and the short Skill routing instructions.
 
-## 12. System Prompt Slimming
+Operational modules move incrementally into Avibe built-ins only after the
+replacement Skill has equivalent behavior and regression coverage.
 
-Managed Skills make it possible to remove long, conditional operating manuals
-from the always-on system prompt.
+## 13. Ownership
 
-The kernel keeps only information required on every Turn:
+One shared resolver owns discovery, permissive parsing, precedence,
+deduplication, pagination, and lookup. Prompt rendering and both CLI commands
+consume it.
 
-- agent identity and Session facts;
-- interaction and output contracts;
-- permission and safety boundaries; and
-- Skill discovery and loading instructions.
-
-Long operational playbooks such as Show Pages, Vault, Harness, and Memory can
-move to Avibe built-in Skills. A short routing invariant may remain in the
-kernel when the agent must know to load a Skill before it can discover the
-relevant workflow.
-
-Prompt slimming is incremental. A module moves only after its built-in Skill
-has equivalent behavior and regression coverage.
-
-## 13. Implementation Ownership
-
-One shared resolver owns discovery, loose parsing, precedence, deduplication,
-sorting, pagination, and lookup. Prompt rendering and both CLI commands consume
-that resolver rather than reimplementing any rule.
-
-Backend adapters own only their native isolation setting and the mechanics for
-applying a changed Avibe prompt to the same backend Session. Built-in
-installation owns only the versioned source-to-runtime mirror.
+Backend adapters own only native isolation, Session-bound command context, and
+application of a changed Avibe prompt. Built-in publication owns only the
+artifact-to-runtime snapshot lifecycle.
 
 The existing [Workbench Skills design](workbench-skills-page.md) remains the
-management surface. This document supersedes its backend selection and
-per-backend availability model as well as assumptions about using native Skill
-Catalogs at runtime.
+management surface. This protocol supersedes its backend selection and
+per-backend runtime availability model.
 
-## 14. Acceptance Criteria
+## 14. Acceptance
 
-### 14.1 Resolver and protocol
+Automated and local Incus regression must prove:
 
-- A fixture covering every discovery root, including Codex's `.system`
-  container, resolves one entry per final name.
-- Enabled Claude plugins contribute their standard `skills` directories to the
-  same Avibe Catalog for all three backends, while disabled plugins do not.
-  Enabled plugin Skills override same-name Codex `.system` defaults but not
-  same-name user Skills from the four static compatibility roots.
-  A custom V2 Claude CLI path is used for both Turn-time and bound-command
-  plugin enumeration.
-  Missing, failing, timed-out, malformed, oversized, or over-count plugin-list
-  results omit only plugin roots, and static compatibility discovery continues;
-  the combined standard output and standard error limit is enforced during
-  capture.
-- Global-root fixtures override `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, and
-  `XDG_CONFIG_HOME` with relative and absolute values; Turn bindings normalize
-  them to the same absolute homes used by their live backends, independent of
-  the command's later shell directory.
-- Built-in, project/global, directory depth, and directory-family precedence
-  match Section 5.
-- Two sibling directories declaring the same name resolve by the final absolute
-  path tie-breaker, independent of filesystem enumeration order.
-- A Skill with a portable name and extractable description is accepted despite
-  unrelated malformed or unknown frontmatter.
-- Invalid candidates do not prevent valid candidates from appearing.
-- A fixture that replaces a regular `SKILL.md` with a FIFO between enumeration
-  and open cannot block discovery: handle-level type validation omits it before
-  any read, and load follows the same descriptor-bound contract.
-- A filesystem-observable in-place rewrite, truncation, or replacement of
-  `SKILL.md` during the verified read is rejected: discovery omits it and load
-  exits non-zero with empty standard output. Atomic namespace replacement after
-  the file is opened is covered separately from in-place handle mutation, and
-  coarse filesystems retain the best-effort boundary stated in Section 4.1.
-- Frontmatter parsing reads no more than 64 KiB before accepting or omitting a
-  candidate, including for oversized or unterminated input.
-- A root with more than 1,024 direct children is omitted after enumerating at
-  most 1,025 entries. Built-ins and combined project/global compatibility
-  inputs each have separate 4,096-direct-child, 1,024-candidate, and 8 MiB
-  frontmatter budgets, so either class can exhaust its own budget without
-  consuming the other's. Cross-root exhaustion follows precedence and the
-  pre-frontmatter path order defined in Section 5.1. The Codex `.system`
-  container counts toward its parent's raw 1,024-child limit regardless of
-  enumeration order, while its contents are scanned only as the explicit
-  system root.
-- Compatibility directory symlinks resolve to their target directory, and
-  replacing either the alias or target after discovery makes load fail. A
-  canonical Skill plus all backend compatibility aliases consumes one candidate
-  and one frontmatter slot while every enumerated alias still consumes one
-  direct-child slot. A candidate whose resolved absolute directory cannot be
-  encoded as UTF-8 is omitted before Catalog or load output.
-- Unquoted YAML comments after `name` or `description` are ignored while `#`
-  inside a quoted scalar remains content.
-- Comment-only and trailing-comment lines around indented plain continuations
-  of required scalars are ignored by the tolerant fallback parser.
-- Standard escapes in a quoted name are decoded before portable-name
-  validation, and indented continuation lines in a plain description remain
-  part of its normalized Catalog value.
-- Valid quoted `name` and `description` mapping keys, including standard escapes
-  in those keys, are accepted. The bounded node parser never constructs typed
-  optional values, while the tolerant scanner still extracts managed fields
-  when unrelated metadata is malformed, deeply nested, or recursively aliased.
-- A Skill declaring `disable-model-invocation: true` is absent from every
-  Catalog page but remains loadable by an explicitly supplied portable name.
-  When every resolved Skill has that policy, the prompt retains generic
-  exact-name load guidance without exposing any protected name or description;
-  a truly empty resolver still emits no Skill block.
-- Prompt and `vibe skill list` pagination are deterministic for an unchanged
-  filesystem, limited to 25 entries, remain within the row budget, and do not
-  expose paths or sources. A multibyte-description fixture proves that every
-  later page starts after the last row actually emitted, without skipping rows
-  when the byte budget wins before the count limit. When later pages exist, the
-  prompt makes further discovery optional, while a user-requested exact name
-  may load directly. A fixture mutating the Catalog between page calls verifies
-  live re-resolution and the documented restart-at-page-1 boundary rather than
-  a hidden snapshot.
-- Oversized descriptions cannot make the Catalog unbounded, and names with
-  whitespace, shell syntax, uppercase characters, or invalid hyphen placement
-  are omitted by the parser-backed portable name boundary. YAML-decoded C0 and
-  C1 control characters cannot reach terminal Catalog output.
-- `vibe skill load` emits the exact XML wrapper, body only, and an absolute
-  directory from which supporting files can be read. A control-character path
-  fixture proves the wrapper contains only the reversible ASCII references and
-  no raw terminal controls.
-- Parser-backed CLI coverage dispatches the canonical
-  `vibe skill load -- pdf-processing` example through the real argument parser
-  and reaches the load handler with `pdf-processing` as its single name.
-- If the selected `SKILL.md` is replaced after discovery, load reparses the
-  exact verified bytes it will emit and fails unless they still declare the
-  requested name.
-- A backend-bound load launched from a different shell directory still uses
-  the Session working directory that produced the advertised Catalog.
-- Replacing, removing, or renaming the selected Skill directory between
-  selection and output produces empty standard output and a non-zero exit; it
-  cannot pair the opened body with a different directory identity.
-- A body over 256 KiB is omitted from discovery, and a body that crosses the
-  limit before load produces empty standard output and a non-zero exit.
-- An invalid UTF-8 body may be advertised from its valid frontmatter but load
-  produces empty standard output and a non-zero exit without replacement text.
-- A body containing C0/C1 terminal controls other than tab, line feed, or
-  carriage return may be advertised from its valid frontmatter but load fails
-  with empty standard output instead of emitting those bytes.
-- Built-in publication rejects an invalid UTF-8 body, so every published
-  built-in that can be advertised is also loadable under the body-encoding
-  contract.
-- A Workbench Session working below its configured non-Git project directory
-  discovers project-level Skills up to that directory on the next Turn and via
-  `vibe skill`; an invalid, non-ancestor, or over-depth project binding is
-  ignored. Persisted pre-upgrade fixtures cover both deriving an unchanged
-  scope's ancestor and retaining that ancestor across a later scope move.
-- Workbench resource policies continue to govern management operations but do
-  not narrow the runtime Catalog or loaded body, matching the ordinary
-  filesystem capability of the agent process.
+- deterministic discovery and the declared precedence across compatibility
+  roots, built-ins, project scope, global scope, duplicates, and invalid input;
+- the exact Catalog, pagination, and load output contracts;
+- body-only load plus direct access to companion scripts and references;
+- live add, edit, rename, and delete behavior in one existing Session;
+- equivalent Catalogs and native isolation across Claude, Codex, and OpenCode;
+- installation and upgrade publication of complete built-in snapshots; and
+- bounded failure of malformed, oversized, unavailable, or concurrently
+  changing inputs without taking down unrelated Skills or backend Turns.
 
-### 14.2 Live Session behavior
-
-For each supported backend, using one existing Avibe Session and
-Avibe-dispatched Turns:
-
-- installing a Skill makes it available on the next Avibe-dispatched Turn;
-- changing its name or description changes the next Avibe-dispatched Turn's
-  Catalog;
-- changing its body changes the next load;
-- deleting it removes it from the next Avibe-dispatched Turn's Catalog; and
-- none of these operations requires a restart or new Session.
-
-Previously loaded content remains in conversation history without forcing a
-reload or rewriting the Session. Backend-native continuations that Avibe does
-not dispatch are outside this acceptance boundary.
-
-### 14.3 Backend isolation
-
-Capture the actual model-facing request for Claude Code, Codex, and OpenCode
-and verify:
-
-- the Avibe Catalog is equivalent across all three backends;
-- the native backend Catalog is absent;
-- OpenCode's native Skill tool is disabled; and
-- OpenCode user permission configuration and released caller-context plugin
-  source are not rewritten, concurrent active
-  Turn bindings preserve each other, and token-guarded cleanup removes only the
-  binding created by that Turn; active original and restored polls renew their
-  released-shape expiry, an abandoned binding expires without a live renewer,
-  and each restored Turn replaces its own entry without pruning other unexpired
-  Sessions. When a managed server is adopted across an `AVIBE_HOME` change,
-  bind, renew, and unbind operations continue using the absolute binding path
-  recorded by that server. Restored polls retain their advertised built-in
-  snapshot and continue conditionally retrying a failed binding publication for
-  the poll lifetime; a new Turn likewise reaches OpenCode after an initial
-  binding exception and retries for its active lifetime; a newer Turn token
-  makes the delayed retry stop without replacing current state; and
-- a cached Claude client is recreated and resumes the same native Session when
-  its bound Skill roots or built-in snapshot change even if page 1 is identical;
-  and
-- each adapter retains the same native Session when the Catalog changes.
-
-Codex `$skill`, backend TUI commands, and ordinary filesystem reads are not v1
-isolation acceptance gates.
-
-### 14.4 Built-in lifecycle
-
-- a fresh installation mirrors all bundled Skills;
-- a real wheel-install fixture proves bundled Skills exist without a source
-  tree and preserves executable modes required by helper scripts;
-- a real sdist-install fixture builds from the source archive, then proves the
-  resulting installation publishes and loads the same bundled Skills without
-  a repository checkout;
-- a fixed snapshot-v1 fixture proves the canonical tree byte stream and
-  lowercase SHA-256 identifier remain stable;
-- release packaging accepts only directories and regular files throughout the
-  complete built-in tree, and every relative path has one unambiguous,
-  cross-platform representation. Representative fixtures cover links and
-  special files, Win32-forbidden or aliased components, empty directories, and
-  every declared entry, byte, frontmatter, body, and root-child bound;
-- release packaging rejects duplicate declared Skill names even when their
-  directories differ;
-- a mode-only built-in change produces a different snapshot and published
-  digest;
-- publication recomputes the snapshot-v1 digest from the completed staging
-  tree and refuses to rename staging bytes under a different digest;
-- publication opens destination files in binary mode where available and
-  preserves mixed newline bytes exactly;
-- publication ignores entries created after its bounded copy enumeration and
-  rejects aggregate file growth observed at hashing or copy time;
-- an upgrade's selected snapshot contains changed Skills and omits retired
-  Skills;
-- after an injected interruption leaves partial staging state, the next
-  publisher reclaims it and completes successfully without exposing a partial
-  snapshot;
-- a wrong-type or unreadable pre-existing digest path fails safely without
-  being traversed, mutated, or rebuilt by runtime commands;
-- two concurrently running artifacts with different bundled trees resolve
-  different version-scoped snapshots;
-- after launcher activation, a command inherited from the older runtime still
-  lists and loads that runtime's retained built-in snapshot path without the
-  older package source and never falls back to the newer snapshot, even when
-  the active `AVIBE_HOME` changed; and
-- every loaded built-in reports an agent-accessible absolute directory.
-
-## 15. Explicit Non-Goals
+## 15. Non-Goals
 
 V1 does not include:
 
 - unified global or project prompt files;
 - disabling native `AGENTS.md` or `CLAUDE.md` loading;
-- a new Skill compatibility schema;
-- source namespaces or source disclosure to the agent;
-- Avibe-specific semantic ranking or compatibility filtering beyond preserving
-  an existing manual-only invocation declaration;
+- an Avibe-specific compatibility schema or source namespace;
+- semantic ranking beyond deterministic precedence;
 - Skill editing or copy-on-write;
-- semantics for `${AVIBE_HOME:-$HOME/.avibe}/skills`;
-- garbage collection of old built-in snapshots;
-- post-publication tamper detection or self-healing for Avibe-owned built-in
-  snapshots;
-- live filesystem watchers or historical-context invalidation; or
-- a security sandbox preventing direct filesystem access.
+- behavior for `${AVIBE_HOME:-$HOME/.avibe}/skills`;
+- historical-context invalidation;
+- built-in snapshot garbage collection or self-healing; or
+- a filesystem security sandbox.

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -194,8 +194,9 @@ Claude root through the existing `vibe.claude_config.get_claude_home()` helper
 so discovery and the live Claude backend honor the same override semantics.
 Codex's `.system` directory is an explicit container root rather than a generic
 recursive exception: Avibe inspects only its direct child Skill directories and
-visits it after every user-managed global root. A same-name project or user
-global Skill therefore wins over the Codex-bundled default. The container entry
+visits it after every user-managed global root, including enabled Claude plugin
+roots. A same-name project or user global Skill therefore wins over the
+Codex-bundled default. The container entry
 counts toward the parent root's raw direct-child enumeration limit, but is not
 a candidate and consumes no frontmatter budget there. Its children are charged
 only when the explicit Codex system root is scanned.
@@ -211,14 +212,16 @@ Disabled plugins and relative installation paths are omitted. This lookup runs
 on every Avibe-dispatched Turn so installing,
 enabling, disabling, or removing a plugin is reflected without restarting Avibe
 or creating a Session. A missing CLI, non-zero exit, timeout after one second,
-invalid UTF-8 or JSON, output over 1 MiB, or more than 256 reported entries
-omits plugin roots without failing the rest of discovery.
+combined standard output and standard error over 1 MiB, invalid UTF-8 or JSON,
+or more than 256 reported entries omits plugin roots without failing the rest
+of discovery. The combined output limit is enforced while both streams are
+drained rather than after either stream has been buffered without a bound.
 
 Enabled Claude plugin roots are compatibility inputs for the shared Avibe
-Catalog, not a Claude-only feature. They are scanned after every static root,
-share the compatibility aggregate budget, and expose only each portable Skill
-name and description. Their plugin ID, installation path, and source are not
-shown to the agent.
+Catalog, not a Claude-only feature. They are scanned after the four user static
+roots and before Codex's bundled `.system` root, share the compatibility
+aggregate budget, and expose only each portable Skill name and description.
+Their plugin ID, installation path, and source are not shown to the agent.
 
 ### 4.5 Reserved root
 
@@ -313,8 +316,8 @@ selected by these rules, in order:
 3. Within project scope, a directory nearer to the working directory over a
    more distant directory.
 4. At the same scope and depth, directory-family priority is:
-   `.avibe` > `.agents` > `.codex` > `.claude` > OpenCode > Codex system >
-   enabled Claude plugins.
+   `.avibe` > `.agents` > `.codex` > `.claude` > OpenCode > enabled Claude
+   plugins > Codex system.
 5. If every preceding dimension ties, the candidate whose absolute directory
    path sorts first by Unicode code-point order wins.
 
@@ -323,8 +326,8 @@ The `.avibe` family reserves the highest family slot for future use, but
 `.opencode` at project scope and `${XDG_CONFIG_HOME:-$HOME/.config}/opencode`
 at global scope. Codex system means the explicit
 `${CODEX_HOME:-$HOME/.codex}/skills/.system` container. Enabled Claude plugin
-roots are last so plugin-bundled defaults cannot shadow any static project or
-global Skill.
+roots follow user static roots but precede Codex system defaults, so no bundled
+default shadows an enabled user plugin.
 
 Resolution must be deterministic. After resolution, entries are sorted by
 name for pagination and prompt rendering.
@@ -848,10 +851,14 @@ Catalogs at runtime.
   container, resolves one entry per final name.
 - Enabled Claude plugins contribute their standard `skills` directories to the
   same Avibe Catalog for all three backends, while disabled plugins do not.
+  Enabled plugin Skills override same-name Codex `.system` defaults but not
+  same-name user Skills from the four static compatibility roots.
   A custom V2 Claude CLI path is used for both Turn-time and bound-command
   plugin enumeration.
   Missing, failing, timed-out, malformed, oversized, or over-count plugin-list
-  results omit only plugin roots, and static compatibility discovery continues.
+  results omit only plugin roots, and static compatibility discovery continues;
+  the combined standard output and standard error limit is enforced during
+  capture.
 - Global-root fixtures override `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, and
   `XDG_CONFIG_HOME` with relative and absolute values; Turn bindings normalize
   them to the same absolute homes used by their live backends, independent of
@@ -890,6 +897,8 @@ Catalogs at runtime.
   encoded as UTF-8 is omitted before Catalog or load output.
 - Unquoted YAML comments after `name` or `description` are ignored while `#`
   inside a quoted scalar remains content.
+- Comment-only and trailing-comment lines around indented plain continuations
+  of required scalars are ignored by the tolerant fallback parser.
 - Standard escapes in a quoted name are decoded before portable-name
   validation, and indented continuation lines in a plain description remain
   part of its normalized Catalog value.

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -120,8 +120,9 @@ with empty standard output. This consistency rule is owned once by the resolver
 rather than reimplemented by Catalog and load call sites.
 
 Backend-bundled or system Skills other than the explicitly listed Codex
-`.system` compatibility root, plugin caches, administrator-only Skills, and
-`.claude/commands` are not discovery sources.
+`.system` compatibility root and enabled Claude plugin roots are not discovery
+sources. Avibe does not crawl plugin caches or marketplaces, import
+administrator-only Skills, or treat `.claude/commands` as Skills.
 
 ### 4.2 Built-in root
 
@@ -198,6 +199,23 @@ global Skill therefore wins over the Codex-bundled default. The container entry
 counts toward the parent root's raw direct-child enumeration limit, but is not
 a candidate and consumes no frontmatter budget there. Its children are charged
 only when the explicit Codex system root is scanned.
+
+If `${CLAUDE_CONFIG_DIR}/plugins/installed_plugins.json` exists, Avibe invokes
+the official `claude plugin list --json` command in the Turn's bound working
+directory and scans `<installPath>/skills` for each entry whose `enabled` field
+is exactly `true`. It does not crawl the installation cache or trust stale
+registry entries directly. Disabled plugins and relative installation paths are
+omitted. This lookup runs on every Avibe-dispatched Turn so installing,
+enabling, disabling, or removing a plugin is reflected without restarting Avibe
+or creating a Session. A missing CLI, non-zero exit, timeout after one second,
+invalid UTF-8 or JSON, output over 1 MiB, or more than 256 reported entries
+omits plugin roots without failing the rest of discovery.
+
+Enabled Claude plugin roots are compatibility inputs for the shared Avibe
+Catalog, not a Claude-only feature. They are scanned after every static root,
+share the compatibility aggregate budget, and expose only each portable Skill
+name and description. Their plugin ID, installation path, and source are not
+shown to the agent.
 
 ### 4.5 Reserved root
 
@@ -283,7 +301,8 @@ selected by these rules, in order:
 3. Within project scope, a directory nearer to the working directory over a
    more distant directory.
 4. At the same scope and depth, directory-family priority is:
-   `.avibe` > `.agents` > `.codex` > `.claude` > OpenCode > Codex system.
+   `.avibe` > `.agents` > `.codex` > `.claude` > OpenCode > Codex system >
+   enabled Claude plugins.
 5. If every preceding dimension ties, the candidate whose absolute directory
    path sorts first by Unicode code-point order wins.
 
@@ -291,8 +310,9 @@ The `.avibe` family reserves the highest family slot for future use, but
 `${AVIBE_HOME:-$HOME/.avibe}/skills` is inactive in v1. OpenCode means
 `.opencode` at project scope and `${XDG_CONFIG_HOME:-$HOME/.config}/opencode`
 at global scope. Codex system means the explicit
-`${CODEX_HOME:-$HOME/.codex}/skills/.system` container; it is last so bundled
-defaults cannot shadow user-managed Skills.
+`${CODEX_HOME:-$HOME/.codex}/skills/.system` container. Enabled Claude plugin
+roots are last so plugin-bundled defaults cannot shadow any static project or
+global Skill.
 
 Resolution must be deterministic. After resolution, entries are sorted by
 name for pagination and prompt rendering.
@@ -574,6 +594,10 @@ latency guarantee; it shows that correctness can precede caching. Per-Turn
 discovery runs outside the controller event loop so bounded cold-filesystem
 latency cannot stall unrelated dispatch.
 
+The common path performs no subprocess lookup when Claude has no installed
+plugin registry. When that registry exists, the official plugin-list lookup is
+also live per Turn and has the one-second failure boundary in Section 4.4.
+
 V1 does not cache discovery results. A future parsed-frontmatter cache cannot
 treat file identity, size, or timestamps as proof that content is unchanged: it
 must read and digest the bounded frontmatter on that Turn before reusing a
@@ -803,6 +827,10 @@ Catalogs at runtime.
 
 - A fixture covering every discovery root, including Codex's `.system`
   container, resolves one entry per final name.
+- Enabled Claude plugins contribute their standard `skills` directories to the
+  same Avibe Catalog for all three backends, while disabled plugins do not.
+  Missing, failing, timed-out, malformed, oversized, or over-count plugin-list
+  results omit only plugin roots, and static compatibility discovery continues.
 - Global-root fixtures override `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, and
   `XDG_CONFIG_HOME` with relative and absolute values; Turn bindings normalize
   them to the same absolute homes used by their live backends, independent of

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -728,10 +728,13 @@ It then re-enumerates one bounded, fixed entry set and copies only those entries
 into staging; entries created after that enumeration are neither traversed nor
 copied. Each file is reopened without following its final path component,
 charged against the aggregate byte budget, read to its opened size, and rejected
-if it changes during the read. Avibe then validates that staging directory and
-recomputes the canonical snapshot-v1 digest from the completed staging tree and
-requires it to equal the target `<snapshot-id>` before atomically renaming it
-once into the previously absent digest path. The staged digest includes every
+if it changes during the read. Source and destination descriptors use binary
+mode where the platform distinguishes it, so publication preserves exact bytes
+on Windows as well as POSIX systems. Avibe then validates that staging
+directory, recomputes the canonical snapshot-v1 digest from the completed
+staging tree, and requires it to equal the target `<snapshot-id>` before
+atomically renaming it once into the previously absent digest path. The staged
+digest includes every
 file byte and executable mode, so copied bytes cannot diverge from the name
 under which they are published. A process interruption can leave only that
 undiscoverable, bounded staging directory, and the next attempt safely replaces
@@ -1020,6 +1023,8 @@ isolation acceptance gates.
   digest;
 - publication recomputes the snapshot-v1 digest from the completed staging
   tree and refuses to rename staging bytes under a different digest;
+- publication opens destination files in binary mode where available and
+  preserves mixed newline bytes exactly;
 - publication ignores entries created after its bounded copy enumeration and
   rejects aggregate file growth observed at hashing or copy time;
 - an upgrade's selected snapshot contains changed Skills and omits retired

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -235,14 +235,15 @@ does not scan it, write to it, or assign it any behavior.
 
 Discovery is deliberately permissive:
 
-- extract `name` and `description` from the leading frontmatter;
+- extract `name`, `description`, and the optional existing
+  `disable-model-invocation` policy from the leading frontmatter;
 - accept the Skill when `description` is non-empty and `name` follows the
   portable Agent Skills grammar;
 - ignore every other field;
 - do not reject a Skill because unrelated frontmatter is unknown or malformed;
 - do not require the declared name to match the directory name; and
-- accept quoted or plain required-field keys and decode standard YAML escapes
-  in quoted required values; and
+- accept quoted or plain managed-field keys and decode standard YAML escapes
+  in quoted keys and required values; and
 - fold plain, quoted, or block `description` continuation lines and whitespace
   into a single-line Catalog value.
 
@@ -251,10 +252,17 @@ failing the whole Catalog. The name grammar is the existing Agent Skills
 boundary: 1-64 lowercase ASCII letters, digits, or hyphens; no leading,
 trailing, or consecutive hyphen. This makes every advertised name one literal
 shell token without Avibe-specific quoting or encoding.
-The parser scans only top-level `name` and `description` syntax. It never
-constructs ignored YAML values, expands aliases, or traverses optional nested
-structures; malformed or recursively aliased unrelated metadata therefore
-cannot amplify work or abort Catalog construction.
+For valid YAML, a base loader composes at most 1,024 nodes and 128 alias
+references, then reads only top-level scalar managed fields; it does not run
+typed constructors or recursively materialize aliases. If composition is
+malformed or exceeds either bound, a line scanner extracts only top-level
+managed fields and ignores nested structures. Unrelated metadata therefore
+cannot amplify work beyond the explicit bounds or abort Catalog construction.
+
+An existing `disable-model-invocation: true` declaration remains manual-only:
+the Skill is omitted from the injected Catalog and `vibe skill list`, but an
+explicit `vibe skill load -- <name>` still resolves it. The field is optional;
+Skills declaring only `name` and `description` remain automatically available.
 
 Catalog parsing and rendering are bounded independently:
 
@@ -885,10 +893,12 @@ Catalogs at runtime.
 - Standard escapes in a quoted name are decoded before portable-name
   validation, and indented continuation lines in a plain description remain
   part of its normalized Catalog value.
-- Valid quoted `name` and `description` mapping keys are accepted, while the
-  tolerant scanner still extracts required fields when unrelated metadata is
-  malformed, deeply nested, or recursively aliased, without constructing those
-  ignored values.
+- Valid quoted `name` and `description` mapping keys, including standard escapes
+  in those keys, are accepted. The bounded node parser never constructs typed
+  optional values, while the tolerant scanner still extracts managed fields
+  when unrelated metadata is malformed, deeply nested, or recursively aliased.
+- A Skill declaring `disable-model-invocation: true` is absent from every
+  Catalog page but remains loadable by an explicitly supplied portable name.
 - Prompt and `vibe skill list` pagination are deterministic for an unchanged
   filesystem, limited to 25 entries, remain within the row budget, and do not
   expose paths or sources. A multibyte-description fixture proves that every
@@ -1026,7 +1036,8 @@ V1 does not include:
 - disabling native `AGENTS.md` or `CLAUDE.md` loading;
 - a new Skill compatibility schema;
 - source namespaces or source disclosure to the agent;
-- semantic ranking or filtering of Skills;
+- Avibe-specific semantic ranking or compatibility filtering beyond preserving
+  an existing manual-only invocation declaration;
 - Skill editing or copy-on-write;
 - semantics for `${AVIBE_HOME:-$HOME/.avibe}/skills`;
 - garbage collection of old built-in snapshots;

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -564,6 +564,11 @@ is guarded by a per-Turn token so an older Turn cannot refresh or remove a newer
 binding for the same native Session. Each new or restored Turn makes its initial
 publication before entering the active poll loop. A delayed initial publication
 or renewal lost to a newer token stops instead of replacing that newer binding.
+If the initial publication for a new Turn raises, Avibe logs the auxiliary
+failure, starts its binding maintainer in the unbound state, and still sends the
+prompt to OpenCode. The maintainer retries conditionally for the active Turn's
+lifetime; binding-store availability never becomes a prerequisite for backend
+execution.
 The persisted shape remains readable by
 an already-running OpenCode server that loaded the released plugin: the
 existing `env`, `updated_at`, and `expires_at` fields are unchanged, while the
@@ -1008,8 +1013,9 @@ and verify:
   bind, renew, and unbind operations continue using the absolute binding path
   recorded by that server. Restored polls retain their advertised built-in
   snapshot and continue conditionally retrying a failed binding publication for
-  the poll lifetime; a newer Turn token makes the delayed retry stop without
-  replacing current state; and
+  the poll lifetime; a new Turn likewise reaches OpenCode after an initial
+  binding exception and retries for its active lifetime; a newer Turn token
+  makes the delayed retry stop without replacing current state; and
 - a cached Claude client is recreated and resumes the same native Session when
   its bound Skill roots or built-in snapshot change even if page 1 is identical;
   and

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -84,11 +84,17 @@ Built-ins are maintained in the repository at:
 skills/<name>/
 ```
 
-An installed Avibe artifact publishes its complete built-in set beneath:
+An installed Avibe artifact publishes its complete built-in set beneath the
+authoritative runtime home returned by `config.paths.get_vibe_remote_dir()`:
 
 ```text
-${AVIBE_HOME:-$HOME/.avibe}/builtin-skills/<runtime-snapshot>/<name>/
+<resolved-avibe-home>/builtin-skills/<runtime-snapshot>/<name>/
 ```
+
+This honors an explicit `AVIBE_HOME` and the existing legacy-home migration
+rules. Snapshot publication must not independently select or create
+`$HOME/.avibe`, because a still-authoritative `$HOME/.vibe_remote` directory
+must remain the single state home when migration cannot complete.
 
 The runtime snapshot is directly readable by the agent. It is separate from
 user-managed Skills and has the highest resolution priority.

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -160,6 +160,11 @@ snapshotted with the Session when the Session is created, so moving the Session
 to another scope does not change which project-level Skills it sees. This also
 lets a Workbench project whose configured directory has no `.git` marker retain
 project-level Skills when an existing Session works in one of its descendants.
+For a pre-upgrade Session without this snapshot, resolution safely derives the
+current scope workdir when it is an ancestor; a later scope move first persists
+that derived value. If an already-moved legacy row has no recoverable ancestor,
+Avibe does not guess the former project base and uses the standalone boundary
+rules.
 A standalone command has no Avibe project binding and therefore uses the first
 Git root; if neither boundary is found, only its active working directory is
 project scope.
@@ -168,8 +173,9 @@ The nearest directory to the active working directory wins within the same
 directory family. Root discovery examines at most 128 directories including
 the active working directory and performs at most 512 project-root probes
 before the existing candidate and byte budgets apply. A bound Avibe project
-base is accepted only when it is an absolute ancestor of the bound working
-directory; otherwise it is ignored.
+base is accepted only when it is an absolute ancestor reachable within those
+128 directories; otherwise it is ignored and the standalone boundary rules
+apply.
 
 ### 4.4 Global roots
 
@@ -224,6 +230,9 @@ failing the whole Catalog. The name grammar is the existing Agent Skills
 boundary: 1-64 lowercase ASCII letters, digits, or hyphens; no leading,
 trailing, or consecutive hyphen. This makes every advertised name one literal
 shell token without Avibe-specific quoting or encoding.
+Any failure while constructing optional typed YAML values falls back to the
+same bounded tolerant extraction of `name` and `description`; malformed
+unrelated metadata cannot abort Catalog construction.
 
 Catalog parsing and rendering are bounded independently:
 
@@ -394,7 +403,10 @@ Contract details:
 - `directory` is the absolute, agent-accessible directory containing
   `SKILL.md`. Compatibility candidates whose resolved absolute directory is
   not valid UTF-8 are omitted; v1 does not invent a second path encoding for
-  model-facing output.
+  model-facing output. After ordinary XML attribute escaping, every Unicode
+  control character in the path is emitted as an ASCII numeric character
+  reference such as `&#xA;`, so the command prints no raw terminal controls and
+  the represented path remains reversible.
 - Load retains an open handle to the selected Skill directory, reads
   `SKILL.md` relative to that handle, and verifies immediately before output
   that the reported absolute path still names the same directory identity. If
@@ -621,8 +633,9 @@ ${AVIBE_HOME:-$HOME/.avibe}/builtin-skills/<snapshot-id>/<name>/
 stream. The stream begins with the ASCII domain separator
 `avibe-builtin-snapshot-v1` followed by NUL. It then contains one record for
 every directory except the source root and every regular file, ordered by the
-UTF-8 bytes of its `/`-separated relative path. A record contains a one-byte
-directory/file tag, the path length as an unsigned 64-bit big-endian integer,
+UTF-8 bytes of its `/`-separated relative path. A record contains the ASCII byte
+`d` (`0x64`) for a directory or `f` (`0x66`) for a file, the path length as an
+unsigned 64-bit big-endian integer,
 and the path bytes. A file record additionally contains its byte length in the
 same integer encoding, its exact bytes, and one byte holding
 `st_mode & 0o111` where POSIX executable bits exist (zero otherwise). Release
@@ -848,7 +861,9 @@ Catalogs at runtime.
   are omitted by the parser-backed portable name boundary. YAML-decoded C0 and
   C1 control characters cannot reach terminal Catalog output.
 - `vibe skill load` emits the exact XML wrapper, body only, and an absolute
-  directory from which supporting files can be read.
+  directory from which supporting files can be read. A control-character path
+  fixture proves the wrapper contains only the reversible ASCII references and
+  no raw terminal controls.
 - Parser-backed CLI coverage dispatches the canonical
   `vibe skill load -- pdf-processing` example through the real argument parser
   and reaches the load handler with `pdf-processing` as its single name.
@@ -869,7 +884,9 @@ Catalogs at runtime.
   contract.
 - A Workbench Session working below its configured non-Git project directory
   discovers project-level Skills up to that directory on the next Turn and via
-  `vibe skill`; an invalid or non-ancestor project binding is ignored.
+  `vibe skill`; an invalid, non-ancestor, or over-depth project binding is
+  ignored. Persisted pre-upgrade fixtures cover both deriving an unchanged
+  scope's ancestor and retaining that ancestor across a later scope move.
 - Workbench resource policies continue to govern management operations but do
   not narrow the runtime Catalog or loaded body, matching the ordinary
   filesystem capability of the agent process.
@@ -922,6 +939,9 @@ isolation acceptance gates.
 - a fresh installation mirrors all bundled Skills;
 - a real wheel-install fixture proves bundled Skills exist without a source
   tree and preserves executable modes required by helper scripts;
+- a real sdist-install fixture builds from the source archive, then proves the
+  resulting installation publishes and loads the same bundled Skills without
+  a repository checkout;
 - a fixed snapshot-v1 fixture proves the canonical tree byte stream and
   lowercase SHA-256 identifier remain stable;
 - release packaging accepts only directories and regular files throughout the

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -201,11 +201,14 @@ a candidate and consumes no frontmatter budget there. Its children are charged
 only when the explicit Codex system root is scanned.
 
 If `${CLAUDE_CONFIG_DIR}/plugins/installed_plugins.json` exists, Avibe invokes
-the official `claude plugin list --json` command in the Turn's bound working
-directory and scans `<installPath>/skills` for each entry whose `enabled` field
-is exactly `true`. It does not crawl the installation cache or trust stale
-registry entries directly. Disabled plugins and relative installation paths are
-omitted. This lookup runs on every Avibe-dispatched Turn so installing,
+the official `<configured-claude-cli> plugin list --json` command in the Turn's
+bound working directory and scans `<installPath>/skills` for each entry whose
+`enabled` field is exactly `true`. The executable is the normalized V2
+`agents.claude.cli_path` used by the live Claude backend, including a custom
+path; standalone commands fall back to the normal Claude executable lookup. It
+does not crawl the installation cache or trust stale registry entries directly.
+Disabled plugins and relative installation paths are omitted. This lookup runs
+on every Avibe-dispatched Turn so installing,
 enabling, disabling, or removing a plugin is reflected without restarting Avibe
 or creating a Session. A missing CLI, non-zero exit, timeout after one second,
 invalid UTF-8 or JSON, output over 1 MiB, or more than 256 reported entries
@@ -515,7 +518,9 @@ When a backend launches either command, Avibe supplies internal bindings:
   cannot combine the retained snapshot ID with a different Avibe home.
 - `AVIBE_SKILL_HOME`, `AVIBE_SKILL_CODEX_HOME`,
   `AVIBE_SKILL_CLAUDE_HOME`, and `AVIBE_SKILL_XDG_CONFIG_HOME` are normalized
-  absolute roots resolved by the advertising Avibe process. A relative
+  absolute roots resolved by the advertising Avibe process.
+  `AVIBE_SKILL_CLAUDE_CLI_PATH` carries its configured Claude executable for
+  plugin enumeration and load-time re-resolution. A relative
   `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, or `XDG_CONFIG_HOME` is therefore resolved
   once at Turn dispatch and cannot select a different compatibility tree merely
   because the agent launches `vibe skill` from another shell directory.
@@ -835,6 +840,8 @@ Catalogs at runtime.
   container, resolves one entry per final name.
 - Enabled Claude plugins contribute their standard `skills` directories to the
   same Avibe Catalog for all three backends, while disabled plugins do not.
+  A custom V2 Claude CLI path is used for both Turn-time and bound-command
+  plugin enumeration.
   Missing, failing, timed-out, malformed, oversized, or over-count plugin-list
   results omit only plugin roots, and static compatibility discovery continues.
 - Global-root fixtures override `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, and

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -147,12 +147,17 @@ $HOME/.agents/skills
 ${CODEX_HOME:-$HOME/.codex}/skills
 ${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills
 ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/skills
+${CODEX_HOME:-$HOME/.codex}/skills/.system
 ```
 
 Native locations are compatibility inputs. Avibe reads them in place and does
 not migrate, rename, or annotate their Skills. Implementations resolve the
 Claude root through the existing `vibe.claude_config.get_claude_home()` helper
 so discovery and the live Claude backend honor the same override semantics.
+Codex's `.system` directory is an explicit container root rather than a generic
+recursive exception: Avibe inspects only its direct child Skill directories and
+visits it after every user-managed global root. A same-name project or user
+global Skill therefore wins over the Codex-bundled default.
 
 ### 4.5 Reserved root
 
@@ -220,14 +225,16 @@ selected by these rules, in order:
 3. Within project scope, a directory nearer to the working directory over a
    more distant directory.
 4. At the same scope and depth, directory-family priority is:
-   `.avibe` > `.agents` > `.codex` > `.claude` > OpenCode.
+   `.avibe` > `.agents` > `.codex` > `.claude` > OpenCode > Codex system.
 5. If every preceding dimension ties, the candidate whose absolute directory
    path sorts first by Unicode code-point order wins.
 
 The `.avibe` family reserves the highest family slot for future use, but
 `${AVIBE_HOME:-$HOME/.avibe}/skills` is inactive in v1. OpenCode means
 `.opencode` at project scope and `${XDG_CONFIG_HOME:-$HOME/.config}/opencode`
-at global scope.
+at global scope. Codex system means the explicit
+`${CODEX_HOME:-$HOME/.codex}/skills/.system` container; it is last so bundled
+defaults cannot shadow user-managed Skills.
 
 Resolution must be deterministic. After resolution, entries are sorted by
 name for pagination and prompt rendering.
@@ -613,7 +620,8 @@ at runtime.
 
 ### 14.1 Resolver and protocol
 
-- A fixture covering every discovery root resolves one entry per final name.
+- A fixture covering every discovery root, including Codex's `.system`
+  container, resolves one entry per final name.
 - Global-root fixtures override `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, and
   `XDG_CONFIG_HOME` and resolve from the same homes as their live backends.
 - Built-in, project/global, directory depth, and directory-family precedence

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -175,7 +175,9 @@ Codex's `.system` directory is an explicit container root rather than a generic
 recursive exception: Avibe inspects only its direct child Skill directories and
 visits it after every user-managed global root. A same-name project or user
 global Skill therefore wins over the Codex-bundled default. The container entry
-is excluded when applying the parent user root's child and candidate limits.
+counts toward the parent root's raw direct-child enumeration limit, but is not
+a candidate and consumes no frontmatter budget there. Its children are charged
+only when the explicit Codex system root is scanned.
 
 ### 4.5 Reserved root
 
@@ -455,20 +457,18 @@ the OpenCode caller-context plugin. They are not prompt text or agent-visible
 command arguments. A standalone command without Avibe bindings uses its own
 current working directory and the snapshot bundled with its own executable.
 
-An OpenCode binding normally lives for the active Avibe-dispatched Turn.
-Binding-file updates are serialized across processes, use a unique
-same-directory temporary file and atomic replacement, and cleanup is guarded
-by a per-Turn token so an older Turn cannot remove a newer binding for the same
-native Session. Normal completion removes the binding, and the plugin rejects
-an entry unless both the owning Avibe PID and its non-reusable process-start
-identity still match. PID liveness alone is insufficient because an operating
-system can reuse a PID after a crash. The binding does not expire while that
-exact process and Turn remain active, so a long-running Turn keeps its advertised
-working directory and snapshot. Restoring a persisted poll publishes a fresh
-binding with the current process identity and absolute Skill roots. During the
-short handoff before restoration, a stale remote binding supplies only the
-previously advertised Skill roots plus remote-deny caller context; it never
-replays an old authorization snapshot as current.
+An OpenCode binding normally lives for the active Avibe-dispatched Turn and
+retains the released bridge's 24-hour expiry as crash cleanup. Binding-file
+updates are serialized across processes, use a unique same-directory temporary
+file and atomic replacement, and cleanup is guarded by a per-Turn token so an
+older Turn cannot remove a newer binding for the same native Session. Each new
+or restored Turn refreshes the entry. The persisted shape remains readable by
+an already-running OpenCode server that loaded the released plugin: the
+existing `env`, `updated_at`, and `expires_at` fields are unchanged, while the
+cleanup token and Skill roots are additive. This feature leaves the released
+plugin source unchanged, so an upgrade can adopt its active server and restore
+polls without requesting a plugin refresh. Expired entries are ignored and
+pruned.
 
 ### 8.3 Runtime access boundary
 
@@ -584,12 +584,13 @@ every forbidden component character (`<`, `>`, `:`, `"`, `\`, `|`, `?`,
 `*`), drive/UNC prefixes,
 Windows-reserved components, trailing-dot/space names, case-insensitive path
 collisions, and empty directories. It also rejects more than 1,024 built-in
-root entries, any direct child that is not a valid Skill directory, more than
-4,096 directories and regular files across the complete tree, more than 32 MiB
-of regular-file bytes across the complete tree, any Skill whose closing
-frontmatter delimiter exceeds 64 KiB, any body over 256 KiB, or a built-in tree
-whose bounded frontmatter exceeds 8 MiB. The aggregate entry and byte checks
-occur before hashing or copying and abort as soon as a limit is crossed.
+root entries, any direct child that is not a valid Skill directory, duplicate
+declared Skill names, more than 4,096 directories and regular files across the
+complete tree, more than 32 MiB of regular-file bytes across the complete tree,
+any Skill whose closing frontmatter delimiter exceeds 64 KiB, any body over 256
+KiB, or a built-in tree whose bounded frontmatter exceeds 8 MiB. The aggregate
+entry and byte checks occur before hashing or copying and abort as soon as a
+limit is crossed.
 
 The runtime directory is deliberately separate from user-managed Skills and
 is directly accessible to the agent so loaded built-ins can use their own
@@ -753,7 +754,10 @@ Catalogs at runtime.
   inputs each have separate 4,096-direct-child, 1,024-candidate, and 8 MiB
   frontmatter budgets, so either class can exhaust its own budget without
   consuming the other's. Cross-root exhaustion follows precedence and the
-  pre-frontmatter path order defined in Section 5.1.
+  pre-frontmatter path order defined in Section 5.1. The Codex `.system`
+  container counts toward its parent's raw 1,024-child limit regardless of
+  enumeration order, while its contents are scanned only as the explicit
+  system root.
 - Compatibility directory symlinks resolve to their target directory, and
   replacing either the alias or target after discovery makes load fail. A
   canonical Skill plus all backend compatibility aliases consumes one candidate
@@ -819,12 +823,12 @@ and verify:
 - the Avibe Catalog is equivalent across all three backends;
 - the native backend Catalog is absent;
 - OpenCode's native Skill tool is disabled; and
-- OpenCode user permission configuration is not rewritten, concurrent active
+- OpenCode user permission configuration and released caller-context plugin
+  source are not rewritten, concurrent active
   Turn bindings preserve each other, and token-guarded cleanup removes only the
-  binding created by that Turn; a binding remains valid for a Turn longer than
-  24 hours while its exact owning Avibe process stays alive, while a stale
-  binding after PID reuse carries only Skill roots and remote-deny caller
-  context until restoration; and
+  binding created by that Turn; a released-shape binding remains usable during
+  an upgrade until its existing expiry, and each restored Turn replaces its own
+  entry without pruning other unexpired Sessions; and
 - a cached Claude client is recreated and resumes the same native Session when
   its bound Skill roots or built-in snapshot change even if page 1 is identical;
   and
@@ -848,6 +852,8 @@ isolation acceptance gates.
   child; a Skill whose closing frontmatter delimiter exceeds 64 KiB; a body
   over 256 KiB; and a tree whose bounded frontmatter exceeds the built-in 8 MiB
   budget;
+- release packaging rejects duplicate declared Skill names even when their
+  directories differ;
 - a mode-only built-in change produces a different snapshot and published
   digest;
 - publication recomputes the snapshot-v1 digest from the completed staging

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -157,7 +157,8 @@ so discovery and the live Claude backend honor the same override semantics.
 Codex's `.system` directory is an explicit container root rather than a generic
 recursive exception: Avibe inspects only its direct child Skill directories and
 visits it after every user-managed global root. A same-name project or user
-global Skill therefore wins over the Codex-bundled default.
+global Skill therefore wins over the Codex-bundled default. The container entry
+is excluded when applying the parent user root's child and candidate limits.
 
 ### 4.5 Reserved root
 

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -292,9 +292,9 @@ resolved rows substituted:
 
 Skills provide specialized instructions and workflows for specific tasks.
 When a task matches a skill's description, run `vibe skill load -- <name>` before proceeding.
-If the user requests a skill by name, load it.
-Only load skill names listed here or returned by `vibe skill list`; do not guess names.
-If no Skill on this page matches the task, inspect each subsequent Catalog page in order until a Skill matches or no page remains.
+If the user requests a skill by exact name, load that name directly.
+Otherwise, only load skill names listed here or returned by `vibe skill list`; do not guess names.
+Use `vibe skill list --page 2` only when more discovery is useful; ordinary tasks do not require scanning every page.
 
 ### Available skills
 - data-analysis: Analyze datasets, generate charts, and create reports.
@@ -302,8 +302,9 @@ If no Skill on this page matches the task, inspect each subsequent Catalog page 
 ```
 
 The system prompt contains page 1 only, within the entry and row budgets in
-Section 5.1. The subsequent-page instruction is present only when another page
-exists. If more entries exist, append exactly:
+Section 5.1. The optional subsequent-page guidance is present only when another
+page exists. A user-requested exact name may be loaded directly without first
+finding it in a paged Catalog. If more entries exist, append exactly:
 
 ```md
 More skills are available. Run `vibe skill list --page 2` to view more.
@@ -444,6 +445,9 @@ When a backend launches either command, Avibe supplies internal bindings:
 - `AVIBE_BUILTIN_SKILLS_SNAPSHOT_ID` selects the version-scoped built-in snapshot
   retained by the Avibe process that created that backend runtime, even if an
   upgrade has since switched the stable `vibe` launcher to another artifact.
+- `AVIBE_BUILTIN_SKILLS_ROOT` is that snapshot's absolute directory. It binds
+  the complete runtime address, so a later launcher or `AVIBE_HOME` change
+  cannot combine the retained snapshot ID with a different Avibe home.
 - `AVIBE_SKILL_HOME`, `AVIBE_SKILL_CODEX_HOME`,
   `AVIBE_SKILL_CLAUDE_HOME`, and `AVIBE_SKILL_XDG_CONFIG_HOME` are normalized
   absolute roots resolved by the advertising Avibe process. A relative
@@ -457,12 +461,14 @@ the OpenCode caller-context plugin. They are not prompt text or agent-visible
 command arguments. A standalone command without Avibe bindings uses its own
 current working directory and the snapshot bundled with its own executable.
 
-An OpenCode binding normally lives for the active Avibe-dispatched Turn and
-retains the released bridge's 24-hour expiry as crash cleanup. Binding-file
-updates are serialized across processes, use a unique same-directory temporary
-file and atomic replacement, and cleanup is guarded by a per-Turn token so an
-older Turn cannot remove a newer binding for the same native Session. Each new
-or restored Turn refreshes the entry. The persisted shape remains readable by
+An OpenCode binding normally lives for the active Avibe-dispatched Turn. Avibe
+renews its released 24-hour expiry throughout active original and restored poll
+loops; after a crash or an ambiguously abandoned poll, the last expiry remains
+the bounded cleanup path. Binding-file updates are serialized across processes,
+use a unique same-directory temporary file and atomic replacement, and cleanup
+is guarded by a per-Turn token so an older Turn cannot refresh or remove a newer
+binding for the same native Session. Each new or restored Turn writes its own
+entry. The persisted shape remains readable by
 an already-running OpenCode server that loaded the released plugin: the
 existing `env`, `updated_at`, and `expires_at` fields are unchanged, while the
 cleanup token and Skill roots are additive. This feature leaves the released
@@ -589,8 +595,9 @@ declared Skill names, more than 4,096 directories and regular files across the
 complete tree, more than 32 MiB of regular-file bytes across the complete tree,
 any Skill whose closing frontmatter delimiter exceeds 64 KiB, any body over 256
 KiB, or a built-in tree whose bounded frontmatter exceeds 8 MiB. The aggregate
-entry and byte checks occur before hashing or copying and abort as soon as a
-limit is crossed.
+entry traversal is capped while enumerating. Hashing and publication also charge
+the size of each regular file at the point it is opened and bound every read to
+that size, so growth after enumeration cannot exceed the aggregate byte budget.
 
 The runtime directory is deliberately separate from user-managed Skills and
 is directly accessible to the agent so loaded built-ins can use their own
@@ -608,7 +615,11 @@ complete mirror that Avibe itself never mutates:
 Publication is serialized by a cross-process lock keyed by snapshot digest.
 The next lock holder first removes the one deterministic hidden staging path
 for that digest, reclaiming any partial tree left by an interrupted publisher.
-It then builds and validates that staging directory and
+It then re-enumerates one bounded, fixed entry set and copies only those entries
+into staging; entries created after that enumeration are neither traversed nor
+copied. Each file is reopened without following its final path component,
+charged against the aggregate byte budget, read to its opened size, and rejected
+if it changes during the read. Avibe then validates that staging directory and
 recomputes the canonical snapshot-v1 digest from the completed staging tree and
 requires it to equal the target `<snapshot-id>` before atomically renaming it
 once into the previously absent digest path. The staged digest includes every
@@ -826,9 +837,10 @@ and verify:
 - OpenCode user permission configuration and released caller-context plugin
   source are not rewritten, concurrent active
   Turn bindings preserve each other, and token-guarded cleanup removes only the
-  binding created by that Turn; a released-shape binding remains usable during
-  an upgrade until its existing expiry, and each restored Turn replaces its own
-  entry without pruning other unexpired Sessions; and
+  binding created by that Turn; active original and restored polls renew their
+  released-shape expiry, an abandoned binding expires without a live renewer,
+  and each restored Turn replaces its own entry without pruning other unexpired
+  Sessions; and
 - a cached Claude client is recreated and resumes the same native Session when
   its bound Skill roots or built-in snapshot change even if page 1 is identical;
   and
@@ -858,6 +870,8 @@ isolation acceptance gates.
   digest;
 - publication recomputes the snapshot-v1 digest from the completed staging
   tree and refuses to rename staging bytes under a different digest;
+- publication ignores entries created after its bounded copy enumeration and
+  rejects aggregate file growth observed at hashing or copy time;
 - an upgrade's selected snapshot contains changed Skills and omits retired
   Skills;
 - after an injected interruption leaves partial staging state, the next
@@ -869,7 +883,8 @@ isolation acceptance gates.
   different version-scoped snapshots;
 - after launcher activation, a command inherited from the older runtime still
   lists and loads that runtime's retained built-in snapshot path without the
-  older package source and never falls back to the newer snapshot; and
+  older package source and never falls back to the newer snapshot, even when
+  the active `AVIBE_HOME` changed; and
 - every loaded built-in reports an agent-accessible absolute directory.
 
 ## 15. Explicit Non-Goals

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -120,8 +120,9 @@ Avibe artifact selects only the version-scoped snapshot derived from its own
 bundled Skill tree. The `builtin-skills` umbrella is not a generic discovery
 root for direct child Skills. The selected snapshot is Avibe-owned runtime
 content, has the highest resolution priority, and contains at most 1,024 direct
-child Skill directories. This keeps every published built-in discoverable
-within the same root cap as compatibility inputs.
+child Skill directories whose bounded frontmatter totals at most 8 MiB. This
+keeps every published built-in discoverable within the same candidate and byte
+budgets as compatibility inputs.
 
 ### 4.3 Project roots
 
@@ -196,12 +197,15 @@ The bounded read happens before decoding or normalizing field values, so a
 large optional field, description, or unterminated frontmatter cannot create
 unbounded per-Turn work. Discovery enumerates at most 1,025 direct child
 entries in any root and omits the entire root if it contains more than 1,024.
-Across accepted roots, one resolution processes at most 1,024 candidate Skill
-directories and 8 MiB of frontmatter bytes. Roots are visited in precedence
-order and each accepted root's candidates in stable name order. Reaching an
-aggregate budget omits the remaining lower-priority roots. These rules make
-omission deterministic without walking the rest of an oversized directory.
-Omission is diagnostic log data, not additional prompt content.
+One resolution gives the built-in root and the combined project/global roots
+independent aggregate budgets of 1,024 candidate Skill directories and 8 MiB
+of frontmatter bytes each. A full built-in root therefore cannot consume the
+capacity reserved for user Skills. Within the compatibility-input budget,
+roots are visited in precedence order and each accepted root's candidates in
+stable name order. Reaching that budget omits the remaining lower-priority
+roots. These rules make omission deterministic without walking the rest of an
+oversized directory. Omission is diagnostic log data, not additional prompt
+content.
 
 These limits do not validate optional frontmatter, require the directory and
 declared name to match, or add compatibility metadata.
@@ -389,7 +393,7 @@ When a backend launches either command, Avibe supplies two internal bindings:
 - `AVIBE_SKILL_WORKING_DIR` is the absolute working directory from which Avibe
   rendered that Session's Catalog. Project discovery always starts there, even
   when the agent runs the command from another directory.
-- `AVIBE_BUILTIN_SKILLS_SNAPSHOT_ID` selects the immutable built-in snapshot
+- `AVIBE_BUILTIN_SKILLS_SNAPSHOT_ID` selects the version-scoped built-in snapshot
   retained by the Avibe process that created that backend runtime, even if an
   upgrade has since switched the stable `vibe` launcher to another artifact.
 
@@ -477,17 +481,25 @@ artifact, Avibe publishes a complete runtime snapshot to:
 ${AVIBE_HOME:-$HOME/.avibe}/builtin-skills/<snapshot-id>/<name>/
 ```
 
-`<snapshot-id>` is a lowercase SHA-256 identifier derived deterministically from
-every relative path, file byte sequence, and executable mode bits
-(`st_mode & 0o111` where POSIX mode bits exist) in the authoritative bundled
-Skill tree. It is a directory identifier, not a second persisted manifest or a
-runtime integrity protocol.
+`<snapshot-id>` is lowercase SHA-256 over an unambiguous snapshot-v1 byte
+stream. The stream begins with the ASCII domain separator
+`avibe-builtin-snapshot-v1` followed by NUL. It then contains one record for
+every directory except the source root and every regular file, ordered by the
+UTF-8 bytes of its `/`-separated relative path. A record contains a one-byte
+directory/file tag, the path length as an unsigned 64-bit big-endian integer,
+and the path bytes. A file record additionally contains its byte length in the
+same integer encoding, its exact bytes, and one byte holding
+`st_mode & 0o111` where POSIX executable bits exist (zero otherwise). Release
+packaging requires relative paths to be valid UTF-8 in NFC form. A fixed
+tree-to-digest fixture freezes this encoding without creating a persisted
+manifest. The identifier selects a directory; it is not a runtime integrity
+protocol.
 
 Built-in source paths must be representable without aliases on every supported
 platform. Release packaging rejects absolute or traversal paths, backslashes,
 NUL, drive/UNC prefixes, Windows-reserved components, trailing-dot/space names,
 and case-insensitive path collisions. It also rejects a 1,025th direct child
-Skill directory.
+Skill directory or a built-in tree whose bounded frontmatter exceeds 8 MiB.
 
 The runtime directory is deliberately separate from user-managed Skills and
 is directly accessible to the agent so loaded built-ins can use their own
@@ -507,11 +519,10 @@ The publisher builds and validates a hidden sibling staging directory, then
 atomically renames it once into the previously absent digest path. A process
 interruption can leave only an undiscoverable staging directory. If the digest
 path already exists, concurrent or later publishers reuse that path without
-mutating it. Because Avibe publication creates the final path only by atomic
-rename, a pre-existing wrong-type, unreadable, or externally changed path is
-treated as unsupported post-publication mutation: list/load fails safely and
-does not repair it from whichever artifact the stable launcher currently
-selects.
+mutating it. A wrong-type or unreadable path fails safely. Readable external
+changes are unsupported post-publication mutation and may affect later
+Catalog/load results; runtime commands neither validate nor repair the path
+from whichever artifact the stable launcher currently selects.
 
 After publication, list/load does not hash the full snapshot, compare it with a
 package source, or repair it. It reads the selected built-in through the same
@@ -621,9 +632,9 @@ at runtime.
 - Frontmatter parsing reads no more than 64 KiB before accepting or omitting a
   candidate, including for oversized or unterminated input.
 - A root with more than 1,024 direct children is omitted after enumerating at
-  most 1,025 entries; one resolution processes at most 1,024 candidates and 8
-  MiB of frontmatter. Budget exhaustion deterministically omits the remaining
-  lower-priority roots without blocking the Turn.
+  most 1,025 entries. Built-ins and combined project/global compatibility
+  inputs each have a separate 1,024-candidate and 8 MiB frontmatter budget, so
+  either class can exhaust its own budget without consuming the other's.
 - Prompt and `vibe skill list` pagination are stable, limited to 25 entries,
   remain within the row budget, and do not expose paths or sources.
 - Oversized descriptions cannot make the Catalog unbounded, and names with
@@ -631,6 +642,9 @@ at runtime.
   are omitted by the parser-backed portable name boundary.
 - `vibe skill load` emits the exact XML wrapper, body only, and an absolute
   directory from which supporting files can be read.
+- Parser-backed CLI coverage dispatches the canonical
+  `vibe skill load -- pdf-processing` example through the real argument parser
+  and reaches the load handler with `pdf-processing` as its single name.
 - If the selected `SKILL.md` is replaced after discovery, load reparses the
   exact verified bytes it will emit and fails unless they still declare the
   requested name.
@@ -676,15 +690,18 @@ isolation acceptance gates.
 - a fresh installation mirrors all bundled Skills;
 - a real wheel-install fixture proves bundled Skills exist without a source
   tree and preserves executable modes required by helper scripts;
+- a fixed snapshot-v1 fixture proves the canonical tree byte stream and
+  lowercase SHA-256 identifier remain stable;
 - release packaging rejects non-portable, Windows-reserved, trailing-dot/space,
-  or case-insensitively colliding built-in paths and a 1,025th direct Skill;
+  or case-insensitively colliding built-in paths, a 1,025th direct Skill, and a
+  tree whose bounded frontmatter exceeds the built-in 8 MiB budget;
 - a mode-only built-in change produces a different snapshot and published
   digest;
 - an upgrade's selected snapshot contains changed Skills and omits retired
   Skills;
 - interrupted publication cannot expose a partial snapshot;
-- a wrong-type, unreadable, or externally changed pre-existing digest path
-  fails safely without being traversed, mutated, or rebuilt by runtime commands;
+- a wrong-type or unreadable pre-existing digest path fails safely without
+  being traversed, mutated, or rebuilt by runtime commands;
 - two concurrently running artifacts with different bundled trees resolve
   different version-scoped snapshots;
 - after launcher activation, a command inherited from the older runtime still

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -459,11 +459,13 @@ Binding-file updates are serialized across processes, use a unique
 same-directory temporary file and atomic replacement, and cleanup is guarded
 by a per-Turn token so an older Turn cannot remove a newer binding for the same
 native Session. Normal completion removes the binding, and the plugin rejects
-an entry whose owning Avibe process is no longer alive. The binding does not
-expire while that process and Turn remain active, so a long-running Turn keeps
-its advertised working directory and snapshot. Restoring a persisted poll
-publishes a fresh binding with the current process identity, authorization
-snapshot, and absolute Skill roots.
+an entry unless both the owning Avibe PID and its non-reusable process-start
+identity still match. PID liveness alone is insufficient because an operating
+system can reuse a PID after a crash. The binding does not expire while that
+exact process and Turn remain active, so a long-running Turn keeps its advertised
+working directory and snapshot. Restoring a persisted poll publishes a fresh
+binding with the current process identity, authorization snapshot, and absolute
+Skill roots.
 
 ### 8.3 Caller authorization
 
@@ -833,7 +835,8 @@ and verify:
 - OpenCode user permission configuration is not rewritten, concurrent active
   Turn bindings preserve each other, and token-guarded cleanup removes only the
   binding created by that Turn; a binding remains valid for a Turn longer than
-  24 hours while its owning Avibe process stays alive; and
+  24 hours while its exact owning Avibe process stays alive, while a stale
+  binding is rejected after PID reuse; and
 - each adapter retains the same native Session when the Catalog changes.
 
 Codex `$skill`, backend TUI commands, and ordinary filesystem reads are not v1

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -145,7 +145,7 @@ budgets as compatibility inputs.
 ### 4.3 Project roots
 
 For each directory `D` from the active working directory up to and including
-the Git project root, Avibe inspects:
+the first project boundary, Avibe inspects:
 
 ```text
 <D>/.agents/skills
@@ -154,12 +154,19 @@ the Git project root, Avibe inspects:
 <D>/.opencode/skills
 ```
 
+The first project boundary is the nearer of the Git project root and the
+Avibe project base bound to the Session. The latter lets a Workbench project
+whose configured directory has no `.git` marker retain project-level Skills
+when an existing Session works in one of its descendants. A standalone command
+has no Avibe project binding and therefore uses the Git root; if neither
+boundary is found, only its active working directory is project scope.
+
 The nearest directory to the active working directory wins within the same
 directory family. Root discovery examines at most 128 directories including
-the active working directory. If no Git root is found within that bound, only
-the active working directory is considered project scope. Thus each Turn
-performs at most 512 project-root probes before the existing candidate and byte
-budgets apply.
+the active working directory and performs at most 512 project-root probes
+before the existing candidate and byte budgets apply. A bound Avibe project
+base is accepted only when it is an absolute ancestor of the bound working
+directory; otherwise it is ignored.
 
 ### 4.4 Global roots
 
@@ -452,6 +459,11 @@ When a backend launches either command, Avibe supplies internal bindings:
 - `AVIBE_SKILL_WORKING_DIR` is the absolute working directory from which Avibe
   rendered that Session's Catalog. Project discovery always starts there, even
   when the agent runs the command from another directory.
+- `AVIBE_SKILL_PROJECT_BASE`, when present, is the normalized absolute Avibe
+  project base that bounded that Session's Catalog. It lets a command launched
+  by an existing Session discover project Skills between a descendant working
+  directory and a configured non-Git project base. Values outside the bound
+  working directory's ancestor chain are ignored.
 - `AVIBE_BUILTIN_SKILLS_SNAPSHOT_ID` selects the version-scoped built-in snapshot
   retained by the Avibe process that created that backend runtime, even if an
   upgrade has since switched the stable `vibe` launcher to another artifact.
@@ -489,6 +501,12 @@ renew, and unbind there until the server is replaced, even when the effective
 `AVIBE_HOME` has changed. A newly started server uses the current runtime path.
 Expired entries are ignored and pruned.
 
+Binding publication and cleanup run outside the controller event loop. A
+restored poll retries publication three times; if the binding store remains
+unavailable, Avibe restores result delivery without the optional shell binding
+rather than stranding the durable poll. The next ordinary Avibe-dispatched Turn
+gets a fresh binding attempt.
+
 ### 8.3 Runtime access boundary
 
 Workbench resource policies continue to authorize the Skills management API:
@@ -514,7 +532,7 @@ Once a Skill body has been loaded, it remains historical context just like any
 other file previously read by the agent. The current Catalog describes current
 availability; it does not retroactively change history.
 
-### 8.4 No watcher in v1
+### 8.5 No watcher in v1
 
 There is no filesystem watcher, change notification, incremental system-prompt
 patch, or long-lived per-Session Catalog. Turn-time rendering is already the
@@ -525,7 +543,9 @@ The initial implementation scans the fixed roots within the candidate and byte
 budgets and reads only enough of each `SKILL.md` to extract frontmatter. A
 reference measurement of six roots, 20 Skill files, and 242 KB total input
 completed in about 1 ms median on a warm local filesystem. This is not a
-latency guarantee; it shows that correctness can precede caching.
+latency guarantee; it shows that correctness can precede caching. Per-Turn
+discovery runs outside the controller event loop so bounded cold-filesystem
+latency cannot stall unrelated dispatch.
 
 V1 does not cache discovery results. A future parsed-frontmatter cache cannot
 treat file identity, size, or timestamps as proof that content is unchanged: it
@@ -591,7 +611,8 @@ directory/file tag, the path length as an unsigned 64-bit big-endian integer,
 and the path bytes. A file record additionally contains its byte length in the
 same integer encoding, its exact bytes, and one byte holding
 `st_mode & 0o111` where POSIX executable bits exist (zero otherwise). Release
-packaging requires relative paths to be valid UTF-8 in NFC form. A fixed
+packaging requires relative paths to be valid UTF-8 in NFC form and every
+built-in `SKILL.md` body to be valid UTF-8. A fixed
 tree-to-digest fixture freezes this encoding without creating a persisted
 manifest. The identifier selects a directory; it is not a runtime integrity
 protocol.
@@ -607,7 +628,8 @@ root entries, any direct child that is not a valid Skill directory, duplicate
 declared Skill names, more than 4,096 directories and regular files across the
 complete tree, more than 32 MiB of regular-file bytes across the complete tree,
 any Skill whose closing frontmatter delimiter exceeds 64 KiB, any body over 256
-KiB, or a built-in tree whose bounded frontmatter exceeds 8 MiB. The aggregate
+KiB, any invalid UTF-8 `SKILL.md` body, or a built-in tree whose bounded
+frontmatter exceeds 8 MiB. The aggregate
 entry traversal is capped while enumerating. Hashing and publication also charge
 the size of each regular file at the point it is opened and bound every read to
 that size, so growth after enumeration cannot exceed the aggregate byte budget.
@@ -824,6 +846,12 @@ Catalogs at runtime.
   limit before load produces empty standard output and a non-zero exit.
 - An invalid UTF-8 body may be advertised from its valid frontmatter but load
   produces empty standard output and a non-zero exit without replacement text.
+- Built-in publication rejects an invalid UTF-8 body, so every published
+  built-in that can be advertised is also loadable under the body-encoding
+  contract.
+- A Workbench Session working below its configured non-Git project directory
+  discovers project-level Skills up to that directory on the next Turn and via
+  `vibe skill`; an invalid or non-ancestor project binding is ignored.
 - Workbench resource policies continue to govern management operations but do
   not narrow the runtime Catalog or loaded body, matching the ordinary
   filesystem capability of the agent process.

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -119,7 +119,11 @@ authoritative when the compatibility migration cannot move it. Each running
 Avibe artifact selects only the immutable snapshot derived from its own bundled
 Skill tree; the `builtin-skills` umbrella is not a generic discovery root for
 direct child Skills. The selected snapshot is Avibe-owned runtime content and
-has the highest resolution priority.
+has the highest resolution priority. Its generated `.avibe-snapshot.json` is
+runtime metadata rather than a discovery candidate and is excluded from the
+direct-child budget. Release packaging permits at most 1,024 direct child Skill
+directories, so every published built-in remains discoverable within the same
+root cap as compatibility inputs.
 
 ### 4.3 Project roots
 
@@ -484,6 +488,9 @@ Manifest v1 is a frozen persisted shape:
 - the top-level JSON object contains `schema_version: 1` and `entries`; each
   entry contains a `/`-separated relative `path`, byte `size`, lowercase
   64-hex `sha256`, and integer `executable` bits (`st_mode & 0o111`);
+- those are the only top-level and entry keys; the schema version is exactly the
+  integer `1`, `entries` is a list, `size` is a non-negative integer no larger
+  than 64 MiB, and `executable` is one of the valid `0o111` bit combinations;
 - entries sort by `path`, object keys sort lexically, and serialization is UTF-8
   without BOM or trailing newline using ASCII escapes and separators `,` and
   `:` with no optional whitespace;
@@ -497,7 +504,13 @@ path is at most 1,024 bytes. Release packaging fails rather than publishing a
 built-in tree outside these limits. Runtime opens the manifest with the same
 nonblocking, same-handle regular-file and verified-read contract as `SKILL.md`,
 applies the byte limit before parsing, and rejects duplicate, absolute, empty,
-`.` or `..` path components.
+`.` or `..` path components. A manifest path is portable only when it is
+relative under both POSIX and Windows parsing: backslashes, NUL, drive prefixes,
+UNC roots, and platform separator aliases are rejected. Runtime reconstructs
+accepted paths component-by-component from an open snapshot-root handle,
+without following symlinks, junctions, or other reparse points, and requires
+each intermediate component to remain a directory and each leaf to remain the
+expected regular file beneath that root.
 The runtime directory is deliberately separate from user-managed Skills and
 is directly accessible to the agent so loaded built-ins can use their own
 scripts and references.
@@ -710,6 +723,10 @@ isolation acceptance gates.
   fixture validates and loads that retained schema without the older package;
 - a FIFO, non-regular, oversized, malformed, duplicate-path, or traversal-path
   manifest is bounded and rejected before use;
+- manifest fixtures reject backslash traversal, drive/UNC paths, symlinks, and
+  reparse points on every supported platform;
+- packaging rejects a 1,025th direct built-in Skill directory, while 1,024
+  Skills plus the generated root manifest remain discoverable;
 - a mode-only built-in change produces a different snapshot and published
   digest;
 - an upgrade's selected snapshot contains changed Skills and omits retired

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -55,7 +55,7 @@ example-skill/
 `-- assets/
 ```
 
-Avibe requires only two non-empty fields in the leading frontmatter:
+Avibe requires only two fields in the leading frontmatter:
 
 ```yaml
 ---
@@ -69,7 +69,8 @@ They are not presented as formats required by the Agent Skills specification.
 
 Existing Skills are usable by default. There is no Avibe-specific portability
 field, compatibility state, validation state, source namespace, or migration
-requirement.
+requirement. Avibe reuses the portable Agent Skills name grammar rather than
+inventing another identifier format; all other frontmatter remains optional.
 
 ## 4. Discovery
 
@@ -91,13 +92,16 @@ and `.claude/commands` are not discovery sources.
 ### 4.2 Built-in root
 
 ```text
-${AVIBE_HOME:-$HOME/.avibe}/builtin-skills
+${AVIBE_HOME:-$HOME/.avibe}/builtin-skills/<snapshot-id>
 ```
 
 This is logical user-facing notation. Implementations resolve it through
 `config.paths.get_vibe_remote_dir()` so a legacy `~/.vibe_remote` home remains
-authoritative when the compatibility migration cannot move it. This is
-Avibe-owned runtime content and has the highest resolution priority.
+authoritative when the compatibility migration cannot move it. Each running
+Avibe artifact selects only the immutable snapshot derived from its own bundled
+Skill tree; the `builtin-skills` umbrella is not a generic discovery root for
+direct child Skills. The selected snapshot is Avibe-owned runtime content and
+has the highest resolution priority.
 
 ### 4.3 Project roots
 
@@ -143,26 +147,31 @@ does not scan it, write to it, or assign it any behavior.
 Discovery is deliberately permissive:
 
 - extract `name` and `description` from the leading frontmatter;
-- accept the Skill when both values are present and non-empty;
+- accept the Skill when `description` is non-empty and `name` follows the
+  portable Agent Skills grammar;
 - ignore every other field;
 - do not reject a Skill because unrelated frontmatter is unknown or malformed;
 - do not require the declared name to match the directory name; and
-- fold whitespace in `name` and `description` into single-line Catalog values.
+- fold whitespace in `description` into a single-line Catalog value.
 
 If either required value cannot be extracted, omit that candidate without
-failing the whole Catalog. To keep every accepted name callable and every
-Catalog bounded, Avibe applies only these output-boundary limits:
+failing the whole Catalog. The name grammar is the existing Agent Skills
+boundary: 1-64 lowercase ASCII letters, digits, or hyphens; no leading,
+trailing, or consecutive hyphen. This makes every advertised name one literal
+shell token without Avibe-specific quoting or encoding.
 
-- omit a candidate whose normalized name exceeds 256 characters;
-- omit a candidate whose normalized name contains `:`, the Catalog row
-  delimiter;
+Catalog parsing and rendering are bounded independently:
+
+- read at most 64 KiB of leading frontmatter, including its delimiters, and
+  omit the candidate if the closing delimiter is not found within that budget;
 - truncate a normalized description beyond 1,024 characters, adding `...`;
-- render at most 25 entries and 16 KiB of Skill rows per page; and
-- use `--` before the name in load commands so option-like names remain
-  callable.
+- render at most 25 entries and 16 KiB of Skill rows per page.
 
-These limits do not validate optional frontmatter, require the directory and
-declared name to match, or add compatibility metadata.
+The bounded read happens before decoding or normalizing field values, so a
+large optional field, description, or unterminated frontmatter cannot create
+unbounded per-Turn work. These limits do not validate optional frontmatter,
+require the directory and declared name to match, or add compatibility
+metadata.
 
 ### 5.2 Deduplication
 
@@ -385,39 +394,43 @@ code resolves the checkout path during development and the packaged resource
 path after installation; it never assumes the repository root exists in a
 wheel environment.
 
-At installation and upgrade, Avibe publishes a complete runtime mirror to:
+Before the first managed Skill resolution from an installed or upgraded Avibe
+artifact, Avibe publishes a complete runtime snapshot to:
 
 ```text
-${AVIBE_HOME:-$HOME/.avibe}/builtin-skills/<name>/
+${AVIBE_HOME:-$HOME/.avibe}/builtin-skills/<snapshot-id>/<name>/
 ```
 
+`<snapshot-id>` is a stable digest of the authoritative bundled Skill tree.
 The runtime directory is deliberately separate from user-managed Skills and
-must be directly accessible to the agent so loaded built-ins can use their own
+is directly accessible to the agent so loaded built-ins can use their own
 scripts and references.
 
 ### 10.2 Replacement lifecycle
 
-The source tree is authoritative for each Avibe version. First run and every
-upgrade perform a full replacement of `builtin-skills`:
+The source tree is authoritative for each Avibe artifact. Each snapshot is a
+complete, immutable mirror:
 
 - new built-ins are added;
 - changed built-ins are replaced; and
-- built-ins removed from the release are deleted from the runtime mirror.
+- built-ins removed from the artifact are absent from its snapshot.
 
-The publisher and every Avibe Catalog, list, and load reader use the same
-cross-process lock. Under that lock, the publisher builds and validates a
-complete sibling staging directory, renames the current mirror to a backup,
-renames the staging directory to `builtin-skills`, and then removes the backup.
-If publication fails, it restores the backup before releasing the lock. After
-a process interruption, the next lock holder completes recovery before any
-Skill resolution.
+The publisher builds and validates a hidden sibling staging directory, then
+atomically renames it once into the previously absent digest path. A process
+interruption can leave only an undiscoverable staging directory. If a valid
+snapshot for the same digest already exists, concurrent publishers reuse it
+instead of mutating it.
 
-This is atomic at the Avibe reader boundary without relying on replacing a
-non-empty directory in place: a managed reader observes either the prior
-complete mirror or the new complete mirror, never the rename interval. The
-installed built-in set therefore exactly matches the running Avibe version
-after publication. The directory is Avibe-owned rather than a user
-customization surface.
+Every resolver selects the digest computed from the bundled source of its own
+running artifact. Concurrent old and new Avibe processes therefore use
+different snapshots when their built-ins differ, while identical trees safely
+share one. Other snapshots are not discovery candidates. V1 retains them so a
+running older process and an already loaded Skill directory remain usable;
+garbage collection of unreferenced snapshots is outside this protocol.
+
+The selected snapshot exactly matches the running artifact and is never
+partially updated. The `builtin-skills` umbrella is Avibe-owned rather than a
+user customization surface.
 
 ## 11. Installation Defaults
 
@@ -488,14 +501,16 @@ at runtime.
 - A fixture covering every discovery root resolves one entry per final name.
 - Built-in, project/global, directory depth, and directory-family precedence
   match Section 5.
-- A Skill with extractable `name` and `description` is accepted despite
+- A Skill with a portable name and extractable description is accepted despite
   unrelated malformed or unknown frontmatter.
 - Invalid candidates do not prevent valid candidates from appearing.
+- Frontmatter parsing reads no more than 64 KiB before accepting or omitting a
+  candidate, including for oversized or unterminated input.
 - Prompt and `vibe skill list` pagination are stable, limited to 25 entries,
   remain within the row budget, and do not expose paths or sources.
-- Oversized descriptions cannot make the Catalog unbounded; delimiter-bearing
-  names are omitted; and option-like or whitespace-containing names remain
-  single-line and callable.
+- Oversized descriptions cannot make the Catalog unbounded, and names with
+  whitespace, shell syntax, uppercase characters, or invalid hyphen placement
+  are omitted by the parser-backed portable name boundary.
 - `vibe skill load` emits the exact XML wrapper, body only, and an absolute
   directory from which supporting files can be read.
 
@@ -529,9 +544,11 @@ isolation acceptance gates.
 
 - a fresh installation mirrors all bundled Skills;
 - a wheel-install fixture proves bundled Skills exist without a source tree;
-- an upgrade replaces changed Skills and removes retired Skills;
-- publication and concurrent managed reads prove the old-or-new atomic reader
-  boundary, including interrupted-publication recovery; and
+- an upgrade's selected snapshot contains changed Skills and omits retired
+  Skills;
+- interrupted publication cannot expose a partial snapshot;
+- two concurrently running artifacts with different bundled trees resolve
+  different immutable snapshots; and
 - every loaded built-in reports an agent-accessible absolute directory.
 
 ## 15. Explicit Non-Goals
@@ -545,5 +562,6 @@ V1 does not include:
 - semantic ranking or filtering of Skills;
 - Skill editing or copy-on-write;
 - semantics for `${AVIBE_HOME:-$HOME/.avibe}/skills`;
+- garbage collection of old built-in snapshots;
 - live filesystem watchers or historical-context invalidation; or
 - a security sandbox preventing direct filesystem access.

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -1,0 +1,502 @@
+# Avibe Managed Skills v1
+
+> **Status:** Accepted
+> **Date:** 2026-09-02
+> **Scope:** Runtime discovery, catalog injection, loading, backend isolation,
+> and built-in Skill lifecycle for Claude Code, Codex, and OpenCode
+
+## 1. Decision
+
+Avibe owns one Skill experience across all supported agent backends:
+
+1. Users install a Skill once.
+2. Avibe discovers compatible global, project, backend-native, and built-in
+   locations.
+3. Every backend receives the same resolved Skill Catalog.
+4. An agent loads a Skill through `vibe skill load <name>`.
+
+The agent sees Skill names and descriptions when choosing a Skill. It sees the
+selected Skill's absolute directory only when loading it, because supporting
+scripts, references, and assets are resolved relative to that directory.
+
+Avibe's Catalog and load command are the product-level entry points. Backend
+namespaces, source locations, conflict resolution, and compatibility metadata
+are implementation details and are not exposed to the agent.
+
+This is product-path isolation, not a filesystem security boundary. An agent
+can still read a known file through ordinary filesystem tools.
+
+## 2. Why Skills First
+
+Backend-native prompt files are not uniform:
+
+- their global and project paths differ;
+- their traversal and injection behavior differ; and
+- not every backend provides a reliable way to disable automatic context-file
+  loading.
+
+Avibe therefore does not attempt to unify `AGENTS.md`, `CLAUDE.md`, or global
+system prompts in v1. That work requires a dependable native opt-out first.
+
+Skills have a smaller and already portable unit: a directory containing a
+`SKILL.md`, optionally accompanied by scripts and references. Avibe keeps that
+storage shape and replaces only native discovery and loading in the Avibe
+runtime path.
+
+## 3. Compatibility Boundary
+
+The on-disk unit remains compatible with the Agent Skills convention:
+
+```text
+example-skill/
+|-- SKILL.md
+|-- scripts/
+|-- references/
+`-- assets/
+```
+
+Avibe requires only two non-empty fields in the leading frontmatter:
+
+```yaml
+---
+name: example-skill
+description: Explain when this Skill should be used.
+---
+```
+
+The Catalog prompt and `vibe skill load` output are Avibe runtime contracts.
+They are not presented as formats required by the Agent Skills specification.
+
+Existing Skills are usable by default. There is no Avibe-specific portability
+field, compatibility state, validation state, source namespace, or migration
+requirement.
+
+## 4. Discovery
+
+### 4.1 Candidate shape
+
+A discovery root contributes only direct child Skill directories:
+
+```text
+<discovery-root>/<skill-directory>/SKILL.md
+```
+
+Avibe does not recursively treat arbitrary nested `SKILL.md` files as separate
+Skills. Directories such as `scripts/`, `references/`, and `assets/` remain
+part of their parent Skill.
+
+Backend-bundled or system Skills, plugin caches, administrator-only Skills,
+and `.claude/commands` are not discovery sources.
+
+### 4.2 Built-in root
+
+```text
+${AVIBE_HOME:-$HOME/.avibe}/builtin-skills
+```
+
+This is Avibe-owned runtime content and has the highest resolution priority.
+
+### 4.3 Project roots
+
+For each directory `D` from the active working directory up to and including
+the Git project root, Avibe inspects:
+
+```text
+<D>/.agents/skills
+<D>/.codex/skills
+<D>/.claude/skills
+<D>/.opencode/skills
+```
+
+The nearest directory to the active working directory wins within the same
+directory family. When there is no Git root, only the active working directory
+is considered project scope.
+
+### 4.4 Global roots
+
+```text
+$HOME/.agents/skills
+${CODEX_HOME:-$HOME/.codex}/skills
+$HOME/.claude/skills
+${XDG_CONFIG_HOME:-$HOME/.config}/opencode/skills
+```
+
+Native locations are compatibility inputs. Avibe reads them in place and does
+not migrate, rename, or annotate their Skills.
+
+### 4.5 Reserved root
+
+```text
+${AVIBE_HOME:-$HOME/.avibe}/skills
+```
+
+This path is reserved for a future user-level Avibe Skill role. In v1 Avibe
+does not scan it, write to it, or assign it any behavior.
+
+## 5. Parsing and Resolution
+
+### 5.1 Loose frontmatter parsing
+
+Discovery is deliberately permissive:
+
+- extract `name` and `description` from the leading frontmatter;
+- accept the Skill when both values are present and non-empty;
+- ignore every other field;
+- do not reject a Skill because unrelated frontmatter is unknown or malformed;
+- do not require the declared name to match the directory name; and
+- fold a multiline description into one line for Catalog display.
+
+If either required value cannot be extracted, omit that candidate without
+failing the whole Catalog.
+
+### 5.2 Deduplication
+
+Candidates are deduplicated by their final declared `name`. The winner is
+selected by these rules, in order:
+
+1. Avibe built-ins over project and global Skills.
+2. Project Skills over global Skills.
+3. Within project scope, a directory nearer to the working directory over a
+   more distant directory.
+4. At the same scope and depth, directory-family priority is:
+   `.avibe` > `.agents` > `.codex` > `.claude` > OpenCode.
+
+The `.avibe` family reserves the highest family slot for future use, but
+`${AVIBE_HOME:-$HOME/.avibe}/skills` is inactive in v1. OpenCode means
+`.opencode` at project scope and `${XDG_CONFIG_HOME:-$HOME/.config}/opencode`
+at global scope.
+
+Resolution must be deterministic. After resolution, entries are sorted by
+name for pagination and prompt rendering.
+
+### 5.3 Agent-visible result
+
+The agent receives only each winning Skill's `name` and `description` in the
+Catalog. It does not receive:
+
+- the discovery root or backend source;
+- a namespace or scope label;
+- duplicate candidates;
+- the conflict rule or selected priority; or
+- compatibility or validation status.
+
+## 6. Skill Catalog Contract
+
+### 6.1 System prompt injection
+
+When at least one Skill is available, Avibe injects this block with the
+resolved rows substituted:
+
+```md
+## Skills
+
+Skills provide specialized instructions and workflows for specific tasks.
+When a task matches a skill's description, run `vibe skill load <name>` before proceeding.
+If the user requests a skill by name, load it.
+Only load skill names listed here or returned by `vibe skill list`; do not guess names.
+
+### Available skills
+- data-analysis: Analyze datasets, generate charts, and create reports.
+- pdf-processing: Extract text, fill forms, and merge PDF files.
+```
+
+The system prompt contains page 1 only, with at most 25 Skills. If more entries
+exist, append exactly:
+
+```md
+More skills are available. Run `vibe skill list --page 2` to view more.
+```
+
+When no Skills are available, omit the entire block.
+
+### 6.2 List command
+
+```text
+vibe skill list
+vibe skill list --page <N>
+```
+
+The default page is page 1. Each page contains at most 25 entries in the same
+stable name order used by the prompt. Standard output uses only Catalog rows:
+
+```text
+- data-analysis: Analyze datasets, generate charts, and create reports.
+- pdf-processing: Extract text, fill forms, and merge PDF files.
+```
+
+When another page exists, the output ends with the same next-page sentence
+used by the prompt, with the appropriate page number. Paths, sources, scopes,
+and resolution metadata are not printed.
+
+## 7. Skill Load Contract
+
+### 7.1 Command
+
+```text
+vibe skill load <name>
+```
+
+The command resolves the live Catalog, selects the current winner for `name`,
+and writes this structure to standard output:
+
+```xml
+<skill_content name="pdf-processing" directory="/absolute/path/to/pdf-processing">
+SKILL BODY ONLY
+</skill_content>
+```
+
+Contract details:
+
+- `name` is the resolved Skill name.
+- `directory` is the absolute, agent-accessible directory containing
+  `SKILL.md`.
+- XML attribute values are escaped.
+- Only the body after the leading frontmatter is emitted.
+- The body is otherwise unchanged: no generated title, indentation, summary,
+  or rewrite is added.
+- Relative references to `scripts/`, `references/`, `assets/`, or other files
+  resolve from `directory`.
+- There is no protocol/version header, JSON envelope, source label,
+  compatibility state, or file manifest.
+
+On failure, standard output is empty, standard error contains a short
+human-readable error, and the process exits non-zero.
+
+The wrapper frames tool output; it does not change instruction precedence. A
+loaded Skill is tool-level context and cannot override Avibe's system prompt,
+permissions, or safety rules.
+
+## 8. Freshness and Session Semantics
+
+### 8.1 New Turn snapshot
+
+Immediately before each actual new backend Turn, Avibe:
+
+1. resolves the Catalog from the current filesystem state;
+2. renders the current system prompt with page 1 of that Catalog; and
+3. dispatches the Turn to the existing backend Session.
+
+This gives an existing Avibe Session newly installed, renamed, edited, or
+removed Skills on its next Turn. No Avibe restart and no new Session are
+required.
+
+A message steered into a backend Turn that is already active is part of that
+same Turn and does not trigger another Catalog refresh. Changes become visible
+on the next actual Turn.
+
+### 8.2 Live commands
+
+`vibe skill list` and `vibe skill load` resolve from disk on every invocation.
+Therefore:
+
+- adding or removing a Skill changes the next command result and next Turn;
+- changing `name` or `description` changes the next Catalog resolution; and
+- changing the body, scripts, or references changes the next load or file
+  read.
+
+### 8.3 Historical context is historical
+
+Avibe does not track which Skills a Session has loaded, attach revisions to
+loaded content, rewrite old conversation history, invalidate prior loads, or
+require a Skill to be reloaded on every Turn.
+
+Once a Skill body has been loaded, it remains historical context just like any
+other file previously read by the agent. The current Catalog describes current
+availability; it does not retroactively change history.
+
+### 8.4 No watcher in v1
+
+There is no filesystem watcher, change notification, incremental system-prompt
+patch, or long-lived per-Session Catalog. Turn-time rendering is already the
+correct consistency boundary, so a second refresh mechanism would add state
+without improving the user-visible contract.
+
+The initial implementation performs a full scan of the fixed roots and reads
+only enough of each `SKILL.md` to extract frontmatter. A reference measurement
+of six roots, 20 Skill files, and 242 KB total input completed in about 1 ms
+median on a warm local filesystem. This is not a latency guarantee; it shows
+that correctness can precede caching.
+
+If production measurements later justify a cache, directory enumeration still
+runs every Turn and parsed frontmatter may be reused by file identity, size,
+and nanosecond modification time. Caching must preserve the same freshness
+contract.
+
+## 9. Backend Isolation and Prompt Application
+
+Avibe disables native Skill presentation in the call path it controls, then
+applies the same Avibe Catalog to all three backends.
+
+| Backend | Native Skill isolation | Applying a changed Avibe prompt |
+| --- | --- | --- |
+| Claude Code | Configure the SDK with `skills=[]`. | Build the candidate prompt every Turn. If it changed, recreate the SDK client and resume the same native session; otherwise reuse the client. |
+| Codex | Set `skills.include_instructions=false`. | Build `developerInstructions` every Turn. Send updated instructions only when they differ, while retaining the same thread/session. |
+| OpenCode | Set the effective Agent permission `skill=deny` and send `tools.skill=false` in every prompt request. | Build and send the current system prompt on every new Turn. |
+
+For OpenCode, `tools.skill=false` is a request parameter, not text appended to
+the system prompt.
+
+The v1 isolation boundary intentionally does not block:
+
+- handwritten Codex `$skill` references;
+- backend TUI or slash-command endpoints that Avibe does not invoke; or
+- ordinary filesystem access to known Skill paths.
+
+Avibe does not add command deny-lists, directory fingerprints, transport
+rebuilds solely for isolation, or backend-specific compatibility warnings.
+The required product outcome is narrower: through Avibe's normal backend call
+path, the model is not shown the native Skill Catalog and is not offered the
+native Skill tool.
+
+## 10. Built-in Skills
+
+### 10.1 Source and runtime mirror
+
+Built-in Skills are maintained in the source tree at:
+
+```text
+skills/<name>/
+```
+
+At installation and upgrade, Avibe publishes a complete runtime mirror to:
+
+```text
+${AVIBE_HOME:-$HOME/.avibe}/builtin-skills/<name>/
+```
+
+The runtime directory is deliberately separate from user-managed Skills and
+must be directly accessible to the agent so loaded built-ins can use their own
+scripts and references.
+
+### 10.2 Replacement lifecycle
+
+The source tree is authoritative for each Avibe version. First run and every
+upgrade perform an atomic full replacement of `builtin-skills`:
+
+- new built-ins are added;
+- changed built-ins are replaced; and
+- built-ins removed from the release are deleted from the runtime mirror.
+
+This guarantees that the installed built-in set exactly matches the running
+Avibe version and never exposes a partially updated set. The directory is
+Avibe-owned rather than a user customization surface.
+
+## 11. Installation Defaults
+
+The default user-level installation target is backend-neutral:
+
+```text
+$HOME/.agents/skills/<name>
+```
+
+An explicitly project-scoped installation targets:
+
+```text
+$PROJECT_ROOT/.agents/skills/<name>
+```
+
+Installing a Skill does not need to copy it into each backend's native
+directory. Existing native directories remain discovery inputs for backward
+compatibility.
+
+Skill editing, adoption, and copy-on-write are outside v1. This protocol owns
+runtime discovery and loading, while the existing Workbench/askill management
+surface owns installation UI and package operations. That surface must adopt
+these default targets when the runtime implementation lands.
+
+## 12. System Prompt Slimming
+
+Managed Skills make it possible to remove long, conditional operating manuals
+from the always-on system prompt.
+
+The kernel keeps only information required on every Turn:
+
+- agent identity and Session facts;
+- interaction and output contracts;
+- permission and safety boundaries; and
+- Skill discovery and loading instructions.
+
+Long operational playbooks such as Show Pages, Vault, Harness, and Memory can
+move to Avibe built-in Skills. A short routing invariant may remain in the
+kernel when the agent must know to load a Skill before it can discover the
+relevant workflow.
+
+Prompt slimming is incremental. A module moves only after its built-in Skill
+has equivalent behavior and regression coverage.
+
+## 13. Implementation Ownership
+
+One shared resolver owns discovery, loose parsing, precedence, deduplication,
+sorting, pagination, and lookup. Prompt rendering and both CLI commands consume
+that resolver rather than reimplementing any rule.
+
+Backend adapters own only their native isolation setting and the mechanics for
+applying a changed Avibe prompt to the same backend Session. Built-in
+installation owns only the versioned source-to-runtime mirror.
+
+The existing [Workbench Skills design](workbench-skills-page.md) remains the
+management surface. This document supersedes only assumptions in that design
+about installing one copy per backend or using backend-native Skill catalogs
+at runtime.
+
+## 14. Acceptance Criteria
+
+### 14.1 Resolver and protocol
+
+- A fixture covering every discovery root resolves one entry per final name.
+- Built-in, project/global, directory depth, and directory-family precedence
+  match Section 5.
+- A Skill with extractable `name` and `description` is accepted despite
+  unrelated malformed or unknown frontmatter.
+- Invalid candidates do not prevent valid candidates from appearing.
+- Prompt and `vibe skill list` pagination are stable, limited to 25 entries,
+  and do not expose paths or sources.
+- `vibe skill load` emits the exact XML wrapper, body only, and an absolute
+  directory from which supporting files can be read.
+
+### 14.2 Live Session behavior
+
+For each supported backend, using one existing Avibe Session:
+
+- installing a Skill makes it available on the next actual Turn;
+- changing its name or description changes the next Turn's Catalog;
+- changing its body changes the next load;
+- deleting it removes it from the next Turn's Catalog; and
+- none of these operations requires a restart or new Session.
+
+Previously loaded content remains in conversation history without forcing a
+reload or rewriting the Session.
+
+### 14.3 Backend isolation
+
+Capture the actual model-facing request for Claude Code, Codex, and OpenCode
+and verify:
+
+- the Avibe Catalog is equivalent across all three backends;
+- the native backend Catalog is absent;
+- OpenCode's native Skill tool is disabled; and
+- each adapter retains the same native Session when the Catalog changes.
+
+Codex `$skill`, backend TUI commands, and ordinary filesystem reads are not v1
+isolation acceptance gates.
+
+### 14.4 Built-in lifecycle
+
+- a fresh installation mirrors all bundled Skills;
+- an upgrade replaces changed Skills and removes retired Skills;
+- replacement is atomic; and
+- every loaded built-in reports an agent-accessible absolute directory.
+
+## 15. Explicit Non-Goals
+
+V1 does not include:
+
+- unified global or project prompt files;
+- disabling native `AGENTS.md` or `CLAUDE.md` loading;
+- a new Skill compatibility schema;
+- source namespaces or source disclosure to the agent;
+- semantic ranking or filtering of Skills;
+- Skill editing or copy-on-write;
+- semantics for `${AVIBE_HOME:-$HOME/.avibe}/skills`;
+- live filesystem watchers or historical-context invalidation; or
+- a security sandbox preventing direct filesystem access.

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -107,11 +107,15 @@ Discovery and load share one verified-read primitive. It records the open
 file's identity, size, high-resolution modification time, and change/version
 metadata available on the platform before the bounded read, queries the same
 handle afterward, and accepts the bytes only when every recorded value remains
-unchanged. Before accepting, it also queries the `SKILL.md` directory entry
+unchanged. This detects changes observable through the host filesystem; on a
+filesystem whose metadata cannot distinguish a same-size concurrent rewrite,
+consistency is best-effort rather than a locking or immutable-snapshot
+guarantee. Before accepting, it also queries the `SKILL.md` directory entry
 again, relative to the retained directory handle when one is available, and
 requires that path to remain a regular file naming the same file identity as
-the open handle. An in-place rewrite, truncation, or atomic path replacement
-during the read therefore omits the candidate during discovery or fails load
+the open handle. An observable in-place rewrite, truncation, or atomic path
+replacement during the read therefore omits the candidate during discovery or
+fails load
 with empty standard output. This consistency rule is owned once by the resolver
 rather than reimplemented by Catalog and load call sites.
 
@@ -244,6 +248,9 @@ prompt content.
 
 These limits do not validate optional frontmatter, require the directory and
 declared name to match, or add compatibility metadata.
+Catalog discovery also does not read the complete body merely to validate its
+encoding. A successful load requires the bounded body to be valid UTF-8; an
+invalid body can appear in the Catalog but load fails with no standard output.
 
 ### 5.2 Deduplication
 
@@ -381,8 +388,9 @@ Contract details:
   name retained from an earlier discovery read with newly opened content.
 - XML attribute values are escaped.
 - Only the body after the leading frontmatter is emitted.
-- The body is otherwise unchanged: no generated title, indentation, escaping,
-  summary, or rewrite is added.
+- On a successful load, the body is otherwise unchanged: no generated title,
+  indentation, escaping, summary, or rewrite is added. Invalid UTF-8 fails load
+  rather than being replaced or re-encoded.
 - A body larger than 256 KiB is not advertised and cannot be loaded. If a file
   grows beyond the limit between discovery and load, load fails with empty
   standard output rather than truncating it.
@@ -784,8 +792,9 @@ Catalogs at runtime.
   malformed.
 - Prompt and `vibe skill list` pagination are deterministic for an unchanged
   filesystem, limited to 25 entries, remain within the row budget, and do not
-  expose paths or sources. When later pages exist, the prompt tells the agent
-  to inspect them if page 1 has no matching Skill. A fixture mutating the
+  expose paths or sources. When later pages exist, the prompt makes further
+  discovery optional, while a user-requested exact name may load directly. A
+  fixture mutating the
   Catalog between page calls verifies live re-resolution and the documented
   restart-at-page-1 boundary rather than a hidden snapshot.
 - Oversized descriptions cannot make the Catalog unbounded, and names with
@@ -806,6 +815,8 @@ Catalogs at runtime.
   cannot pair the opened body with a different directory identity.
 - A body over 256 KiB is omitted from discovery, and a body that crosses the
   limit before load produces empty standard output and a non-zero exit.
+- An invalid UTF-8 body may be advertised from its valid frontmatter but load
+  produces empty standard output and a non-zero exit without replacement text.
 - Workbench resource policies continue to govern management operations but do
   not narrow the runtime Catalog or loaded body, matching the ordinary
   filesystem capability of the agent process.
@@ -856,14 +867,11 @@ isolation acceptance gates.
   tree and preserves executable modes required by helper scripts;
 - a fixed snapshot-v1 fixture proves the canonical tree byte stream and
   lowercase SHA-256 identifier remain stable;
-- release packaging rejects all Win32-forbidden component characters and
-  controls (`U+0000`-`U+001F`),
-  Windows-reserved, trailing-dot/space, case-insensitively colliding, or empty
-  built-in paths; more than 1,024 root entries; more than 4,096 total subtree
-  entries; more than 32 MiB of aggregate regular-file bytes; a non-Skill direct
-  child; a Skill whose closing frontmatter delimiter exceeds 64 KiB; a body
-  over 256 KiB; and a tree whose bounded frontmatter exceeds the built-in 8 MiB
-  budget;
+- release packaging accepts only directories and regular files throughout the
+  complete built-in tree, and every relative path has one unambiguous,
+  cross-platform representation. Representative fixtures cover links and
+  special files, Win32-forbidden or aliased components, empty directories, and
+  every declared entry, byte, frontmatter, body, and root-child bound;
 - release packaging rejects duplicate declared Skill names even when their
   directories differ;
 - a mode-only built-in change produces a different snapshot and published

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -154,12 +154,15 @@ the first project boundary, Avibe inspects:
 <D>/.opencode/skills
 ```
 
-The first project boundary is the nearer of the Git project root and the
-Avibe project base bound to the Session. The latter lets a Workbench project
-whose configured directory has no `.git` marker retain project-level Skills
-when an existing Session works in one of its descendants. A standalone command
-has no Avibe project binding and therefore uses the Git root; if neither
-boundary is found, only its active working directory is project scope.
+When a Session has a bound Avibe project base, that base is the project
+boundary even if the Session works inside a nested Git checkout. The base is
+snapshotted with the Session when the Session is created, so moving the Session
+to another scope does not change which project-level Skills it sees. This also
+lets a Workbench project whose configured directory has no `.git` marker retain
+project-level Skills when an existing Session works in one of its descendants.
+A standalone command has no Avibe project binding and therefore uses the first
+Git root; if neither boundary is found, only its active working directory is
+project scope.
 
 The nearest directory to the active working directory wins within the same
 directory family. Root discovery examines at most 128 directories including
@@ -230,6 +233,8 @@ Catalog parsing and rendering are bounded independently:
   frontmatter delimiter to end of file without reading the body during Catalog
   discovery;
 - truncate a normalized description beyond 1,024 characters, adding `...`;
+- replace decoded Unicode control characters with spaces before collapsing
+  whitespace, so Catalog output cannot carry terminal control sequences; and
 - render at most 25 entries and 16 KiB of Skill rows per page.
 
 The bounded read happens before decoding or normalizing field values, so a
@@ -345,6 +350,10 @@ invocation. Standard output uses only Catalog rows:
 When another page exists, the output ends with the same next-page sentence
 used by the prompt, with the appropriate page number. Paths, sources, scopes,
 and resolution metadata are not printed.
+
+Page boundaries are packed from the stable name order under both limits. Page
+`N+1` starts with the first entry after the last row actually emitted on page
+`N`; the 16 KiB limit never skips entries that did not fit an earlier page.
 
 Pagination is deliberately live rather than a cross-command snapshot. If the
 filesystem changes between `list --page` invocations, entries can move between
@@ -501,11 +510,17 @@ renew, and unbind there until the server is replaced, even when the effective
 `AVIBE_HOME` has changed. A newly started server uses the current runtime path.
 Expired entries are ignored and pruned.
 
+The active-poll record retains the exact built-in snapshot ID and root that the
+Turn's Catalog advertised. A process adopting that poll restores those values,
+not the newer process default, so an overlapping upgrade cannot change a
+same-Turn load.
+
 Binding publication and cleanup run outside the controller event loop. A
-restored poll retries publication three times; if the binding store remains
-unavailable, Avibe restores result delivery without the optional shell binding
-rather than stranding the durable poll. The next ordinary Avibe-dispatched Turn
-gets a fresh binding attempt.
+restored poll makes three immediate publication attempts. If the binding store
+remains unavailable, Avibe restores result delivery without waiting, then keeps
+retrying for the lifetime of that active poll and resumes expiry renewal after
+publication succeeds. This preserves the durable result path without
+permanently dropping the Turn's shell binding after a transient failure.
 
 ### 8.3 Runtime access boundary
 
@@ -821,14 +836,17 @@ Catalogs at runtime.
   malformed.
 - Prompt and `vibe skill list` pagination are deterministic for an unchanged
   filesystem, limited to 25 entries, remain within the row budget, and do not
-  expose paths or sources. When later pages exist, the prompt makes further
-  discovery optional, while a user-requested exact name may load directly. A
-  fixture mutating the
-  Catalog between page calls verifies live re-resolution and the documented
-  restart-at-page-1 boundary rather than a hidden snapshot.
+  expose paths or sources. A multibyte-description fixture proves that every
+  later page starts after the last row actually emitted, without skipping rows
+  when the byte budget wins before the count limit. When later pages exist, the
+  prompt makes further discovery optional, while a user-requested exact name
+  may load directly. A fixture mutating the Catalog between page calls verifies
+  live re-resolution and the documented restart-at-page-1 boundary rather than
+  a hidden snapshot.
 - Oversized descriptions cannot make the Catalog unbounded, and names with
   whitespace, shell syntax, uppercase characters, or invalid hyphen placement
-  are omitted by the parser-backed portable name boundary.
+  are omitted by the parser-backed portable name boundary. YAML-decoded C0 and
+  C1 control characters cannot reach terminal Catalog output.
 - `vibe skill load` emits the exact XML wrapper, body only, and an absolute
   directory from which supporting files can be read.
 - Parser-backed CLI coverage dispatches the canonical
@@ -888,7 +906,9 @@ and verify:
   and each restored Turn replaces its own entry without pruning other unexpired
   Sessions. When a managed server is adopted across an `AVIBE_HOME` change,
   bind, renew, and unbind operations continue using the absolute binding path
-  recorded by that server; and
+  recorded by that server. Restored polls retain their advertised built-in
+  snapshot and continue retrying a failed binding publication for the poll
+  lifetime; and
 - a cached Claude client is recreated and resumes the same native Session when
   its bound Skill roots or built-in snapshot change even if page 1 is identical;
   and

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -288,8 +288,10 @@ instructions; portable names cannot begin with an option prefix, but the
 end-of-options marker keeps the command contract explicit.
 
 The command resolves live global and project roots together with the caller's
-bound built-in snapshot, selects the current winner for `name`, and writes this
-structure to standard output:
+bound Session working directory and built-in snapshot, selects the current
+winner for `name`, and writes this structure to standard output. A bound
+command never derives project scope from the shell command's own current
+directory:
 
 ```xml
 <skill_content name="pdf-processing" directory="/absolute/path/to/pdf-processing">
@@ -302,6 +304,11 @@ Contract details:
 - `name` is the resolved Skill name.
 - `directory` is the absolute, agent-accessible directory containing
   `SKILL.md`.
+- Load retains an open handle to the selected Skill directory, reads
+  `SKILL.md` relative to that handle, and verifies immediately before output
+  that the reported absolute path still names the same directory identity. If
+  the directory moved, disappeared, or was replaced during load, the command
+  fails instead of pairing one body with another directory.
 - XML attribute values are escaped.
 - Only the body after the leading frontmatter is emitted.
 - The body is otherwise unchanged: no generated title, indentation, escaping,
@@ -311,6 +318,9 @@ Contract details:
   standard output rather than truncating it.
 - Relative references to `scripts/`, `references/`, `assets/`, or other files
   resolve from `directory`.
+- The directory-identity check covers the load operation; it does not make a
+  mutable user Skill immutable after the command returns. Later edits follow
+  ordinary filesystem semantics and become visible to later reads or loads.
 - There is no protocol/version header, JSON envelope, source label,
   compatibility state, or file manifest.
 
@@ -357,13 +367,20 @@ Therefore:
 - changing the body, scripts, or references changes the next load or file
   read.
 
-When a backend launches either command, it inherits
-`AVIBE_BUILTIN_SKILLS_SNAPSHOT_ID` from the Avibe process that created that
-backend runtime. The command uses that retained immutable snapshot even if an
-upgrade has since switched the stable `vibe` launcher to another artifact. The
-identifier is an environment binding, not prompt text or an agent-visible
-command argument. A standalone command without that binding uses the snapshot
-bundled with its own executable.
+When a backend launches either command, Avibe supplies two internal bindings:
+
+- `AVIBE_SKILL_WORKING_DIR` is the absolute working directory from which Avibe
+  rendered that Session's Catalog. Project discovery always starts there, even
+  when the agent runs the command from another directory.
+- `AVIBE_BUILTIN_SKILLS_SNAPSHOT_ID` selects the immutable built-in snapshot
+  retained by the Avibe process that created that backend runtime, even if an
+  upgrade has since switched the stable `vibe` launcher to another artifact.
+
+These values use the existing per-Session shell-environment path for each
+backend: Claude SDK process environment, Codex `shell_environment_policy`, and
+the OpenCode caller-context plugin. They are not prompt text or agent-visible
+command arguments. A standalone command without Avibe bindings uses its own
+current working directory and the snapshot bundled with its own executable.
 
 ### 8.3 Historical context is historical
 
@@ -582,6 +599,11 @@ at runtime.
   are omitted by the parser-backed portable name boundary.
 - `vibe skill load` emits the exact XML wrapper, body only, and an absolute
   directory from which supporting files can be read.
+- A backend-bound load launched from a different shell directory still uses
+  the Session working directory that produced the advertised Catalog.
+- Replacing, removing, or renaming the selected Skill directory between
+  selection and output produces empty standard output and a non-zero exit; it
+  cannot pair the opened body with a different directory identity.
 - A body over 256 KiB is omitted from discovery, and a body that crosses the
   limit before load produces empty standard output and a non-zero exit.
 

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -116,14 +116,12 @@ ${AVIBE_HOME:-$HOME/.avibe}/builtin-skills/<snapshot-id>
 This is logical user-facing notation. Implementations resolve it through
 `config.paths.get_vibe_remote_dir()` so a legacy `~/.vibe_remote` home remains
 authoritative when the compatibility migration cannot move it. Each running
-Avibe artifact selects only the immutable snapshot derived from its own bundled
-Skill tree; the `builtin-skills` umbrella is not a generic discovery root for
-direct child Skills. The selected snapshot is Avibe-owned runtime content and
-has the highest resolution priority. Its generated `.avibe-snapshot.json` is
-runtime metadata rather than a discovery candidate and is excluded from the
-direct-child budget. Release packaging permits at most 1,024 direct child Skill
-directories, so every published built-in remains discoverable within the same
-root cap as compatibility inputs.
+Avibe artifact selects only the version-scoped snapshot derived from its own
+bundled Skill tree. The `builtin-skills` umbrella is not a generic discovery
+root for direct child Skills. The selected snapshot is Avibe-owned runtime
+content, has the highest resolution priority, and contains at most 1,024 direct
+child Skill directories. This keeps every published built-in discoverable
+within the same root cap as compatibility inputs.
 
 ### 4.3 Project roots
 
@@ -324,6 +322,10 @@ Contract details:
   that the reported absolute path still names the same directory identity. If
   the directory moved, disappeared, or was replaced during load, the command
   fails instead of pairing one body with another directory.
+- The required frontmatter and bounded body are parsed from one verified
+  `SKILL.md` read after selection. Load confirms that those exact bytes still
+  declare the requested portable name before emitting; it never combines a
+  name retained from an earlier discovery read with newly opened content.
 - XML attribute values are escaped.
 - Only the body after the leading frontmatter is emitted.
 - The body is otherwise unchanged: no generated title, indentation, escaping,
@@ -475,42 +477,18 @@ artifact, Avibe publishes a complete runtime snapshot to:
 ${AVIBE_HOME:-$HOME/.avibe}/builtin-skills/<snapshot-id>/<name>/
 ```
 
-`<snapshot-id>` is the digest of a canonical manifest containing every relative
-path, file-content digest, and executable mode bits (`st_mode & 0o111` where
-POSIX mode bits exist) in the authoritative bundled Skill tree. The same
-manifest is stored as snapshot-root runtime metadata at
-`.avibe-snapshot.json`; it is not an entry in its own digest. A command bound to
-an older snapshot can therefore validate it without access to the older package
-artifact.
+`<snapshot-id>` is a lowercase SHA-256 identifier derived deterministically from
+every relative path, file byte sequence, and executable mode bits
+(`st_mode & 0o111` where POSIX mode bits exist) in the authoritative bundled
+Skill tree. It is a directory identifier, not a second persisted manifest or a
+runtime integrity protocol.
 
-Manifest v1 is a frozen persisted shape:
+Built-in source paths must be representable without aliases on every supported
+platform. Release packaging rejects absolute or traversal paths, backslashes,
+NUL, drive/UNC prefixes, Windows-reserved components, trailing-dot/space names,
+and case-insensitive path collisions. It also rejects a 1,025th direct child
+Skill directory.
 
-- the top-level JSON object contains `schema_version: 1` and `entries`; each
-  entry contains a `/`-separated relative `path`, byte `size`, lowercase
-  64-hex `sha256`, and integer `executable` bits (`st_mode & 0o111`);
-- those are the only top-level and entry keys; the schema version is exactly the
-  integer `1`, `entries` is a list, `size` is a non-negative integer no larger
-  than 64 MiB, and `executable` is one of the valid `0o111` bit combinations;
-- entries sort by `path`, object keys sort lexically, and serialization is UTF-8
-  without BOM or trailing newline using ASCII escapes and separators `,` and
-  `:` with no optional whitespace;
-- `<snapshot-id>` is lowercase SHA-256 of those exact manifest bytes; and
-- newer launchers retain decoders for every released manifest schema. An
-  unknown or malformed schema is omitted by Catalog and fails load safely; it
-  is never guessed or rewritten by a runtime command.
-
-The manifest is at most 1 MiB, contains at most 4,096 entries, and each encoded
-path is at most 1,024 bytes. Release packaging fails rather than publishing a
-built-in tree outside these limits. Runtime opens the manifest with the same
-nonblocking, same-handle regular-file and verified-read contract as `SKILL.md`,
-applies the byte limit before parsing, and rejects duplicate, absolute, empty,
-`.` or `..` path components. A manifest path is portable only when it is
-relative under both POSIX and Windows parsing: backslashes, NUL, drive prefixes,
-UNC roots, and platform separator aliases are rejected. Runtime reconstructs
-accepted paths component-by-component from an open snapshot-root handle,
-without following symlinks, junctions, or other reparse points, and requires
-each intermediate component to remain a directory and each leaf to remain the
-expected regular file beneath that root.
 The runtime directory is deliberately separate from user-managed Skills and
 is directly accessible to the agent so loaded built-ins can use their own
 scripts and references.
@@ -518,7 +496,7 @@ scripts and references.
 ### 10.2 Replacement lifecycle
 
 The source tree is authoritative for each Avibe artifact. Each snapshot is a
-complete, immutable mirror:
+complete mirror that Avibe itself never mutates:
 
 - new built-ins are added;
 - changed built-ins are replaced; and
@@ -527,41 +505,20 @@ complete, immutable mirror:
 Publication is serialized by a cross-process lock keyed by snapshot digest.
 The publisher builds and validates a hidden sibling staging directory, then
 atomically renames it once into the previously absent digest path. A process
-interruption can leave only an undiscoverable staging directory. If a valid
-snapshot for the same digest already exists, concurrent publishers reuse it
-instead of mutating it. Validation recomputes the same path, content, and
-executable-mode manifest and verifies that its digest is `<snapshot-id>` before
-reuse.
+interruption can leave only an undiscoverable staging directory. If the digest
+path already exists, concurrent or later publishers reuse that path without
+mutating it. Because Avibe publication creates the final path only by atomic
+rename, a pre-existing wrong-type, unreadable, or externally changed path is
+treated as unsupported post-publication mutation: list/load fails safely and
+does not repair it from whichever artifact the stable launcher currently
+selects.
 
-If the digest path exists but is not a valid snapshot, the lock holder
-atomically renames that entry itself to a unique hidden quarantine sibling,
-publishes the validated staging directory into the now-absent digest path, and
-removes the quarantine only after final validation. A crash before publication
-leaves no selectable digest path; the next lock holder rebuilds it before
-resolution. This repair belongs only to an artifact publishing its own bundled
-tree. Runtime list/load commands never attempt to rebuild a retained snapshot
-from whichever newer artifact the stable launcher currently selects.
-
-Runtime integrity is manifest-bound at the bytes each command uses:
-
-- Catalog accepts a built-in candidate only when the verified `SKILL.md` bytes
-  and executable mode match that path's entry in a manifest whose canonical
-  digest is the bound `<snapshot-id>`.
-- Load first verifies the bound manifest, then verifies every path, byte digest,
-  and executable mode in the selected built-in Skill directory against its
-  manifest entries, rejecting missing, changed, or extra content. The body it
-  emits comes from that same verified `SKILL.md` read.
-- A selected built-in Skill may contain at most 1,024 manifest files and 64 MiB
-  of expected file bytes. Verification compares the same-handle file size with
-  the manifest before hashing, reads at most that expected size, and visits at
-  most 2,049 filesystem entries while checking for extras. Exceeding any bound
-  fails before further traversal or content reads; release packaging enforces
-  the same limits on authoritative built-ins.
-- A mismatch omits the candidate during Catalog discovery or fails load with
-  empty standard output. It is not repaired by the command.
-
-This avoids a validate-then-open trust gap and lets a new launcher validate an
-older retained snapshot without possessing the old artifact's source bytes.
+After publication, list/load does not hash the full snapshot, compare it with a
+package source, or repair it. It reads the selected built-in through the same
+bounded verified-file contract as every other Skill. The snapshot is an
+Avibe-owned lifecycle surface, not a user customization or security boundary;
+direct post-publication mutation is unsupported and may change or omit a later
+Catalog/load result.
 
 Every resolver selects the digest computed from the bundled source of its own
 running artifact. Concurrent old and new Avibe processes therefore use
@@ -574,13 +531,10 @@ Backend runtimes inherit this selected digest as
 `AVIBE_BUILTIN_SKILLS_SNAPSHOT_ID`, so `vibe skill list` and
 `vibe skill load` remain bound to the advertising runtime's built-ins across an
 overlapping upgrade. The digest is validated as an identifier under the
-`builtin-skills` umbrella before use; it cannot select an arbitrary path.
-
-Publication never exposes a partial snapshot, and Catalog/load never accepts
-built-in bytes that differ from the bound snapshot manifest. A later filesystem
-write is detected at the next command boundary; this remains a consistency
-contract rather than a security sandbox. The `builtin-skills` umbrella is
-Avibe-owned rather than a user customization surface.
+`builtin-skills` umbrella before use; it cannot select an arbitrary path. A
+newer stable launcher needs only that retained path, not the older package
+source. A missing or unreadable retained snapshot fails safely instead of
+falling back to the newer artifact's built-ins.
 
 ## 11. Installation Defaults
 
@@ -677,6 +631,9 @@ at runtime.
   are omitted by the parser-backed portable name boundary.
 - `vibe skill load` emits the exact XML wrapper, body only, and an absolute
   directory from which supporting files can be read.
+- If the selected `SKILL.md` is replaced after discovery, load reparses the
+  exact verified bytes it will emit and fails unless they still declare the
+  requested name.
 - A backend-bound load launched from a different shell directory still uses
   the Session working directory that produced the advertised Catalog.
 - Replacing, removing, or renaming the selected Skill directory between
@@ -719,33 +676,20 @@ isolation acceptance gates.
 - a fresh installation mirrors all bundled Skills;
 - a real wheel-install fixture proves bundled Skills exist without a source
   tree and preserves executable modes required by helper scripts;
-- released manifest-v1 bytes have a fixed digest fixture, and a newer-launcher
-  fixture validates and loads that retained schema without the older package;
-- a FIFO, non-regular, oversized, malformed, duplicate-path, or traversal-path
-  manifest is bounded and rejected before use;
-- manifest fixtures reject backslash traversal, drive/UNC paths, symlinks, and
-  reparse points on every supported platform;
-- packaging rejects a 1,025th direct built-in Skill directory, while 1,024
-  Skills plus the generated root manifest remain discoverable;
+- release packaging rejects non-portable, Windows-reserved, trailing-dot/space,
+  or case-insensitively colliding built-in paths and a 1,025th direct Skill;
 - a mode-only built-in change produces a different snapshot and published
   digest;
 - an upgrade's selected snapshot contains changed Skills and omits retired
   Skills;
 - interrupted publication cannot expose a partial snapshot;
-- an invalid pre-existing digest path, including a wrong type, changed byte, or
-  changed executable mode, is quarantined and rebuilt by the artifact publishing
-  that digest; an interrupted publication resumes without selecting quarantine;
-- a snapshot altered after publication is omitted by the next Catalog or fails
-  the next load, and the command does not rebuild it from a different artifact;
-- Catalog verifies the exact built-in `SKILL.md` bytes it parses, while load
-  verifies the selected built-in Skill subtree and emits the same verified body;
-- built-in verification rejects a size mismatch before hashing, and its file,
-  byte, and visited-entry bounds cannot be exceeded by corrupted snapshot data;
+- a wrong-type, unreadable, or externally changed pre-existing digest path
+  fails safely without being traversed, mutated, or rebuilt by runtime commands;
 - two concurrently running artifacts with different bundled trees resolve
-  different immutable snapshots; and
+  different version-scoped snapshots;
 - after launcher activation, a command inherited from the older runtime still
-  validates, lists, and loads that runtime's retained built-in snapshot using
-  its digest-bound manifest, without the older package source; and
+  lists and loads that runtime's retained built-in snapshot path without the
+  older package source and never falls back to the newer snapshot; and
 - every loaded built-in reports an agent-accessible absolute directory.
 
 ## 15. Explicit Non-Goals
@@ -760,5 +704,7 @@ V1 does not include:
 - Skill editing or copy-on-write;
 - semantics for `${AVIBE_HOME:-$HOME/.avibe}/skills`;
 - garbage collection of old built-in snapshots;
+- post-publication tamper detection or self-healing for Avibe-owned built-in
+  snapshots;
 - live filesystem watchers or historical-context invalidation; or
 - a security sandbox preventing direct filesystem access.

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -376,7 +376,9 @@ Contract details:
 
 - `name` is the resolved Skill name.
 - `directory` is the absolute, agent-accessible directory containing
-  `SKILL.md`.
+  `SKILL.md`. Compatibility candidates whose resolved absolute directory is
+  not valid UTF-8 are omitted; v1 does not invent a second path encoding for
+  model-facing output.
 - Load retains an open handle to the selected Skill directory, reads
   `SKILL.md` relative to that handle, and verifies immediately before output
   that the reported absolute path still names the same directory identity. If
@@ -481,8 +483,11 @@ an already-running OpenCode server that loaded the released plugin: the
 existing `env`, `updated_at`, and `expires_at` fields are unchanged, while the
 cleanup token and Skill roots are additive. This feature leaves the released
 plugin source unchanged, so an upgrade can adopt its active server and restore
-polls without requesting a plugin refresh. Expired entries are ignored and
-pruned.
+polls without requesting a plugin refresh. The adopting process reads the
+binding-file path recorded for that managed server and continues to bind,
+renew, and unbind there until the server is replaced, even when the effective
+`AVIBE_HOME` has changed. A newly started server uses the current runtime path.
+Expired entries are ignored and pruned.
 
 ### 8.3 Runtime access boundary
 
@@ -762,10 +767,11 @@ Catalogs at runtime.
 - A fixture that replaces a regular `SKILL.md` with a FIFO between enumeration
   and open cannot block discovery: handle-level type validation omits it before
   any read, and load follows the same descriptor-bound contract.
-- An in-place rewrite, truncation, or replacement of `SKILL.md` during the
-  verified read is never accepted: discovery omits it and load exits non-zero
-  with empty standard output. Atomic namespace replacement after the file is
-  opened is covered separately from in-place handle mutation.
+- A filesystem-observable in-place rewrite, truncation, or replacement of
+  `SKILL.md` during the verified read is rejected: discovery omits it and load
+  exits non-zero with empty standard output. Atomic namespace replacement after
+  the file is opened is covered separately from in-place handle mutation, and
+  coarse filesystems retain the best-effort boundary stated in Section 4.1.
 - Frontmatter parsing reads no more than 64 KiB before accepting or omitting a
   candidate, including for oversized or unterminated input.
 - A root with more than 1,024 direct children is omitted after enumerating at
@@ -781,7 +787,8 @@ Catalogs at runtime.
   replacing either the alias or target after discovery makes load fail. A
   canonical Skill plus all backend compatibility aliases consumes one candidate
   and one frontmatter slot while every enumerated alias still consumes one
-  direct-child slot.
+  direct-child slot. A candidate whose resolved absolute directory cannot be
+  encoded as UTF-8 is omitted before Catalog or load output.
 - Unquoted YAML comments after `name` or `description` are ignored while `#`
   inside a quoted scalar remains content.
 - Standard escapes in a quoted name are decoded before portable-name
@@ -851,7 +858,9 @@ and verify:
   binding created by that Turn; active original and restored polls renew their
   released-shape expiry, an abandoned binding expires without a live renewer,
   and each restored Turn replaces its own entry without pruning other unexpired
-  Sessions; and
+  Sessions. When a managed server is adopted across an `AVIBE_HOME` change,
+  bind, renew, and unbind operations continue using the absolute binding path
+  recorded by that server; and
 - a cached Claude client is recreated and resumes the same native Session when
   its bound Skill roots or built-in snapshot change even if page 1 is identical;
   and

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -223,7 +223,10 @@ Skill directories, and 8 MiB of frontmatter bytes each. A full built-in root
 therefore cannot consume the capacity reserved for user Skills. Within each
 class, roots are visited in precedence order. Before reading frontmatter,
 direct children of each root are sorted by their absolute entry path; declared
-names participate only after parsing. If a root would exceed the remaining
+names participate only after parsing. Compatibility entries that resolve to the
+same directory identity are visited once in precedence order and consume one
+candidate and frontmatter slot; each alias remains charged to the direct-child
+budget because it was enumerated. If a root would exceed the remaining
 direct-child budget, Avibe observes at most one entry beyond that remainder,
 omits the whole root, and omits all lower-priority roots. Reaching the candidate
 or frontmatter budget likewise omits remaining lower-priority roots. These
@@ -716,7 +719,10 @@ Catalogs at runtime.
   consuming the other's. Cross-root exhaustion follows precedence and the
   pre-frontmatter path order defined in Section 5.1.
 - Compatibility directory symlinks resolve to their target directory, and
-  replacing either the alias or target after discovery makes load fail.
+  replacing either the alias or target after discovery makes load fail. A
+  canonical Skill plus all backend compatibility aliases consumes one candidate
+  and one frontmatter slot while every enumerated alias still consumes one
+  direct-child slot.
 - Unquoted YAML comments after `name` or `description` are ignored while `#`
   inside a quoted scalar remains content.
 - Prompt and `vibe skill list` pagination are deterministic for an unchanged

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -283,7 +283,7 @@ Skills provide specialized instructions and workflows for specific tasks.
 When a task matches a skill's description, run `vibe skill load -- <name>` before proceeding.
 If the user requests a skill by name, load it.
 Only load skill names listed here or returned by `vibe skill list`; do not guess names.
-If no Skill on this page matches the task, inspect subsequent Catalog pages before proceeding.
+If no Skill on this page matches the task, inspect each subsequent Catalog page in order until a Skill matches or no page remains.
 
 ### Available skills
 - data-analysis: Analyze datasets, generate charts, and create reports.

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -164,14 +164,25 @@ Catalog parsing and rendering are bounded independently:
 
 - read at most 64 KiB of leading frontmatter, including its delimiters, and
   omit the candidate if the closing delimiter is not found within that budget;
+- accept a body of at most 256 KiB of encoded bytes, measured from the closing
+  frontmatter delimiter to end of file without reading the body during Catalog
+  discovery;
 - truncate a normalized description beyond 1,024 characters, adding `...`;
 - render at most 25 entries and 16 KiB of Skill rows per page.
 
 The bounded read happens before decoding or normalizing field values, so a
 large optional field, description, or unterminated frontmatter cannot create
-unbounded per-Turn work. These limits do not validate optional frontmatter,
-require the directory and declared name to match, or add compatibility
-metadata.
+unbounded per-Turn work. Discovery enumerates at most 1,025 direct child
+entries in any root and omits the entire root if it contains more than 1,024.
+Across accepted roots, one resolution processes at most 1,024 candidate Skill
+directories and 8 MiB of frontmatter bytes. Roots are visited in precedence
+order and each accepted root's candidates in stable name order. Reaching an
+aggregate budget omits the remaining lower-priority roots. These rules make
+omission deterministic without walking the rest of an oversized directory.
+Omission is diagnostic log data, not additional prompt content.
+
+These limits do not validate optional frontmatter, require the directory and
+declared name to match, or add compatibility metadata.
 
 ### 5.2 Deduplication
 
@@ -261,11 +272,13 @@ vibe skill load <name>
 vibe skill load -- <name>
 ```
 
-The first form covers ordinary names; the second is the canonical form emitted
-in agent instructions and also handles names that begin with an option prefix.
+Both forms are accepted. The second is the canonical form emitted in agent
+instructions; portable names cannot begin with an option prefix, but the
+end-of-options marker keeps the command contract explicit.
 
-The command resolves the live Catalog, selects the current winner for `name`,
-and writes this structure to standard output:
+The command resolves live global and project roots together with the caller's
+bound built-in snapshot, selects the current winner for `name`, and writes this
+structure to standard output:
 
 ```xml
 <skill_content name="pdf-processing" directory="/absolute/path/to/pdf-processing">
@@ -282,6 +295,9 @@ Contract details:
 - Only the body after the leading frontmatter is emitted.
 - The body is otherwise unchanged: no generated title, indentation, escaping,
   summary, or rewrite is added.
+- A body larger than 256 KiB is not advertised and cannot be loaded. If a file
+  grows beyond the limit between discovery and load, load fails with empty
+  standard output rather than truncating it.
 - Relative references to `scripts/`, `references/`, `assets/`, or other files
   resolve from `directory`.
 - There is no protocol/version header, JSON envelope, source label,
@@ -298,21 +314,27 @@ and cannot override Avibe's system prompt, permissions, or safety rules.
 
 ## 8. Freshness and Session Semantics
 
-### 8.1 New Turn snapshot
+### 8.1 Avibe-dispatched Turn snapshot
 
-Immediately before each actual new backend Turn, Avibe:
+Immediately before each new Turn that Avibe dispatches to a backend, Avibe:
 
 1. resolves the Catalog from the current filesystem state;
 2. renders the current system prompt with page 1 of that Catalog; and
 3. dispatches the Turn to the existing backend Session.
 
 This gives an existing Avibe Session newly installed, renamed, edited, or
-removed Skills on its next Turn. No Avibe restart and no new Session are
-required.
+removed Skills on its next Avibe-dispatched Turn. No Avibe restart and no new
+Session are required.
 
 A message steered into a backend Turn that is already active is part of that
 same Turn and does not trigger another Catalog refresh. Changes become visible
-on the next actual Turn.
+on the next Avibe-dispatched Turn.
+
+A backend-native continuation that starts without an Avibe dispatch, such as a
+Claude background-tool completion or native wakeup, cannot be intercepted
+before it begins and may use the prompt snapshot already held by that backend
+client. It does not weaken the next Avibe-dispatched Turn guarantee and is not
+part of the v1 freshness contract.
 
 ### 8.2 Live commands
 
@@ -323,6 +345,14 @@ Therefore:
 - changing `name` or `description` changes the next Catalog resolution; and
 - changing the body, scripts, or references changes the next load or file
   read.
+
+When a backend launches either command, it inherits
+`AVIBE_BUILTIN_SKILLS_SNAPSHOT_ID` from the Avibe process that created that
+backend runtime. The command uses that retained immutable snapshot even if an
+upgrade has since switched the stable `vibe` launcher to another artifact. The
+identifier is an environment binding, not prompt text or an agent-visible
+command argument. A standalone command without that binding uses the snapshot
+bundled with its own executable.
 
 ### 8.3 Historical context is historical
 
@@ -341,11 +371,11 @@ patch, or long-lived per-Session Catalog. Turn-time rendering is already the
 correct consistency boundary, so a second refresh mechanism would add state
 without improving the user-visible contract.
 
-The initial implementation performs a full scan of the fixed roots and reads
-only enough of each `SKILL.md` to extract frontmatter. A reference measurement
-of six roots, 20 Skill files, and 242 KB total input completed in about 1 ms
-median on a warm local filesystem. This is not a latency guarantee; it shows
-that correctness can precede caching.
+The initial implementation scans the fixed roots within the candidate and byte
+budgets and reads only enough of each `SKILL.md` to extract frontmatter. A
+reference measurement of six roots, 20 Skill files, and 242 KB total input
+completed in about 1 ms median on a warm local filesystem. This is not a
+latency guarantee; it shows that correctness can precede caching.
 
 If production measurements later justify a cache, directory enumeration still
 runs every Turn and parsed frontmatter may be reused by file identity, size,
@@ -428,6 +458,12 @@ share one. Other snapshots are not discovery candidates. V1 retains them so a
 running older process and an already loaded Skill directory remain usable;
 garbage collection of unreferenced snapshots is outside this protocol.
 
+Backend runtimes inherit this selected digest as
+`AVIBE_BUILTIN_SKILLS_SNAPSHOT_ID`, so `vibe skill list` and
+`vibe skill load` remain bound to the advertising runtime's built-ins across an
+overlapping upgrade. The digest is validated as an identifier under the
+`builtin-skills` umbrella before use; it cannot select an arbitrary path.
+
 The selected snapshot exactly matches the running artifact and is never
 partially updated. The `builtin-skills` umbrella is Avibe-owned rather than a
 user customization surface.
@@ -506,6 +542,10 @@ at runtime.
 - Invalid candidates do not prevent valid candidates from appearing.
 - Frontmatter parsing reads no more than 64 KiB before accepting or omitting a
   candidate, including for oversized or unterminated input.
+- A root with more than 1,024 direct children is omitted after enumerating at
+  most 1,025 entries; one resolution processes at most 1,024 candidates and 8
+  MiB of frontmatter. Budget exhaustion deterministically omits the remaining
+  lower-priority roots without blocking the Turn.
 - Prompt and `vibe skill list` pagination are stable, limited to 25 entries,
   remain within the row budget, and do not expose paths or sources.
 - Oversized descriptions cannot make the Catalog unbounded, and names with
@@ -513,19 +553,24 @@ at runtime.
   are omitted by the parser-backed portable name boundary.
 - `vibe skill load` emits the exact XML wrapper, body only, and an absolute
   directory from which supporting files can be read.
+- A body over 256 KiB is omitted from discovery, and a body that crosses the
+  limit before load produces empty standard output and a non-zero exit.
 
 ### 14.2 Live Session behavior
 
-For each supported backend, using one existing Avibe Session:
+For each supported backend, using one existing Avibe Session and
+Avibe-dispatched Turns:
 
-- installing a Skill makes it available on the next actual Turn;
-- changing its name or description changes the next Turn's Catalog;
+- installing a Skill makes it available on the next Avibe-dispatched Turn;
+- changing its name or description changes the next Avibe-dispatched Turn's
+  Catalog;
 - changing its body changes the next load;
 - deleting it removes it from the next Turn's Catalog; and
 - none of these operations requires a restart or new Session.
 
 Previously loaded content remains in conversation history without forcing a
-reload or rewriting the Session.
+reload or rewriting the Session. Backend-native continuations that Avibe does
+not dispatch are outside this acceptance boundary.
 
 ### 14.3 Backend isolation
 
@@ -549,6 +594,8 @@ isolation acceptance gates.
 - interrupted publication cannot expose a partial snapshot;
 - two concurrently running artifacts with different bundled trees resolve
   different immutable snapshots; and
+- after launcher activation, a command inherited from the older runtime still
+  lists and loads that runtime's retained built-in snapshot; and
 - every loaded built-in reports an agent-accessible absolute directory.
 
 ## 15. Explicit Non-Goals

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -86,6 +86,11 @@ Avibe does not recursively treat arbitrary nested `SKILL.md` files as separate
 Skills. Directories such as `scripts/`, `references/`, and `assets/` remain
 part of their parent Skill.
 
+Before parsing or loading, Avibe resolves the `SKILL.md` target and requires it
+to be a regular file. FIFOs, sockets, devices, directories, broken links, and
+links to non-regular targets are omitted without opening them. Load repeats the
+file-type check so a candidate changed after discovery cannot bypass it.
+
 Backend-bundled or system Skills, plugin caches, administrator-only Skills,
 and `.claude/commands` are not discovery sources.
 
@@ -124,12 +129,14 @@ is considered project scope.
 ```text
 $HOME/.agents/skills
 ${CODEX_HOME:-$HOME/.codex}/skills
-$HOME/.claude/skills
+${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills
 ${XDG_CONFIG_HOME:-$HOME/.config}/opencode/skills
 ```
 
 Native locations are compatibility inputs. Avibe reads them in place and does
-not migrate, rename, or annotate their Skills.
+not migrate, rename, or annotate their Skills. Implementations resolve the
+Claude root through the existing `vibe.claude_config.get_claude_home()` helper
+so discovery and the live Claude backend honor the same override semantics.
 
 ### 4.5 Reserved root
 
@@ -422,7 +429,8 @@ Release artifacts must carry that authoritative tree: wheels force-include it
 under a package-owned resource path and sdists include `skills/**`. Runtime
 code resolves the checkout path during development and the packaged resource
 path after installation; it never assumes the repository root exists in a
-wheel environment.
+wheel environment. Built-in trees contain only directories and regular files;
+release packaging and publication preserve whether each file is executable.
 
 Before the first managed Skill resolution from an installed or upgraded Avibe
 artifact, Avibe publishes a complete runtime snapshot to:
@@ -431,7 +439,9 @@ artifact, Avibe publishes a complete runtime snapshot to:
 ${AVIBE_HOME:-$HOME/.avibe}/builtin-skills/<snapshot-id>/<name>/
 ```
 
-`<snapshot-id>` is a stable digest of the authoritative bundled Skill tree.
+`<snapshot-id>` is a stable digest of every relative path, file byte sequence,
+and executable mode bits (`st_mode & 0o111` where POSIX mode bits exist) in the
+authoritative bundled Skill tree.
 The runtime directory is deliberately separate from user-managed Skills and
 is directly accessible to the agent so loaded built-ins can use their own
 scripts and references.
@@ -449,7 +459,8 @@ The publisher builds and validates a hidden sibling staging directory, then
 atomically renames it once into the previously absent digest path. A process
 interruption can leave only an undiscoverable staging directory. If a valid
 snapshot for the same digest already exists, concurrent publishers reuse it
-instead of mutating it.
+instead of mutating it. Validation recomputes the same path, content, and
+executable-mode digest from the published mirror before reuse.
 
 Every resolver selects the digest computed from the bundled source of its own
 running artifact. Concurrent old and new Avibe processes therefore use
@@ -535,11 +546,15 @@ at runtime.
 ### 14.1 Resolver and protocol
 
 - A fixture covering every discovery root resolves one entry per final name.
+- Global-root fixtures override `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, and
+  `XDG_CONFIG_HOME` and resolve from the same homes as their live backends.
 - Built-in, project/global, directory depth, and directory-family precedence
   match Section 5.
 - A Skill with a portable name and extractable description is accepted despite
   unrelated malformed or unknown frontmatter.
 - Invalid candidates do not prevent valid candidates from appearing.
+- A FIFO, socket, device, directory, broken link, or link to a non-regular
+  `SKILL.md` target is omitted without opening it; load rechecks the target.
 - Frontmatter parsing reads no more than 64 KiB before accepting or omitting a
   candidate, including for oversized or unterminated input.
 - A root with more than 1,024 direct children is omitted after enumerating at
@@ -565,7 +580,7 @@ Avibe-dispatched Turns:
 - changing its name or description changes the next Avibe-dispatched Turn's
   Catalog;
 - changing its body changes the next load;
-- deleting it removes it from the next Turn's Catalog; and
+- deleting it removes it from the next Avibe-dispatched Turn's Catalog; and
 - none of these operations requires a restart or new Session.
 
 Previously loaded content remains in conversation history without forcing a
@@ -588,7 +603,10 @@ isolation acceptance gates.
 ### 14.4 Built-in lifecycle
 
 - a fresh installation mirrors all bundled Skills;
-- a wheel-install fixture proves bundled Skills exist without a source tree;
+- a real wheel-install fixture proves bundled Skills exist without a source
+  tree and preserves executable modes required by helper scripts;
+- a mode-only built-in change produces a different snapshot and published
+  digest;
 - an upgrade's selected snapshot contains changed Skills and omits retired
   Skills;
 - interrupted publication cannot expose a partial snapshot;

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -86,10 +86,14 @@ Avibe does not recursively treat arbitrary nested `SKILL.md` files as separate
 Skills. Directories such as `scripts/`, `references/`, and `assets/` remain
 part of their parent Skill.
 
-Before parsing or loading, Avibe resolves the `SKILL.md` target and requires it
-to be a regular file. FIFOs, sockets, devices, directories, broken links, and
-links to non-regular targets are omitted without opening them. Load repeats the
-file-type check so a candidate changed after discovery cannot bypass it.
+Avibe opens `SKILL.md` with platform nonblocking semantics, immediately uses
+`fstat` or the platform-equivalent handle query to verify that same open handle
+is a regular file, and performs the bounded parse or load through that handle.
+It performs no potentially blocking read before handle-level type verification.
+A path-level check alone never authorizes a read, so replacing a candidate
+between enumeration and open cannot redirect the checked operation to a FIFO,
+socket, device, directory, broken link, or other non-regular target. Load
+repeats the same open-handle contract.
 
 Backend-bundled or system Skills, plugin caches, administrator-only Skills,
 and `.claude/commands` are not discovery sources.
@@ -455,12 +459,21 @@ complete, immutable mirror:
 - changed built-ins are replaced; and
 - built-ins removed from the artifact are absent from its snapshot.
 
+Publication is serialized by a cross-process lock keyed by snapshot digest.
 The publisher builds and validates a hidden sibling staging directory, then
 atomically renames it once into the previously absent digest path. A process
 interruption can leave only an undiscoverable staging directory. If a valid
 snapshot for the same digest already exists, concurrent publishers reuse it
 instead of mutating it. Validation recomputes the same path, content, and
 executable-mode digest from the published mirror before reuse.
+
+If the digest path exists but is not a valid snapshot, the lock holder
+atomically renames that entry itself to a unique hidden quarantine sibling,
+publishes the validated staging directory into the now-absent digest path, and
+removes the quarantine only after final validation. A crash before publication
+leaves no selectable digest path; the next lock holder rebuilds it before
+resolution. If quarantine or publication cannot complete, managed resolution
+fails explicitly and never reads the invalid entry.
 
 Every resolver selects the digest computed from the bundled source of its own
 running artifact. Concurrent old and new Avibe processes therefore use
@@ -553,8 +566,9 @@ at runtime.
 - A Skill with a portable name and extractable description is accepted despite
   unrelated malformed or unknown frontmatter.
 - Invalid candidates do not prevent valid candidates from appearing.
-- A FIFO, socket, device, directory, broken link, or link to a non-regular
-  `SKILL.md` target is omitted without opening it; load rechecks the target.
+- A fixture that replaces a regular `SKILL.md` with a FIFO between enumeration
+  and open cannot block discovery: handle-level type validation omits it before
+  any read, and load follows the same descriptor-bound contract.
 - Frontmatter parsing reads no more than 64 KiB before accepting or omitting a
   candidate, including for oversized or unterminated input.
 - A root with more than 1,024 direct children is omitted after enumerating at
@@ -610,6 +624,9 @@ isolation acceptance gates.
 - an upgrade's selected snapshot contains changed Skills and omits retired
   Skills;
 - interrupted publication cannot expose a partial snapshot;
+- an invalid pre-existing digest path, including a wrong type, changed byte, or
+  changed executable mode, is quarantined and rebuilt before resolution; an
+  interrupted repair resumes without selecting the quarantine;
 - two concurrently running artifacts with different bundled trees resolve
   different immutable snapshots; and
 - after launcher activation, a command inherited from the older runtime still

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -198,7 +198,8 @@ Discovery is deliberately permissive:
 - ignore every other field;
 - do not reject a Skill because unrelated frontmatter is unknown or malformed;
 - do not require the declared name to match the directory name; and
-- decode standard YAML escapes in quoted required fields; and
+- accept quoted or plain required-field keys and decode standard YAML escapes
+  in quoted required values; and
 - fold plain, quoted, or block `description` continuation lines and whitespace
   into a single-line Catalog value.
 
@@ -464,43 +465,25 @@ identity still match. PID liveness alone is insufficient because an operating
 system can reuse a PID after a crash. The binding does not expire while that
 exact process and Turn remain active, so a long-running Turn keeps its advertised
 working directory and snapshot. Restoring a persisted poll publishes a fresh
-binding with the current process identity, authorization snapshot, and absolute
-Skill roots.
+binding with the current process identity and absolute Skill roots. During the
+short handoff before restoration, a stale remote binding supplies only the
+previously advertised Skill roots plus remote-deny caller context; it never
+replays an old authorization snapshot as current.
 
-### 8.3 Caller authorization
+### 8.3 Runtime access boundary
 
-For a remote Workbench caller, the same `resource_user_context` used by the
-Skills management surface is carried in the backend caller binding. Catalog
-rendering, `vibe skill list`, and `vibe skill load` each resolve the current
-winner and filter it through that context before exposing its description or
-body through the managed product path. Missing, malformed, or unavailable
-remote authorization state fails closed while that remote binding is present.
-Avibe built-ins are product runtime content and remain available without
-per-user resource policies. A command with no Avibe caller binding uses local
-owner semantics.
+Workbench resource policies continue to authorize the Skills management API:
+who may install, remove, or inspect packages through the Web surface. They do
+not filter the runtime Catalog or `vibe skill load`. Once a Session can operate
+an agent on the local machine, that agent can use ordinary filesystem tools to
+read known Skill paths, so an environment-backed runtime filter would create a
+false security boundary that the same shell could bypass.
 
-Authorization belongs to the resolved candidate, not merely its declared name.
-The backend-neutral `.agents` candidate uses the three legacy backend policy
-identifiers for its one logical installation. A backend-native candidate uses
-only its own backend policy identifier: Codex for `.codex` and Codex system,
-Claude for `.claude`, and OpenCode for `.opencode` or the OpenCode config root.
-Compatibility entries that resolve to the same physical Skill directory merge
-their backend policy identifiers while remaining one discovery candidate.
-Distinct backend-family directories that merely declare the same name remain
-distinct policy candidates, so access to a losing Claude candidate cannot
-authorize a winning Codex candidate. Within one backend family and project, the
-policy identity is the logical project Skill name; nearer and farther same-name
-directories are resolution inputs for that one logical resource rather than
-independently managed policy objects. These source and policy details remain
-internal and are never shown in the agent-facing Catalog.
-
-Caller bindings are environment supplied to an agent-controlled shell, not an
-unforgeable security credential. An agent can remove or alter them, and this
-protocol deliberately permits ordinary filesystem access to known Skill paths.
-Resource filtering therefore keeps the managed Catalog, load command, and
-Workbench presentation coherent; it is not a confidentiality boundary against
-the agent process. Enforcing one would require a sandboxed command/filesystem
-broker and is outside v1.
+The runtime Catalog is therefore the same resolved local capability set for
+Claude, Codex, and OpenCode. Backend caller bindings select the advertised
+working directory, compatibility roots, and built-in snapshot only. A real
+per-user confidentiality boundary would require a sandboxed command and
+filesystem broker and is outside v1.
 
 ### 8.4 Historical context is historical
 
@@ -537,7 +520,7 @@ applies the same Avibe Catalog to all three backends.
 
 | Backend | Native Skill isolation | Applying a changed Avibe prompt |
 | --- | --- | --- |
-| Claude Code | Configure the SDK with `skills=[]`. | Build the candidate prompt every Turn. If it changed, recreate the SDK client and resume the same native session; otherwise reuse the client. |
+| Claude Code | Configure the SDK with `skills=[]`. | Build the candidate prompt and complete Skill-binding state every Turn. If either changed, recreate the SDK client and resume the same native session; otherwise reuse the client. |
 | Codex | Set `skills.include_instructions=false`. | Build `developerInstructions` every Turn. Send updated instructions only when they differ, while retaining the same thread/session. |
 | OpenCode | Send `tools.skill=false` in every prompt request without rewriting user permission configuration. | Build and send the current system prompt on every new Turn. |
 
@@ -596,15 +579,17 @@ protocol.
 
 Built-in source paths must be representable without aliases on every supported
 platform. Release packaging rejects absolute or traversal paths, backslashes,
-NUL, drive/UNC prefixes, Windows-reserved components, trailing-dot/space names,
-case-insensitive path collisions, and empty directories. It also rejects more
-than 1,024 built-in root entries, any direct child that is not a valid Skill
-directory, more than 4,096 directories and regular files across the complete
-tree, more than 32 MiB of regular-file bytes across the complete tree, any
-Skill whose closing frontmatter delimiter exceeds 64 KiB, any body over 256
-KiB, or a built-in tree whose bounded frontmatter exceeds 8 MiB. The aggregate
-entry and byte checks occur before hashing or copying and abort as soon as a
-limit is crossed.
+NUL and every Win32-forbidden control character (`U+0001`-`U+001F`), plus
+every forbidden component character (`<`, `>`, `:`, `"`, `\`, `|`, `?`,
+`*`), drive/UNC prefixes,
+Windows-reserved components, trailing-dot/space names, case-insensitive path
+collisions, and empty directories. It also rejects more than 1,024 built-in
+root entries, any direct child that is not a valid Skill directory, more than
+4,096 directories and regular files across the complete tree, more than 32 MiB
+of regular-file bytes across the complete tree, any Skill whose closing
+frontmatter delimiter exceeds 64 KiB, any body over 256 KiB, or a built-in tree
+whose bounded frontmatter exceeds 8 MiB. The aggregate entry and byte checks
+occur before hashing or copying and abort as soon as a limit is crossed.
 
 The runtime directory is deliberately separate from user-managed Skills and
 is directly accessible to the agent so loaded built-ins can use their own
@@ -620,13 +605,16 @@ complete mirror that Avibe itself never mutates:
 - built-ins removed from the artifact are absent from its snapshot.
 
 Publication is serialized by a cross-process lock keyed by snapshot digest.
-The publisher builds and validates a hidden sibling staging directory, then
+The next lock holder first removes the one deterministic hidden staging path
+for that digest, reclaiming any partial tree left by an interrupted publisher.
+It then builds and validates that staging directory and
 recomputes the canonical snapshot-v1 digest from the completed staging tree and
 requires it to equal the target `<snapshot-id>` before atomically renaming it
 once into the previously absent digest path. The staged digest includes every
 file byte and executable mode, so copied bytes cannot diverge from the name
-under which they are published. A process interruption can leave only an
-undiscoverable staging directory. If the digest path already exists,
+under which they are published. A process interruption can leave only that
+undiscoverable, bounded staging directory, and the next attempt safely replaces
+it before retrying. If the digest path already exists,
 concurrent or later publishers reuse that path without
 mutating it. A wrong-type or unreadable path fails safely. Readable external
 changes are unsupported post-publication mutation and may affect later
@@ -687,11 +675,9 @@ compatibility inputs; Avibe does not move or rewrite user files during this
 migration. New backend-neutral installs create all three legacy Workbench
 access-policy identifiers for the one logical `.agents` Skill, and logical
 removal removes all three identifiers and askill-managed links. Existing
-backend-native Skills retain their own backend policy identity; a same-name
-candidate from another backend is never a policy alias. Physical askill links
-and any other compatibility entries that resolve to one physical directory
-merge policy identities as defined in Section 8.3. The API
-may continue accepting a
+backend-native Skills retain their existing management-policy identities.
+These identifiers govern the management surface only and do not narrow the
+runtime Catalog. The API may continue accepting a
 legacy `backends` field for compatibility, but validates and ignores narrowing
 requests. The UI removes backend filters, chips, install selectors, and
 availability switches.
@@ -778,6 +764,9 @@ Catalogs at runtime.
 - Standard escapes in a quoted name are decoded before portable-name
   validation, and indented continuation lines in a plain description remain
   part of its normalized Catalog value.
+- Valid quoted `name` and `description` mapping keys are accepted, while the
+  tolerant fallback still extracts required fields when unrelated metadata is
+  malformed.
 - Prompt and `vibe skill list` pagination are deterministic for an unchanged
   filesystem, limited to 25 entries, remain within the row budget, and do not
   expose paths or sources. When later pages exist, the prompt tells the agent
@@ -802,11 +791,9 @@ Catalogs at runtime.
   cannot pair the opened body with a different directory identity.
 - A body over 256 KiB is omitted from discovery, and a body that crosses the
   limit before load produces empty standard output and a non-zero exit.
-- With its remote caller binding intact, a caller denied by the resolved
-  candidate's Skill policy sees neither its managed Catalog row nor its loaded
-  body. A same-name accessible candidate from a different backend directory
-  cannot authorize the winner, while physical askill aliases of one
-  backend-neutral directory retain logical access.
+- Workbench resource policies continue to govern management operations but do
+  not narrow the runtime Catalog or loaded body, matching the ordinary
+  filesystem capability of the agent process.
 
 ### 14.2 Live Session behavior
 
@@ -836,7 +823,11 @@ and verify:
   Turn bindings preserve each other, and token-guarded cleanup removes only the
   binding created by that Turn; a binding remains valid for a Turn longer than
   24 hours while its exact owning Avibe process stays alive, while a stale
-  binding is rejected after PID reuse; and
+  binding after PID reuse carries only Skill roots and remote-deny caller
+  context until restoration; and
+- a cached Claude client is recreated and resumes the same native Session when
+  its bound Skill roots or built-in snapshot change even if page 1 is identical;
+  and
 - each adapter retains the same native Session when the Catalog changes.
 
 Codex `$skill`, backend TUI commands, and ordinary filesystem reads are not v1
@@ -849,19 +840,23 @@ isolation acceptance gates.
   tree and preserves executable modes required by helper scripts;
 - a fixed snapshot-v1 fixture proves the canonical tree byte stream and
   lowercase SHA-256 identifier remain stable;
-- release packaging rejects non-portable, Windows-reserved, trailing-dot/space,
-  case-insensitively colliding, or empty built-in paths; more than 1,024 root
-  entries; more than 4,096 total subtree entries; more than 32 MiB of aggregate
-  regular-file bytes; a non-Skill direct child; a Skill whose closing
-  frontmatter delimiter exceeds 64 KiB; a body over 256 KiB; and a tree whose
-  bounded frontmatter exceeds the built-in 8 MiB budget;
+- release packaging rejects all Win32-forbidden component characters and
+  controls (`U+0000`-`U+001F`),
+  Windows-reserved, trailing-dot/space, case-insensitively colliding, or empty
+  built-in paths; more than 1,024 root entries; more than 4,096 total subtree
+  entries; more than 32 MiB of aggregate regular-file bytes; a non-Skill direct
+  child; a Skill whose closing frontmatter delimiter exceeds 64 KiB; a body
+  over 256 KiB; and a tree whose bounded frontmatter exceeds the built-in 8 MiB
+  budget;
 - a mode-only built-in change produces a different snapshot and published
   digest;
 - publication recomputes the snapshot-v1 digest from the completed staging
   tree and refuses to rename staging bytes under a different digest;
 - an upgrade's selected snapshot contains changed Skills and omits retired
   Skills;
-- interrupted publication cannot expose a partial snapshot;
+- after an injected interruption leaves partial staging state, the next
+  publisher reclaims it and completes successfully without exposing a partial
+  snapshot;
 - a wrong-type or unreadable pre-existing digest path fails safely without
   being traversed, mutated, or rebuilt by runtime commands;
 - two concurrently running artifacts with different bundled trees resolve

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -88,6 +88,12 @@ part of their parent Skill. The only nested container exception is the
 explicit Codex `.system` discovery root in Section 4.4; its direct children
 still follow the same candidate shape.
 
+Compatibility roots accept either a direct child directory or a direct child
+directory symlink. A symlink contributes the resolved target as the directory
+shown by `vibe skill load`; discovery and load revalidate both the alias and
+target identities so replacing either cannot pair one Skill body with another
+directory. Avibe-owned built-in snapshots remain symlink-free.
+
 Avibe opens `SKILL.md` with platform nonblocking semantics, immediately uses
 `fstat` or the platform-equivalent handle query to verify that same open handle
 is a regular file, and performs the bounded parse or load through that handle.
@@ -212,14 +218,18 @@ large optional field, description, or unterminated frontmatter cannot create
 unbounded per-Turn work. Discovery enumerates at most 1,025 direct child
 entries in any root and omits the entire root if it contains more than 1,024.
 One resolution gives the built-in root and the combined project/global roots
-independent aggregate budgets of 1,024 candidate Skill directories and 8 MiB
-of frontmatter bytes each. A full built-in root therefore cannot consume the
-capacity reserved for user Skills. Within the compatibility-input budget,
-roots are visited in precedence order and each accepted root's candidates in
-stable name order. Reaching that budget omits the remaining lower-priority
-roots. These rules make omission deterministic without walking the rest of an
-oversized directory. Omission is diagnostic log data, not additional prompt
-content.
+independent aggregate budgets of 4,096 direct child entries, 1,024 candidate
+Skill directories, and 8 MiB of frontmatter bytes each. A full built-in root
+therefore cannot consume the capacity reserved for user Skills. Within each
+class, roots are visited in precedence order. Before reading frontmatter,
+direct children of each root are sorted by their absolute entry path; declared
+names participate only after parsing. If a root would exceed the remaining
+direct-child budget, Avibe observes at most one entry beyond that remainder,
+omits the whole root, and omits all lower-priority roots. Reaching the candidate
+or frontmatter budget likewise omits remaining lower-priority roots. These
+rules make pre-parse work and omission deterministic without walking the rest
+of an oversized directory. Omission is diagnostic log data, not additional
+prompt content.
 
 These limits do not validate optional frontmatter, require the directory and
 declared name to match, or add compatibility metadata.
@@ -273,6 +283,7 @@ Skills provide specialized instructions and workflows for specific tasks.
 When a task matches a skill's description, run `vibe skill load -- <name>` before proceeding.
 If the user requests a skill by name, load it.
 Only load skill names listed here or returned by `vibe skill list`; do not guess names.
+If no Skill on this page matches the task, inspect subsequent Catalog pages before proceeding.
 
 ### Available skills
 - data-analysis: Analyze datasets, generate charts, and create reports.
@@ -280,7 +291,8 @@ Only load skill names listed here or returned by `vibe skill list`; do not guess
 ```
 
 The system prompt contains page 1 only, within the entry and row budgets in
-Section 5.1. If more entries exist, append exactly:
+Section 5.1. The subsequent-page instruction is present only when another page
+exists. If more entries exist, append exactly:
 
 ```md
 More skills are available. Run `vibe skill list --page 2` to view more.
@@ -419,6 +431,15 @@ the OpenCode caller-context plugin. They are not prompt text or agent-visible
 command arguments. A standalone command without Avibe bindings uses its own
 current working directory and the snapshot bundled with its own executable.
 
+An OpenCode binding lives for the active Avibe-dispatched Turn rather than for
+a wall-clock TTL. Binding-file updates are serialized across processes, use a
+unique same-directory temporary file and atomic replacement, and cleanup is
+guarded by a per-Turn token so an older Turn cannot remove a newer binding for
+the same native Session. Normal completion removes the binding; after a crash,
+the plugin rejects entries whose owner process is no longer alive. Legacy
+entries with an expiry remain readable until that expiry for upgrade
+compatibility.
+
 ### 8.3 Historical context is historical
 
 Avibe does not track which Skills a Session has loaded, attach revisions to
@@ -456,7 +477,7 @@ applies the same Avibe Catalog to all three backends.
 | --- | --- | --- |
 | Claude Code | Configure the SDK with `skills=[]`. | Build the candidate prompt every Turn. If it changed, recreate the SDK client and resume the same native session; otherwise reuse the client. |
 | Codex | Set `skills.include_instructions=false`. | Build `developerInstructions` every Turn. Send updated instructions only when they differ, while retaining the same thread/session. |
-| OpenCode | Set the effective Agent permission `skill=deny` and send `tools.skill=false` in every prompt request. | Build and send the current system prompt on every new Turn. |
+| OpenCode | Send `tools.skill=false` in every prompt request without rewriting user permission configuration. | Build and send the current system prompt on every new Turn. |
 
 For OpenCode, `tools.skill=false` is a request parameter, not text appended to
 the system prompt.
@@ -653,10 +674,18 @@ at runtime.
   candidate, including for oversized or unterminated input.
 - A root with more than 1,024 direct children is omitted after enumerating at
   most 1,025 entries. Built-ins and combined project/global compatibility
-  inputs each have a separate 1,024-candidate and 8 MiB frontmatter budget, so
-  either class can exhaust its own budget without consuming the other's.
+  inputs each have separate 4,096-direct-child, 1,024-candidate, and 8 MiB
+  frontmatter budgets, so either class can exhaust its own budget without
+  consuming the other's. Cross-root exhaustion follows precedence and the
+  pre-frontmatter path order defined in Section 5.1.
+- Compatibility directory symlinks resolve to their target directory, and
+  replacing either the alias or target after discovery makes load fail.
+- Unquoted YAML comments after `name` or `description` are ignored while `#`
+  inside a quoted scalar remains content.
 - Prompt and `vibe skill list` pagination are stable, limited to 25 entries,
-  remain within the row budget, and do not expose paths or sources.
+  remain within the row budget, and do not expose paths or sources. When later
+  pages exist, the prompt tells the agent to inspect them if page 1 has no
+  matching Skill.
 - Oversized descriptions cannot make the Catalog unbounded, and names with
   whitespace, shell syntax, uppercase characters, or invalid hyphen placement
   are omitted by the parser-backed portable name boundary.
@@ -700,6 +729,9 @@ and verify:
 - the Avibe Catalog is equivalent across all three backends;
 - the native backend Catalog is absent;
 - OpenCode's native Skill tool is disabled; and
+- OpenCode user permission configuration is not rewritten, concurrent active
+  Turn bindings preserve each other, and token-guarded cleanup removes only the
+  binding created by that Turn; and
 - each adapter retains the same native Session when the Catalog changes.
 
 Codex `$skill`, backend TUI commands, and ordinary filesystem reads are not v1

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -95,6 +95,15 @@ between enumeration and open cannot redirect the checked operation to a FIFO,
 socket, device, directory, broken link, or other non-regular target. Load
 repeats the same open-handle contract.
 
+Discovery and load share one verified-read primitive. It records the open
+file's identity, size, high-resolution modification time, and change/version
+metadata available on the platform before the bounded read, queries the same
+handle afterward, and accepts the bytes only when every recorded value remains
+unchanged. An in-place rewrite, truncation, or replacement during the read
+therefore omits the candidate during discovery or fails load with empty standard
+output. This consistency rule is owned once by the resolver rather than
+reimplemented by Catalog and load call sites.
+
 Backend-bundled or system Skills, plugin caches, administrator-only Skills,
 and `.claude/commands` are not discovery sources.
 
@@ -206,6 +215,8 @@ selected by these rules, in order:
    more distant directory.
 4. At the same scope and depth, directory-family priority is:
    `.avibe` > `.agents` > `.codex` > `.claude` > OpenCode.
+5. If every preceding dimension ties, the candidate whose absolute directory
+   path sorts first by Unicode code-point order wins.
 
 The `.avibe` family reserves the highest family slot for future use, but
 `${AVIBE_HOME:-$HOME/.avibe}/skills` is inactive in v1. OpenCode means
@@ -405,10 +416,10 @@ reference measurement of six roots, 20 Skill files, and 242 KB total input
 completed in about 1 ms median on a warm local filesystem. This is not a
 latency guarantee; it shows that correctness can precede caching.
 
-If production measurements later justify a cache, directory enumeration still
-runs every Turn and parsed frontmatter may be reused by file identity, size,
-and nanosecond modification time. Caching must preserve the same freshness
-contract.
+V1 does not cache discovery results. A future parsed-frontmatter cache cannot
+treat file identity, size, or timestamps as proof that content is unchanged: it
+must read and digest the bounded frontmatter on that Turn before reusing a
+parsed value. Any optimization must preserve the same freshness contract.
 
 ## 9. Backend Isolation and Prompt Application
 
@@ -492,6 +503,13 @@ leaves no selectable digest path; the next lock holder rebuilds it before
 resolution. If quarantine or publication cannot complete, managed resolution
 fails explicitly and never reads the invalid entry.
 
+Initial publication is not a lifetime trust decision. Before every Catalog
+resolution and built-in load, the resolver validates the selected snapshot
+against the running artifact's expected path, content, and executable-mode
+digest under the same per-digest lock. An altered snapshot enters the repair
+path above before any of its Skills are selected. There is no process-local
+"already validated" flag or metadata-only cache that can authorize reuse.
+
 Every resolver selects the digest computed from the bundled source of its own
 running artifact. Concurrent old and new Avibe processes therefore use
 different snapshots when their built-ins differ, while identical trees safely
@@ -505,8 +523,10 @@ Backend runtimes inherit this selected digest as
 overlapping upgrade. The digest is validated as an identifier under the
 `builtin-skills` umbrella before use; it cannot select an arbitrary path.
 
-The selected snapshot exactly matches the running artifact and is never
-partially updated. The `builtin-skills` umbrella is Avibe-owned rather than a
+At each resolution or load boundary, the selected snapshot exactly matches the
+running artifact and is never partially updated. A later filesystem write is
+detected at the next boundary; this remains a consistency contract rather than
+a security sandbox. The `builtin-skills` umbrella is Avibe-owned rather than a
 user customization surface.
 
 ## 11. Installation Defaults
@@ -580,12 +600,17 @@ at runtime.
   `XDG_CONFIG_HOME` and resolve from the same homes as their live backends.
 - Built-in, project/global, directory depth, and directory-family precedence
   match Section 5.
+- Two sibling directories declaring the same name resolve by the final absolute
+  path tie-breaker, independent of filesystem enumeration order.
 - A Skill with a portable name and extractable description is accepted despite
   unrelated malformed or unknown frontmatter.
 - Invalid candidates do not prevent valid candidates from appearing.
 - A fixture that replaces a regular `SKILL.md` with a FIFO between enumeration
   and open cannot block discovery: handle-level type validation omits it before
   any read, and load follows the same descriptor-bound contract.
+- An in-place rewrite, truncation, or replacement of `SKILL.md` during the
+  verified read is never accepted: discovery omits it and load exits non-zero
+  with empty standard output.
 - Frontmatter parsing reads no more than 64 KiB before accepting or omitting a
   candidate, including for oversized or unterminated input.
 - A root with more than 1,024 direct children is omitted after enumerating at
@@ -649,6 +674,8 @@ isolation acceptance gates.
 - an invalid pre-existing digest path, including a wrong type, changed byte, or
   changed executable mode, is quarantined and rebuilt before resolution; an
   interrupted repair resumes without selecting the quarantine;
+- a snapshot altered after a prior successful resolution is revalidated and
+  repaired before the next Catalog resolution or built-in load;
 - two concurrently running artifacts with different bundled trees resolve
   different immutable snapshots; and
 - after launcher activation, a command inherited from the older runtime still

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -579,9 +579,10 @@ An explicitly project-scoped installation targets:
 $PROJECT_BASE/.agents/skills/<name>
 ```
 
-`$PROJECT_BASE` is the Git project root when one exists and the active working
-directory otherwise. This matches the project-scope fallback used by
-discovery.
+`$PROJECT_BASE` is the Git project root when discovery finds it within the
+128-directory ascent bound and the active working directory otherwise. The
+installer and resolver share this bounded project-base rule, so an installed
+project Skill is always in a root that the next Turn scans.
 
 Installing a Skill does not need to copy it into each backend's native
 directory. Existing native directories remain discovery inputs for backward

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -308,7 +308,8 @@ vibe skill list --page <N>
 ```
 
 The default page is page 1. Each page contains at most 25 entries in the same
-stable name order used by the prompt. Standard output uses only Catalog rows:
+stable name order used by the prompt for the filesystem state observed by that
+invocation. Standard output uses only Catalog rows:
 
 ```text
 - data-analysis: Analyze datasets, generate charts, and create reports.
@@ -318,6 +319,14 @@ stable name order used by the prompt. Standard output uses only Catalog rows:
 When another page exists, the output ends with the same next-page sentence
 used by the prompt, with the appropriate page number. Paths, sources, scopes,
 and resolution metadata are not printed.
+
+Pagination is deliberately live rather than a cross-command snapshot. If the
+filesystem changes between `list --page` invocations, entries can move between
+pages; after installing, editing, renaming, or deleting a Skill while paging,
+the caller restarts at page 1. V1 does not add a hidden per-Session cursor or
+freeze the Catalog merely to linearize an uncommon concurrent scan. With an
+unchanged filesystem, every invocation produces the same order and page
+boundaries.
 
 ## 7. Skill Load Contract
 
@@ -416,7 +425,7 @@ Therefore:
 - changing the body, scripts, or references changes the next load or file
   read.
 
-When a backend launches either command, Avibe supplies two internal bindings:
+When a backend launches either command, Avibe supplies internal bindings:
 
 - `AVIBE_SKILL_WORKING_DIR` is the absolute working directory from which Avibe
   rendered that Session's Catalog. Project discovery always starts there, even
@@ -424,6 +433,12 @@ When a backend launches either command, Avibe supplies two internal bindings:
 - `AVIBE_BUILTIN_SKILLS_SNAPSHOT_ID` selects the version-scoped built-in snapshot
   retained by the Avibe process that created that backend runtime, even if an
   upgrade has since switched the stable `vibe` launcher to another artifact.
+- `AVIBE_SKILL_HOME`, `AVIBE_SKILL_CODEX_HOME`,
+  `AVIBE_SKILL_CLAUDE_HOME`, and `AVIBE_SKILL_XDG_CONFIG_HOME` are normalized
+  absolute roots resolved by the advertising Avibe process. A relative
+  `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, or `XDG_CONFIG_HOME` is therefore resolved
+  once at Turn dispatch and cannot select a different compatibility tree merely
+  because the agent launches `vibe skill` from another shell directory.
 
 These values use the existing per-Session shell-environment path for each
 backend: Claude SDK process environment, Codex `shell_environment_policy`, and
@@ -431,14 +446,16 @@ the OpenCode caller-context plugin. They are not prompt text or agent-visible
 command arguments. A standalone command without Avibe bindings uses its own
 current working directory and the snapshot bundled with its own executable.
 
-An OpenCode binding lives for the active Avibe-dispatched Turn rather than for
-a wall-clock TTL. Binding-file updates are serialized across processes, use a
-unique same-directory temporary file and atomic replacement, and cleanup is
-guarded by a per-Turn token so an older Turn cannot remove a newer binding for
-the same native Session. Normal completion removes the binding; after a crash,
-the plugin rejects entries whose owner process is no longer alive. Legacy
-entries with an expiry remain readable until that expiry for upgrade
-compatibility.
+An OpenCode binding normally lives for the active Avibe-dispatched Turn.
+Binding-file updates are serialized across processes, use a unique
+same-directory temporary file and atomic replacement, and cleanup is guarded
+by a per-Turn token so an older Turn cannot remove a newer binding for the same
+native Session. Normal completion removes the binding. Every entry also has a
+bounded 24-hour safety expiry, so an operating-system PID reused after a crash
+cannot make an abandoned binding valid indefinitely; the plugin rejects an
+entry when either its owner process is gone or its expiry has passed. Restoring
+a persisted poll publishes a fresh binding with the current process identity,
+authorization snapshot, absolute Skill roots, and a new expiry.
 
 ### 8.3 Historical context is historical
 
@@ -535,10 +552,11 @@ protocol.
 Built-in source paths must be representable without aliases on every supported
 platform. Release packaging rejects absolute or traversal paths, backslashes,
 NUL, drive/UNC prefixes, Windows-reserved components, trailing-dot/space names,
-and case-insensitive path collisions. It also rejects more than 1,024 total
-direct child entries, any direct child that is not a valid Skill directory,
-any Skill whose closing frontmatter delimiter exceeds 64 KiB, any body over
-256 KiB, or a built-in tree whose bounded frontmatter exceeds 8 MiB.
+case-insensitive path collisions, and empty directories. It also rejects more
+than 1,024 total direct child entries, any direct child that is not a valid
+Skill directory, any Skill whose closing frontmatter delimiter exceeds 64 KiB,
+any body over 256 KiB, or a built-in tree whose bounded frontmatter exceeds
+8 MiB.
 
 The runtime directory is deliberately separate from user-managed Skills and
 is directly accessible to the agent so loaded built-ins can use their own
@@ -555,9 +573,13 @@ complete mirror that Avibe itself never mutates:
 
 Publication is serialized by a cross-process lock keyed by snapshot digest.
 The publisher builds and validates a hidden sibling staging directory, then
-atomically renames it once into the previously absent digest path. A process
-interruption can leave only an undiscoverable staging directory. If the digest
-path already exists, concurrent or later publishers reuse that path without
+recomputes the canonical snapshot-v1 digest from the completed staging tree and
+requires it to equal the target `<snapshot-id>` before atomically renaming it
+once into the previously absent digest path. The staged digest includes every
+file byte and executable mode, so copied bytes cannot diverge from the name
+under which they are published. A process interruption can leave only an
+undiscoverable staging directory. If the digest path already exists,
+concurrent or later publishers reuse that path without
 mutating it. A wrong-type or unreadable path fails safely. Readable external
 changes are unsupported post-publication mutation and may affect later
 Catalog/load results; runtime commands neither validate nor repair the path
@@ -605,9 +627,22 @@ $PROJECT_BASE/.agents/skills/<name>
 installer and resolver share this bounded project-base rule, so an installed
 project Skill is always in a root that the next Turn scans.
 
-Installing a Skill does not need to copy it into each backend's native
-directory. Existing native directories remain discovery inputs for backward
-compatibility.
+The Workbench exposes one installation, not a backend selector or per-backend
+toggle. New installs invoke askill for Claude Code, Codex, and OpenCode
+together. askill keeps the authoritative directory in the backend-neutral
+`.agents/skills` target and may create its normal backend-native compatibility
+links; native presentation is disabled in Avibe's runtime path, so those links
+do not create three product-level copies.
+
+Existing backend-native installs remain in place and are discovered as
+compatibility inputs; Avibe does not move or rewrite user files during this
+migration. Existing backend-specific Workbench access-policy identifiers are
+treated as aliases for one logical Skill: any accessible alias permits the
+logical Skill, new installs create all three aliases, and logical removal
+removes all aliases and askill-managed links. The API may continue accepting a
+legacy `backends` field for compatibility, but validates and ignores narrowing
+requests. The UI removes backend filters, chips, install selectors, and
+availability switches.
 
 Skill editing, adoption, and copy-on-write are outside v1. This protocol owns
 runtime discovery and loading, while the existing Workbench/askill management
@@ -645,9 +680,9 @@ applying a changed Avibe prompt to the same backend Session. Built-in
 installation owns only the versioned source-to-runtime mirror.
 
 The existing [Workbench Skills design](workbench-skills-page.md) remains the
-management surface. This document supersedes only assumptions in that design
-about installing one copy per backend or using backend-native Skill catalogs
-at runtime.
+management surface. This document supersedes its backend selection and
+per-backend availability model as well as assumptions about using native Skill
+Catalogs at runtime.
 
 ## 14. Acceptance Criteria
 
@@ -656,7 +691,9 @@ at runtime.
 - A fixture covering every discovery root, including Codex's `.system`
   container, resolves one entry per final name.
 - Global-root fixtures override `CODEX_HOME`, `CLAUDE_CONFIG_DIR`, and
-  `XDG_CONFIG_HOME` and resolve from the same homes as their live backends.
+  `XDG_CONFIG_HOME` with relative and absolute values; Turn bindings normalize
+  them to the same absolute homes used by their live backends, independent of
+  the command's later shell directory.
 - Built-in, project/global, directory depth, and directory-family precedence
   match Section 5.
 - Two sibling directories declaring the same name resolve by the final absolute
@@ -682,10 +719,12 @@ at runtime.
   replacing either the alias or target after discovery makes load fail.
 - Unquoted YAML comments after `name` or `description` are ignored while `#`
   inside a quoted scalar remains content.
-- Prompt and `vibe skill list` pagination are stable, limited to 25 entries,
-  remain within the row budget, and do not expose paths or sources. When later
-  pages exist, the prompt tells the agent to inspect them if page 1 has no
-  matching Skill.
+- Prompt and `vibe skill list` pagination are deterministic for an unchanged
+  filesystem, limited to 25 entries, remain within the row budget, and do not
+  expose paths or sources. When later pages exist, the prompt tells the agent
+  to inspect them if page 1 has no matching Skill. A fixture mutating the
+  Catalog between page calls verifies live re-resolution and the documented
+  restart-at-page-1 boundary rather than a hidden snapshot.
 - Oversized descriptions cannot make the Catalog unbounded, and names with
   whitespace, shell syntax, uppercase characters, or invalid hyphen placement
   are omitted by the parser-backed portable name boundary.
@@ -745,12 +784,14 @@ isolation acceptance gates.
 - a fixed snapshot-v1 fixture proves the canonical tree byte stream and
   lowercase SHA-256 identifier remain stable;
 - release packaging rejects non-portable, Windows-reserved, trailing-dot/space,
-  or case-insensitively colliding built-in paths; more than 1,024 total direct
-  child entries; a non-Skill direct child; a Skill whose closing frontmatter
-  delimiter exceeds 64 KiB; a body over 256 KiB; and a tree whose bounded
-  frontmatter exceeds the built-in 8 MiB budget;
+  case-insensitively colliding, or empty built-in paths; more than 1,024 total
+  direct child entries; a non-Skill direct child; a Skill whose closing
+  frontmatter delimiter exceeds 64 KiB; a body over 256 KiB; and a tree whose
+  bounded frontmatter exceeds the built-in 8 MiB budget;
 - a mode-only built-in change produces a different snapshot and published
   digest;
+- publication recomputes the snapshot-v1 digest from the completed staging
+  tree and refuses to rename staging bytes under a different digest;
 - an upgrade's selected snapshot contains changed Skills and omits retired
   Skills;
 - interrupted publication cannot expose a partial snapshot;

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -198,7 +198,9 @@ Discovery is deliberately permissive:
 - ignore every other field;
 - do not reject a Skill because unrelated frontmatter is unknown or malformed;
 - do not require the declared name to match the directory name; and
-- fold whitespace in `description` into a single-line Catalog value.
+- decode standard YAML escapes in quoted required fields; and
+- fold plain, quoted, or block `description` continuation lines and whitespace
+  into a single-line Catalog value.
 
 If either required value cannot be extracted, omit that candidate without
 failing the whole Catalog. The name grammar is the existing Agent Skills
@@ -456,35 +458,47 @@ An OpenCode binding normally lives for the active Avibe-dispatched Turn.
 Binding-file updates are serialized across processes, use a unique
 same-directory temporary file and atomic replacement, and cleanup is guarded
 by a per-Turn token so an older Turn cannot remove a newer binding for the same
-native Session. Normal completion removes the binding. Every entry also has a
-bounded 24-hour safety expiry, so an operating-system PID reused after a crash
-cannot make an abandoned binding valid indefinitely; the plugin rejects an
-entry when either its owner process is gone or its expiry has passed. Restoring
-a persisted poll publishes a fresh binding with the current process identity,
-authorization snapshot, absolute Skill roots, and a new expiry.
+native Session. Normal completion removes the binding, and the plugin rejects
+an entry whose owning Avibe process is no longer alive. The binding does not
+expire while that process and Turn remain active, so a long-running Turn keeps
+its advertised working directory and snapshot. Restoring a persisted poll
+publishes a fresh binding with the current process identity, authorization
+snapshot, and absolute Skill roots.
 
 ### 8.3 Caller authorization
 
-For a remote Workbench caller, the same trusted `resource_user_context` used by
-the Skills management surface is carried in the backend caller binding. Catalog
+For a remote Workbench caller, the same `resource_user_context` used by the
+Skills management surface is carried in the backend caller binding. Catalog
 rendering, `vibe skill list`, and `vibe skill load` each resolve the current
 winner and filter it through that context before exposing its description or
-body. Missing, malformed, or unavailable remote authorization state fails
-closed for compatibility Skills. Avibe built-ins are product runtime content
-and remain available without per-user resource policies. A genuinely local
-caller retains local owner access.
+body through the managed product path. Missing, malformed, or unavailable
+remote authorization state fails closed while that remote binding is present.
+Avibe built-ins are product runtime content and remain available without
+per-user resource policies. A command with no Avibe caller binding uses local
+owner semantics.
 
 Authorization belongs to the resolved candidate, not merely its declared name.
 The backend-neutral `.agents` candidate uses the three legacy backend policy
 identifiers for its one logical installation. A backend-native candidate uses
 only its own backend policy identifier: Codex for `.codex` and Codex system,
 Claude for `.claude`, and OpenCode for `.opencode` or the OpenCode config root.
-askill compatibility links that resolve back to the selected backend-neutral
-`.agents` directory do not add candidates or policy identities. Distinct
-directories that declare the same name remain distinct candidates, so access
-to a losing Claude candidate cannot authorize a winning Codex candidate. These
-source and policy details remain internal and are never shown in the
-agent-facing Catalog.
+Compatibility entries that resolve to the same physical Skill directory merge
+their backend policy identifiers while remaining one discovery candidate.
+Distinct backend-family directories that merely declare the same name remain
+distinct policy candidates, so access to a losing Claude candidate cannot
+authorize a winning Codex candidate. Within one backend family and project, the
+policy identity is the logical project Skill name; nearer and farther same-name
+directories are resolution inputs for that one logical resource rather than
+independently managed policy objects. These source and policy details remain
+internal and are never shown in the agent-facing Catalog.
+
+Caller bindings are environment supplied to an agent-controlled shell, not an
+unforgeable security credential. An agent can remove or alter them, and this
+protocol deliberately permits ordinary filesystem access to known Skill paths.
+Resource filtering therefore keeps the managed Catalog, load command, and
+Workbench presentation coherent; it is not a confidentiality boundary against
+the agent process. Enforcing one would require a sandboxed command/filesystem
+broker and is outside v1.
 
 ### 8.4 Historical context is historical
 
@@ -671,9 +685,10 @@ compatibility inputs; Avibe does not move or rewrite user files during this
 migration. New backend-neutral installs create all three legacy Workbench
 access-policy identifiers for the one logical `.agents` Skill, and logical
 removal removes all three identifiers and askill-managed links. Existing
-backend-native Skills retain their own backend policy identity; same-name
-directories are never policy aliases. Physical askill links back to the selected
-backend-neutral directory are deduplicated as defined in Section 8.3. The API
+backend-native Skills retain their own backend policy identity; a same-name
+candidate from another backend is never a policy alias. Physical askill links
+and any other compatibility entries that resolve to one physical directory
+merge policy identities as defined in Section 8.3. The API
 may continue accepting a
 legacy `backends` field for compatibility, but validates and ignores narrowing
 requests. The UI removes backend filters, chips, install selectors, and
@@ -758,6 +773,9 @@ Catalogs at runtime.
   direct-child slot.
 - Unquoted YAML comments after `name` or `description` are ignored while `#`
   inside a quoted scalar remains content.
+- Standard escapes in a quoted name are decoded before portable-name
+  validation, and indented continuation lines in a plain description remain
+  part of its normalized Catalog value.
 - Prompt and `vibe skill list` pagination are deterministic for an unchanged
   filesystem, limited to 25 entries, remain within the row budget, and do not
   expose paths or sources. When later pages exist, the prompt tells the agent
@@ -782,10 +800,11 @@ Catalogs at runtime.
   cannot pair the opened body with a different directory identity.
 - A body over 256 KiB is omitted from discovery, and a body that crosses the
   limit before load produces empty standard output and a non-zero exit.
-- A remote caller denied by the resolved candidate's Skill policy sees neither
-  its Catalog row nor its loaded body. A same-name accessible candidate from a
-  different backend directory cannot authorize the winner, while physical
-  askill aliases of one backend-neutral directory retain logical access.
+- With its remote caller binding intact, a caller denied by the resolved
+  candidate's Skill policy sees neither its managed Catalog row nor its loaded
+  body. A same-name accessible candidate from a different backend directory
+  cannot authorize the winner, while physical askill aliases of one
+  backend-neutral directory retain logical access.
 
 ### 14.2 Live Session behavior
 
@@ -813,7 +832,8 @@ and verify:
 - OpenCode's native Skill tool is disabled; and
 - OpenCode user permission configuration is not rewritten, concurrent active
   Turn bindings preserve each other, and token-guarded cleanup removes only the
-  binding created by that Turn; and
+  binding created by that Turn; a binding remains valid for a Turn longer than
+  24 hours while its owning Avibe process stays alive; and
 - each adapter retains the same native Session when the Catalog changes.
 
 Codex `$skill`, backend TUI commands, and ordinary filesystem reads are not v1

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -471,9 +471,13 @@ artifact, Avibe publishes a complete runtime snapshot to:
 ${AVIBE_HOME:-$HOME/.avibe}/builtin-skills/<snapshot-id>/<name>/
 ```
 
-`<snapshot-id>` is a stable digest of every relative path, file byte sequence,
-and executable mode bits (`st_mode & 0o111` where POSIX mode bits exist) in the
-authoritative bundled Skill tree.
+`<snapshot-id>` is the digest of a canonical manifest containing every relative
+path, file-content digest, and executable mode bits (`st_mode & 0o111` where
+POSIX mode bits exist) in the authoritative bundled Skill tree. The same
+manifest is stored as snapshot-root runtime metadata at
+`.avibe-snapshot.json`; it is not an entry in its own digest. A command bound to
+an older snapshot can therefore validate it without access to the older package
+artifact.
 The runtime directory is deliberately separate from user-managed Skills and
 is directly accessible to the agent so loaded built-ins can use their own
 scripts and references.
@@ -493,22 +497,32 @@ atomically renames it once into the previously absent digest path. A process
 interruption can leave only an undiscoverable staging directory. If a valid
 snapshot for the same digest already exists, concurrent publishers reuse it
 instead of mutating it. Validation recomputes the same path, content, and
-executable-mode digest from the published mirror before reuse.
+executable-mode manifest and verifies that its digest is `<snapshot-id>` before
+reuse.
 
 If the digest path exists but is not a valid snapshot, the lock holder
 atomically renames that entry itself to a unique hidden quarantine sibling,
 publishes the validated staging directory into the now-absent digest path, and
 removes the quarantine only after final validation. A crash before publication
 leaves no selectable digest path; the next lock holder rebuilds it before
-resolution. If quarantine or publication cannot complete, managed resolution
-fails explicitly and never reads the invalid entry.
+resolution. This repair belongs only to an artifact publishing its own bundled
+tree. Runtime list/load commands never attempt to rebuild a retained snapshot
+from whichever newer artifact the stable launcher currently selects.
 
-Initial publication is not a lifetime trust decision. Before every Catalog
-resolution and built-in load, the resolver validates the selected snapshot
-against the running artifact's expected path, content, and executable-mode
-digest under the same per-digest lock. An altered snapshot enters the repair
-path above before any of its Skills are selected. There is no process-local
-"already validated" flag or metadata-only cache that can authorize reuse.
+Runtime integrity is manifest-bound at the bytes each command uses:
+
+- Catalog accepts a built-in candidate only when the verified `SKILL.md` bytes
+  and executable mode match that path's entry in a manifest whose canonical
+  digest is the bound `<snapshot-id>`.
+- Load first verifies the bound manifest, then verifies every path, byte digest,
+  and executable mode in the selected built-in Skill directory against its
+  manifest entries, rejecting missing, changed, or extra content. The body it
+  emits comes from that same verified `SKILL.md` read.
+- A mismatch omits the candidate during Catalog discovery or fails load with
+  empty standard output. It is not repaired by the command.
+
+This avoids a validate-then-open trust gap and lets a new launcher validate an
+older retained snapshot without possessing the old artifact's source bytes.
 
 Every resolver selects the digest computed from the bundled source of its own
 running artifact. Concurrent old and new Avibe processes therefore use
@@ -523,11 +537,11 @@ Backend runtimes inherit this selected digest as
 overlapping upgrade. The digest is validated as an identifier under the
 `builtin-skills` umbrella before use; it cannot select an arbitrary path.
 
-At each resolution or load boundary, the selected snapshot exactly matches the
-running artifact and is never partially updated. A later filesystem write is
-detected at the next boundary; this remains a consistency contract rather than
-a security sandbox. The `builtin-skills` umbrella is Avibe-owned rather than a
-user customization surface.
+Publication never exposes a partial snapshot, and Catalog/load never accepts
+built-in bytes that differ from the bound snapshot manifest. A later filesystem
+write is detected at the next command boundary; this remains a consistency
+contract rather than a security sandbox. The `builtin-skills` umbrella is
+Avibe-owned rather than a user customization surface.
 
 ## 11. Installation Defaults
 
@@ -672,14 +686,17 @@ isolation acceptance gates.
   Skills;
 - interrupted publication cannot expose a partial snapshot;
 - an invalid pre-existing digest path, including a wrong type, changed byte, or
-  changed executable mode, is quarantined and rebuilt before resolution; an
-  interrupted repair resumes without selecting the quarantine;
-- a snapshot altered after a prior successful resolution is revalidated and
-  repaired before the next Catalog resolution or built-in load;
+  changed executable mode, is quarantined and rebuilt by the artifact publishing
+  that digest; an interrupted publication resumes without selecting quarantine;
+- a snapshot altered after publication is omitted by the next Catalog or fails
+  the next load, and the command does not rebuild it from a different artifact;
+- Catalog verifies the exact built-in `SKILL.md` bytes it parses, while load
+  verifies the selected built-in Skill subtree and emits the same verified body;
 - two concurrently running artifacts with different bundled trees resolve
   different immutable snapshots; and
 - after launcher activation, a command inherited from the older runtime still
-  lists and loads that runtime's retained built-in snapshot; and
+  validates, lists, and loads that runtime's retained built-in snapshot using
+  its digest-bound manifest, without the older package source; and
 - every loaded built-in reports an agent-accessible absolute directory.
 
 ## 15. Explicit Non-Goals

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -478,6 +478,26 @@ manifest is stored as snapshot-root runtime metadata at
 `.avibe-snapshot.json`; it is not an entry in its own digest. A command bound to
 an older snapshot can therefore validate it without access to the older package
 artifact.
+
+Manifest v1 is a frozen persisted shape:
+
+- the top-level JSON object contains `schema_version: 1` and `entries`; each
+  entry contains a `/`-separated relative `path`, byte `size`, lowercase
+  64-hex `sha256`, and integer `executable` bits (`st_mode & 0o111`);
+- entries sort by `path`, object keys sort lexically, and serialization is UTF-8
+  without BOM or trailing newline using ASCII escapes and separators `,` and
+  `:` with no optional whitespace;
+- `<snapshot-id>` is lowercase SHA-256 of those exact manifest bytes; and
+- newer launchers retain decoders for every released manifest schema. An
+  unknown or malformed schema is omitted by Catalog and fails load safely; it
+  is never guessed or rewritten by a runtime command.
+
+The manifest is at most 1 MiB, contains at most 4,096 entries, and each encoded
+path is at most 1,024 bytes. Release packaging fails rather than publishing a
+built-in tree outside these limits. Runtime opens the manifest with the same
+nonblocking, same-handle regular-file and verified-read contract as `SKILL.md`,
+applies the byte limit before parsing, and rejects duplicate, absolute, empty,
+`.` or `..` path components.
 The runtime directory is deliberately separate from user-managed Skills and
 is directly accessible to the agent so loaded built-ins can use their own
 scripts and references.
@@ -518,6 +538,12 @@ Runtime integrity is manifest-bound at the bytes each command uses:
   and executable mode in the selected built-in Skill directory against its
   manifest entries, rejecting missing, changed, or extra content. The body it
   emits comes from that same verified `SKILL.md` read.
+- A selected built-in Skill may contain at most 1,024 manifest files and 64 MiB
+  of expected file bytes. Verification compares the same-handle file size with
+  the manifest before hashing, reads at most that expected size, and visits at
+  most 2,049 filesystem entries while checking for extras. Exceeding any bound
+  fails before further traversal or content reads; release packaging enforces
+  the same limits on authoritative built-ins.
 - A mismatch omits the candidate during Catalog discovery or fails load with
   empty standard output. It is not repaired by the command.
 
@@ -680,6 +706,10 @@ isolation acceptance gates.
 - a fresh installation mirrors all bundled Skills;
 - a real wheel-install fixture proves bundled Skills exist without a source
   tree and preserves executable modes required by helper scripts;
+- released manifest-v1 bytes have a fixed digest fixture, and a newer-launcher
+  fixture validates and loads that retained schema without the older package;
+- a FIFO, non-regular, oversized, malformed, duplicate-path, or traversal-path
+  manifest is bounded and rejected before use;
 - a mode-only built-in change produces a different snapshot and published
   digest;
 - an upgrade's selected snapshot contains changed Skills and omits retired
@@ -692,6 +722,8 @@ isolation acceptance gates.
   the next load, and the command does not rebuild it from a different artifact;
 - Catalog verifies the exact built-in `SKILL.md` bytes it parses, while load
   verifies the selected built-in Skill subtree and emits the same verified body;
+- built-in verification rejects a size mismatch before hashing, and its file,
+  byte, and visited-entry bounds cannot be exceeded by corrupted snapshot data;
 - two concurrently running artifacts with different bundled trees resolve
   different immutable snapshots; and
 - after launcher activation, a command inherited from the older runtime still

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -84,7 +84,9 @@ A discovery root contributes only direct child Skill directories:
 
 Avibe does not recursively treat arbitrary nested `SKILL.md` files as separate
 Skills. Directories such as `scripts/`, `references/`, and `assets/` remain
-part of their parent Skill.
+part of their parent Skill. The only nested container exception is the
+explicit Codex `.system` discovery root in Section 4.4; its direct children
+still follow the same candidate shape.
 
 Avibe opens `SKILL.md` with platform nonblocking semantics, immediately uses
 `fstat` or the platform-equivalent handle query to verify that same open handle
@@ -104,8 +106,9 @@ therefore omits the candidate during discovery or fails load with empty standard
 output. This consistency rule is owned once by the resolver rather than
 reimplemented by Catalog and load call sites.
 
-Backend-bundled or system Skills, plugin caches, administrator-only Skills,
-and `.claude/commands` are not discovery sources.
+Backend-bundled or system Skills other than the explicitly listed Codex
+`.system` compatibility root, plugin caches, administrator-only Skills, and
+`.claude/commands` are not discovery sources.
 
 ### 4.2 Built-in root
 
@@ -119,9 +122,11 @@ authoritative when the compatibility migration cannot move it. Each running
 Avibe artifact selects only the version-scoped snapshot derived from its own
 bundled Skill tree. The `builtin-skills` umbrella is not a generic discovery
 root for direct child Skills. The selected snapshot is Avibe-owned runtime
-content, has the highest resolution priority, and contains at most 1,024 direct
-child Skill directories whose bounded frontmatter totals at most 8 MiB. This
-keeps every published built-in discoverable within the same candidate and byte
+content, has the highest resolution priority, and contains at most 1,024 total
+direct child entries, each a valid Skill directory, whose bounded frontmatter
+totals at most 8 MiB. Every closing frontmatter delimiter is within the 64 KiB
+per-candidate bound and every body is at most 256 KiB. This keeps every
+published built-in discoverable within the same root, candidate, and byte
 budgets as compatibility inputs.
 
 ### 4.3 Project roots
@@ -137,8 +142,11 @@ the Git project root, Avibe inspects:
 ```
 
 The nearest directory to the active working directory wins within the same
-directory family. When there is no Git root, only the active working directory
-is considered project scope.
+directory family. Root discovery examines at most 128 directories including
+the active working directory. If no Git root is found within that bound, only
+the active working directory is considered project scope. Thus each Turn
+performs at most 512 project-root probes before the existing candidate and byte
+budgets apply.
 
 ### 4.4 Global roots
 
@@ -506,8 +514,10 @@ protocol.
 Built-in source paths must be representable without aliases on every supported
 platform. Release packaging rejects absolute or traversal paths, backslashes,
 NUL, drive/UNC prefixes, Windows-reserved components, trailing-dot/space names,
-and case-insensitive path collisions. It also rejects a 1,025th direct child
-Skill directory or a built-in tree whose bounded frontmatter exceeds 8 MiB.
+and case-insensitive path collisions. It also rejects more than 1,024 total
+direct child entries, any direct child that is not a valid Skill directory,
+any Skill whose closing frontmatter delimiter exceeds 64 KiB, any body over
+256 KiB, or a built-in tree whose bounded frontmatter exceeds 8 MiB.
 
 The runtime directory is deliberately separate from user-managed Skills and
 is directly accessible to the agent so loaded built-ins can use their own
@@ -702,8 +712,10 @@ isolation acceptance gates.
 - a fixed snapshot-v1 fixture proves the canonical tree byte stream and
   lowercase SHA-256 identifier remain stable;
 - release packaging rejects non-portable, Windows-reserved, trailing-dot/space,
-  or case-insensitively colliding built-in paths, a 1,025th direct Skill, and a
-  tree whose bounded frontmatter exceeds the built-in 8 MiB budget;
+  or case-insensitively colliding built-in paths; more than 1,024 total direct
+  child entries; a non-Skill direct child; a Skill whose closing frontmatter
+  delimiter exceeds 64 KiB; a body over 256 KiB; and a tree whose bounded
+  frontmatter exceeds the built-in 8 MiB budget;
 - a mode-only built-in change produces a different snapshot and published
   digest;
 - an upgrade's selected snapshot contains changed Skills and omits retired

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -107,10 +107,13 @@ Discovery and load share one verified-read primitive. It records the open
 file's identity, size, high-resolution modification time, and change/version
 metadata available on the platform before the bounded read, queries the same
 handle afterward, and accepts the bytes only when every recorded value remains
-unchanged. An in-place rewrite, truncation, or replacement during the read
-therefore omits the candidate during discovery or fails load with empty standard
-output. This consistency rule is owned once by the resolver rather than
-reimplemented by Catalog and load call sites.
+unchanged. Before accepting, it also queries the `SKILL.md` directory entry
+again, relative to the retained directory handle when one is available, and
+requires that path to remain a regular file naming the same file identity as
+the open handle. An in-place rewrite, truncation, or atomic path replacement
+during the read therefore omits the candidate during discovery or fails load
+with empty standard output. This consistency rule is owned once by the resolver
+rather than reimplemented by Catalog and load call sites.
 
 Backend-bundled or system Skills other than the explicitly listed Codex
 `.system` compatibility root, plugin caches, administrator-only Skills, and
@@ -460,7 +463,30 @@ entry when either its owner process is gone or its expiry has passed. Restoring
 a persisted poll publishes a fresh binding with the current process identity,
 authorization snapshot, absolute Skill roots, and a new expiry.
 
-### 8.3 Historical context is historical
+### 8.3 Caller authorization
+
+For a remote Workbench caller, the same trusted `resource_user_context` used by
+the Skills management surface is carried in the backend caller binding. Catalog
+rendering, `vibe skill list`, and `vibe skill load` each resolve the current
+winner and filter it through that context before exposing its description or
+body. Missing, malformed, or unavailable remote authorization state fails
+closed for compatibility Skills. Avibe built-ins are product runtime content
+and remain available without per-user resource policies. A genuinely local
+caller retains local owner access.
+
+Authorization belongs to the resolved candidate, not merely its declared name.
+The backend-neutral `.agents` candidate uses the three legacy backend policy
+identifiers for its one logical installation. A backend-native candidate uses
+only its own backend policy identifier: Codex for `.codex` and Codex system,
+Claude for `.claude`, and OpenCode for `.opencode` or the OpenCode config root.
+askill compatibility links that resolve back to the selected backend-neutral
+`.agents` directory do not add candidates or policy identities. Distinct
+directories that declare the same name remain distinct candidates, so access
+to a losing Claude candidate cannot authorize a winning Codex candidate. These
+source and policy details remain internal and are never shown in the
+agent-facing Catalog.
+
+### 8.4 Historical context is historical
 
 Avibe does not track which Skills a Session has loaded, attach revisions to
 loaded content, rewrite old conversation history, invalidate prior loads, or
@@ -556,10 +582,13 @@ Built-in source paths must be representable without aliases on every supported
 platform. Release packaging rejects absolute or traversal paths, backslashes,
 NUL, drive/UNC prefixes, Windows-reserved components, trailing-dot/space names,
 case-insensitive path collisions, and empty directories. It also rejects more
-than 1,024 total direct child entries, any direct child that is not a valid
-Skill directory, any Skill whose closing frontmatter delimiter exceeds 64 KiB,
-any body over 256 KiB, or a built-in tree whose bounded frontmatter exceeds
-8 MiB.
+than 1,024 built-in root entries, any direct child that is not a valid Skill
+directory, more than 4,096 directories and regular files across the complete
+tree, more than 32 MiB of regular-file bytes across the complete tree, any
+Skill whose closing frontmatter delimiter exceeds 64 KiB, any body over 256
+KiB, or a built-in tree whose bounded frontmatter exceeds 8 MiB. The aggregate
+entry and byte checks occur before hashing or copying and abort as soon as a
+limit is crossed.
 
 The runtime directory is deliberately separate from user-managed Skills and
 is directly accessible to the agent so loaded built-ins can use their own
@@ -639,10 +668,13 @@ do not create three product-level copies.
 
 Existing backend-native installs remain in place and are discovered as
 compatibility inputs; Avibe does not move or rewrite user files during this
-migration. Existing backend-specific Workbench access-policy identifiers are
-treated as aliases for one logical Skill: any accessible alias permits the
-logical Skill, new installs create all three aliases, and logical removal
-removes all aliases and askill-managed links. The API may continue accepting a
+migration. New backend-neutral installs create all three legacy Workbench
+access-policy identifiers for the one logical `.agents` Skill, and logical
+removal removes all three identifiers and askill-managed links. Existing
+backend-native Skills retain their own backend policy identity; same-name
+directories are never policy aliases. Physical askill links back to the selected
+backend-neutral directory are deduplicated as defined in Section 8.3. The API
+may continue accepting a
 legacy `backends` field for compatibility, but validates and ignores narrowing
 requests. The UI removes backend filters, chips, install selectors, and
 availability switches.
@@ -709,7 +741,8 @@ Catalogs at runtime.
   any read, and load follows the same descriptor-bound contract.
 - An in-place rewrite, truncation, or replacement of `SKILL.md` during the
   verified read is never accepted: discovery omits it and load exits non-zero
-  with empty standard output.
+  with empty standard output. Atomic namespace replacement after the file is
+  opened is covered separately from in-place handle mutation.
 - Frontmatter parsing reads no more than 64 KiB before accepting or omitting a
   candidate, including for oversized or unterminated input.
 - A root with more than 1,024 direct children is omitted after enumerating at
@@ -749,6 +782,10 @@ Catalogs at runtime.
   cannot pair the opened body with a different directory identity.
 - A body over 256 KiB is omitted from discovery, and a body that crosses the
   limit before load produces empty standard output and a non-zero exit.
+- A remote caller denied by the resolved candidate's Skill policy sees neither
+  its Catalog row nor its loaded body. A same-name accessible candidate from a
+  different backend directory cannot authorize the winner, while physical
+  askill aliases of one backend-neutral directory retain logical access.
 
 ### 14.2 Live Session behavior
 
@@ -790,8 +827,9 @@ isolation acceptance gates.
 - a fixed snapshot-v1 fixture proves the canonical tree byte stream and
   lowercase SHA-256 identifier remain stable;
 - release packaging rejects non-portable, Windows-reserved, trailing-dot/space,
-  case-insensitively colliding, or empty built-in paths; more than 1,024 total
-  direct child entries; a non-Skill direct child; a Skill whose closing
+  case-insensitively colliding, or empty built-in paths; more than 1,024 root
+  entries; more than 4,096 total subtree entries; more than 32 MiB of aggregate
+  regular-file bytes; a non-Skill direct child; a Skill whose closing
   frontmatter delimiter exceeds 64 KiB; a body over 256 KiB; and a tree whose
   bounded frontmatter exceeds the built-in 8 MiB budget;
 - a mode-only built-in change produces a different snapshot and published

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -154,10 +154,12 @@ failing the whole Catalog. To keep every accepted name callable and every
 Catalog bounded, Avibe applies only these output-boundary limits:
 
 - omit a candidate whose normalized name exceeds 256 characters;
+- omit a candidate whose normalized name contains `:`, the Catalog row
+  delimiter;
 - truncate a normalized description beyond 1,024 characters, adding `...`;
 - render at most 25 entries and 16 KiB of Skill rows per page; and
 - use `--` before the name in load commands so option-like names remain
-  callable without imposing a new name grammar.
+  callable.
 
 These limits do not validate optional frontmatter, require the directory and
 declared name to match, or add compatibility metadata.
@@ -396,15 +398,26 @@ scripts and references.
 ### 10.2 Replacement lifecycle
 
 The source tree is authoritative for each Avibe version. First run and every
-upgrade perform an atomic full replacement of `builtin-skills`:
+upgrade perform a full replacement of `builtin-skills`:
 
 - new built-ins are added;
 - changed built-ins are replaced; and
 - built-ins removed from the release are deleted from the runtime mirror.
 
-This guarantees that the installed built-in set exactly matches the running
-Avibe version and never exposes a partially updated set. The directory is
-Avibe-owned rather than a user customization surface.
+The publisher and every Avibe Catalog, list, and load reader use the same
+cross-process lock. Under that lock, the publisher builds and validates a
+complete sibling staging directory, renames the current mirror to a backup,
+renames the staging directory to `builtin-skills`, and then removes the backup.
+If publication fails, it restores the backup before releasing the lock. After
+a process interruption, the next lock holder completes recovery before any
+Skill resolution.
+
+This is atomic at the Avibe reader boundary without relying on replacing a
+non-empty directory in place: a managed reader observes either the prior
+complete mirror or the new complete mirror, never the rename interval. The
+installed built-in set therefore exactly matches the running Avibe version
+after publication. The directory is Avibe-owned rather than a user
+customization surface.
 
 ## 11. Installation Defaults
 
@@ -417,8 +430,12 @@ $HOME/.agents/skills/<name>
 An explicitly project-scoped installation targets:
 
 ```text
-$PROJECT_ROOT/.agents/skills/<name>
+$PROJECT_BASE/.agents/skills/<name>
 ```
+
+`$PROJECT_BASE` is the Git project root when one exists and the active working
+directory otherwise. This matches the project-scope fallback used by
+discovery.
 
 Installing a Skill does not need to copy it into each backend's native
 directory. Existing native directories remain discovery inputs for backward
@@ -476,8 +493,9 @@ at runtime.
 - Invalid candidates do not prevent valid candidates from appearing.
 - Prompt and `vibe skill list` pagination are stable, limited to 25 entries,
   remain within the row budget, and do not expose paths or sources.
-- Oversized descriptions cannot make the Catalog unbounded, and option-like or
-  whitespace-containing names remain single-line and callable.
+- Oversized descriptions cannot make the Catalog unbounded; delimiter-bearing
+  names are omitted; and option-like or whitespace-containing names remain
+  single-line and callable.
 - `vibe skill load` emits the exact XML wrapper, body only, and an absolute
   directory from which supporting files can be read.
 
@@ -512,7 +530,8 @@ isolation acceptance gates.
 - a fresh installation mirrors all bundled Skills;
 - a wheel-install fixture proves bundled Skills exist without a source tree;
 - an upgrade replaces changed Skills and removes retired Skills;
-- replacement is atomic; and
+- publication and concurrent managed reads prove the old-or-new atomic reader
+  boundary, including interrupted-publication recovery; and
 - every loaded built-in reports an agent-accessible absolute directory.
 
 ## 15. Explicit Non-Goals

--- a/docs/plans/managed-skills.md
+++ b/docs/plans/managed-skills.md
@@ -94,7 +94,10 @@ and `.claude/commands` are not discovery sources.
 ${AVIBE_HOME:-$HOME/.avibe}/builtin-skills
 ```
 
-This is Avibe-owned runtime content and has the highest resolution priority.
+This is logical user-facing notation. Implementations resolve it through
+`config.paths.get_vibe_remote_dir()` so a legacy `~/.vibe_remote` home remains
+authoritative when the compatibility migration cannot move it. This is
+Avibe-owned runtime content and has the highest resolution priority.
 
 ### 4.3 Project roots
 
@@ -144,10 +147,20 @@ Discovery is deliberately permissive:
 - ignore every other field;
 - do not reject a Skill because unrelated frontmatter is unknown or malformed;
 - do not require the declared name to match the directory name; and
-- fold a multiline description into one line for Catalog display.
+- fold whitespace in `name` and `description` into single-line Catalog values.
 
 If either required value cannot be extracted, omit that candidate without
-failing the whole Catalog.
+failing the whole Catalog. To keep every accepted name callable and every
+Catalog bounded, Avibe applies only these output-boundary limits:
+
+- omit a candidate whose normalized name exceeds 256 characters;
+- truncate a normalized description beyond 1,024 characters, adding `...`;
+- render at most 25 entries and 16 KiB of Skill rows per page; and
+- use `--` before the name in load commands so option-like names remain
+  callable without imposing a new name grammar.
+
+These limits do not validate optional frontmatter, require the directory and
+declared name to match, or add compatibility metadata.
 
 ### 5.2 Deduplication
 
@@ -191,7 +204,7 @@ resolved rows substituted:
 ## Skills
 
 Skills provide specialized instructions and workflows for specific tasks.
-When a task matches a skill's description, run `vibe skill load <name>` before proceeding.
+When a task matches a skill's description, run `vibe skill load -- <name>` before proceeding.
 If the user requests a skill by name, load it.
 Only load skill names listed here or returned by `vibe skill list`; do not guess names.
 
@@ -200,8 +213,8 @@ Only load skill names listed here or returned by `vibe skill list`; do not guess
 - pdf-processing: Extract text, fill forms, and merge PDF files.
 ```
 
-The system prompt contains page 1 only, with at most 25 Skills. If more entries
-exist, append exactly:
+The system prompt contains page 1 only, within the entry and row budgets in
+Section 5.1. If more entries exist, append exactly:
 
 ```md
 More skills are available. Run `vibe skill list --page 2` to view more.
@@ -234,7 +247,11 @@ and resolution metadata are not printed.
 
 ```text
 vibe skill load <name>
+vibe skill load -- <name>
 ```
+
+The first form covers ordinary names; the second is the canonical form emitted
+in agent instructions and also handles names that begin with an option prefix.
 
 The command resolves the live Catalog, selects the current winner for `name`,
 and writes this structure to standard output:
@@ -252,8 +269,8 @@ Contract details:
   `SKILL.md`.
 - XML attribute values are escaped.
 - Only the body after the leading frontmatter is emitted.
-- The body is otherwise unchanged: no generated title, indentation, summary,
-  or rewrite is added.
+- The body is otherwise unchanged: no generated title, indentation, escaping,
+  summary, or rewrite is added.
 - Relative references to `scripts/`, `references/`, `assets/`, or other files
   resolve from `directory`.
 - There is no protocol/version header, JSON envelope, source label,
@@ -262,9 +279,11 @@ Contract details:
 On failure, standard output is empty, standard error contains a short
 human-readable error, and the process exits non-zero.
 
-The wrapper frames tool output; it does not change instruction precedence. A
-loaded Skill is tool-level context and cannot override Avibe's system prompt,
-permissions, or safety rules.
+The wrapper is XML-like model-facing framing, not an XML document consumed by
+an XML parser. Only its attributes use XML escaping; the Markdown body is an
+opaque, unchanged payload and may itself contain XML-looking text. The wrapper
+does not change instruction precedence. A loaded Skill is tool-level context
+and cannot override Avibe's system prompt, permissions, or safety rules.
 
 ## 8. Freshness and Session Semantics
 
@@ -358,6 +377,12 @@ Built-in Skills are maintained in the source tree at:
 skills/<name>/
 ```
 
+Release artifacts must carry that authoritative tree: wheels force-include it
+under a package-owned resource path and sdists include `skills/**`. Runtime
+code resolves the checkout path during development and the packaged resource
+path after installation; it never assumes the repository root exists in a
+wheel environment.
+
 At installation and upgrade, Avibe publishes a complete runtime mirror to:
 
 ```text
@@ -450,7 +475,9 @@ at runtime.
   unrelated malformed or unknown frontmatter.
 - Invalid candidates do not prevent valid candidates from appearing.
 - Prompt and `vibe skill list` pagination are stable, limited to 25 entries,
-  and do not expose paths or sources.
+  remain within the row budget, and do not expose paths or sources.
+- Oversized descriptions cannot make the Catalog unbounded, and option-like or
+  whitespace-containing names remain single-line and callable.
 - `vibe skill load` emits the exact XML wrapper, body only, and an absolute
   directory from which supporting files can be read.
 
@@ -483,6 +510,7 @@ isolation acceptance gates.
 ### 14.4 Built-in lifecycle
 
 - a fresh installation mirrors all bundled Skills;
+- a wheel-install fixture proves bundled Skills exist without a source tree;
 - an upgrade replaces changed Skills and removes retired Skills;
 - replacement is atomic; and
 - every loaded built-in reports an agent-accessible absolute directory.

--- a/tests/test_harness_skill_guidance.py
+++ b/tests/test_harness_skill_guidance.py
@@ -201,7 +201,7 @@ def test_pr_delivery_loop_delegates_waiters_to_background_watch_skill() -> None:
     assert not (ROOT / ".agents/skills/pr-delivery-loop/scripts").exists()
     assert not (ROOT / ".agents/skills/pr-delivery-loop/tests").exists()
 
-    assert "the `pr-delivery-loop` skill for every PR-producing task" in agents
+    assert "the `pr-delivery-loop` skill for every implementation task" in agents
     assert "use the `background-watch-hook` skill" in agents
     assert "one durable `--forever` combined PR/CI Watch" in agents
     assert "one durable `--forever` combined PR watch" in body

--- a/tests/test_harness_skill_guidance.py
+++ b/tests/test_harness_skill_guidance.py
@@ -201,7 +201,7 @@ def test_pr_delivery_loop_delegates_waiters_to_background_watch_skill() -> None:
     assert not (ROOT / ".agents/skills/pr-delivery-loop/scripts").exists()
     assert not (ROOT / ".agents/skills/pr-delivery-loop/tests").exists()
 
-    assert "the `pr-delivery-loop` skill for every implementation task" in agents
+    assert "the `pr-delivery-loop` skill for every PR-producing task" in agents
     assert "use the `background-watch-hook` skill" in agents
     assert "one durable `--forever` combined PR/CI Watch" in agents
     assert "one durable `--forever` combined PR watch" in body


### PR DESCRIPTION
## Summary

- define the accepted Managed Skills v1 product and runtime contract
- specify discovery, precedence, Catalog and load formats, Turn freshness,
  backend isolation, built-in lifecycle, and installation defaults
- move detailed PR delivery mechanics out of `AGENTS.md` and keep the
  `pr-delivery-loop` Skill as their single owner
- add the shared product and technical decision-making philosophy for
  repository collaborators

## Evidence

- Unit: not applicable; documentation-only change
- Contract: exact prompt, CLI output, directory, precedence, and backend
  requirements are recorded in `docs/plans/managed-skills.md`
- Scenario: no existing scenario catalog entry applies
- Manual: `git diff --check`, trailing-whitespace checks, and link existence
  checks passed

## Known by design

- unified `AGENTS.md`, `CLAUDE.md`, and global prompt management remain outside
  v1 until every backend exposes a dependable native opt-out
- native TUI commands, handwritten Codex `$skill` references, and ordinary
  filesystem reads are outside the product-path isolation boundary
- the design records model-facing and user-observable behavior; exact resource
  ceilings, filesystem race defenses, subprocess capture, and persisted helper
  fields remain implementation and test contracts rather than public protocol
