### PR TITLE
fix(e2e): make upgrade polling fail diagnostically

### DIFF
--- a/tests/e2e/test_upgrade_command.py
+++ b/tests/e2e/test_upgrade_command.py
@@ -1,4 +1,4 @@
-"""Docker regression for upgrading the released 3.0.13 wheel to a built wheel."""
+"""Upgrade regression helpers and Docker coverage for the released 3.0.13 wheel."""
 
 from __future__ import annotations
 
@@ -24,6 +24,99 @@ INITIAL_RELEASE_WHEEL_URL = (
 )
 INITIAL_RELEASE_WHEEL_SHA256 = "994adbfd23228ea387f0479db8a4efe0ef121847bd04efa550486203a6b03542"
 TEST_RELEASE_VERSION = "9999.0.0"
+
+_UPGRADE_WAIT_HELPERS = r"""
+resolve_vibe_runtime() {
+    local launcher_var="$1"
+    local resolved_var="$2"
+    local python_var="$3"
+    local mode="${4:-report}"
+    local launcher=""
+    local resolved=""
+    local python_path=""
+
+    printf -v "$launcher_var" '%s' ""
+    printf -v "$resolved_var" '%s' ""
+    printf -v "$python_var" '%s' ""
+
+    launcher="$(command -v vibe 2>/dev/null || true)"
+    if [ -z "$launcher" ]; then
+        VIBE_RUNTIME_DIAGNOSTIC="vibe launcher is unavailable on PATH"
+    else
+        resolved="$(readlink -f "$launcher" 2>/dev/null || true)"
+        if [ -z "$resolved" ]; then
+            VIBE_RUNTIME_DIAGNOSTIC="vibe launcher $launcher could not be resolved"
+        else
+            python_path="$(dirname "$resolved")/python"
+            if [ ! -x "$python_path" ]; then
+                VIBE_RUNTIME_DIAGNOSTIC="resolved vibe launcher $resolved has no executable Python at $python_path"
+            else
+                printf -v "$launcher_var" '%s' "$launcher"
+                printf -v "$resolved_var" '%s' "$resolved"
+                printf -v "$python_var" '%s' "$python_path"
+                VIBE_RUNTIME_DIAGNOSTIC=""
+                return 0
+            fi
+        fi
+    fi
+
+    if [ "$mode" != "quiet" ]; then
+        printf 'Unable to resolve the vibe runtime: %s\n' "$VIBE_RUNTIME_DIAGNOSTIC" >&2
+    fi
+    return 1
+}
+
+memory_runtime_ready() {
+    local memory_probe_output=""
+
+    if ! resolve_vibe_runtime current_launcher current_vibe current_python quiet; then
+        WAIT_DIAGNOSTIC="$VIBE_RUNTIME_DIAGNOSTIC"
+        return 1
+    fi
+    if memory_probe_output="$(
+        "$current_python" -c \
+            'import sys; from importlib.metadata import version; assert version("avibe-memory") == sys.argv[1]' \
+            "$EXPECTED_AVIBE_VERSION" 2>&1
+    )"; then
+        WAIT_DIAGNOSTIC=""
+        return 0
+    fi
+
+    WAIT_DIAGNOSTIC="resolved $current_launcher to $current_python, but the avibe-memory $EXPECTED_AVIBE_VERSION probe failed: ${memory_probe_output:-no output}"
+    return 1
+}
+
+vibe_service_running() {
+    status_output="$(vibe status 2>&1 || true)"
+    if printf '%s' "$status_output" | grep -q '"running": true'; then
+        WAIT_DIAGNOSTIC=""
+        return 0
+    fi
+
+    WAIT_DIAGNOSTIC="vibe status did not report running=true: ${status_output:-no output}"
+    return 1
+}
+
+wait_until() {
+    local attempts="$1"
+    local interval_seconds="$2"
+    local description="$3"
+    shift 3
+    local attempt
+
+    for ((attempt = 1; attempt <= attempts; attempt++)); do
+        WAIT_DIAGNOSTIC=""
+        if "$@"; then
+            return 0
+        fi
+        sleep "$interval_seconds"
+    done
+
+    printf 'Timed out after %s attempts waiting for %s. Last observation: %s\n' \
+        "$attempts" "$description" "${WAIT_DIAGNOSTIC:-no diagnostic available}" >&2
+    return 1
+}
+""".strip()
 
 
 def _docker_available() -> bool:
@@ -85,6 +178,85 @@ def _released_initial_wheel(fixtures_dir: Path) -> Path:
     return wheel_path
 
 
+def _run_upgrade_wait_helper(script: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", f"{_UPGRADE_WAIT_HELPERS}\n{script}"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_upgrade_wait_clears_missing_launcher_paths_before_failure() -> None:
+    result = _run_upgrade_wait_helper(
+        r"""
+        sleep() { :; }
+        export EXPECTED_AVIBE_VERSION=9999.0.0
+        PATH=/path/that/does/not/exist
+        current_launcher=stale-launcher
+        current_vibe=stale-resolved-launcher
+        current_python=./python
+
+        wait_until 1 0 "avibe-memory 9999.0.0 to become available" memory_runtime_ready
+        wait_result=$?
+        printf 'launcher=<%s> resolved=<%s> python=<%s>\n' \
+            "$current_launcher" "$current_vibe" "$current_python"
+        exit "$wait_result"
+        """
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == "launcher=<> resolved=<> python=<>\n"
+    assert "vibe launcher is unavailable on PATH" in result.stderr
+    assert "./python" not in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
+    ("setup", "description", "predicate", "last_observation"),
+    [
+        (
+            """
+            export EXPECTED_AVIBE_VERSION=9999.0.0
+            memory_probe_fails() { return 1; }
+            resolve_vibe_runtime() {
+                printf -v "$1" '%s' /tmp/vibe
+                printf -v "$2" '%s' /tmp/resolved-vibe
+                printf -v "$3" '%s' memory_probe_fails
+            }
+            """,
+            "avibe-memory 9999.0.0 to become available",
+            "memory_runtime_ready",
+            "the avibe-memory 9999.0.0 probe failed: no output",
+        ),
+        (
+            """
+            vibe() { printf '%s\\n' '{"running": false}'; }
+            """,
+            "vibe service to report running=true",
+            "vibe_service_running",
+            'vibe status did not report running=true: {"running": false}',
+        ),
+    ],
+)
+def test_upgrade_wait_reports_the_last_observation_on_exhaustion(
+    setup: str,
+    description: str,
+    predicate: str,
+    last_observation: str,
+) -> None:
+    result = _run_upgrade_wait_helper(
+        f"""
+        sleep() {{ :; }}
+        {setup}
+        wait_until 2 0 {shlex.quote(description)} {predicate}
+        """
+    )
+
+    assert result.returncode == 1
+    assert f"Timed out after 2 attempts waiting for {description}." in result.stderr
+    assert last_observation in result.stderr
+
+
 @pytest.mark.integration
 def test_memory_indep_026_upgrade_command_bridges_released_3_0_13_generation():
     """The released bundled-Memory upgrader converges onto the split package pair."""
@@ -128,6 +300,8 @@ def test_memory_indep_026_upgrade_command_bridges_released_3_0_13_generation():
         container_name = f"vibe-upgrade-smoke-{os.getpid()}"
         command = " && ".join(
             [
+                _UPGRADE_WAIT_HELPERS,
+                f"export EXPECTED_AVIBE_VERSION={shlex.quote(TEST_RELEASE_VERSION)}",
                 "apt-get update >/dev/null",
                 "apt-get install -y --no-install-recommends curl ca-certificates bash procps >/dev/null",
                 "curl -LsSf https://astral.sh/uv/install.sh | sh",
@@ -136,10 +310,9 @@ def test_memory_indep_026_upgrade_command_bridges_released_3_0_13_generation():
                 "VIBE_INSTALL_SKIP_NODE=1 VIBE_INSTALL_SKIP_SHOW_RUNTIME=1 "
                 f"AVIBE_INSTALL_PACKAGE_SPEC=/fixtures/{initial_wheel_path.name} bash /work/install.sh",
                 'export PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin"',
-                'initial_vibe="$(readlink -f "$HOME/.local/bin/vibe")"',
-                'initial_python="$(dirname "$initial_vibe")/python"',
+                "resolve_vibe_runtime initial_launcher initial_vibe initial_python",
                 'printf "%s\\n" "$initial_vibe" | grep "/uv/tools/"',
-                "vibe version",
+                '"$initial_launcher" version',
                 '"$initial_python" -c "from config.v2_config import V2Config; V2Config.default().save()"',
                 f'"$initial_python" -c {shlex.quote(enable_memory)}',
                 '"$initial_python" -c "from config.v2_config import V2Config; assert V2Config.load().memory.enabled"',
@@ -149,31 +322,23 @@ def test_memory_indep_026_upgrade_command_bridges_released_3_0_13_generation():
                 "AVIBE_UPDATE_METADATA_URL=file:///fixtures/metadata.json "
                 f"VIBE_INSTALL_SKIP_SHOW_RUNTIME=1 AVIBE_UPGRADE_PACKAGE_SPEC=/fixtures/{wheel_path.name} vibe upgrade",
                 "hash -r",
-                'printf "launcher=%s\n" "$(command -v vibe)"',
-                "vibe version",
+                "resolve_vibe_runtime upgraded_launcher upgraded_vibe upgraded_python",
+                'printf "launcher=%s\n" "$upgraded_launcher"',
+                '"$upgraded_launcher" version',
                 'test -x "$initial_vibe"',
                 'test "$(cat "$AVIBE_HOME/upgrade-state-marker")" = "preserved"',
                 "AVIBE_UPDATE_METADATA_URL=file:///fixtures/metadata.json vibe check-update",
-                'upgraded_vibe="$(readlink -f "$(command -v vibe)")"',
-                'upgraded_python="$(dirname "$upgraded_vibe")/python"',
                 '"$upgraded_python" -c "import importlib.util; from config.v2_config import V2Config; '
                 "assert V2Config.load().memory.enabled; assert importlib.util.find_spec('avibe_memory') is None\"",
                 "export UV_FIND_LINKS=/fixtures",
                 "export PIP_FIND_LINKS=/fixtures",
-                "vibe",
-                "for attempt in $(seq 1 120); do "
-                'current_vibe="$(readlink -f "$(command -v vibe)")"; '
-                'current_python="$(dirname "$current_vibe")/python"; '
-                f'if "$current_python" -c "from importlib.metadata import version; assert version(\'avibe-memory\') == \'{TEST_RELEASE_VERSION}\'" 2>/dev/null; '
-                "then break; fi; sleep 1; done",
+                '"$upgraded_launcher"',
+                f'wait_until 120 1 "avibe-memory {TEST_RELEASE_VERSION} to become available" memory_runtime_ready',
                 '"$current_python" -c "from config.v2_config import V2Config; '
                 f"from importlib.metadata import version; assert V2Config.load().memory.enabled; assert version('avibe-os') == '{TEST_RELEASE_VERSION}'; "
                 f"assert version('avibe-memory') == '{TEST_RELEASE_VERSION}'\"",
-                "for attempt in $(seq 1 120); do "
-                'status_output="$(vibe status 2>/dev/null || true)"; '
-                "if printf '%s' \"$status_output\" | grep -q '\"running\": true'; then break; fi; sleep 1; done",
+                'wait_until 120 1 "vibe service to report running=true" vibe_service_running',
                 "printf '%s\\n' \"$status_output\"",
-                "printf '%s' \"$status_output\" | grep -q '\"running\": true'",
             ]
         )
 


### PR DESCRIPTION
## Summary

- make `MEMORY-INDEP-026` resolve the active `vibe` launcher, its real target, and its sibling Python through one checked shell helper
- make both the Memory-package and service-readiness polls use one bounded wait helper that fails with the last observed cause
- preserve the original wait intent: 120 probes at one-second intervals for each readiness condition

## Root cause

The test starts `vibe`, which repairs `avibe-memory` in the background. During `uv tool install --force`, the launcher can briefly disappear. The old nested `command -v vibe` / `readlink -f` / `dirname` sequence silently converted a missing launcher into `./python`. The poll also fell through after all 120 attempts, so its final command used the last stale value and hid whether the launcher or the target package had remained unavailable.

This change treats launcher lookup, symlink resolution, and the sibling interpreter as one validated operation. Failed resolution clears every output variable. If a poll exhausts, it exits non-zero with the condition and final launcher/package/status observation instead of continuing.

The repository-wide search found no other e2e test that derives a Python path from an unchecked `command -v vibe` result. Within this file, the helper now owns all three launcher-to-Python resolutions, and the bounded wait helper owns both 120-attempt polls, so this closes the local failure class rather than patching only the reported line.

## Evidence

- deterministic helper tests force a missing launcher and assert that stale launcher/Python values are cleared, `./python` cannot propagate, and the failure identifies the missing launcher
- deterministic exhaustion tests force both the Memory readiness and service status predicates to time out and assert that each failure includes the waited condition and its last observation
- `tests/e2e/test_upgrade_command.py`: 3 helper tests passed; the Docker scenario was skipped because Docker is unavailable locally
- `tests/scenarios/memory_independence/test_memory_independence_catalog.py`: 5 passed
- `ruff check tests/e2e/test_upgrade_command.py`: passed

Because the original failure is flaky, one green Docker run would not prove the race is fixed. The deterministic tests are the property-level evidence; `install-upgrade-regression` CI remains the real-container integration observation and is still required before handoff.

## Review request

@rkrkrkk, this polling was introduced in #1802. Could you please confirm that retaining 120 one-second probes first for the split `avibe-memory` package and then for the running service matches the original intent? The change only makes launcher resolution and exhaustion explicit; it does not extend or shorten either wait budget.

## Dependencies and residual checks

- No PR dependency.
- Residual integration check: exact-head GitHub CI must pass the Docker-backed `install-upgrade-regression` job.
