### PR TITLE
test(watches): await timeout terminal state

### DIFF
--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -895,8 +895,11 @@ def test_managed_watch_service_forever_timeout_disables_and_enqueues_failure(tmp
 
     async def _run() -> None:
         await _start_watch_service(service)
-        await asyncio.sleep(0.2)
-        await service.stop()
+        watch_task = service._active_tasks[watch.id]
+        try:
+            await asyncio.wait_for(asyncio.shield(watch_task), timeout=10)
+        finally:
+            await service.stop()
 
     asyncio.run(_run())
 


### PR DESCRIPTION
## What changed

- Wait for the managed Watch task to reach its terminal lifecycle state before stopping the service.
- Keep a bounded 10-second test guard and always stop the service in `finally`.

## Why

The previous test slept for 0.2 seconds and then stopped the service. That interval also had to cover waiter supervisor startup, the 0.05-second cycle timeout, process-tree cleanup, lifecycle persistence, and failure-request enqueueing. On a loaded CI runner, `stop()` could cancel the Watch task before the terminal commit, leaving the pending queue empty even though production timeout handling was correct.

Fixes #1752

## Scenario coverage

- No scenario catalog entry is directly affected; this is test-only synchronization for existing Watch timeout coverage.

## Evidence

- Focused timeout lifecycle test: passed.
- Related Watch suite: 123 passed.
- Ruff on the changed Python file: passed.
- Diff whitespace check: passed.

## Dependencies

- None.

## Known-by-design ledger

- None.

## Residual risk

- No production behavior changed. The 10-second bound is only a deadlock/failure guard; assertions still verify one queued failure notice, disabled state, and exit code 124.
