### PR TITLE
test(model-hub): seed offline engine archives for E2E

### DIFF
--- a/docs/plans/model-hub-e2e-test-plan.md
+++ b/docs/plans/model-hub-e2e-test-plan.md
@@ -18,6 +18,7 @@ Out of scope (documented, not dropped silently):
 
 - Runtime: hermetic `AVIBE_HOME` under the test dir; `VIBE_MODEL_HUB_ENABLED=1`. Docker `tests/e2e` service with `command: ["full"]` (controller + UI in one process pair) or an equivalent local hermetic run; whichever the implementing lane proves stable first.
 - Engine binary: no GitHub egress in CI. Use `VIBE_MODEL_HUB_ENGINE_MANIFEST_PATH` / `VIBE_MODEL_HUB_ENGINE_OFFLINE` (`vibe/model_hub_runtime/installer.py:105-109`) with the pinned cliproxyapi v7.2.95 assets vendored per platform (linux-amd64/arm64, darwin-arm64/x64).
+- Offline archive seeding: when the selected manifest asset uses `file://`, the harness verifies its declared size and SHA-256, then copies it into the hermetic `$AVIBE_HOME/runtime/model-hub/engine/downloads/` cache before spawning child processes. `VIBE_MODEL_HUB_ENGINE_OFFLINE=1` remains set, and non-file assets are never fetched.
 - **Mock upstream provider** (new test fixture, `tests/e2e/drivers/mock_llm_upstream.py`): implements, per protocol — `POST /v1/messages`, `POST /v1/responses`, `POST /v1/chat/completions`, `GET /v1/models` — with:
   - configurable model inventory (ids only, plus Anthropic-style `display_name` and relay-style `context_length` extensions to prove they are dropped, B-list);
   - auth modes: accept / 401 / 403(banned-pattern) / 402 / 429 / quota-message / 5xx;

--- a/tests/e2e/drivers/model_hub_app.py
+++ b/tests/e2e/drivers/model_hub_app.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import http.cookiejar
+import hashlib
 import json
 import logging
 import os
+import shutil
 import signal
 import socket
 import subprocess
@@ -16,11 +18,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 from urllib.request import (
     HTTPCookieProcessor,
     ProxyHandler,
     Request,
     build_opener,
+    url2pathname,
 )
 
 import psutil
@@ -28,6 +32,7 @@ import psutil
 
 _MISSING = object()
 _MUTATION_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+_ENGINE_MANIFEST_PATH_ENV = "VIBE_MODEL_HUB_ENGINE_MANIFEST_PATH"
 _SAFE_INHERITED_ENV = (
     "LANG",
     "LC_ALL",
@@ -35,6 +40,7 @@ _SAFE_INHERITED_ENV = (
     "SSL_CERT_DIR",
     "SSL_CERT_FILE",
     "TZ",
+    _ENGINE_MANIFEST_PATH_ENV,
 )
 _UI_PORT_START_ATTEMPTS = 3
 _OWNED_PROCESS_GRACE_SECONDS = 3.0
@@ -249,6 +255,136 @@ class ModelHubTestApp:
         env.update(extra_env)
         return env
 
+    def _seed_local_engine_archive(self) -> None:
+        """Put a verified local engine asset in the isolated offline cache."""
+
+        raw_manifest_path = self.env.get(_ENGINE_MANIFEST_PATH_ENV, "").strip()
+        if not raw_manifest_path:
+            return
+        manifest_path = Path(raw_manifest_path).expanduser()
+        if not manifest_path.is_absolute():
+            manifest_path = self.repo_root / manifest_path
+
+        from vibe.model_hub_runtime.installer import EngineRuntimeManager
+
+        runtime_dir = (
+            self.avibe_home / "runtime" / "model-hub" / "engine"
+        )
+        manager = EngineRuntimeManager(
+            runtime_dir=runtime_dir,
+            manifest_path=manifest_path,
+            offline=True,
+        )
+        contract = manager.contract_manifest()
+        if contract.get("resolution") != "resolved":
+            return
+        selected = next(
+            (
+                asset
+                for asset in contract.get("assets", ())
+                if isinstance(asset, Mapping)
+                and asset.get("platform") == manager.host_platform()
+            ),
+            None,
+        )
+        if selected is None:
+            return
+        archive_url = selected.get("url")
+        if not isinstance(archive_url, str):
+            return
+        parsed_url = urlparse(archive_url)
+        if parsed_url.scheme != "file":
+            return
+        if (
+            parsed_url.netloc not in {"", "localhost"}
+            or parsed_url.query
+            or parsed_url.fragment
+        ):
+            raise RuntimeError(
+                "local Model Hub engine archive must use a plain local file URL"
+            )
+        source = Path(url2pathname(parsed_url.path))
+        if not source.is_absolute():
+            raise RuntimeError(
+                "local Model Hub engine archive URL must be absolute"
+            )
+
+        expected_size = selected.get("size_bytes")
+        expected_sha256 = selected.get("sha256")
+        if (
+            not isinstance(expected_size, int)
+            or isinstance(expected_size, bool)
+            or not isinstance(expected_sha256, str)
+        ):
+            raise RuntimeError(
+                "local Model Hub engine archive requires size and sha256"
+            )
+        self._verify_local_engine_archive(
+            source,
+            expected_size=expected_size,
+            expected_sha256=expected_sha256,
+        )
+
+        archive_status = manager.status().get("archive")
+        if not isinstance(archive_status, Mapping):
+            return
+        archive_name = archive_status.get("name")
+        if (
+            not isinstance(archive_name, str)
+            or not archive_name
+            or Path(archive_name).name != archive_name
+        ):
+            raise RuntimeError("local Model Hub engine archive name is unsafe")
+
+        downloads = runtime_dir / "downloads"
+        downloads.mkdir(parents=True, exist_ok=True)
+        cached = downloads / archive_name
+        temporary = downloads / f".{archive_name}.seed.tmp"
+        try:
+            shutil.copyfile(source, temporary)
+            self._verify_local_engine_archive(
+                temporary,
+                expected_size=expected_size,
+                expected_sha256=expected_sha256,
+            )
+            temporary.replace(cached)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    @staticmethod
+    def _verify_local_engine_archive(
+        path: Path,
+        *,
+        expected_size: int,
+        expected_sha256: str,
+    ) -> None:
+        try:
+            actual_size = path.stat().st_size
+        except OSError as exc:
+            raise RuntimeError(
+                f"local Model Hub engine archive is unavailable: {path}"
+            ) from exc
+        if actual_size != expected_size:
+            raise RuntimeError(
+                "local Model Hub engine archive size mismatch: "
+                f"expected {expected_size}, got {actual_size}"
+            )
+        digest = hashlib.sha256()
+        try:
+            with path.open("rb") as archive:
+                for chunk in iter(lambda: archive.read(1024 * 1024), b""):
+                    digest.update(chunk)
+        except OSError as exc:
+            raise RuntimeError(
+                f"local Model Hub engine archive is unavailable: {path}"
+            ) from exc
+        actual_sha256 = digest.hexdigest()
+        if actual_sha256 != expected_sha256.lower():
+            raise RuntimeError(
+                "local Model Hub engine archive sha256 mismatch: "
+                f"expected {expected_sha256.lower()}, got {actual_sha256}"
+            )
+
     def start(self) -> "ModelHubTestApp":
         try:
             self.home.mkdir(parents=True, exist_ok=True)
@@ -257,6 +393,7 @@ class ModelHubTestApp:
             (self.runtime_root / "tmp").mkdir(
                 parents=True, exist_ok=True
             )
+            self._seed_local_engine_archive()
             self._initialize_config()
             self._start_controller()
             self._start_ui_with_port_retry()

--- a/tests/e2e/test_model_hub_routing.py
+++ b/tests/e2e/test_model_hub_routing.py
@@ -110,7 +110,7 @@ def _prepare_probe_chain(
     first, _ = _create_source(
         app,
         first_upstream,
-        nonce="scn_dprobe000000001",
+        nonce="scn_dprobe0000000001",
         vendor="anthropic",
         display_name="First probe source",
     )
@@ -124,7 +124,7 @@ def _prepare_probe_chain(
         second, _ = _create_source(
             app,
             second_upstream,
-            nonce="scn_dprobe000000002",
+            nonce="scn_dprobe0000000002",
             vendor="anthropic",
             display_name="Second probe source",
         )
@@ -188,9 +188,15 @@ def test_d2_healthy_hop_is_served_by_the_real_engine_probe(
             if item["path"] == "/v1/messages"
         ]
         assert captured
+        # The engine forwards Anthropic credentials as Bearer; x-api-key is
+        # used only by Avibe's direct discovery probe path.
         assert all(
-            item["headers"].get("x-api-key") == SYNTHETIC_API_KEY
+            item["headers"].get("authorization")
+            == f"Bearer {SYNTHETIC_API_KEY}"
             for item in captured
+        )
+        assert all(
+            item["headers"].get("anthropic-version") for item in captured
         )
 
 

--- a/tests/e2e/test_model_hub_runtime.py
+++ b/tests/e2e/test_model_hub_runtime.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 import signal
 import socket
@@ -42,13 +44,8 @@ def _local_engine_manifest() -> str:
 
 
 def _engine_app(model_hub_app_factory):
-    manifest = _local_engine_manifest()
-    return model_hub_app_factory(
-        extra_env={
-            "VIBE_MODEL_HUB_ENGINE_MANIFEST_PATH": manifest,
-            "VIBE_MODEL_HUB_ENGINE_OFFLINE": "1",
-        }
-    )
+    _local_engine_manifest()
+    return model_hub_app_factory()
 
 
 def _install_engine(app) -> list[str]:
@@ -143,6 +140,181 @@ def test_harness_scrubs_inherited_backend_credentials(
     assert set(inherited).isdisjoint(app.env)
     assert app.env["HOME"] == str(tmp_path / "home")
     assert app.env["CODEX_HOME"] == str(tmp_path / "home" / ".codex")
+
+
+def _write_harness_engine_manifest(
+    path: Path,
+    *,
+    archive_url: str,
+    size_bytes: int,
+    sha256: str,
+) -> Path:
+    manifest = path / "manifest.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "name": "cliproxyapi",
+                "version": "v7.2.95",
+                "source": "router-for-me/CLIProxyAPI",
+                "source_url": "https://example.test/source",
+                "source_sha": "f71ec0eb6776854457892452cf28c47f0d658251",
+                "release_tag": "v7.2.95",
+                "license": "MIT",
+                "assets": [
+                    {
+                        "platform": platform,
+                        "url": archive_url,
+                        "size_bytes": size_bytes,
+                        "sha256": sha256,
+                        "binary_sha256": "b" * 64,
+                        "bin_path": "cli-proxy-api",
+                    }
+                    for platform in (
+                        "darwin-arm64",
+                        "darwin-x64",
+                        "linux-amd64",
+                        "linux-arm64",
+                    )
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_harness_inherits_only_the_engine_manifest_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Harness contract: the outer manifest path is the only engine control."""
+
+    manifest_path = tmp_path / "outer-manifest.json"
+    monkeypatch.setenv(
+        "VIBE_MODEL_HUB_ENGINE_MANIFEST_PATH", str(manifest_path)
+    )
+    monkeypatch.setenv(
+        "VIBE_MODEL_HUB_ENGINE_MANIFEST_URL",
+        "https://inherited.example/manifest.json",
+    )
+    monkeypatch.setenv("VIBE_MODEL_HUB_ENGINE_OFFLINE", "0")
+
+    app = ModelHubTestApp(Path.cwd(), tmp_path / "runtime")
+
+    assert app.env["VIBE_MODEL_HUB_ENGINE_MANIFEST_PATH"] == str(
+        manifest_path
+    )
+    assert "VIBE_MODEL_HUB_ENGINE_MANIFEST_URL" not in app.env
+    assert app.env["VIBE_MODEL_HUB_ENGINE_OFFLINE"] == "1"
+
+
+def test_harness_seeds_a_verified_file_archive_before_child_start(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Harness contract: local assets enter the offline cache before spawn."""
+
+    archive = tmp_path / "fixture" / "CLIProxyAPI_fixture.tar.gz"
+    archive.parent.mkdir(parents=True)
+    archive.write_bytes(b"verified local engine archive")
+    manifest = _write_harness_engine_manifest(
+        tmp_path / "fixture",
+        archive_url=archive.as_uri(),
+        size_bytes=archive.stat().st_size,
+        sha256=hashlib.sha256(archive.read_bytes()).hexdigest(),
+    )
+    monkeypatch.setenv("VIBE_MODEL_HUB_ENGINE_MANIFEST_PATH", str(manifest))
+    app = ModelHubTestApp(Path.cwd(), tmp_path / "runtime")
+    cached = (
+        app.avibe_home
+        / "runtime"
+        / "model-hub"
+        / "engine"
+        / "downloads"
+        / archive.name
+    )
+    calls: list[str] = []
+
+    def initialize_config() -> None:
+        calls.append("config")
+
+    def start_controller() -> None:
+        assert cached.read_bytes() == archive.read_bytes()
+        calls.append("controller")
+
+    monkeypatch.setattr(app, "_initialize_config", initialize_config)
+    monkeypatch.setattr(app, "_start_controller", start_controller)
+    monkeypatch.setattr(
+        app,
+        "_start_ui_with_port_retry",
+        lambda: calls.append("ui"),
+    )
+
+    app.start()
+
+    assert calls == ["config", "controller", "ui"]
+    assert app.env["VIBE_MODEL_HUB_ENGINE_OFFLINE"] == "1"
+
+
+@pytest.mark.parametrize(
+    ("size_delta", "sha256", "error"),
+    [
+        (1, None, "archive size mismatch"),
+        (0, "0" * 64, "archive sha256 mismatch"),
+    ],
+)
+def test_harness_rejects_unverified_local_engine_archives(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    size_delta: int,
+    sha256: str | None,
+    error: str,
+) -> None:
+    """Harness contract: neither size nor digest mismatches enter the cache."""
+
+    archive = tmp_path / "fixture" / "CLIProxyAPI_fixture.tar.gz"
+    archive.parent.mkdir(parents=True)
+    archive.write_bytes(b"local engine archive")
+    manifest = _write_harness_engine_manifest(
+        tmp_path / "fixture",
+        archive_url=archive.as_uri(),
+        size_bytes=archive.stat().st_size + size_delta,
+        sha256=sha256
+        or hashlib.sha256(archive.read_bytes()).hexdigest(),
+    )
+    monkeypatch.setenv("VIBE_MODEL_HUB_ENGINE_MANIFEST_PATH", str(manifest))
+    app = ModelHubTestApp(Path.cwd(), tmp_path / "runtime")
+
+    with pytest.raises(RuntimeError, match=error):
+        app._seed_local_engine_archive()
+
+    assert not (
+        app.avibe_home / "runtime" / "model-hub" / "engine" / "downloads"
+    ).exists()
+
+
+def test_harness_does_not_fetch_non_file_engine_assets(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Harness contract: offline seeding never turns into network egress."""
+
+    manifest = _write_harness_engine_manifest(
+        tmp_path / "fixture",
+        archive_url="https://network.invalid/CLIProxyAPI_fixture.tar.gz",
+        size_bytes=1,
+        sha256="0" * 64,
+    )
+    monkeypatch.setenv("VIBE_MODEL_HUB_ENGINE_MANIFEST_PATH", str(manifest))
+    app = ModelHubTestApp(Path.cwd(), tmp_path / "runtime")
+
+    app._seed_local_engine_archive()
+
+    assert not (
+        app.avibe_home / "runtime" / "model-hub" / "engine" / "downloads"
+    ).exists()
 
 
 def test_harness_cleans_controller_when_ui_start_fails(


### PR DESCRIPTION
## Capability

Make the hermetic Model Hub pytest harness execute engine-dependent scenarios from a verified local `file://` archive while retaining `VIBE_MODEL_HUB_ENGINE_OFFLINE=1` and zero HTTP(S) archive egress.

This follows the `avibe-test` regression on `master e77326b0`, where all seven engine scenarios failed after install settled with `status.health == "not_installed"`. The failure reproduced locally with the real pinned CLIProxyAPI archive. The managed installer intentionally refuses every uncached archive in offline mode before URL parsing, so the harness now verifies and seeds local assets into its unique `AVIBE_HOME` cache before any child starts.

The run also exposed two previously masked test-contract defects: the shared D-suite nonce was one character too short, and the real engine normalizes Anthropic upstream credentials to exact `Authorization: Bearer` transport rather than `x-api-key`. Both are corrected as tests-only evidence.

The branch incorporates `master a51bc695`, including CLIProxyAPI v7.2.105 and the duplicate-key source regression. The merge retains one verified cache-seeding owner in `ModelHubTestApp`; the runtime suite no longer carries a second unverified copy path.

## Scenario Coverage

| Scenario | Status | Evidence |
| --- | --- | --- |
| A2 | assert | Verified offline install, start, stop, and hardened engine config |
| A5 | assert | Controller restart during OAuth polling reports engine-down behavior |
| D2 | assert | Healthy real-engine probe reaches the mock; exact synthetic key bytes arrive in Bearer authorization with Anthropic version metadata |
| D3 | partial assert | Rate-limit cooldown and next-request selection; same-turn walk remains owned outside this layer |
| D4 | partial assert | Quota cooldown and next-request selection; same-turn walk remains owned outside this layer |
| D5 | assert | Non-refreshable 401 transitions the static key to repair state |
| D6 | baseline assert | Current flat server-error cooldown behavior for open decision D-4 |

No scenario is newly xfailed or skipped. No default CI wiring changes are included.

## Evidence Layers

- **Unit/harness:** manifest-only safe inheritance; normalized parent path propagation; pre-spawn cache seeding; declared size and SHA-256 verification; mismatch rejection; non-file assets are not fetched.
- **Contract:** `VIBE_MODEL_HUB_ENGINE_OFFLINE=1` remains authoritative; only `VIBE_MODEL_HUB_ENGINE_MANIFEST_PATH` is newly inherited; D2 freezes CLIProxyAPI's actual Bearer normalization while proving credential bytes are unchanged.
- **Scenario:** real pinned v7.2.105 archive: `75 passed, 4 xfailed`; A2/A5/D2-D6 plus the duplicate-key source regression: `8 passed`. Without a manifest: `67 passed, 8 skipped, 4 xfailed`.
- **Residual manual:** after merge, redeploy `master` to `avibe-test` and rerun the complete Linux VM suite with its offline `file://` manifest/archive.

## Self-Audit

- Skip policy: manifest absence remains an environmental precondition, while accepted-manifest/install failures remain red.
- Xfail granularity and layer honesty: unchanged; all seven engine scenarios execute with the real archive.
- Environment ownership: seeding starts no process or thread, writes only below the unique hermetic `AVIBE_HOME`, and removes temporary cache files on failure.
- Catalog single resolver: untouched; scenario IDs and existing partial-evidence ownership remain unchanged.
