### PR TITLE
fix: restore public Show Page request-intent negotiation

### DIFF
--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -1992,8 +1992,43 @@ def _public_representation_runtime_manager() -> _FakeShowRuntimeManager:
             "Authorization": "Bearer caller-secret",
             "X-Vibe-CSRF-Token": "caller-secret",
         },
-        {"User-Agent": "ChatGPT-User/1.0"},
+        {
+            "User-Agent": (
+                "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; "
+                "ChatGPT-User/1.0; +https://openai.com/bot)"
+            )
+        },
         {"User-Agent": "Mozilla/5.0 (compatible; Googlebot/2.1)"},
+        {
+            "User-Agent": (
+                "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; "
+                "Claude-User/1.0; +Claude-User@anthropic.com)"
+            )
+        },
+        {
+            "User-Agent": (
+                "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; "
+                "Perplexity-User/1.0; +https://perplexity.ai/perplexity-user)"
+            )
+        },
+        {
+            "User-Agent": (
+                "Mozilla/5.0 (compatible; MistralAI-User/1.0; "
+                "+https://docs.mistral.ai/robots)"
+            )
+        },
+        {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Microsoft Windows 10.0.19045; "
+                "en-US) WindowsPowerShell/5.1.19041.5608"
+            )
+        },
+        {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Microsoft Windows 10.0.19045; "
+                "en-US) PowerShell/7.2.6"
+            )
+        },
     ],
 )
 def test_public_show_page_infers_markdown_for_non_browser_reads(
@@ -2503,6 +2538,36 @@ def test_show_page_markdown_keeps_extensionless_assets_on_the_app_proxy(
     assert response.content == b"extensionless asset"
     assert manager.render_markdown_capability_calls == 0
     assert [call[1] for call in manager.calls] == [runtime_path]
+
+
+def test_public_show_page_classifies_non_document_before_limited_admission(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "limited")
+    (ensure_show_page_dir("ses123") / "report").write_text(
+        "extensionless asset",
+        encoding="utf-8",
+    )
+    manager = _FakeShowRuntimeManager(render_markdown_supported=True)
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/report",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+            headers={"Accept": "*/*", "User-Agent": "curl/8.10.1"},
+            follow_redirects=False,
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "not_found"}
+    assert manager.calls == []
+    assert manager.render_markdown_capability_calls == 0
 
 
 def test_private_show_page_markdown_requires_auth_then_strips_identity_headers(

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -825,7 +825,7 @@ def test_limited_show_page_shows_access_denied_to_authenticated_viewer(
             f"/p/{share_id}/",
             base_url="https://alex.avibe.bot",
             environ_base=_remote_peer(),
-            headers={"Accept": "application/json"},
+            headers={"Accept": "application/json", "Sec-Fetch-Dest": "empty"},
             follow_redirects=False,
         )
 
@@ -1308,11 +1308,13 @@ def test_rotated_public_share_rejects_an_old_guest_lease(monkeypatch, tmp_path):
         f"/p/{old_share_id}/",
         base_url="https://alex.avibe.bot",
         environ_base=_remote_peer(),
+        headers={"Accept": "text/html"},
     )
     new_response = app.test_client().get(
         "/p/rotated-public-share/",
         base_url="https://alex.avibe.bot",
         environ_base=_remote_peer(),
+        headers={"Accept": "text/html"},
     )
 
     assert old_response.status_code == 404
@@ -1575,7 +1577,7 @@ def test_limited_show_guest_is_rechecked_after_access_changes(
                 entry_path,
                 base_url="https://alex.avibe.bot",
                 environ_base=_remote_peer(),
-                headers={"Accept": "application/json"},
+                headers={"Accept": "application/json", "Sec-Fetch-Dest": "empty"},
                 follow_redirects=False,
             )
             assert non_html_entry.status_code == 404
@@ -1958,6 +1960,346 @@ def _assert_markdown_response_headers(response, *, success: bool) -> None:
         assert response.headers["content-type"].startswith("application/json")
 
 
+def _assert_public_representation_vary(response, *additional: str) -> None:
+    vary = {item.strip().lower() for item in response.headers["vary"].split(",")}
+    assert {
+        "accept",
+        "sec-fetch-dest",
+        "sec-fetch-mode",
+        "user-agent",
+        *(item.lower() for item in additional),
+    } <= vary
+
+
+def _public_representation_runtime_manager() -> _FakeShowRuntimeManager:
+    manager = _markdown_runtime_manager()
+    manager.bodies_by_path["/sessions/ses123/app/"] = b"<h1>HTML page</h1>"
+    manager.headers_by_path["/sessions/ses123/app/"] = {
+        "content-type": "text/html; charset=utf-8"
+    }
+    return manager
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {"Accept": ""},
+        {"Accept": "*/*"},
+        {"Accept": "application/json", "User-Agent": "generic-reader/1.0"},
+        {"User-Agent": "curl/8.10.1"},
+        {
+            "User-Agent": "curl/8.10.1",
+            "Authorization": "Bearer caller-secret",
+            "X-Vibe-CSRF-Token": "caller-secret",
+        },
+        {"User-Agent": "ChatGPT-User/1.0"},
+        {"User-Agent": "Mozilla/5.0 (compatible; Googlebot/2.1)"},
+    ],
+)
+def test_public_show_page_infers_markdown_for_non_browser_reads(
+    monkeypatch,
+    tmp_path,
+    headers,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+    manager = _public_representation_runtime_manager()
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+            headers=headers,
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert response.content == b"# Runtime page\n"
+    assert manager.calls[0][1] == "/sessions/ses123/render-markdown"
+    assert "authorization" not in manager.calls[0][2]
+    assert "x-vibe-csrf-token" not in manager.calls[0][2]
+    _assert_markdown_response_headers(response, success=True)
+    _assert_public_representation_vary(response)
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        {
+            "Accept": "*/*",
+            "User-Agent": "Mozilla/5.0 AppleWebKit/537.36 Chrome/140.0 Safari/537.36",
+        },
+        {
+            "Sec-Fetch-Mode": "navigate",
+            "Sec-Fetch-Dest": "document",
+            "User-Agent": "curl/8.10.1",
+        },
+        {
+            "Sec-Fetch-Dest": "empty",
+            "User-Agent": "ambiguous-client/1.0",
+        },
+    ],
+)
+def test_public_show_page_keeps_browser_shaped_reads_on_html(
+    monkeypatch,
+    tmp_path,
+    headers,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+    manager = _public_representation_runtime_manager()
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+            headers=headers,
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert b"HTML page" in response.content
+    assert manager.calls[0][1] == "/sessions/ses123/app/"
+    assert manager.render_markdown_capability_calls == 0
+    _assert_public_representation_vary(response)
+
+
+@pytest.mark.parametrize(
+    ("headers", "expected_path"),
+    [
+        (
+            {"Accept": "text/html", "User-Agent": "curl/8.10.1"},
+            "/sessions/ses123/app/",
+        ),
+        (
+            {"Accept": "application/xhtml+xml", "User-Agent": "curl/8.10.1"},
+            "/sessions/ses123/app/",
+        ),
+        (
+            {
+                "Accept": "text/markdown",
+                "Sec-Fetch-Mode": "navigate",
+                "Sec-Fetch-Dest": "document",
+                "User-Agent": "Mozilla/5.0 Chrome/140.0",
+            },
+            "/sessions/ses123/render-markdown",
+        ),
+        (
+            {
+                "Accept": "text/markdown;q=0.4, text/html;q=0.9",
+                "User-Agent": "curl/8.10.1",
+            },
+            "/sessions/ses123/app/",
+        ),
+        (
+            {
+                "Accept": "text/markdown;q=0.9, text/html;q=0.4",
+                "User-Agent": "Mozilla/5.0 Chrome/140.0",
+            },
+            "/sessions/ses123/render-markdown",
+        ),
+    ],
+)
+def test_public_show_page_explicit_accept_overrides_client_inference(
+    monkeypatch,
+    tmp_path,
+    headers,
+    expected_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+    manager = _public_representation_runtime_manager()
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+            headers=headers,
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert manager.calls[0][1] == expected_path
+    _assert_public_representation_vary(response)
+
+
+def test_private_show_page_keeps_implicit_agent_request_on_html_after_authorization(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    manager = _public_representation_runtime_manager()
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        _active_org_cookie(config, "editor@example.com", "editor-1"),
+        domain="alex.avibe.bot",
+    )
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = client.get(
+            "/show/ses123/",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+            headers={"User-Agent": "curl/8.10.1"},
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert b"HTML page" in response.content
+    assert manager.calls[0][1] == "/sessions/ses123/app/"
+    assert manager.render_markdown_capability_calls == 0
+    vary = {item.strip().lower() for item in response.headers.get("Vary", "").split(",")}
+    assert not {
+        "sec-fetch-dest",
+        "sec-fetch-mode",
+        "user-agent",
+    } & vary
+
+
+def test_private_show_page_implicit_agent_request_does_not_bypass_authorization(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_show_page("ses123", "private")
+    manager = _public_representation_runtime_manager()
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            "/show/ses123/",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+            headers={"User-Agent": "curl/8.10.1"},
+            follow_redirects=False,
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 401
+    assert manager.calls == []
+    assert manager.render_markdown_capability_calls == 0
+
+
+def test_public_show_page_implicit_markdown_errors_keep_representation_vary(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+    manager = _FakeShowRuntimeManager(render_markdown_supported=False)
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+            headers={
+                "Accept": "*/*",
+                "Accept-Encoding": "gzip",
+                "User-Agent": "curl/8.10.1",
+            },
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 503
+    assert response.get_json()["error"]["code"] == "renderer_unavailable"
+    assert manager.calls == []
+    _assert_markdown_response_headers(response, success=False)
+    _assert_public_representation_vary(response)
+
+
+def test_public_show_page_infers_markdown_for_spa_history_routes(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    share_id = _create_show_page("ses123", "public")
+    manager = _markdown_runtime_manager()
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            f"/p/{share_id}/reports/daily?view=week",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+            headers={"Accept": "*/*", "User-Agent": "curl/8.10.1"},
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert manager.calls[0][1] == "/sessions/ses123/render-markdown"
+    assert manager.calls[0][2][SHOW_RUNTIME_TARGET_HEADER] == "/reports/daily?view=week"
+    _assert_public_representation_vary(response)
+
+
+@pytest.mark.parametrize(
+    ("visibility", "share_id", "status_code", "code"),
+    [
+        (None, "unknown-share", 404, "session_unknown"),
+        ("offline", None, 404, "page_offline"),
+        ("limited", None, 401, "authentication_required"),
+    ],
+)
+def test_public_show_page_implicit_markdown_preserves_admission_errors(
+    monkeypatch,
+    tmp_path,
+    visibility,
+    share_id,
+    status_code,
+    code,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    if visibility is not None:
+        share_id = _create_show_page("ses123", visibility)
+
+    response = app.test_client().get(
+        f"/p/{share_id}/",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+        headers={"Accept": "*/*", "User-Agent": "curl/8.10.1"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == status_code
+    assert response.get_json()["error"]["code"] == code
+    _assert_markdown_response_headers(response, success=False)
+    _assert_public_representation_vary(response)
+
+
+def test_show_cli_guidance_distinguishes_public_and_private_markdown_contracts():
+    translations = {
+        language: json.loads(
+            (Path(ui_server.__file__).parent / "i18n" / f"{language}.json").read_text(
+                encoding="utf-8"
+            )
+        )["show"]["markdown"]["help"]
+        for language in ("en", "zh")
+    }
+
+    assert "Public Show Page" in translations["en"]
+    assert "automatically" in translations["en"]
+    assert "authorized private" in translations["en"]
+    assert "公共 Show Page" in translations["zh"]
+    assert "自动" in translations["zh"]
+    assert "已授权的私有页面" in translations["zh"]
+    assert all("Accept: text/markdown" in value for value in translations.values())
+
+
 @pytest.mark.parametrize(
     ("accept", "expected_path"),
     [
@@ -2102,10 +2444,19 @@ def test_show_page_markdown_negotiates_authored_documents(
 
 
 @pytest.mark.parametrize("surface", ["private", "public"])
+@pytest.mark.parametrize(
+    "request_headers",
+    [
+        {"Accept": "text/markdown"},
+        {"Accept": "*/*", "User-Agent": "curl/8.10.1"},
+    ],
+    ids=["explicit-markdown", "implicit-agent"],
+)
 def test_show_page_markdown_keeps_extensionless_assets_on_the_app_proxy(
     monkeypatch,
     tmp_path,
     surface,
+    request_headers,
 ):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
@@ -2142,7 +2493,7 @@ def test_show_page_markdown_keeps_extensionless_assets_on_the_app_proxy(
     try:
         response = client.get(
             url,
-            headers={"Accept": "text/markdown"},
+            headers=request_headers,
             **request_kwargs,
         )
     finally:
@@ -2219,6 +2570,7 @@ def test_public_show_page_markdown_is_anonymous_and_uses_public_base(monkeypatch
 
     assert response.status_code == 200
     _assert_markdown_response_headers(response, success=True)
+    _assert_public_representation_vary(response)
     assert manager.calls[0][2]["X-Avibe-Show-Context"] == "shared"
     assert manager.calls[0][2][SHOW_RUNTIME_BASE_HEADER] == f"/p/{share_id}/"
 
@@ -2254,6 +2606,7 @@ def test_limited_guest_show_page_markdown_reuses_existing_admission(monkeypatch,
 
     assert response.status_code == 200
     _assert_markdown_response_headers(response, success=True)
+    _assert_public_representation_vary(response, "cookie")
     assert manager.calls[0][2]["X-Avibe-Show-Context"] == "shared"
     assert manager.calls[0][2][SHOW_RUNTIME_BASE_HEADER] == f"/p/{share_id}/"
 
@@ -2493,15 +2846,17 @@ def test_offline_show_page_markdown_maps_to_page_offline(monkeypatch, tmp_path, 
         (502, "render_failed"),
     ],
 )
+@pytest.mark.parametrize("surface", ["private", "public"])
 def test_show_page_markdown_preserves_runtime_contract_errors(
     monkeypatch,
     tmp_path,
     status_code,
     code,
+    surface,
 ):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
-    _create_show_page("ses123", "private")
+    share_id = _create_show_page("ses123", "public" if surface == "public" else "private")
     message = f"runtime {code} hint"
     manager = _markdown_runtime_manager(
         status_code=status_code,
@@ -2510,10 +2865,22 @@ def test_show_page_markdown_preserves_runtime_contract_errors(
     )
     set_show_runtime_manager_for_tests(manager)
     try:
+        if surface == "public":
+            url = f"/p/{share_id}/"
+            request_kwargs = {
+                "base_url": "https://alex.avibe.bot",
+                "environ_base": _remote_peer(),
+                "headers": {"Accept": "*/*", "User-Agent": "curl/8.10.1"},
+            }
+        else:
+            url = "/show/ses123/"
+            request_kwargs = {
+                "base_url": "http://127.0.0.1:5123",
+                "headers": {"Accept": "text/markdown"},
+            }
         response = app.test_client().get(
-            "/show/ses123/",
-            base_url="http://127.0.0.1:5123",
-            headers={"Accept": "text/markdown"},
+            url,
+            **request_kwargs,
         )
     finally:
         set_show_runtime_manager_for_tests(None)
@@ -2521,6 +2888,8 @@ def test_show_page_markdown_preserves_runtime_contract_errors(
     assert response.status_code == status_code
     assert response.get_json() == {"error": {"code": code, "message": message}}
     _assert_markdown_response_headers(response, success=False)
+    if surface == "public":
+        _assert_public_representation_vary(response)
 
 
 @pytest.mark.parametrize("failure", ["capability_missing", "route_missing", "unreachable"])
@@ -2655,22 +3024,29 @@ def test_show_page_markdown_head_uses_runtime_get_without_a_body(monkeypatch, tm
     _assert_markdown_response_headers(response, success=True)
 
 
-def test_show_page_markdown_compresses_large_success_responses(monkeypatch, tmp_path):
+@pytest.mark.parametrize("surface", ["private", "public"])
+def test_show_page_markdown_compresses_large_success_responses(monkeypatch, tmp_path, surface):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
-    _create_show_page("ses123", "private")
+    share_id = _create_show_page("ses123", "public" if surface == "public" else "private")
     body = b"# Runtime page\n" + (b"Repeated Markdown content.\n" * 400)
     manager = _markdown_runtime_manager(body=body)
     client = app.test_client()
+    if surface == "public":
+        url = f"https://alex.avibe.bot/p/{share_id}/"
+        remote_addr = "203.0.113.10"
+    else:
+        url = "http://127.0.0.1:5123/show/ses123/"
+        remote_addr = "127.0.0.1"
     set_show_runtime_manager_for_tests(manager)
     try:
         with client._client.stream(
             "GET",
-            "http://127.0.0.1:5123/show/ses123/",
+            url,
             headers={
                 "Accept": "text/markdown",
                 "Accept-Encoding": "gzip",
-                TEST_REMOTE_ADDR_HEADER: "127.0.0.1",
+                TEST_REMOTE_ADDR_HEADER: remote_addr,
             },
         ) as response:
             compressed = b"".join(response.iter_raw())
@@ -2681,17 +3057,32 @@ def test_show_page_markdown_compresses_large_success_responses(monkeypatch, tmp_
     assert response.headers["Content-Encoding"] == "gzip"
     assert response.headers["Content-Length"] == str(len(compressed))
     vary = {item.strip().lower() for item in response.headers["Vary"].split(",")}
-    assert vary == {"accept", "accept-encoding"}
+    expected_vary = {"accept", "accept-encoding"}
+    if surface == "public":
+        expected_vary.update({"sec-fetch-dest", "sec-fetch-mode", "user-agent"})
+    assert vary == expected_vary
     assert gzip.decompress(compressed) == body
 
 
 @pytest.mark.parametrize("surface", ["private", "public"])
-@pytest.mark.parametrize("asset_path", ["app.js", "api/data", "__vite_hmr"])
+@pytest.mark.parametrize(
+    "asset_path",
+    ["app.js", "styles.css", "image.png", "api/data", "__vite_hmr"],
+)
+@pytest.mark.parametrize(
+    "request_headers",
+    [
+        {"Accept": "text/markdown"},
+        {"Accept": "*/*", "User-Agent": "curl/8.10.1"},
+    ],
+    ids=["explicit-markdown", "implicit-agent"],
+)
 def test_show_page_assets_never_negotiate_markdown(
     monkeypatch,
     tmp_path,
     surface,
     asset_path,
+    request_headers,
 ):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
@@ -2716,7 +3107,7 @@ def test_show_page_assets_never_negotiate_markdown(
     try:
         response = app.test_client().get(
             url,
-            headers={"Accept": "text/markdown"},
+            headers=request_headers,
             **request_kwargs,
         )
     finally:
@@ -2729,11 +3120,20 @@ def test_show_page_assets_never_negotiate_markdown(
 
 @pytest.mark.parametrize("surface", ["private", "public"])
 @pytest.mark.parametrize("event_path", ["__events", "__show/events"])
+@pytest.mark.parametrize(
+    "request_headers",
+    [
+        {"Accept": "text/markdown"},
+        {"Accept": "*/*", "User-Agent": "curl/8.10.1"},
+    ],
+    ids=["explicit-markdown", "implicit-agent"],
+)
 def test_show_page_event_routes_never_negotiate_markdown(
     monkeypatch,
     tmp_path,
     surface,
     event_path,
+    request_headers,
 ):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
@@ -2752,7 +3152,7 @@ def test_show_page_event_routes_never_negotiate_markdown(
     try:
         response = app.test_client().get(
             url,
-            headers={"Accept": "text/markdown"},
+            headers=request_headers,
             **request_kwargs,
         )
     finally:
@@ -3637,6 +4037,7 @@ def test_show_live_035_public_show_page_injects_auth_aware_annotation_config(
             f"/p/{share_id}/",
             base_url="https://alex.avibe.bot",
             environ_base=_remote_peer(),
+            headers={"Accept": "text/html"},
         )
     finally:
         set_show_runtime_manager_for_tests(None)
@@ -3850,6 +4251,7 @@ def test_public_show_runtime_html_rewrites_private_runtime_client_paths(monkeypa
         response = app.test_client().get(
             f"/p/{share_id}/",
             base_url="http://127.0.0.1:5123",
+            headers={"Accept": "text/html"},
         )
     finally:
         set_show_runtime_manager_for_tests(None)
@@ -3949,7 +4351,11 @@ def test_public_show_page_does_not_inject_write_runtime_config(monkeypatch, tmp_
     )
     set_show_runtime_manager_for_tests(manager)
     try:
-        response = app.test_client().get(f"/p/{share_id}/", base_url="http://127.0.0.1:5123")
+        response = app.test_client().get(
+            f"/p/{share_id}/",
+            base_url="http://127.0.0.1:5123",
+            headers={"Accept": "text/html"},
+        )
     finally:
         set_show_runtime_manager_for_tests(None)
 
@@ -4044,11 +4450,14 @@ def test_show_recovery_retry_header_cannot_bypass_for_viewers(monkeypatch, tmp_p
     else:
         path = f"/p/{share_id}/"
     try:
+        headers = {"X-Avibe-Show-Recovery-Retry": "1"}
+        if surface == "public":
+            headers["Accept"] = "text/html"
         response = client.get(
             path,
             base_url="https://alex.avibe.bot",
             environ_base=_remote_peer(),
-            headers={"X-Avibe-Show-Recovery-Retry": "1"},
+            headers=headers,
         )
     finally:
         set_show_runtime_manager_for_tests(None)
@@ -4904,13 +5313,13 @@ def test_public_show_transport_failure_remains_manually_retryable(
             f"/p/{share_id}/",
             base_url="https://alex.avibe.bot",
             environ_base=_remote_peer(),
-            headers={"Accept-Language": accept_language},
+            headers={"Accept": "text/html", "Accept-Language": accept_language},
         )
         response = app.test_client().get(
             f"/p/{share_id}/",
             base_url="https://alex.avibe.bot",
             environ_base=_remote_peer(),
-            headers={"Accept-Language": accept_language},
+            headers={"Accept": "text/html", "Accept-Language": accept_language},
         )
     finally:
         set_show_runtime_manager_for_tests(None)
@@ -6110,7 +6519,11 @@ def test_public_show_page_clears_show_event_write_cookie(monkeypatch, tmp_path):
     _create_agent_session("ses123")
     share_id = _create_show_page("ses123", "public")
 
-    response = app.test_client().get(f"/p/{share_id}/", base_url="http://127.0.0.1:5123")
+    response = app.test_client().get(
+        f"/p/{share_id}/",
+        base_url="http://127.0.0.1:5123",
+        headers={"Accept": "text/html"},
+    )
 
     assert response.status_code == 200
     cookies = "\n".join(response.headers.getlist("set-cookie"))
@@ -7446,6 +7859,7 @@ def test_public_show_page_preserves_external_redirect_location(monkeypatch, tmp_
             f"/p/{share_id}/foo",
             base_url="https://alex.avibe.bot",
             environ_base=_remote_peer(),
+            headers={"Accept": "text/html"},
             follow_redirects=False,
         )
     finally:
@@ -12267,6 +12681,7 @@ def test_public_show_page_skips_remote_login_but_requires_public_host(monkeypatc
             f"/p/{share_id}/",
             base_url="https://alex.avibe.bot",
             environ_base=_remote_peer(),
+            headers={"Accept": "text/html"},
             follow_redirects=False,
         )
 
@@ -12281,6 +12696,7 @@ def test_public_show_page_skips_remote_login_but_requires_public_host(monkeypatc
             f"/p/{share_id}/",
             base_url="https://evil.example",
             environ_base=_remote_peer(),
+            headers={"Accept": "text/html"},
             follow_redirects=False,
         )
     finally:
@@ -12301,6 +12717,7 @@ def test_public_show_page_uses_runtime_when_available(monkeypatch, tmp_path):
             f"/p/{share_id}/",
             base_url="https://alex.avibe.bot",
             environ_base=_remote_peer(),
+            headers={"Accept": "text/html"},
         )
     finally:
         set_show_runtime_manager_for_tests(None)
@@ -12331,6 +12748,7 @@ def test_private_and_public_surfaces_share_one_stable_runtime_base(monkeypatch, 
             f"/p/{share_id}/",
             base_url="https://alex.avibe.bot",
             environ_base=_remote_peer(),
+            headers={"Accept": "text/html"},
         )
         private_after = app.test_client().get(
             "/show/ses123/",
@@ -12364,6 +12782,7 @@ def test_public_show_page_materializes_workspace_before_runtime_proxy(monkeypatc
             f"/p/{share_id}/",
             base_url="https://alex.avibe.bot",
             environ_base=_remote_peer(),
+            headers={"Accept": "text/html"},
         )
     finally:
         set_show_runtime_manager_for_tests(None)
@@ -12397,6 +12816,7 @@ def test_public_show_page_rewrites_runtime_redirect_location(monkeypatch, tmp_pa
             f"/p/{share_id}/foo",
             base_url="https://alex.avibe.bot",
             environ_base=_remote_peer(),
+            headers={"Accept": "text/html"},
             follow_redirects=False,
         )
     finally:
@@ -12647,7 +13067,12 @@ def test_public_show_page_redirects_without_trailing_slash(monkeypatch, tmp_path
     assert response.status_code == 302
     assert response.headers["Location"] == f"/p/{share_id}/"
 
-    followed = app.test_client().get(f"/p/{share_id}", base_url="http://127.0.0.1:5123", follow_redirects=True)
+    followed = app.test_client().get(
+        f"/p/{share_id}",
+        base_url="http://127.0.0.1:5123",
+        headers={"Accept": "text/html"},
+        follow_redirects=True,
+    )
     assert followed.status_code == 200
     assert b"Show Page" in followed.content
 
@@ -12691,7 +13116,7 @@ def test_public_show_not_found_respects_html_quality():
     response = app.test_client().get(
         "/p/unknown-share/",
         base_url="http://127.0.0.1:5123",
-        headers={"Accept": "application/json, text/html;q=0"},
+        headers={"Accept": "application/json, text/html;q=0", "Sec-Fetch-Dest": "empty"},
     )
 
     assert response.status_code == 404
@@ -12709,8 +13134,16 @@ def test_rotated_public_share_url_stops_working(monkeypatch, tmp_path):
     finally:
         store.close()
 
-    old_response = app.test_client().get(f"/p/{old_share_id}/", base_url="http://127.0.0.1:5123")
-    new_response = app.test_client().get(f"/p/{page.share_id}/", base_url="http://127.0.0.1:5123")
+    old_response = app.test_client().get(
+        f"/p/{old_share_id}/",
+        base_url="http://127.0.0.1:5123",
+        headers={"Accept": "text/html"},
+    )
+    new_response = app.test_client().get(
+        f"/p/{page.share_id}/",
+        base_url="http://127.0.0.1:5123",
+        headers={"Accept": "text/html"},
+    )
 
     assert old_response.status_code == 404
     assert new_response.status_code == 200
@@ -12727,7 +13160,11 @@ def test_offline_show_page_returns_explanatory_page(monkeypatch, tmp_path):
     finally:
         store.close()
 
-    response = app.test_client().get(f"/p/{share_id}/", base_url="http://127.0.0.1:5123")
+    response = app.test_client().get(
+        f"/p/{share_id}/",
+        base_url="http://127.0.0.1:5123",
+        headers={"Accept": "text/html"},
+    )
 
     assert response.status_code == 401
     assert b"offline" in response.content
@@ -12949,7 +13386,11 @@ def test_public_show_page_passes_runtime_importmap_through_unmodified(monkeypatc
     )
     set_show_runtime_manager_for_tests(manager)
     try:
-        response = app.test_client().get(f"/p/{share_id}/", base_url="http://127.0.0.1:5123")
+        response = app.test_client().get(
+            f"/p/{share_id}/",
+            base_url="http://127.0.0.1:5123",
+            headers={"Accept": "text/html"},
+        )
     finally:
         set_show_runtime_manager_for_tests(None)
 

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -31,7 +31,7 @@
       "back": "Back to home"
     },
     "markdown": {
-      "help": "Every Show Page URL also has an agent-readable representation: request it with Accept: text/markdown.",
+      "help": "Public Show Page links automatically return agent-readable Markdown to Agents and command-line clients. For an authorized private read, request the URL with Accept: text/markdown.",
       "errors": {
         "authenticationRequired": "Authentication is required to read this Show Page.",
         "forbidden": "You do not have permission to read this Show Page.",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -31,7 +31,7 @@
       "back": "返回首页"
     },
     "markdown": {
-      "help": "每个 Show Page URL 都提供 Agent 可读的表示；请求时设置 Accept: text/markdown 即可获取。",
+      "help": "公共 Show Page 链接会自动向 Agent 和命令行客户端返回 Agent 可读的 Markdown。读取已授权的私有页面时，请在请求 URL 时设置 Accept: text/markdown。",
       "errors": {
         "authenticationRequired": "需要先完成身份验证才能读取此 Show Page。",
         "forbidden": "你无权读取此 Show Page。",

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -12832,8 +12832,12 @@ _PUBLIC_SHOW_REPRESENTATION_HEADERS = (
     "User-Agent",
 )
 _SHOW_PAGE_CRAWLER_USER_AGENT_RE = re.compile(
-    r"(?:bot\b|crawler|spider|slurp|chatgpt-user|claudebot|perplexitybot|"
+    r"(?:bot\b|crawler|spider|slurp|claudebot|perplexitybot|"
     r"anthropic-ai|cohere-ai|google-extended|bytespider)",
+    re.IGNORECASE,
+)
+_SHOW_PAGE_KNOWN_NON_BROWSER_USER_AGENT_RE = re.compile(
+    r"(?:chatgpt-user|claude-user|perplexity-user|mistralai-user|powershell/)",
     re.IGNORECASE,
 )
 _SHOW_PAGE_BROWSER_USER_AGENT_RE = re.compile(
@@ -12891,6 +12895,11 @@ def _public_show_page_prefers_markdown(starlette_request: FastAPIRequest) -> boo
 
     user_agent = starlette_request.headers.get("user-agent", "").strip()
     if _SHOW_PAGE_CRAWLER_USER_AGENT_RE.search(user_agent):
+        return True
+    # User-initiated Agent fetchers and PowerShell deliberately use
+    # browser-compatible UA prefixes. Their product tokens are more specific
+    # than the surrounding Mozilla/WebKit tokens.
+    if _SHOW_PAGE_KNOWN_NON_BROWSER_USER_AGENT_RE.search(user_agent):
         return True
     if _SHOW_PAGE_BROWSER_USER_AGENT_RE.search(user_agent):
         return False
@@ -15713,6 +15722,20 @@ async def serve_public_show_page(share_id, asset_path):
             if markdown_requested:
                 return _show_page_markdown_error_response("page_offline", 404)
             return _show_page_offline_response()
+        runtime_path_denied = _is_show_page_runtime_denied_path(
+            asset_path,
+            session_id=page.session_id,
+            confine_to_workspace=True,
+        )
+        if not runtime_path_denied:
+            representation_candidate = (
+                representation_candidate
+                and _show_page_markdown_target_is_document(page.session_id, asset_path)
+            )
+            request._request.state.public_show_representation_varies = (
+                representation_candidate
+            )
+            markdown_requested = markdown_requested and representation_candidate
         is_spa_navigation = markdown_requested or _is_show_page_spa_route_request(
             asset_path,
             request._request,
@@ -15838,20 +15861,10 @@ async def serve_public_show_page(share_id, asset_path):
             if markdown_requested:
                 return _show_page_markdown_error_response("session_unknown", 404)
             return _show_page_not_found_response()
-        if _is_show_page_runtime_denied_path(
-            asset_path,
-            session_id=page.session_id,
-            confine_to_workspace=True,
-        ):
+        if runtime_path_denied:
             if markdown_requested:
                 return _show_page_markdown_error_response("session_unknown", 404)
             return _show_page_file_not_found_response()
-        representation_candidate = (
-            representation_candidate
-            and _show_page_markdown_target_is_document(page.session_id, asset_path)
-        )
-        request._request.state.public_show_representation_varies = representation_candidate
-        markdown_requested = markdown_requested and representation_candidate
         if markdown_requested:
             return await _show_page_markdown_runtime_response(
                 page.session_id,

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2982,6 +2982,23 @@ def compress_materialized_api_response(response: Response) -> Response:
 
 
 @app.after_request
+def add_public_show_representation_vary(response: Response) -> Response:
+    if not getattr(request._request.state, "public_show_representation_varies", False):
+        return response
+    for header in _PUBLIC_SHOW_REPRESENTATION_HEADERS:
+        response.headers["Vary"] = _append_vary_header(
+            response.headers.get("Vary"),
+            header,
+        )
+    if getattr(request._request.state, "public_show_representation_varies_cookie", False):
+        response.headers["Vary"] = _append_vary_header(
+            response.headers.get("Vary"),
+            "Cookie",
+        )
+    return response
+
+
+@app.after_request
 def add_api_timing_headers(response: Response) -> Response:
     started_at = getattr(g, "api_request_started_at", None)
     if started_at is None:
@@ -12808,6 +12825,80 @@ def _show_page_accepts_markdown_value(accept: str) -> bool:
     return markdown_quality > 0.0 and markdown_quality >= html_quality
 
 
+_PUBLIC_SHOW_REPRESENTATION_HEADERS = (
+    "Accept",
+    "Sec-Fetch-Dest",
+    "Sec-Fetch-Mode",
+    "User-Agent",
+)
+_SHOW_PAGE_CRAWLER_USER_AGENT_RE = re.compile(
+    r"(?:bot\b|crawler|spider|slurp|chatgpt-user|claudebot|perplexitybot|"
+    r"anthropic-ai|cohere-ai|google-extended|bytespider)",
+    re.IGNORECASE,
+)
+_SHOW_PAGE_BROWSER_USER_AGENT_RE = re.compile(
+    r"(?:mozilla/|applewebkit/|chrome/|chromium/|firefox/|safari/|edg/|opr/)",
+    re.IGNORECASE,
+)
+_SHOW_PAGE_AGENT_OR_CLI_USER_AGENT_RE = re.compile(
+    r"(?:curl/|wget/|httpie/|python-requests/|python-httpx/|go-http-client/|"
+    r"libwww-perl/|powershell/|openai|anthropic|claude|perplexity|cohere|agent)",
+    re.IGNORECASE,
+)
+
+
+def _public_show_page_explicit_representation(accept: str) -> str | None:
+    """Return an explicit Show representation choice, if the header makes one."""
+    media_types = {
+        item.split(";", 1)[0].strip().lower()
+        for item in accept.split(",")
+    }
+    markdown_quality = _show_page_accept_quality(accept, "text/markdown")
+    html_quality = max(
+        _show_page_accept_quality(accept, "text/html"),
+        _show_page_accept_quality(accept, "application/xhtml+xml"),
+    )
+    html_explicit = bool({"text/html", "application/xhtml+xml"} & media_types)
+    if (
+        _show_page_accepts_markdown_value(accept)
+        and (not html_explicit or markdown_quality >= html_quality)
+    ):
+        return "markdown"
+    if html_explicit and html_quality > 0.0:
+        return "html"
+    if "text/markdown" in media_types:
+        # An explicit Markdown range that loses quality negotiation (including
+        # q=0) must not be turned back into Markdown by implicit client inference.
+        return "html"
+    return None
+
+
+def _public_show_page_prefers_markdown(starlette_request: FastAPIRequest) -> bool:
+    explicit = _public_show_page_explicit_representation(
+        starlette_request.headers.get("accept", "")
+    )
+    if explicit is not None:
+        return explicit == "markdown"
+
+    # Fetch Metadata is a strong browser-shaped signal. Any supplied mode or
+    # destination is conservatively kept on the interactive HTML surface,
+    # including incomplete or contradictory browser requests.
+    if (
+        starlette_request.headers.get("sec-fetch-mode", "").strip()
+        or starlette_request.headers.get("sec-fetch-dest", "").strip()
+    ):
+        return False
+
+    user_agent = starlette_request.headers.get("user-agent", "").strip()
+    if _SHOW_PAGE_CRAWLER_USER_AGENT_RE.search(user_agent):
+        return True
+    if _SHOW_PAGE_BROWSER_USER_AGENT_RE.search(user_agent):
+        return False
+    if _SHOW_PAGE_AGENT_OR_CLI_USER_AGENT_RE.search(user_agent):
+        return True
+    return True
+
+
 def _show_page_not_found_html_response():
     language = _request_ui_language()
     title = html.escape(t("show.pageUnavailable.title", language), quote=True)
@@ -12961,6 +13052,29 @@ def _is_show_page_spa_route_request(asset_path: str, starlette_request: FastAPIR
     if not segments or segments[0] in {"api", "__show"}:
         return False
     return True
+
+
+def _is_public_show_page_document_candidate(
+    asset_path: str,
+    starlette_request: FastAPIRequest,
+) -> bool:
+    if starlette_request.method not in {"GET", "HEAD"}:
+        return False
+    if not _is_show_page_entry_asset(asset_path) and _is_show_page_non_document_path(asset_path):
+        return False
+    relative = _decode_show_page_asset_path(asset_path)
+    segments = [segment for segment in relative.split("/") if segment]
+    return not segments or segments[0] not in {"api", "__show"}
+
+
+def _is_public_show_page_markdown_request(
+    asset_path: str,
+    starlette_request: FastAPIRequest,
+) -> bool:
+    return (
+        _is_public_show_page_document_candidate(asset_path, starlette_request)
+        and _public_show_page_prefers_markdown(starlette_request)
+    )
 
 
 def _is_show_page_non_document_path(asset_path: str) -> bool:
@@ -15562,9 +15676,15 @@ async def serve_public_show_page(share_id, asset_path):
     from core.show_pages import ShowPageError, ShowPageStore, ensure_show_page_dir
     from vibe import show_identity
 
-    markdown_requested = _is_show_page_markdown_request(asset_path, request._request)
+    representation_candidate = _is_public_show_page_document_candidate(
+        asset_path,
+        request._request,
+    )
+    request._request.state.public_show_representation_varies = representation_candidate
+    markdown_requested = _is_public_show_page_markdown_request(asset_path, request._request)
     config = _load_remote_access_config()
     lease = _show_guest_lease(config, share_id)
+    request._request.state.public_show_representation_varies_cookie = lease is not None
     editor_admitted = False
     limited_authenticated = False
     store = ShowPageStore()
@@ -15582,6 +15702,8 @@ async def serve_public_show_page(share_id, asset_path):
             if markdown_requested:
                 return _show_page_markdown_error_response("session_unknown", 404)
             return _show_page_not_found_response()
+        if page.visibility == "limited":
+            request._request.state.public_show_representation_varies_cookie = True
         limited_guest = (
             lease is not None
             and lease.page_id == page.session_id
@@ -15591,7 +15713,7 @@ async def serve_public_show_page(share_id, asset_path):
             if markdown_requested:
                 return _show_page_markdown_error_response("page_offline", 404)
             return _show_page_offline_response()
-        is_spa_navigation = _is_show_page_spa_route_request(
+        is_spa_navigation = markdown_requested or _is_show_page_spa_route_request(
             asset_path,
             request._request,
         )
@@ -15724,10 +15846,12 @@ async def serve_public_show_page(share_id, asset_path):
             if markdown_requested:
                 return _show_page_markdown_error_response("session_unknown", 404)
             return _show_page_file_not_found_response()
-        markdown_requested = markdown_requested and _show_page_markdown_target_is_document(
-            page.session_id,
-            asset_path,
+        representation_candidate = (
+            representation_candidate
+            and _show_page_markdown_target_is_document(page.session_id, asset_path)
         )
+        request._request.state.public_show_representation_varies = representation_candidate
+        markdown_requested = markdown_requested and representation_candidate
         if markdown_requested:
             return await _show_page_markdown_runtime_response(
                 page.session_id,


### PR DESCRIPTION
## Summary

Keep the current explicit `Accept` classifier as the shared/private contract, and add a production-used public request classifier in `vibe/ui_server.py` that first honors explicit Markdown or HTML preferences before considering navigation headers and User-Agent/request shape. Invoke the implicit branch only from `serve_public_show_page`, with conservative browser detection that resolves ambiguous browser signals to HTML and resolves absent, wildcard, or otherwise noncommittal non-browser requests to Markdown. Continue passing the result through the existing SPA/document boundary so assets, APIs, events, HMR, Runtime-internal routes, and authored non-document files never reach Markdown rendering, while admission still completes before the renderer is called.

Public Show Page documents currently enter the Markdown renderer only when `Accept` explicitly prefers `text/markdown`, so ordinary `curl` and Agent reads receive the HTML application shell. The public `/p/<share_id>/` surface must instead infer representation intent after explicit media preferences: browser navigations stay HTML, while known Agent/crawler/CLI clients and generic non-browser reads default to Markdown. This inference must remain a representation decision only, after the existing public or limited-share admission rules, and must never weaken private `/show/<session_id>/` authorization or its explicit-only Markdown contract. Existing document-path filtering, SSR capability/error behavior, header stripping, and browser interactivity remain unchanged.

Fixes #1797

## Scenario Coverage

Not applicable to this change.

## Validation

A public entry document requested with curl-like or generic non-browser headers and absent, wildcard, or noncommittal `Accept` reaches `/render-markdown`, returns `text/markdown`, and varies on every header used by the classifier.
A normal browser document navigation and an ambiguous browser-shaped request stay on the HTML app path, while known Agent, crawler, and CLI User-Agents select Markdown when no explicit representation preference exists.
Explicit `Accept: text/html` overrides a CLI-like User-Agent and explicit `Accept: text/markdown` overrides a browser-like User-Agent, including quality-weighted preferences.
Public SPA history routes remain eligible, but JavaScript, CSS, images, extensionless authored assets, page APIs, event endpoints, HMR, and internal Runtime paths never probe or call Markdown rendering even with Agent-like headers.
An unauthorized private request remains denied regardless of User-Agent; an authorized private request with implicit Agent-like headers remains HTML, and only explicit Markdown negotiation selects the private renderer.
Public limited/offline/not-found and Runtime capability, timeout, malformed-response, and render-error paths retain their existing admission and deterministic no-HTML-fallback behavior, privacy header stripping, and complete cache-variation policy.
English and Chinese CLI help describe the same public automatic-selection and private explicit-negotiation contract.

## Risks / Follow-ups

Scoped to the files listed above; no other caller or consumer changes.

AI was used for assistance.
