### PR TITLE
fix(model-hub): keep route editor open when cancelling grab

### DIFF
--- a/ui/e2e/d-routing.spec.ts
+++ b/ui/e2e/d-routing.spec.ts
@@ -129,35 +129,51 @@ test.describe('D · route chains and priority order', () => {
     await expect(dialog).toHaveCount(0);
   });
 
-  // A defect this suite found, not a scenario from §3, and reported rather than
-  // patched (this lane changes no product code) — filed as #1819.
-  //
-  // Escape during a keyboard grab is meant to be an undo: `onGripKeyDown` puts
-  // the hop back, refocuses it, and announces `reorder.cancelled`. It does all
-  // three — and then the dialog closes on the same keystroke, discarding every
-  // unsaved edit, so nobody ever reads that announcement. The handler calls
-  // `preventDefault()` only; Radix's dismissable layer listens on the document
-  // and does not consult `defaultPrevented`. `SourceOrderDrawer` gets this right
-  // twice over: `stopPropagation()` in the row handler AND an `onEscapeKeyDown`
-  // guard on the dialog content. The route dialog has neither.
-  //
-  // Unfixme once #1819 lands the same guard on the route dialog; the assertion
-  // is the two lines below, which is exactly what the drawer spec already
-  // asserts.
-  test.fixme('D · Escape cancels a grab without discarding the chain edit', async ({ hub, gateway, page }) => {
-    await hub.goto();
-    await hub.firstRouteRow(gateway.backend).click();
-    const dialog = hub.routeDialog;
-    const grip = dialog.locator('.model-hub-route-hop').first().getByRole('button', {
-      name: copy('routeDialog.grip'),
-      exact: true,
-    });
-    await grip.press(' ');
-    await page.keyboard.press('Escape');
-    await expect(dialog).toBeVisible();
-    await expect(dialog.locator('[aria-live="polite"]')).toHaveText(
-      copy('routeDialog.reorder.cancelled', { position: 1 }),
-    );
+  test('D · Escape cancels a grab without discarding the chain edit', async ({ api, hub, gateway, page }) => {
+    const original = await captureAgentChain(api, gateway);
+    const arranged = gateway.sources.map((source) => ({
+      source_id: source.id,
+      model_id: source.models[0].id,
+    }));
+    try {
+      expect(await api.putAgentChain(gateway.backend, gateway.model, arranged)).toBe(true);
+      await hub.goto();
+      await hub.routeRow(gateway.backend, gateway.model).click();
+
+      const dialog = hub.routeDialog;
+      const hops = dialog.locator('.model-hub-route-hop');
+      const models = dialog.locator('.model-hub-route-hop-model');
+      const announcer = dialog.locator('[aria-live="polite"]');
+      const gripName = copy('routeDialog.grip');
+      const unsavedOrder = [arranged[1].model_id, arranged[0].model_id];
+      const firstGrip = hops.first().getByRole('button', { name: gripName, exact: true });
+
+      await firstGrip.focus();
+      await firstGrip.press(' ');
+      await firstGrip.press('ArrowDown');
+      const heldGrip = dialog.locator('[aria-grabbed="true"]');
+      await expect(heldGrip).toBeFocused();
+      await heldGrip.press(' ');
+      await expect(models).toHaveText(unsavedOrder);
+      await expect(labelledButton(dialog, copy('routeDialog.save'))).toBeEnabled();
+
+      const unsavedGrip = hops.last().getByRole('button', { name: gripName, exact: true });
+      await unsavedGrip.press(' ');
+      await unsavedGrip.press('ArrowUp');
+      await expect(dialog.locator('[aria-grabbed="true"]')).toBeFocused();
+      await page.keyboard.press('Escape');
+
+      await expect(dialog).toBeVisible();
+      await expect(announcer).toHaveText(copy('routeDialog.reorder.cancelled', { position: 2 }));
+      await expect(dialog.locator('[aria-grabbed="true"]')).toHaveCount(0);
+      await expect(models).toHaveText(unsavedOrder);
+      await expect(hops.last().getByRole('button', { name: gripName, exact: true })).toBeFocused();
+      await expect(labelledButton(dialog, copy('routeDialog.save'))).toBeEnabled();
+
+      await labelledButton(dialog, copy('routeDialog.cancel')).click();
+    } finally {
+      await restoreAgentChain(api, gateway, original);
+    }
   });
 
   test('D · Reorder by Source order restates the chain, and says which it did', async ({ hub, gateway, api }) => {

--- a/ui/e2e/d-routing.spec.ts
+++ b/ui/e2e/d-routing.spec.ts
@@ -138,6 +138,9 @@ test.describe('D · route chains and priority order', () => {
     try {
       expect(await api.putAgentChain(gateway.backend, gateway.model, arranged)).toBe(true);
       await hub.goto();
+      const card = hub.agentCard(gateway.backend);
+      const expand = card.locator('.model-hub-model-collapse').first();
+      if (await expand.count()) await expand.click();
       await hub.routeRow(gateway.backend, gateway.model).click();
 
       const dialog = hub.routeDialog;

--- a/ui/src/components/settings/models/RouteChainDialog.test.tsx
+++ b/ui/src/components/settings/models/RouteChainDialog.test.tsx
@@ -149,14 +149,14 @@ const renderStockedDialog = () => {
     </I18nextProvider>,
   );
 };
-const renderDialog = (onCommitted = vi.fn()) => {
+const renderDialog = (onCommitted = vi.fn(), onClose = vi.fn()) => {
   vi.spyOn(modelsApi, "getAgentChain").mockResolvedValue(chain);
   return render(
     <I18nextProvider i18n={i18n}>
       <RouteChainDialog
         selection={{ agent, modelId: "opus-5", read: readyRegion(chain) }}
         sources={sources}
-        onClose={vi.fn()}
+        onClose={onClose}
         onCommitted={onCommitted}
         readAgents={vi.fn().mockResolvedValue(observation([agent]))}
         readSources={vi.fn().mockResolvedValue(observation(sources))}
@@ -768,16 +768,43 @@ describe("RouteChainDialog", () => {
     );
   });
 
-  it("supports the grip keyboard contract and restores the draft on Escape", async () => {
+  it("cancels only the active grab and preserves the earlier unsaved draft", async () => {
     const user = userEvent.setup();
-    renderDialog();
+    const onClose = vi.fn();
+    renderDialog(vi.fn(), onClose);
     const grips = await screen.findAllByRole("button", {
       name: "Reorder this hop",
     });
 
-    await user.click(grips[1]);
+    await user.click(grips[0]);
     await user.keyboard("{Space}");
-    expect(grips[1].getAttribute("aria-grabbed")).toBe("true");
+    await user.keyboard("{ArrowDown}");
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        screen.getAllByRole("button", { name: "Reorder this hop" })[1],
+      ),
+    );
+    await user.keyboard("{Space}");
+    expect(
+      screen.getAllByRole("button", { name: "Reorder this hop" })[1]
+        .getAttribute("aria-grabbed"),
+    ).toBe("false");
+    const unsavedOrder = ["Claude subscription", "API key"];
+    expect(
+      [...document.querySelectorAll(".model-hub-route-hop-name")].map(
+        (node) => node.textContent,
+      ),
+    ).toEqual(unsavedOrder);
+    expect(
+      (screen.getByRole("button", { name: "Save" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+
+    await user.keyboard("{Space}");
+    expect(
+      screen.getAllByRole("button", { name: "Reorder this hop" })[1]
+        .getAttribute("aria-grabbed"),
+    ).toBe("true");
     await user.keyboard("{ArrowUp}");
     expect(screen.getByText("Moved to hop 1.")).toBeTruthy();
     await waitFor(() =>
@@ -786,7 +813,15 @@ describe("RouteChainDialog", () => {
       ),
     );
     await user.keyboard("{Escape}");
-    expect(screen.getByText("Reorder cancelled. Restored to hop 2.")).toBeTruthy();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("Reorder cancelled. Restored to hop 2."),
+    ).toBeTruthy();
+    expect(
+      [...document.querySelectorAll(".model-hub-route-hop-name")].map(
+        (node) => node.textContent,
+      ),
+    ).toEqual(unsavedOrder);
     const restoredGrips = screen.getAllByRole("button", {
       name: "Reorder this hop",
     });
@@ -795,6 +830,17 @@ describe("RouteChainDialog", () => {
     expect(
       (screen.getByRole("button", { name: "Save" }) as HTMLButtonElement)
         .disabled,
-    ).toBe(true);
+    ).toBe(false);
+  });
+
+  it("keeps the native Escape dismissal when no hop is grabbed", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderDialog(vi.fn(), onClose);
+    await screen.findAllByRole("button", { name: "Reorder this hop" });
+
+    await user.keyboard("{Escape}");
+
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/src/components/settings/models/RouteChainDialog.tsx
+++ b/ui/src/components/settings/models/RouteChainDialog.tsx
@@ -312,6 +312,14 @@ export const RouteChainDialog: React.FC<{
       position: next.focusIndex + 1,
     });
   };
+  const cancelGrab = () => {
+    if (!interactionRef.current.grab) return;
+    const next = advanceInteraction({ type: "cancel-grab" });
+    requestAnimationFrame(() => gripRefs.current[next.focusIndex]?.focus());
+    announce("settings.models.routeDialog.reorder.cancelled", {
+      position: next.focusIndex + 1,
+    });
+  };
   const onGripKeyDown = (
     event: React.KeyboardEvent<HTMLButtonElement>,
     index: number,
@@ -341,11 +349,7 @@ export const RouteChainDialog: React.FC<{
       }
     } else if (event.key === "Escape" && grabbed !== null) {
       event.preventDefault();
-      const next = advanceInteraction({ type: "cancel-grab" });
-      requestAnimationFrame(() => gripRefs.current[next.focusIndex]?.focus());
-      announce("settings.models.routeDialog.reorder.cancelled", {
-        position: next.focusIndex + 1,
-      });
+      event.stopPropagation();
     } else if (event.key === "ArrowUp" || event.key === "ArrowDown") {
       event.preventDefault();
       if (grabbed === null) {
@@ -1028,6 +1032,12 @@ export const RouteChainDialog: React.FC<{
           onOpenAutoFocus={(event) => {
             event.preventDefault();
             cancelButtonRef.current?.focus();
+          }}
+          onEscapeKeyDown={(event) => {
+            if (phase === "ready" && interactionRef.current.grab) {
+              event.preventDefault();
+              cancelGrab();
+            }
           }}
         >
           <header className="model-hub-route-head flex flex-col border-b border-border">


### PR DESCRIPTION
## Summary

- make the route dialog content own Escape cancellation while a keyboard grab is active
- keep the grip handler responsible only for isolating that consumed key event, so draft rollback, focus restoration, and the live-region announcement happen once
- preserve Radix's native Escape dismissal when no hop is grabbed and promote the browser regression from `test.fixme` to a real test

## Behavior contract

- During an active keyboard grab, Escape restores the order from before that grab, clears `aria-grabbed`, returns focus to the original grip, announces the cancellation, and keeps the dialog plus any earlier unsaved draft open.
- Without an active grab, Escape continues to dismiss the dialog normally.
- Saving, guards, impact confirmation, and nested candidate popover behavior are unchanged.

## Verification

- Pre-fix real Chromium run against the isolated `origin/master` build failed because the route dialog disappeared after Escape.
- Focused Vitest: 32 passed across RouteChainDialog, route-chain interaction, and SourceOrderDrawer.
- Full UI Vitest: 270 files and 3,408 tests passed.
- UI lint, E2E TypeScript check, focused ESLint, and production build passed.
- Fixed real Chromium scenario passed against the isolated Incus deployment; all four non-fixme D-routing scenarios also passed across the focused and regression runs.

## Residual risk

The fix intentionally depends on Radix's content-level Escape hook remaining the dismissal interception point. Both the real Dialog component test and Chromium regression exercise that integration rather than mocking it.

Fixes #1819
