### PR TITLE
feat(model-hub): vendor marks in the add-key vendor picker

### DIFF
--- a/ui/e2e/b-add-api-key.spec.ts
+++ b/ui/e2e/b-add-api-key.spec.ts
@@ -135,7 +135,9 @@ test.describe('B · add an API-key source', () => {
     await hub.addApiKeyButton.click();
     await expect(hub.addKeyDialog).toBeVisible();
     await fillApiKeyForm(hub.addKeyDialog, {
-      vendor: preset.id,
+      // Picked the way a user picks it, by the name on the row; the id below is
+      // what that click has to end up sending.
+      vendor: preset.label,
       name,
       baseUrl: mockBaseUrl(),
       apiKey: 'e2e-add',

--- a/ui/e2e/support/hub.ts
+++ b/ui/e2e/support/hub.ts
@@ -387,7 +387,11 @@ export const fillApiKeyForm = async (
   values: { vendor?: string; name?: string; baseUrl: string; apiKey: string; protocol?: string },
 ): Promise<void> => {
   if (values.vendor) {
-    await dialog.getByLabel(hub('addKey.field.vendor'), { exact: true }).click();
+    // Not `exact`, and not by label: the trigger is a button, which a `for`
+    // association cannot name, so it names itself with the label AND its own
+    // contents — the vendor currently chosen. The label is the stable prefix of
+    // that name, not the whole of it.
+    await dialog.getByRole('combobox', { name: hub('addKey.field.vendor') }).click();
     await dialog.page().getByRole('option', { name: values.vendor, exact: true }).click();
   }
   if (values.name !== undefined) {

--- a/ui/e2e/support/hub.ts
+++ b/ui/e2e/support/hub.ts
@@ -370,18 +370,25 @@ export const labelledButton = (scope: Locator, name: string): Locator =>
  * here for the same reason: a spec that does not care about the label should
  * not have to invent one.
  *
- * `vendor` is a catalog id and goes FIRST, because choosing one rewrites the
- * Base URL and retires whatever interface was selected — filling those before it
- * would fill them into a form the next click resets. It also removes the manual
- * disclosure, so `vendor` and `protocol` are alternatives, not a pair: the pin IS
- * the interface, and there is no control left for `protocol` to press.
+ * `vendor` is the label a vendor is offered under and goes FIRST, because
+ * choosing one rewrites the Base URL and retires whatever interface was selected
+ * — filling those before it would fill them into a form the next click resets.
+ * It also removes the manual disclosure, so `vendor` and `protocol` are
+ * alternatives, not a pair: the pin IS the interface, and there is no control
+ * left for `protocol` to press.
+ *
+ * It is a label rather than the catalog id it sends, because the picker carries
+ * each vendor's mark and so cannot be a `<select>`: there are no option values
+ * left to name, only the row a user would point at. The panel is anchored, not
+ * nested, so the rows are looked up on the page rather than inside the dialog.
  */
 export const fillApiKeyForm = async (
   dialog: Locator,
   values: { vendor?: string; name?: string; baseUrl: string; apiKey: string; protocol?: string },
 ): Promise<void> => {
   if (values.vendor) {
-    await dialog.getByLabel(hub('addKey.field.vendor'), { exact: true }).selectOption(values.vendor);
+    await dialog.getByLabel(hub('addKey.field.vendor'), { exact: true }).click();
+    await dialog.page().getByRole('option', { name: values.vendor, exact: true }).click();
   }
   if (values.name !== undefined) {
     await dialog.getByLabel(hub('addKey.field.name'), { exact: true }).fill(values.name);

--- a/ui/src/components/settings/models/AddApiKeyDialog.test.tsx
+++ b/ui/src/components/settings/models/AddApiKeyDialog.test.tsx
@@ -163,6 +163,17 @@ const vendorOptionName = (id: string) => (id === CUSTOM_VENDOR
   ? i18n.t('settings.models.addKey.field.vendor.custom')
   : apiKeyVendorPreset(id)?.label ?? id);
 
+/** The order the menu should read in: the shipped catalog A–Z by the name on the
+ *  row, then the entry that is not a vendor. Derived from the file rather than
+ *  listed, so a vendor added to the catalog is expected in its alphabetical
+ *  place instead of wherever the file happens to put it. */
+const offeredInOrder = (): string[] => [
+  ...API_KEY_VENDOR_PRESETS
+    .map((row) => row.id)
+    .sort((one, other) => vendorOptionName(one).localeCompare(vendorOptionName(other), 'en', { sensitivity: 'base' })),
+  CUSTOM_VENDOR,
+];
+
 const selectVendor = async (user: ReturnType<typeof userEvent.setup>, id: string) => {
   await user.click(vendorField());
   await user.click(await screen.findByRole('option', { name: vendorOptionName(id) }));
@@ -1057,8 +1068,9 @@ describe('AddApiKeyDialog · vendor', () => {
 
     await user.click(vendorField());
     const rows = await screen.findAllByRole('option');
-    // The shipped catalog in file order, after the one entry that is not a vendor.
-    const offered = [CUSTOM_VENDOR, ...API_KEY_VENDOR_PRESETS.map((row) => row.id)];
+    // A–Z by the name on the row, with 自定义 at the bottom: it is the absence of
+    // a vendor, so it belongs after them rather than sorted among them.
+    const offered = offeredInOrder();
     expect(rows).toHaveLength(offered.length);
     expect(offered.map((id) => rows.indexOf(screen.getByRole('option', { name: vendorOptionName(id) }))))
       .toEqual(offered.map((_, position) => position));
@@ -1072,19 +1084,75 @@ describe('AddApiKeyDialog · vendor', () => {
     expect(vendorField().querySelector('.model-hub-add-key-vendor-glyph')).toBeTruthy();
   });
 
-  it('opens on the vendor already chosen and takes a keyboard all the way to the next one', async () => {
-    const [first, second] = API_KEY_VENDOR_PRESETS;
+  // The highlight has to be readable, not merely visible: while the panel is
+  // open, focus sits on an element that IS a combobox and NAMES the row the
+  // arrow keys are on, so a screen reader announces each vendor as it is
+  // reached. A picker that consumed the arrow keys on a roleless container
+  // would pass the sighted half of this test and tell a screen-reader user
+  // nothing — which is what the shared control's search input is for.
+  it('announces the highlighted row and takes a keyboard to a vendor', async () => {
+    const [top, next] = offeredInOrder();
+    const reached = apiKeyVendorPreset(next);
     renderDialog();
     const user = userEvent.setup();
 
-    await selectVendor(user, first.id);
-    await user.keyboard('{Enter}');
-    await waitFor(() => expect(screen.getByRole('option', { name: first.label }).getAttribute('aria-selected'))
-      .toBe('true'));
+    await user.click(vendorField());
+    const rows = await screen.findAllByRole('option');
+    const focused = () => document.activeElement as HTMLElement;
+    expect(focused().getAttribute('role')).toBe('combobox');
+    expect(document.getElementById(focused().getAttribute('aria-controls') ?? '')?.getAttribute('role'))
+      .toBe('listbox');
+    expect(rows[0].getAttribute('aria-selected')).toBe('true');
+    expect(rows[0].textContent).toContain(vendorOptionName(top));
 
-    await user.keyboard('{ArrowDown}{Enter}');
-    await waitFor(() => expect(vendorField().textContent).toContain(second.label));
-    expect(baseUrlInput().value).toBe(second.official_base_url);
+    // Arrowing moves the highlight AND the focused combobox's pointer to it.
+    const highlighted = () => document.getElementById(focused().getAttribute('aria-activedescendant') ?? '');
+    await user.keyboard('{ArrowDown}');
+    await waitFor(() => expect(highlighted()?.textContent).toContain(vendorOptionName(next)));
+    expect(highlighted()?.getAttribute('role')).toBe('option');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(vendorField().textContent).toContain(vendorOptionName(next)));
+    expect(baseUrlInput().value).toBe(reached?.official_base_url);
+  });
+
+  it('treats picking the vendor already picked as no choice at all', async () => {
+    // The switch is destructive by design — it resets the address, drops the
+    // interface and retires the detection — so it must fire on a CHANGE, not on
+    // a click. Reopening the menu and confirming what is already there is how a
+    // user checks what they chose.
+    const entry = preset('openai_chat');
+    renderDialog();
+    const user = userEvent.setup();
+
+    await selectVendor(user, entry.id);
+    await user.type(baseUrlInput(), '/edge');
+    const edited = baseUrlInput().value;
+    expect(edited).not.toBe(entry.official_base_url);
+
+    await selectVendor(user, entry.id);
+
+    expect(baseUrlInput().value).toBe(edited);
+    expect(vendorField().textContent).toContain(entry.label);
+  });
+
+  it('narrows the catalog by name and offers nothing that is not in it', async () => {
+    const entry = preset('anthropic');
+    renderDialog();
+    const user = userEvent.setup();
+
+    await user.click(vendorField());
+    const search = screen.getByPlaceholderText(/Search vendors|搜索服务商/);
+    await user.type(search, entry.label);
+    await waitFor(() => expect(screen.getAllByRole('option').map((row) => row.textContent))
+      .toEqual([expect.stringContaining(entry.label)]));
+
+    // A vendor is a catalog row and the request sends its id, so a typed name
+    // that matches none is a dead end rather than a value to adopt — the
+    // opposite of the model pickers this control also serves.
+    await user.clear(search);
+    await user.type(search, 'not-a-vendor');
+    await waitFor(() => expect(screen.queryAllByRole('option')).toEqual([]));
+    expect(screen.getByText(/No vendor by that name|没有同名的服务商/)).toBeTruthy();
   });
 
   it('prefills the official address and sends the catalog id with its pinned interface', async () => {

--- a/ui/src/components/settings/models/AddApiKeyDialog.test.tsx
+++ b/ui/src/components/settings/models/AddApiKeyDialog.test.tsx
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import i18n from '@/i18n';
 import { AddApiKeyDialog } from './AddApiKeyDialog';
-import { API_KEY_VENDOR_PRESETS } from './apiKeyVendors';
+import { API_KEY_VENDOR_PRESETS, apiKeyVendorPreset, CUSTOM_VENDOR } from './apiKeyVendors';
 import { createSourceCollectionReadAuthority } from './collectionReadAuthority';
 import { ApiCallError, modelsApi } from './modelsApi';
 import type {
@@ -145,7 +145,7 @@ const fillCredentials = async () => {
   return user;
 };
 
-const vendorSelect = () => screen.getByRole('combobox', { name: /^Vendor$|^服务商$/ }) as HTMLSelectElement;
+const vendorField = () => screen.getByRole('combobox', { name: /^Vendor$|^服务商$/ });
 const baseUrlInput = () => screen.getByRole('textbox', { name: /^Base URL$/i }) as HTMLInputElement;
 const disclosure = () => screen.queryByRole('button', { name: /Manually specify interface type|手动指定接口类型/i });
 
@@ -158,8 +158,14 @@ const preset = (protocol: string) => {
   return entry;
 };
 
+/** What a row of the picker reads as — the only handle a user, or a spec, has on it. */
+const vendorOptionName = (id: string) => (id === CUSTOM_VENDOR
+  ? i18n.t('settings.models.addKey.field.vendor.custom')
+  : apiKeyVendorPreset(id)?.label ?? id);
+
 const selectVendor = async (user: ReturnType<typeof userEvent.setup>, id: string) => {
-  await user.selectOptions(vendorSelect(), id);
+  await user.click(vendorField());
+  await user.click(await screen.findByRole('option', { name: vendorOptionName(id) }));
 };
 
 const openManualProtocol = async (user: ReturnType<typeof userEvent.setup>) => {
@@ -176,6 +182,14 @@ const clickConfirm = async (user: ReturnType<typeof userEvent.setup>) => {
 
 beforeEach(async () => {
   await i18n.changeLanguage('en');
+  // The 服务商 picker anchors a popover over its trigger and scrolls the
+  // highlighted row into view; jsdom implements neither measurement.
+  vi.stubGlobal('ResizeObserver', class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  });
+  Element.prototype.scrollIntoView = vi.fn();
 });
 
 afterEach(() => {
@@ -1031,6 +1045,46 @@ describe('AddApiKeyDialog · vendor', () => {
     expect(observe.mock.calls[0][0].vendor).toBe('custom');
     expect(observe.mock.calls[0][0].protocol).toBeUndefined();
     expect(create.mock.calls[0][0].vendor).toBe('custom');
+  });
+
+  // A vendor is recognised by its mark before its name is read, so the mark has
+  // to be on the row AND on the field that shows what was chosen — the second is
+  // the half a `<select>` could never carry.
+  it('puts a mark on every row and on the field once a vendor is chosen', async () => {
+    const entry = preset('anthropic');
+    renderDialog();
+    const user = userEvent.setup();
+
+    await user.click(vendorField());
+    const rows = await screen.findAllByRole('option');
+    // The shipped catalog in file order, after the one entry that is not a vendor.
+    const offered = [CUSTOM_VENDOR, ...API_KEY_VENDOR_PRESETS.map((row) => row.id)];
+    expect(rows).toHaveLength(offered.length);
+    expect(offered.map((id) => rows.indexOf(screen.getByRole('option', { name: vendorOptionName(id) }))))
+      .toEqual(offered.map((_, position) => position));
+    for (const row of rows) {
+      expect(row.querySelector('.model-hub-add-key-vendor-glyph'), row.textContent ?? '').toBeTruthy();
+    }
+
+    await user.click(screen.getByRole('option', { name: entry.label }));
+    expect(screen.queryAllByRole('option')).toEqual([]);
+    expect(vendorField().textContent).toContain(entry.label);
+    expect(vendorField().querySelector('.model-hub-add-key-vendor-glyph')).toBeTruthy();
+  });
+
+  it('opens on the vendor already chosen and takes a keyboard all the way to the next one', async () => {
+    const [first, second] = API_KEY_VENDOR_PRESETS;
+    renderDialog();
+    const user = userEvent.setup();
+
+    await selectVendor(user, first.id);
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(screen.getByRole('option', { name: first.label }).getAttribute('aria-selected'))
+      .toBe('true'));
+
+    await user.keyboard('{ArrowDown}{Enter}');
+    await waitFor(() => expect(vendorField().textContent).toContain(second.label));
+    expect(baseUrlInput().value).toBe(second.official_base_url);
   });
 
   it('prefills the official address and sends the catalog id with its pinned interface', async () => {

--- a/ui/src/components/settings/models/AddApiKeyDialog.test.tsx
+++ b/ui/src/components/settings/models/AddApiKeyDialog.test.tsx
@@ -145,7 +145,9 @@ const fillCredentials = async () => {
   return user;
 };
 
-const vendorField = () => screen.getByRole('combobox', { name: /^Vendor$|^服务商$/ });
+/** Named by its label AND its own contents, so the name starts with 服务商 and
+ *  continues with whichever vendor is currently chosen. */
+const vendorField = () => screen.getByRole('combobox', { name: /^(Vendor|服务商)(\s|$)/ });
 const baseUrlInput = () => screen.getByRole('textbox', { name: /^Base URL$/i }) as HTMLInputElement;
 const disclosure = () => screen.queryByRole('button', { name: /Manually specify interface type|手动指定接口类型/i });
 
@@ -1115,6 +1117,27 @@ describe('AddApiKeyDialog · vendor', () => {
     expect(baseUrlInput().value).toBe(reached?.official_base_url);
   });
 
+  it('names the field with its label and with the vendor it is holding', async () => {
+    // A `<button>` is not labelable, so the visible 服务商 label never reaches the
+    // trigger's accessible name and the field has to carry one. It carries the
+    // label AND the selection: a name replaces the trigger's contents rather
+    // than adding to them, so the label alone would announce the field as 服务商
+    // and never say which vendor it holds — the one thing a native select
+    // always said.
+    const entry = preset('anthropic');
+    const named = (vendor: string) => new RegExp(
+      `^${i18n.t('settings.models.addKey.field.vendor')}\\s+${vendorOptionName(vendor)}$`,
+    );
+    renderDialog();
+    const user = userEvent.setup();
+
+    expect(screen.getByRole('combobox', { name: named(CUSTOM_VENDOR) })).toBe(vendorField());
+
+    await selectVendor(user, entry.id);
+
+    expect(screen.getByRole('combobox', { name: named(entry.id) })).toBe(vendorField());
+  });
+
   it('treats picking the vendor already picked as no choice at all', async () => {
     // The switch is destructive by design — it resets the address, drops the
     // interface and retires the detection — so it must fire on a CHANGE, not on
@@ -1191,6 +1214,28 @@ describe('AddApiKeyDialog · vendor', () => {
     expect(row?.textContent).toMatch(/Built-in catalog/);
     expect(disclosure()).toBeNull();
     expect(screen.queryByRole('button', { name: 'OpenAI Responses' })).toBeNull();
+  });
+
+  it('puts the pin’s explanation under the interface it explains, not beside it', async () => {
+    // The statement and the sentence about it are two lines: the hint is the
+    // longer text, so beside the glyph it wrapped around the very name it is
+    // about. Asserted structurally, because "on the next line" is a fact about
+    // which element the hint is a child of, not about its text.
+    const entry = preset('anthropic');
+    renderDialog();
+    const user = userEvent.setup();
+
+    await selectVendor(user, entry.id);
+
+    const row = document.querySelector('.model-hub-add-key-protocol-idle-row');
+    const statement = row?.querySelector('.model-hub-add-key-protocol-idle-line');
+    const hint = row?.querySelector('.model-hub-add-key-hint');
+    expect(statement?.textContent).toMatch(/Anthropic Messages/);
+    expect(statement?.textContent).toMatch(/Built-in catalog/);
+    expect(hint?.textContent).toMatch(/no longer has to prove the interface|不再需要靠返回结构证明接口/);
+    // A sibling of the statement's line, not a child of it.
+    expect(hint?.parentElement).toBe(row);
+    expect(statement?.contains(hint ?? null)).toBe(false);
   });
 
   it('retires an observation taken under the previous vendor', async () => {

--- a/ui/src/components/settings/models/AddApiKeyDialog.tsx
+++ b/ui/src/components/settings/models/AddApiKeyDialog.tsx
@@ -810,11 +810,12 @@ export const AddApiKeyDialog: React.FC<AddApiKeyDialogProps> = (props) => {
               {(id) => (
                 <Combobox
                   id={id}
-                  // The field mints the id and its label points here, but a `for`
-                  // association contributes nothing to a button's accessible
-                  // name, so the label text is given again. The chosen vendor
-                  // stays the control's contents — where a combobox's value is
-                  // read from — so the two do not collide.
+                  // The label points here, but a `for` association contributes
+                  // nothing to a button's accessible name, so the field has to
+                  // name itself. The primitive appends the selection to what is
+                  // passed here: the label alone would replace the trigger's
+                  // contents, and those contents are the chosen vendor — the one
+                  // thing a picker exists to report.
                   ariaLabel={t('settings.models.addKey.field.vendor')}
                   className="model-hub-add-key-input"
                   options={vendorOptions}
@@ -883,19 +884,27 @@ export const AddApiKeyDialog: React.FC<AddApiKeyDialogProps> = (props) => {
               )}
               {phase.kind === 'form' && !phase.report && !segmentsOpen && (
                 <div className="model-hub-add-key-protocol-idle-row">
-                  {/* Whatever 检测 is about to send, and nothing else: a catalog
-                      pin and a concrete choice are each the active constraint
-                      even while the disclosure that could have made one is shut
-                      — or, under a pin, is not offered at all. */}
-                  <span className="model-hub-add-key-protocol-active">
-                    {constrainedProtocol && <ProtocolGlyph protocol={constrainedProtocol} />}
-                    {t(constrainedProtocol
-                      ? PROTOCOL_COPY_KEYS[constrainedProtocol]
-                      : 'settings.models.addKey.protocol.auto')}
-                  </span>
-                  {/* The pin is the reason this row has no control beside it, so
-                      it says so here rather than only on the strip 检测 returns. */}
-                  {vendorPreset && protocolBadge}
+                  {/* The statement and its badge are one line; the sentence that
+                      explains them is the next. Beside the glyph the hint read as
+                      a second statement competing with the first, and it is the
+                      longer of the two — it wrapped around the name it belongs
+                      to. Underneath, at its own smaller scale, it is plainly
+                      subordinate to the line above. */}
+                  <div className="model-hub-add-key-protocol-idle-line">
+                    {/* Whatever 检测 is about to send, and nothing else: a catalog
+                        pin and a concrete choice are each the active constraint
+                        even while the disclosure that could have made one is shut
+                        — or, under a pin, is not offered at all. */}
+                    <span className="model-hub-add-key-protocol-active">
+                      {constrainedProtocol && <ProtocolGlyph protocol={constrainedProtocol} />}
+                      {t(constrainedProtocol
+                        ? PROTOCOL_COPY_KEYS[constrainedProtocol]
+                        : 'settings.models.addKey.protocol.auto')}
+                    </span>
+                    {/* The pin is the reason this row has no control beside it, so
+                        it says so here rather than only on the strip 检测 returns. */}
+                    {vendorPreset && protocolBadge}
+                  </div>
                   {/* The idle hint promises automatic identification, which is
                       only what Auto does. A named interface has already answered
                       it; a pin answers a different question — what 检测 still has

--- a/ui/src/components/settings/models/AddApiKeyDialog.tsx
+++ b/ui/src/components/settings/models/AddApiKeyDialog.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import {
+  Check,
   CheckCircle2,
   ChevronDown,
   CircleX,
@@ -14,8 +15,15 @@ import {
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { fieldBaseClass } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
-import { Select } from '@/components/ui/select';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 import { API_KEY_VENDOR_PRESETS, apiKeyVendorPreset, CUSTOM_VENDOR } from './apiKeyVendors';
 import { classifyModelHubFailure, type ModelHubFailureClass } from './asyncLifetime';
@@ -53,6 +61,7 @@ import {
 } from './types';
 import { ProtocolGlyph } from './protocolGlyph';
 import { optionalTrimmedTextWithin } from './validation';
+import { VendorGlyph } from './vendorGlyph';
 
 type Phase =
   | { kind: 'form'; report: SourceObservation | null }
@@ -122,6 +131,120 @@ const ProtocolSegments: React.FC<{
         </button>
       ))}
     </div>
+  );
+};
+
+/**
+ * The 服务商 field: the shipped catalog in file order, after the one entry that
+ * is not a vendor at all.
+ *
+ * Not a `<select>`, because a vendor is recognised by its mark long before its
+ * name is read and an `<option>` holds text only — the closed control then shows
+ * whatever the option could hold, so the mark is missing exactly where the
+ * choice is already made. The list is assembled from the two surfaces this app
+ * already picks with, a `Popover` for the panel and `Command` for the arrow keys
+ * and Enter, and stays `role="combobox"` over a `role="listbox"` panel so it is
+ * the same control it was to a screen reader.
+ *
+ * `modal`, like every other combobox here: a non-modal popover opened inside a
+ * Dialog has its wheel events cancelled by the Dialog's scroll lock, and the
+ * catalog is longer than the list is tall.
+ */
+const VendorPicker: React.FC<{
+  id: string;
+  value: string;
+  disabled: boolean;
+  onSelect: (vendor: string) => void;
+}> = ({ id, value, disabled, onSelect }) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = React.useState(false);
+  // cmdk's highlight, seeded from the selection each time the panel opens: a
+  // keyboard user arrives where they left off rather than at the top of twelve.
+  const [highlighted, setHighlighted] = React.useState(value);
+  const listRef = React.useRef<HTMLDivElement>(null);
+  const naming = (vendor: string) => (vendor === CUSTOM_VENDOR
+    ? t('settings.models.addKey.field.vendor.custom')
+    : apiKeyVendorPreset(vendor)?.label ?? vendor);
+
+  return (
+    <Popover
+      modal
+      open={open}
+      onOpenChange={(next) => {
+        if (next) setHighlighted(value);
+        setOpen(next);
+      }}
+    >
+      <PopoverTrigger asChild>
+        <button
+          id={id}
+          type="button"
+          role="combobox"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          // The field still mints the id and its label element still points at
+          // this control, but a `for` association contributes nothing to a
+          // button's accessible name, so the label text is also given here. The
+          // chosen vendor stays the control's contents, which is where a
+          // combobox's value is read from.
+          aria-label={t('settings.models.addKey.field.vendor')}
+          disabled={disabled}
+          className={cn(
+            fieldBaseClass,
+            'model-hub-add-key-input flex cursor-pointer items-center justify-between gap-2 text-left',
+          )}
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            <VendorGlyph vendor={value} />
+            <span className="truncate">{naming(value)}</span>
+          </span>
+          <ChevronDown aria-hidden="true" className="size-4 shrink-0 opacity-60" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[--radix-popover-trigger-width] p-0"
+        // Radix would focus the first option and paint a ring on a row nobody
+        // picked. The list takes focus instead — which is also where cmdk
+        // listens for the arrow keys and Enter.
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          listRef.current?.focus();
+        }}
+      >
+        <Command
+          ref={listRef}
+          tabIndex={-1}
+          shouldFilter={false}
+          value={highlighted}
+          onValueChange={setHighlighted}
+          className="outline-none"
+        >
+          <CommandList>
+            <CommandGroup>
+              {[CUSTOM_VENDOR, ...API_KEY_VENDOR_PRESETS.map((preset) => preset.id)].map((option) => (
+                <CommandItem
+                  key={option}
+                  value={option}
+                  className="cursor-pointer gap-2"
+                  onSelect={() => {
+                    onSelect(option);
+                    setOpen(false);
+                  }}
+                >
+                  <VendorGlyph vendor={option} />
+                  <span className="min-w-0 flex-1 truncate">{naming(option)}</span>
+                  <Check
+                    aria-hidden="true"
+                    className={cn('size-3.5 shrink-0', option === value ? 'opacity-100' : 'opacity-0')}
+                  />
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
   );
 };
 
@@ -761,8 +884,7 @@ export const AddApiKeyDialog: React.FC<AddApiKeyDialogProps> = (props) => {
           <div className="model-hub-add-key-body flex flex-col">
             {/* First, because it is the field the rest are conditioned on: it
                 decides what the Base URL starts as and whether the interface is
-                still a question. Options are the shipped catalog in file order,
-                after the one entry that is not a vendor at all. */}
+                still a question. */}
             <Field
               className="model-hub-add-key-field"
               labelClassName="model-hub-add-key-label"
@@ -771,18 +893,7 @@ export const AddApiKeyDialog: React.FC<AddApiKeyDialogProps> = (props) => {
               hint={t('settings.models.addKey.field.vendor.hint')}
             >
               {(id) => (
-                <Select
-                  id={id}
-                  value={vendor}
-                  disabled={formLocked}
-                  onChange={(event) => editVendor(event.target.value)}
-                  className="model-hub-add-key-input"
-                >
-                  <option value={CUSTOM_VENDOR}>{t('settings.models.addKey.field.vendor.custom')}</option>
-                  {API_KEY_VENDOR_PRESETS.map((preset) => (
-                    <option key={preset.id} value={preset.id}>{preset.label}</option>
-                  ))}
-                </Select>
+                <VendorPicker id={id} value={vendor} disabled={formLocked} onSelect={editVendor} />
               )}
             </Field>
             <Field className="model-hub-add-key-field" labelClassName="model-hub-add-key-label" label={t('settings.models.addKey.field.name')}>

--- a/ui/src/components/settings/models/AddApiKeyDialog.tsx
+++ b/ui/src/components/settings/models/AddApiKeyDialog.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import {
-  Check,
   CheckCircle2,
   ChevronDown,
   CircleX,
@@ -15,15 +14,8 @@ import {
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
-import {
-  Command,
-  CommandGroup,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
-import { fieldBaseClass } from '@/components/ui/field';
+import { Combobox, type ComboboxOption } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 import { API_KEY_VENDOR_PRESETS, apiKeyVendorPreset, CUSTOM_VENDOR } from './apiKeyVendors';
 import { classifyModelHubFailure, type ModelHubFailureClass } from './asyncLifetime';
@@ -135,117 +127,32 @@ const ProtocolSegments: React.FC<{
 };
 
 /**
- * The 服务商 field: the shipped catalog in file order, after the one entry that
- * is not a vendor at all.
+ * The 服务商 field's rows: the shipped catalog A–Z by label, then the one entry
+ * that is not a vendor at all, each carrying its mark.
  *
- * Not a `<select>`, because a vendor is recognised by its mark long before its
- * name is read and an `<option>` holds text only — the closed control then shows
- * whatever the option could hold, so the mark is missing exactly where the
- * choice is already made. The list is assembled from the two surfaces this app
- * already picks with, a `Popover` for the panel and `Command` for the arrow keys
- * and Enter, and stays `role="combobox"` over a `role="listbox"` panel so it is
- * the same control it was to a screen reader.
+ * A–Z because the file's order is the backend's business — whatever it means
+ * there, on screen it reads as arbitrary, and a name is what a user scans for.
+ * The comparison is base-sensitivity English so case and accents do not split
+ * the alphabet. 自定义 sorts nowhere: it is the absence of a vendor, so it sits
+ * at the end of the vendors rather than inside them, while staying the value the
+ * field opens on.
  *
- * `modal`, like every other combobox here: a non-modal popover opened inside a
- * Dialog has its wheel events cancelled by the Dialog's scroll lock, and the
- * catalog is longer than the list is tall.
+ * The mark is why the field is no longer a `<select>`. A vendor is recognised by
+ * its logo long before its name is read, and an `<option>` holds text only — so
+ * the closed control could only ever show what an option could hold, dropping
+ * the mark exactly where the choice has already been made. What replaces it is
+ * this app's one picker, `Combobox`, given a mark per row; a second local
+ * implementation of the same trigger, panel, and keyboard would only be a place
+ * for the two to diverge.
  */
-const VendorPicker: React.FC<{
-  id: string;
-  value: string;
-  disabled: boolean;
-  onSelect: (vendor: string) => void;
-}> = ({ id, value, disabled, onSelect }) => {
+const useVendorOptions = (): ComboboxOption[] => {
   const { t } = useTranslation();
-  const [open, setOpen] = React.useState(false);
-  // cmdk's highlight, seeded from the selection each time the panel opens: a
-  // keyboard user arrives where they left off rather than at the top of twelve.
-  const [highlighted, setHighlighted] = React.useState(value);
-  const listRef = React.useRef<HTMLDivElement>(null);
-  const naming = (vendor: string) => (vendor === CUSTOM_VENDOR
-    ? t('settings.models.addKey.field.vendor.custom')
-    : apiKeyVendorPreset(vendor)?.label ?? vendor);
-
-  return (
-    <Popover
-      modal
-      open={open}
-      onOpenChange={(next) => {
-        if (next) setHighlighted(value);
-        setOpen(next);
-      }}
-    >
-      <PopoverTrigger asChild>
-        <button
-          id={id}
-          type="button"
-          role="combobox"
-          aria-haspopup="listbox"
-          aria-expanded={open}
-          // The field still mints the id and its label element still points at
-          // this control, but a `for` association contributes nothing to a
-          // button's accessible name, so the label text is also given here. The
-          // chosen vendor stays the control's contents, which is where a
-          // combobox's value is read from.
-          aria-label={t('settings.models.addKey.field.vendor')}
-          disabled={disabled}
-          className={cn(
-            fieldBaseClass,
-            'model-hub-add-key-input flex cursor-pointer items-center justify-between gap-2 text-left',
-          )}
-        >
-          <span className="flex min-w-0 items-center gap-2">
-            <VendorGlyph vendor={value} />
-            <span className="truncate">{naming(value)}</span>
-          </span>
-          <ChevronDown aria-hidden="true" className="size-4 shrink-0 opacity-60" />
-        </button>
-      </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        className="w-[--radix-popover-trigger-width] p-0"
-        // Radix would focus the first option and paint a ring on a row nobody
-        // picked. The list takes focus instead — which is also where cmdk
-        // listens for the arrow keys and Enter.
-        onOpenAutoFocus={(event) => {
-          event.preventDefault();
-          listRef.current?.focus();
-        }}
-      >
-        <Command
-          ref={listRef}
-          tabIndex={-1}
-          shouldFilter={false}
-          value={highlighted}
-          onValueChange={setHighlighted}
-          className="outline-none"
-        >
-          <CommandList>
-            <CommandGroup>
-              {[CUSTOM_VENDOR, ...API_KEY_VENDOR_PRESETS.map((preset) => preset.id)].map((option) => (
-                <CommandItem
-                  key={option}
-                  value={option}
-                  className="cursor-pointer gap-2"
-                  onSelect={() => {
-                    onSelect(option);
-                    setOpen(false);
-                  }}
-                >
-                  <VendorGlyph vendor={option} />
-                  <span className="min-w-0 flex-1 truncate">{naming(option)}</span>
-                  <Check
-                    aria-hidden="true"
-                    className={cn('size-3.5 shrink-0', option === value ? 'opacity-100' : 'opacity-0')}
-                  />
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
-  );
+  return React.useMemo(() => ([
+    ...API_KEY_VENDOR_PRESETS
+      .map((preset) => ({ value: preset.id, label: preset.label }))
+      .sort((one, other) => one.label.localeCompare(other.label, 'en', { sensitivity: 'base' })),
+    { value: CUSTOM_VENDOR, label: t('settings.models.addKey.field.vendor.custom') },
+  ].map((option) => ({ ...option, icon: <VendorGlyph vendor={option.value} /> }))), [t]);
 };
 
 type ReplaceOutcome =
@@ -378,6 +285,7 @@ export const AddApiKeyDialog: React.FC<AddApiKeyDialogProps> = (props) => {
   const addOnAdded = replaceMode ? null : props.onAdded;
   const replaceSourceId = replaceMode ? props.source.id : null;
   const { t } = useTranslation();
+  const vendorOptions = useVendorOptions();
   const [vendor, setVendor] = React.useState<string>(CUSTOM_VENDOR);
   const [displayName, setDisplayName] = React.useState('');
   const [baseUrl, setBaseUrl] = React.useState('');
@@ -744,7 +652,14 @@ export const AddApiKeyDialog: React.FC<AddApiKeyDialogProps> = (props) => {
   // `retireProvedEvidence` would have kept, and an ④/failure the new vendor may
   // simply not have. §1.5: switching resets the URL to the new vendor's official
   // one, drops the interface selection, and retires the observation outright.
+  // Picking the vendor that is already picked is not a switch, and everything
+  // below is destructive: it would throw away a hand-edited address, a declared
+  // interface, and a completed detection to arrive back where it started. The
+  // guard is here rather than in the picker because this function is what
+  // destroys that state — a caller that re-announces the same choice is not
+  // wrong, acting on it is.
   const editVendor = (value: string) => {
+    if (value === vendor) return;
     setVendor(value);
     setBaseUrl(apiKeyVendorPreset(value)?.official_base_url ?? '');
     setProtocolSelection('auto');
@@ -893,7 +808,25 @@ export const AddApiKeyDialog: React.FC<AddApiKeyDialogProps> = (props) => {
               hint={t('settings.models.addKey.field.vendor.hint')}
             >
               {(id) => (
-                <VendorPicker id={id} value={vendor} disabled={formLocked} onSelect={editVendor} />
+                <Combobox
+                  id={id}
+                  // The field mints the id and its label points here, but a `for`
+                  // association contributes nothing to a button's accessible
+                  // name, so the label text is given again. The chosen vendor
+                  // stays the control's contents — where a combobox's value is
+                  // read from — so the two do not collide.
+                  ariaLabel={t('settings.models.addKey.field.vendor')}
+                  className="model-hub-add-key-input"
+                  options={vendorOptions}
+                  value={vendor}
+                  onValueChange={editVendor}
+                  // A vendor is a catalog row, and the request sends its id: there
+                  // is no typed value this field could accept.
+                  allowCustomValue={false}
+                  disabled={formLocked}
+                  searchPlaceholder={t('settings.models.addKey.field.vendor.search')}
+                  emptyText={t('settings.models.addKey.field.vendor.empty')}
+                />
               )}
             </Field>
             <Field className="model-hub-add-key-field" labelClassName="model-hub-add-key-label" label={t('settings.models.addKey.field.name')}>

--- a/ui/src/components/settings/models/dialogFields.test.tsx
+++ b/ui/src/components/settings/models/dialogFields.test.tsx
@@ -39,8 +39,8 @@ describe('Field', () => {
   });
 
   it('names a control with no icon inset', () => {
-    // The vendor <select> takes the same path minus the wrapper — the branch that
-    // renders `children(id)` bare is the one that could drop the argument.
+    // A field with no icon takes the same path minus the wrapper — the branch
+    // that renders `children(id)` bare is the one that could drop the argument.
     const { labelFor, controlId } = pair(
       renderToStaticMarkup(
         <Field label="Vendor">

--- a/ui/src/components/settings/models/dialogFields.tsx
+++ b/ui/src/components/settings/models/dialogFields.tsx
@@ -55,7 +55,7 @@ const IconField: React.FC<{
  * control: taking it as a prop would let a caller pass its own and drift, and
  * cloning the child to inject it would do the same thing invisibly.
  *
- * `icon` is optional because a `<Select>` carries its own chevron; `hint` because
+ * `icon` is optional because a picker carries its own chevron; `hint` because
  * only two of the four fields explain themselves.
  */
 export const Field: React.FC<{

--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -622,13 +622,6 @@
   padding-inline: var(--model-hub-add-key-input-padding);
   font-size: var(--model-hub-add-key-input-size);
 }
-/* Same field surface, one exception: `Select` lays its chevron over the trailing
-   edge, so the shared inline padding has to leave that side room. Qualified by
-   element rather than by a second class, which would make every future select
-   here a call site that can forget it. */
-.model-hub-add-key-input:is(select) {
-  padding-inline-end: calc(var(--model-hub-add-key-input-padding) + 20px);
-}
 .model-hub-add-key-secret { width: 100%; }
 .model-hub-add-key-hint {
   color: var(--model-hub-muted-b3);
@@ -709,7 +702,11 @@
   font-size: var(--model-hub-add-key-hint-size);
   font-weight: 600;
 }
-.model-hub-add-key-protocol-glyph {
+/* Interface glyphs and vendor marks are one visual family at one size, so they
+   share the rule rather than each declaring 14px and drifting apart. Two names
+   because a vendor's logo is not a statement about its interface. */
+.model-hub-add-key-protocol-glyph,
+.model-hub-add-key-vendor-glyph {
   width: 14px;
   height: 14px;
   flex-shrink: 0;

--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -641,17 +641,27 @@
   display: flex;
   gap: 3px;
 }
+/* Two lines, not one: the statement and its badge, then the sentence that
+   explains them. The hint is the longer text of the two, so beside the statement
+   it wrapped around the name it is about; underneath, it starts where that name
+   starts and reads as its subordinate. */
 .model-hub-add-key-protocol-idle-row {
-  flex-direction: row;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
+}
+.model-hub-add-key-protocol-idle-line {
+  display: flex;
+  width: 100%;
   flex-wrap: wrap;
   align-items: baseline;
   gap: 8px;
 }
 /* The element that carries the statement is the element that sizes it. The idle
    row holds two deliberately different scales -- this 12px statement and the
-   10.5px hint beside it -- so the scale sits on each child rather than on the row
-   the way the single-child detecting row does. Color stays inherited so the
-   row's `.is-idle` dimming keeps applying to it. */
+   10.5px hint on the line below -- so the scale sits on each child rather than on
+   the row the way the single-child detecting row does. Color stays inherited so
+   the row's `.is-idle` dimming keeps applying to it. */
 .model-hub-add-key-protocol-active {
   display: inline-flex;
   align-items: center;
@@ -664,7 +674,7 @@
    takes both border and ink from `currentColor` so it annotates whatever it sits
    in -- mint inside ①″ -- rather than introducing an ink of its own. On a strip
    it goes to the trailing edge, out of the way of text that wraps; on the idle
-   row it stays in the reading order, between the statement and its hint. */
+   row it stays on the statement's own line, directly after it. */
 .model-hub-add-key-protocol-badge {
   flex-shrink: 0;
   align-self: center;

--- a/ui/src/components/settings/models/protocolGlyph.tsx
+++ b/ui/src/components/settings/models/protocolGlyph.tsx
@@ -2,11 +2,15 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 import type { SourceProtocol } from './types';
+import { ANTHROPIC_MARK, OPENAI_MARK } from './vendorGlyph';
 
 type GlyphProps = React.SVGProps<SVGSVGElement>;
 
 const glyphClassName = (className?: string) => cn('model-hub-add-key-protocol-glyph', className);
 
+// A protocol family is named after the vendor that published it, so its glyph is
+// that vendor's mark. The artwork lives with the other vendor marks; this file
+// owns only the mapping from an interface to the one that stands for it.
 export const AnthropicGlyph: React.FC<GlyphProps> = ({ className, ...props }) => (
   <svg
     viewBox="0 0 24 24"
@@ -16,7 +20,7 @@ export const AnthropicGlyph: React.FC<GlyphProps> = ({ className, ...props }) =>
     className={glyphClassName(className)}
     {...props}
   >
-    <path d="M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z" />
+    <path d={ANTHROPIC_MARK} />
   </svg>
 );
 
@@ -29,7 +33,7 @@ export const OpenAIGlyph: React.FC<GlyphProps> = ({ className, ...props }) => (
     className={glyphClassName(className)}
     {...props}
   >
-    <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" />
+    <path d={OPENAI_MARK} />
   </svg>
 );
 

--- a/ui/src/components/settings/models/vendorGlyph.test.tsx
+++ b/ui/src/components/settings/models/vendorGlyph.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+// A mark is only worth drawing if it tells one vendor from another, so the
+// properties held here are drawn-at-all and drawn-once — asserted over whatever
+// the shipped catalog contains rather than over a list restated in the test,
+// which would keep passing for the twelve rows it knew about.
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { API_KEY_VENDOR_PRESETS, CUSTOM_VENDOR } from './apiKeyVendors';
+import { VendorGlyph } from './vendorGlyph';
+
+afterEach(cleanup);
+
+/** Every choice the 服务商 field offers, including the one that is not a vendor. */
+const CHOICES = [CUSTOM_VENDOR, ...API_KEY_VENDOR_PRESETS.map((preset) => preset.id)];
+
+const glyphOf = (vendor: string) => {
+  const { container, unmount } = render(<VendorGlyph vendor={vendor} />);
+  const svg = container.querySelector('svg');
+  const drawn = { className: svg?.getAttribute('class') ?? '', hidden: svg?.getAttribute('aria-hidden'), art: svg?.innerHTML ?? '', markup: svg?.outerHTML ?? '' };
+  unmount();
+  return drawn;
+};
+
+describe('VendorGlyph', () => {
+  it('draws every choice as one theme-following mark of the shared size', () => {
+    expect(CHOICES.length).toBeGreaterThan(1);
+    for (const vendor of CHOICES) {
+      const glyph = glyphOf(vendor);
+      expect(glyph.art, `${vendor} draws nothing`).not.toBe('');
+      expect(glyph.className, `${vendor} is not sized with the others`)
+        .toContain('model-hub-add-key-vendor-glyph');
+      // A mark names the row next to it; it is not a second thing to read.
+      expect(glyph.hidden, `${vendor} is exposed to a screen reader`).toBe('true');
+      // Theme-following means the ink comes from the text around it. A baked
+      // channel would be a light-theme defect nobody sees while developing dark.
+      expect(glyph.markup, `${vendor} bakes its own color`).not.toMatch(/#[\da-f]{3,8}\b|\b(?:rgba?|hsla?|oklch)\(/i);
+    }
+  });
+
+  it('never draws one mark for two choices', () => {
+    const owner = new Map<string, string>();
+    for (const vendor of CHOICES) {
+      const { art } = glyphOf(vendor);
+      expect(owner.get(art), `${vendor} draws the same mark as ${owner.get(art)}`).toBeUndefined();
+      owner.set(art, vendor);
+    }
+  });
+});

--- a/ui/src/components/settings/models/vendorGlyph.tsx
+++ b/ui/src/components/settings/models/vendorGlyph.tsx
@@ -1,0 +1,83 @@
+// Vendor marks for the API-key 服务商 picker.
+//
+// One mark per catalog id, never one per protocol: DeepSeek and OpenAI sit in
+// the same list, so drawing the OpenAI flower for both would remove the only
+// thing a mark is there for. Each is the vendor's own single-path Simple Icons
+// artwork, inlined as `currentColor` geometry in the same 24-unit box as
+// `protocolGlyph.tsx` — nothing to load, no brand fill, and Light/Dark follow
+// the surrounding text.
+//
+// Anthropic and OpenAI are defined here because a protocol family is named
+// after the vendor that published it: `protocolGlyph.tsx` reads these two
+// rather than keeping a second copy of the same artwork.
+//
+// Five shipped vendors publish no single-color mark Simple Icons carries. They
+// draw their initial in the same box instead: a letter is honest about standing
+// in for artwork, where a neighbour's logo would be a lie and an invented one
+// worse. That fallback follows the label rather than a list, so a vendor added
+// to the catalog is distinguishable before anyone draws it. The one thing the
+// picker cannot survive is two rows drawing the same glyph, which is the
+// property `vendorGlyph.test.tsx` holds.
+import * as React from 'react';
+import { Globe } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { apiKeyVendorPreset, CUSTOM_VENDOR } from './apiKeyVendors';
+
+/** The two marks `protocolGlyph.tsx` also draws: a protocol family is named
+ *  after the vendor that published it, so the artwork is shared, not copied. */
+export const ANTHROPIC_MARK = 'M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z';
+
+export const OPENAI_MARK = 'M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z';
+
+const MARKS: Record<string, string | undefined> = {
+  deepseek: 'M23.748 4.651c-.254-.124-.364.113-.512.233-.051.04-.094.09-.137.137-.372.397-.806.657-1.373.626-.829-.046-1.537.214-2.163.848-.133-.782-.575-1.248-1.247-1.548-.352-.155-.708-.311-.955-.65-.172-.24-.219-.509-.305-.774-.055-.16-.11-.323-.293-.35-.2-.031-.278.136-.356.276-.313.572-.434 1.202-.422 1.84.027 1.436.633 2.58 1.838 3.393.137.094.172.187.129.323-.082.28-.18.553-.266.833-.055.179-.137.218-.328.14a5.5 5.5 0 0 1-1.737-1.179c-.857-.828-1.631-1.743-2.597-2.46a12 12 0 0 0-.689-.47c-.985-.957.13-1.743.387-1.836.27-.098.094-.433-.778-.428-.872.003-1.67.295-2.687.685a3 3 0 0 1-.465.136 9.6 9.6 0 0 0-2.883-.101c-1.885.21-3.39 1.1-4.497 2.622C.082 8.776-.231 10.854.152 13.02c.403 2.284 1.568 4.175 3.36 5.653 1.857 1.533 3.997 2.284 6.438 2.14 1.482-.085 3.132-.284 4.994-1.86.47.234.962.328 1.78.398.629.058 1.235-.031 1.705-.129.735-.155.684-.836.418-.961-2.155-1.004-1.682-.595-2.112-.926 1.095-1.295 2.768-3.598 3.284-6.733.05-.346.115-.834.108-1.114-.004-.171.035-.238.23-.257a4.2 4.2 0 0 0 1.545-.475c1.397-.763 1.96-2.016 2.093-3.517.02-.23-.004-.467-.247-.588M11.58 18.168c-2.088-1.642-3.101-2.183-3.52-2.16-.39.024-.32.472-.234.763.09.288.207.487.371.74.114.167.192.416-.113.603-.673.416-1.842-.14-1.897-.168-1.361-.801-2.5-1.86-3.301-3.306-.775-1.393-1.225-2.888-1.299-4.482-.02-.385.094-.522.477-.592a4.7 4.7 0 0 1 1.53-.038c2.131.311 3.946 1.264 5.467 2.774.868.86 1.525 1.887 2.202 2.89.72 1.066 1.494 2.082 2.48 2.915.348.291.626.513.892.677-.802.09-2.14.109-3.055-.615zm1.001-6.44a.306.306 0 0 1 .415-.287.3.3 0 0 1 .113.074.3.3 0 0 1 .086.214c0 .17-.136.307-.308.307a.303.303 0 0 1-.306-.307m3.11 1.596c-.2.081-.4.151-.591.16a1.25 1.25 0 0 1-.798-.254c-.274-.23-.47-.358-.551-.758a1.7 1.7 0 0 1 .015-.588c.07-.327-.007-.537-.238-.727-.188-.156-.426-.199-.689-.199a.6.6 0 0 1-.254-.078.253.253 0 0 1-.114-.358 1 1 0 0 1 .192-.21c.356-.202.767-.136 1.146.016.352.144.618.408 1.001.782.392.451.462.576.685.915.176.264.336.536.446.848.066.194-.02.353-.25.45',
+  qwen: 'M23.919 14.545 20.817 9.17l1.47-2.544a.56.56 0 0 0 0-.566l-1.633-2.83a.57.57 0 0 0-.49-.283h-6.207L12.487.402a.57.57 0 0 0-.49-.284H8.732a.56.56 0 0 0-.49.284L5.139 5.775h-2.94a.56.56 0 0 0-.49.284L.077 8.887a.56.56 0 0 0 0 .567L3.18 14.83l-1.47 2.545a.56.56 0 0 0 0 .566l1.634 2.83a.57.57 0 0 0 .49.283h6.205l1.47 2.545a.57.57 0 0 0 .49.284h3.266a.57.57 0 0 0 .49-.284l3.104-5.375h2.94a.57.57 0 0 0 .49-.283l1.634-2.828a.55.55 0 0 0-.004-.568M8.733.686l1.634 2.828-1.634 2.828H21.8L20.164 9.17H7.425L5.63 6.06Zm1.306 19.801-6.205-.002 1.634-2.83h3.265L2.201 6.344h3.267q3.182 5.517 6.367 11.032zm10.124-5.66L18.53 12l-6.532 11.315-1.634-2.83c2.129-3.673 4.25-7.351 6.373-11.028h3.592l3.102 5.374z',
+  kimi: 'M21.765.351C22.998.351 24 1.353 24 2.586S22.998 4.82 21.765 4.82h-1.974c-.15 0-.26-.12-.26-.26V2.586A2.237 2.237 0 0 1 21.765.35M9.41 13.388l8.447-8.377c.16-.16.07-.471-.14-.471h-4.55s-.1.02-.14.06l-9.099 9.029c-.14.14-.35.02-.35-.21V4.81c0-.15-.1-.27-.221-.27H.22c-.12 0-.22.12-.22.27v18.57c0 .15.1.27.22.27h3.137c.12 0 .22-.12.22-.27v-3.79c0-.08.03-.16.08-.21l2.826-2.796c.07-.07.16-.08.241-.03l7.546 5.551a8.9 8.9 0 0 0 4.018 1.493c.12.01.23-.11.23-.27V19.76c0-.14-.08-.25-.19-.26a5.8 5.8 0 0 1-2.355-.942l-6.533-4.73c-.14-.09-.15-.32-.03-.441',
+  openrouter: 'M16.778 1.844v1.919q-.569-.026-1.138-.032-.708-.008-1.415.037c-1.93.126-4.023.728-6.149 2.237-2.911 2.066-2.731 1.95-4.14 2.75-.396.223-1.342.574-2.185.798-.841.225-1.753.333-1.751.333v4.229s.768.108 1.61.333c.842.224 1.789.575 2.185.799 1.41.798 1.228.683 4.14 2.75 2.126 1.509 4.22 2.11 6.148 2.236.88.058 1.716.041 2.555.005v1.918l7.222-4.168-7.222-4.17v2.176c-.86.038-1.611.065-2.278.021-1.364-.09-2.417-.357-3.979-1.465-2.244-1.593-2.866-2.027-3.68-2.508.889-.518 1.449-.906 3.822-2.59 1.56-1.109 2.614-1.377 3.978-1.466.667-.044 1.418-.017 2.278.02v2.176L24 6.014Z',
+  mistral: 'M17.143 3.429v3.428h-3.429v3.429h-3.428V6.857H6.857V3.43H3.43v13.714H0v3.428h10.286v-3.428H6.857v-3.429h3.429v3.429h3.429v-3.429h3.428v3.429h-3.428v3.428H24v-3.428h-3.43V3.429z',
+  openai: OPENAI_MARK,
+  anthropic: ANTHROPIC_MARK,
+};
+
+const glyphClassName = (className?: string) => cn('model-hub-add-key-vendor-glyph', className);
+
+const Mark: React.FC<{ path: string; className?: string }> = ({ path, className }) => (
+  <svg
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    focusable="false"
+    fill="currentColor"
+    className={glyphClassName(className)}
+  >
+    <path d={path} />
+  </svg>
+);
+
+const Monogram: React.FC<{ letter: string; className?: string }> = ({ letter, className }) => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" className={glyphClassName(className)}>
+    <text
+      x="12"
+      y="12"
+      textAnchor="middle"
+      dominantBaseline="central"
+      fontSize="19"
+      fontWeight="700"
+      fill="currentColor"
+    >
+      {letter}
+    </text>
+  </svg>
+);
+
+/**
+ * The mark for one vendor id. 自定义 is not a vendor and gets no logo: it takes
+ * the field's own subject, an address you supply.
+ */
+export const VendorGlyph: React.FC<{ vendor: string; className?: string }> = ({ vendor, className }) => {
+  if (vendor === CUSTOM_VENDOR) return <Globe aria-hidden="true" focusable="false" className={glyphClassName(className)} />;
+  const mark = MARKS[vendor];
+  if (mark) return <Mark path={mark} className={className} />;
+  const label = apiKeyVendorPreset(vendor)?.label ?? vendor;
+  return <Monogram letter={Array.from(label.trim())[0].toUpperCase()} className={className} />;
+};

--- a/ui/src/components/ui/combobox.test.tsx
+++ b/ui/src/components/ui/combobox.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+//
+// The picker every field in this app selects with. What is asserted here is what
+// a call site is allowed to rely on: a row may carry a mark, the trigger shows
+// the chosen row's mark as well as its label, a row that carries none is
+// rendered exactly as it always was, and a disabled field does not open.
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Combobox, type ComboboxOption } from './combobox';
+
+beforeEach(() => {
+  // Radix measures the trigger to size the panel and cmdk scrolls the highlighted
+  // row into view; jsdom implements neither.
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+const MARK = <svg data-testid="mark" aria-hidden="true" viewBox="0 0 24 24" />;
+
+const marked: ComboboxOption[] = [
+  { value: 'a', label: 'Alpha', icon: MARK },
+  { value: 'b', label: 'Beta', icon: MARK },
+];
+
+const plain: ComboboxOption[] = [
+  { value: 'a', label: 'Alpha' },
+  { value: 'b', label: 'Beta' },
+];
+
+const trigger = () => screen.getByRole('combobox', { name: 'Vendor' });
+
+/** The open panel is modal, so it hides the rest of the document from the
+ *  accessibility tree — including the trigger. It is taken by hand first, which
+ *  is also the only way to compare the field before and after a choice. */
+const open = async (options: ComboboxOption[], props: Record<string, unknown> = {}) => {
+  const user = userEvent.setup();
+  render(<Combobox options={options} value="a" onValueChange={vi.fn()} ariaLabel="Vendor" {...props} />);
+  const field = trigger();
+  await user.click(field);
+  return { user, field };
+};
+
+describe('Combobox', () => {
+  it('marks each row and keeps the chosen row’s mark on the closed field', async () => {
+    // The second half is the reason the mark is a property of the option rather
+    // than of the list: a picker whose closed state drops it shows less than the
+    // choice already contains, which is what a `<select>` is stuck with.
+    const { field } = await open(marked);
+
+    for (const row of screen.getAllByRole('option')) {
+      expect(row.querySelector('[data-testid="mark"]'), row.textContent ?? '').toBeTruthy();
+    }
+    expect(field.querySelector('[data-testid="mark"]')).toBeTruthy();
+    expect(field.textContent).toContain('Alpha');
+  });
+
+  it('renders a row that carries no mark with nothing added to it', async () => {
+    // The model pickers pass `{value, label}` and must be untouched by the mark
+    // arriving: the selected row is its check plus its text, and no wrapper.
+    const { field } = await open(plain);
+
+    const [selected] = screen.getAllByRole('option');
+    expect(selected.textContent).toBe('Alpha');
+    expect(selected.querySelectorAll('span')).toHaveLength(0);
+    expect(selected.querySelectorAll('svg')).toHaveLength(1);
+    // The trigger keeps only its chevron.
+    expect(field.querySelectorAll('svg')).toHaveLength(1);
+  });
+
+  it('names the trigger for a field label that cannot reach it', async () => {
+    // A `<label for>` does not name a button, so a labelled field passes both the
+    // id it minted and the label text; the value stays the trigger's contents.
+    render(
+      <Combobox options={marked} value="b" onValueChange={vi.fn()} id="vendor-field" ariaLabel="Vendor" />,
+    );
+    expect(trigger().id).toBe('vendor-field');
+    expect(trigger().textContent).toContain('Beta');
+  });
+
+  it('does not open while the field is disabled', async () => {
+    await open(marked, { disabled: true });
+    expect(screen.queryAllByRole('option')).toEqual([]);
+  });
+});

--- a/ui/src/components/ui/combobox.test.tsx
+++ b/ui/src/components/ui/combobox.test.tsx
@@ -42,14 +42,32 @@ const plain: ComboboxOption[] = [
   { value: 'b', label: 'Beta' },
 ];
 
-const trigger = () => screen.getByRole('combobox', { name: 'Vendor' });
+/** Named by its label AND by whatever it currently holds, in that order. */
+const trigger = () => screen.getByRole('combobox', { name: /^Vendor(\s|$)/ });
+
+/** A labelled field, wired the way a call site has to wire one: a visible
+ *  `<label for>` for the pointer, and the same text handed to the primitive
+ *  because that association does not reach a button. */
+const labelled = (options: ComboboxOption[], props: Record<string, unknown> = {}) => (
+  <>
+    <label htmlFor="vendor-field">Vendor</label>
+    <Combobox
+      options={options}
+      value="a"
+      onValueChange={vi.fn()}
+      id="vendor-field"
+      ariaLabel="Vendor"
+      {...props}
+    />
+  </>
+);
 
 /** The open panel is modal, so it hides the rest of the document from the
  *  accessibility tree — including the trigger. It is taken by hand first, which
  *  is also the only way to compare the field before and after a choice. */
 const open = async (options: ComboboxOption[], props: Record<string, unknown> = {}) => {
   const user = userEvent.setup();
-  render(<Combobox options={options} value="a" onValueChange={vi.fn()} ariaLabel="Vendor" {...props} />);
+  render(labelled(options, props));
   const field = trigger();
   await user.click(field);
   return { user, field };
@@ -82,14 +100,24 @@ describe('Combobox', () => {
     expect(field.querySelectorAll('svg')).toHaveLength(1);
   });
 
-  it('names the trigger for a field label that cannot reach it', async () => {
-    // A `<label for>` does not name a button, so a labelled field passes both the
-    // id it minted and the label text; the value stays the trigger's contents.
-    render(
-      <Combobox options={marked} value="b" onValueChange={vi.fn()} id="vendor-field" ariaLabel="Vendor" />,
-    );
-    expect(trigger().id).toBe('vendor-field');
-    expect(trigger().textContent).toContain('Beta');
+  it('names the trigger with the label it cannot be reached by, and with its value', async () => {
+    // A `<label for>` does not name a button, so the name is written here — and
+    // written as label PLUS selection, because a name is a replacement, not an
+    // addition: the label on its own would announce the field while withholding
+    // the vendor it is holding, which is the half a screen reader most needs.
+    render(labelled(marked, { value: 'b' }));
+
+    const field = screen.getByRole('combobox', { name: 'Vendor Beta' });
+    expect(field.id).toBe('vendor-field');
+  });
+
+  it('names a field given no label with nothing at all', async () => {
+    // Every other call site passes no label, and for those the trigger's own
+    // contents are already the whole name. Composing one anyway would prepend an
+    // empty string, or worse, repeat the value.
+    render(<Combobox options={marked} value="b" onValueChange={vi.fn()} />);
+
+    expect(screen.getByRole('combobox').getAttribute('aria-label')).toBeNull();
   });
 
   it('does not open while the field is disabled', async () => {

--- a/ui/src/components/ui/combobox.tsx
+++ b/ui/src/components/ui/combobox.tsx
@@ -21,6 +21,11 @@ import {
 export interface ComboboxOption {
   value: string
   label: string
+  /** A mark for this option, shown on its row AND on the trigger once it is the
+   *  selection — a picker whose closed state drops the mark is showing less than
+   *  the choice already contains. Expected to be a small inline glyph that
+   *  inherits `currentColor`, so it follows the theme like the label beside it. */
+  icon?: React.ReactNode
 }
 
 interface ComboboxProps {
@@ -32,10 +37,17 @@ interface ComboboxProps {
   emptyText?: string
   allowCustomValue?: boolean
   className?: string
+  /** For a labelled field: the `<label for>` target. A `for` association does not
+   *  name a button, so `ariaLabel` carries the same text — pass both. */
+  id?: string
+  ariaLabel?: string
+  disabled?: boolean
   commitOnClose?: boolean
   createLabel?: (value: string) => string
   createHeading?: string
-  /** Show a folder icon before each option + the create row (design.pen group picker). */
+  /** The design.pen group-picker skin: one folder mark for every row plus its own
+   *  active fill and trailing check. A row layout, not the per-option `icon`
+   *  above — that one says which mark a row carries, this one which list it is. */
   withFolderIcon?: boolean
   /** When set, the create affordance renders as a bordered input + this-labelled button
    *  (design.pen `e3rPI`) instead of an inline command item. */
@@ -51,6 +63,9 @@ export function Combobox({
   emptyText = "No results found.",
   allowCustomValue = true,
   className,
+  id,
+  ariaLabel,
+  disabled = false,
   commitOnClose = false,
   createLabel,
   createHeading,
@@ -124,9 +139,12 @@ export function Combobox({
     >
       <PopoverTrigger asChild>
         <button
+          id={id}
           type="button"
           role="combobox"
           aria-expanded={open}
+          aria-label={ariaLabel}
+          disabled={disabled}
           className={cn(
             fieldBaseClass,
             "flex h-9 items-center justify-between px-3",
@@ -135,6 +153,7 @@ export function Combobox({
         >
           <span className={cn("flex items-center gap-2 truncate", !displayValue && "text-muted")}>
             {withFolderIcon && displayValue && <Folder className="size-4 shrink-0 text-muted" />}
+            {selectedOption?.icon}
             {displayValue || placeholder}
           </span>
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
@@ -195,6 +214,9 @@ export function Combobox({
                           <Check
                             className={cn("mr-2 h-4 w-4", active ? "opacity-100" : "opacity-0")}
                           />
+                          {option.icon && (
+                            <span className="mr-2 flex shrink-0 items-center">{option.icon}</span>
+                          )}
                           {option.label}
                         </>
                       )}

--- a/ui/src/components/ui/combobox.tsx
+++ b/ui/src/components/ui/combobox.tsx
@@ -37,9 +37,14 @@ interface ComboboxProps {
   emptyText?: string
   allowCustomValue?: boolean
   className?: string
-  /** For a labelled field: the `<label for>` target. A `for` association does not
-   *  name a button, so `ariaLabel` carries the same text — pass both. */
+  /** For a labelled field: the `<label for>` target. */
   id?: string
+  /** The field's label, for a control a `for` association cannot name — a
+   *  `<button>` is not a labelable element. The selection is appended to it: a
+   *  label alone would REPLACE the trigger's contents in the accessible name,
+   *  and those contents are the chosen option, which is the half of a picker a
+   *  screen reader most needs. Composed here rather than left to an
+   *  `aria-labelledby` self-reference, whose support is uneven. */
   ariaLabel?: string
   disabled?: boolean
   commitOnClose?: boolean
@@ -143,7 +148,7 @@ export function Combobox({
           type="button"
           role="combobox"
           aria-expanded={open}
-          aria-label={ariaLabel}
+          aria-label={ariaLabel && [ariaLabel, displayValue].filter(Boolean).join(" ")}
           disabled={disabled}
           className={cn(
             fieldBaseClass,

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1371,6 +1371,8 @@
           "vendor": "Vendor",
           "vendor.custom": "Custom · compatible endpoint",
           "vendor.hint": "Pick DeepSeek, Qwen, Kimi and the like to prefill the official address and pin the interface",
+          "vendor.search": "Search vendors",
+          "vendor.empty": "No vendor by that name",
           "name": "Name (optional)",
           "protocol": "Interface type",
           "protocol.hint": "Use Auto detect when unsure; choose a type to declare that interface. If authentication succeeds it can be added, a wrong choice can fail at runtime, and the saved type cannot be changed",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1371,6 +1371,8 @@
           "vendor": "服务商",
           "vendor.custom": "自定义 · 兼容端点",
           "vendor.hint": "选 DeepSeek / Qwen / Kimi 等时，预填官方地址并钉死接口",
+          "vendor.search": "搜索服务商",
+          "vendor.empty": "没有同名的服务商",
           "name": "名称(可选)",
           "protocol": "接口类型",
           "protocol.hint": "不确定时用自动探测；已知类型时可直接声明所选接口。该路径鉴权成功即可添加；选错了运行时可能失败，而且保存后不可更改",


### PR DESCRIPTION
# Vendor marks in the add-key vendor picker

The 服务商 field added in #1851 lists twelve vendors as text. A vendor is
recognised by its mark long before its name is read, so this puts each one's
logo on its row **and** on the field once it is chosen.

## What changed

- **The field is no longer a `<select>`; it is a consumer of the shared
  `Combobox`.** An `<option>` holds text only, so the closed control could only
  ever show what an option could hold — the mark would be missing exactly where
  the choice has already been made. `ui/src/components/ui/combobox.tsx` owns this
  app's one trigger + popover + `Command` picker, so it was extended rather than
  copied: `ComboboxOption.icon` renders on the row **and** on the closed trigger,
  and `id` / `ariaLabel` / `disabled` make it usable as a labelled field in a
  lockable form. Its always-present `CommandInput` is the semantic
  `role="combobox"` that owns the `role="listbox"` and the active option, so the
  keyboard and screen-reader path is the same one every other picker here has.
- **Rows read A–Z by label, with 自定义 last.** The catalog file's order is the
  backend's business; on screen it reads as arbitrary, and a name is what a user
  scans for. Sorted with `localeCompare('en', { sensitivity: 'base' })` at
  render, so `api_key_vendors.json` is untouched. 自定义 sorts nowhere — it is the
  absence of a vendor, so it sits after them rather than among them. The default
  **value** is unchanged: an empty form still opens on 自定义.
- **Re-picking the vendor already picked is a no-op.** `editVendor` resets the
  address, drops the declared interface and retires the observation, so it now
  returns early on an unchanged value. Reopening the menu to confirm what you
  chose can no longer erase a hand-edited Base URL.
- **One mark per catalog id, never one per protocol.** DeepSeek and OpenAI sit in
  the same list; drawing the OpenAI flower for both would remove the only thing a
  mark is there for. New `vendorGlyph.tsx` holds the artwork — single-path
  `currentColor` geometry in the same 24-unit box as the interface glyphs, sharing
  their 14px CSS rule, so Light/Dark follow the surrounding text. No raster, no
  brand fill, no new dependency, nothing to load.
- **`protocolGlyph.tsx` now reads the two marks it shares** (Anthropic, OpenAI)
  instead of keeping a second copy. A protocol family is named after the vendor
  that published it, so that file keeps only the interface → mark mapping, and
  stays protocol-family only. A vendor row never carries the protocol class.
- **自定义 is not a vendor and gets no logo.** It takes the field's own subject, a
  `globe`, from the lucide set the dialog already uses.
- **The field announces the vendor it holds, not just its name.** An accessible
  name *replaces* the trigger's contents, and those contents are the chosen
  vendor, so the label alone said 「服务商」 and withheld the answer. The primitive
  now composes `<label> <selection>`. The obvious alternative —
  `aria-labelledby="<label-id> <trigger-id>"`, letting the self-reference pull
  the contents back in — was measured and does not work: `dom-accessibility-api`
  ignores the self IDREF and the computed name stayed `服务商`. Composing the
  string needs no label-id plumbing, so `dialogFields.tsx` is untouched.
- **The pinned row's explanation moved to its own line.** It sat beside the mark
  and the interface name, where it was the longer of the two texts and wrapped
  around the name it is about. The row is a column now: interface + 内置目录
  badge, then the sentence, at its own smaller scale, starting under the name.
  Same hint, same glyph size.

Not changed: the observe/create payload (a catalog id is still what the click
sends), the pin / declaration / detect-then-confirm behavior, replace-key mode,
the protocol-row glyphs, and the shipped catalog file.

## Evidence

- **Unit** — `vendorGlyph.test.tsx` (new) holds the two properties a mark exists
  for, over whatever the shipped catalog contains rather than over a list
  restated in the test: every choice draws something, theme-following and
  aria-hidden, and **no two choices draw the same art**. That is the stronger
  form of "every id has a glyph", which is total by construction here and so
  could only ever pass.
- **Unit** — `combobox.test.tsx` (new) pins what a call site may rely on now that
  the primitive is shared: a mark on every row and the chosen mark on the closed
  field; an option carrying **no** mark rendered with nothing added to it (its
  check plus its text, zero wrapper `<span>`s, one `<svg>`) so the two existing
  call sites are provably unaffected; `ariaLabel` naming a trigger a
  `<label for>` cannot reach, *with* its value appended, and a field given no
  label left with no `aria-label` at all; and a disabled field that does not
  open.
- **Unit** — `AddApiKeyDialog.test.tsx`: a mark on every row and on the field
  after a choice; the menu offered A–Z with 自定义 last, derived from the catalog
  rather than listed, so a vendor added later is expected in its alphabetical
  place; the focused element after opening is a `role="combobox"` whose
  `aria-controls` names the `listbox` and whose `aria-activedescendant` names the
  `option` that ArrowDown highlights and Enter commits; search narrows to one row
  by name and offers nothing for a non-vendor; and re-picking the current vendor
  preserves a hand-edited address. Plus the accessible name carrying label and
  selection through a vendor switch, and the pinned row's hint asserted as a
  sibling of the statement line rather than inside it. The existing vendor cases
  now drive the picker and are otherwise unchanged.
- **Scenario** — B1 (`ui/e2e/b-add-api-key.spec.ts`). Intent unchanged;
  `fillApiKeyForm` picks by the visible name instead of a `selectOption` value,
  and B1 still asserts the created source carries the catalog **id**. Both are
  order-agnostic, so the A–Z ruling needed no e2e change. The vendor locator
  moved from `getByLabel(..., { exact: true })` to a non-exact
  `getByRole('combobox', { name: <label> })`, because the label is now the prefix
  of that name rather than the whole of it. Playwright is not installed in this
  environment, so B1 was not run locally.
- Full `ui/` vitest suite: 283 files / 3709 tests green. `npm run lint`
  (baseline) clean, `tsc -b` and `npm run build` clean.
- The reselect guard was verified to bite by removing it: the new case fails with
  `expected 'https://api.deepseek.com' to be 'https://api.deepseek.com/edge'`.

## Known by design

- **Five shipped vendors publish no single-color mark Simple Icons carries**
  (Zhipu AI, Groq, xAI, Together, Fireworks — every plausible slug was probed).
  They draw their initial in the same box, at the same size, in the same ink. A
  letter is honest about standing in for artwork; a neighbour's logo would be a
  lie and an invented one worse. In particular the `x` mark was **rejected**: it
  is X/Twitter, a different company from xAI, and a wrong logo is the exact
  collision this change exists to remove. The fallback follows the label rather
  than a list, so a vendor added to the catalog is distinguishable before anyone
  draws it.
- **The primitive gained an option `icon`, not a `renderOption`.** Handing row
  layout back to each call site is what lets two pickers diverge; a mark per
  option is the whole of what this field needed. There is likewise no non-search
  mode: the search input is what replaces the earlier fork's "reopen on the row
  you last chose" for a twelve-row catalog, and it is the element that carries
  the combobox semantics. Two i18n keys carry its copy (`vendor.search`,
  `vendor.empty`), which the folder's source-grep policy test requires anyway.
- **The picker no longer opens with the current selection highlighted.** cmdk
  highlights the first row, as it does at every other `Combobox` call site. This
  field behaving differently from the rest of the app is the divergence the P1
  was about, and typing two letters beats twelve arrow presses.
- **`withFolderIcon`, `createButtonLabel` and `commitOnClose` have no call
  sites.** Found while extending the primitive; left in place, since deleting
  them is unrelated cleanup and would be unreviewed scope here. `withFolderIcon`
  is now documented as a row *skin* (a folder on every row) as distinct from the
  per-option mark, so the two are not confused later.
- **The `.model-hub-add-key-input:is(select)` rule from #1851 was deleted.** It
  existed to leave room for the native select's overlaid chevron; the shared
  trigger's chevron is a flex child, and no other control in the folder carries
  that class.
- **The composed name lives in the primitive, and reaches one field.** The
  vendor picker is the only `Combobox` in the app that passes `ariaLabel`; every
  other call site passes none and keeps `aria-label` absent, which the new test
  asserts. Fixing it at the primitive rather than at this call site means a
  future labelled picker inherits the correct name instead of re-deriving it.
- Two comments were reworded (`dialogFields.tsx`, `dialogFields.test.tsx`)
  because they named the vendor `<select>` that no longer exists — the second one
  also trips the folder's own hand-rolled-label tripwire on the literal text.
- `lint` / `unit-tests` is flaky on master at the base commit
  (`tests/test_ui_show_pages.py::test_show_runtime_prepare_and_request_share_one_install_admission`
  failed on 7bbdfd4a's push run, passed on #1851's PR run). Unrelated to this
  UI-only change.

Branched from `origin/master` at 7bbdfd4a (includes #1851). No dependencies.
