### PR TITLE
feat(claude): add Fable 5.1 model metadata

### DIFF
--- a/tests/test_backend_model_catalog.py
+++ b/tests/test_backend_model_catalog.py
@@ -391,7 +391,11 @@ def test_claude_snapshot_merges_configured_custom_models(monkeypatch, tmp_path):
 
     assert "custom-claude-model" in snapshot["models"]
     assert "custom-fast-model" in snapshot["models"]
-    assert snapshot["models"][:2] == ["claude-fable-5", "claude-opus-5"]
+    assert snapshot["models"][:2] == ["claude-fable-5-1", "claude-fable-5"]
+    assert snapshot["model_labels"]["claude-fable-5-1"] == "claude-fable-5-1 [1M]"
+    assert [
+        option["value"] for option in snapshot["reasoning_options"]["claude-fable-5-1"]
+    ] == ["__default__", "low", "medium", "high", "xhigh", "max"]
     assert snapshot["model_labels"]["claude-opus-5"] == "claude-opus-5 [1M]"
     assert snapshot["model_labels"]["claude-opus-4-6"] == "claude-opus-4-6 [1M]"
 

--- a/tests/test_claude_model_catalog.py
+++ b/tests/test_claude_model_catalog.py
@@ -13,6 +13,11 @@ def test_fable_is_tracked_in_catalog_and_fallback():
     assert "claude-fable-5" in FALLBACK_CLAUDE_MODELS
 
 
+def test_fable_5_1_is_tracked_in_catalog_and_fallback():
+    assert "claude-fable-5-1" in load_catalog_models()
+    assert "claude-fable-5-1" in FALLBACK_CLAUDE_MODELS
+
+
 def test_sonnet_5_is_tracked_in_catalog_and_fallback():
     assert "claude-sonnet-5" in load_catalog_models()
     assert "claude-sonnet-5" in FALLBACK_CLAUDE_MODELS
@@ -30,6 +35,7 @@ def test_catalog_excludes_dated_4_6_and_later_internal_ids():
     assert "claude-sonnet-4-6-20251114" not in models
     assert "claude-sonnet-5-20260630" not in sort_catalog_models(["claude-sonnet-5-20260630"])
     assert "claude-fable-5-20260609" not in sort_catalog_models(["claude-fable-5-20260609"])
+    assert "claude-fable-5-1-20260901" not in sort_catalog_models(["claude-fable-5-1-20260901"])
     assert "claude-opus-5-20260724" not in sort_catalog_models(["claude-opus-5-20260724"])
 
 
@@ -38,27 +44,36 @@ def test_fable_sorts_above_other_families():
         [
             "claude-haiku-4-5",
             "claude-opus-4-8",
+            "claude-fable-5-1",
             "claude-fable-5",
             "claude-sonnet-4-6",
         ]
     )
     # Fable is the Mythos-class tier and must lead the catalog ordering.
-    assert ordered[0] == "claude-fable-5"
+    assert ordered[0] == "claude-fable-5-1"
+    assert ordered.index("claude-fable-5-1") < ordered.index("claude-fable-5")
     assert ordered.index("claude-fable-5") < ordered.index("claude-opus-4-8")
 
 
 def test_bundle_inference_detects_fable_and_skips_mythos_preview(tmp_path):
     bundle = tmp_path / "cli.js"
     bundle.write_bytes(
-        b'pick("claude-fable-5");fallback="claude-opus-4-8";'
+        b'pick("claude-fable-5-1");previous="claude-fable-5";fallback="claude-opus-4-8";'
         b'"claude-opus-5";"claude-sonnet-5";"claude-opus-4-6-20251101";'
         b'"claude-sonnet-4-6-20251114";"claude-sonnet-5-20260630";'
-        b'"claude-fable-5-20260609";"claude-opus-5-20260724";"claude-mythos-preview"'
+        b'"claude-fable-5-20260609";"claude-fable-5-1-20260901";'
+        b'"claude-opus-5-20260724";"claude-mythos-preview"'
     )
 
     models = infer_models_from_bundle(bundle)
 
-    assert models == ["claude-fable-5", "claude-opus-5", "claude-opus-4-8", "claude-sonnet-5"]
+    assert models == [
+        "claude-fable-5-1",
+        "claude-fable-5",
+        "claude-opus-5",
+        "claude-opus-4-8",
+        "claude-sonnet-5",
+    ]
     # `claude-mythos-preview` carries no version segment and is not a publicly
     # callable model, so it must not leak into the catalog.
     assert "claude-mythos-preview" not in models
@@ -68,4 +83,5 @@ def test_bundle_inference_detects_fable_and_skips_mythos_preview(tmp_path):
     assert "claude-sonnet-4-6-20251114" not in models
     assert "claude-sonnet-5-20260630" not in models
     assert "claude-fable-5-20260609" not in models
+    assert "claude-fable-5-1-20260901" not in models
     assert "claude-opus-5-20260724" not in models

--- a/tests/test_claude_model_catalog.py
+++ b/tests/test_claude_model_catalog.py
@@ -39,6 +39,24 @@ def test_catalog_excludes_dated_4_6_and_later_internal_ids():
     assert "claude-opus-5-20260724" not in sort_catalog_models(["claude-opus-5-20260724"])
 
 
+def test_dateless_model_ids_sort_before_matching_snapshots():
+    models = load_catalog_models()
+    ordered = sort_catalog_models(models)
+    positions = {model: index for index, model in enumerate(ordered)}
+
+    matching_pairs = []
+    for model in models:
+        parts = model.split("-")
+        if len(parts[-1]) != 8 or not parts[-1].isdigit():
+            continue
+        dateless_model = "-".join(parts[:-1])
+        if dateless_model in positions:
+            matching_pairs.append((dateless_model, model))
+
+    assert matching_pairs
+    assert all(positions[dateless] < positions[snapshot] for dateless, snapshot in matching_pairs)
+
+
 def test_fable_sorts_above_other_families():
     ordered = sort_catalog_models(
         [

--- a/tests/test_claude_reasoning_options.py
+++ b/tests/test_claude_reasoning_options.py
@@ -53,6 +53,12 @@ def test_claude_reasoning_options_add_xhigh_and_max_for_fable_5() -> None:
     assert [item["value"] for item in options] == ["__default__", "low", "medium", "high", "xhigh", "max"]
 
 
+def test_claude_reasoning_options_add_xhigh_and_max_for_fable_5_1() -> None:
+    options = build_claude_reasoning_options("claude-fable-5-1")
+
+    assert [item["value"] for item in options] == ["__default__", "low", "medium", "high", "xhigh", "max"]
+
+
 def test_claude_reasoning_options_add_xhigh_and_max_for_sonnet_5() -> None:
     options = build_claude_reasoning_options("claude-sonnet-5")
 
@@ -139,6 +145,8 @@ def test_normalize_claude_reasoning_effort_drops_invalid_efforts() -> None:
     assert normalize_claude_reasoning_effort("claude-sonnet-4-6", "max") == "max"
     assert normalize_claude_reasoning_effort("claude-fable-5", "xhigh") == "xhigh"
     assert normalize_claude_reasoning_effort("claude-fable-5", "max") == "max"
+    assert normalize_claude_reasoning_effort("claude-fable-5-1", "xhigh") == "xhigh"
+    assert normalize_claude_reasoning_effort("claude-fable-5-1", "max") == "max"
     assert normalize_claude_reasoning_effort("opus", "xhigh") == "xhigh"
     assert normalize_claude_reasoning_effort("opus", "max") == "max"
 
@@ -151,6 +159,7 @@ def test_claude_1m_context_labels() -> None:
     assert format_claude_model_label("claude-sonnet-5") == "claude-sonnet-5 [1M]"
     assert format_claude_model_label("claude-sonnet-4-6") == "claude-sonnet-4-6 [1M]"
     assert format_claude_model_label("claude-fable-5") == "claude-fable-5 [1M]"
+    assert format_claude_model_label("claude-fable-5-1") == "claude-fable-5-1 [1M]"
     assert format_claude_model_label("opus[1m]") == "opus[1m] [1M]"
     assert format_claude_model_label("sonnet") == "sonnet [1M]"
     assert format_claude_model_label("sonnet[1m]") == "sonnet[1m] [1M]"

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -2393,8 +2393,9 @@ def test_claude_models_merge_catalog_and_settings(monkeypatch, tmp_path):
     result = api.claude_models(schedule_refresh=False)
 
     assert result["ok"] is True
-    assert result["models"][0] == "claude-fable-5"
-    assert result["models"][1] == "claude-opus-5"
+    assert result["models"][0] == "claude-fable-5-1"
+    assert result["models"][1] == "claude-fable-5"
+    assert result["models"][2] == "claude-opus-5"
     assert "opus" in result["models"]
     assert "sonnet" in result["models"]
     assert "haiku" in result["models"]

--- a/vibe/claude_model_catalog.py
+++ b/vibe/claude_model_catalog.py
@@ -147,4 +147,7 @@ def _int_or_none(value: str) -> int | None:
 
 
 def _model_version(model: str) -> tuple[int, ...]:
-    return tuple(int(part) for part in model.split("-")[2:] if part.isdigit())
+    parts = model.split("-")[2:]
+    if parts and len(parts[-1]) == 8 and parts[-1].isdigit():
+        parts = parts[:-1]
+    return tuple(int(part) for part in parts if part.isdigit())

--- a/vibe/claude_model_catalog.py
+++ b/vibe/claude_model_catalog.py
@@ -8,6 +8,7 @@ from typing import Iterable
 
 DEFAULT_CLAUDE_MODEL_ALIASES: tuple[str, ...] = ("opus", "sonnet", "haiku")
 FALLBACK_CLAUDE_MODELS: tuple[str, ...] = (
+    "claude-fable-5-1",
     "claude-fable-5",
     "claude-opus-5",
     "claude-opus-4-8",
@@ -82,11 +83,17 @@ def infer_models_from_bundle(bundle_path: Path) -> list[str]:
 
 def sort_catalog_models(models: Iterable[str]) -> list[str]:
     normalized = [model for model in _dedupe_str_values(models) if _is_public_catalog_model(model)]
+    max_version_parts = max(
+        (len(_model_version(model)) for model in normalized),
+        default=0,
+    )
 
     def sort_key(model: str) -> tuple[int, tuple[int, ...], str]:
         parts = model.split("-")
         family = parts[1] if len(parts) > 1 else ""
-        version_numbers = tuple(-int(part) for part in parts[2:] if part.isdigit())
+        version = _model_version(model)
+        padded_version = version + (0,) * (max_version_parts - len(version))
+        version_numbers = tuple(-part for part in padded_version)
         return (
             _CLAUDE_FAMILY_ORDER.get(family, len(_CLAUDE_FAMILY_ORDER)),
             version_numbers,
@@ -137,3 +144,7 @@ def _int_or_none(value: str) -> int | None:
         return int(value)
     except ValueError:
         return None
+
+
+def _model_version(model: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in model.split("-")[2:] if part.isdigit())

--- a/vibe/data/backend_models.json
+++ b/vibe/data/backend_models.json
@@ -3,6 +3,7 @@
   "backends": {
     "claude": {
       "models": [
+        {"id": "claude-fable-5-1", "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]},
         {"id": "claude-fable-5", "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]},
         {"id": "claude-opus-5", "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]},
         {"id": "claude-opus-4-8", "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]},

--- a/vibe/data/claude_models.json
+++ b/vibe/data/claude_models.json
@@ -1,5 +1,6 @@
 {
   "models": [
+    "claude-fable-5-1",
     "claude-fable-5",
     "claude-opus-5",
     "claude-opus-4",


### PR DESCRIPTION
## Summary

- add the official `claude-fable-5-1` model to Avibe's tracked Claude catalog, runtime fallback, and bundled backend catalog
- expose the inherited 1M context label and `low`, `medium`, `high`, `xhigh`, and `max` effort ladder
- make semantic minor releases sort newest-first so bundle regeneration keeps Fable 5.1 ahead of Fable 5

Official references:
- https://platform.claude.com/docs/en/models/fable-5-1/overview
- https://platform.claude.com/docs/en/models/overview

## Evidence

- Unit: 166 focused catalog, reasoning, backend snapshot, and API tests passed
- Contract: the Claude backend snapshot asserts Fable 5.1 ordering, label, and reasoning metadata; a catalog-wide invariant covers every dateless/snapshot pair
- Scenario: no catalog scenario IDs are defined for this metadata-only change
- Manual: Claude Code 2.1.251 successfully completed a live call with `--model claude-fable-5-1`; the result identified `claude-fable-5-1` as the canonical model
- Static: Ruff and `git diff --check` passed
- CI: all 14 checks in the `lint` workflow passed

## Dependencies

None.

## Residual checks

- Model entitlement still depends on the user's Anthropic account and provider availability.
- The installed Claude Code build accepts the full model ID but labels it unrecognized locally; newer Claude Code releases can update their built-in picker independently of Avibe.

## Known-by-design ledger

None.
