### PR TITLE
fix(model-hub): picker footer order on narrow viewports matches the design

### DIFF
--- a/ui/e2e/picker-footer.spec.ts
+++ b/ui/e2e/picker-footer.spec.ts
@@ -1,0 +1,128 @@
+// Where the picker's footer actions are PAINTED, at a phone width and at a
+// desktop one.
+//
+// No scenario ID, for `model-list.spec.ts`'s reason: `docs/plans/
+// model-hub-e2e-test-plan.md` §3 has no family for a dialog's footer layout,
+// so the title states the property instead of borrowing a letter the plan
+// cannot resolve.
+//
+// This lives here rather than in `BackendModelPickerDialog.test.tsx` because
+// the claim is about the cascade. The footer's three actions are in one DOM
+// order at every width and are painted in two different ones; jsdom loads no
+// stylesheet and computes no layout, so a unit test cannot tell the two apart —
+// it would pass identically against a footer that stacks the wrong way up. A
+// real browser with the real bundle is the only place the question has an
+// answer.
+//
+// Read-only: it opens the picker and cancels out of it, leaving the instance's
+// model list exactly as it found it.
+import { hub as copy } from './support/copy';
+import {
+  requireMockUpstream,
+  requireModelHub,
+  requireRuntimeRunning,
+} from './support/fixtures';
+import { expect, test } from './support/gateway';
+import { labelledButton, type ModelHubPage } from './support/hub';
+import type { Locator } from '@playwright/test';
+
+/** The box a visible element occupies, as a value the assertions can compare.
+ *  `boundingBox()` is nullable for elements that render nothing, which is a
+ *  different failure than the one under test — so it is asserted here, once,
+ *  instead of being widened away with `?.` at every use. */
+const boxOf = async (locator: Locator) => {
+  const box = await locator.boundingBox();
+  expect(box, 'the element occupies no box, so its position cannot be read').not.toBeNull();
+  return box!;
+};
+
+/** Two widths on either side of the one breakpoint the footer changes at.
+ *  Named by what they stand for rather than by the device that suggested them:
+ *  the property is "below the breakpoint" and "above it", and the numbers are
+ *  one ordinary phone and one ordinary desktop from that side of it. */
+const PHONE = { width: 390, height: 844 };
+const DESKTOP = { width: 1440, height: 900 };
+
+test.describe('Model picker footer · where its actions are painted', () => {
+  test.beforeEach(async ({ api, mock }) => {
+    await requireModelHub(api);
+    await requireRuntimeRunning(api);
+    await requireMockUpstream(mock);
+  });
+
+  /** The picker, reached the one way the product offers: the backend's model
+   *  list, then that list's add action. */
+  const openPicker = async (hub: ModelHubPage, backend: string) => {
+    await hub.goto();
+    await hub.manageModelsButton(backend).click();
+    const catalog = hub.catalogDialog;
+    await expect(catalog).toBeVisible();
+    const addModels = labelledButton(catalog, copy('gateway.catalog.add'));
+    await expect(addModels).toBeEnabled();
+    await addModels.click();
+    const picker = hub.pickerDialog;
+    await expect(picker).toBeVisible();
+    return { catalog, picker };
+  };
+
+  test('below the breakpoint the custom-model action is above the decision, which sits last', async ({
+    page,
+    hub,
+    gateway,
+  }) => {
+    await page.setViewportSize(PHONE);
+    const { catalog, picker } = await openPicker(hub, gateway.backend);
+
+    const footer = picker.locator('.model-hub-catalog-foot');
+    const custom = labelledButton(footer, copy('gateway.picker.custom'));
+    const cancel = labelledButton(footer, copy('gateway.catalog.cancel'));
+    await expect(custom).toBeVisible();
+    await expect(cancel).toBeVisible();
+
+    const customBox = await boxOf(custom);
+    const cancelBox = await boxOf(cancel);
+
+    // The property, in the order a thumb meets it: the tertiary action is a
+    // full row of its own, entirely above the row that decides the dialog —
+    // so the decision is the last thing on the screen, nearest the thumb.
+    expect(
+      customBox.y + customBox.height,
+      'the custom-model action must end above where the decision row begins',
+    ).toBeLessThanOrEqual(cancelBox.y);
+    expect(customBox.width, 'the custom-model action spans its own row').toBeGreaterThan(cancelBox.width);
+
+    await labelledButton(picker, copy('gateway.catalog.cancel')).click();
+    await labelledButton(catalog, copy('gateway.catalog.cancel')).click();
+  });
+
+  test('above the breakpoint the same three actions share one row, custom first', async ({
+    page,
+    hub,
+    gateway,
+  }) => {
+    await page.setViewportSize(DESKTOP);
+    const { catalog, picker } = await openPicker(hub, gateway.backend);
+
+    const footer = picker.locator('.model-hub-catalog-foot');
+    const custom = labelledButton(footer, copy('gateway.picker.custom'));
+    const cancel = labelledButton(footer, copy('gateway.catalog.cancel'));
+    await expect(custom).toBeVisible();
+    await expect(cancel).toBeVisible();
+
+    const customBox = await boxOf(custom);
+    const cancelBox = await boxOf(cancel);
+
+    // Sharing a row is asserted as overlapping vertical extents rather than as
+    // equal `y`: the three controls are centred against each other, and two
+    // buttons of different heights on one row do not start at the same pixel.
+    expect(
+      customBox.y,
+      'the custom-model action and the decision row overlap vertically, i.e. one row',
+    ).toBeLessThan(cancelBox.y + cancelBox.height);
+    expect(cancelBox.y).toBeLessThan(customBox.y + customBox.height);
+    expect(customBox.x, 'the custom-model action is the leading edge of that row').toBeLessThan(cancelBox.x);
+
+    await labelledButton(picker, copy('gateway.catalog.cancel')).click();
+    await labelledButton(catalog, copy('gateway.catalog.cancel')).click();
+  });
+});

--- a/ui/src/components/settings/models/BackendModelPickerDialog.tsx
+++ b/ui/src/components/settings/models/BackendModelPickerDialog.tsx
@@ -232,7 +232,15 @@ export const BackendModelPickerDialog: React.FC<{
           </div>
         </div>
 
-        <DialogFooter className="model-hub-catalog-foot shrink-0 items-center border-t border-border sm:justify-between">
+        {/* `max-sm:flex-col` overrides the shared footer's `flex-col-reverse`,
+            which exists so a Cancel/Confirm PAIR puts its primary nearest the
+            thumb. This footer's first child is a third, tertiary action, so
+            reversing lifts "Add custom model…" below the pair instead of
+            leaving it above it. Stacking in DOM order restores the approved
+            order — ghost row first, then Cancel/Confirm at the very bottom —
+            and the `sm:` half of the primitive still owns the one-row desktop
+            layout. */}
+        <DialogFooter className="model-hub-catalog-foot shrink-0 items-center border-t border-border max-sm:flex-col sm:justify-between">
           <Button
             type="button"
             variant="ghost"


### PR DESCRIPTION
## What changes

Below the `sm` breakpoint (640px), the backend model picker painted its
`Cancel` / confirm row **above** the `Add custom model…` action. The approved
mobile picker frame puts `Add custom model…` on its own full-width row **first**
and the decision row at the very bottom, nearest the thumb.

The picker footer now opts out of the shared footer's reversal on narrow
viewports only. Desktop is untouched.

## Why it happened

`DialogFooter` is `flex flex-col-reverse … sm:flex-row sm:justify-end`. The
reversal is deliberate and correct for the shape it was written for: a
`Cancel` / `Confirm` **pair**, whose primary should end up on top when the pair
stacks.

This footer has three children, and the first one is a *tertiary* action, not
half of that pair. Reversing therefore lifts the pair over it and buries the
tertiary action underneath — the reported defect.

The fix is one utility on the picker's own footer, `max-sm:flex-col`, which
overrides the base `flex-col-reverse` and stacks in DOM order. The primitive's
`sm:` half still owns the one-row desktop layout, so nothing above the
breakpoint moves. No shared `Dialog` primitive change; no new i18n.

## Evidence

**Render, against a live hermetic instance (Chromium, real bundle).** Bounding
boxes of the `Add custom model…` action vs. the `Cancel` button, measured
before and after the change on the same instance:

| Width | State | `Add custom model…` | `Cancel` | Painted order |
| --- | --- | --- | --- | --- |
| 390 | before | y 1515, w 348 | y 1467, w 171 | decision **above** the ghost — the defect |
| 390 | after | y 1501, w 348 | y 1549, w 171 | ghost row first, decision last ✅ |
| 1440 | before | x 411, y 708 | x 831, y 708 | one row, ghost leading |
| 1440 | after | x 417, y 703 | x 829, y 703 | one row, ghost leading |

The desktop claim is stronger than those numbers suggest: the element
screenshot of the whole footer at 1440 is **byte-identical** before and after
(`sha256 beb227a07afd46d7…`, 678×69 both times). The small `x`/`y` deltas in the
table are page scroll offsets between the two runs, not layout movement. At 390
the same footer screenshot differs, at identical dimensions (388×117) — the
order changed, the geometry did not.

**Guard: `ui/e2e/picker-footer.spec.ts` (new).** Two specs stating the property
at either side of the breakpoint: below it the custom-model action ends above
where the decision row begins and spans its own row; above it the three actions
overlap vertically (one row) with the custom action at the leading edge.

Verified as a real guard, not a tautology: stashing the one-line source change,
rebuilding, and re-running the spec fails the narrow case
(`the custom-model action must end above where the decision row begins`) and
passes the desktop case. That is the shape a regression would take.

**Why the guard is an e2e spec and not a unit test.** The fix changes CSS
`flex-direction`, not DOM order — the footer's children are in the same order in
both the broken and the fixed state. jsdom loads no stylesheet and computes no
layout, so a `BackendModelPickerDialog.test.tsx` assertion on child order would
pass identically against the broken footer and prove nothing. The only
alternative available in jsdom is asserting the literal class string, which is
an enumeration of the implementation rather than the property. No existing test
asserted footer order, so nothing was adjusted.

**Gates** (cwd `ui/`): `npx vitest run` 3679/3679 passed · `npm run lint`
baseline clean, no drift · `npm run build` ✅ · `npm run validate:theme` ✅ ·
`npm run validate:catalog` ✅ (26 UI citations across 26 rows).

**Scenario IDs:** none. `docs/plans/model-hub-e2e-test-plan.md` §3 has no family
for a dialog's footer layout, and per `ui/e2e/README.md` a Playwright spec
cannot be cited in `tests/scenarios/model_hub/catalog.yaml` because it collects
under neither runner. The spec states the property in its title instead, the
same way `model-list.spec.ts` does.

**Dependencies:** none.

## Known by design

- **The shared `DialogFooter` keeps `flex-col-reverse`.** It is right for the
  two-child Cancel/Confirm footers that are the majority, and changing the
  primitive would move every one of them. The picker overrides it locally
  because the picker is the footer whose first child is not part of that pair.
- **`BackendModelCatalogDialog` carries the same footer className and is not
  touched.** Its first child is a status block (the model count, plus a save
  failure line), not an action — so the reversal there puts the buttons above a
  label rather than burying an action, which is a separate design question and
  outside this PR's scope.
- **`ui/e2e/` is not wired into CI.** The new spec is a runnable check against a
  live instance, not a merge gate. That is the suite's existing posture, not a
  regression introduced here.
- **The comparison is against the frame's written description, not the exported
  pixels.** `avibe-docs/design.pen` could not be opened from this session (Pen
  needs the file open in the editor), so frames F and B were matched on their
  stated ordering rather than pixel-diffed. The ordering claim is unambiguous
  and the renders above satisfy it; a pixel comparison can be redone if wanted.
