### PR TITLE
perf(ui): remove hover layout churn while scrolling

### DIFF
--- a/ui/src/components/workbench/ChatArchivedReadOnly.test.tsx
+++ b/ui/src/components/workbench/ChatArchivedReadOnly.test.tsx
@@ -860,8 +860,9 @@ describe('Agent result metrics tail', () => {
     expect(markup.split(displayedFooter)).toHaveLength(2);
     expect(markup.indexOf('2026-07-27')).toBeLessThan(markup.indexOf(displayedFooter));
     expect(markup).toContain(
-      'opacity-0 transition-opacity duration-150 group-hover/message:opacity-100 group-focus-within/message:opacity-100 pointer-coarse:opacity-100',
+      'opacity-0 group-hover/message:opacity-100 group-focus-within/message:opacity-100 pointer-coarse:opacity-100',
     );
+    expect(markup).not.toContain('transition-opacity');
     expect(markup).toContain('flex-wrap');
   });
 

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -4561,9 +4561,11 @@ export const MessageRow = memo(function MessageRow({
   // carries a NAMED group (``group/message``) so this reveal can't collide with
   // the unnamed ``group-hover`` ChatImage uses for its own overlay button.
   // Coarse pointers (touch) have no hover, so keep it always visible there.
+  // Keep the reveal immediate: scrolling moves rows beneath a stationary pointer,
+  // and an opacity transition would keep restyling and painting after each crossing.
   const time = (
     <span
-      className="inline-flex max-w-full flex-wrap items-center gap-x-1.5 gap-y-0.5 px-1 font-mono text-[10px] text-muted opacity-0 transition-opacity duration-150 group-hover/message:opacity-100 group-focus-within/message:opacity-100 pointer-coarse:opacity-100"
+      className="inline-flex max-w-full flex-wrap items-center gap-x-1.5 gap-y-0.5 px-1 font-mono text-[10px] text-muted opacity-0 group-hover/message:opacity-100 group-focus-within/message:opacity-100 pointer-coarse:opacity-100"
     >
       <span className="whitespace-nowrap">{formatLocalDateTime(message.created_at)}</span>
       {resultPresentation.footer ? <span className="min-w-0 break-words">{resultPresentation.footer}</span> : null}

--- a/ui/src/components/workbench/SessionPinAction.test.tsx
+++ b/ui/src/components/workbench/SessionPinAction.test.tsx
@@ -7,7 +7,6 @@ import {
   SESSION_ROW_ACTION_BUTTON_CLASS,
   SESSION_ROW_MENU_POSITION_CLASS,
   SESSION_ROW_PIN_POSITION_CLASS,
-  sessionRowActionPaddingClass,
 } from './sessionRowLayout';
 
 const renderAction = (pinned: boolean, pending = false) =>
@@ -76,21 +75,5 @@ describe('SessionPinAction', () => {
     expect(html).toContain('disabled=""');
     expect(html).toContain('animate-spin');
     expect(html).toContain('cursor-wait');
-  });
-});
-
-describe('sessionRowActionPaddingClass', () => {
-  it('gives the title full width until the two-button rail is revealed', () => {
-    const className = sessionRowActionPaddingClass(false, false);
-
-    expect(className).toContain('pr-2.5');
-    expect(className).toContain('hover:pr-11');
-    expect(className).toContain('focus-within:pr-11');
-    expect(className).toContain('pointer-coarse:pr-11');
-  });
-
-  it('reserves the rail while the menu is open or the pin stays visible', () => {
-    expect(sessionRowActionPaddingClass(true, false)).toBe('pr-11');
-    expect(sessionRowActionPaddingClass(false, true)).toBe('pr-11');
   });
 });

--- a/ui/src/components/workbench/WorkbenchSidebar.sessionRow.test.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.sessionRow.test.tsx
@@ -117,4 +117,15 @@ describe('session row actions rail', () => {
     // A read-only row has no rail: no pin, no menu, nothing to reserve space for.
     expect(railOffsets(row({ canManageMetadata: false }))).toEqual([]);
   });
+
+  it('keeps the editable rail width stable while hover and focus move across rows', () => {
+    const editable = row({ canManageMetadata: true });
+
+    expect(editable).toContain('pr-11');
+    expect(editable).not.toMatch(/(?:hover|focus-within|pointer-coarse):pr-/);
+    expect(editable).not.toContain('padding-right');
+
+    const readOnly = row({ canManageMetadata: false });
+    expect(readOnly).toContain('pr-2.5');
+  });
 });

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -33,7 +33,7 @@ import { useWindowManager } from '../../context/WindowManagerContext';
 import { useUnsavedChangesActionGuard } from '../../context/useUnsavedChangesActionGuard';
 import type { InboxSession, WorkbenchProject, WorkbenchSession } from '../../context/ApiContext';
 import { SessionPinAction } from './SessionPinAction';
-import { SESSION_ROW_MENU_POSITION_CLASS, sessionRowActionPaddingClass } from './sessionRowLayout';
+import { SESSION_ROW_MENU_POSITION_CLASS } from './sessionRowLayout';
 import { SessionActionMenuContent, SessionActionsTrigger } from './sessionActions';
 import { useSessionActions } from './useSessionActions';
 import { formatRelativeTime } from '../../lib/relativeTime';
@@ -310,8 +310,8 @@ export const SessionRow: React.FC<{
             setMenuOpen(true);
           }}
           className={clsx(
-            'group/sess relative flex items-center gap-2 rounded-md py-1.5 pl-[26px] text-left transition-[background-color,padding-right] duration-150 ease-out motion-reduce:transition-none',
-            sessionRowActionPaddingClass(menuOpen, session.pinned),
+            'group/sess relative flex items-center gap-2 rounded-md py-1.5 pl-[26px] text-left transition-colors duration-150 ease-out motion-reduce:transition-none',
+            canManageMetadata ? 'pr-11' : 'pr-2.5',
             active
               ? 'border-l-2 border-mint bg-mint-soft pl-[24px] font-semibold text-foreground'
               : 'hover:bg-foreground/[0.04]',

--- a/ui/src/components/workbench/sessionRowLayout.ts
+++ b/ui/src/components/workbench/sessionRowLayout.ts
@@ -4,8 +4,3 @@
 export const SESSION_ROW_ACTION_BUTTON_CLASS = 'size-5 rounded-md';
 export const SESSION_ROW_PIN_POSITION_CLASS = 'right-5';
 export const SESSION_ROW_MENU_POSITION_CLASS = 'right-0';
-
-// Pinned rows reserve the rail at rest; unpinned rows expand it only while
-// either control is revealed through hover/focus or while the menu is open.
-export const sessionRowActionPaddingClass = (menuOpen: boolean, pinned: boolean) =>
-  menuOpen || pinned ? 'pr-11' : 'pr-2.5 hover:pr-11 focus-within:pr-11 pointer-coarse:pr-11';


### PR DESCRIPTION
## Summary

- keep editable Session rows at a stable width by reserving their action rail instead of animating right padding on hover
- keep Chat timestamps available on hover, focus, and coarse pointers while making the reveal immediate instead of running an opacity transition for every row crossed during scrolling
- add regression assertions that prohibit hover-driven Session-row padding and timestamp opacity transitions

## Evidence

- focused Vitest suite: 53 tests passed
- production UI build passed
- browser performance A/B against a 108-Session regression list: 280 wheel events reduced layout from 754 runs before the change to 1 run after it; the pin and menu controls still reveal while padding stays at 44px
- browser interaction check: Chat timestamps remain hidden at rest and visible on hover with a 0s transition duration

## Scope

This removes the two measured scroll-time performance costs. It does not claim that they are the unconfirmed root cause of the separately reported whole-list white flash.

No dependencies. No scenario catalog entry applies to this rendering-only change.
