### PR TITLE
docs(model-hub): backend catalog v2 — compose from providers

### DIFF
--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -246,8 +246,9 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
   with an empty route. The picker echoes what it showed: `PUT` accepts
   `expected_suppliers?: {<id>: [{source_id, model_id}]}` for caller-added ids, and when the
   server's matching result differs for any listed id it commits nothing and refuses with
-  `409 candidate_suppliers_changed` carrying the current projection for those ids; the picker
-  refreshes its candidates and asks again. The success response is the existing
+  `409 {ok: false, contract_version, error: "candidate_suppliers_changed", changed: {<id>:
+  [{source_id, model_id}]}}` — its own registered response shape, not a guard refusal, since
+  nothing is removed or interrupted; the picker refreshes its candidates and asks again. The success response is the existing
   `{agent: AgentSupply}`.
 - **C2 — Proposed values travel in the candidates read; the save is literal.** The server
   proposes `display_name` and `reasoning_efforts` for every candidate (C4): for a built-in
@@ -297,8 +298,11 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
   in the set, at the position question 9 defines, seeds it per C1 and C2, and invalidates the
   backend's runtime projection; it never removes a row. The picker's `builtin` group lists
   removed built-ins so they are one click away. Legacy initialization: a persisted catalog
-  without the field is initialized once, at load, to `built-in snapshot ids − menu ids` and
-  persisted. This is deliberately conservative: a v1 upgrade changes nothing the user sees, and
+  without the field is initialized once to `built-in snapshot ids − menu ids` and persisted —
+  but only when the snapshot is complete: the bundled catalog, a last-known-good remote
+  catalog, and the local CLI cache (when that CLI is installed) have each been read at least
+  once. Until then the field stays absent, reconcile does not run, and the menu is served
+  unchanged, so a partial snapshot can never be mistaken for the user's removals. This is deliberately conservative: a v1 upgrade changes nothing the user sees, and
   the price is that a built-in that entered the snapshot between the v1 save and the first v2
   load is treated as removed — recoverable from the picker, not auto-added. Reconcile runs only
   once the field exists. Claude Code's locked `default` row is not a built-in candidate and
@@ -322,15 +326,21 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
 ### Contract artifact changes (complete; the contracts lane's checklist)
 
 Every shape C1–C7 introduces maps to exactly one row here; a delta that needs an artifact not
-listed is a spec defect to report, not a lane decision.
+listed is a spec defect to report, not a lane decision. The closure property is normative: the
+contract guard, the response guard, authorization coverage, and version closure all pass with
+the v2 shapes on the same head.
 
 | Artifact | Change |
 | --- | --- |
 | `docs/plans/model-hub-contracts/backend-model.schema.json` and its TypeScript mirror (`ui/src/components/settings/models/types.ts`) | `origin` enum gains `provider` |
 | `docs/plans/model-hub-contracts/api.md` route table | `PUT /api/models/agents/<backend>/models` row: optional `force`, `would_remove_hops`, `would_interrupt`, `expected_suppliers`; refusals `backend_model_in_route`, `candidate_suppliers_changed`; success `{agent}` or `{agent, removed_hops, interrupted}`. New row `GET /api/models/agents/<backend>/models/candidates`. `GET /api/models/catalog/models-dev` row: additive `first_party`, dedupe, ranking, cap 8 |
 | `docs/plans/model-hub-contracts/api-response.schema.json` | the models `PUT` accepts the forced-success shape beside `AgentResponse`; new candidates response (`Candidate` shape from C4); models-dev response gains `first_party` |
-| `docs/plans/model-hub-contracts/guard-refusal.schema.json` | `error` enum gains `backend_model_in_route` and `candidate_suppliers_changed`; a `detail` property; the nonempty-`would_remove_hops` relation extends to `backend_model_in_route`; `candidate_suppliers_changed` carries its `changed: {<id>: [{source_id, model_id}]}` sibling |
-| `docs/plans/model-hub-contracts/mirror-registry.json` | registers the two new error codes and the new `origin` value with their consumers |
+| `docs/plans/model-hub-contracts/guard-refusal.schema.json` | `error` enum gains `backend_model_in_route`; a `detail` property; the nonempty-`would_remove_hops` relation extends to `backend_model_in_route` |
+| `docs/plans/model-hub-contracts/api-response.schema.json` (stale-candidate refusal) | new registered shape for `409 candidate_suppliers_changed` — `{ok, contract_version, error, changed}` — outside the guard-refusal `anyOf` |
+| `contract_version` closure (every registered location listed in `docs/plans/model-hub-contracts/README.md` "Version closure", server and UI mirrors alike) | 6 → 7, because v1 shipped closed shapes (`additionalProperties: false`) that v2 extends |
+| `vibe/authorization.py` role table and its coverage test (`tests/test_instance_authorization.py`) | `GET /api/models/agents/<backend>/models/candidates` is admitted for every role that may `GET /api/models/agents/<backend>/models` |
+| `docs/plans/model-hub-contracts/README.md` (product model) and `docs/plans/model-hub-contracts/opencode-overlay.md` | Add Source is no longer the sole matching/placement point: a menu-model add (C1) and a reconcile add (C6) are the other one-time points; runtime still never re-matches |
+| `docs/plans/model-hub-contracts/mirror-registry.json` | registers the two new error codes, the new `origin` value, and the new response shapes with their consumers |
 | `vibe/i18n/*.json` and `ui/src/components/settings/models/serverCopy.ts` | `detail` keys for the two new error codes |
 | `config/v2_config.py` persisted shape | `agents.<backend>.removed_model_ids` with legacy initialization (C6) and a load fixture for the v1 file shape |
 | `vibe/data/model_vendors.json` (new, versioned) | the vendor map and aggregator order C7 defines, covered by a test |

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -246,9 +246,9 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
   with an empty route. The picker echoes what it showed: `PUT` accepts
   `expected_suppliers?: {<id>: [{source_id, model_id}]}` for caller-added ids, and when the
   server's matching result differs for any listed id it commits nothing and refuses with
-  `409 {ok: false, contract_version, error: "candidate_suppliers_changed", changed: {<id>:
-  [{source_id, model_id}]}}` — its own registered response shape, not a guard refusal, since
-  nothing is removed or interrupted; the picker refreshes its candidates and asks again. The success response is the existing
+  `409 {ok: false, contract_version, error: "candidate_suppliers_changed", detail, changed:
+  {<id>: [{source_id, model_id}]}}` — its own registered response shape (with the `detail` key
+  every `ModelHubError` carries), not a guard refusal, since nothing is removed or interrupted; the picker refreshes its candidates and asks again. The success response is the existing
   `{agent: AgentSupply}`.
 - **C2 — Proposed values travel in the candidates read; the save is literal.** The server
   proposes `display_name` and `reasoning_efforts` for every candidate (C4): for a built-in
@@ -310,7 +310,13 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
   `removed_model_ids` is set to its current contents ∪ (`built-in snapshot ids − menu ids`).
   Removals made while the marker is false are recorded in `removed_model_ids` immediately, like
   any other removal, and survive initialization. Until the marker is true the menu is served
-  unchanged, so a partial snapshot can never be mistaken for the user's removals. A catalog
+  unchanged, so a partial snapshot can never be mistaken for the user's removals. Reconcile is
+  controller-owned and pull-based: the controller records the generation (content hash) of the
+  built-in snapshot it last reconciled against, and re-reads the snapshot inputs — bundled
+  catalog, remote catalog cache file, CLI cache file — before serving any Model Hub agent read
+  or mutation and at startup; a changed generation triggers reconcile in that same request.
+  No cache producer (the UI process's background refresher included) has to notify the
+  controller, so the two processes stay decoupled as `AGENTS.md` requires. A catalog
   created fresh under v2 is written with the marker already true and an empty removed set, so
   the pending window exists only for files that predate the marker; a fresh-install fixture is
   distinct from the v1 migration fixtures. Both fields are persisted configuration only: the
@@ -349,7 +355,7 @@ the v2 shapes on the same head.
 | `docs/plans/model-hub-contracts/api.md` route table | `PUT /api/models/agents/<backend>/models` row: optional `force`, `would_remove_hops`, `would_interrupt`, `expected_suppliers`; refusals `backend_model_in_route`, `candidate_suppliers_changed`; success `{agent}` or `{agent, removed_hops, interrupted}`. New row `GET /api/models/agents/<backend>/models/candidates`. `GET /api/models/catalog/models-dev` row: additive `first_party`, dedupe, ranking, cap 8 |
 | `docs/plans/model-hub-contracts/api-response.schema.json` | the models `PUT` accepts the forced-success shape beside `AgentResponse`; new candidates response (`Candidate` shape from C4); models-dev response gains `first_party` |
 | `docs/plans/model-hub-contracts/guard-refusal.schema.json` | `error` enum gains `backend_model_in_route`; a `detail` property; the nonempty-`would_remove_hops` relation extends to `backend_model_in_route` |
-| `docs/plans/model-hub-contracts/api-response.schema.json` (stale-candidate refusal) | new registered shape for `409 candidate_suppliers_changed` — `{ok, contract_version, error, changed}` — outside the guard-refusal `anyOf` |
+| `docs/plans/model-hub-contracts/api-response.schema.json` (stale-candidate refusal) | new registered shape for `409 candidate_suppliers_changed` — `{ok, contract_version, error, detail, changed}` — outside the guard-refusal `anyOf` |
 | `contract_version` closure (every registered location listed in `docs/plans/model-hub-contracts/README.md` "Version closure", server and UI mirrors alike) | 6 → 7, because v1 shipped closed shapes (`additionalProperties: false`) that v2 extends |
 | `vibe/authorization.py` role table and its coverage test (`tests/test_instance_authorization.py`) | `GET /api/models/agents/<backend>/models/candidates` is **member-tier**, the same boundary as Source inventory reads, because it carries supplier ids and names; the editor-tier catalog read stays supplier-free |
 | `docs/plans/model-hub-contracts/README.md` (product model) and `docs/plans/model-hub-contracts/opencode-overlay.md` | Add Source is no longer the sole matching/placement point: a menu-model add (C1) and a reconcile add (C6) are the other one-time points; runtime still never re-matches |

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -272,7 +272,7 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
   `{candidates: {builtin: Candidate[], providers: Candidate[], in_list: Candidate[]}}` where `Candidate` is
   `{id, display_name, reasoning_efforts, suppliers: [{source_id, source_name, model_id}],
   origin}`. `builtin` is the merged remote + bundled + local-CLI snapshot for the backend
-  (served regardless of Gateway/Direct mode; empty for OpenCode) minus menu ids, hidden ones
+  (served regardless of Gateway/Direct mode; empty for OpenCode) minus menu ids, removed ones
   included; `providers` is the deduplicated (question 1) inventory of the backend's ordered,
   configuration-eligible Sources minus menu ids and minus ids already in `builtin`; `in_list`
   is every current menu row with the same projection, so an already-added model is found by

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -1,6 +1,6 @@
 # Backend Model Catalogs
 
-Status: implementation contract — v1 shipped in #1814; **v2 (compose from providers) below is the current definition of done, pending owner approval 2026-09-03**
+Status: implementation contract — v1 shipped in #1814; **v2 (compose from providers) below is the current definition of done, approved by the owner on 2026-09-03; C1–C8 are normative**
 
 ## Outcome
 
@@ -125,33 +125,36 @@ including `deepseek-v3.2`) and `openrouter` (also `deepseek-v3.2`), `aihub` firs
 Codex's Source order. `Manage models` → `Add models` → type `deepseek` → under `From your providers` the row
 `deepseek-v3.2 · aihub, openrouter` → check → `Add 1 model`. Result: Codex's menu gains
 `deepseek-v3.2` with display name and reasoning efforts taken from the supplying Source
-models and context/output/modalities filled from models.dev when one exact match exists;
-its route is `aihub → deepseek-v3.2`, `openrouter → deepseek-v3.2`; the Codex card row
+models (both editable in the list before Save; other metadata stays empty until the user
+fills it); its route is `aihub → deepseek-v3.2`, `openrouter → deepseek-v3.2`; the Codex card row
 reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
 
 ### One product model — the seven questions
 
 1. **Candidate identity when several providers supply the same model.** For Claude Code
-   and Codex a candidate is one distinct upstream model id across all
-   configuration-eligible, non-retired Source models — that id is exactly what the menu
-   id will be. The row lists its supplying providers in Source order. For OpenCode a
+   and Codex a candidate is one distinct upstream model id across the non-retired models —
+   discovered or manually added — of every Source that is configuration-eligible for the
+   backend **and present in that backend's Source order**; a Source held out of the order
+   supplies nothing here. That id is exactly what the menu id will be. The row lists its
+   supplying providers in Source order. For OpenCode a
    candidate is the existing OpenCode identifier `vendor/model` (§4.8), so two Sources
    with the same standard vendor collapse into one candidate and two vendors offering the
    same bare model stay two candidates, as OpenCode itself would show them.
 2. **Membership key and metadata owner.** Unchanged: membership is keyed by backend
    model id per backend, and the `BackendModel` row owns display name, capabilities,
-   context, output, and reasoning efforts. Selection seeds those fields — display name
-   and reasoning efforts from the supplying Source model(s), the rest from models.dev —
-   and every field stays editable afterwards.
+   context, output, and reasoning efforts. Selection seeds display name and reasoning
+   efforts from the supplying Source model(s) into the editable draft before Save; other
+   metadata stays empty until the user fills it (the custom-model editor's models.dev
+   lookup is the assistant for that). Every field stays editable.
 3. **One selection → one menu entry → one route with N hops**, one hop per supplying
    Source in Source order, written by the existing `placement-v1` rule. The picker never
    edits an existing route; the Route dialog remains the only place that adds, removes,
    reorders, or cross-maps hops.
-4. **models.dev** proposes, never rules. At add time the server fills empty metadata only
-   when exactly one exact match exists (`provider/model` or model-id equality) and records
-   `models_dev_id`. In the editor the `Model` typeahead proposes models.dev matches while the
-   user types and fills the form on selection. No refresh ever overwrites a field the user
-   has set; a proposal is reversible by editing the field.
+4. **models.dev** proposes, never rules. The server never fills metadata on a user's save.
+   In the editor the `Model` typeahead proposes models.dev matches while the user types and
+   fills the form on selection, recording `models_dev_id`; the user can change any field
+   before saving. No refresh ever overwrites a field the user has set; a proposal is
+   reversible by editing the field.
 5. **A supplying model disappears, is retired, or its Source is disabled or deleted.**
    Routes are configuration and are not rewritten by health (existing rule). The menu
    entry stays; its row shows the existing states (`Supply paused`, `No model route
@@ -172,9 +175,10 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
       (bundled + remote backend catalog + the local CLI cache the product already merges)
       minus what is already in the menu. This is where a removed built-in is found again.
       OpenCode has no built-in list; the group is absent for it.
-   2. **`From your providers`** — every configuration-eligible, non-retired Source model
-      not already in the menu, deduplicated by the identity rule in question 1, with its
-      supplying providers as read-only chips in Source order.
+   2. **`From your providers`** — every non-retired model, discovered or manual, of the
+      backend's ordered and configuration-eligible Sources, not already in the menu,
+      deduplicated by the identity rule in question 1, with its supplying providers as
+      read-only chips in Source order.
    3. **`Add custom model…`** — the picker's footer-left action (and, when a query matches
       nothing, an inline `Add "{{query}}" as a custom model…` under `No model matches.`). It
       opens the existing model editor for a model neither the backend nor your providers
@@ -190,8 +194,10 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
    Rules that hold across all groups: a provider chip on any row — built-in included — means
    exactly "one of your providers supplies this id", in Source order, and nothing else ever
    renders as a chip. With an empty query the list shows only what can be added; with a
-   query, models already in the list also appear in their group as disabled rows tagged
-   `In list`, so a search never dead-ends on something that exists. The editor's typeahead
+   query, every model already in the list that matches — built-in, provider, or custom
+   alike — appears in one search-only group, `Already in the list`, as disabled rows, so a
+   search never dead-ends on something that exists and never offers a duplicate. The
+   editor's typeahead
    shows a loading state while a lookup is in flight and `models.dev unavailable` when the
    catalogue cannot be reached; typing an id by hand always still works.
    Checked rows commit together through the footer primary (`Add {{count}} models`; with
@@ -215,60 +221,85 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
    provider may still serve it. The menu is therefore always "the backend's list, minus what
    you removed, plus what you added" — with no mode switch to explain.
 
-### Contract deltas (normative once approved; lanes cite these by number)
+### Contract deltas (normative — owner-approved 2026-09-03; lanes cite these by number)
 
 - **C1 — Menu-model add runs matching once.** `PUT /api/models/agents/<backend>/models`
   treats every row added relative to the latest stored list as a one-time matching point:
-  the server runs `matching-v1` for that menu model against configuration-eligible Sources
-  and writes the accepted hops with `placement-v1`. `model-hub.md` §4.2 and §4.6 are
+  the server runs `matching-v1` for that menu model against the Sources present in that
+  backend's Source order that are configuration-eligible, over each Source's complete
+  non-retired inventory — discovered and manual models alike (§4.2's
+  `observed.discovered_models` restriction belongs to Add-Source observation, not to this
+  point) — and writes the accepted hops with `placement-v1`. `model-hub.md` §4.2 and §4.6 are
   amended so that "catalog change never repeats matching" reads "a menu-model add matches
   once at that write; refresh, restart, health, and turns still never re-match". Manual
   adds of an id no Source lists therefore still start with an empty route.
   The success response is the existing `{agent: AgentSupply}`; the seeded hops are visible
   in `agent.routes[<id>].hops` and `agent.model_supply` in the same response.
-- **C2 — Metadata seeding.** For each added row the server fills `display_name` and
-  `reasoning_efforts` from the matched Source model(s) when the client sent them empty
-  (union of efforts across matched Sources, Source order), then fills remaining empty
-  metadata from models.dev only when exactly one exact match exists, recording
-  `models_dev_id` and `origin: "models_dev"`. A models.dev cache miss is silent; the row is
-  still written. `origin` gains the value `"provider"` for rows picked from
-  `From your providers`; `"builtin"`, `"models_dev"`, and `"manual"` keep their meaning.
+- **C2 — Seeding and provenance.** Seeding for a user-initiated add happens in the client
+  draft before Save, never on the server at `PUT`: the picker seeds `display_name` (from the
+  first ordered supplier that has one) and `reasoning_efforts` (union across suppliers, Source
+  order) from the Source models it already holds; the custom editor seeds from the chosen
+  models.dev suggestion. The server stores the request literally — an empty field in the
+  request is an empty field — so a value the user cleared before the first Save stays
+  cleared. Server-side seeding exists only for built-ins the reconcile (C6) adds without a
+  user draft: label and efforts from the built-in snapshot. `origin` records the creation
+  path only — `builtin` (built-in group or reconcile), `provider` (provider group),
+  `models_dev` (custom editor via a models.dev suggestion), `manual` (custom editor by hand)
+  — and `models_dev_id` records enrichment independently; enrichment never changes `origin`.
 - **C3 — Removal cascades through the guard.** `PUT /api/models/agents/<backend>/models`
   accepts the guarded-mutation fields beside `baseline` and `models`:
   `{baseline, models, force?: boolean, would_remove_hops?: RouteHopRef[], would_interrupt?: SupplyGap[]}`.
   Removing a row whose route has hops without `force` returns the existing guard-refusal
-  envelope `409 {ok: false, error: "backend_model_in_route", would_remove_hops: RouteHopRef[],
-  would_interrupt: SupplyGap[]}` (`guard-refusal.schema.json`; `RouteHopRef` is
+  envelope `409 {ok: false, contract_version, error: "backend_model_in_route", detail?,
+  would_remove_hops: RouteHopRef[], would_interrupt: SupplyGap[]}`; `guard-refusal.schema.json`'s
+  `error` enum gains `backend_model_in_route`, registered in `mirror-registry.json`,
+  `api-response.schema.json`, and the locale keys the contract guard requires (`RouteHopRef` is
   `{backend, menu_model, source_id, model_id, position}`). A retry with `force: true` that
   echoes both arrays unchanged removes the rows and their routes in one transaction and
   returns `{agent: AgentSupply, removed_hops: RouteHopRef[], interrupted: SupplyGap[]}`.
   Removing rows whose routes are empty needs no confirmation and returns `{agent}` as
   today. The v1 hard refusal is retired.
 - **C4 — Candidates come from reads that already exist.** The picker derives its groups from
-  reads the page already has or the product already serves: the built-in group from the
-  backend model catalog snapshot (`agent_model_options` / `fetchBackendModels`, the same
-  merged remote + bundled + local-CLI snapshot every model picker uses) minus menu ids and
-  including hidden built-ins; the provider group from `GET /api/models/sources` and
+  reads the page already has or the product already serves: the built-in group from
+  `builtin_models` and `hidden_builtin_ids` on the agent models read (C8) minus menu ids —
+  not from `fetchBackendModels`, which in Gateway mode returns the persisted catalog; the
+  provider group from `GET /api/models/sources` and
   `AgentSupply.sources` eligibility (the Route dialog's candidate derivation, promoted to a
   shared helper); the editor typeahead from `GET /api/models/catalog/models-dev?query=` (C7).
   No new read endpoint.
 - **C6 — Hidden built-ins and built-in reconcile.** The backend catalog persists the set of
   hidden built-in ids (`agents.<backend>.hidden_builtin_ids: string[]`, absent on older
   files = empty). `PUT .../models` marks a removed row hidden when its id is in the current
-  built-in snapshot and clears the mark when such an id is added. On every built-in snapshot
-  change (startup, remote catalog refresh, CLI cache change) the service adds each built-in
-  id that is neither in the menu nor hidden, at the position question 9 defines, running C1
+  built-in snapshot and clears the mark when such an id is added. Legacy initialization: a
+  persisted catalog without the field is initialized once, at load, to `built-in snapshot ids
+  − menu ids` and persisted, so an upgrade from v1 changes nothing the user sees and a
+  built-in removed under v1 does not return; only built-ins that enter the snapshot after that
+  initialization arrive by question 9. Reconcile runs only once the field exists. On every
+  built-in snapshot change (startup, remote catalog refresh, CLI cache change) the service
+  adds each built-in id that is neither in the menu nor hidden, at the position question 9 defines, running C1
   and C2 for it, and invalidates the backend's runtime projection. It never removes a row.
   Claude Code's locked `default` row is not a built-in candidate and cannot be hidden.
 - **C7 — models.dev read serves the editor typeahead.** `GET /api/models/catalog/models-dev?query=`
   returns `{models: [...]}` deduplicated by model id and ranked first-party vendor first, then
   exact-id, then name matches; each item carries `vendor_id`, `vendor_name`, `first_party:
-  boolean`, and the existing metadata fields. First-party means the provider that makes the
-  model; aggregator providers (openrouter, together, fireworks, groq, deepinfra, …) never win
-  the ranking when a first-party entry exists. Results are capped at 8 for the typeahead.
+  boolean`, and the existing metadata fields; results are capped at 8. `first_party` is derived
+  from a repo-owned, versioned vendor map (`vibe/data/model_vendors.json`: model-id family
+  prefix → models.dev provider id, e.g. `claude-` → `anthropic`, `gpt-`/`o` → `openai`,
+  `gemini-` → `google`, `deepseek-` → `deepseek`, `glm-` → `zhipuai`, `kimi-` → `moonshotai`,
+  `grok-` → `xai`, `qwen` → `alibaba`, `mistral-`/`codestral-` → `mistral`): a provider is
+  first-party for a model exactly when the map names it. When no listed provider is
+  first-party, the winner is the first provider in the map's ordered aggregator list
+  (`openrouter`, `together`, `fireworks-ai`, `groq`, `deepinfra`), and providers the map does
+  not know rank after those alphabetically. The map is the closed rule; extending it is a
+  versioned data change covered by a test.
+- **C8 — Built-in snapshot on the agent models read.** `GET /api/models/agents/<backend>/models`
+  returns, beside `catalog_models`, `builtin_models: [{id, display_name, reasoning_efforts}]` —
+  the merged remote + bundled + local-CLI snapshot for that backend, served regardless of
+  Gateway/Direct mode — and `hidden_builtin_ids: string[]`. OpenCode returns an empty
+  `builtin_models`. No new endpoint.
 - **C5 — Unchanged.** Source inventories, Source-side manual add, Route dialog, Source
   order, direct/gateway modes, and every runtime projection are byte-for-byte unchanged
-  except through C1–C3.
+  except through C1–C3, C6, and C8.
 
 ### Copy (English source; `zh.json` mirrors 1:1)
 
@@ -278,7 +309,7 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
 | Picker title | `Add {{backend}} models` |
 | Picker search placeholder | `Search models or providers` |
 | Group headers | `{{backend}} built-in` · `From your providers` |
-| Already-in-list row (search only) | `In list` |
+| Already-in-list group (search only) | header `Already in the list`; rows disabled |
 | Picker no match | `No model matches.` · inline action `Add "{{query}}" as a custom model…` |
 | Picker footer, left | `Add custom model…` |
 | Picker confirm | `Add {{count}} models`; disabled `Add models` when nothing is selected |
@@ -313,6 +344,9 @@ No string explains mechanism.
   menu was saved is present in the menu on the next read unless it was removed before, and
   a previously removed id never returns on its own.
 - The picker lists each candidate id exactly once across all groups.
+- A field the user cleared before the first Save is empty after Save.
+- Loading a v1 catalog shows exactly the same menu before and after the first load, and a
+  built-in the user removed under v1 does not return on its own.
 - In the editor, a models.dev suggestion fills every metadata field it knows and leaves each
   one editable; an id models.dev does not know can still be entered and saved.
 

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -206,15 +206,14 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
    everything with one `PUT`. Whatever the origin, adding a row runs the same one-time
    matching for its initial route (C1); an id no provider supplies simply starts with an
    empty route and the row shows `No model route configured`.
-8. **A removed built-in must be recoverable.** Removing a built-in row hides it rather than
-   forgetting it: the backend catalog records the hidden built-in id, the row leaves the
-   menu and its route follows the removal rule (C3), and the id reappears in the
-   `Codex built-in` group of the picker. Picking it again clears the hidden mark. Removing
-   any other row deletes it; a provider model reappears in `From your providers`, and a
-   custom model is defined again through `Add custom model…`.
+8. **A removed built-in must be recoverable, and nothing removed comes back by itself.**
+   Removing any row records its id as removed (C6); the row leaves the menu and its route
+   follows the removal rule (C3). A removed built-in reappears in the `Codex built-in` group
+   of the picker, a removed provider model in `From your providers`, and picking either again
+   clears the mark; a removed custom model is re-created through `Add custom model…`.
 9. **New built-ins join the menu by themselves; removed ones stay removed.** When the
    backend's built-in list gains a model (a Codex update, a refreshed remote catalog), the
-   product adds it to the menu unless its id carries the hidden mark, inserting it where the
+   product adds it to the menu unless its id is in the removed set (C6), inserting it where the
    built-in list orders it among the built-ins still present (after the last one when none
    follows; at the end when none remains) and seeding its route by C1. Nothing is ever
    removed automatically: a built-in the backend withdraws stays in the menu because a
@@ -230,7 +229,8 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
 - **C1 — Menu-model add runs matching once.** `PUT /api/models/agents/<backend>/models` keeps
   its existing optimistic three-way merge: the caller's additions are `desired − baseline`,
   merged onto the latest stored list, so a concurrent removal of an unrelated row survives.
-  Each addition is a one-time matching point: the server runs the existing `matching-v1`
+  Each addition that is still absent from the latest stored list at commit time is a one-time
+  matching point (an id another caller added meanwhile keeps its existing route untouched): the server runs the existing `matching-v1`
   (including its Claude alias rule) for that menu model against the Sources present in that
   backend's Source order that are configuration-eligible, over each Source's complete
   non-retired inventory — discovered and manual alike (`model-hub.md` §4.2's
@@ -238,7 +238,12 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
   writes the accepted hops with `placement-v1`. §4.2 and §4.6 are amended so that "catalog
   change never repeats matching" reads "a menu-model add matches once at that write; refresh,
   restart, health, and turns still never re-match". An id no ordered Source supplies starts
-  with an empty route. The success response is the existing `{agent: AgentSupply}`.
+  with an empty route. The picker echoes what it showed: `PUT` accepts
+  `expected_suppliers?: {<id>: [{source_id, model_id}]}` for caller-added ids, and when the
+  server's matching result differs for any listed id it commits nothing and refuses with
+  `409 candidate_suppliers_changed` carrying the current projection for those ids; the picker
+  refreshes its candidates and asks again. The success response is the existing
+  `{agent: AgentSupply}`.
 - **C2 — Proposed values travel in the candidates read; the save is literal.** The server
   proposes `display_name` and `reasoning_efforts` for every candidate (C4): for a built-in
   from the built-in snapshot, for a provider model from its suppliers (display name from the
@@ -264,28 +269,33 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
   response guard exercises it. The v1 hard refusal is retired.
 - **C4 — The server serves the picker's candidates; the client only renders.** One read,
   `GET /api/models/agents/<backend>/models/candidates`, returns
-  `{candidates: {builtin: Candidate[], providers: Candidate[]}}` where `Candidate` is
+  `{candidates: {builtin: Candidate[], providers: Candidate[], in_list: Candidate[]}}` where `Candidate` is
   `{id, display_name, reasoning_efforts, suppliers: [{source_id, source_name, model_id}],
   origin}`. `builtin` is the merged remote + bundled + local-CLI snapshot for the backend
   (served regardless of Gateway/Direct mode; empty for OpenCode) minus menu ids, hidden ones
   included; `providers` is the deduplicated (question 1) inventory of the backend's ordered,
-  configuration-eligible Sources minus menu ids and minus ids already in `builtin`.
+  configuration-eligible Sources minus menu ids and minus ids already in `builtin`; `in_list`
+  is every current menu row with the same projection, so an already-added model is found by
+  its supplier's name too and its disabled row shows authoritative chips.
   `suppliers` is the server's own `matching-v1` projection for that id — so a Claude alias hop
   appears here exactly as C1 would seed it — in Source order, possibly empty. No client
   re-implements matching, aliasing, eligibility, or snapshot merging. The picker filters both
-  groups by the query on id, display name, and supplier name, and builds `Already in the list`
-  from the catalog it already holds.
-- **C6 — Hidden built-ins and built-in reconcile.** The backend catalog persists
-  `agents.<backend>.hidden_builtin_ids: string[]`. Removing a row whose persisted `origin` is
-  `builtin` marks its id hidden — provenance, not current-snapshot membership, so a built-in
-  the backend has temporarily withdrawn is marked too; adding an id that is hidden clears the
-  mark. Legacy initialization: a persisted catalog without the field is initialized once, at
-  load, to `built-in snapshot ids − menu ids` and persisted, so an upgrade from v1 changes
-  nothing the user sees; reconcile runs only once the field exists. On every built-in snapshot
-  change (startup, remote catalog refresh, CLI cache change) the service adds each snapshot id
-  that is neither in the menu nor hidden, at the position question 9 defines, seeds it per C1
-  and C2, and invalidates the backend's runtime projection. It never removes a row. Claude
-  Code's locked `default` row is not a built-in candidate and cannot be hidden.
+  arrays by the query on id, display name, and supplier name, rendering `in_list` matches as
+  the disabled `Already in the list` group.
+- **C6 — Removed ids never return on their own.** The backend catalog persists
+  `agents.<backend>.removed_model_ids: string[]`. Every row the user removes leaves its id in
+  the set, whatever the row's origin was and whether or not the backend lists the id right now;
+  adding a row with that id by any path clears it. Reconcile — on startup, remote catalog
+  refresh, or CLI cache change — adds each built-in snapshot id that is neither in the menu nor
+  in the set, at the position question 9 defines, seeds it per C1 and C2, and invalidates the
+  backend's runtime projection; it never removes a row. The picker's `builtin` group lists
+  removed built-ins so they are one click away. Legacy initialization: a persisted catalog
+  without the field is initialized once, at load, to `built-in snapshot ids − menu ids` and
+  persisted. This is deliberately conservative: a v1 upgrade changes nothing the user sees, and
+  the price is that a built-in that entered the snapshot between the v1 save and the first v2
+  load is treated as removed — recoverable from the picker, not auto-added. Reconcile runs only
+  once the field exists. Claude Code's locked `default` row is not a built-in candidate and
+  cannot be removed.
 - **C7 — models.dev read serves the editor typeahead, additively.** The existing
   `GET /api/models/catalog/models-dev?query=` keeps its shipped shape — `matches`, `provider_id`,
   `provider_name`, and the metadata fields — and gains: deduplication by model id, ranking
@@ -341,13 +351,16 @@ No string explains mechanism.
   reveals a seventh-plus row (the #1829 behaviour is retained).
 - Direct mode still hides the editor and preserves the catalog unchanged.
 - Removing a built-in row and reopening the picker shows that id under the built-in group;
-  picking it restores the row. A built-in id that appears in the backend snapshot after the
-  menu was saved is present in the menu on the next read unless it was removed before, and
-  a previously removed id never returns on its own.
+  picking it restores the row. A built-in id that enters the backend snapshot after the menu
+  was saved is present in the menu on the next read unless a row with that id was removed
+  before — and an id the user removed never returns on its own, whatever the removed row's
+  origin was.
 - The picker lists each candidate id exactly once across all groups.
 - A field the user cleared before the first Save is empty after Save.
 - Every supplier chip the picker shows for a candidate equals the hop set C1 seeds when that
-  candidate is added (the server projects both from the same rule).
+  candidate is added (the server projects both from the same rule), or the add is refused and
+  re-asked with the current chips.
+- Two callers adding the same id concurrently leave exactly one row and one route, matched once.
 - A built-in removed while the backend had withdrawn it does not return when the backend
   lists it again.
 - Loading a v1 catalog shows exactly the same menu before and after the first load, and a

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -173,34 +173,28 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
    2. **`From your providers`** — every configuration-eligible, non-retired Source model
       not already in the menu, deduplicated by the identity rule in question 1, with its
       supplying providers as read-only chips in Source order.
-   3. **`models.dev`** — a browsable catalogue, never a blank box. With an empty query the
-      group shows one row of vendor chips (`Anthropic` `OpenAI` `Google` `DeepSeek` `Zhipu`
-      `Moonshot` `Qwen` `xAI` `Mistral` … `More`); choosing a vendor lists that vendor's
-      models as ordinary rows (the chip stays selected; choosing it again clears). With a
-      query the group lists matching models ranked first-party first (the vendor that makes
-      the model), then exact-id, then name matches. One row per model: when several
-      models.dev providers list the same model, only the first-party entry is shown and the
-      aggregator copies are collapsed, because for Claude Code and Codex the menu id is the
-      bare model id either way, and for OpenCode the id is `vendor/model` with the
-      first-party vendor. A row shows the display name, the mono id, and the vendor as muted
-      text (omitted when a vendor chip already filters the list); it never shows a chip.
-   4. **`Add "{{query}}" by ID`** — not a group and not an input box: one fallback row that
-      appears at the end of the list only while a query is typed, offering the typed text as
-      a model id. Its checkbox joins the selection like any row; it is disabled when the text
-      is not a valid id for the backend. With an empty query there is nothing to add by id,
-      so the row is absent.
+   3. **`Add custom model…`** — the picker's footer-left action (and, when a query matches
+      nothing, an inline `Add "{{query}}" as a custom model…` under `No model matches.`). It
+      opens the existing model editor for a model neither the backend nor your providers
+      list. models.dev lives here, as the lookup that helps fill the form: the editor's
+      first field, `Model`, is a typeahead (`Search models.dev or enter a model ID`) whose
+      suggestions are models.dev matches ranked first-party vendor first, deduplicated by
+      model (aggregator copies collapsed), each showing name, mono id, vendor, and context;
+      choosing one fills id, display name, context, output, modalities, tools, reasoning,
+      and efforts, all still editable; the last suggestion is always `Use "{{query}}" as the
+      model ID` for an id models.dev does not know. The old `Fill from models.dev` button is
+      retired — the typeahead is the same capability, offered before typing instead of after.
+      For OpenCode the filled id is `vendor/model` with the first-party vendor.
    Rules that hold across all groups: a provider chip on any row — built-in included — means
    exactly "one of your providers supplies this id", in Source order, and nothing else ever
-   renders as a chip; models.dev vendor chips are the one exception and live only in the
-   models.dev group's browse row, where they are filters, not suppliers. With an empty query
-   the list shows only what can be added; with a query, models already in the list also
-   appear in their group as disabled rows tagged `In list`, so a search never dead-ends on
-   something that exists. The models.dev group shows a loading state while a query is in
-   flight and `models.dev unavailable` when the catalogue cannot be reached; it is omitted
-   when a query matches nothing there.
-   Checked rows — including a checked `Add "{{query}}" by ID` row — commit together through the footer (`{{count}} selected`
-   · `Add {{count}} models`; with nothing selected the primary button reads `Add models`
-   and is disabled, so the footer never moves) into the catalog draft; the list's single `Save` still writes
+   renders as a chip. With an empty query the list shows only what can be added; with a
+   query, models already in the list also appear in their group as disabled rows tagged
+   `In list`, so a search never dead-ends on something that exists. The editor's typeahead
+   shows a loading state while a lookup is in flight and `models.dev unavailable` when the
+   catalogue cannot be reached; typing an id by hand always still works.
+   Checked rows commit together through the footer primary (`Add {{count}} models`; with
+   nothing selected it reads `Add models` and is disabled, so the footer never moves) into the
+   catalog draft; a custom model returns from the editor into the same draft; the list's single `Save` still writes
    everything with one `PUT`. Whatever the origin, adding a row runs the same one-time
    matching for its initial route (C1); an id no provider supplies simply starts with an
    empty route and the row shows `No model route configured`.
@@ -264,14 +258,12 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
   id that is neither in the menu nor hidden, at the position question 9 defines, running C1
   and C2 for it, and invalidates the backend's runtime projection. It never removes a row.
   Claude Code's locked `default` row is not a built-in candidate and cannot be hidden.
-- **C7 — models.dev read serves browse and ranked search.** `GET /api/models/catalog/models-dev`
-  gains `vendor=<provider_id>` beside `query=`, and returns `{vendors: [{id, name, model_count}],
-  models: [...]}`. `models` is deduplicated by model id, ranked first-party vendor first, then
+- **C7 — models.dev read serves the editor typeahead.** `GET /api/models/catalog/models-dev?query=`
+  returns `{models: [...]}` deduplicated by model id and ranked first-party vendor first, then
   exact-id, then name matches; each item carries `vendor_id`, `vendor_name`, `first_party:
-  boolean`, and the existing metadata fields. With neither parameter the response carries only
-  `vendors`, first-party vendors ordered by model count. First-party means the provider that
-  makes the model; aggregator providers (openrouter, together, fireworks, groq, deepinfra, …)
-  never win the ranking when a first-party entry exists.
+  boolean`, and the existing metadata fields. First-party means the provider that makes the
+  model; aggregator providers (openrouter, together, fireworks, groq, deepinfra, …) never win
+  the ranking when a first-party entry exists. Results are capped at 8 for the typeahead.
 - **C5 — Unchanged.** Source inventories, Source-side manual add, Route dialog, Source
   order, direct/gateway modes, and every runtime projection are byte-for-byte unchanged
   except through C1–C3.
@@ -282,20 +274,21 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
 | --- | --- |
 | Catalog dialog add action (the only one) | `Add models` |
 | Picker title | `Add {{backend}} models` |
-| Picker search placeholder | `Search models or vendors` |
-| Group headers | `{{backend}} built-in` · `From your providers` · `models.dev` |
-| models.dev browse row | vendor chips by display name, then `More` |
-| models.dev group, empty query | `Type to search models.dev` |
-| Fallback row (query only) | `Add "{{query}}" by ID` |
-| Group with nothing to offer | the group is omitted, never an empty header |
-| Picker footer count | `{{count}} selected` |
-| Picker confirm | `Add {{count}} models`; disabled `Add models` when nothing is selected |
+| Picker search placeholder | `Search models or providers` |
+| Group headers | `{{backend}} built-in` · `From your providers` |
 | Already-in-list row (search only) | `In list` |
-| models.dev group states | vendor chips (empty query) · loading · `models.dev unavailable` |
+| Picker no match | `No model matches.` · inline action `Add "{{query}}" as a custom model…` |
+| Picker footer, left | `Add custom model…` |
+| Picker confirm | `Add {{count}} models`; disabled `Add models` when nothing is selected |
+| Editor first field | label `Model` · placeholder `Search models.dev or enter a model ID` |
+| Editor typeahead item | `{{name}}` · `{{id}}` · `{{vendor}}` · `{{context}}` |
+| Editor typeahead last item | `Use "{{query}}" as the model ID` |
+| Editor typeahead states | loading · `models.dev unavailable` |
 | Remove with route | `Also removes its route: {{hops}}` · button `Remove` |
 
 Every other existing string in `settings.models.gateway.catalog.*` and
-`settings.models.gateway.modelEditor.*` stays. No string explains mechanism.
+`settings.models.gateway.modelEditor.*` stays, except `Fill from models.dev`, which is removed.
+No string explains mechanism.
 
 ### Acceptance (properties, not enumerations)
 
@@ -318,6 +311,8 @@ Every other existing string in `settings.models.gateway.catalog.*` and
   menu was saved is present in the menu on the next read unless it was removed before, and
   a previously removed id never returns on its own.
 - The picker lists each candidate id exactly once across all groups.
+- In the editor, a models.dev suggestion fills every metadata field it knows and leaves each
+  one editable; an id models.dev does not know can still be entered and saved.
 
 ### Delivery notes
 

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -179,8 +179,20 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
    4. **`By ID`** — one input row (`Model ID` · `Add`). When the query matches nothing in
       any group, the row reads `Add "{{query}}" by ID`. A By-ID entry joins the selection
       like any checked row.
+   Rules that hold across all groups: a provider chip on any row — built-in included — means
+   exactly "one of your providers supplies this id", in Source order, and nothing else ever
+   renders as a chip; a models.dev row shows its models.dev identity as the mono id
+   (`google/gemini-2.5-pro`) and no chip. With an empty query the list shows only what can
+   be added; with a query, models already in the list also appear in their group as
+   disabled rows tagged `In list`, so a search never dead-ends on something that exists.
+   The By-ID row always offers the current query and its `Add` is enabled only when that
+   text is a valid id for the backend. The models.dev group shows `Type to search
+   models.dev` on an empty query, a loading state while a query is in flight, and
+   `models.dev unavailable` when the catalog cannot be reached; it is omitted when a query
+   matches nothing there.
    Checked rows and By-ID entries commit together through the footer (`{{count}} selected`
-   · `Add {{count}} models`) into the catalog draft; the list's single `Save` still writes
+   · `Add {{count}} models`; with nothing selected the primary button reads `Add models`
+   and is disabled, so the footer never moves) into the catalog draft; the list's single `Save` still writes
    everything with one `PUT`. Whatever the origin, adding a row runs the same one-time
    matching for its initial route (C1); an id no provider supplies simply starts with an
    empty route and the row shows `No model route configured`.
@@ -260,7 +272,9 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
 | By-ID row | input placeholder `Model ID` · button `Add`; with an unmatched query the row reads `Add "{{query}}" by ID` |
 | Group with nothing to offer | the group is omitted, never an empty header |
 | Picker footer count | `{{count}} selected` |
-| Picker confirm | `Add {{count}} models` |
+| Picker confirm | `Add {{count}} models`; disabled `Add models` when nothing is selected |
+| Already-in-list row (search only) | `In list` |
+| models.dev group states | `Type to search models.dev` · loading · `models.dev unavailable` |
 | Remove with route | `Also removes its route: {{hops}}` · button `Remove` |
 
 Every other existing string in `settings.models.gateway.catalog.*` and

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -310,7 +310,12 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
   `removed_model_ids` is set to its current contents ∪ (`built-in snapshot ids − menu ids`).
   Removals made while the marker is false are recorded in `removed_model_ids` immediately, like
   any other removal, and survive initialization. Until the marker is true the menu is served
-  unchanged, so a partial snapshot can never be mistaken for the user's removals. Load and
+  unchanged, so a partial snapshot can never be mistaken for the user's removals. A catalog
+  created fresh under v2 is written with the marker already true and an empty removed set, so
+  the pending window exists only for files that predate the marker; a fresh-install fixture is
+  distinct from the v1 migration fixtures. Both fields are persisted configuration only: the
+  `AgentSupply` wire projection omits them (`agent-supply.schema.json` stays closed) and the
+  response guard covers that omission. Load and
   mutation fixtures cover the v1 file, the pending window, and the initialized state. This is deliberately conservative: a v1 upgrade changes nothing the user sees, and
   the price is that a built-in that entered the snapshot between the v1 save and the first v2
   load is treated as removed — recoverable from the picker, not auto-added. Claude Code's locked `default` row is not a built-in candidate and
@@ -352,7 +357,8 @@ the v2 shapes on the same head.
 | `vibe/i18n/*.json` and `ui/src/components/settings/models/serverCopy.ts` | `detail` keys for the two new error codes |
 | `config/v2_config.py` persisted shape | `agents.<backend>.removed_model_ids` and `agents.<backend>.builtin_baseline_initialized` (C6), with load and mutation fixtures for the v1 file, the pending window, and the initialized state |
 | `vibe/data/model_vendors.json` (new, versioned) | the vendor map and aggregator order C7 defines, covered by a test |
-| `docs/plans/model-hub.md` §4.2 / §4.6 | matching-point wording (C1); removed-id and reconcile rules (C6) |
+| `docs/plans/model-hub.md` §4.2 / §4.6 and its **Guard error-plan relation** table (authoritative per `mirror-registry.json` D18) | matching-point wording (C1); removed-id, marker, and reconcile rules (C6); a new relation row for `backend_model_in_route` requiring a nonempty `would_remove_hops` plan |
+| `config/v2_config.py` → `AgentSupply` projection (`_agent_payload` / `to_payload` split) and the response guard | `removed_model_ids` and `builtin_baseline_initialized` are persisted only and never appear in any `AgentSupply` response |
 
 ### Copy (English source; `zh.json` mirrors 1:1)
 

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -1,6 +1,6 @@
 # Backend Model Catalogs
 
-Status: implementation contract
+Status: implementation contract — v1 shipped in #1814; **v2 (compose from providers) below is the current definition of done, pending owner approval 2026-09-03**
 
 ## Outcome
 
@@ -90,3 +90,156 @@ menu, so showing this editor there would falsely imply that these rows change Di
   user separately edits them.
 - Direct mode preserves the catalog unchanged; switching back to Gateway restores the
   same editable list.
+
+---
+
+## v2 — Compose from providers (2026-09-03)
+
+### Why v1 is wrong as a product
+
+v1 shipped `Manage models` as a hand-typed record editor: the user types a backend model
+id, optionally asks models.dev to fill metadata, saves, then opens the Route dialog and
+picks the same upstream model again. The product already owns that fact twice — every
+Source lists the models it supplies, and Add Source already matches those models into
+routes once — so the flow re-enters data the product holds and hides the relationship
+between providers, backend menus, and routes. The asymmetry is in `model-hub.md` §4.6:
+matching runs when a Source is added but never when a menu model is added, so a model
+added after its provider can only be routed by hand.
+
+### Outcome
+
+A backend's model menu is composed primarily by **selecting models that providers already
+supply**. Typing a model id by hand remains available as the fallback for a model no
+provider lists. Selecting a model creates one menu entry and its initial route — every
+provider that supplies that id, in the backend's Source order — so the user immediately
+sees what the Agent menu will show and where requests will go. Routes remain a separate
+surface and are never edited inside the picker.
+
+Worked example. Codex is in Gateway mode with two API-key Sources, `aihub` (24 models,
+including `deepseek-v3.2`) and `openrouter` (also `deepseek-v3.2`), `aihub` first in
+Codex's Source order. `Manage models` → `Add from providers` → type `deepseek` → the row
+`deepseek-v3.2 · aihub, openrouter` → check → `Add 1 model`. Result: Codex's menu gains
+`deepseek-v3.2` with display name and reasoning efforts taken from the supplying Source
+models and context/output/modalities filled from models.dev when one exact match exists;
+its route is `aihub → deepseek-v3.2`, `openrouter → deepseek-v3.2`; the Codex card row
+reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
+
+### One product model — the seven questions
+
+1. **Candidate identity when several providers supply the same model.** For Claude Code
+   and Codex a candidate is one distinct upstream model id across all
+   configuration-eligible, non-retired Source models — that id is exactly what the menu
+   id will be. The row lists its supplying providers in Source order. For OpenCode a
+   candidate is the existing OpenCode identifier `vendor/model` (§4.8), so two Sources
+   with the same standard vendor collapse into one candidate and two vendors offering the
+   same bare model stay two candidates, as OpenCode itself would show them.
+2. **Membership key and metadata owner.** Unchanged: membership is keyed by backend
+   model id per backend, and the `BackendModel` row owns display name, capabilities,
+   context, output, and reasoning efforts. Selection seeds those fields — display name
+   and reasoning efforts from the supplying Source model(s), the rest from models.dev —
+   and every field stays editable afterwards.
+3. **One selection → one menu entry → one route with N hops**, one hop per supplying
+   Source in Source order, written by the existing `placement-v1` rule. The picker never
+   edits an existing route; the Route dialog remains the only place that adds, removes,
+   reorders, or cross-maps hops.
+4. **models.dev** proposes, never rules. At add time the server fills empty metadata only
+   when exactly one exact match exists (`provider/model` or model-id equality) and records
+   `models_dev_id`. The editor's existing `Fill from models.dev` re-proposes on demand.
+   No refresh ever overwrites a field the user has set; a proposal is reversible by
+   editing the field.
+5. **A supplying model disappears, is retired, or its Source is disabled or deleted.**
+   Routes are configuration and are not rewritten by health (existing rule). The menu
+   entry stays; its row shows the existing states (`Supply paused`, `No model route
+   configured`). Source deletion removes hops through the existing guard. The picker shows
+   such an entry as already added and never removes anything on its own.
+6. **Claude locked/default and backend id constraints.** Claude Code's `default` row stays
+   locked at position 0. Claude candidates are only upstream ids Claude accepts as menu ids
+   (bundled builtins or `claude-` / `anthropic-`); any other upstream model reaches Claude
+   Code only as an explicit mapped hop under a Claude-named menu model, configured in the
+   Route dialog, where the mapping is visible on the row. Codex accepts any canonical id.
+   OpenCode requires `vendor/model`, which the picker produces; the manual editor keeps
+   its existing validation.
+7. **Interaction without route controls.** `Manage models` keeps the list with edit,
+   reorder, and remove. Its primary action becomes `Add from providers`, which opens the
+   picker: search over model id, display name, and provider name; one row per candidate
+   with a checkbox; already-added models shown checked and disabled; footer `Add N
+   models`. `Add manually` is the secondary action and opens the existing editor. Duplicate
+   prevention is by id. Removing an entry removes its route too: with a non-empty route the
+   dialog first shows the hops that go with it and asks once (existing guard shape
+   `would_remove_hops`); with an empty route removal is immediate. An empty catalog offers
+   `Add from providers` when any eligible provider has inventory and otherwise says no
+   provider supplies this backend yet and offers `Add manually`.
+
+### Contract deltas (normative once approved; lanes cite these by number)
+
+- **C1 — Menu-model add runs matching once.** `PUT /api/models/agents/<backend>/models`
+  treats every row added relative to the latest stored list as a one-time matching point:
+  the server runs `matching-v1` for that menu model against configuration-eligible Sources
+  and writes the accepted hops with `placement-v1`. `model-hub.md` §4.2 and §4.6 are
+  amended so that "catalog change never repeats matching" reads "a menu-model add matches
+  once at that write; refresh, restart, health, and turns still never re-match". Manual
+  adds of an id no Source lists therefore still start with an empty route.
+- **C2 — Metadata seeding.** For each added row the server fills `display_name` and
+  `reasoning_efforts` from the matched Source model(s) when the client sent them empty
+  (union of efforts across matched Sources, Source order), then fills remaining empty
+  metadata from models.dev only when exactly one exact match exists, recording
+  `models_dev_id` and `origin: "models_dev"`. A models.dev cache miss is silent; the row is
+  still written.
+- **C3 — Removal cascades through the guard.** Removing a row whose route has hops returns
+  the guarded `409 backend_model_in_route` with `would_remove_hops`; a `force: true` retry
+  echoing that plan removes the row and its route in one transaction. The hard refusal in
+  v1 is retired. Removing a row with an empty route needs no confirmation.
+- **C4 — Candidates are derived, not served.** The picker derives candidates from
+  `GET /api/models/sources` and `AgentSupply.sources` eligibility already loaded on the
+  page (the same derivation the Route dialog's candidate popover uses), deduplicated by
+  the identity rule in question 1 and minus ids already in the catalog. No new read
+  endpoint.
+- **C5 — Unchanged.** Source inventories, Source-side manual add, Route dialog, Source
+  order, direct/gateway modes, and every runtime projection are byte-for-byte unchanged
+  except through C1–C3.
+
+### Copy (English source; `zh.json` mirrors 1:1)
+
+| Where | String |
+| --- | --- |
+| Catalog dialog primary action | `Add from providers` |
+| Catalog dialog secondary action | `Add manually` |
+| Picker title | `Add {{backend}} models` |
+| Picker search placeholder | `Search models or providers` |
+| Picker columns | `Model` · `Providers` |
+| Already-added row state | `Added` |
+| Picker footer count | `{{count}} selected` |
+| Picker confirm | `Add {{count}} models` |
+| Picker empty (no eligible inventory) | `No provider supplies models for {{backend}} yet.` |
+| Picker no match | `No model matches.` |
+| Remove with route | `Also removes its route: {{hops}}` · button `Remove` |
+
+Every other existing string in `settings.models.gateway.catalog.*` and
+`settings.models.gateway.modelEditor.*` stays. No string explains mechanism.
+
+### Acceptance (properties, not enumerations)
+
+- Every menu entry created through the picker has a route whose hops are exactly the
+  Sources supplying that id at add time, in that backend's Source order.
+- The picker offers exactly the configuration-eligible, non-retired Source models for the
+  backend that are not already in its catalog, deduplicated by the identity rule, and a
+  search matches on id, display name, or provider name.
+- A manual add of an id no Source lists still succeeds and leaves an empty route.
+- Removing an entry with hops requires the guarded confirmation and removes both; without
+  hops it is immediate.
+- Source inventories, unrelated routes, and Source order are byte-identical before and
+  after any catalog mutation.
+- After a picker add, the real backend selector shows the new id after runtime refresh
+  (Codex `codex debug models`, OpenCode overlay, Claude discovery), and the Codex card
+  reveals a seventh-plus row (the #1829 behaviour is retained).
+- Direct mode still hides the editor and preserves the catalog unchanged.
+
+### Delivery notes
+
+- PR #1829 (`fix(model-hub): reveal newly saved models`) stays valid independently of
+  this redesign: the picker saves through the same `PUT` and the card still collapses at
+  six rows. Decision: **keep and merge on its own gates**; the v2 UI lane bases on master
+  after it lands.
+- Design PR avibe-docs #34 carries the earlier "Batch Add / Agent Model Picker" proposal
+  frames; v2 frames are drawn on that branch with sparse copy and the proposal frames are
+  renamed `Superseded —` rather than deleted.

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -97,8 +97,10 @@ menu, so showing this editor there would falsely imply that these rows change Di
 
 ### Why v1 is wrong as a product
 
-Revision 2026-09-03 (owner review): one add action with four origins, recoverable built-ins,
-and automatic arrival of new built-ins replace the earlier two-button proposal.
+Revision 2026-09-03 (owner review, approved): one `Add models` action that selects what already
+exists (the backend's built-in list, your providers' inventories) and hands everything else to a
+custom-model editor where models.dev is the lookup; built-ins are recoverable after removal and
+new built-ins arrive by themselves.
 
 v1 shipped `Manage models` as a hand-typed record editor: the user types a backend model
 id, optionally asks models.dev to fill metadata, saves, then opens the Route dialog and
@@ -111,9 +113,9 @@ added after its provider can only be routed by hand.
 
 ### Outcome
 
-A backend's model menu is composed primarily by **selecting models that providers already
-supply**. Typing a model id by hand remains available as the fallback for a model no
-provider lists. Selecting a model creates one menu entry and its initial route — every
+A backend's model menu is composed primarily by **selecting models that already exist** — the
+backend's own built-in list and the models your providers supply. A custom model, looked up
+on models.dev or typed by hand in the editor, remains the fallback for anything neither lists. Selecting a model creates one menu entry and its initial route — every
 provider that supplies that id, in the backend's Source order — so the user immediately
 sees what the Agent menu will show and where requests will go. Routes remain a separate
 surface and are never edited inside the picker.
@@ -147,9 +149,9 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
    reorders, or cross-maps hops.
 4. **models.dev** proposes, never rules. At add time the server fills empty metadata only
    when exactly one exact match exists (`provider/model` or model-id equality) and records
-   `models_dev_id`. The editor's existing `Fill from models.dev` re-proposes on demand.
-   No refresh ever overwrites a field the user has set; a proposal is reversible by
-   editing the field.
+   `models_dev_id`. In the editor the `Model` typeahead proposes models.dev matches while the
+   user types and fills the form on selection. No refresh ever overwrites a field the user
+   has set; a proposal is reversible by editing the field.
 5. **A supplying model disappears, is retired, or its Source is disabled or deleted.**
    Routes are configuration and are not rewritten by health (existing rule). The menu
    entry stays; its row shows the existing states (`Supply paused`, `No model route
@@ -162,10 +164,10 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
    Route dialog, where the mapping is visible on the row. Codex accepts any canonical id.
    OpenCode requires `vendor/model`, which the picker produces; the manual editor keeps
    its existing validation.
-7. **One `Add models` action, four origins, one list.** `Manage models` keeps the list with
-   edit, reorder, and remove, and has exactly one add action, `Add models`. It opens a picker
-   whose body is one grouped list filtered by one search box; a candidate id appears in
-   exactly one group, the first that knows it:
+7. **One `Add models` action: select what exists, define the rest.** `Manage models` keeps the
+   list with edit, reorder, and remove, and has exactly one add action, `Add models`. It opens
+   a picker whose body is one grouped list filtered by one search box; a candidate id appears
+   in exactly one group, the first that knows it:
    1. **`Codex built-in`** (`Claude Code built-in`) — the backend's own model list
       (bundled + remote backend catalog + the local CLI cache the product already merges)
       minus what is already in the menu. This is where a removed built-in is found again.
@@ -202,8 +204,8 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
    forgetting it: the backend catalog records the hidden built-in id, the row leaves the
    menu and its route follows the removal rule (C3), and the id reappears in the
    `Codex built-in` group of the picker. Picking it again clears the hidden mark. Removing
-   any other row deletes it; a provider model reappears in `From your providers`, a
-   models.dev or By-ID model is found again through search.
+   any other row deletes it; a provider model reappears in `From your providers`, and a
+   custom model is defined again through `Add custom model…`.
 9. **New built-ins join the menu by themselves; removed ones stay removed.** When the
    backend's built-in list gains a model (a Codex update, a refreshed remote catalog), the
    product adds it to the menu unless its id carries the hidden mark, inserting it where the
@@ -248,7 +250,7 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
   merged remote + bundled + local-CLI snapshot every model picker uses) minus menu ids and
   including hidden built-ins; the provider group from `GET /api/models/sources` and
   `AgentSupply.sources` eligibility (the Route dialog's candidate derivation, promoted to a
-  shared helper); the models.dev group from `GET /api/models/catalog/models-dev?query=`.
+  shared helper); the editor typeahead from `GET /api/models/catalog/models-dev?query=` (C7).
   No new read endpoint.
 - **C6 — Hidden built-ins and built-in reconcile.** The backend catalog persists the set of
   hidden built-in ids (`agents.<backend>.hidden_builtin_ids: string[]`, absent on older
@@ -316,10 +318,9 @@ No string explains mechanism.
 
 ### Delivery notes
 
-- PR #1829 (`fix(model-hub): reveal newly saved models`) stays valid independently of
-  this redesign: the picker saves through the same `PUT` and the card still collapses at
-  six rows. Decision: **keep and merge on its own gates**; the v2 UI lane bases on master
-  after it lands.
+- PR #1829 (`fix(model-hub): reveal newly saved models`) stayed valid independently of this
+  redesign — the picker saves through the same `PUT` and the card still collapses at six
+  rows — and was merged on its own gates (`aa6d4d99e`). The v2 lanes base on master after it.
 - Design PR avibe-docs #34 carries the earlier "Batch Add / Agent Model Picker" proposal
   frames; v2 frames are drawn on that branch with sparse copy and the proposal frames are
   renamed `Superseded —` rather than deleted.

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -283,7 +283,9 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
   origin}`. `builtin` is the merged remote + bundled + local-CLI snapshot for the backend
   (served regardless of Gateway/Direct mode; empty for OpenCode) minus menu ids, removed ones
   included; `providers` is the deduplicated (question 1) inventory of the backend's ordered,
-  configuration-eligible Sources minus menu ids and minus ids already in `builtin`; `in_list`
+  configuration-eligible Sources minus menu ids and minus ids already in `builtin`, and minus
+  any id the backend's admission rule would reject (length, canonical form, Claude prefix,
+  OpenCode `vendor/model`) — a candidate is by definition addable; `in_list`
   is every current menu row with the same projection, so an already-added model is found by
   its supplier's name too and its disabled row shows authoritative chips.
   `suppliers` is the server's own `matching-v1` projection for that id — so a Claude alias hop
@@ -311,8 +313,7 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
   unchanged, so a partial snapshot can never be mistaken for the user's removals. Load and
   mutation fixtures cover the v1 file, the pending window, and the initialized state. This is deliberately conservative: a v1 upgrade changes nothing the user sees, and
   the price is that a built-in that entered the snapshot between the v1 save and the first v2
-  load is treated as removed — recoverable from the picker, not auto-added. Reconcile runs only
-  once the field exists. Claude Code's locked `default` row is not a built-in candidate and
+  load is treated as removed — recoverable from the picker, not auto-added. Claude Code's locked `default` row is not a built-in candidate and
   cannot be removed.
 - **C7 — models.dev read serves the editor typeahead, additively.** The existing
   `GET /api/models/catalog/models-dev?query=` keeps its shipped shape — `matches`, `provider_id`,

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -97,6 +97,9 @@ menu, so showing this editor there would falsely imply that these rows change Di
 
 ### Why v1 is wrong as a product
 
+Revision 2026-09-03 (owner review): one add action with four origins, recoverable built-ins,
+and automatic arrival of new built-ins replace the earlier two-button proposal.
+
 v1 shipped `Manage models` as a hand-typed record editor: the user types a backend model
 id, optionally asks models.dev to fill metadata, saves, then opens the Route dialog and
 picks the same upstream model again. The product already owns that fact twice — every
@@ -117,7 +120,7 @@ surface and are never edited inside the picker.
 
 Worked example. Codex is in Gateway mode with two API-key Sources, `aihub` (24 models,
 including `deepseek-v3.2`) and `openrouter` (also `deepseek-v3.2`), `aihub` first in
-Codex's Source order. `Manage models` → `Add from providers` → type `deepseek` → the row
+Codex's Source order. `Manage models` → `Add models` → type `deepseek` → under `From your providers` the row
 `deepseek-v3.2 · aihub, openrouter` → check → `Add 1 model`. Result: Codex's menu gains
 `deepseek-v3.2` with display name and reasoning efforts taken from the supplying Source
 models and context/output/modalities filled from models.dev when one exact match exists;
@@ -159,16 +162,42 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
    Route dialog, where the mapping is visible on the row. Codex accepts any canonical id.
    OpenCode requires `vendor/model`, which the picker produces; the manual editor keeps
    its existing validation.
-7. **Interaction without route controls.** `Manage models` keeps the list with edit,
-   reorder, and remove. Its primary action becomes `Add from providers`, which opens the
-   picker: search over model id, display name, and provider name; one row per candidate
-   with a checkbox; already-added models shown checked and disabled; footer `Add N
-   models`. `Add manually` is the secondary action and opens the existing editor. Duplicate
-   prevention is by id. Removing an entry removes its route too: with a non-empty route the
-   dialog first shows the hops that go with it and asks once (existing guard shape
-   `would_remove_hops`); with an empty route removal is immediate. An empty catalog offers
-   `Add from providers` when any eligible provider has inventory and otherwise says no
-   provider supplies this backend yet and offers `Add manually`.
+7. **One `Add models` action, four origins, one list.** `Manage models` keeps the list with
+   edit, reorder, and remove, and has exactly one add action, `Add models`. It opens a picker
+   whose body is one grouped list filtered by one search box; a candidate id appears in
+   exactly one group, the first that knows it:
+   1. **`Codex built-in`** (`Claude Code built-in`) — the backend's own model list
+      (bundled + remote backend catalog + the local CLI cache the product already merges)
+      minus what is already in the menu. This is where a removed built-in is found again.
+      OpenCode has no built-in list; the group is absent for it.
+   2. **`From your providers`** — every configuration-eligible, non-retired Source model
+      not already in the menu, deduplicated by the identity rule in question 1, with its
+      supplying providers as read-only chips in Source order.
+   3. **`models.dev`** — search-driven: with an empty query the group shows one muted line
+      `Type to search models.dev`; with a query it lists exact and fuzzy matches (name,
+      mono id, models.dev provider chip). A models.dev pick carries its metadata snapshot.
+   4. **`By ID`** — one input row (`Model ID` · `Add`). When the query matches nothing in
+      any group, the row reads `Add "{{query}}" by ID`. A By-ID entry joins the selection
+      like any checked row.
+   Checked rows and By-ID entries commit together through the footer (`{{count}} selected`
+   · `Add {{count}} models`) into the catalog draft; the list's single `Save` still writes
+   everything with one `PUT`. Whatever the origin, adding a row runs the same one-time
+   matching for its initial route (C1); an id no provider supplies simply starts with an
+   empty route and the row shows `No model route configured`.
+8. **A removed built-in must be recoverable.** Removing a built-in row hides it rather than
+   forgetting it: the backend catalog records the hidden built-in id, the row leaves the
+   menu and its route follows the removal rule (C3), and the id reappears in the
+   `Codex built-in` group of the picker. Picking it again clears the hidden mark. Removing
+   any other row deletes it; a provider model reappears in `From your providers`, a
+   models.dev or By-ID model is found again through search.
+9. **New built-ins join the menu by themselves; removed ones stay removed.** When the
+   backend's built-in list gains a model (a Codex update, a refreshed remote catalog), the
+   product adds it to the menu unless its id carries the hidden mark, inserting it where the
+   built-in list orders it among the built-ins still present (after the last one when none
+   follows; at the end when none remains) and seeding its route by C1. Nothing is ever
+   removed automatically: a built-in the backend withdraws stays in the menu because a
+   provider may still serve it. The menu is therefore always "the backend's list, minus what
+   you removed, plus what you added" — with no mode switch to explain.
 
 ### Contract deltas (normative once approved; lanes cite these by number)
 
@@ -186,7 +215,8 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
   (union of efforts across matched Sources, Source order), then fills remaining empty
   metadata from models.dev only when exactly one exact match exists, recording
   `models_dev_id` and `origin: "models_dev"`. A models.dev cache miss is silent; the row is
-  still written.
+  still written. `origin` gains the value `"provider"` for rows picked from
+  `From your providers`; `"builtin"`, `"models_dev"`, and `"manual"` keep their meaning.
 - **C3 — Removal cascades through the guard.** `PUT /api/models/agents/<backend>/models`
   accepts the guarded-mutation fields beside `baseline` and `models`:
   `{baseline, models, force?: boolean, would_remove_hops?: RouteHopRef[], would_interrupt?: SupplyGap[]}`.
@@ -198,11 +228,22 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
   returns `{agent: AgentSupply, removed_hops: RouteHopRef[], interrupted: SupplyGap[]}`.
   Removing rows whose routes are empty needs no confirmation and returns `{agent}` as
   today. The v1 hard refusal is retired.
-- **C4 — Candidates are derived, not served.** The picker derives candidates from
-  `GET /api/models/sources` and `AgentSupply.sources` eligibility already loaded on the
-  page (the same derivation the Route dialog's candidate popover uses), deduplicated by
-  the identity rule in question 1 and minus ids already in the catalog. No new read
-  endpoint.
+- **C4 — Candidates come from reads that already exist.** The picker derives its groups from
+  reads the page already has or the product already serves: the built-in group from the
+  backend model catalog snapshot (`agent_model_options` / `fetchBackendModels`, the same
+  merged remote + bundled + local-CLI snapshot every model picker uses) minus menu ids and
+  including hidden built-ins; the provider group from `GET /api/models/sources` and
+  `AgentSupply.sources` eligibility (the Route dialog's candidate derivation, promoted to a
+  shared helper); the models.dev group from `GET /api/models/catalog/models-dev?query=`.
+  No new read endpoint.
+- **C6 — Hidden built-ins and built-in reconcile.** The backend catalog persists the set of
+  hidden built-in ids (`agents.<backend>.hidden_builtin_ids: string[]`, absent on older
+  files = empty). `PUT .../models` marks a removed row hidden when its id is in the current
+  built-in snapshot and clears the mark when such an id is added. On every built-in snapshot
+  change (startup, remote catalog refresh, CLI cache change) the service adds each built-in
+  id that is neither in the menu nor hidden, at the position question 9 defines, running C1
+  and C2 for it, and invalidates the backend's runtime projection. It never removes a row.
+  Claude Code's locked `default` row is not a built-in candidate and cannot be hidden.
 - **C5 — Unchanged.** Source inventories, Source-side manual add, Route dialog, Source
   order, direct/gateway modes, and every runtime projection are byte-for-byte unchanged
   except through C1–C3.
@@ -211,16 +252,15 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
 
 | Where | String |
 | --- | --- |
-| Catalog dialog primary action | `Add from providers` |
-| Catalog dialog secondary action | `Add manually` |
+| Catalog dialog add action (the only one) | `Add models` |
 | Picker title | `Add {{backend}} models` |
-| Picker search placeholder | `Search models or providers` |
-| Picker columns | `Model` · `Providers` |
-| Already-added row state | `Added` |
+| Picker search placeholder | `Search models, providers, or models.dev` |
+| Group headers | `{{backend}} built-in` · `From your providers` · `models.dev` · `By ID` |
+| models.dev group, empty query | `Type to search models.dev` |
+| By-ID row | input placeholder `Model ID` · button `Add`; with an unmatched query the row reads `Add "{{query}}" by ID` |
+| Group with nothing to offer | the group is omitted, never an empty header |
 | Picker footer count | `{{count}} selected` |
 | Picker confirm | `Add {{count}} models` |
-| Picker empty (no eligible inventory) | `No provider supplies models for {{backend}} yet.` |
-| Picker no match | `No model matches.` |
 | Remove with route | `Also removes its route: {{hops}}` · button `Remove` |
 
 Every other existing string in `settings.models.gateway.catalog.*` and
@@ -242,6 +282,11 @@ Every other existing string in `settings.models.gateway.catalog.*` and
   (Codex `codex debug models`, OpenCode overlay, Claude discovery), and the Codex card
   reveals a seventh-plus row (the #1829 behaviour is retained).
 - Direct mode still hides the editor and preserves the catalog unchanged.
+- Removing a built-in row and reopening the picker shows that id under the built-in group;
+  picking it restores the row. A built-in id that appears in the backend snapshot after the
+  menu was saved is present in the menu on the next read unless it was removed before, and
+  a previously removed id never returns on its own.
+- The picker lists each candidate id exactly once across all groups.
 
 ### Delivery notes
 

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -1,6 +1,6 @@
 # Backend Model Catalogs
 
-Status: implementation contract — v1 shipped in #1814; **v2 (compose from providers) below is the current definition of done, approved by the owner on 2026-09-03; C1–C8 are normative**
+Status: implementation contract — v1 shipped in #1814; **v2 (compose from providers) below is the current definition of done, approved by the owner on 2026-09-03; C1–C7 are normative**
 
 ## Outcome
 
@@ -173,8 +173,8 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
    in exactly one group, the first that knows it:
    1. **`Codex built-in`** (`Claude Code built-in`) — the backend's own model list
       (bundled + remote backend catalog + the local CLI cache the product already merges)
-      minus what is already in the menu. This is where a removed built-in is found again.
-      OpenCode has no built-in list; the group is absent for it.
+      minus what is already in the menu, served by C4. This is where a removed built-in is
+      found again. OpenCode has no built-in list; the group is absent for it.
    2. **`From your providers`** — every non-retired model, discovered or manual, of the
       backend's ordered and configuration-eligible Sources, not already in the menu,
       deduplicated by the identity rule in question 1, with its supplying providers as
@@ -190,7 +190,7 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
       and efforts, all still editable; the last suggestion is always `Use "{{query}}" as the
       model ID` for an id models.dev does not know. The old `Fill from models.dev` button is
       retired — the typeahead is the same capability, offered before typing instead of after.
-      For OpenCode the filled id is `vendor/model` with the first-party vendor.
+      For OpenCode the filled id follows C7's provider rule.
    Rules that hold across all groups: a provider chip on any row — built-in included — means
    exactly "one of your providers supplies this id", in Source order, and nothing else ever
    renders as a chip. With an empty query the list shows only what can be added; with a
@@ -223,83 +223,84 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
 
 ### Contract deltas (normative — owner-approved 2026-09-03; lanes cite these by number)
 
-- **C1 — Menu-model add runs matching once.** `PUT /api/models/agents/<backend>/models`
-  treats every row added relative to the latest stored list as a one-time matching point:
-  the server runs `matching-v1` for that menu model against the Sources present in that
+Authority rule for this section: it states *what must hold*; the exact schema, route-table,
+and mirror-registry edits belong to the lane that owns `docs/plans/model-hub-contracts/`, with
+the contract guard as the test. Nothing here introduces a second vocabulary for a shipped shape.
+
+- **C1 — Menu-model add runs matching once.** `PUT /api/models/agents/<backend>/models` keeps
+  its existing optimistic three-way merge: the caller's additions are `desired − baseline`,
+  merged onto the latest stored list, so a concurrent removal of an unrelated row survives.
+  Each addition is a one-time matching point: the server runs the existing `matching-v1`
+  (including its Claude alias rule) for that menu model against the Sources present in that
   backend's Source order that are configuration-eligible, over each Source's complete
-  non-retired inventory — discovered and manual models alike (§4.2's
-  `observed.discovered_models` restriction belongs to Add-Source observation, not to this
-  point) — and writes the accepted hops with `placement-v1`. `model-hub.md` §4.2 and §4.6 are
-  amended so that "catalog change never repeats matching" reads "a menu-model add matches
-  once at that write; refresh, restart, health, and turns still never re-match". Manual
-  adds of an id no Source lists therefore still start with an empty route.
-  The success response is the existing `{agent: AgentSupply}`; the seeded hops are visible
-  in `agent.routes[<id>].hops` and `agent.model_supply` in the same response.
-- **C2 — Seeding and provenance.** Seeding for a user-initiated add happens in the client
-  draft before Save, never on the server at `PUT`: the picker seeds `display_name` (from the
-  first ordered supplier that has one) and `reasoning_efforts` (union across suppliers, Source
-  order) from the Source models it already holds; the custom editor seeds from the chosen
-  models.dev suggestion. The server stores the request literally — an empty field in the
-  request is an empty field — so a value the user cleared before the first Save stays
-  cleared. Server-side seeding exists only for built-ins the reconcile (C6) adds without a
-  user draft: label and efforts from the built-in snapshot. `origin` records the creation
-  path only — `builtin` (built-in group or reconcile), `provider` (provider group),
-  `models_dev` (custom editor via a models.dev suggestion), `manual` (custom editor by hand)
-  — and `models_dev_id` records enrichment independently; enrichment never changes `origin`.
+  non-retired inventory — discovered and manual alike (`model-hub.md` §4.2's
+  `observed.discovered_models` restriction belongs to Add-Source observation, not here) — and
+  writes the accepted hops with `placement-v1`. §4.2 and §4.6 are amended so that "catalog
+  change never repeats matching" reads "a menu-model add matches once at that write; refresh,
+  restart, health, and turns still never re-match". An id no ordered Source supplies starts
+  with an empty route. The success response is the existing `{agent: AgentSupply}`.
+- **C2 — Proposed values travel in the candidates read; the save is literal.** The server
+  proposes `display_name` and `reasoning_efforts` for every candidate (C4): for a built-in
+  from the built-in snapshot, for a provider model from its suppliers (display name from the
+  first ordered supplier that has one; efforts = union in Source order). The picker copies
+  those proposals into the editable catalog draft; the custom editor copies the chosen
+  models.dev suggestion. `PUT` stores the request literally — an empty field in the request
+  is an empty field — so a value the user cleared before the first Save stays cleared.
+  Server-side seeding at write time exists only for built-ins the reconcile (C6) adds without
+  a user draft, from the same snapshot values. `origin` records the creation path only —
+  `builtin` (built-in group or reconcile), `provider` (provider group), `models_dev` (custom
+  editor via a models.dev suggestion), `manual` (custom editor by hand); `models_dev_id`
+  records enrichment independently and never changes `origin`.
 - **C3 — Removal cascades through the guard.** `PUT /api/models/agents/<backend>/models`
-  accepts the guarded-mutation fields beside `baseline` and `models`:
-  `{baseline, models, force?: boolean, would_remove_hops?: RouteHopRef[], would_interrupt?: SupplyGap[]}`.
-  Removing a row whose route has hops without `force` returns the existing guard-refusal
-  envelope `409 {ok: false, contract_version, error: "backend_model_in_route", detail?,
-  would_remove_hops: RouteHopRef[], would_interrupt: SupplyGap[]}`; `guard-refusal.schema.json`'s
-  `error` enum gains `backend_model_in_route`, registered in `mirror-registry.json`,
-  `api-response.schema.json`, and the locale keys the contract guard requires (`RouteHopRef` is
-  `{backend, menu_model, source_id, model_id, position}`). A retry with `force: true` that
-  echoes both arrays unchanged removes the rows and their routes in one transaction and
-  returns `{agent: AgentSupply, removed_hops: RouteHopRef[], interrupted: SupplyGap[]}`.
-  Removing rows whose routes are empty needs no confirmation and returns `{agent}` as
-  today. The v1 hard refusal is retired.
-- **C4 — Candidates come from reads that already exist.** The picker derives its groups from
-  reads the page already has or the product already serves: the built-in group from
-  `builtin_models` and `hidden_builtin_ids` on the agent models read (C8) minus menu ids —
-  not from `fetchBackendModels`, which in Gateway mode returns the persisted catalog; the
-  provider group from `GET /api/models/sources` and
-  `AgentSupply.sources` eligibility (the Route dialog's candidate derivation, promoted to a
-  shared helper); the editor typeahead from `GET /api/models/catalog/models-dev?query=` (C7).
-  No new read endpoint.
-- **C6 — Hidden built-ins and built-in reconcile.** The backend catalog persists the set of
-  hidden built-in ids (`agents.<backend>.hidden_builtin_ids: string[]`, absent on older
-  files = empty). `PUT .../models` marks a removed row hidden when its id is in the current
-  built-in snapshot and clears the mark when such an id is added. Legacy initialization: a
-  persisted catalog without the field is initialized once, at load, to `built-in snapshot ids
-  − menu ids` and persisted, so an upgrade from v1 changes nothing the user sees and a
-  built-in removed under v1 does not return; only built-ins that enter the snapshot after that
-  initialization arrive by question 9. Reconcile runs only once the field exists. On every
-  built-in snapshot change (startup, remote catalog refresh, CLI cache change) the service
-  adds each built-in id that is neither in the menu nor hidden, at the position question 9 defines, running C1
-  and C2 for it, and invalidates the backend's runtime projection. It never removes a row.
-  Claude Code's locked `default` row is not a built-in candidate and cannot be hidden.
-- **C7 — models.dev read serves the editor typeahead.** `GET /api/models/catalog/models-dev?query=`
-  returns `{models: [...]}` deduplicated by model id and ranked first-party vendor first, then
-  exact-id, then name matches; each item carries `vendor_id`, `vendor_name`, `first_party:
-  boolean`, and the existing metadata fields; results are capped at 8. `first_party` is derived
-  from a repo-owned, versioned vendor map (`vibe/data/model_vendors.json`: model-id family
-  prefix → models.dev provider id, e.g. `claude-` → `anthropic`, `gpt-`/`o` → `openai`,
-  `gemini-` → `google`, `deepseek-` → `deepseek`, `glm-` → `zhipuai`, `kimi-` → `moonshotai`,
-  `grok-` → `xai`, `qwen` → `alibaba`, `mistral-`/`codestral-` → `mistral`): a provider is
-  first-party for a model exactly when the map names it. When no listed provider is
-  first-party, the winner is the first provider in the map's ordered aggregator list
-  (`openrouter`, `together`, `fireworks-ai`, `groq`, `deepinfra`), and providers the map does
-  not know rank after those alphabetically. The map is the closed rule; extending it is a
-  versioned data change covered by a test.
-- **C8 — Built-in snapshot on the agent models read.** `GET /api/models/agents/<backend>/models`
-  returns, beside `catalog_models`, `builtin_models: [{id, display_name, reasoning_efforts}]` —
-  the merged remote + bundled + local-CLI snapshot for that backend, served regardless of
-  Gateway/Direct mode — and `hidden_builtin_ids: string[]`. OpenCode returns an empty
-  `builtin_models`. No new endpoint.
-- **C5 — Unchanged.** Source inventories, Source-side manual add, Route dialog, Source
-  order, direct/gateway modes, and every runtime projection are byte-for-byte unchanged
-  except through C1–C3, C6, and C8.
+  accepts the guarded-mutation fields beside `baseline` and `models` (`force?`,
+  `would_remove_hops?`, `would_interrupt?`). Removing a row whose route has hops without
+  `force` is refused with the guard-refusal envelope, `error: "backend_model_in_route"`, and a
+  nonempty `would_remove_hops` (`RouteHopRef` = `{backend, menu_model, source_id, model_id,
+  position}`); a retry with `force: true` echoing the plan removes the rows and their routes in
+  one transaction and returns `{agent, removed_hops, interrupted}`; rows with empty routes are
+  removed without confirmation and return `{agent}`. Property: every refusal the API emits for
+  this error validates against `guard-refusal.schema.json` after the lane amends that schema
+  and its mirrors (error enum, `detail`, and the nonempty-hop relation for this error), and the
+  response guard exercises it. The v1 hard refusal is retired.
+- **C4 — The server serves the picker's candidates; the client only renders.** One read,
+  `GET /api/models/agents/<backend>/models/candidates`, returns
+  `{candidates: {builtin: Candidate[], providers: Candidate[]}}` where `Candidate` is
+  `{id, display_name, reasoning_efforts, suppliers: [{source_id, source_name, model_id}],
+  origin}`. `builtin` is the merged remote + bundled + local-CLI snapshot for the backend
+  (served regardless of Gateway/Direct mode; empty for OpenCode) minus menu ids, hidden ones
+  included; `providers` is the deduplicated (question 1) inventory of the backend's ordered,
+  configuration-eligible Sources minus menu ids and minus ids already in `builtin`.
+  `suppliers` is the server's own `matching-v1` projection for that id — so a Claude alias hop
+  appears here exactly as C1 would seed it — in Source order, possibly empty. No client
+  re-implements matching, aliasing, eligibility, or snapshot merging. The picker filters both
+  groups by the query on id, display name, and supplier name, and builds `Already in the list`
+  from the catalog it already holds.
+- **C6 — Hidden built-ins and built-in reconcile.** The backend catalog persists
+  `agents.<backend>.hidden_builtin_ids: string[]`. Removing a row whose persisted `origin` is
+  `builtin` marks its id hidden — provenance, not current-snapshot membership, so a built-in
+  the backend has temporarily withdrawn is marked too; adding an id that is hidden clears the
+  mark. Legacy initialization: a persisted catalog without the field is initialized once, at
+  load, to `built-in snapshot ids − menu ids` and persisted, so an upgrade from v1 changes
+  nothing the user sees; reconcile runs only once the field exists. On every built-in snapshot
+  change (startup, remote catalog refresh, CLI cache change) the service adds each snapshot id
+  that is neither in the menu nor hidden, at the position question 9 defines, seeds it per C1
+  and C2, and invalidates the backend's runtime projection. It never removes a row. Claude
+  Code's locked `default` row is not a built-in candidate and cannot be hidden.
+- **C7 — models.dev read serves the editor typeahead, additively.** The existing
+  `GET /api/models/catalog/models-dev?query=` keeps its shipped shape — `matches`, `provider_id`,
+  `provider_name`, and the metadata fields — and gains: deduplication by model id, ranking
+  (first-party provider first, then exact-id, then name matches), `first_party: boolean`, and a
+  cap of 8. `first_party` is derived from a repo-owned, versioned vendor map
+  (`vibe/data/model_vendors.json`: model-id family prefix → models.dev provider id, plus an
+  ordered aggregator list): a provider is first-party exactly when the map names it; when none
+  is, the first listed aggregator wins and unknown providers rank after it alphabetically. The
+  map is the closed rule; extending it is a tested data change. For OpenCode the filled id is
+  `<provider>/<model>` where `<provider>` is the selected match's `provider_id` passed through
+  the existing OpenCode vendor normalization (§4.8) — a standard vendor keeps its id, anything
+  else becomes `custom/`.
+- **C5 — Unchanged.** Source inventories, Source-side manual add, Route dialog, Source order,
+  direct/gateway modes, and every runtime projection are byte-for-byte unchanged except
+  through C1–C4 and C6.
 
 ### Copy (English source; `zh.json` mirrors 1:1)
 
@@ -345,6 +346,10 @@ No string explains mechanism.
   a previously removed id never returns on its own.
 - The picker lists each candidate id exactly once across all groups.
 - A field the user cleared before the first Save is empty after Save.
+- Every supplier chip the picker shows for a candidate equals the hop set C1 seeds when that
+  candidate is added (the server projects both from the same rule).
+- A built-in removed while the backend had withdrawn it does not return when the backend
+  lists it again.
 - Loading a v1 catalog shows exactly the same menu before and after the first load, and a
   built-in the user removed under v1 does not return on its own.
 - In the editor, a models.dev suggestion fills every metadata field it knows and leaves each

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -173,24 +173,32 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
    2. **`From your providers`** — every configuration-eligible, non-retired Source model
       not already in the menu, deduplicated by the identity rule in question 1, with its
       supplying providers as read-only chips in Source order.
-   3. **`models.dev`** — search-driven: with an empty query the group shows one muted line
-      `Type to search models.dev`; with a query it lists exact and fuzzy matches (name,
-      mono id, models.dev provider chip). A models.dev pick carries its metadata snapshot.
-   4. **`By ID`** — one input row (`Model ID` · `Add`). When the query matches nothing in
-      any group, the row reads `Add "{{query}}" by ID`. A By-ID entry joins the selection
-      like any checked row.
+   3. **`models.dev`** — a browsable catalogue, never a blank box. With an empty query the
+      group shows one row of vendor chips (`Anthropic` `OpenAI` `Google` `DeepSeek` `Zhipu`
+      `Moonshot` `Qwen` `xAI` `Mistral` … `More`); choosing a vendor lists that vendor's
+      models as ordinary rows (the chip stays selected; choosing it again clears). With a
+      query the group lists matching models ranked first-party first (the vendor that makes
+      the model), then exact-id, then name matches. One row per model: when several
+      models.dev providers list the same model, only the first-party entry is shown and the
+      aggregator copies are collapsed, because for Claude Code and Codex the menu id is the
+      bare model id either way, and for OpenCode the id is `vendor/model` with the
+      first-party vendor. A row shows the display name, the mono id, and the vendor as muted
+      text (omitted when a vendor chip already filters the list); it never shows a chip.
+   4. **`Add "{{query}}" by ID`** — not a group and not an input box: one fallback row that
+      appears at the end of the list only while a query is typed, offering the typed text as
+      a model id. Its checkbox joins the selection like any row; it is disabled when the text
+      is not a valid id for the backend. With an empty query there is nothing to add by id,
+      so the row is absent.
    Rules that hold across all groups: a provider chip on any row — built-in included — means
    exactly "one of your providers supplies this id", in Source order, and nothing else ever
-   renders as a chip; a models.dev row shows its models.dev identity as the mono id
-   (`google/gemini-2.5-pro`) and no chip. With an empty query the list shows only what can
-   be added; with a query, models already in the list also appear in their group as
-   disabled rows tagged `In list`, so a search never dead-ends on something that exists.
-   The By-ID row always offers the current query and its `Add` is enabled only when that
-   text is a valid id for the backend. The models.dev group shows `Type to search
-   models.dev` on an empty query, a loading state while a query is in flight, and
-   `models.dev unavailable` when the catalog cannot be reached; it is omitted when a query
-   matches nothing there.
-   Checked rows and By-ID entries commit together through the footer (`{{count}} selected`
+   renders as a chip; models.dev vendor chips are the one exception and live only in the
+   models.dev group's browse row, where they are filters, not suppliers. With an empty query
+   the list shows only what can be added; with a query, models already in the list also
+   appear in their group as disabled rows tagged `In list`, so a search never dead-ends on
+   something that exists. The models.dev group shows a loading state while a query is in
+   flight and `models.dev unavailable` when the catalogue cannot be reached; it is omitted
+   when a query matches nothing there.
+   Checked rows — including a checked `Add "{{query}}" by ID` row — commit together through the footer (`{{count}} selected`
    · `Add {{count}} models`; with nothing selected the primary button reads `Add models`
    and is disabled, so the footer never moves) into the catalog draft; the list's single `Save` still writes
    everything with one `PUT`. Whatever the origin, adding a row runs the same one-time
@@ -256,6 +264,14 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
   id that is neither in the menu nor hidden, at the position question 9 defines, running C1
   and C2 for it, and invalidates the backend's runtime projection. It never removes a row.
   Claude Code's locked `default` row is not a built-in candidate and cannot be hidden.
+- **C7 — models.dev read serves browse and ranked search.** `GET /api/models/catalog/models-dev`
+  gains `vendor=<provider_id>` beside `query=`, and returns `{vendors: [{id, name, model_count}],
+  models: [...]}`. `models` is deduplicated by model id, ranked first-party vendor first, then
+  exact-id, then name matches; each item carries `vendor_id`, `vendor_name`, `first_party:
+  boolean`, and the existing metadata fields. With neither parameter the response carries only
+  `vendors`, first-party vendors ordered by model count. First-party means the provider that
+  makes the model; aggregator providers (openrouter, together, fireworks, groq, deepinfra, …)
+  never win the ranking when a first-party entry exists.
 - **C5 — Unchanged.** Source inventories, Source-side manual add, Route dialog, Source
   order, direct/gateway modes, and every runtime projection are byte-for-byte unchanged
   except through C1–C3.
@@ -266,15 +282,16 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
 | --- | --- |
 | Catalog dialog add action (the only one) | `Add models` |
 | Picker title | `Add {{backend}} models` |
-| Picker search placeholder | `Search models, providers, or models.dev` |
-| Group headers | `{{backend}} built-in` · `From your providers` · `models.dev` · `By ID` |
+| Picker search placeholder | `Search models or vendors` |
+| Group headers | `{{backend}} built-in` · `From your providers` · `models.dev` |
+| models.dev browse row | vendor chips by display name, then `More` |
 | models.dev group, empty query | `Type to search models.dev` |
-| By-ID row | input placeholder `Model ID` · button `Add`; with an unmatched query the row reads `Add "{{query}}" by ID` |
+| Fallback row (query only) | `Add "{{query}}" by ID` |
 | Group with nothing to offer | the group is omitted, never an empty header |
 | Picker footer count | `{{count}} selected` |
 | Picker confirm | `Add {{count}} models`; disabled `Add models` when nothing is selected |
 | Already-in-list row (search only) | `In list` |
-| models.dev group states | `Type to search models.dev` · loading · `models.dev unavailable` |
+| models.dev group states | vendor chips (empty query) · loading · `models.dev unavailable` |
 | Remove with route | `Also removes its route: {{hops}}` · button `Remove` |
 
 Every other existing string in `settings.models.gateway.catalog.*` and

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -179,16 +179,25 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
   amended so that "catalog change never repeats matching" reads "a menu-model add matches
   once at that write; refresh, restart, health, and turns still never re-match". Manual
   adds of an id no Source lists therefore still start with an empty route.
+  The success response is the existing `{agent: AgentSupply}`; the seeded hops are visible
+  in `agent.routes[<id>].hops` and `agent.model_supply` in the same response.
 - **C2 — Metadata seeding.** For each added row the server fills `display_name` and
   `reasoning_efforts` from the matched Source model(s) when the client sent them empty
   (union of efforts across matched Sources, Source order), then fills remaining empty
   metadata from models.dev only when exactly one exact match exists, recording
   `models_dev_id` and `origin: "models_dev"`. A models.dev cache miss is silent; the row is
   still written.
-- **C3 — Removal cascades through the guard.** Removing a row whose route has hops returns
-  the guarded `409 backend_model_in_route` with `would_remove_hops`; a `force: true` retry
-  echoing that plan removes the row and its route in one transaction. The hard refusal in
-  v1 is retired. Removing a row with an empty route needs no confirmation.
+- **C3 — Removal cascades through the guard.** `PUT /api/models/agents/<backend>/models`
+  accepts the guarded-mutation fields beside `baseline` and `models`:
+  `{baseline, models, force?: boolean, would_remove_hops?: RouteHopRef[], would_interrupt?: SupplyGap[]}`.
+  Removing a row whose route has hops without `force` returns the existing guard-refusal
+  envelope `409 {ok: false, error: "backend_model_in_route", would_remove_hops: RouteHopRef[],
+  would_interrupt: SupplyGap[]}` (`guard-refusal.schema.json`; `RouteHopRef` is
+  `{backend, menu_model, source_id, model_id, position}`). A retry with `force: true` that
+  echoes both arrays unchanged removes the rows and their routes in one transaction and
+  returns `{agent: AgentSupply, removed_hops: RouteHopRef[], interrupted: SupplyGap[]}`.
+  Removing rows whose routes are empty needs no confirmation and returns `{agent}` as
+  today. The v1 hard refusal is retired.
 - **C4 — Candidates are derived, not served.** The picker derives candidates from
   `GET /api/models/sources` and `AgentSupply.sources` eligibility already loaded on the
   page (the same derivation the Route dialog's candidate popover uses), deduplicated by

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -272,8 +272,9 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
   one transaction and returns `{agent, removed_hops, interrupted}`; rows with empty routes are
   removed without confirmation and return `{agent}`. Property: every response this route
   emits — the plain success, the forced success with `removed_hops` and `interrupted`, and
-  the refusal — validates against the response registry and `guard-refusal.schema.json` after
-  the artifact changes below, and the response guard exercises each of them. The v1 hard
+  the refusal — validates against the response registry after the artifact changes below,
+  the 409 refusal alone also validates against `guard-refusal.schema.json`, and the response
+  guard exercises each of them. The v1 hard
   refusal is retired.
 - **C4 — The server serves the picker's candidates; the client only renders.** One read,
   `GET /api/models/agents/<backend>/models/candidates`, returns
@@ -287,7 +288,9 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
   its supplier's name too and its disabled row shows authoritative chips.
   `suppliers` is the server's own `matching-v1` projection for that id — so a Claude alias hop
   appears here exactly as C1 would seed it — in Source order, possibly empty. No client
-  re-implements matching, aliasing, eligibility, or snapshot merging. The picker filters both
+  re-implements matching, aliasing, eligibility, or snapshot merging. The read is member-tier
+  (it names Sources); `Add models` is offered only to roles that may read Sources, exactly as
+  the page already gates its Source surfaces. The picker filters both
   arrays by the query on id, display name, and supplier name, rendering `in_list` matches as
   the disabled `Already in the list` group.
 - **C6 — Removed ids never return on their own.** The backend catalog persists
@@ -297,12 +300,16 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
   refresh, or CLI cache change — adds each built-in snapshot id that is neither in the menu nor
   in the set, at the position question 9 defines, seeds it per C1 and C2, and invalidates the
   backend's runtime projection; it never removes a row. The picker's `builtin` group lists
-  removed built-ins so they are one click away. Legacy initialization: a persisted catalog
-  without the field is initialized once to `built-in snapshot ids − menu ids` and persisted —
-  but only when the snapshot is complete: the bundled catalog, a last-known-good remote
-  catalog, and the local CLI cache (when that CLI is installed) have each been read at least
-  once. Until then the field stays absent, reconcile does not run, and the menu is served
-  unchanged, so a partial snapshot can never be mistaken for the user's removals. This is deliberately conservative: a v1 upgrade changes nothing the user sees, and
+  removed built-ins so they are one click away. Legacy initialization is a separate persisted
+  marker, `agents.<backend>.builtin_baseline_initialized: boolean` (absent on v1 files =
+  false): reconcile runs only while it is true. It becomes true once — when the snapshot is
+  complete (the bundled catalog, a last-known-good remote catalog, and the local CLI cache
+  when that CLI is installed have each been read at least once) — and at that moment
+  `removed_model_ids` is set to its current contents ∪ (`built-in snapshot ids − menu ids`).
+  Removals made while the marker is false are recorded in `removed_model_ids` immediately, like
+  any other removal, and survive initialization. Until the marker is true the menu is served
+  unchanged, so a partial snapshot can never be mistaken for the user's removals. Load and
+  mutation fixtures cover the v1 file, the pending window, and the initialized state. This is deliberately conservative: a v1 upgrade changes nothing the user sees, and
   the price is that a built-in that entered the snapshot between the v1 save and the first v2
   load is treated as removed — recoverable from the picker, not auto-added. Reconcile runs only
   once the field exists. Claude Code's locked `default` row is not a built-in candidate and
@@ -338,11 +345,11 @@ the v2 shapes on the same head.
 | `docs/plans/model-hub-contracts/guard-refusal.schema.json` | `error` enum gains `backend_model_in_route`; a `detail` property; the nonempty-`would_remove_hops` relation extends to `backend_model_in_route` |
 | `docs/plans/model-hub-contracts/api-response.schema.json` (stale-candidate refusal) | new registered shape for `409 candidate_suppliers_changed` — `{ok, contract_version, error, changed}` — outside the guard-refusal `anyOf` |
 | `contract_version` closure (every registered location listed in `docs/plans/model-hub-contracts/README.md` "Version closure", server and UI mirrors alike) | 6 → 7, because v1 shipped closed shapes (`additionalProperties: false`) that v2 extends |
-| `vibe/authorization.py` role table and its coverage test (`tests/test_instance_authorization.py`) | `GET /api/models/agents/<backend>/models/candidates` is admitted for every role that may `GET /api/models/agents/<backend>/models` |
+| `vibe/authorization.py` role table and its coverage test (`tests/test_instance_authorization.py`) | `GET /api/models/agents/<backend>/models/candidates` is **member-tier**, the same boundary as Source inventory reads, because it carries supplier ids and names; the editor-tier catalog read stays supplier-free |
 | `docs/plans/model-hub-contracts/README.md` (product model) and `docs/plans/model-hub-contracts/opencode-overlay.md` | Add Source is no longer the sole matching/placement point: a menu-model add (C1) and a reconcile add (C6) are the other one-time points; runtime still never re-matches |
 | `docs/plans/model-hub-contracts/mirror-registry.json` | registers the two new error codes, the new `origin` value, and the new response shapes with their consumers |
 | `vibe/i18n/*.json` and `ui/src/components/settings/models/serverCopy.ts` | `detail` keys for the two new error codes |
-| `config/v2_config.py` persisted shape | `agents.<backend>.removed_model_ids` with legacy initialization (C6) and a load fixture for the v1 file shape |
+| `config/v2_config.py` persisted shape | `agents.<backend>.removed_model_ids` and `agents.<backend>.builtin_baseline_initialized` (C6), with load and mutation fixtures for the v1 file, the pending window, and the initialized state |
 | `vibe/data/model_vendors.json` (new, versioned) | the vendor map and aggregator order C7 defines, covered by a test |
 | `docs/plans/model-hub.md` §4.2 / §4.6 | matching-point wording (C1); removed-id and reconcile rules (C6) |
 

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -138,8 +138,10 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
    supplies nothing here. That id is exactly what the menu id will be. The row lists its
    supplying providers in Source order. For OpenCode a
    candidate is the existing OpenCode identifier `vendor/model` (§4.8), so two Sources
-   with the same standard vendor collapse into one candidate and two vendors offering the
-   same bare model stay two candidates, as OpenCode itself would show them.
+   with the same standard vendor collapse into one candidate, two distinct standard vendors
+   offering the same bare model stay two candidates, and Sources whose vendor §4.8 normalizes
+   to `custom/` collapse into one `custom/<model>` candidate with several suppliers — exactly
+   the identities OpenCode itself would show.
 2. **Membership key and metadata owner.** Unchanged: membership is keyed by backend
    model id per backend, and the `BackendModel` row owns display name, capabilities,
    context, output, and reasoning efforts. Selection seeds display name and reasoning
@@ -209,8 +211,11 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
 8. **A removed built-in must be recoverable, and nothing removed comes back by itself.**
    Removing any row records its id as removed (C6); the row leaves the menu and its route
    follows the removal rule (C3). A removed built-in reappears in the `Codex built-in` group
-   of the picker, a removed provider model in `From your providers`, and picking either again
-   clears the mark; a removed custom model is re-created through `Add custom model…`.
+   of the picker for as long as the backend still lists it, a removed provider model in
+   `From your providers` for as long as an ordered Source supplies it, and picking either
+   again clears the mark; anything else — a removed custom model, or a built-in the backend has
+   since withdrawn — is re-created through `Add custom model…`. The product keeps no history
+   of candidates it no longer serves.
 9. **New built-ins join the menu by themselves; removed ones stay removed.** When the
    backend's built-in list gains a model (a Codex update, a refreshed remote catalog), the
    product adds it to the menu unless its id is in the removed set (C6), inserting it where the
@@ -249,7 +254,8 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
   from the built-in snapshot, for a provider model from its suppliers (display name from the
   first ordered supplier that has one; efforts = union in Source order). The picker copies
   those proposals into the editable catalog draft; the custom editor copies the chosen
-  models.dev suggestion. `PUT` stores the request literally — an empty field in the request
+  models.dev suggestion. A proposal contains only values the catalog can store — an effort
+  value that violates `backend-model.schema.json` is left out of the proposal, never copied. `PUT` stores the request literally — an empty field in the request
   is an empty field — so a value the user cleared before the first Save stays cleared.
   Server-side seeding at write time exists only for built-ins the reconcile (C6) adds without
   a user draft, from the same snapshot values. `origin` records the creation path only —
@@ -263,10 +269,11 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
   nonempty `would_remove_hops` (`RouteHopRef` = `{backend, menu_model, source_id, model_id,
   position}`); a retry with `force: true` echoing the plan removes the rows and their routes in
   one transaction and returns `{agent, removed_hops, interrupted}`; rows with empty routes are
-  removed without confirmation and return `{agent}`. Property: every refusal the API emits for
-  this error validates against `guard-refusal.schema.json` after the lane amends that schema
-  and its mirrors (error enum, `detail`, and the nonempty-hop relation for this error), and the
-  response guard exercises it. The v1 hard refusal is retired.
+  removed without confirmation and return `{agent}`. Property: every response this route
+  emits — the plain success, the forced success with `removed_hops` and `interrupted`, and
+  the refusal — validates against the response registry and `guard-refusal.schema.json` after
+  the artifact changes below, and the response guard exercises each of them. The v1 hard
+  refusal is retired.
 - **C4 — The server serves the picker's candidates; the client only renders.** One read,
   `GET /api/models/agents/<backend>/models/candidates`, returns
   `{candidates: {builtin: Candidate[], providers: Candidate[], in_list: Candidate[]}}` where `Candidate` is
@@ -311,6 +318,23 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
 - **C5 — Unchanged.** Source inventories, Source-side manual add, Route dialog, Source order,
   direct/gateway modes, and every runtime projection are byte-for-byte unchanged except
   through C1–C4 and C6.
+
+### Contract artifact changes (complete; the contracts lane's checklist)
+
+Every shape C1–C7 introduces maps to exactly one row here; a delta that needs an artifact not
+listed is a spec defect to report, not a lane decision.
+
+| Artifact | Change |
+| --- | --- |
+| `docs/plans/model-hub-contracts/backend-model.schema.json` and its TypeScript mirror (`ui/src/components/settings/models/types.ts`) | `origin` enum gains `provider` |
+| `docs/plans/model-hub-contracts/api.md` route table | `PUT /api/models/agents/<backend>/models` row: optional `force`, `would_remove_hops`, `would_interrupt`, `expected_suppliers`; refusals `backend_model_in_route`, `candidate_suppliers_changed`; success `{agent}` or `{agent, removed_hops, interrupted}`. New row `GET /api/models/agents/<backend>/models/candidates`. `GET /api/models/catalog/models-dev` row: additive `first_party`, dedupe, ranking, cap 8 |
+| `docs/plans/model-hub-contracts/api-response.schema.json` | the models `PUT` accepts the forced-success shape beside `AgentResponse`; new candidates response (`Candidate` shape from C4); models-dev response gains `first_party` |
+| `docs/plans/model-hub-contracts/guard-refusal.schema.json` | `error` enum gains `backend_model_in_route` and `candidate_suppliers_changed`; a `detail` property; the nonempty-`would_remove_hops` relation extends to `backend_model_in_route`; `candidate_suppliers_changed` carries its `changed: {<id>: [{source_id, model_id}]}` sibling |
+| `docs/plans/model-hub-contracts/mirror-registry.json` | registers the two new error codes and the new `origin` value with their consumers |
+| `vibe/i18n/*.json` and `ui/src/components/settings/models/serverCopy.ts` | `detail` keys for the two new error codes |
+| `config/v2_config.py` persisted shape | `agents.<backend>.removed_model_ids` with legacy initialization (C6) and a load fixture for the v1 file shape |
+| `vibe/data/model_vendors.json` (new, versioned) | the vendor map and aggregator order C7 defines, covered by a test |
+| `docs/plans/model-hub.md` §4.2 / §4.6 | matching-point wording (C1); removed-id and reconcile rules (C6) |
 
 ### Copy (English source; `zh.json` mirrors 1:1)
 


### PR DESCRIPTION
## What changed

- `docs/plans/backend-model-catalogs.md` gains the owner-approved **v2 — Compose from providers** section: the product diagnosis of the v1 `Manage models` flow, the single-`Add models` interaction (select what exists: backend built-ins and provider inventories; define the rest in the editor with a models.dev typeahead), recoverable built-ins, automatic arrival of new built-ins, the copy table, and acceptance properties.
- Contract deltas C1–C7 are stated here as the definition of done for the implementation lanes; the normative amendments to `model-hub.md` §4.2/§4.6 and `model-hub-contracts/*` land with the backend lane's PR.

## Why

The shipped flow re-enters data the product already owns (a model id typed by hand, then picked again in the Route dialog) and hides the relationship between providers, backend menus, and routes. The root cause is the asymmetry in `model-hub.md` §4.6: matching runs when a Source is added but never when a menu model is added.

## Validation

Documentation only. Design frames: avibe-docs PR #34 (`Model Hub v2 — …`). No code, no test, no runtime change.


## Review-gate decision (owner, 2026-09-03 15:5x CST)

Spec-only PR. Five Codex rounds were fixed in full (32 threads). The owner ruled that from the next round on, findings that are implementation-closure items (schema/mirror/version/authorization enumeration the code lanes' own Codex reviews and contract guards re-check with real code) are **advisory** for this PR: they are forwarded to the implementation lanes as requirements, answered and resolved here, and the PR merges on CI green + zero unresolved threads + CLEAN. Product- or model-level findings are still fixed in the spec before merge.
