### PR TITLE
docs(model-hub): close out backend catalog v2 — spec sync, e2e runbook, scenario row

### DIFF
--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -435,8 +435,11 @@ No string explains mechanism.
   observed concurrently with a mutation leaves the stored configuration byte-identical to what
   that mutation alone would have produced, and the candidates read's reconcile is serialized
   by the mutation lock like every write.
-- A built-in that enters the snapshot through any process's refresh is in the menu within one
-  controller tick, and immediately when the picker's candidates read runs.
+- While the config store is writable, a built-in that enters the snapshot through any
+  process's refresh is in the menu within one controller tick, and immediately when the
+  picker's candidates read runs. Recovery mode is the same guarantee under its own
+  precondition, not an exception to it: reconcile changes nothing, so the menu holds its
+  last reconciled state until the store is writable again, and the bound resumes there.
 - No reconcile task outlives Model Hub shutdown.
 - Every producer shares one admission predicate, and it is stricter than the persisted shape
   alone: a proposal is admissible exactly when the backend's identity policy admits the id —

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -419,9 +419,11 @@ No string explains mechanism.
 - Direct mode still hides the editor and preserves the catalog unchanged.
 - Removing a built-in row and reopening the picker shows that id under the built-in group;
   picking it restores the row. A built-in id that enters the backend snapshot after the menu
-  was saved is present in the menu on the next read unless a row with that id was removed
-  before — and an id the user removed never returns on its own, whatever the removed row's
-  origin was.
+  was saved is in the menu after the next reconcile trigger — startup, a snapshot refresh
+  completing, the periodic tick, or the picker's candidates read — unless a row with that id
+  was removed before; an ordinary read reconciles nothing and observes whichever of those ran
+  last. An id the user removed never returns on its own, whatever the removed row's origin
+  was.
 - The picker lists each candidate id exactly once across all groups.
 - A field the user cleared before the first Save is empty after Save.
 - Every supplier chip the picker shows for a candidate equals the hop set C1 seeds when that

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -193,7 +193,10 @@ reads `aihub → deepseek-v3.2`. Nothing was typed except the search.
       model ID` for an id models.dev does not know (for OpenCode it offers `custom/<query>`
       unless the query is already an admissible `vendor/model` id). The old `Fill from models.dev` button is
       retired — the typeahead is the same capability, offered before typing instead of after.
-      For OpenCode the filled id follows C7's provider rule.
+      For OpenCode the filled id follows C7's provider rule; the manual path applies three
+      buckets — a bare model id gains exactly one `custom/` prefix, a complete valid
+      `provider/model` identity (any syntactically valid provider) is kept verbatim, and a
+      malformed identity (`openai/`, `/model`) is rejected, never repaired into another id.
    Rules that hold across all groups: a provider chip on any row — built-in included — means
    exactly "one of your providers supplies this id", in Source order, and nothing else ever
    renders as a chip. With an empty query the list shows only what can be added; with a
@@ -273,8 +276,12 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
   nonempty `would_remove_hops` (`RouteHopRef` = `{backend, menu_model, source_id, model_id,
   position}`); a retry with `force: true` echoing the plan removes the rows and their routes in
   one transaction and returns `{agent, removed_hops, interrupted}`; rows with empty routes are
-  removed without confirmation and return `{agent}`. The confirmation shows both the hops and
-  any interrupted Agents with the existing guard-impact surface and echoes both arrays. Property: every response this route
+  removed without confirmation and return `{agent}`. The client never constructs a plan it
+  sends: the in-row confirmation may preview the consequence from the routes it already holds,
+  but the arrays it echoes with `force` are always the server's own refusal arrays, verbatim
+  and in the server's order; when the server's plan equals the previewed one as a set the retry
+  is automatic, otherwise the server's plan is shown and confirmed. The confirmation shows both
+  the hops and any interrupted Agents with the existing guard-impact surface. Property: every response this route
   emits — the plain success, the forced success with `removed_hops` and `interrupted`, and
   the refusal — validates against the response registry after the artifact changes below,
   the 409 refusal alone also validates against `guard-refusal.schema.json`, and the response
@@ -284,7 +291,10 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
   `GET /api/models/agents/<backend>/models/candidates`, returns
   `{candidates: {builtin: Candidate[], providers: Candidate[], in_list: Candidate[]}}` where `Candidate` is
   `{id, display_name, reasoning_efforts, suppliers: [{source_id, source_name, model_id}],
-  origin}`. `builtin` is the merged remote + bundled + local-CLI snapshot for the backend
+  origin, group_if_removed?: "builtin" | "providers" | null}` — `group_if_removed` is set on
+  `in_list` candidates only and names where the server would offer the id if it left the menu
+  (in the current built-in snapshot → `builtin`; else supplied → `providers`; else `null`), so
+  the client never infers current availability from `origin`. `builtin` is the merged remote + bundled + local-CLI snapshot for the backend
   (served regardless of Gateway/Direct mode; empty for OpenCode) minus menu ids, removed ones
   included, and filtered by the backend's admission rule — configured or cache-only values the
   backend would not accept as menu ids (an `ANTHROPIC_MODEL` override, an over-long Codex id)
@@ -304,9 +314,17 @@ the contract guard as the test. Nothing here introduces a second vocabulary for 
 - **C6 — Removed ids never return on their own.** The backend catalog persists
   `agents.<backend>.removed_model_ids: string[]`. Every row the user removes leaves its id in
   the set, whatever the row's origin was and whether or not the backend lists the id right now;
-  adding a row with that id by any path clears it. Reconcile — on startup and before serving
-  any Model Hub agent read or mutation, controller-owned and pull-based on the built-in
-  snapshot's generation — adds each snapshot id that is neither in the menu nor in the set,
+  adding a row with that id by any path clears it. Reconcile is a controller-owned mutation
+  under the same lock every catalog write takes, comparing the snapshot's generation with the
+  last one reconciled inside that critical section. It runs at four moments and nowhere else:
+  controller startup; completion of a controller-side snapshot refresh; a controller periodic
+  tick (five minutes) that re-reads the snapshot inputs — the catch-all for refreshes another
+  process performed, so no IPC is needed and arrival lags a refresh by at most one tick; and,
+  as the one read that is defined as refresh-then-project (precedent: the agents read's
+  `refresh_cli_presence`), the picker's candidates read, which first runs that same locked
+  reconcile when the generation changed and then projects. Every other read is pure. Reconcile
+  tasks are tracked and gated on shutdown: Model Hub stop cancels or joins them before the
+  service stops, and a completion arriving during shutdown schedules nothing. It adds each snapshot id that is neither in the menu nor in the set,
   at the position question 9 defines, seeds it per C1 and C2, and invalidates the backend's
   runtime projection; it never removes a row, and it never persists or raises while the config
   store is not writable (recovery mode serves the stored configuration unchanged). A partial
@@ -413,6 +431,15 @@ No string explains mechanism.
 - A built-in removed while the backend had withdrawn it does not return when the backend
   lists it again.
 - No Model Hub read or mutation fails or writes while the config store is in recovery mode.
+- Reads never write, with the candidates read as the single defined exception: any other read
+  observed concurrently with a mutation leaves the stored configuration byte-identical to what
+  that mutation alone would have produced, and the candidates read's reconcile is serialized
+  by the mutation lock like every write.
+- A built-in that enters the snapshot through any process's refresh is in the menu within one
+  controller tick, and immediately when the picker's candidates read runs.
+- No reconcile task outlives Model Hub shutdown.
+- Every producer predicate is the persisted validator itself: a proposal is admissible exactly
+  when `ModelHubBackendModelConfig.from_payload` accepts the row it would create.
 - A catalog file without `removed_model_ids` loads with an empty set and reconciles normally.
 - In the editor, a models.dev suggestion fills every metadata field it knows and leaves each
   one editable; an id models.dev does not know can still be entered and saved.
@@ -425,3 +452,19 @@ No string explains mechanism.
 - Design PR avibe-docs #34 carries the earlier "Batch Add / Agent Model Picker" proposal
   frames; v2 frames are drawn on that branch with sparse copy and the proposal frames are
   renamed `Superseded —` rather than deleted.
+
+### Delivery record
+
+v2 shipped in four lanes off this spec: #1830 published it as the normative contract, #1837
+built the server side (candidates read, `removed_model_ids` with its reconcile, the guard
+plan the client echoes), #1839 built the UI (picker groups, the id and row chokepoints, the
+guard re-ask), and #1843 follows up with a distinct close label for the catalog dialog and
+the e2e allow-list for tier provenance — open at the time of writing, so it is the one lane
+this record does not describe as merged. The frames are avibe-docs #34 (v2 frames drawn over
+the superseded proposal set) and #35 (picker search grouping in-list matches). Two
+design-fidelity deltas found by #1839's render are ruled Known-by-design there and await an
+owner decision, because both belong to surfaces wider than this feature: `.model-hub-pill`
+renders 23px tall against the frame's 19px chip, which stacks a picker row to 60px where
+frame B‴ measures 52 — retuning the pill would move every pill in the Model Hub — and the
+narrow-viewport footer orders its two buttons the other way, which is the shared `Dialog`
+primitive's own narrow layout. Neither hides nor clips anything.

--- a/docs/plans/backend-model-catalogs.md
+++ b/docs/plans/backend-model-catalogs.md
@@ -438,8 +438,13 @@ No string explains mechanism.
 - A built-in that enters the snapshot through any process's refresh is in the menu within one
   controller tick, and immediately when the picker's candidates read runs.
 - No reconcile task outlives Model Hub shutdown.
-- Every producer predicate is the persisted validator itself: a proposal is admissible exactly
-  when `ModelHubBackendModelConfig.from_payload` accepts the row it would create.
+- Every producer shares one admission predicate, and it is stricter than the persisted shape
+  alone: a proposal is admissible exactly when the backend's identity policy admits the id —
+  it equals its own canonical form, an OpenCode id is a valid menu identity, and a Claude id
+  is either a current built-in or `claude-`/`anthropic-` prefixed — and
+  `ModelHubBackendModelConfig.from_payload` then accepts the row it would create, with the id
+  it persists unchanged. The validator alone is the weaker half: it accepts ids that the
+  identity policy, and therefore the shipped API, refuses.
 - A catalog file without `removed_model_ids` loads with an empty set and reconciles normally.
 - In the editor, a models.dev suggestion fills every metadata field it knows and leaves each
   one editable; an id models.dev does not know can still be entered and saved.

--- a/tests/scenarios/INDEX.yaml
+++ b/tests/scenarios/INDEX.yaml
@@ -150,6 +150,7 @@ capabilities:
       - ui/src/components/settings/models/UsageTab.test.tsx
       - ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
       - ui/src/components/settings/models/RouteChainDialog.test.tsx
+      - ui/src/components/settings/models/BackendModelCatalogDialog.test.tsx
       - ui/scripts/scenarioCatalog.test.mjs
   - id: harness_failure_recovery
     name: Harness per-Session failure recovery

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -17,6 +17,7 @@ capability:
     - ui/src/components/settings/models/UsageTab.test.tsx
     - ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
     - ui/src/components/settings/models/RouteChainDialog.test.tsx
+    - ui/src/components/settings/models/BackendModelCatalogDialog.test.tsx
     # The gate that resolves those rows against vitest's own collection, and
     # its own evidence.
     - ui/scripts/scenarioCatalog.test.mjs
@@ -118,6 +119,22 @@ scenarios:
     kind: mutation
     layer: scenario
     test: tests/scenarios/model_hub/test_model_hub_configured_route_scenarios.py::test_mh_menu_add_001_seeds_overlapping_suppliers_in_source_order
+  # The client half of MH-MENU-ADD-001: the server seeds a route from whatever
+  # supply exists at commit time, and this is what makes that supply the one the
+  # user was shown. The picker's other two doors — an id the list already holds,
+  # and one no provider offers, reached through the models.dev lookup — are each
+  # a case of their own, named under related_tests because a row resolves through
+  # evidence named for itself and a citation reaching two cases identifies
+  # neither.
+  - id: MH-MENU-COMPOSE-001
+    name: A backend's list is composed from its providers, and an add seeds the route from exactly the suppliers the picker displayed
+    status: covered
+    kind: mutation
+    layer: unit
+    test: ui/src/components/settings/models/BackendModelCatalogDialog.test.tsx::MH-MENU-COMPOSE-001
+    related_tests:
+      - ui/src/components/settings/models/BackendModelPickerDialog.test.tsx::finds an already-added model by its supplier and shows it as already added
+      - ui/src/components/settings/models/BackendModelCatalogDialog.test.tsx::asks which row a typed ID names as the ID it would be saved as
   - id: MH-SRC-DELETE-001
     name: Source deletion removes every reference while preserving survivor order
     status: covered

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -127,7 +127,7 @@ scenarios:
   # evidence named for itself and a citation reaching two cases identifies
   # neither.
   - id: MH-MENU-COMPOSE-001
-    name: A backend's list is composed from its providers, and an add seeds the route from exactly the suppliers the picker displayed
+    name: A backend's list is composed from its providers, and the save request carries exactly the suppliers the picker displayed for what was added
     status: covered
     kind: mutation
     layer: unit

--- a/ui/e2e/README.md
+++ b/ui/e2e/README.md
@@ -52,8 +52,11 @@ privileged, though: the suite talks to it over HTTP alone, so any server
 implementing the §5a control plane will do in its place — `POST
 /__control/config` with `auth`, `protocol`, `models_endpoint`, `stream`, and
 `models`; `GET /__control/requests` returning `{"requests": [...]}`; `DELETE
-/__control/requests` to reset; plus the protocol endpoint each `protocol`
-names, `/v1/messages`, `/v1/responses`, or `/v1/chat/completions`.
+/__control/requests` to reset; `GET /v1/models`, which serves the configured
+`models` when `models_endpoint` is `ok` and otherwise produces the failure it
+names — `http_404`, `http_500`, `timeout`, or `malformed_json`; plus the
+protocol endpoint each `protocol` names, `/v1/messages`, `/v1/responses`, or
+`/v1/chat/completions`.
 
 ## Preconditions, and why they skip instead of fail
 

--- a/ui/e2e/README.md
+++ b/ui/e2e/README.md
@@ -36,14 +36,24 @@ over its own HTTP control plane.
 
 ### The mock upstream
 
-The driver the repo's own instructions reference (`tests/e2e/drivers/
-mock_llm_upstream.py`) ships with the pytest lane and is not in this PR, so a
-clean checkout has no bundled copy. Any server implementing the §5a control
-plane will do: `POST /__control/config` with `auth`, `protocol`,
-`models_endpoint`, `stream`, and `models`; `GET /__control/requests` returning
-`{"requests": [...]}`; `DELETE /__control/requests` to reset; plus the
-Anthropic/OpenAI protocol endpoints under `/v1/*`. Until the pytest lane lands
-its driver, run the suite with a mock you provide on that contract.
+The repo bundles one: `tests/e2e/drivers/mock_llm_upstream.py`, the driver the
+pytest lane uses. It runs standalone on a port you pick, so a checkout needs
+nothing else —
+
+```
+python3 -m tests.e2e.drivers.mock_llm_upstream --port 8791
+```
+
+— and `VIBE_E2E_MOCK_UPSTREAM_URL=http://127.0.0.1:8791` is what the specs then
+steer. It binds loopback unless `--host` says otherwise, which is the same
+reachability caveat below: the instance is what dials the mock, so a remote
+target needs an address that resolves from there. Nothing about the driver is
+privileged, though: the suite talks to it over HTTP alone, so any server
+implementing the §5a control plane will do in its place — `POST
+/__control/config` with `auth`, `protocol`, `models_endpoint`, `stream`, and
+`models`; `GET /__control/requests` returning `{"requests": [...]}`; `DELETE
+/__control/requests` to reset; plus the protocol endpoint each `protocol`
+names, `/v1/messages`, `/v1/responses`, or `/v1/chat/completions`.
 
 ## Preconditions, and why they skip instead of fail
 

--- a/ui/e2e/README.md
+++ b/ui/e2e/README.md
@@ -41,11 +41,11 @@ pytest lane uses. It runs standalone on a port you pick, so a checkout needs
 nothing else —
 
 ```
-python3 -m tests.e2e.drivers.mock_llm_upstream --port 8791
+python3 -m tests.e2e.drivers.mock_llm_upstream --port 9931
 ```
 
-— and `VIBE_E2E_MOCK_UPSTREAM_URL=http://127.0.0.1:8791` is what the specs then
-steer. It binds loopback unless `--host` says otherwise, which is the same
+— and `VIBE_E2E_MOCK_UPSTREAM_URL=http://127.0.0.1:9931`, the port both runnable
+examples below already pass, is what the specs then steer. It binds loopback unless `--host` says otherwise, which is the same
 reachability caveat below: the instance is what dials the mock, so a remote
 target needs an address that resolves from there. Nothing about the driver is
 privileged, though: the suite talks to it over HTTP alone, so any server

--- a/ui/src/components/settings/models/BackendModelCatalogDialog.test.tsx
+++ b/ui/src/components/settings/models/BackendModelCatalogDialog.test.tsx
@@ -140,7 +140,7 @@ describe('BackendModelCatalogDialog', () => {
     expect(screen.queryByText('src_a')).toBeNull();
   });
 
-  it('adds what the providers offer, and promises the suppliers it displayed', async () => {
+  it('MH-MENU-COMPOSE-001: adds what the providers offer, and promises the suppliers it displayed', async () => {
     const user = userEvent.setup();
     const catalog = [locked, model('alpha')];
     const glm = candidate('glm-5.2', {


### PR DESCRIPTION
Close-out documentation for Model Hub backend catalog v2. Docs, scenario catalog, and one test-title tag; no product code.

## What changed

**1. `docs/plans/backend-model-catalogs.md` — synced to the authoritative spec.**
Five hunks, each verified against the merged code before copying. The code that shipped is the fact, and in one place the authoritative copy was not — see the amendment below the table:

| Delta | Verified against |
| --- | --- |
| C6 reconcile is a locked mutation at four moments (startup, refresh completion, 5-minute tick, the candidates read) + shutdown gating | `core/handlers/model_hub/service.py:4322` takes `_mutation_lock` and compares generation inside it; the four callers are `core/controller.py:689` (startup), `:442` (refresh completion), `_model_hub_snapshot_reconcile_loop` with `_MODEL_HUB_SNAPSHOT_RECONCILE_INTERVAL_SECONDS = 5 * 60` (`core/controller.py:85`), and `core/handlers/model_hub/rpc.py:125` (candidates read); `_stop_model_hub_snapshot_reconciliation` cancels the loop and joins the task, and every scheduling entry point returns early once `_model_hub_snapshot_reconcile_stopping` is set |
| `group_if_removed` on `in_list` candidates only | `core/handlers/model_hub/service.py:3945` emits it for `in_list` rows only: `builtin` when the id is in the current snapshot, else `providers` when supplied and admissible, else `null` |
| Verbatim guard-plan echo | `ui/.../BackendModelCatalogDialog.tsx:628` — the forced arrays are produced only from the stored refusal, in the server's own order, gated by `echoableRefusal` |
| OpenCode manual-id three-bucket rule | `ui/.../backendCatalog.ts:388` `backendModelId` returns an id containing `/` verbatim and prefixes a bare id through `buildIdentifier`, which resolves an empty vendor to `custom`; `opencodeMenuIdentity` rejects `openai/` and `/model` at the field rather than repairing them |

**Amendment (`e226022`, from review).** The copy carried one acceptance criterion that the shipped code contradicts: *"Every producer predicate is the persisted validator itself: a proposal is admissible exactly when `ModelHubBackendModelConfig.from_payload` accepts the row it would create."* `core/handlers/model_hub/catalog_admission.py::admissible_backend_model` is a conjunction — `backend_model_admission_error` must clear first (canonical round-trip; `canonical_opencode_menu_identity` for OpenCode; built-in-or-`claude-`/`anthropic-` prefix for Claude), then `from_payload` must accept, and the persisted `model.id` must still equal the proposed id. The identity policy is strictly the tighter half, so the stated equivalence would have licensed rows the API refuses. The criterion now names both halves and says which one is weaker, still as a property rather than a list of rejected shapes. **The orchestrator's authoritative copy needs the same correction at source.**

**Amendment 2 (round 2, orchestrator-authorized).** Three claims asserted more than their referent supported — one root-cause class, escalated as a complete inventory (4 broken of 12 members audited, no fifth) and closed in one push. (a) The menu-latency criterion stated the one-tick / immediate-on-candidates-read bound unconditionally, contradicting the recovery-mode criterion directly above it: `reconcile_builtin_models` derives `changed_snapshots` through `store_writable` (`service.py:4332`), so in recovery mode nothing reconciles. It now carries the writable-store precondition and says what recovery mode holds instead. (b) The scenario row's name claimed the add "seeds the route", which the cited test cannot observe — it mocks `putAgentModels` and asserts the request payload. The name is now bounded to that client-side promise. (c) The §5a contract omitted `GET /v1/models` while claiming any server implementing the listed endpoints would do; `b-add-api-key.spec.ts:218` depends on it failing. It is now named with the behaviors `models_endpoint` selects. **The orchestrator has corrected the admission conjunction (`25c490872`) and the recovery precondition at source, so the next sync will not regress either.**

**Amendment 3 (round 3, orchestrator-authorized).** Same class, found on the other axis: the criterion at `:421-423` is pre-existing master text, but the C6 rule this PR synced ("it runs at four moments and nowhere else … every other read is pure") made its promise that a new built-in is "present in the menu on the next read" false — `rpc.py`'s `get_agent_sources` path never calls `reconcile_builtin_models`. Narrowed in `e3e15cc73` to the four triggers, with what an ordinary read observes stated rather than implied. The round-2 audit had checked *introduced* criteria against the code but not *pre-existing* criteria against the introduced text; that second axis has now been swept as well, and `:421-423` was its only conflict (question 9 at `:223-228` states behavior, not timing, so it holds). The same correction is in the authoritative copy at source.

**2. `docs/plans/backend-model-catalogs.md` — new "Delivery record".** Names #1830 / #1837 / #1839 as merged and #1843 as still open, the two design PRs (avibe-docs #34, #35), and the two design-fidelity follow-ups awaiting the owner (the 23px `.model-hub-pill` against the frame's 19px chip, stacking a picker row to 60px where frame B‴ measures 52; and the narrow-viewport footer button order owned by the shared `Dialog` primitive).

**3. `ui/e2e/README.md` — the mock-upstream paragraph now points at the bundled driver.** It claimed `tests/e2e/drivers/mock_llm_upstream.py` was "not in this PR, so a clean checkout has no bundled copy"; the file is in the repo and runs standalone. The §5a control-plane contract text is kept — it is what makes the driver replaceable — and now names the three protocol endpoints instead of the wrong `/v1/*` glob. The launch command uses **9931**, the port the two runnable examples at `:102` and `:203` already pass (`e226022`, from review): a reader who launched on a different port would have had the liveness fixture treat the configured URL as an absent mock and skip the very specs the runbook was advertising.

**4. `tests/scenarios/model_hub/catalog.yaml` — one new row, `MH-MENU-COMPOSE-001`.**

## Scenario IDs

- `MH-MENU-COMPOSE-001` (new) — *A backend's list is composed from its providers, and the save request carries exactly the suppliers the picker displayed for what was added.* Evidence: `ui/src/components/settings/models/BackendModelCatalogDialog.test.tsx::MH-MENU-COMPOSE-001`, the existing property test that drives picker → add → save and asserts the `PUT` carries `expected_suppliers` for the addition and for nothing else. It is the client half of the merged `MH-MENU-ADD-001`, and the name is bounded by that: the test mocks the response, so route seeding is the server half's property (`MH-MENU-ADD-001`), not this row's.

The evidence gate binds one row to exactly one collected vitest case (`resolveUiEvidence`: a citation reaching two cases identifies neither, and a row may not resolve through a sibling's evidence), and `test_mh_catalog_001` additionally requires the row's ID to appear in the cited file. So the picker's other two doors — an id the list already holds, found under *Already in the list*, and one no provider offers, reached through the models.dev lookup — are named under `related_tests` (a pointer the resolver deliberately does not read as a coverage claim) rather than folded into this row's name. Registering them as coverage would have been a claim the gate exists to prevent.

`docs/plans/model-hub-e2e-test-plan.md` §3 has no family for the backend model list — its suites are gating, sources, OAuth, routing, usage, migration, guards, and the protocol floor — which `ui/e2e/README.md` already states. So there is no §3 id to cross-reference here.

## Evidence

| Layer | What ran |
| --- | --- |
| Catalog gate | `cd ui && npm run validate:catalog` → *26 UI citations across 26 rows each name one collected vitest case* |
| Catalog integrity | `pytest tests/scenarios/model_hub/test_model_hub_catalog.py` → 1 passed |
| Unit | `npx vitest run BackendModelCatalogDialog.test.tsx scripts/scenarioCatalog.test.mjs` → 37 passed |
| Runbook | `python3 -m tests.e2e.drivers.mock_llm_upstream --port 9931` started and answered `GET /__control/requests` with `{"requests":[]}` — the README's new command was run, not just written |

No Python source changed, so there is nothing for `ruff` to cover beyond what CI runs; no UI source changed, so `npm run build` has no new input.

## Dependencies

None. Everything cited is already on `master` (`77c1fd8a4`), including #1839.

## Known-by-design ledger

1. **The test-title tag is the one non-docs edit.** `test_mh_catalog_001` asserts the scenario ID appears inside the cited file, and `resolveUiEvidence` requires the collected case name to contain the citation. A catalog row cannot be registered without it. The convention is the file's own: `MH-ROUTE-EDIT-001`, `[MH-OVERVIEW-001]`, `MH-USAGE-021:` are all existing case-name tags. Behavior is untouched.
2. **`MH-MENU-COMPOSE-001` is `layer: unit`, not `scenario`.** The property is about what the client promises the server, which is observable in the dialog and nowhere below it. The server half is already `MH-MENU-ADD-001` at `layer: scenario`.
3. **The README keeps the §5a contract text.** The bundled driver is now named, but the suite still talks to it over HTTP only, so the contract remains the actual interface and a replacement mock remains supported. Deleting it would have made the driver load-bearing in a way the code does not require.
