### PR TITLE
fix(model-hub): guarded catalog removal excludes the removed model from interruptions

### DIFF
--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -4468,6 +4468,7 @@ class ModelHubService:
                 for model in baseline_models
                 if model.id not in desired_by_id and model.id in current_by_id
             ]
+            removed_model_id_set = set(removed_model_ids)
             for model_id in removed_model_ids:
                 route = agent.routes.get(model_id)
                 current = current_by_id.get(model_id)
@@ -4485,6 +4486,16 @@ class ModelHubService:
                         for position, hop in enumerate(route.hops, start=1)
                     )
                     route.hops = ()
+                merged_by_id.pop(model_id, None)
+                agent.routes.pop(model_id, None)
+                if model_id not in agent.removed_model_ids:
+                    agent.removed_model_ids.append(model_id)
+
+            agent.models = [
+                model
+                for model in agent.models
+                if model.id not in removed_model_id_set
+            ]
 
             newly_empty_routes = frozenset(
                 (backend, item["menu_model"])
@@ -4503,12 +4514,6 @@ class ModelHubService:
                 would_interrupt=interrupted,
                 error="backend_model_in_route",
             )
-
-            for model_id in removed_model_ids:
-                merged_by_id.pop(model_id, None)
-                agent.routes.pop(model_id, None)
-                if model_id not in agent.removed_model_ids:
-                    agent.removed_model_ids.append(model_id)
 
             for model_id, desired in desired_by_id.items():
                 baseline_model = baseline_by_id.get(model_id)

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -738,7 +738,7 @@ def test_every_model_hub_endpoint_returns_its_contract_response(
                             "position": 1,
                         }
                     ],
-                    "would_interrupt": [{"backend": "claude", "model_id": model_id, "agents": []}],
+                    "would_interrupt": [],
                 }
             )
     elif setup == "candidate_suppliers_guard":
@@ -2921,7 +2921,10 @@ def test_backend_catalog_mutations_leave_every_unrelated_model_shape_byte_identi
     assert untouched_state() == expected_untouched
 
 
-def test_backend_catalog_refuses_model_removal_while_route_is_configured(tmp_path):
+def test_backend_catalog_guarded_removal_excludes_removed_model_and_accepts_echo(
+    monkeypatch,
+    tmp_path,
+):
     service, store, _adapter = _service(tmp_path)
     backend = "codex"
     baseline = next(agent["catalog_models"] for agent in service.list_agents() if agent["backend"] == backend)
@@ -2947,19 +2950,27 @@ def test_backend_catalog_refuses_model_removal_while_route_is_configured(tmp_pat
     before_other_agents = {
         name: copy.deepcopy(agent.to_payload()) for name, agent in store.config.agents.items() if name != backend
     }
+    monkeypatch.setattr(ui_server, "_model_hub_service", lambda: _as_ui_client(service))
+    client = app.test_client()
+    base_url = "http://127.0.0.1:15131"
+    headers = csrf_headers(client, base_url)
+    endpoint = f"/api/models/agents/{backend}/models"
+    request_body = {
+        "baseline": baseline,
+        "models": baseline[1:],
+    }
 
-    with pytest.raises(ModelHubError) as raised:
-        asyncio.run(
-            service.set_agent_models(
-                backend,
-                baseline,
-                baseline[1:],
-            )
-        )
+    refused = client.put(
+        endpoint,
+        json=request_body,
+        headers=headers,
+        base_url=base_url,
+    )
 
-    assert raised.value.code == "backend_model_in_route"
-    assert raised.value.status == 409
-    assert raised.value.data["would_remove_hops"] == [
+    assert refused.status_code == 409
+    refusal = refused.get_json()
+    assert refusal["error"] == "backend_model_in_route"
+    assert refusal["would_remove_hops"] == [
         {
             "backend": backend,
             "menu_model": model_id,
@@ -2968,21 +2979,31 @@ def test_backend_catalog_refuses_model_removal_while_route_is_configured(tmp_pat
             "position": 1,
         }
     ]
+    assert refusal["would_interrupt"] == []
+    _assert_valid("guard-refusal.schema.json", refusal)
     assert store.config.agents[backend].models[0].id == model_id
 
-    result = asyncio.run(
-        service.set_agent_models(
-            backend,
-            baseline,
-            baseline[1:],
-            force=True,
-            confirmed_remove_hops=raised.value.data["would_remove_hops"],
-            confirmed_interruptions=raised.value.data["would_interrupt"],
-        )
+    committed = client.put(
+        endpoint,
+        json={
+            **request_body,
+            "force": True,
+            "would_remove_hops": refusal["would_remove_hops"],
+            "would_interrupt": refusal["would_interrupt"],
+        },
+        headers=headers,
+        base_url=base_url,
     )
 
-    assert result["removed_hops"] == raised.value.data["would_remove_hops"]
-    assert result["interrupted"] == raised.value.data["would_interrupt"]
+    assert committed.status_code == 200
+    result = committed.get_json()
+    Draft7Validator(
+        {"$ref": "model-hub/api-response.schema.json#/definitions/AgentModelsResponse"},
+        registry=_api_response_registry(),
+        format_checker=FormatChecker(),
+    ).validate(result)
+    assert result["removed_hops"] == refusal["would_remove_hops"]
+    assert result["interrupted"] == []
     assert model_id not in store.config.agents[backend].routes
     assert model_id in store.config.agents[backend].removed_model_ids
     assert store.config.to_payload()["sources"] == before_sources


### PR DESCRIPTION
## Summary

- evaluate removal interruptions against the projected post-removal catalog and route map
- keep the guarded hop-removal plan, force echo, and cascade behavior unchanged
- cover the refusal schema and the API-level forced retry using the server's hops-only plan

## Evidence

- `tests/test_model_hub_api.py`: 377 passed
- endpoint response-conformance matrix: 40 passed
- Ruff passed on both changed Python files

## Scenarios

- No dedicated guarded-catalog-removal scenario ID exists in the catalog.
- Genuine supply interruption remains covered by the existing Source-deletion invariant (`MH-SRC-DELETE-001`) and its focused service test.

## Known By Design

- None.

## Residual Checks

- No Incus acceptance update was run; the orchestrator's integration pass can repeat the live catalog removal flow.
