### PR TITLE
fix(model-hub): size the add-key interface row on the result scale

### DIFF
--- a/docs/plans/model-hub-ui-spec.md
+++ b/docs/plans/model-hub-ui-spec.md
@@ -3357,6 +3357,18 @@ The dialog is now a single add flow:
   written over exits: whether a state happens to expose an editable field today
   decides only whether it fires, never whether it applies.
 
+**2026-09-04 owner ruling — no text in this dialog inherits the document's default
+type scale** `[derived]`. Manual verification found the idle/ready row's
+active-interface statement rendering at 16px, larger than the 15px dialog title,
+because the element carrying that statement declared only layout. Its scale is
+12 / 600 — `--model-hub-add-key-strip-title-size`, already the detecting row's and
+the identified strip's scale — while the 自动探测 hint beside it keeps the 10.5
+field-hint scale. Stated as the property rather than as that one row: **every text
+node in this dialog declares its own size.** The element that owns a statement is
+the element that sizes it, which is why the two-scale idle row sizes each child
+instead of the row, and why a row added later is measured by the rule rather than by
+whether it appears in the Metrics list below.
+
 **Element inventory**
 
 | Element | Displays | Data source | Interactive | On activate |

--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -646,10 +646,17 @@
   align-items: baseline;
   gap: 8px;
 }
+/* The element that carries the statement is the element that sizes it. The idle
+   row holds two deliberately different scales -- this 12px statement and the
+   10.5px hint beside it -- so the scale sits on each child rather than on the row
+   the way the single-child detecting row does. Color stays inherited so the
+   row's `.is-idle` dimming keeps applying to it. */
 .model-hub-add-key-protocol-active {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  font-size: var(--model-hub-add-key-strip-title-size);
+  font-weight: 600;
 }
 .model-hub-add-key-protocol-manual {
   flex-direction: column;


### PR DESCRIPTION
## What changes

The add-key dialog's interface-type row rendered its active-interface statement at
the document's default **16px** — larger than the 15px dialog title, and off the
dialog's 10.5–12px scale. The owner caught it during manual verification on
`avibe-test`: 「接口类型」 → glyph + "Anthropic Messages" oversized.

`.model-hub-add-key-protocol-active` was introduced with the #1831 P2-b fix
("reflect the active manual protocol in the result row") declaring only
`display` / `align-items` / `gap`. Nothing in its ancestor chain sets a
`font-size` — not the row, not `.model-hub-add-key-protocol-area`, not
`.model-hub-add-key-body`, not `.model-hub-add-key-dialog`, and `index.css` sets
none on `html` / `body` — so it inherited the browser default.

It now carries the result-row scale the detecting row and the identified strip
already use: `--model-hub-add-key-strip-title-size` (12px) + 600. Color is left
inherited so the row's `.is-idle` 0.55 dimming keeps applying.

**The scale sits on the statement element, not on the row.** The single-child
detecting row can size its container, but this row holds two deliberately
different scales — the 12px statement and the 10.5px `addKey.protocol.idleHint`
beside it — so each child owns its own size. Sizing the row would state "the row
is 12px", which is true of only one of its children.

## Dialog sweep

Every text node in the add-key dialog was checked against the stylesheet for a
`font-size` owner. Result: `.model-hub-add-key-protocol-active` was the only one
inheriting the document default. Title 15, subtitle 10.5, labels 11.5, inputs
11.5, hints 10.5, strip titles 12, strip details 10.5, segments 11.5, disclosure
10.5, footer actions 12, guard rows all explicitly sized, replace-mode strips on
`strip-title` / Tailwind arbitraries. Glyphs are fixed at 14px.

## Spec

§1.5's Metrics block was **silent** on this row's type scale, so a dated
`2026-09-04` revision states it. It is written as the property rather than as this
one row: **every text node in this dialog declares its own size** — the element
that owns a statement is the element that sizes it. A row added later is measured
by that rule instead of by whether it appears in the Metrics list.

## Evidence

- **Root cause verified, not assumed** — walked the full ancestor chain plus
  `index.css` to confirm no `font-size` owner exists above the element, so the
  inherited value is the browser default rather than a smaller app base.
- **Build gate** — `npm run build` → `✓ built`; only the pre-existing vendor
  `@hpke/common` PURE-annotation and chunk-size warnings.
- **Rule survives the build** — the emitted stylesheet carries it:
  `.model-hub-add-key-protocol-active{font-size:var(--model-hub-add-key-strip-title-size);…;font-weight:600;…}`
- **Typecheck** — `npx tsc -b` clean.
- **Unit** — `npx vitest run src/components/settings/models` → 74 files / 1083
  tests passed. No test changed: the three existing assertions on this selector
  read presence and text content, not style, and jsdom applies no stylesheet, so
  a unit test cannot assert the computed size here.
- **Residual manual check** — the rendered size itself. The owner's original
  screenshot is the report; re-verification is one look at the dialog's idle row
  against the title.

## Scenario IDs

`tests/scenarios/model_hub/catalog.yaml` exists, but every entry is a behavior
scenario (`MH-PROTOCOL-*`, `MH-MENU-ADD-*`, `MH-USAGE-*`); none covers dialog
typography, and this change alters no behavior any of them asserts. No scenario ID
applies, and none was force-fitted.

## Scope

`modelHubSurface.css` + `docs/plans/model-hub-ui-spec.md` §1.5 only. No dialog
TSX, no behavior, no tests — nothing pinned the style token.

## Dependencies

None. Based on `2791092d`, which already contains #1831.
