### PR TITLE
fix(model-hub): distinct close label for the catalog dialog; e2e allow-list for tier provenance

### DIFF
--- a/ui/e2e/b-add-api-key.spec.ts
+++ b/ui/e2e/b-add-api-key.spec.ts
@@ -197,24 +197,30 @@ test.describe('B · add an API-key source', () => {
     await expect(hub.sourceDetailDialog).toBeVisible({ timeout: 30_000 });
 
     const created = (await api.sources()).find((source) => source.display_name === name);
-    expect(created?.models.map((model) => model.id).sort()).toEqual(
-      inventory.map((model) => model.id).sort(),
+
+    // assert-current: everything the upstream said about a model except its id
+    // is discarded on the way to storage. The whole row is stated rather than
+    // its key set, so each drop is asserted as a value and not merely as a name
+    // that exists. `reasoning_efforts_source` is the one that matters: it is
+    // #1836's tier provenance, product shape to record here rather than a leak
+    // to strip, and `null` is the claim — the persisted schema also admits
+    // `catalog` alongside an empty tier list, so a regression stamping it would
+    // make the UI treat these tiers as managed and non-editable while a key
+    // check still passed. A field arriving later fails this too.
+    const byId = (one: { id: string }, other: { id: string }) => one.id.localeCompare(other.id);
+    expect([...(created?.models ?? [])].sort(byId)).toEqual(
+      inventory
+        .map((model) => ({
+          id: model.id,
+          origin: 'discovered',
+          display_name: null,
+          reasoning_efforts: [],
+          reasoning_efforts_source: null,
+          discovered_at: expect.any(String),
+          retired: false,
+        }))
+        .sort(byId),
     );
-    for (const model of created?.models ?? []) {
-      // assert-current: everything the upstream said about a model except its id
-      // is discarded on the way to storage. The set is pinned rather than
-      // sampled so that a field arriving later cannot slip in unnoticed — which
-      // is what it just caught: `reasoning_efforts_source` is #1836's tier
-      // provenance, product shape to record here, not a leak to strip.
-      expect(Object.keys(model).sort()).toEqual(
-        [
-          'discovered_at', 'display_name', 'id', 'origin',
-          'reasoning_efforts', 'reasoning_efforts_source', 'retired',
-        ],
-      );
-      expect(model.display_name).toBeNull();
-      expect(model.reasoning_efforts).toEqual([]);
-    }
   });
 
   test('B4 · a proven interface with no model list can still be added, on the record', async ({ hub, mock, api }) => {

--- a/ui/e2e/b-add-api-key.spec.ts
+++ b/ui/e2e/b-add-api-key.spec.ts
@@ -202,9 +202,15 @@ test.describe('B · add an API-key source', () => {
     );
     for (const model of created?.models ?? []) {
       // assert-current: everything the upstream said about a model except its id
-      // is discarded on the way to storage.
+      // is discarded on the way to storage. The set is pinned rather than
+      // sampled so that a field arriving later cannot slip in unnoticed — which
+      // is what it just caught: `reasoning_efforts_source` is #1836's tier
+      // provenance, product shape to record here, not a leak to strip.
       expect(Object.keys(model).sort()).toEqual(
-        ['discovered_at', 'display_name', 'id', 'origin', 'reasoning_efforts', 'retired'],
+        [
+          'discovered_at', 'display_name', 'id', 'origin',
+          'reasoning_efforts', 'reasoning_efforts_source', 'retired',
+        ],
       );
       expect(model.display_name).toBeNull();
       expect(model.reasoning_efforts).toEqual([]);

--- a/ui/scripts/travellingTokens.mjs
+++ b/ui/scripts/travellingTokens.mjs
@@ -1,0 +1,185 @@
+// Which custom properties a class can actually resolve where it renders.
+//
+// `customPropertiesIn` answers "is this name declared anywhere", which is the
+// question that let this defect ship. Every `--model-hub-guard-*` token was
+// declared -- on `.model-hub-guard-dialog` -- so the token layer looked whole.
+// But `GuardImpact` and `GuardGapList` are the shared evidence body for a
+// guarded Model Hub mutation, and three of the four dialogs that mount them are
+// not that dialog. In those three the `var()` named a property no ancestor
+// declares, which is invalid at computed-value time, so the declaration drew
+// nothing: `gap` fell back to `normal`, `font-size` to the inherited size, and
+// the count's `padding` to zero. Not a pill missing a margin -- "Hops that will
+// be removed2 hops" in one unbroken run.
+//
+// A rendered test cannot catch it. jsdom computes no cascade and loads no
+// stylesheet, so `getComputedStyle` there reports the inline truth and agrees
+// with itself in every root. The only place the mistake exists is the
+// stylesheet's scope graph, so that is what gets read.
+//
+// The property asserted is self-sufficiency, not a list of tokens: a class that
+// travels resolves every name it consumes from itself or from a scope every
+// element inherits. A token added to such a class later is covered without
+// editing anything, and a token parked back on a dialog root fails here rather
+// than in a screenshot nobody takes.
+
+// A selector that can match the document root, so a custom property declared
+// there is inherited by every element regardless of where it mounts. Derived
+// from shape rather than from a list of the project's current scopes: `:root`,
+// `[data-theme="light"]`, `:root:not([data-theme="dark"])` and a bare `html`
+// all qualify because each one's subject is at or above the body, and a scope
+// spelled some new way qualifies on the same grounds.
+const REACHES_EVERY_ELEMENT = /^(:root|html|body|\*|\[)/;
+
+// `var(--x)` on an undeclared name draws nothing; `var(--x, 6px)` draws 6px.
+// The second is not this defect, so the fallback is what decides whether a use
+// counts -- otherwise every deliberately-optional token reads as a violation
+// and the gate fails correct CSS.
+const UNGUARDED_USE = /var\(\s*(--[\w-]+)\s*\)/g;
+
+function insideTheme(node) {
+  for (let at = node.parent; at; at = at.parent) {
+    if (at.type === 'atrule' && at.name === 'theme') return true;
+  }
+  return false;
+}
+
+// The leftmost compound of a selector is the only part that says which subtree
+// a rule belongs to. `.guard-label > span` and `.guard-hop strong` are the
+// travelling body styling its own descendants, so their tokens are the
+// travelling body's problem; `.catalog-dialog .guard-label` would be a rule
+// about one dialog and is deliberately none of this fold's business.
+function firstCompound(selector) {
+  let depth = 0;
+  for (let index = 0; index < selector.length; index += 1) {
+    const character = selector[index];
+    if (character === '(' || character === '[') depth += 1;
+    else if (character === ')' || character === ']') depth -= 1;
+    else if (depth === 0 && ' >+~'.includes(character)) return selector.slice(0, index);
+  }
+  return selector;
+}
+
+// `:not(.model-hub-guard-dialog)` names a class it excludes, so the
+// parenthesised groups come out before the class names go in.
+function classesOf(compound) {
+  const bare = compound.replace(/\([^)]*\)/g, '');
+  return [...bare.matchAll(/\.(-?[_a-zA-Z][\w-]*)/g)].map((match) => match[1]);
+}
+
+/**
+ * Every class name a component renders, read from its own source.
+ *
+ * The component is the authority on this, not a list kept next to the check: a
+ * class it stops rendering stops being asserted, and one it starts rendering
+ * starts. Only `className` is read, so a class named in a comment or a log line
+ * is not mistaken for one that ships.
+ */
+function classesRenderedBy(source) {
+  const found = new Set();
+  const attribute = /className\s*=\s*/g;
+
+  for (let match = attribute.exec(source); match; match = attribute.exec(source)) {
+    let cursor = match.index + match[0].length;
+    let end = cursor;
+
+    if (source[cursor] === '{') {
+      // Read the whole expression, so `cn('a', flag && 'b')` contributes both.
+      let depth = 0;
+      for (; end < source.length; end += 1) {
+        if (source[end] === '{') depth += 1;
+        else if (source[end] === '}') {
+          depth -= 1;
+          if (depth === 0) { end += 1; break; }
+        }
+      }
+    } else {
+      const quote = source[cursor];
+      if (quote !== '"' && quote !== "'" && quote !== '`') continue;
+      end = source.indexOf(quote, cursor + 1) + 1;
+      if (end === 0) continue;
+    }
+
+    const expression = source.slice(cursor, end);
+    for (const literal of expression.matchAll(/["'`]([^"'`]*)["'`]/g)) {
+      for (const name of literal[1].split(/\s+/)) if (name) found.add(name);
+    }
+  }
+
+  return found;
+}
+
+/**
+ * The tokens ``classNames`` consume but cannot resolve where they render.
+ *
+ * ``sheets`` is the materialised `eachStylesheet` walk -- materialised because
+ * this needs two passes over the same trees, and a generator gives one.
+ * Returns one entry per unresolvable use, naming the class whose subtree
+ * consumes it and the origin to report, so a failure reads as an instruction.
+ */
+function unscopedTokens(sheets, classNames) {
+  const travelling = new Set(classNames);
+  const inheritable = new Set();
+  const declaredOn = new Map();
+
+  for (const [, root] of sheets) {
+    // A registered name resolves to its initial value everywhere, so a use of
+    // one is not this defect. A registration carrying no initial value under
+    // `syntax: "*"` does draw nothing, which this treats as resolvable and so
+    // will not report -- a miss rather than a false positive, on the same
+    // grounds `customProperties.mjs` records the name at all.
+    root.walkAtRules('property', (rule) => inheritable.add(rule.params.trim()));
+
+    root.walkDecls((declaration) => {
+      if (!declaration.prop.startsWith('--')) return;
+
+      const owner = declaration.parent;
+      if (owner.type !== 'rule') {
+        if (insideTheme(declaration)) inheritable.add(declaration.prop);
+        return;
+      }
+      if (insideTheme(declaration) || owner.selectors.some((one) => REACHES_EVERY_ELEMENT.test(one.trim()))) {
+        inheritable.add(declaration.prop);
+      }
+
+      for (const one of owner.selectors) {
+        const selector = one.trim();
+        for (const name of classesOf(selector)) {
+          // Only a declaration on the class ITSELF is inherited by the whole
+          // subtree. One on `.guard-label > span` reaches that span's children
+          // and no sibling, so counting it would sanction a scope narrower than
+          // the one being consumed.
+          if (selector !== `.${name}`) continue;
+          if (!declaredOn.has(name)) declaredOn.set(name, new Set());
+          declaredOn.get(name).add(declaration.prop);
+        }
+      }
+    });
+  }
+
+  const unresolved = [];
+  for (const [origin, root] of sheets) {
+    root.walkDecls((declaration) => {
+      const owner = declaration.parent;
+      if (owner.type !== 'rule') return;
+
+      const used = [...declaration.value.matchAll(UNGUARDED_USE)].map((match) => match[1]);
+      if (used.length === 0) return;
+
+      for (const one of owner.selectors) {
+        const selector = one.trim();
+        for (const name of classesOf(firstCompound(selector))) {
+          if (!travelling.has(name)) continue;
+          for (const property of used) {
+            if (inheritable.has(property)) continue;
+            if (declaredOn.get(name)?.has(property)) continue;
+            unresolved.push({ className: name, property, origin, selector, declaration: declaration.prop });
+          }
+        }
+      }
+    });
+  }
+
+  return unresolved;
+}
+
+export { classesRenderedBy, firstCompound, unscopedTokens };

--- a/ui/scripts/travellingTokens.mjs
+++ b/ui/scripts/travellingTokens.mjs
@@ -21,14 +21,35 @@
 // element inherits. A token added to such a class later is covered without
 // editing anything, and a token parked back on a dialog root fails here rather
 // than in a screenshot nobody takes.
+//
+// "Resolves" is the whole difficulty, and it is not "is declared somewhere".
+// A declaration counts only where it is in force, so both halves of its reach
+// are compared against the use: which subtree its selector claims, and which
+// conditions its enclosing at-rules put on it. A rule that answers only the
+// first half sanctions exactly the kind of scope this file exists to catch.
 
-// A selector that can match the document root, so a custom property declared
-// there is inherited by every element regardless of where it mounts. Derived
-// from shape rather than from a list of the project's current scopes: `:root`,
-// `[data-theme="light"]`, `:root:not([data-theme="dark"])` and a bare `html`
-// all qualify because each one's subject is at or above the body, and a scope
-// spelled some new way qualifies on the same grounds.
-const REACHES_EVERY_ELEMENT = /^(:root|html|body|\*|\[)/;
+// A selector that matches the document root itself, so a custom property
+// declared there is inherited by every element regardless of where it mounts.
+// The whole selector has to match, not its prefix. A qualified root reaches
+// every element only while its qualifier holds, which is a narrower promise
+// than the one being consumed: `[data-theme="dark"]` names an attribute this
+// repo also sets on nested elements (`AppWindow.tsx:259`,
+// `AppsEditorPage.tsx:114`, `confirm-dialog.tsx:108`), and even on `<html>` it
+// is one half of a theme pair, so a token declared only there is missing
+// wherever the other half applies. Such tokens resolve because a `:root` base
+// declares them and the themed block overrides it -- and that base is what
+// this looks for.
+const DOCUMENT_ROOT = /^(:root|html|body|\*)$/;
+
+// An at-rule whose body applies only when its condition holds. A declaration
+// inside one is in force for a use only if the use is inside it too, so the
+// chain is compared rather than discarded -- 72 token declarations and 19 uses
+// in this project sit under `@media`, so the difference is not hypothetical.
+// `@layer` and `@theme` are deliberately absent: they set precedence and
+// origin, not whether the body applies. An at-rule spelled some new way counts
+// as unconditional, a miss rather than a false positive -- the same bias as
+// the fallback rule below.
+const CONDITIONAL = new Set(['media', 'supports', 'container', 'scope', 'document']);
 
 // `var(--x)` on an undeclared name draws nothing; `var(--x, 6px)` draws 6px.
 // The second is not this defect, so the fallback is what decides whether a use
@@ -41,6 +62,28 @@ function insideTheme(node) {
     if (at.type === 'atrule' && at.name === 'theme') return true;
   }
   return false;
+}
+
+// Every condition standing between a node and the stylesheet, innermost first.
+// Params are whitespace-collapsed so one query spelled two ways still reads as
+// one condition.
+function conditionsOn(node) {
+  const chain = [];
+  for (let at = node.parent; at; at = at.parent) {
+    if (at.type === 'atrule' && CONDITIONAL.has(at.name)) {
+      chain.push(`@${at.name} ${at.params.replace(/\s+/g, ' ').trim()}`);
+    }
+  }
+  return chain;
+}
+
+// Whether any of `chains` describes a declaration that is in force wherever a
+// use guarded by `conditions` applies. That holds when every condition on the
+// declaration also guards the use: the use cannot apply without them, so the
+// declaration cannot be missing. An unconditional declaration has an empty
+// chain and so is in force everywhere, which is the ordinary case.
+function inForce(chains, conditions) {
+  return (chains ?? []).some((chain) => chain.every((one) => conditions.includes(one)));
 }
 
 // The leftmost compound of a selector is the only part that says which subtree
@@ -118,8 +161,15 @@ function classesRenderedBy(source) {
  */
 function unscopedTokens(sheets, classNames) {
   const travelling = new Set(classNames);
-  const inheritable = new Set();
+  // Both keyed to the conditions the declaration was made under, because a
+  // name being declared somewhere is not the question -- that is what
+  // `customPropertiesIn` answers, and what let this defect ship.
+  const inheritable = new Map();
   const declaredOn = new Map();
+  const record = (into, key, conditions) => {
+    if (!into.has(key)) into.set(key, []);
+    into.get(key).push(conditions);
+  };
 
   for (const [, root] of sheets) {
     // A registered name resolves to its initial value everywhere, so a use of
@@ -127,19 +177,17 @@ function unscopedTokens(sheets, classNames) {
     // `syntax: "*"` does draw nothing, which this treats as resolvable and so
     // will not report -- a miss rather than a false positive, on the same
     // grounds `customProperties.mjs` records the name at all.
-    root.walkAtRules('property', (rule) => inheritable.add(rule.params.trim()));
+    root.walkAtRules('property', (rule) => record(inheritable, rule.params.trim(), conditionsOn(rule)));
 
     root.walkDecls((declaration) => {
       if (!declaration.prop.startsWith('--')) return;
 
       const owner = declaration.parent;
-      if (owner.type !== 'rule') {
-        if (insideTheme(declaration)) inheritable.add(declaration.prop);
-        return;
-      }
-      if (insideTheme(declaration) || owner.selectors.some((one) => REACHES_EVERY_ELEMENT.test(one.trim()))) {
-        inheritable.add(declaration.prop);
-      }
+      const conditions = conditionsOn(declaration);
+      const fromRoot = owner.type === 'rule'
+        && owner.selectors.some((one) => DOCUMENT_ROOT.test(one.trim()));
+      if (insideTheme(declaration) || fromRoot) record(inheritable, declaration.prop, conditions);
+      if (owner.type !== 'rule') return;
 
       for (const one of owner.selectors) {
         const selector = one.trim();
@@ -149,8 +197,7 @@ function unscopedTokens(sheets, classNames) {
           // and no sibling, so counting it would sanction a scope narrower than
           // the one being consumed.
           if (selector !== `.${name}`) continue;
-          if (!declaredOn.has(name)) declaredOn.set(name, new Set());
-          declaredOn.get(name).add(declaration.prop);
+          record(declaredOn, `${name}|${declaration.prop}`, conditions);
         }
       }
     });
@@ -165,13 +212,14 @@ function unscopedTokens(sheets, classNames) {
       const used = [...declaration.value.matchAll(UNGUARDED_USE)].map((match) => match[1]);
       if (used.length === 0) return;
 
+      const conditions = conditionsOn(declaration);
       for (const one of owner.selectors) {
         const selector = one.trim();
         for (const name of classesOf(firstCompound(selector))) {
           if (!travelling.has(name)) continue;
           for (const property of used) {
-            if (inheritable.has(property)) continue;
-            if (declaredOn.get(name)?.has(property)) continue;
+            if (inForce(inheritable.get(property), conditions)) continue;
+            if (inForce(declaredOn.get(`${name}|${property}`), conditions)) continue;
             unresolved.push({ className: name, property, origin, selector, declaration: declaration.prop });
           }
         }

--- a/ui/scripts/travellingTokens.test.mjs
+++ b/ui/scripts/travellingTokens.test.mjs
@@ -27,6 +27,27 @@ const TRAVELLING_COMPONENTS = [
   'src/components/settings/models/GuardGapList.tsx',
 ];
 
+// The body's outer wrapper has no component of its own: every caller writes the
+// `<div className="model-hub-guard-body">` itself, so no single file's
+// `className` values name it the way the two components above name theirs.
+// Hence the name here. One name covers every caller, present and future,
+// because what gets asserted is a property of the class -- it resolves its
+// tokens from itself or from an inherited scope -- and that holds under
+// whichever root a caller mounts it in.
+const TRAVELLING_WRAPPERS = ['model-hub-guard-body'];
+
+// Every shipped source, so a class can be asked who renders it. Tests are
+// excluded: a class named only by an assertion does not ship.
+function* shippedSources(directory) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const at = path.join(directory, entry.name);
+    if (entry.isDirectory()) yield* shippedSources(at);
+    else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+      yield fs.readFileSync(at, 'utf8');
+    }
+  }
+}
+
 describe('firstCompound', () => {
   it('keeps the whole selector when nothing follows the subject', () => {
     expect(firstCompound('.model-hub-guard-label')).toBe('.model-hub-guard-label');
@@ -71,11 +92,28 @@ describe('unscopedTokens', () => {
   });
 
   it('accepts a token from a scope every element inherits', () => {
-    for (const scope of [':root', 'html', '[data-theme="light"]', ':root:not([data-theme="dark"])']) {
+    for (const scope of [':root', 'html', 'body', '*']) {
       const sheets = sheetsOf(`${scope} { --gap: 6px } .travels { gap: var(--gap); }`);
 
       expect(unscopedTokens(sheets, ['travels'])).toEqual([]);
     }
+  });
+
+  it('reports a token only a qualified root declares, because the other half has none', () => {
+    // A themed root reaches every element only while that theme applies, so it
+    // cannot answer for a use that applies always.
+    for (const scope of ['[data-theme="light"]', ':root:not([data-theme="dark"])', 'html[data-theme="dark"]']) {
+      const sheets = sheetsOf(`${scope} { --gap: 6px } .travels { gap: var(--gap); }`);
+
+      expect(unscopedTokens(sheets, ['travels'])).toHaveLength(1);
+    }
+  });
+
+  it('accepts a themed override once a root base declares the same token', () => {
+    // The project's own shape: `:root` states the value, the theme overrides it.
+    const sheets = sheetsOf(':root { --gap: 6px } [data-theme="dark"] { --gap: 8px } .travels { gap: var(--gap); }');
+
+    expect(unscopedTokens(sheets, ['travels'])).toEqual([]);
   });
 
   it('accepts a token the class declares on itself and a descendant consumes', () => {
@@ -115,16 +153,70 @@ describe('unscopedTokens', () => {
 
     expect(unscopedTokens(sheets, ['travels'])).toEqual([]);
   });
+
+  it('reports a token the class declares only inside a query the use does not share', () => {
+    const sheets = sheetsOf('@media (min-width: 600px) { .travels { --gap: 6px } } .travels { gap: var(--gap); }');
+
+    expect(unscopedTokens(sheets, ['travels'])).toHaveLength(1);
+  });
+
+  it('accepts it when the use stands under the same query', () => {
+    const sheets = sheetsOf('@media (min-width: 600px) { .travels { --gap: 6px } .travels { gap: var(--gap); } }');
+
+    expect(unscopedTokens(sheets, ['travels'])).toEqual([]);
+  });
+
+  it('accepts a use nested deeper than the declaration it relies on', () => {
+    // The use cannot apply without the query that guards the declaration, so
+    // the declaration cannot be missing where the use is.
+    const sheets = sheetsOf(
+      '@media (min-width: 600px) { .travels { --gap: 6px } @supports (gap: 1px) { .travels { gap: var(--gap); } } }',
+    );
+
+    expect(unscopedTokens(sheets, ['travels'])).toEqual([]);
+  });
+
+  it('reports an inherited scope that is itself conditional, registration included', () => {
+    // The same miss as a class token: `:root`, `@theme` and `@property` each
+    // promise every element, and a query around any of them takes that back.
+    for (const declared of [
+      ':root { --gap: 6px }',
+      '@theme { --gap: 6px }',
+      '@property --gap { syntax: "*"; inherits: true; initial-value: 6px }',
+    ]) {
+      const sheets = sheetsOf(`@media print { ${declared} } .travels { gap: var(--gap); }`);
+
+      expect(unscopedTokens(sheets, ['travels'])).toHaveLength(1);
+    }
+  });
+
+  it('treats a layer as no condition at all, because its body always applies', () => {
+    const sheets = sheetsOf('@layer base { .travels { --gap: 6px } } .travels { gap: var(--gap); }');
+
+    expect(unscopedTokens(sheets, ['travels'])).toEqual([]);
+  });
 });
 
 describe('the shared guard body', () => {
   const sheets = [...eachStylesheet(UI_ROOT)];
-  const travelling = new Set();
+  const travelling = new Set(TRAVELLING_WRAPPERS);
   for (const relative of TRAVELLING_COMPONENTS) {
     for (const name of classesRenderedBy(fs.readFileSync(path.join(UI_ROOT, relative), 'utf8'))) {
       travelling.add(name);
     }
   }
+
+  it('names only wrappers the product still renders', () => {
+    // The other half of the subject check below. A wrapper no file renders any
+    // more is a name nobody checks, so it fails here rather than sitting in the
+    // list looking like coverage.
+    const rendered = new Set();
+    for (const source of shippedSources(path.join(UI_ROOT, 'src'))) {
+      for (const name of classesRenderedBy(source)) rendered.add(name);
+    }
+
+    for (const wrapper of TRAVELLING_WRAPPERS) expect(rendered).toContain(wrapper);
+  });
 
   it('renders classes this project styles, so the check has a subject', () => {
     // Without this the assertion below passes by asking about nothing, which is

--- a/ui/scripts/travellingTokens.test.mjs
+++ b/ui/scripts/travellingTokens.test.mjs
@@ -1,0 +1,161 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import postcss from 'postcss';
+
+import { eachStylesheet } from './stylesheets.mjs';
+import { classesRenderedBy, firstCompound, unscopedTokens } from './travellingTokens.mjs';
+
+const UI_ROOT = fileURLToPath(new URL('../', import.meta.url));
+
+// The components whose styling has to survive being mounted somewhere else.
+// This is the one thing the stylesheet cannot know and the check cannot derive:
+// a class is only "travelling" because more than one dialog renders it, which
+// is a fact about the React tree. So it is stated once, as the subject of the
+// check -- and the classes themselves are then read out of these files, so the
+// enumeration ends here rather than being copied into an assertion.
+//
+// Add a component to this list when it becomes shared. Both of these are: they
+// are the evidence body of a guarded Model Hub mutation, and `SourceDetailPanel`,
+// `SourceMutationReport`, `BackendModelCatalogDialog`, `AddApiKeyDialog` and
+// `RouteChainDialog` each mount them under a different root class.
+const TRAVELLING_COMPONENTS = [
+  'src/components/settings/models/GuardImpact.tsx',
+  'src/components/settings/models/GuardGapList.tsx',
+];
+
+describe('firstCompound', () => {
+  it('keeps the whole selector when nothing follows the subject', () => {
+    expect(firstCompound('.model-hub-guard-label')).toBe('.model-hub-guard-label');
+  });
+
+  it('stops at every combinator, so a descendant rule is attributed to its subject', () => {
+    for (const combinator of [' ', ' > ', ' + ', ' ~ ', '>']) {
+      expect(firstCompound(`.a${combinator}span`)).toBe('.a');
+    }
+  });
+
+  it('does not mistake a combinator inside a functional or attribute part for the end', () => {
+    expect(firstCompound('.a:not(.b > .c)[data-x="y > z"] span')).toBe('.a:not(.b > .c)[data-x="y > z"]');
+  });
+});
+
+describe('classesRenderedBy', () => {
+  it('reads a plain literal, a helper call and a conditional alike', () => {
+    const source = [
+      'const a = <div className="one two" />;',
+      "const b = <div className={cn('three', flag && 'four')} />;",
+      'const c = <div className={`five`} />;',
+    ].join('\n');
+
+    expect(classesRenderedBy(source)).toEqual(new Set(['one', 'two', 'three', 'four', 'five']));
+  });
+
+  it('ignores a class name that is only talked about', () => {
+    const source = '// .model-hub-guard-label is styled elsewhere\nconst tip = ".model-hub-guard-hop";';
+
+    expect(classesRenderedBy(source)).toEqual(new Set());
+  });
+});
+
+describe('unscopedTokens', () => {
+  const sheetsOf = (css) => [['inline', postcss.parse(css)]];
+
+  it('accepts a token the class declares on itself', () => {
+    const sheets = sheetsOf('.travels { --gap: 6px; gap: var(--gap); }');
+
+    expect(unscopedTokens(sheets, ['travels'])).toEqual([]);
+  });
+
+  it('accepts a token from a scope every element inherits', () => {
+    for (const scope of [':root', 'html', '[data-theme="light"]', ':root:not([data-theme="dark"])']) {
+      const sheets = sheetsOf(`${scope} { --gap: 6px } .travels { gap: var(--gap); }`);
+
+      expect(unscopedTokens(sheets, ['travels'])).toEqual([]);
+    }
+  });
+
+  it('accepts a token the class declares on itself and a descendant consumes', () => {
+    const sheets = sheetsOf('.travels { --pad: 8px } .travels > span { padding: var(--pad); }');
+
+    expect(unscopedTokens(sheets, ['travels'])).toEqual([]);
+  });
+
+  it('reports a token only some ancestor declares, naming the class and the property', () => {
+    const sheets = sheetsOf('.host { --gap: 6px } .travels { gap: var(--gap); }');
+
+    expect(unscopedTokens(sheets, ['travels'])).toEqual([
+      { className: 'travels', property: '--gap', origin: 'inline', selector: '.travels', declaration: 'gap' },
+    ]);
+  });
+
+  it('reports it for a descendant of the class too', () => {
+    const sheets = sheetsOf('.host { --pad: 8px } .travels > span { padding: var(--pad); }');
+
+    expect(unscopedTokens(sheets, ['travels'])).toHaveLength(1);
+  });
+
+  it('leaves a rule about one host alone, because that rule is not travelling', () => {
+    const sheets = sheetsOf('.host { --gap: 6px } .host .travels { gap: var(--gap); }');
+
+    expect(unscopedTokens(sheets, ['travels'])).toEqual([]);
+  });
+
+  it('accepts a use that carries a fallback, which draws something either way', () => {
+    const sheets = sheetsOf('.host { --gap: 6px } .travels { gap: var(--gap, 6px); }');
+
+    expect(unscopedTokens(sheets, ['travels'])).toEqual([]);
+  });
+
+  it('says nothing about a class that does not travel', () => {
+    const sheets = sheetsOf('.host { --gap: 6px } .stays-put { gap: var(--gap); }');
+
+    expect(unscopedTokens(sheets, ['travels'])).toEqual([]);
+  });
+});
+
+describe('the shared guard body', () => {
+  const sheets = [...eachStylesheet(UI_ROOT)];
+  const travelling = new Set();
+  for (const relative of TRAVELLING_COMPONENTS) {
+    for (const name of classesRenderedBy(fs.readFileSync(path.join(UI_ROOT, relative), 'utf8'))) {
+      travelling.add(name);
+    }
+  }
+
+  it('renders classes this project styles, so the check has a subject', () => {
+    // Without this the assertion below passes by asking about nothing, which is
+    // how a check outlives the thing it checks. `readFileSync` already fails
+    // loudly if a component moves; this covers the quieter half, where the
+    // files still parse but nothing recognisable comes out of them.
+    expect(travelling.size).toBeGreaterThan(0);
+
+    // Not every class needs a rule here: these components also render Tailwind
+    // utilities (`flex-1`, `min-w-0`), which are generated at build time and
+    // carry no custom properties, and `unscopedTokens` never reaches a class no
+    // rule takes as its subject. So the requirement is that the project styles
+    // some of what they render -- not all of it.
+    const styled = new Set();
+    for (const [, root] of sheets) {
+      root.walkRules((rule) => {
+        for (const one of rule.selectors) {
+          for (const name of travelling) if (one.includes(`.${name}`)) styled.add(name);
+        }
+      });
+    }
+    expect(styled.size).toBeGreaterThan(0);
+  });
+
+  it('resolves every token it consumes wherever a caller mounts it', () => {
+    // The four roots are `.model-hub-guard-dialog`, `.model-hub-catalog-dialog`,
+    // `.model-hub-add-key-dialog` and `.model-hub-route-dialog`. None of them is
+    // named here on purpose: a token resolvable from the class itself or from
+    // `:root` is resolvable under all four and under a fifth nobody has written
+    // yet, which is the property that makes the body shared rather than the
+    // guard dialog's.
+    expect(unscopedTokens(sheets, travelling)).toEqual([]);
+  });
+});

--- a/ui/src/components/settings/models/BackendModelCatalogDialog.test.tsx
+++ b/ui/src/components/settings/models/BackendModelCatalogDialog.test.tsx
@@ -126,6 +126,36 @@ describe('BackendModelCatalogDialog', () => {
     expect(screen.getByLabelText('搜索名称或模型 ID')).toBeTruthy();
   });
 
+  it.each([
+    ['en', { corner: 'Close', footer: 'Cancel' }],
+    ['zh', { corner: '关闭', footer: '取消' }],
+  ] as const)('names the corner and footer exits apart in %s', async (language, exit) => {
+    await i18n.changeLanguage(language);
+    vi.spyOn(modelsApi, 'getAgentSources').mockResolvedValue(agent([model('alpha')]));
+    const user = userEvent.setup();
+    const { onClose } = renderDialog();
+
+    // The model id is the one string here no locale rewrites.
+    await screen.findByText('alpha');
+
+    // Both ways out leave without saving, which is why they were once given the
+    // same word — and why that word named neither. `getByRole` is singular, so
+    // each line below also asserts the name it asks for reaches nothing else in
+    // the dialog; the pair then has to be two controls rather than one found
+    // twice. A screen reader is under the same constraint: one word announced
+    // for the corner and the footer alike describes the dialog as having a
+    // single exit, and offers no way to say which one is being read.
+    const dialog = within(screen.getByRole('dialog'));
+    const exits = [
+      dialog.getByRole('button', { name: exit.corner }),
+      dialog.getByRole('button', { name: exit.footer }),
+    ];
+    expect(new Set(exits).size).toBe(exits.length);
+
+    for (const control of exits) await user.click(control);
+    expect(onClose).toHaveBeenCalledTimes(exits.length);
+  });
+
   it('shows the catalog and nothing else — no source, route, fallback or mapping control', async () => {
     vi.spyOn(modelsApi, 'getAgentSources').mockResolvedValue(agent([model('alpha')], {
       routes: { alpha: { hops: [{ source_id: 'src_a', model_id: 'alpha' }] } },
@@ -962,9 +992,10 @@ describe('BackendModelCatalogDialog', () => {
 
       await screen.findByRole('checkbox', { name: /Backup relay/ });
       // Either control the picker offers to leave is the same answer, and the
-      // dialog treats it as one: 「add none of these」.
-      const [dismiss] = within(screen.getByRole('dialog', { name: 'Add Claude Code models' }))
-        .getAllByRole('button', { name: 'Cancel' });
+      // dialog treats it as one: 「add none of these」. Asked of one name, since
+      // the corner control answers to 「Close」 and only the footer to this.
+      const dismiss = within(screen.getByRole('dialog', { name: 'Add Claude Code models' }))
+        .getByRole('button', { name: 'Cancel' });
       await user.click(dismiss);
 
       // The row and its promise go together. What is left is the list the server
@@ -1004,11 +1035,11 @@ describe('BackendModelCatalogDialog', () => {
       // promise: what remains is the list the server already holds, so there is
       // nothing to save — the surest statement that the refused projection
       // cannot go out again. Asked back at the catalog, since the door closed
-      // the picker on its way out; the editor's own control is named for it,
-      // because the catalog behind it carries that word too.
+      // the picker on its way out; scoped to the editor, whose footer is the
+      // one control in it that carries this word.
       expect((await screen.findByLabelText('Model') as HTMLInputElement).value).toBe('');
-      const [leave] = within(screen.getByRole('dialog', { name: 'Add model' }))
-        .getAllByRole('button', { name: 'Cancel' });
+      const leave = within(screen.getByRole('dialog', { name: 'Add model' }))
+        .getByRole('button', { name: 'Cancel' });
       await user.click(leave);
       await waitFor(() => expect(screen.queryByText('GLM 5.2')).toBeNull());
       expect(screen.getByRole('button', { name: 'Save' }).hasAttribute('disabled')).toBe(true);

--- a/ui/src/components/settings/models/BackendModelCatalogDialog.tsx
+++ b/ui/src/components/settings/models/BackendModelCatalogDialog.tsx
@@ -950,7 +950,7 @@ export const BackendModelCatalogDialog: React.FC<{
       >
         <DialogContent
           mobileSheetHeight="tall"
-          closeLabel={t('settings.models.gateway.catalog.cancel') as string}
+          closeLabel={t('common.close') as string}
           className="model-hub-catalog-dialog flex h-[min(642px,calc(100dvh-32px))] w-[min(680px,calc(100vw-32px))] max-w-[680px] flex-col gap-0 overflow-hidden rounded-[14px] border-border-strong bg-surface p-0 shadow-[var(--model-hub-dialog-shadow)] max-md:w-full max-md:max-w-none max-md:rounded-t-2xl max-md:p-0 max-md:pt-2"
           onEscapeKeyDown={(event) => { if (busy || grabbedId) event.preventDefault(); }}
           onPointerDownOutside={(event) => { if (busy) event.preventDefault(); }}

--- a/ui/src/components/settings/models/BackendModelEditorDialog.test.tsx
+++ b/ui/src/components/settings/models/BackendModelEditorDialog.test.tsx
@@ -650,13 +650,19 @@ describe('BackendModelEditorDialog', () => {
 
     await user.type(modelField(), 'abandoned');
     // The header close and the footer button are the same decision, so both
-    // discard the draft rather than one of them saving it.
-    const cancels = screen.getAllByRole('button', { name: 'Cancel' });
-    expect(cancels).toHaveLength(2);
-    await user.click(cancels[0]);
-    await user.click(cancels[1]);
+    // discard the draft rather than one of them saving it. They are still two
+    // controls, so they answer to two names: each `getByRole` below is singular
+    // and throws if the name it asks for reaches more than one of them, which
+    // is what sharing 「Cancel」 did — a screen reader announcing it twice named
+    // neither, and a by-name locator could not address either.
+    const exits = [
+      screen.getByRole('button', { name: 'Close' }),
+      screen.getByRole('button', { name: 'Cancel' }),
+    ];
+    expect(new Set(exits).size).toBe(exits.length);
+    for (const exit of exits) await user.click(exit);
 
-    expect(onCancel).toHaveBeenCalledTimes(2);
+    expect(onCancel).toHaveBeenCalledTimes(exits.length);
     expect(onCommit).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/components/settings/models/BackendModelEditorDialog.tsx
+++ b/ui/src/components/settings/models/BackendModelEditorDialog.tsx
@@ -419,7 +419,7 @@ export const BackendModelEditorDialog: React.FC<{
     <Dialog open={open} onOpenChange={(next) => { if (!next) onCancel(); }}>
       <DialogContent
         mobileSheetHeight="tall"
-        closeLabel={t('settings.models.gateway.modelEditor.cancel') as string}
+        closeLabel={t('common.close') as string}
         className="model-hub-model-editor flex h-[min(660px,calc(100dvh-32px))] w-[min(720px,calc(100vw-32px))] max-w-[720px] flex-col gap-0 overflow-hidden rounded-[14px] border-border-strong bg-surface p-0 shadow-[var(--model-hub-dialog-shadow)] max-md:w-full max-md:max-w-none max-md:rounded-t-2xl max-md:p-0 max-md:pt-2"
       >
         <DialogHeader className="model-hub-model-editor-head shrink-0 justify-center border-b border-border">

--- a/ui/src/components/settings/models/BackendModelPickerDialog.test.tsx
+++ b/ui/src/components/settings/models/BackendModelPickerDialog.test.tsx
@@ -254,12 +254,18 @@ describe('BackendModelPickerDialog', () => {
     const { onCancel, onAdd } = renderPicker();
 
     await user.click(await screen.findByRole('checkbox', { name: 'gpt-6' }));
-    const exits = screen.getAllByRole('button', { name: 'Cancel' });
+    // Every way out is the same way out, and each one is still addressable on
+    // its own: the corner control is named for what it is rather than borrowing
+    // the footer's word, so neither name reaches both. `getByRole` is singular
+    // and enforces that — sharing 「Cancel」 made each of these throw.
+    const exits = [
+      screen.getByRole('button', { name: 'Close' }),
+      screen.getByRole('button', { name: 'Cancel' }),
+    ];
+    expect(new Set(exits).size).toBe(exits.length);
     for (const exit of exits) await user.click(exit);
 
-    // Every way out is the same way out: the corner control borrows the
-    // footer's label rather than inventing a second word for it, and neither
-    // one takes the picks with it.
+    // And neither one takes the picks with it.
     expect(onCancel).toHaveBeenCalledTimes(exits.length);
     expect(onAdd).not.toHaveBeenCalled();
   });

--- a/ui/src/components/settings/models/BackendModelPickerDialog.tsx
+++ b/ui/src/components/settings/models/BackendModelPickerDialog.tsx
@@ -168,7 +168,7 @@ export const BackendModelPickerDialog: React.FC<{
     <Dialog open={open} onOpenChange={(next) => { if (!next) onCancel(); }}>
       <DialogContent
         mobileSheetHeight="tall"
-        closeLabel={t('settings.models.gateway.catalog.cancel') as string}
+        closeLabel={t('common.close') as string}
         className="model-hub-catalog-dialog model-hub-picker flex h-[min(642px,calc(100dvh-32px))] w-[min(680px,calc(100vw-32px))] max-w-[680px] flex-col gap-0 overflow-hidden rounded-[14px] border-border-strong bg-surface p-0 shadow-[var(--model-hub-dialog-shadow)] max-md:w-full max-md:max-w-none max-md:rounded-t-2xl max-md:p-0 max-md:pt-2"
       >
         <DialogHeader className="model-hub-catalog-head shrink-0 justify-center border-b border-border">

--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -1185,6 +1185,24 @@
 }
 
 .model-hub-guard-overlay { background: var(--model-hub-scrim); }
+/* Only the chrome's metrics. The head, title, subtitle, close, foot and action
+   are this dialog's own furniture and render nowhere else, so they resolve here.
+   The evidence BODY below is a different kind of thing: `GuardImpact` and
+   `GuardGapList` are shared, and they mount inside four separate dialogs — this
+   one, the catalog dialog's in-row removal confirmation, the Add-key replace
+   phase, and the route chain's guard phase. A body token declared here reached
+   exactly one of them; in the other three `var()` named a property no ancestor
+   declares, which is invalid at computed-value time, so the declaration drew
+   nothing: the label lost its gap AND its size, and the count lost its padding
+   AND its size, which is not a pill missing a margin but 「Hops that will be
+   removed2 hops」 in one unbroken run at the inherited font.
+
+   It is the argument `.model-hub-route-selector` makes further up, arrived at
+   from the other side. There a popover is portalled out of its dialog and
+   inherits nothing; here nothing is portalled — the body is simply mounted
+   somewhere else, which the stylesheet cannot see and the token scope must not
+   assume. So each body class carries what it and its descendants consume, and a
+   caller may mount it under any root at all. */
 .model-hub-guard-dialog {
   --model-hub-guard-width: 520px;
   --model-hub-guard-radius: 14px;
@@ -1195,28 +1213,6 @@
   --model-hub-guard-subtitle-size: 10.5px;
   --model-hub-guard-close-size: 27px;
   --model-hub-guard-close-icon-size: 15px;
-  --model-hub-guard-body-padding: 20px;
-  --model-hub-guard-body-gap: 14px;
-  --model-hub-guard-label-gap: 6px;
-  --model-hub-guard-label-size: 10.5px;
-  --model-hub-guard-count-padding-y: 3px;
-  --model-hub-guard-count-padding-x: 8px;
-  --model-hub-guard-count-size: 10px;
-  --model-hub-guard-list-padding: 8px;
-  --model-hub-guard-list-gap: 6px;
-  --model-hub-guard-list-radius: 10px;
-  --model-hub-guard-hop-height: 52px;
-  --model-hub-guard-hop-padding-x: 10px;
-  --model-hub-guard-hop-gap: 10px;
-  --model-hub-guard-hop-radius: 8px;
-  --model-hub-guard-hop-name-size: 12px;
-  --model-hub-guard-hop-detail-gap: 3px;
-  --model-hub-guard-hop-detail-size: 10.5px;
-  --model-hub-guard-hint-gap: 7px;
-  --model-hub-guard-hint-size: 11.5px;
-  --model-hub-guard-hint-line: 17px;
-  --model-hub-guard-hint-icon-size: 13px;
-  --model-hub-guard-hint-icon-offset: 2px;
   --model-hub-guard-foot-padding-y: 14px;
   --model-hub-guard-foot-padding-x: 20px;
   --model-hub-guard-foot-gap: 8px;
@@ -1240,14 +1236,77 @@
 .model-hub-guard-subtitle { color: var(--muted); font-family: 'JetBrains Mono', monospace; font-size: var(--model-hub-guard-subtitle-size); }
 .model-hub-guard-close { width: var(--model-hub-guard-close-size); height: var(--model-hub-guard-close-size); color: var(--model-hub-ink-59); }
 .model-hub-guard-close svg { width: var(--model-hub-guard-close-icon-size); height: var(--model-hub-guard-close-icon-size); }
-.model-hub-guard-body { padding: var(--model-hub-guard-body-padding); display: flex; flex-direction: column; gap: var(--model-hub-guard-body-gap); }
-.model-hub-guard-label { display: flex; align-items: center; justify-content: flex-start; gap: var(--model-hub-guard-label-gap); color: var(--model-hub-ink-73); font-size: var(--model-hub-guard-label-size); font-weight: 700; }
+/* The travelling body. Each class declares the metrics it and its own
+   selector-descendants consume, so none of them depends on where a caller
+   mounted it — not on the guard dialog, and not on each other either: a hop
+   outside a list still measures like a hop. */
+.model-hub-guard-body {
+  --model-hub-guard-body-padding: 20px;
+  --model-hub-guard-body-gap: 14px;
+  padding: var(--model-hub-guard-body-padding);
+  display: flex;
+  flex-direction: column;
+  gap: var(--model-hub-guard-body-gap);
+}
+.model-hub-guard-label {
+  --model-hub-guard-label-gap: 6px;
+  --model-hub-guard-label-size: 10.5px;
+  --model-hub-guard-count-padding-y: 3px;
+  --model-hub-guard-count-padding-x: 8px;
+  --model-hub-guard-count-size: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--model-hub-guard-label-gap);
+  color: var(--model-hub-ink-73);
+  font-size: var(--model-hub-guard-label-size);
+  font-weight: 700;
+}
 .model-hub-guard-label > span { padding: var(--model-hub-guard-count-padding-y) var(--model-hub-guard-count-padding-x); border: 1px solid var(--border); border-radius: 999px; background: var(--model-hub-wash-0a); color: var(--muted); font-size: var(--model-hub-guard-count-size); font-weight: 600; }
-.model-hub-guard-list { padding: var(--model-hub-guard-list-padding); display: flex; flex-direction: column; gap: var(--model-hub-guard-list-gap); border: 1px solid var(--border); border-radius: var(--model-hub-guard-list-radius); background: var(--background); }
-.model-hub-guard-hop { min-height: var(--model-hub-guard-hop-height); padding: 0 var(--model-hub-guard-hop-padding-x); display: flex; align-items: center; gap: var(--model-hub-guard-hop-gap); border: 1px solid var(--border); border-radius: var(--model-hub-guard-hop-radius); background: var(--model-hub-wash-08); }
+.model-hub-guard-list {
+  --model-hub-guard-list-padding: 8px;
+  --model-hub-guard-list-gap: 6px;
+  --model-hub-guard-list-radius: 10px;
+  padding: var(--model-hub-guard-list-padding);
+  display: flex;
+  flex-direction: column;
+  gap: var(--model-hub-guard-list-gap);
+  border: 1px solid var(--border);
+  border-radius: var(--model-hub-guard-list-radius);
+  background: var(--background);
+}
+.model-hub-guard-hop {
+  --model-hub-guard-hop-height: 52px;
+  --model-hub-guard-hop-padding-x: 10px;
+  --model-hub-guard-hop-gap: 10px;
+  --model-hub-guard-hop-radius: 8px;
+  --model-hub-guard-hop-name-size: 12px;
+  --model-hub-guard-hop-detail-gap: 3px;
+  --model-hub-guard-hop-detail-size: 10.5px;
+  min-height: var(--model-hub-guard-hop-height);
+  padding: 0 var(--model-hub-guard-hop-padding-x);
+  display: flex;
+  align-items: center;
+  gap: var(--model-hub-guard-hop-gap);
+  border: 1px solid var(--border);
+  border-radius: var(--model-hub-guard-hop-radius);
+  background: var(--model-hub-wash-08);
+}
 .model-hub-guard-hop strong { display: block; color: color-mix(in srgb, var(--foreground) 70.2%, transparent); font-size: var(--model-hub-guard-hop-name-size); font-weight: 600; }
 .model-hub-guard-hop span span { margin-top: var(--model-hub-guard-hop-detail-gap); display: block; color: var(--model-hub-muted-b3); font-family: 'JetBrains Mono', monospace; font-size: var(--model-hub-guard-hop-detail-size); }
-.model-hub-guard-hint { display: flex; align-items: flex-start; gap: var(--model-hub-guard-hint-gap); color: var(--model-hub-ink-73); font-size: var(--model-hub-guard-hint-size); line-height: var(--model-hub-guard-hint-line); }
+.model-hub-guard-hint {
+  --model-hub-guard-hint-gap: 7px;
+  --model-hub-guard-hint-size: 11.5px;
+  --model-hub-guard-hint-line: 17px;
+  --model-hub-guard-hint-icon-size: 13px;
+  --model-hub-guard-hint-icon-offset: 2px;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--model-hub-guard-hint-gap);
+  color: var(--model-hub-ink-73);
+  font-size: var(--model-hub-guard-hint-size);
+  line-height: var(--model-hub-guard-hint-line);
+}
 .model-hub-guard-hint svg { width: var(--model-hub-guard-hint-icon-size); height: var(--model-hub-guard-hint-icon-size); margin-top: var(--model-hub-guard-hint-icon-offset); flex: none; color: var(--model-hub-ink-59); }
 .model-hub-guard-foot { padding: var(--model-hub-guard-foot-padding-y) var(--model-hub-guard-foot-padding-x); display: flex; align-items: center; justify-content: flex-end; gap: var(--model-hub-guard-foot-gap); border-top: 1px solid var(--border); background: var(--model-hub-wash-05); }
 .model-hub-guard-action { height: auto; padding: var(--model-hub-guard-action-padding-y) var(--model-hub-guard-action-padding-x); border-radius: var(--model-hub-guard-action-radius); font-size: var(--model-hub-guard-action-size); font-weight: 600; }


### PR DESCRIPTION
Follow-up to #1839, from the hermetic E2E run of the merged feature (31 passed / 2 failed / 7 skipped). Both failures are fixed here, plus one visual defect found by the integration walk and folded in because it lives in the same dialogs.

## What changed

**Product — one name per control.** All three Model Hub dialogs passed their footer's Cancel label into `DialogContent`'s `closeLabel`, and that prop *is* the header close control's accessible name (`ui/src/components/ui/dialog.tsx:60` renders it into an `sr-only` span). One word therefore named two controls: a screen reader announced it twice with no way to say which exit it was reading, and any by-name locator resolved neither.

| Dialog | Header close control was named by | Now |
| --- | --- | --- |
| `BackendModelCatalogDialog` | `settings.models.gateway.catalog.cancel` | `common.close` |
| `BackendModelPickerDialog` | `settings.models.gateway.catalog.cancel` | `common.close` |
| `BackendModelEditorDialog` | `settings.models.gateway.modelEditor.cancel` | `common.close` |

Every footer Cancel is unchanged. No i18n key was added, so `en.json` and `zh.json` stay 1:1 by construction; `common.close` already carries exactly the requested strings — `Close` and `关闭`.

`model-list.spec.ts` then passes without a locator hack, because the ambiguity was in the accessible names and not in the spec: `labelledButton` filters by `hasText`, and `sr-only` text is real text content, so no filter could have separated the two.

**Product — the shared guard body carries its own metrics.** The reported symptom was one missing gap in the catalog dialog's in-row removal confirmation: 「Hops that will be removed2 hops」. The cause is a token-scope defect, and it is wider than the gap and wider than that dialog.

`GuardImpact` and `GuardGapList` are the evidence body of every guarded Model Hub mutation. Every `--model-hub-guard-*` token was declared on `.model-hub-guard-dialog`, while the body's own classes are global — and only two of the five callers mount the body inside that dialog. In the other three, `var()` named a property no ancestor declares, which is invalid at computed-value time, so the declaration drew *nothing*. Measured under each root against the real stylesheet:

| Mounted under | `--…-label-gap` | label `gap` | label `font-size` | count `padding` | count `font-size` |
| --- | --- | --- | --- | --- | --- |
| `.model-hub-guard-dialog` — `SourceDetailPanel`, `SourceMutationReport` | `6px` | `6px` | `10.5px` | `3px / 8px` | `10px` |
| `.model-hub-catalog-dialog` — the reported in-row confirm | *(undefined)* | `normal` | `12px` | `0 / 0` | `12px` |
| `.model-hub-route-dialog` — `RouteChainDialog` guard phase | *(undefined)* | `normal` | `16px` | `0 / 0` | `16px` |
| `.model-hub-add-key-dialog` — `AddApiKeyDialog` replace phase | *(undefined)* | `normal` | `16px` | `0 / 0` | `16px` |

So the count was not a pill missing a margin — it had no padding, no radius and the inherited font, which is why it read as part of the label's sentence rather than as a badge beside it. Each body class now declares what it and its selector-descendants consume; the dialog root keeps the chrome's metrics, which render nowhere else. **No value changed** — the diff moves declarations and adds none.

That is the argument `.model-hub-route-selector` already makes 300 lines up ("its metrics live here rather than on `.model-hub-route-dialog` because the popover is portalled out of the dialog and inherits nothing from it"), reached from the other side: nothing here is portalled, the body is simply mounted somewhere else — which the stylesheet cannot see and the token scope must not assume.

**Re-measured after the fix:** all four roots report `6px` / `6px` / `10.5px` / `3px 8px` / `10px` / `999px`, the guard dialog's chrome is unchanged (`16px 20px` head, `27px` close, `8px 14px` action, …), and a hop mounted with no list around it still measures `52px / 10px`.

**e2e — B3's key allow-list.** `b-add-api-key.spec.ts` pins the keys a saved source model may carry. That set predates #1836, so the tier provenance #1836 added (`reasoning_efforts_source`) read as an unexpected field. It is intentional product shape, so it is recorded rather than stripped.

## Three deliberate deviations from the brief

All three are reported to the orchestrator alongside this PR, as decisions to ratify or reverse rather than as fait accompli.

**1 · Reused `common.close` instead of minting `settings.models.gateway.catalog.close`.** The key already exists with the requested strings, already 1:1 across the bundles, and is already this app's name for this affordance in the identical `sr-only` shape — `MenuDrawer.tsx:91`, `VersionBadge.tsx:183`, `BackendLifecycleChip.tsx:267`, `AgentGraphDetail.tsx:192`, and three more. A new key under `gateway.catalog` would additionally have needed siblings under `gateway.picker` and `gateway.modelEditor` to cover the other two dialogs, i.e. three keys for one word the bundle already has.

**2 · Fixed all three dialogs, not only the catalog.** The defect is a class, not a one-off: catalog, picker, and editor all passed a footer label as the close control's name, and the spec only reached the first. Closing the class here rather than one dialog per review round.

This reverses an intent the codebase documented: three unit tests' comments blessed the shared label ("the corner control borrows the footer's label rather than inventing a second word for it"). Those comments are rewritten to state the new property. The reversal looks right on three counts — a11y distinguishability, the app's own convention disagreeing with those three call sites, and the fact that inside the catalog dialog "Cancel" already labelled two genuinely different actions (`BackendModelCatalogDialog.tsx:1097` dismisses the dialog, `:929` answers the guarded-removal confirm), so the close control was a third claim on one word.

**3 · Fixed the token scope rather than adding the missing gap, and the brief's comparison target turned out to be broken too.** The instruction was to "add the missing gap using the existing guard-label spacing token/class (compare the Route dialog's rendering of the same `GuardImpact` label)". Neither half survived measurement:

- **The token is not in scope to reuse.** `--model-hub-guard-label-gap` has exactly one declaration site, on `.model-hub-guard-dialog`, and the catalog dialog is not inside it. Setting `gap` from that name again would have drawn nothing again.
- **The gap is not the only casualty.** The same scope miss takes the label's `font-size` and the count's entire pill — `padding`, `border-radius`, `font-size`. A gap alone would have left an unstyled count badge sitting next to the label.
- **The Route dialog renders it identically broken** — `(undefined)` / `normal` / `0` — so it could not serve as the reference rendering. Only `SourceDetailPanel` and `SourceMutationReport` were ever correct.

Hence three dialogs fixed, in the one place that fixes all of them, rather than one `gap` declaration in one dialog. Reverse me if you want this split out of this PR.

## Evidence

**Tests state the property, not the enumeration.** The old assertions counted controls (`expect(cancels).toHaveLength(2)`) or took the first of several (`const [dismiss] = getAllByRole(...)`). The new ones ask for each exit by its own name: `getByRole` is singular, so each query also asserts that the name it asks for reaches nothing else in the dialog, and `expect(new Set(exits).size).toBe(exits.length)` states that the two names reached two controls rather than one control found twice. A fourth exit added later is covered without editing the assertion shape.

The new `BackendModelCatalogDialog` test runs in both locales (`en` corner `Close` / footer `Cancel`; `zh` `关闭` / `取消`), which is where the en/zh 1:1 requirement is actually enforced — a bundle whose two locales disagree fails one of the two cases.

**Counterfactual, verified locally:** with `closeLabel` reverted to `catalog.cancel`, the new test fails in both locales; restored before committing.

**The token-scope defect gets a static guard, because no rendered test can catch it.** jsdom computes no cascade and loads no stylesheet, so `getComputedStyle` there reports the inline truth and agrees with itself under every root — the mistake exists only in the stylesheet's scope graph. `validate:theme` cannot see it either: `customPropertiesIn` records names globally, so a token declared in one scope and consumed in another still looks declared.

`ui/scripts/travellingTokens.mjs` reads the scope graph instead, following the house pattern (pure analyzer beside `customProperties.mjs` / `cssDeclarations.mjs`, colocated `.test.mjs` collected by `npx vitest run`, reusing `eachStylesheet`). The assertion is a property, not a list: *a class that travels resolves every name it consumes from itself or from a scope every element inherits.* The class names are read out of `GuardImpact.tsx` and `GuardGapList.tsx`'s own `className` values, so a token or a class added later is covered without editing the assertion, and the four root classes are named nowhere — a token resolvable this way is resolvable under a fifth root nobody has written yet.

**Counterfactual, verified locally:** against the previous stylesheet it reports all **23** unresolvable uses, each naming the class, the property, and the declaration it silently killed (`model-hub-guard-label` / `--model-hub-guard-label-gap` / `gap`, …). Its own 20 unit cases cover the analyzer's edges — a combinator inside `:not(…)` or an attribute value, a `var()` fallback (which draws something, so it is not this defect), a `.host .travels` rule (about one host, so deliberately out of scope), `:root` / `@theme` / `@property` as scopes every element inherits, and a themed or query-guarded scope as one that is *not*.

### What the first review round changed in the guard

Codex found four things at `6432666`, all four real; all fixed in one push, each thread answered and resolved. Three were one class — **the check asked whether a name is declared where the question is whether the declaration reaches the use**, which is the very mistake it exists to catch:

- **A qualified root is not the document root.** The prefix match accepted any `[…]` selector. `data-theme` is set on nested elements in this repo (`AppWindow.tsx:259`, `AppsEditorPage.tsx:114`, `confirm-dialog.tsx:108`), and even on `<html>` a themed root is one half of a pair. Now the whole selector must be `:root`, `html`, `body` or `*`.
- **A conditional at-rule takes back what its body promises.** Condition chains are now compared instead of discarded: a declaration counts only when every condition guarding it also guards the use. `@media` wraps **72** token declarations and **19** `var()` uses here, `@supports` one — not hypothetical.
- **The same miss applied to `:root`, `@theme` and `@property`**, which the review had not reached. All three go through the same comparison now, so the class is closed rather than its two flagged members.

The fourth was the subject set: no component owns `.model-hub-guard-body` — each caller writes the div — so nothing the two scanned components render named it, and reverting just that class's tokens would have passed. It is named explicitly now, which is why the counterfactual above reports 23 rather than 21.

**Both tightenings were measured before adoption, because the risk was failing correct CSS.** The loose rule had been accepting exactly three token-declaring scopes (`[data-theme="dark"]`, `[data-theme="light"]`, `:root:not([data-theme="dark"])`); under the strict rule plus condition comparison the check still reports **zero** findings on the current tree, because those tokens resolve from a `:root` base that the themed block overrides. So the soundness cost no false positives.

**A list-free form was tried and rejected on evidence.** Deriving the subject instead of naming it — for every token declared on a root class, require that every file rendering a consumer also renders that root — measured **27** findings across five other roots, nearly all false: `SourcesCard.tsx` renders `.model-hub-upstream-info` while the *page* mounts it inside `.model-hub-overview`, and a per-file scan cannot see React composition. `stylesheets.mjs` warns that a false positive "fails somebody else's pull request over code that is right", so the named subject stayed.

### Five UI gates — all green (cwd `ui/`)

| Gate | Result |
| --- | --- |
| `npx vitest run` | 280 files, 3679 tests, all passed |
| `npm run lint` | baseline check passed — 790 sources, 212 baselined violations, 45 baselined suppressions, no drift in any (file, rule) pair |
| `npm run build` | built (`tsc -b` + vite) |
| `npm run validate:theme` | passed |
| `npm run validate:catalog` | 25 UI citations across 25 rows, each naming one collected vitest case |

### The two affected specs, re-run against a hermetic instance

**Run at head `2afd56edd`, not re-run at the current head.** The only change since is the stylesheet's token scope, and no spec in either file reads a computed style or a CSS custom property — they locate by role and name and assert saved shape. The five gates above *were* re-run at the current head, including the render-scope guard. Say so and I will stand the instance back up.

This suite is not in CI, so it was run per `ui/e2e/README.md` against a throwaway instance on port 5199 with its own `AVIBE_HOME`, its own `HOME`/XDG/`CLAUDE_CONFIG_DIR`/`CODEX_HOME`, the mock upstream from `tests/e2e/drivers/mock_llm_upstream.py` on 9931, and the gateway engine (`cliproxyapi` v7.2.105) installed and running inside that instance.

```
Running 10 tests using 1 worker
  ✓ 1 b-add-api-key.spec.ts:94  B1 · Add identifies a anthropic upstream without being told (4.5s)
  ✓ 2 b-add-api-key.spec.ts:94  B1 · Add identifies a openai_responses upstream without being told (4.2s)
  ✓ 3 b-add-api-key.spec.ts:94  B1 · Add identifies a openai_chat upstream without being told (4.2s)
  ✓ 4 b-add-api-key.spec.ts:118 B1 · a rejected credential is named as a credential problem (2.8s)
  ✓ 5 b-add-api-key.spec.ts:143 B2 · naming the wrong interface is refused, and says why (2.9s)
  ✓ 6 b-add-api-key.spec.ts:171 B3 · Detect reports the count, and only ids survive the save (4.7s)
  ✓ 7 b-add-api-key.spec.ts:220 B4 · a proven interface with no model list can still be added, on the record (4.0s)
  ✓ 8 b-add-api-key.spec.ts:250 B6 · replacing the key reuses the same dialog, and reports what it did (6.6s)
  ✓ 9 model-list.spec.ts:37     one way in, ending at an id the backend accepts, and a cancel that leaves nothing (5.2s)
  - 10 model-list.spec.ts:104   every model the picker offers can be added, and the confirm says how many

  1 skipped
  9 passed (44.5s)
```

Both reported failures now pass: `model-list.spec.ts:37` (the strict-mode violation) and `b-add-api-key.spec.ts:171` (B3).

**B3's assertions were strengthened after that run, and not re-executed — stated plainly because this suite is not in CI.** The review asked B3 to assert the provenance *value*, not just allow its key, and it was right: `v2_config.py:2771-2775` rejects `upstream`/`user` for an empty tier list but permits `catalog`, so a regression stamping `catalog` would be schema-valid, would make the UI treat those tiers as managed and non-editable, and would have passed. B3 now states the whole persisted row in one assertion, which subsumes the key-set pin and the id comparison, and closes the same gap for `origin`, `retired` and `discovered_at`.

The row's **shape** is not a guess: the key-set pin that passed in the run above already fixed it to exactly those seven fields. Only four values are newly asserted, each from a named line — `reasoning_efforts_source: null` (`service.py:1687-1688`, no existing row), `origin: 'discovered'` (`service.py:1686`), `retired: false` (`_source_payload`, `service.py:1877-1878`), and `discovered_at: expect.any(String)` (a timestamp, so nothing fixed is claimed). `npx tsc -p e2e/tsconfig.json --noEmit` is clean, which matters because the `tsc -b` build gate covers only the app and node projects, not `e2e/`. Re-running B3 needs a hermetic instance with the gateway runtime running and the earlier one was torn down; say so and I will stand it back up.

**What the skip means, and what it leaves unexercised.** Spec 10 skipped on its own documented precondition at `model-list.spec.ts:130` — *"Every model this instance can offer this backend is already in its list, so the picker has nothing left to add."* On this instance the chosen backend's builtin menu is complete, so the picker has no candidate to offer. That is a fact about the instance, not a defect. It does mean one of the three `labelledButton(catalog, …catalog.cancel)` call sites — `model-list.spec.ts:151` — was not exercised; the identical locator shape at `:93` and `:101` was, in the spec that passed. (`GET /api/models/agents/claude/models/candidates` answered 200 with a `candidates` object on this instance, so `servesModelCandidates` was not the cause.)

### Three deviations from the README recipe, and why

- **Playwright ran outside the isolated shell**, so it could reach the already-installed Chromium in the machine's own browser cache. The README sanctions the equivalent (`PLAYWRIGHT_BROWSERS_PATH` to a stable path); isolation is a property of the two *server* processes, which read the CLI credential stores, and Playwright opens a fresh browser context either way.
- **`codex` and `opencode` were shimmed alongside `claude`.** The README only requires the `claude` shim, for the macOS keychain channel. But CLI presence is PATH resolution, so the real `codex` and `opencode` binaries were visible to the instance; shimming all three means it could not exec a real CLI even on a path nobody predicted.
- **The gateway was turned on over the API** (`POST /api/models/runtime/install` then `/start`, with the CSRF token from `GET /api/csrf-token` and an `Origin` header) rather than by clicking `/settings/models`. Same endpoints the page calls.

Teardown killed all three processes, stopped the engine through the product first, and deleted the instance's home.

## Known-by-design ledger

1. **`DialogContent`'s `closeLabel` default is the hardcoded English `'Close'`** (`ui/src/components/ui/dialog.tsx:37`) — a pre-existing i18n gap for every dialog that passes no label. Fixing it means `useTranslation` inside a shared primitive and touching every dialog's rendered output, which is a wider change than this brief; the three Model Hub dialogs here all pass an explicit localized label.
2. **B3 states the whole persisted row, which is still an `assert-current` canary rather than a sampled property.** That is deliberate and survives the review: its value is failing when a field appears, which is exactly what it just did with #1836's `reasoning_efforts_source`. The first round asked for the provenance *value* on top of the key, so the row is now asserted as values — strictly stronger, and a field arriving later still fails it. A sampled property would have let #1836's field through silently.
3. **`ui/e2e/README.md` has one stale sentence.** Its mock-upstream section says the driver "ships with the pytest lane and is not in this PR, so a clean checkout has no bundled copy". `tests/e2e/drivers/mock_llm_upstream.py` is on master now, and this run used it. Left unedited because it is outside this PR's stated scope (`ui/` only, three named items) and the fact it describes belongs to the pytest lane; reported to the orchestrator instead.

