### PR TITLE
test(model-hub): cover hub subscription fallback to API key

### DIFF
--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -378,6 +378,12 @@ scenarios:
     kind: compatibility
     layer: scenario
     test: tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py::test_mh_res_live_003_started_stream_never_retries
+  - id: MH-RES-LIVE-004
+    name: Live turn walks a hub subscription onto a metered API key before streaming starts
+    status: covered
+    kind: recovery
+    layer: scenario
+    test: tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py::test_mh_res_live_004_hub_subscription_falls_back_to_api_key_within_turn
   - id: MH-EVT-002
     name: Causal switch events survive service restart
     status: covered

--- a/tests/scenarios/model_hub/observations.yaml
+++ b/tests/scenarios/model_hub/observations.yaml
@@ -8,6 +8,7 @@ observations:
       - MH-S1-001
       - MH-TAKEOVER-001
       - MH-CREDENTIAL-001
+      - MH-RES-LIVE-004
   - id: MH-OBS-002
     source: engine-survey-s1
     summary: Engine usage events can contain credential material, so Model Hub emits only its own redacted records.

--- a/tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py
+++ b/tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py
@@ -551,6 +551,78 @@ def test_mh_res_live_003_started_stream_never_retries(tmp_path: Path) -> None:
     asyncio.run(exercise())
 
 
+def test_mh_res_live_004_hub_subscription_falls_back_to_api_key_within_turn(
+    tmp_path: Path,
+) -> None:
+    """MH-RES-LIVE-004: a hub subscription quota failure serves the next hop in the same turn and marks the switch as entered_metered."""
+
+    async def exercise() -> None:
+        clock = [datetime(2026, 7, 25, tzinfo=timezone.utc)]
+        subscription = _source("src_primary1", kind="subscription")
+        api_key = _source("src_backup01")
+        assert subscription.kind == "subscription"
+        assert subscription.supply_channel == "hub"
+        assert subscription.billing == "monthly"
+        assert api_key.kind == "api_key"
+        assert api_key.billing == "metered"
+        adapter = AdapterBoundaryFake(
+            [
+                AdapterResult(
+                    RawOutcomeKind.HTTP_ERROR,
+                    status=429,
+                    code="quota_exceeded",
+                ),
+                AdapterResult(RawOutcomeKind.SUCCESS, status=200, body=b'{"ok":true}'),
+                AdapterResult(RawOutcomeKind.SUCCESS, status=200, body=b'{"recovered":true}'),
+            ]
+        )
+        store = MemoryStore(_config(subscription, api_key))
+        service = _service(tmp_path, store, adapter, now=lambda: clock[0])
+        gateway = ModelHubTurnGateway(service)
+        router = ModelHubRuntimeRouter(service=service, turn_gateway=gateway)
+        try:
+            status, body = await _post_turn(
+                await router.resolve("claude", _requested_model("claude"))
+            )
+            assert status == 200
+            assert body == b'{"ok":true}'
+            assert [call[0] for call in adapter.invocations] == [
+                "src_primary1",
+                "src_backup01",
+            ]
+            cooled = store.load().sources[0]
+            assert cooled.id == "src_primary1"
+            assert cooled.state.status == "cooldown"
+            assert cooled.state.detail_key == "models.source.cooldown.quota_exhausted"
+            assert cooled.state.retry_at == (clock[0] + timedelta(seconds=300)).isoformat()
+            events = service.list_events(limit=5)
+            assert [event["kind"] for event in events[:2]] == ["switch", "cooldown"]
+            assert events[0]["from_source"] == "src_primary1"
+            assert events[0]["to_source"] == "src_backup01"
+            assert events[0]["reason"] == "quota_exhausted"
+            assert events[0]["billing_note"] == "entered_metered"
+            assert events[1]["reason"] == "quota_exhausted"
+
+            clock[0] += timedelta(minutes=6)
+            recovered_status, recovered_body = await _post_turn(
+                await router.resolve("claude", _requested_model("claude"))
+            )
+            assert recovered_status == 200
+            assert recovered_body == b'{"recovered":true}'
+            assert adapter.invocations[-1][0] == "src_primary1"
+            recovered = store.load().sources[0]
+            assert recovered.state.status == "standby"
+            assert recovered.state.retry_at is None
+            recovered_events = service.list_events(limit=5)
+            assert recovered_events[0]["kind"] == "recover"
+            assert recovered_events[0]["reason"] == "recovery"
+            assert recovered_events[0]["to_source"] == "src_primary1"
+        finally:
+            await gateway.close()
+
+    asyncio.run(exercise())
+
+
 def test_mh_effort_001_undeclared_effort_is_omitted_and_turn_completes(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Capability

Model Hub live-turn fallback now has closed-loop evidence that a **hub-channel monthly subscription** can walk onto a **metered API key in the same turn**.

Previously MH-RES-LIVE-001 / MH-TAKEOVER-001 walked two API keys, and MH-EVT-002 only covered native-CLI subscription → API key on the *next* turn after `record_native_failure`. The monthly→metered `entered_metered` billing note had no Python consumer.

## Scenario

- **MH-RES-LIVE-004** — Live turn walks a hub subscription onto a metered API key before streaming starts

## Evidence

- **Scenario:** `tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py::test_mh_res_live_004_hub_subscription_falls_back_to_api_key_within_turn`
  - Hop 0 is a hub `subscription` (`billing=monthly`); hop 1 is an `api_key` (`billing=metered`).
  - Upstream returns `quota_exceeded` on hop 0; the real turn gateway still returns 200 from hop 1.
  - Switch event carries `billing_note=entered_metered`; hop 0 cools for 300s with `models.source.cooldown.quota_exhausted`.
  - After the deadline, the same route recovers hop 0, emits `recover`/`recovery`, and serves it again.
- **Contract:** catalog + observation rows for MH-RES-LIVE-004 (`tests/scenarios/model_hub/catalog.yaml`, `observations.yaml`); catalog integrity check still passes.
- **Unit:** none added (no production change).
- **Residual manual:** none for this gap. End-to-end against a live vendor 429 remains deferred.

## Out of scope

- Native CLI subscription → API key *within the same turn* (native hops return immediately; that path remains next-turn via MH-EVT-002).
- Product decision D-1 (append-at-tail vs subscription-first placement).
