### PR TITLE
Fix Model Hub duplicate-key routes failing before egress

### DIFF
--- a/tests/e2e/test_model_hub_routing.py
+++ b/tests/e2e/test_model_hub_routing.py
@@ -110,7 +110,7 @@ def _prepare_probe_chain(
     first, _ = _create_source(
         app,
         first_upstream,
-        nonce="scn_dprobe000000001",
+        nonce="scn_dprobe0000000001",
         vendor="anthropic",
         display_name="First probe source",
     )
@@ -124,7 +124,7 @@ def _prepare_probe_chain(
         second, _ = _create_source(
             app,
             second_upstream,
-            nonce="scn_dprobe000000002",
+            nonce="scn_dprobe0000000002",
             vendor="anthropic",
             display_name="Second probe source",
         )
@@ -168,6 +168,14 @@ def _source_by_id(app, source_id: str):
     )
 
 
+def _request_credential(request: dict) -> str | None:
+    headers = request["headers"]
+    if key := headers.get("x-api-key"):
+        return key
+    authorization = headers.get("authorization", "")
+    return authorization.removeprefix("Bearer ") or None
+
+
 def test_d2_healthy_hop_is_served_by_the_real_engine_probe(
     model_hub_app_factory,
     mock_llm_upstream,
@@ -189,8 +197,135 @@ def test_d2_healthy_hop_is_served_by_the_real_engine_probe(
         ]
         assert captured
         assert all(
-            item["headers"].get("x-api-key") == SYNTHETIC_API_KEY
+            _request_credential(item) == SYNTHETIC_API_KEY
             for item in captured
+        )
+
+
+def test_replaced_shared_key_keeps_source_identity_and_reaches_upstream_once(
+    model_hub_app_factory,
+    mock_llm_upstream,
+) -> None:
+    """A replaced duplicate key keeps each Source's own model registration."""
+
+    route_model = "e2e-route-1"
+    original_key = "sk-model-hub-e2e-original"
+    replacement_key = "sk-model-hub-e2e-replacement"
+    with _engine_app(model_hub_app_factory) as app:
+        _install_engine(app)
+
+        _configure_protocol(
+            mock_llm_upstream,
+            "anthropic",
+            models=[{"id": MENU_MODEL}],
+        )
+        _create_source(
+            app,
+            mock_llm_upstream,
+            nonce="scn_1818anchor000001",
+            vendor="anthropic",
+            display_name="Shared-key anchor",
+            extra={"key": replacement_key},
+        )
+
+        _configure_protocol(
+            mock_llm_upstream,
+            "anthropic",
+            models=[{"id": route_model}],
+        )
+        routed, _ = _create_source(
+            app,
+            mock_llm_upstream,
+            nonce="scn_1818route0000001",
+            vendor="anthropic",
+            display_name="Replaced routed source",
+            extra={"key": original_key},
+        )
+        _create_source(
+            app,
+            mock_llm_upstream,
+            nonce="scn_1818sibling00001",
+            vendor="anthropic",
+            display_name="Shared-key sibling",
+            extra={"key": replacement_key},
+        )
+
+        mode = app.client.patch(
+            "/api/models/agents/claude/mode",
+            {"mode": "hub"},
+        )
+        assert mode.status == 200, mode.json()
+        chain = app.client.put(
+            f"/api/models/agents/claude/chain?model={MENU_MODEL}",
+            {
+                "hops": [
+                    {
+                        "source_id": routed["id"],
+                        "model_id": route_model,
+                    }
+                ]
+            },
+        )
+        assert chain.status == 200, chain.json()
+        started = app.client.post("/api/models/runtime/start", {})
+        assert started.status == 200, started.json()
+        first_port = started.json()["runtime"]["status"]["listening"][
+            "port"
+        ]
+
+        original_ref = routed["credential_ref"]
+        replaced = app.client.put(
+            f"/api/models/sources/{routed['id']}/credential",
+            {"key": replacement_key},
+        )
+        replaced_body = replaced.json()
+        assert replaced.status == 200, replaced_body
+        assert replaced_body["source"]["id"] == routed["id"]
+        assert replaced_body["source"]["credential_ref"] != original_ref
+        after_replace = app.client.get("/api/models/runtime/status")
+        assert after_replace.status == 200, after_replace.json()
+        replaced_port = after_replace.json()["runtime"]["status"][
+            "listening"
+        ]["port"]
+        assert replaced_port != first_port
+
+        app.restart_controller()
+        mock_llm_upstream.reset_requests()
+        response = _probe(app)
+        body = response.json()
+        assert response.status == 200, body
+        captured = [
+            item
+            for item in mock_llm_upstream.requests()
+            if item["path"] == "/v1/messages"
+        ]
+        assert body["probe"]["reachable"] is True, {
+            "probe": body["probe"],
+            "upstream_request_count": len(captured),
+        }
+        assert body["probe"]["source_id"] == routed["id"]
+        assert body["probe"]["model_id"] == route_model
+        assert len(captured) == 1
+        assert _request_credential(captured[0]) == replacement_key
+        assert _source_by_id(app, routed["id"])["state"] == {
+            "status": "standby",
+            "retry_at": None,
+            "detail_key": None,
+        }
+
+        mock_llm_upstream.reset_requests()
+        repeated = _probe(app)
+        assert repeated.status == 200, repeated.json()
+        assert repeated.json()["probe"]["reachable"] is True
+        repeated_requests = [
+            item
+            for item in mock_llm_upstream.requests()
+            if item["path"] == "/v1/messages"
+        ]
+        assert len(repeated_requests) == 1
+        assert (
+            _source_by_id(app, routed["id"])["state"]["retry_at"]
+            is None
         )
 
 

--- a/tests/e2e/test_model_hub_runtime.py
+++ b/tests/e2e/test_model_hub_runtime.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import json
 import os
+import shutil
 import signal
 import socket
 import subprocess
 import sys
 import tempfile
 import time
+import urllib.parse
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -16,6 +19,7 @@ import psutil
 import pytest
 import yaml
 
+from core.managed_runtime import runtime_platform_tag
 from tests.e2e.drivers.model_hub_app import (
     HTTPResult,
     ModelHubTestApp,
@@ -24,6 +28,10 @@ from tests.e2e.drivers.model_hub_app import (
 
 
 pytestmark = pytest.mark.e2e_model_hub
+
+_ENGINE_MANIFEST_PLATFORMS = {
+    "linux-x64": "linux-amd64",
+}
 
 
 def _local_engine_manifest() -> str:
@@ -43,11 +51,51 @@ def _local_engine_manifest() -> str:
 
 def _engine_app(model_hub_app_factory):
     manifest = _local_engine_manifest()
+
+    def seed_archive(app: ModelHubTestApp) -> None:
+        payload = json.loads(Path(manifest).read_text(encoding="utf-8"))
+        host_platform = runtime_platform_tag()
+        platform = _ENGINE_MANIFEST_PLATFORMS.get(
+            host_platform,
+            host_platform,
+        )
+        archive = next(
+            (
+                item
+                for item in payload["assets"]
+                if item["platform"] == platform
+            ),
+            None,
+        )
+        if archive is None:
+            return
+        parsed = urllib.parse.urlparse(archive["url"])
+        if parsed.scheme != "file" or parsed.netloc not in {"", "localhost"}:
+            pytest.skip(
+                "managed Model Hub E2E requires a local file archive "
+                "in its offline manifest"
+            )
+        source = Path(urllib.parse.unquote(parsed.path))
+        if not source.is_file():
+            pytest.skip(
+                f"managed Model Hub engine archive does not exist: {source}"
+            )
+        downloads = (
+            app.avibe_home
+            / "runtime"
+            / "model-hub"
+            / "engine"
+            / "downloads"
+        )
+        downloads.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, downloads / source.name)
+
     return model_hub_app_factory(
         extra_env={
             "VIBE_MODEL_HUB_ENGINE_MANIFEST_PATH": manifest,
             "VIBE_MODEL_HUB_ENGINE_OFFLINE": "1",
-        }
+        },
+        before_start=seed_archive,
     )
 
 

--- a/tests/test_model_hub_runtime.py
+++ b/tests/test_model_hub_runtime.py
@@ -763,32 +763,32 @@ def test_packaged_manifest_matches_frozen_runtime_dependency_values(
     assert manifest == {
         "name": "cliproxyapi",
         "resolution": "resolved",
-        "version": "v7.2.95",
-        "source_sha": "f71ec0eb6776854457892452cf28c47f0d658251",
+        "version": "v7.2.105",
+        "source_sha": "4a2eb54dc6bf943196be4fb515e6a9407a4db143",
         "assets": [
             {
                 "platform": "darwin-arm64",
-                "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/CLIProxyAPI_7.2.95_darwin_aarch64.tar.gz",
-                "size_bytes": 14384655,
-                "sha256": "c7ccc28b7db5d1799999a9e22725ccc6bd0e36d9aa023da6b52b7c1a71aad978",
+                "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.105/CLIProxyAPI_7.2.105_darwin_aarch64.tar.gz",
+                "size_bytes": 18975205,
+                "sha256": "641de855c486d373b3c69704bec55a5c5ce3efa523149cc9bd253f76040470d7",
             },
             {
                 "platform": "darwin-x64",
-                "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/CLIProxyAPI_7.2.95_darwin_amd64.tar.gz",
-                "size_bytes": 15372282,
-                "sha256": "fbee90c29ee1047a8b3041d736500422bea22cd2ebb306782efcd74c0a10939c",
+                "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.105/CLIProxyAPI_7.2.105_darwin_amd64.tar.gz",
+                "size_bytes": 20513376,
+                "sha256": "c9332b8401cd54d357e7c66e88bce603fdb497701a7fa86ee2f82bb1aad846b9",
             },
             {
                 "platform": "linux-amd64",
-                "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/CLIProxyAPI_7.2.95_linux_amd64.tar.gz",
-                "size_bytes": 15401775,
-                "sha256": "826604e2dbf11913b0f373047f7bca1829eb2bab8a45d3a1916cc2534c7a9fd5",
+                "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.105/CLIProxyAPI_7.2.105_linux_amd64.tar.gz",
+                "size_bytes": 20558559,
+                "sha256": "f432872815fe85ac4b0f83b5598253725eea70aae4c95025194cf558f6acef31",
             },
             {
                 "platform": "linux-arm64",
-                "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/CLIProxyAPI_7.2.95_linux_aarch64.tar.gz",
-                "size_bytes": 14062559,
-                "sha256": "acc1173c73db2a2ee203438bac9a956491855d4955c5175855abc62d12ae0184",
+                "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.105/CLIProxyAPI_7.2.105_linux_aarch64.tar.gz",
+                "size_bytes": 18559648,
+                "sha256": "b72245cf1958251330eae9e17f1fc5a077f94146b2eea30e23ab5012c6059981",
             },
         ],
     }
@@ -1237,30 +1237,30 @@ def test_installing_projection_matches_live_owner_or_resumable_claim(
         (
             "darwin-arm64",
             "darwin-arm64",
-            14384655,
-            "c7ccc28b7db5d1799999a9e22725ccc6bd0e36d9aa023da6b52b7c1a71aad978",
-            "ad81a4c82700bf96eaa4cf5811690b0498ebcfe6087e26ffc0498b8fc8e867af",
+            18975205,
+            "641de855c486d373b3c69704bec55a5c5ce3efa523149cc9bd253f76040470d7",
+            "e8da44e6bf9d85fe7b98a2843d33ff509156727222d6a1ad5dd1a79709849337",
         ),
         (
             "darwin-x64",
             "darwin-x64",
-            15372282,
-            "fbee90c29ee1047a8b3041d736500422bea22cd2ebb306782efcd74c0a10939c",
-            "6b5d209c3bc6adcff035060a862b9fe6eccf8f4ca3c8c0bb7fc88c0b625d38d5",
+            20513376,
+            "c9332b8401cd54d357e7c66e88bce603fdb497701a7fa86ee2f82bb1aad846b9",
+            "07a607965a40f782f63625c557eeeddb39b08e08b1a3057881bb13fe6e887109",
         ),
         (
             "linux-x64",
             "linux-amd64",
-            15401775,
-            "826604e2dbf11913b0f373047f7bca1829eb2bab8a45d3a1916cc2534c7a9fd5",
-            "2be8e4581fe802fe522126b273bc099c01910b6179dca4a4e1b451dd0c80a1c0",
+            20558559,
+            "f432872815fe85ac4b0f83b5598253725eea70aae4c95025194cf558f6acef31",
+            "2717656b33a0d76a7c02b451797341e8791f740a72d4e71577140886f42ba628",
         ),
         (
             "linux-arm64",
             "linux-arm64",
-            14062559,
-            "acc1173c73db2a2ee203438bac9a956491855d4955c5175855abc62d12ae0184",
-            "647a48ab6b2f5520d1279061c4a7aa7ff65729a68614495b1e431debbf4f8706",
+            18559648,
+            "b72245cf1958251330eae9e17f1fc5a077f94146b2eea30e23ab5012c6059981",
+            "8c389d565b8555d5788314e56258c64d675ff76bb9e32047d339088f2789b07e",
         ),
     ],
 )
@@ -3734,6 +3734,115 @@ def test_engine_client_marks_loopback_stream_disconnect_as_engine_down(
         assert outcome.kind is RawOutcomeKind.NETWORK_ERROR
         assert outcome.error_code == "engine_down"
         assert outcome.stream_started is True
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize(
+    (
+        "status",
+        "reported_model",
+        "expected_kind",
+        "expected_code",
+        "expected_reason",
+    ),
+    (
+        (
+            502,
+            "source-fixture123/model-a",
+            RawOutcomeKind.NETWORK_ERROR,
+            "engine_down",
+            None,
+        ),
+        (
+            502,
+            "source-fixture123/model-b",
+            RawOutcomeKind.HTTP_ERROR,
+            None,
+            "server_error",
+        ),
+        (
+            503,
+            "source-fixture123/model-a",
+            RawOutcomeKind.HTTP_ERROR,
+            None,
+            "server_error",
+        ),
+    ),
+)
+def test_engine_client_distinguishes_local_model_registration_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    status: int,
+    reported_model: str,
+    expected_kind: RawOutcomeKind,
+    expected_code: str | None,
+    expected_reason: str | None,
+) -> None:
+    async def run() -> None:
+        payload = json.dumps(
+            {
+                "type": "error",
+                "error": {
+                    "type": "api_error",
+                    "message": f"unknown provider for model {reported_model}",
+                },
+            }
+        ).encode()
+
+        class Content:
+            reads = 0
+
+            async def read(self, _size: int) -> bytes:
+                self.reads += 1
+                return payload if self.reads == 1 else b""
+
+        class Response:
+            content = Content()
+            headers = {"Content-Type": "application/json"}
+
+            def __init__(self) -> None:
+                self.status = status
+
+            def close(self) -> None:
+                return None
+
+        class Session:
+            async def post(self, *_args, **_kwargs):
+                return Response()
+
+            async def close(self) -> None:
+                return None
+
+        monkeypatch.setattr(
+            client_module.aiohttp,
+            "ClientSession",
+            lambda **_: Session(),
+        )
+        source = SourceRecord(
+            source_id="src_fixture123",
+            vendor="custom",
+            protocol="anthropic",
+            base_url="https://api.example.test/v1",
+            credential_ref="cred_fixture123",
+            allowed_origins=(),
+            model_ids=("model-a",),
+            prefix="source-fixture123",
+        )
+
+        handle = await EngineClient(
+            EngineConnection(
+                "http://127.0.0.1:15220",
+                "management",
+                "gateway",
+            )
+        ).invoke(source, "model-a", {}, stream=False)
+        outcome = await handle.outcome()
+        decision = classify_outcome(outcome)
+
+        assert outcome.kind is expected_kind
+        assert outcome.error_code == expected_code
+        assert decision.error_code == expected_code
+        assert decision.reason == expected_reason
 
     asyncio.run(run())
 

--- a/vibe/model_hub_runtime/client.py
+++ b/vibe/model_hub_runtime/client.py
@@ -346,7 +346,8 @@ class EngineClient:
         request_protocol = request_protocol or source.protocol
         endpoint = _endpoint_for_protocol(request_protocol)
         body = dict(request)
-        body["model"] = f"{source.prefix}/{model_id}"
+        routed_model = f"{source.prefix}/{model_id}"
+        body["model"] = routed_model
         body["stream"] = stream
         headers = {
             key.lower(): value for key, value in (request_headers or {}).items() if key.lower() in _PROTOCOL_HEADERS
@@ -422,6 +423,21 @@ class EngineClient:
                     observed_payload = ProtocolObservation()
                 finally:
                     error_body.close()
+                if response.status == 502 and _is_local_model_registration_failure(
+                    payload,
+                    routed_model=routed_model,
+                ):
+                    outcome = _outcome(
+                        kind=RawOutcomeKind.NETWORK_ERROR,
+                        source=source,
+                        model_id=model_id,
+                        http_status=response.status,
+                        error_code="engine_down",
+                        message="engine rejected its registered routed model",
+                    )
+                    response.close()
+                    await session.close()
+                    return ended(outcome)
                 outcome = _reduce_protocol_observation(
                     replace(
                         observed_payload,
@@ -913,6 +929,32 @@ def _project_model_inventory_before_deadline(
         payload,
         _project_model_inventory,
         deadline=deadline,
+    )
+
+
+def _is_local_model_registration_failure(
+    payload: bytes,
+    *,
+    routed_model: str,
+) -> bool:
+    """Identify CLIProxyAPI's local pre-egress model registry rejection."""
+
+    try:
+        decoded = json.loads(payload)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return False
+    if (
+        not isinstance(decoded, dict)
+        or "type" not in decoded
+        or decoded["type"] != "error"
+    ):
+        return False
+    error = decoded.get("error")
+    error_type, _, _ = _raw_error_fields(payload)
+    return (
+        isinstance(error, dict)
+        and error_type == "api_error"
+        and error.get("message") == f"unknown provider for model {routed_model}"
     )
 
 

--- a/vibe/model_hub_runtime/cliproxyapi_manifest.json
+++ b/vibe/model_hub_runtime/cliproxyapi_manifest.json
@@ -1,43 +1,43 @@
 {
   "schema_version": 1,
   "name": "cliproxyapi",
-  "version": "v7.2.95",
+  "version": "v7.2.105",
   "source": "router-for-me/CLIProxyAPI",
-  "source_url": "https://github.com/router-for-me/CLIProxyAPI/tree/f71ec0eb6776854457892452cf28c47f0d658251",
-  "source_sha": "f71ec0eb6776854457892452cf28c47f0d658251",
-  "release_tag": "v7.2.95",
+  "source_url": "https://github.com/router-for-me/CLIProxyAPI/tree/4a2eb54dc6bf943196be4fb515e6a9407a4db143",
+  "source_sha": "4a2eb54dc6bf943196be4fb515e6a9407a4db143",
+  "release_tag": "v7.2.105",
   "license": "MIT",
   "assets": [
     {
       "platform": "darwin-arm64",
-      "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/CLIProxyAPI_7.2.95_darwin_aarch64.tar.gz",
-      "size_bytes": 14384655,
-      "sha256": "c7ccc28b7db5d1799999a9e22725ccc6bd0e36d9aa023da6b52b7c1a71aad978",
-      "binary_sha256": "ad81a4c82700bf96eaa4cf5811690b0498ebcfe6087e26ffc0498b8fc8e867af",
+      "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.105/CLIProxyAPI_7.2.105_darwin_aarch64.tar.gz",
+      "size_bytes": 18975205,
+      "sha256": "641de855c486d373b3c69704bec55a5c5ce3efa523149cc9bd253f76040470d7",
+      "binary_sha256": "e8da44e6bf9d85fe7b98a2843d33ff509156727222d6a1ad5dd1a79709849337",
       "bin_path": "cli-proxy-api"
     },
     {
       "platform": "darwin-x64",
-      "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/CLIProxyAPI_7.2.95_darwin_amd64.tar.gz",
-      "size_bytes": 15372282,
-      "sha256": "fbee90c29ee1047a8b3041d736500422bea22cd2ebb306782efcd74c0a10939c",
-      "binary_sha256": "6b5d209c3bc6adcff035060a862b9fe6eccf8f4ca3c8c0bb7fc88c0b625d38d5",
+      "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.105/CLIProxyAPI_7.2.105_darwin_amd64.tar.gz",
+      "size_bytes": 20513376,
+      "sha256": "c9332b8401cd54d357e7c66e88bce603fdb497701a7fa86ee2f82bb1aad846b9",
+      "binary_sha256": "07a607965a40f782f63625c557eeeddb39b08e08b1a3057881bb13fe6e887109",
       "bin_path": "cli-proxy-api"
     },
     {
       "platform": "linux-amd64",
-      "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/CLIProxyAPI_7.2.95_linux_amd64.tar.gz",
-      "size_bytes": 15401775,
-      "sha256": "826604e2dbf11913b0f373047f7bca1829eb2bab8a45d3a1916cc2534c7a9fd5",
-      "binary_sha256": "2be8e4581fe802fe522126b273bc099c01910b6179dca4a4e1b451dd0c80a1c0",
+      "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.105/CLIProxyAPI_7.2.105_linux_amd64.tar.gz",
+      "size_bytes": 20558559,
+      "sha256": "f432872815fe85ac4b0f83b5598253725eea70aae4c95025194cf558f6acef31",
+      "binary_sha256": "2717656b33a0d76a7c02b451797341e8791f740a72d4e71577140886f42ba628",
       "bin_path": "cli-proxy-api"
     },
     {
       "platform": "linux-arm64",
-      "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/CLIProxyAPI_7.2.95_linux_aarch64.tar.gz",
-      "size_bytes": 14062559,
-      "sha256": "acc1173c73db2a2ee203438bac9a956491855d4955c5175855abc62d12ae0184",
-      "binary_sha256": "647a48ab6b2f5520d1279061c4a7aa7ff65729a68614495b1e431debbf4f8706",
+      "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.105/CLIProxyAPI_7.2.105_linux_aarch64.tar.gz",
+      "size_bytes": 18559648,
+      "sha256": "b72245cf1958251330eae9e17f1fc5a077f94146b2eea30e23ab5012c6059981",
+      "binary_sha256": "8c389d565b8555d5788314e56258c64d675ff76bb9e32047d339088f2789b07e",
       "bin_path": "cli-proxy-api"
     }
   ]


### PR DESCRIPTION
## Summary

- upgrade the pinned CLIProxyAPI runtime from v7.2.95 to v7.2.105, the first release containing the upstream per-config identity fix
- classify CLIProxyAPI's exact loopback-only `unknown provider for model <source-prefix>/<model>` rejection as an engine invariant failure, so it cannot repeatedly mutate Source health as a provider 5xx
- add a real-engine regression that replaces a routed Source key shared by Sources with different model inventories, restarts the controller, observes an engine port change, and proves exactly one request reaches the mock upstream with the replacement credential

## Root cause

CLIProxyAPI v7.2.95 generated a distinct auth registration for every Avibe Source, but its SDK resolved each registration back to provider config by `(api-key, base-url)` and selected the first match. When multiple Sources shared a credential and URL while advertising different model inventories, later Source prefixes inherited the first Source's model list. The engine then rejected a valid routed model locally with HTTP 502 before selecting a provider adapter, so the mock upstream saw zero requests.

Upstream commit `f32291436ad9fbbd42b4875e3a4ee63eb1f9191b` gives every config registration a `config_index` and resolves it by that identity. v7.2.105 is the first release containing that commit. This is deterministic order-dependent config ambiguity, not the reported race/stale-handle hypothesis.

The local 502 carried the generic `api_error` machine type, which Avibe previously treated as a transient provider server error. Every post-expiry attempt hit the unchanged local registry and wrote a new 30-second cooldown. The exact engine-originated rejection is now terminal `engine_down`; genuine provider 5xx behavior remains unchanged.

## Evidence

- v7.2.95 direct hermetic reproduction: 3/3 attempts returned the engine's local 502 and made zero upstream POSTs
- v7.2.95 regression test: fails with `reachable=false` and `upstream_request_count=0`
- v7.2.105 exact-head real-engine routing E2E: 7 passed, including replacement identity/credential, exactly-once egress, controller restart, engine port change, stable Source state, and genuine provider 5xx cooldown
- Model Hub unit/contract suite: 1201 passed, 1 expected xfail
- focused runtime/L3 suite: 429 passed, 1 expected xfail
- Ruff and diff checks pass

## Relation to #1816

#1816 is an independent test-only Playwright lane (observed head `d7ba28ed7e3948f88d3cdd32d270b10ace32eb8c`). This PR neither modifies nor stacks on that lane. It carries its own deterministic regression at the real engine/API boundary.

## Residual risk

The four v7.2.105 release archives and extracted binaries are pinned by verified sizes and SHA-256 values. The real binary was executed on darwin-arm64; Linux and darwin-x64 coverage relies on the same installer contract and CI/platform consumers.

Fixes #1818
