### PR TITLE
fix(ui-server): keep UI connections alive past the tunnel's idle pool

### DIFF
--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -254,6 +254,52 @@ def test_run_ui_server_retries_when_prebind_reports_port_in_use(monkeypatch):
     assert len(run_calls) == 1
 
 
+def test_run_ui_server_keepalive_outlives_upstream_proxy_pool(monkeypatch):
+    """The UI's idle keep-alive must outlive any proxy pooling its connections.
+
+    cloudflared reuses idle origin connections for up to its own keep-alive
+    timeout. If the server expires them first, a reused connection races the
+    close and the browser gets a 502 from a perfectly healthy service. Assert
+    the ordering property rather than a specific number, so retuning either
+    constant cannot silently reintroduce the race.
+    """
+
+    from vibe import ui_server
+    from core.services import settings as settings_service
+
+    captured: dict = {}
+
+    class DummySocket:
+        def close(self):
+            return None
+
+    class DummyServer:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def run(self, sockets=None):
+            return None
+
+    def capture_config(*args, **kwargs):
+        captured.update(kwargs)
+        return (args, kwargs)
+
+    fake_uvicorn = types.ModuleType("uvicorn")
+    fake_uvicorn.Config = capture_config
+    fake_uvicorn.Server = DummyServer
+    monkeypatch.setitem(sys.modules, "uvicorn", fake_uvicorn)
+
+    monkeypatch.setattr(ui_server.paths, "ensure_data_dirs", lambda: None)
+    # Keep the probe hermetic: no real config load, no remote-access reconcile.
+    monkeypatch.setattr(settings_service, "load_config", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ui_server, "_bind_ui_socket", lambda _host, _port: DummySocket())
+    monkeypatch.setattr(ui_server, "_reconcile_remote_access_for_ui_start", lambda _config: None)
+
+    ui_server.run_ui_server("127.0.0.1", 5123)
+
+    assert captured["timeout_keep_alive"] > ui_server._CLOUDFLARED_PROXY_KEEPALIVE_TIMEOUT_SECONDS
+
+
 def test_ui_error_handler_does_not_explicitly_capture_exceptions():
     source = Path("vibe/ui_server.py").read_text(encoding="utf-8")
     module = ast.parse(source)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -16127,6 +16127,19 @@ app.add_event_handler("shutdown", _stop_startup_dependency_reconcile)
 app.add_event_handler("shutdown", stop_show_runtime_on_shutdown)
 
 
+# cloudflared holds idle origin connections in a pool for up to
+# --proxy-keepalive-timeout (default 1m30s) and reuses them for later requests.
+# uvicorn's own default is 5s, so the origin closes connections the tunnel still
+# considers reusable: a request handed to one while it is being torn down loses
+# the race, cloudflared reports "connection reset by peer", and the browser sees
+# a 502 even though the server is healthy. Outliving the upstream pool keeps
+# idle teardown on the proxy side, where it cannot collide with a live request.
+# The same reasoning covers any reverse proxy in front of the UI; nginx's
+# keepalive_timeout default (75s) is also below this value.
+_CLOUDFLARED_PROXY_KEEPALIVE_TIMEOUT_SECONDS = 90
+_UI_KEEPALIVE_TIMEOUT_SECONDS = 120
+
+
 def _bind_ui_socket(host: str, port: int) -> socket.socket:
     family = socket.AF_INET6 if host and ":" in host else socket.AF_INET
     sock = socket.socket(family)
@@ -16183,6 +16196,7 @@ def run_ui_server(host: str, port: int) -> None:
                 loop="asyncio",
                 lifespan="on",
                 workers=1,
+                timeout_keep_alive=_UI_KEEPALIVE_TIMEOUT_SECONDS,
             )
             bound_socket = _bind_ui_socket(host, port)
             _server = uvicorn.Server(uvicorn_config)


### PR DESCRIPTION
## What changed

The UI server (`vibe/ui_server.py`) now passes an explicit
`timeout_keep_alive` to `uvicorn.Config`, set above the idle-pool timeout of any
reverse proxy in front of it.

## Why

cloudflared keeps idle origin connections in a pool for up to
`--proxy-keepalive-timeout` (default `1m30s`) and reuses them for later
requests. uvicorn's default `timeout_keep_alive` is 5 seconds, so the origin was
expiring connections the tunnel still considered reusable. A request handed to
one of those connections during teardown loses the race, cloudflared reports
`connection reset by peer`, and the browser gets a 502 from a service that is
perfectly healthy.

Observed on a local install: **17 failed requests across 86 seconds**, while the
service process had been up for over a day, kept logging normally throughout the
window, and emitted no WARNING or ERROR. The tunnel-side evidence:

```
ERR  error="Unable to reach the origin service ... read tcp
127.0.0.1:64057->127.0.0.1:5100: read: connection reset by peer"
ERR failed to serve incoming request error="Failed to proxy HTTP: ..."
```

The same signature accounts for 130 occurrences in that log since 15 Jul,
normally 2/day, with occasional 34-36 event clusters.

### Why the fix has to live on the origin side

The tunnel is remotely managed through ingress rules (`Updated to new
configuration config="{\"ingress\":[...]}"`), and cloudflared's help is explicit
that `--proxy-keepalive-timeout` "only takes effect if you define your origin
with `--url` and if you do not use ingress rules". Changing the tunnel side
would mean editing `originRequest.keepAliveTimeout` in the control plane. The
origin is the only side this repository can tune.

## Choice of value

Two named constants make the relationship explicit rather than leaving a magic
number: `_CLOUDFLARED_PROXY_KEEPALIVE_TIMEOUT_SECONDS = 90` records the upstream
constraint that is the only reason the number exists, and
`_UI_KEEPALIVE_TIMEOUT_SECONDS = 120` is derived from it with margin. 120s also
clears nginx's `keepalive_timeout` default (75s), so a Docker deployment behind
nginx inherits the fix. Cost is bounded: cloudflared's pool caps at 100
connections.

## Evidence layers

- **Unit** — `test_run_ui_server_keepalive_outlives_upstream_proxy_pool` in
  `tests/test_sentry_integration.py`, alongside the existing `run_ui_server`
  startup-path tests. It asserts the *ordering property*
  (`timeout_keep_alive > _CLOUDFLARED_PROXY_KEEPALIVE_TIMEOUT_SECONDS`) rather
  than a specific number, so retuning either constant cannot silently
  reintroduce the race.
- **Mutation-checked** — the test was verified to fail in both failure modes:
  removing the `timeout_keep_alive` argument (`KeyError`), and lowering the
  value to 90 so it merely equals the upstream timeout. A test that passes
  before the fix would have been worthless here.
- **Regression suites** — `tests/test_sentry_integration.py` 24 passed;
  `tests/test_vibe_cli.py -k ui` 19 passed; `ruff check` clean on both changed
  files.
- **Contract / scenario** — not applicable; no catalog covers UI server startup
  configuration, and no cross-lane interface changes.
- **Residual manual check** — the 502 itself is a timing race against a live
  tunnel and cannot be reproduced in a unit test. Confirming the reset
  disappears needs a UI process restart on an install with remote access, which
  is deferred to the integration/regression pass rather than done against the
  running local service.

## Dependencies

None.
