### PR TITLE
feat(memory): consume managed rerank through typed MAK

### DIFF
--- a/avibe_memory/everos.py
+++ b/avibe_memory/everos.py
@@ -670,7 +670,7 @@ class EverOSPort:
             return all(result is True for result in results)
 
     async def preflight(self) -> MemoryPreflightResult:
-        """Run bounded requests for startup-critical processing endpoints."""
+        """Run one bounded request for each configured processing endpoint."""
         checks = [
             (
                 "llm",
@@ -689,6 +689,18 @@ class EverOSPort:
                 "model": self._embedding_model, "input": "OK",
             }, _valid_embedding_probe_response),
         ]
+        if self._rerank_configured():
+            probe = self._rerank_probe_spec()
+            checks.append(
+                (
+                    "rerank",
+                    probe.base_url,
+                    probe.api_key,
+                    probe.path,
+                    probe.payload,
+                    probe.validator,
+                )
+            )
         if self._multimodal_configured():
             checks.append(
                 (

--- a/avibe_memory/everos.py
+++ b/avibe_memory/everos.py
@@ -609,11 +609,13 @@ class EverOSPort:
         return snapshot
 
     async def processing_healthy(self) -> bool:
-        """Probe configured model endpoints with fixed synthetic requests.
+        """Probe the mandatory LLM and embedding endpoints.
 
         The worker may call this after ambiguous provider errors.  The lock keeps
         several queued rows from multiplying credential probes during an outage.
         Matching provider credentials are serialized; independent groups overlap.
+        Optional rerank availability is reported by sidecar health and gates only
+        agentic recall, so it is deliberately excluded from this aggregate.
         """
 
         async with self._processing_lock:
@@ -645,8 +647,6 @@ class EverOSPort:
                     validator=_valid_embedding_probe_response,
                 ),
             ]
-            if self._rerank_configured():
-                probes.append(self._rerank_probe_spec())
             if self._multimodal_configured():
                 probes.append(
                     _ProcessingProbeSpec(
@@ -670,7 +670,7 @@ class EverOSPort:
             return all(result is True for result in results)
 
     async def preflight(self) -> MemoryPreflightResult:
-        """Run one bounded request for each configured processing endpoint."""
+        """Run bounded requests for startup-critical processing endpoints."""
         checks = [
             (
                 "llm",
@@ -689,18 +689,6 @@ class EverOSPort:
                 "model": self._embedding_model, "input": "OK",
             }, _valid_embedding_probe_response),
         ]
-        if self._rerank_configured():
-            probe = self._rerank_probe_spec()
-            checks.append(
-                (
-                    "rerank",
-                    probe.base_url,
-                    probe.api_key,
-                    probe.path,
-                    probe.payload,
-                    probe.validator,
-                )
-            )
         if self._multimodal_configured():
             checks.append(
                 (

--- a/avibe_memory/runtime.py
+++ b/avibe_memory/runtime.py
@@ -2364,6 +2364,9 @@ class MemoryRuntime:
         self._require_lifecycle_work()
         candidate = deepcopy(config or self._config)
         processing = candidate.runtime_processing()
+        preflight_rerank = (
+            processing.rerank if candidate.runtime_source() == "custom" else None
+        )
         provider = EverOSPort(
             self._socket_path,
             llm_base_url=processing.llm.base_url,
@@ -2372,11 +2375,11 @@ class MemoryRuntime:
             embedding_base_url=processing.embedding.base_url,
             embedding_model=processing.embedding.model,
             embedding_api_key=processing.embedding.api_key,
-            rerank_base_url=(processing.rerank.base_url if processing.rerank else None),
-            rerank_model=(processing.rerank.model if processing.rerank else None),
-            rerank_api_key=(processing.rerank.api_key if processing.rerank else None),
+            rerank_base_url=(preflight_rerank.base_url if preflight_rerank else None),
+            rerank_model=(preflight_rerank.model if preflight_rerank else None),
+            rerank_api_key=(preflight_rerank.api_key if preflight_rerank else None),
             rerank_provider=(
-                processing.rerank.rerank_provider() if processing.rerank else None
+                preflight_rerank.rerank_provider() if preflight_rerank else None
             ),
             multimodal_base_url=(
                 processing.multimodal.base_url

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -2246,10 +2246,15 @@ class MemoryConfig:
             or self.cloud.embedding_identity
         )
         rerank = None
-        rerank_projection = managed_rerank_projection(
-            key,
-            self.cloud.rerank_access_key,
-        )
+        rerank_projection = None
+        if (
+            self.cloud.access_key_revision is not None
+            and self.cloud.access_key_revision == self.cloud.revision
+        ):
+            rerank_projection = managed_rerank_projection(
+                key,
+                self.cloud.rerank_access_key,
+            )
         if rerank_projection is not None:
             rerank_provider, rerank_path, rerank_model = rerank_projection
             rerank = MemoryEndpointConfig(

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -1284,6 +1284,8 @@ def _recover_memory_cloud_section(payload: dict, field_name: Optional[str]) -> b
         cloud["capabilities"] = {}
         cloud["embedding_identity"] = None
         cloud["model_access_key"] = None
+        cloud["rerank_access_key"] = None
+        cloud["access_key_revision"] = None
         cloud["proxy_base_url"] = None
 
     if managed_fence and field_name in {
@@ -1871,6 +1873,7 @@ _MEMORY_MAX_URL_BYTES = 2048
 _MEMORY_MAX_MODEL_BYTES = 512
 _MEMORY_MAX_API_KEY_BYTES = 16 * 1024
 _MEMORY_CLOUD_MODEL_ALIAS = "avibe-cloud-chat"
+_MEMORY_CLOUD_RERANK_ALIAS = "avibe-cloud-rerank"
 _MEMORY_CLOUD_MULTIMODAL_ALIAS = "avibe-cloud-multimodal"
 
 MemoryMode = Literal["platform", "custom"]
@@ -1880,6 +1883,44 @@ MemoryRerankProvider = Literal["deepinfra", "vllm", "dashscope"]
 MEMORY_RERANK_PROVIDERS = frozenset(get_args(MemoryRerankProvider))
 DEFAULT_MEMORY_RERANK_PROVIDER: MemoryRerankProvider = "deepinfra"
 DASHSCOPE_RERANK_MODEL = "gte-rerank-v2"
+
+_MEMORY_CLOUD_RERANK_PROJECTIONS: tuple[
+    tuple[str, MemoryRerankProvider, str, str], ...
+] = (
+    (
+        "mak_rr_deepinfra_",
+        "deepinfra",
+        "rerank/deepinfra",
+        _MEMORY_CLOUD_RERANK_ALIAS,
+    ),
+    (
+        "mak_rr_dashscope_",
+        "dashscope",
+        "rerank/dashscope",
+        DASHSCOPE_RERANK_MODEL,
+    ),
+)
+
+
+def managed_rerank_projection(
+    base_access_key: object,
+    rerank_access_key: object,
+) -> tuple[MemoryRerankProvider, str, str] | None:
+    """Resolve one typed MAK through Avibe's closed managed-rerank table."""
+
+    if (
+        not isinstance(base_access_key, str)
+        or not base_access_key.startswith("mak_")
+        or not isinstance(rerank_access_key, str)
+    ):
+        return None
+    opaque = base_access_key.removeprefix("mak_")
+    if not opaque:
+        return None
+    for prefix, provider, path, model in _MEMORY_CLOUD_RERANK_PROJECTIONS:
+        if rerank_access_key == f"{prefix}{opaque}":
+            return provider, path, model
+    return None
 
 
 @dataclass
@@ -2017,6 +2058,8 @@ class MemoryCloudConfig:
     revision: int | None = None
     quota_enforced: bool = False
     model_access_key: str | None = field(default=None, repr=False)
+    rerank_access_key: str | None = field(default=None, repr=False)
+    access_key_revision: int | None = None
     proxy_base_url: str | None = None
     source_instance_id: str = ""
     organization_attached: bool = False
@@ -2064,6 +2107,14 @@ class MemoryCloudConfig:
             or self.revision < 0
         ):
             raise ValueError("Config 'memory.cloud.revision' must be a non-negative integer or null")
+        if self.access_key_revision is not None and (
+            isinstance(self.access_key_revision, bool)
+            or not isinstance(self.access_key_revision, int)
+            or self.access_key_revision < 0
+        ):
+            raise ValueError(
+                "Config 'memory.cloud.access_key_revision' must be a non-negative integer or null"
+            )
         for name, value in (
             ("quota_enforced", self.quota_enforced),
             ("organization_attached", self.organization_attached),
@@ -2089,6 +2140,19 @@ class MemoryCloudConfig:
             )
             if not self.model_access_key.startswith("mak_"):
                 raise ValueError("Config 'memory.cloud.model_access_key' is invalid")
+        if self.rerank_access_key is not None:
+            self.rerank_access_key = _validate_memory_key(
+                self.rerank_access_key,
+                path="memory.cloud.rerank_access_key",
+            )
+            if (
+                managed_rerank_projection(
+                    self.model_access_key,
+                    self.rerank_access_key,
+                )
+                is None
+            ):
+                raise ValueError("Config 'memory.cloud.rerank_access_key' is invalid")
 
     def memory_capability_available(self) -> bool:
         return bool(
@@ -2181,6 +2245,19 @@ class MemoryConfig:
             self.cloud.applied_embedding_identity
             or self.cloud.embedding_identity
         )
+        rerank = None
+        rerank_projection = managed_rerank_projection(
+            key,
+            self.cloud.rerank_access_key,
+        )
+        if rerank_projection is not None:
+            rerank_provider, rerank_path, rerank_model = rerank_projection
+            rerank = MemoryEndpointConfig(
+                base_url=f"{base_url}/{rerank_path}",
+                model=rerank_model,
+                api_key=self.cloud.rerank_access_key,
+                provider=rerank_provider,
+            )
         multimodal = None
         if self.cloud.capabilities.multimodal:
             multimodal = MemoryEndpointConfig(
@@ -2199,7 +2276,7 @@ class MemoryConfig:
                 model=f"avibe-cloud-embedding-{embedding_identity}",
                 api_key=key,
             ),
-            rerank=None,
+            rerank=rerank,
             multimodal=multimodal,
         )
 
@@ -2350,34 +2427,41 @@ def memory_config_to_payload(
         )
     if memory.processing.multimodal is not None:
         processing["multimodal"] = endpoint_payload(memory.processing.multimodal)
+    cloud_payload = {
+        "scope": memory.cloud.scope,
+        "capabilities": {
+            "asr": memory.cloud.capabilities.asr,
+            "chat": memory.cloud.capabilities.chat,
+            "embedding": memory.cloud.capabilities.embedding,
+            "multimodal": memory.cloud.capabilities.multimodal,
+            "memory_llm": memory.cloud.capabilities.memory_llm,
+        },
+        "memory_llm_source": memory.cloud.memory_llm_source,
+        "embedding_identity": memory.cloud.embedding_identity,
+        "revision": memory.cloud.revision,
+        "quota_enforced": memory.cloud.quota_enforced,
+        "model_access_key": (
+            memory.cloud.model_access_key if include_secrets else None
+        ),
+        "has_model_access_key": bool(memory.cloud.model_access_key),
+        "proxy_base_url": memory.cloud.proxy_base_url,
+        "source_instance_id": memory.cloud.source_instance_id,
+        "organization_attached": memory.cloud.organization_attached,
+        "transition_notice_pending": memory.cloud.transition_notice_pending,
+        "applied_embedding_identity": memory.cloud.applied_embedding_identity,
+        "runtime_apply_pending": memory.cloud.runtime_apply_pending,
+    }
+    if include_secrets:
+        if memory.cloud.rerank_access_key is not None:
+            cloud_payload["rerank_access_key"] = memory.cloud.rerank_access_key
+        if memory.cloud.access_key_revision is not None:
+            cloud_payload["access_key_revision"] = memory.cloud.access_key_revision
+
     payload = {
         "enabled": memory.enabled,
         "mode": memory.mode,
         "processing": processing,
-        "cloud": {
-            "scope": memory.cloud.scope,
-            "capabilities": {
-                "asr": memory.cloud.capabilities.asr,
-                "chat": memory.cloud.capabilities.chat,
-                "embedding": memory.cloud.capabilities.embedding,
-                "multimodal": memory.cloud.capabilities.multimodal,
-                "memory_llm": memory.cloud.capabilities.memory_llm,
-            },
-            "memory_llm_source": memory.cloud.memory_llm_source,
-            "embedding_identity": memory.cloud.embedding_identity,
-            "revision": memory.cloud.revision,
-            "quota_enforced": memory.cloud.quota_enforced,
-            "model_access_key": (
-                memory.cloud.model_access_key if include_secrets else None
-            ),
-            "has_model_access_key": bool(memory.cloud.model_access_key),
-            "proxy_base_url": memory.cloud.proxy_base_url,
-            "source_instance_id": memory.cloud.source_instance_id,
-            "organization_attached": memory.cloud.organization_attached,
-            "transition_notice_pending": memory.cloud.transition_notice_pending,
-            "applied_embedding_identity": memory.cloud.applied_embedding_identity,
-            "runtime_apply_pending": memory.cloud.runtime_apply_pending,
-        },
+        "cloud": cloud_payload,
     }
     if include_internal and memory.legacy_needs_repair:
         payload["repair_required"] = True

--- a/tests/scenarios/memory_search/catalog.yaml
+++ b/tests/scenarios/memory_search/catalog.yaml
@@ -122,3 +122,9 @@ scenarios:
     kind: boundary
     layer: contract
     test: tests/test_memory_module.py::test_capture_and_search_delegate_payload_size_to_everos
+  - id: MEMORY-SEARCH-019
+    name: Basic Memory ignores optional rerank failure while agentic recall fails closed
+    status: covered
+    kind: capability
+    layer: contract
+    test: tests/test_memory_everos.py::test_basic_processing_aggregates_exclude_the_optional_reranker

--- a/tests/scenarios/memory_search/catalog.yaml
+++ b/tests/scenarios/memory_search/catalog.yaml
@@ -127,4 +127,4 @@ scenarios:
     status: covered
     kind: capability
     layer: contract
-    test: tests/test_memory_everos.py::test_basic_processing_aggregates_exclude_the_optional_reranker
+    test: tests/test_memory_everos.py::test_basic_processing_health_excludes_the_optional_reranker

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from config import paths
+from config import v2_config as v2_config_module
 from config.v2_config import (
     MemoryConfig,
     MemoryCloudConfig,
@@ -287,6 +288,227 @@ def test_released_optional_endpoint_shapes_remain_stable(tmp_path: Path) -> None
     stored = json.loads(path.read_text(encoding="utf-8"))["memory"]["processing"]
     assert "rerank" not in stored
     assert "multimodal" not in stored
+
+
+def test_older_cloud_cache_loads_without_typed_key_fields_or_shape_churn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    path = tmp_path / "config.json"
+    path.write_text(
+        json.dumps(
+            _payload(
+                {
+                    "enabled": False,
+                    "mode": "platform",
+                    "cloud": {
+                        "revision": 4,
+                        "model_access_key": "mak_opaque",
+                    },
+                }
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = V2Config.load(path)
+
+    assert loaded.memory.cloud.model_access_key == "mak_opaque"
+    assert loaded.memory.cloud.rerank_access_key is None
+    assert loaded.memory.cloud.access_key_revision is None
+    loaded.save(path)
+    stored_cloud = json.loads(path.read_text(encoding="utf-8"))["memory"]["cloud"]
+    assert "rerank_access_key" not in stored_cloud
+    assert "access_key_revision" not in stored_cloud
+
+
+def test_typed_rerank_persists_one_secret_without_provider_or_status_state(
+    tmp_path: Path,
+) -> None:
+    config = V2Config.from_payload(
+        _payload(
+            {
+                "enabled": False,
+                "mode": "platform",
+                "cloud": {
+                    "revision": 7,
+                    "model_access_key": "mak_opaque",
+                    "rerank_access_key": "mak_rr_deepinfra_opaque",
+                    "access_key_revision": 7,
+                },
+            }
+        )
+    )
+    path = tmp_path / "config.json"
+    config.save(path)
+
+    stored_cloud = json.loads(path.read_text(encoding="utf-8"))["memory"]["cloud"]
+    public_cloud = config_to_payload(config)["memory"]["cloud"]
+    cloud_fields = {field_info.name for field_info in fields(MemoryCloudConfig)}
+
+    assert stored_cloud["model_access_key"] == "mak_opaque"
+    assert stored_cloud["rerank_access_key"] == "mak_rr_deepinfra_opaque"
+    assert stored_cloud["access_key_revision"] == 7
+    assert "rerank_access_key" not in public_cloud
+    assert "access_key_revision" not in public_cloud
+    assert "rerank_provider" not in cloud_fields
+    assert "rerank" not in stored_cloud["capabilities"]
+    assert "mak_opaque" not in repr(config.memory.cloud)
+    assert "mak_rr_deepinfra_opaque" not in repr(config.memory.cloud)
+
+
+@pytest.mark.parametrize(
+    ("typed_prefix", "provider", "path", "model"),
+    [
+        (
+            "mak_rr_deepinfra_",
+            "deepinfra",
+            "rerank/deepinfra",
+            "avibe-cloud-rerank",
+        ),
+        (
+            "mak_rr_dashscope_",
+            "dashscope",
+            "rerank/dashscope",
+            "gte-rerank-v2",
+        ),
+    ],
+)
+def test_managed_rerank_closed_table_projects_exact_everos_endpoint(
+    typed_prefix: str,
+    provider: str,
+    path: str,
+    model: str,
+) -> None:
+    memory = MemoryConfig(
+        enabled=True,
+        mode="platform",
+        cloud=MemoryCloudConfig(
+            scope="platform",
+            capabilities=v2_config_module.MemoryCloudCapabilities(
+                chat=True,
+                embedding=True,
+            ),
+            embedding_identity="emb-v1",
+            applied_embedding_identity="emb-v1",
+            model_access_key="mak_opaque",
+            rerank_access_key=f"{typed_prefix}opaque",
+            proxy_base_url="https://backend.example.test/v1/model",
+        ),
+    )
+    memory.validate()
+
+    rerank = memory.runtime_processing().rerank
+
+    assert rerank == MemoryEndpointConfig(
+        base_url=f"https://backend.example.test/v1/model/{path}",
+        model=model,
+        api_key=f"{typed_prefix}opaque",
+        provider=provider,
+    )
+
+
+def test_managed_rerank_prefix_table_is_closed_and_rejects_all_other_shapes() -> None:
+    projections = v2_config_module._MEMORY_CLOUD_RERANK_PROJECTIONS  # noqa: SLF001
+    assert {prefix for prefix, _provider, _path, _model in projections} == {
+        "mak_rr_deepinfra_",
+        "mak_rr_dashscope_",
+    }
+
+    unusable = {
+        None,
+        "",
+        "mak_rr_future_opaque",
+        "mak_rr_deepinfra_",
+        "mak_rr_deepinfra_different",
+        "mak_rr_dashscope_opaque ",
+    }
+    assert all(
+        v2_config_module.managed_rerank_projection("mak_opaque", value) is None
+        for value in unusable
+    )
+
+
+@pytest.mark.parametrize(
+    "rerank_access_key",
+    [[], "mak_rr_future_opaque", "mak_rr_deepinfra_different"],
+)
+def test_disk_load_recovers_only_an_unusable_typed_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rerank_access_key: object,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "home"))
+    path = tmp_path / "config.json"
+    path.write_text(
+        json.dumps(
+            _payload(
+                {
+                    "enabled": False,
+                    "mode": "platform",
+                    "cloud": {
+                        "revision": 2,
+                        "model_access_key": "mak_opaque",
+                        "rerank_access_key": rerank_access_key,
+                        "access_key_revision": 2,
+                    },
+                }
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    loaded = V2Config.load(path)
+
+    assert loaded.memory.cloud.model_access_key == "mak_opaque"
+    assert loaded.memory.cloud.rerank_access_key is None
+    assert loaded.memory.cloud.access_key_revision == 2
+    assert loaded.recovered_sections == ("memory.cloud.rerank_access_key",)
+
+
+def test_managed_rerank_is_optional_for_basic_memory_and_custom_rerank_is_independent() -> None:
+    managed = MemoryConfig(
+        enabled=True,
+        mode="platform",
+        cloud=MemoryCloudConfig(
+            scope="platform",
+            capabilities=v2_config_module.MemoryCloudCapabilities(
+                chat=True,
+                embedding=True,
+            ),
+            embedding_identity="emb-v1",
+            applied_embedding_identity="emb-v1",
+            model_access_key="mak_opaque",
+            proxy_base_url="https://backend.example.test/v1/model",
+        ),
+    )
+    managed.validate()
+    assert managed.runtime_source() == "cloud"
+    assert managed.runtime_processing().rerank is None
+
+    processing = _complete_processing()
+    processing["rerank"] = {
+        "base_url": "https://rerank.example.test/v1/inference",
+        "model": "custom-rerank",
+        "api_key": "custom-secret",
+        "provider": "deepinfra",
+    }
+    custom = V2Config.from_payload(
+        _payload(
+            {
+                "enabled": True,
+                "mode": "custom",
+                "processing": processing,
+                "cloud": {
+                    "model_access_key": "mak_opaque",
+                    "rerank_access_key": "mak_rr_dashscope_opaque",
+                },
+            }
+        )
+    ).memory
+    assert custom.runtime_source() == "custom"
+    assert custom.runtime_processing().rerank == custom.processing.rerank
 
 
 def test_atomic_memory_update_writes_only_canonical_shape(

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -392,8 +392,10 @@ def test_managed_rerank_closed_table_projects_exact_everos_endpoint(
             ),
             embedding_identity="emb-v1",
             applied_embedding_identity="emb-v1",
+            revision=3,
             model_access_key="mak_opaque",
             rerank_access_key=f"{typed_prefix}opaque",
+            access_key_revision=3,
             proxy_base_url="https://backend.example.test/v1/model",
         ),
     )

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -1625,6 +1625,57 @@ def test_processing_health_probes_both_authenticated_endpoints() -> None:
     assert json.loads(requests[0].content)["max_tokens"] == 8
 
 
+@pytest.mark.parametrize("operation", ["preflight", "processing_healthy"])
+def test_basic_processing_aggregates_exclude_the_optional_reranker(
+    operation: str,
+) -> None:
+    """MEMORY-SEARCH-019: basic processing does not gate on rerank."""
+
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.endswith("/chat/completions"):
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "OK"}}]},
+            )
+        if request.url.path.endswith("/embeddings"):
+            return httpx.Response(200, json={"data": [{"embedding": [0.1]}]})
+        return httpx.Response(401, json={"error": {"code": "invalid_key"}})
+
+    async def run():
+        provider = EverOSPort(
+            Path("/tmp/everos.sock"),
+            llm_base_url="https://llm.example.test/v1",
+            llm_model="chat",
+            llm_api_key="llm-secret",
+            embedding_base_url="https://embed.example.test/v1",
+            embedding_model="embed",
+            embedding_api_key="embedding-secret",
+            rerank_base_url="https://rerank.example.test/v1/inference",
+            rerank_model="rerank-model",
+            rerank_api_key="rerank-secret",
+        )
+        return await getattr(provider, operation)()
+
+    real_async_client = httpx.AsyncClient
+    with patch("avibe_memory.everos.httpx.AsyncClient", autospec=True) as client_type:
+        client_type.side_effect = lambda **kwargs: real_async_client(
+            transport=httpx.MockTransport(handler), **kwargs
+        )
+        result = asyncio.run(run())
+
+    if operation == "processing_healthy":
+        assert result is True
+    else:
+        assert result.ok is True
+    assert [request.url.path for request in requests] == [
+        "/v1/chat/completions",
+        "/v1/embeddings",
+    ]
+
+
 def test_processing_health_serializes_identical_provider_credentials(monkeypatch) -> None:
     provider = EverOSPort(
         Path("/tmp/everos.sock"),
@@ -1659,7 +1710,7 @@ def test_processing_health_serializes_identical_provider_credentials(monkeypatch
         )
         max_total_active = max(max_total_active, sum(active_by_group.values()))
         started.append((group, name))
-        if len(started) == 3:
+        if len(started) == 2:
             first_wave_started.set()
         try:
             await release.wait()
@@ -1675,14 +1726,14 @@ def test_processing_health_serializes_identical_provider_credentials(monkeypatch
         assert {name for _group, name in started} == {
             "chat-model",
             "embedding-model",
-            "rerank-model",
         }
         release.set()
         return await task
 
     assert asyncio.run(run()) is True
     assert [name for _group, name in started].count("vision-model") == 1
-    assert max_total_active == 3
+    assert [name for _group, name in started].count("rerank-model") == 0
+    assert max_total_active == 2
     assert all(active == 1 for active in max_active_by_group.values())
 
 
@@ -2003,7 +2054,7 @@ def test_processing_preflight_rejects_unhashable_finish_reason() -> None:
     assert result.failure.diagnostic.message == "provider_response_invalid_finish_reason"
 
 
-def test_processing_preflight_probes_configured_rerank_endpoint() -> None:
+def test_deepinfra_rerank_probe_keeps_provider_native_request_shape() -> None:
     requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -2015,18 +2066,21 @@ def test_processing_preflight_probes_configured_rerank_endpoint() -> None:
         return httpx.Response(200, json={"scores": [[0.9]]})
 
     async def run():
-        return await EverOSPort(
+        provider = EverOSPort(
             Path("/tmp/everos.sock"),
-            llm_base_url="https://llm.example.test/v1",
-            llm_model="chat",
-            llm_api_key="llm-secret",
-            embedding_base_url="https://embed.example.test/v1",
-            embedding_model="embed",
-            embedding_api_key="embedding-secret",
             rerank_base_url="https://rerank.example.test/v1/inference",
             rerank_model="Qwen/Qwen3-Reranker-4B",
             rerank_api_key="rerank-secret",
-        ).preflight()
+        )
+        probe = provider._rerank_probe_spec()  # noqa: SLF001
+        return await provider._preflight_endpoint(  # noqa: SLF001
+            "rerank",
+            probe.base_url,
+            probe.api_key,
+            probe.path,
+            probe.payload,
+            probe.validator,
+        )
 
     real_async_client = httpx.AsyncClient
     with patch("avibe_memory.everos.httpx.AsyncClient", autospec=True) as client_type:
@@ -2035,11 +2089,9 @@ def test_processing_preflight_probes_configured_rerank_endpoint() -> None:
         )
         result = asyncio.run(run())
 
-    assert result.ok is True
+    assert result is None
     assert [request.url.path for request in requests] == [
-        "/v1/chat/completions",
-        "/v1/embeddings",
-        "/v1/inference/Qwen/Qwen3-Reranker-4B",
+        "/v1/inference/Qwen/Qwen3-Reranker-4B"
     ]
     assert json.loads(requests[-1].content) == {
         "queries": ["OK"],
@@ -2048,7 +2100,7 @@ def test_processing_preflight_probes_configured_rerank_endpoint() -> None:
     assert requests[-1].headers["authorization"] == "Bearer rerank-secret"
 
 
-def test_processing_preflight_probes_vllm_rerank_endpoint() -> None:
+def test_vllm_rerank_probe_keeps_custom_provider_request_shape() -> None:
     requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -2060,19 +2112,22 @@ def test_processing_preflight_probes_vllm_rerank_endpoint() -> None:
         return httpx.Response(200, json={"results": [{"index": 0, "relevance_score": 0.9}]})
 
     async def run():
-        return await EverOSPort(
+        provider = EverOSPort(
             Path("/tmp/everos.sock"),
-            llm_base_url="https://llm.example.test/v1",
-            llm_model="chat",
-            llm_api_key="llm-secret",
-            embedding_base_url="https://embed.example.test/v1",
-            embedding_model="embed",
-            embedding_api_key="embedding-secret",
             rerank_base_url="http://localhost:8000/v1",
             rerank_model="Qwen/Qwen3-Reranker-4B",
             rerank_api_key="rerank-secret",
             rerank_provider="vllm",
-        ).preflight()
+        )
+        probe = provider._rerank_probe_spec()  # noqa: SLF001
+        return await provider._preflight_endpoint(  # noqa: SLF001
+            "rerank",
+            probe.base_url,
+            probe.api_key,
+            probe.path,
+            probe.payload,
+            probe.validator,
+        )
 
     real_async_client = httpx.AsyncClient
     with patch("avibe_memory.everos.httpx.AsyncClient", autospec=True) as client_type:
@@ -2081,8 +2136,8 @@ def test_processing_preflight_probes_vllm_rerank_endpoint() -> None:
         )
         result = asyncio.run(run())
 
-    assert result.ok is True
-    assert [request.url.path for request in requests][-1] == "/v1/rerank"
+    assert result is None
+    assert [request.url.path for request in requests] == ["/v1/rerank"]
     assert json.loads(requests[-1].content) == {
         "model": "Qwen/Qwen3-Reranker-4B",
         "query": "OK",
@@ -2090,7 +2145,7 @@ def test_processing_preflight_probes_vllm_rerank_endpoint() -> None:
     }
 
 
-def test_processing_preflight_probes_dashscope_rerank_endpoint() -> None:
+def test_dashscope_rerank_probe_keeps_provider_native_request_shape() -> None:
     requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -2105,19 +2160,22 @@ def test_processing_preflight_probes_dashscope_rerank_endpoint() -> None:
         )
 
     async def run():
-        return await EverOSPort(
+        provider = EverOSPort(
             Path("/tmp/everos.sock"),
-            llm_base_url="https://llm.example.test/v1",
-            llm_model="chat",
-            llm_api_key="llm-secret",
-            embedding_base_url="https://embed.example.test/v1",
-            embedding_model="embed",
-            embedding_api_key="embedding-secret",
             rerank_base_url="https://dashscope.aliyuncs.com",
             rerank_model="gte-rerank-v2",
             rerank_api_key="rerank-secret",
             rerank_provider="dashscope",
-        ).preflight()
+        )
+        probe = provider._rerank_probe_spec()  # noqa: SLF001
+        return await provider._preflight_endpoint(  # noqa: SLF001
+            "rerank",
+            probe.base_url,
+            probe.api_key,
+            probe.path,
+            probe.payload,
+            probe.validator,
+        )
 
     real_async_client = httpx.AsyncClient
     with patch("avibe_memory.everos.httpx.AsyncClient", autospec=True) as client_type:
@@ -2126,10 +2184,10 @@ def test_processing_preflight_probes_dashscope_rerank_endpoint() -> None:
         )
         result = asyncio.run(run())
 
-    assert result.ok is True
-    assert [request.url.path for request in requests][-1] == (
+    assert result is None
+    assert [request.url.path for request in requests] == [
         "/api/v1/services/rerank/text-rerank/text-rerank"
-    )
+    ]
     assert json.loads(requests[-1].content) == {
         "model": "gte-rerank-v2",
         "input": {"query": "OK", "documents": ["OK"]},
@@ -2137,7 +2195,7 @@ def test_processing_preflight_probes_dashscope_rerank_endpoint() -> None:
     }
 
 
-def test_processing_preflight_infers_dashscope_from_maas_url_without_provider() -> None:
+def test_dashscope_rerank_probe_keeps_existing_provider_inference() -> None:
     requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -2152,18 +2210,21 @@ def test_processing_preflight_infers_dashscope_from_maas_url_without_provider() 
         )
 
     async def run():
-        return await EverOSPort(
+        provider = EverOSPort(
             Path("/tmp/everos.sock"),
-            llm_base_url="https://llm.example.test/v1",
-            llm_model="chat",
-            llm_api_key="llm-secret",
-            embedding_base_url="https://embed.example.test/v1",
-            embedding_model="embed",
-            embedding_api_key="embedding-secret",
             rerank_base_url="https://llm-space.example.maas.aliyuncs.com",
             rerank_model="gte-rerank-v2",
             rerank_api_key="rerank-secret",
-        ).preflight()
+        )
+        probe = provider._rerank_probe_spec()  # noqa: SLF001
+        return await provider._preflight_endpoint(  # noqa: SLF001
+            "rerank",
+            probe.base_url,
+            probe.api_key,
+            probe.path,
+            probe.payload,
+            probe.validator,
+        )
 
     real_async_client = httpx.AsyncClient
     with patch("avibe_memory.everos.httpx.AsyncClient", autospec=True) as client_type:
@@ -2172,10 +2233,10 @@ def test_processing_preflight_infers_dashscope_from_maas_url_without_provider() 
         )
         result = asyncio.run(run())
 
-    assert result.ok is True
-    assert [request.url.path for request in requests][-1] == (
+    assert result is None
+    assert [request.url.path for request in requests] == [
         "/api/v1/services/rerank/text-rerank/text-rerank"
-    )
+    ]
     assert json.loads(requests[-1].content)["input"] == {"query": "OK", "documents": ["OK"]}
 
 
@@ -2285,7 +2346,7 @@ def test_processing_preflight_returns_typed_multimodal_failure() -> None:
     assert result.failure.diagnostic.provider_error_code == "invalid_key"
 
 
-def test_processing_preflight_returns_typed_rerank_failure() -> None:
+def test_targeted_rerank_probe_still_returns_typed_failure() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path.endswith("/chat/completions"):
             return httpx.Response(200, json={"choices": [{"message": {"content": "OK"}}]})
@@ -2294,18 +2355,21 @@ def test_processing_preflight_returns_typed_rerank_failure() -> None:
         return httpx.Response(401, json={"error": {"code": "invalid_key"}})
 
     async def run():
-        return await EverOSPort(
+        provider = EverOSPort(
             Path("/tmp/everos.sock"),
-            llm_base_url="https://llm.example.test/v1",
-            llm_model="chat",
-            llm_api_key="llm-secret",
-            embedding_base_url="https://embed.example.test/v1",
-            embedding_model="embed",
-            embedding_api_key="embedding-secret",
             rerank_base_url="https://rerank.example.test/v1/inference",
             rerank_model="rerank-model",
             rerank_api_key="rerank-secret",
-        ).preflight()
+        )
+        probe = provider._rerank_probe_spec()  # noqa: SLF001
+        return await provider._preflight_endpoint(  # noqa: SLF001
+            "rerank",
+            probe.base_url,
+            probe.api_key,
+            probe.path,
+            probe.payload,
+            probe.validator,
+        )
 
     real_async_client = httpx.AsyncClient
     with patch("avibe_memory.everos.httpx.AsyncClient", autospec=True) as client_type:
@@ -2314,12 +2378,11 @@ def test_processing_preflight_returns_typed_rerank_failure() -> None:
         )
         result = asyncio.run(run())
 
-    assert result.ok is False
-    assert result.failure is not None
-    assert result.failure.error == "memory_rerank_unavailable"
-    assert result.failure.diagnostic.side == "rerank"
-    assert result.failure.diagnostic.http_status == 401
-    assert result.failure.diagnostic.provider_error_code == "invalid_key"
+    assert result is not None
+    assert result.error == "memory_rerank_unavailable"
+    assert result.diagnostic.side == "rerank"
+    assert result.diagnostic.http_status == 401
+    assert result.diagnostic.provider_error_code == "invalid_key"
 
 
 def test_processing_preflight_scrubs_provider_error_code() -> None:

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -1625,10 +1625,7 @@ def test_processing_health_probes_both_authenticated_endpoints() -> None:
     assert json.loads(requests[0].content)["max_tokens"] == 8
 
 
-@pytest.mark.parametrize("operation", ["preflight", "processing_healthy"])
-def test_basic_processing_aggregates_exclude_the_optional_reranker(
-    operation: str,
-) -> None:
+def test_basic_processing_health_excludes_the_optional_reranker() -> None:
     """MEMORY-SEARCH-019: basic processing does not gate on rerank."""
 
     requests: list[httpx.Request] = []
@@ -1657,7 +1654,7 @@ def test_basic_processing_aggregates_exclude_the_optional_reranker(
             rerank_model="rerank-model",
             rerank_api_key="rerank-secret",
         )
-        return await getattr(provider, operation)()
+        return await provider.processing_healthy()
 
     real_async_client = httpx.AsyncClient
     with patch("avibe_memory.everos.httpx.AsyncClient", autospec=True) as client_type:
@@ -1666,10 +1663,7 @@ def test_basic_processing_aggregates_exclude_the_optional_reranker(
         )
         result = asyncio.run(run())
 
-    if operation == "processing_healthy":
-        assert result is True
-    else:
-        assert result.ok is True
+    assert result is True
     assert [request.url.path for request in requests] == [
         "/v1/chat/completions",
         "/v1/embeddings",

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -13,7 +13,7 @@ from avibe_memory.attachments import (
     AttachmentPinError,
     AttachmentPinStore,
 )
-from avibe_memory.everos import FakeMemoryProvider
+from avibe_memory.everos import FakeMemoryProvider, ProviderHealthSnapshot
 from avibe_memory.module import MIN_FREE_DISK_BYTES, MemoryModule
 from avibe_memory.store import MemoryStore, VolatileAdmission
 from avibe_memory.types import (
@@ -31,6 +31,7 @@ from avibe_memory.types import (
     MemoryProfileTrait,
     OperationFailed,
     ProviderSearchItem,
+    RecallPolicy,
 )
 from avibe_memory.writer import MAX_WRITER_PERMITS
 
@@ -68,6 +69,68 @@ def _module(
         effective_home=tmp_path,
     )
     return module, store, provider
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "health",
+    [
+        ProviderHealthSnapshot(
+            status="ok",
+            version="1.2.3",
+            capabilities={
+                "llm": True,
+                "embed": True,
+                "rerank": False,
+                "multimodal_llm": True,
+                "parser": True,
+            },
+            disabled_features=(),
+            cascade=None,
+        ),
+        ProviderHealthSnapshot(
+            status="degraded",
+            version="1.2.3",
+            capabilities={
+                "llm": True,
+                "embed": True,
+                "rerank": True,
+                "multimodal_llm": True,
+                "parser": True,
+            },
+            disabled_features=("agentic_search",),
+            cascade=None,
+        ),
+    ],
+)
+async def test_agentic_recall_fails_closed_without_a_usable_reranker(
+    tmp_path: Path,
+    health: ProviderHealthSnapshot,
+) -> None:
+    """MEMORY-SEARCH-019: agentic recall requires usable rerank health."""
+
+    provider = FakeMemoryProvider(
+        agentic_budget_enforced_flag=True,
+        health_snapshot_value=health,
+    )
+    module, _store, _provider = _module(tmp_path, provider=provider)
+
+    result = await module.recall(
+        "connect the clues",
+        policy=RecallPolicy(
+            mode="agentic",
+            max_results=2,
+            timeout_seconds=1,
+            max_model_calls=1,
+            cost_budget_tokens=100,
+        ),
+        principal_id=PRINCIPAL,
+        project_id="default",
+    )
+
+    assert result == OperationFailed(error="memory_capability_unavailable")
+    assert provider.search_policies == []
+    await module.close_writer()
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -17,7 +17,11 @@ from config.v2_config import (
     MemoryEndpointConfig,
     MemoryProcessingConfig,
 )
-from avibe_memory.everos import ProviderHealthSnapshot
+from avibe_memory.everos import (
+    MemoryPreflightDiagnostic,
+    MemoryPreflightFailure,
+    ProviderHealthSnapshot,
+)
 from avibe_memory.processing_record import (
     MaintenanceObservation,
     RuntimeHealthProjection,
@@ -55,8 +59,10 @@ def test_typed_rerank_change_reaches_sidecar_without_embedding_rebuild() -> None
             memory_llm_source="chat_fallback",
             embedding_identity="emb-v1",
             applied_embedding_identity="emb-v1",
+            revision=1,
             model_access_key="mak_opaque",
             rerank_access_key="mak_rr_deepinfra_opaque",
+            access_key_revision=1,
             proxy_base_url="https://backend.example.test/v1/model",
             source_instance_id="instance-1",
         ),
@@ -70,8 +76,10 @@ def test_typed_rerank_change_reaches_sidecar_without_embedding_rebuild() -> None
             memory_llm_source="chat_fallback",
             embedding_identity="emb-v1",
             applied_embedding_identity="emb-v1",
+            revision=1,
             model_access_key="mak_opaque",
             rerank_access_key="mak_rr_dashscope_opaque",
+            access_key_revision=1,
             proxy_base_url="https://backend.example.test/v1/model",
             source_instance_id="instance-1",
         ),
@@ -91,6 +99,93 @@ def test_typed_rerank_change_reaches_sidecar_without_embedding_rebuild() -> None
     assert settings.rerank_model == "gte-rerank-v2"
     assert settings.rerank_api_key == "mak_rr_dashscope_opaque"
     assert settings.rerank_provider == "dashscope"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("managed", "expected_sides", "expected_ok"),
+    [
+        (False, ["llm", "embedding", "rerank"], False),
+        (True, ["llm", "embedding"], True),
+    ],
+)
+async def test_candidate_preflight_validates_only_custom_rerank(
+    managed: bool,
+    expected_sides: list[str],
+    expected_ok: bool,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _runtime(tmp_path)
+    custom_processing = MemoryProcessingConfig(
+        llm=MemoryEndpointConfig(
+            "https://llm.example.test/v1",
+            "chat",
+            "llm-secret",
+        ),
+        embedding=MemoryEndpointConfig(
+            "https://embedding.example.test/v1",
+            "embedding",
+            "embedding-secret",
+        ),
+        rerank=MemoryEndpointConfig(
+            "https://rerank.example.test/v1/inference",
+            "rerank",
+            "rerank-secret",
+            provider="deepinfra",
+        ),
+    )
+    if managed:
+        candidate = MemoryConfig(
+            enabled=True,
+            mode="platform",
+            cloud=MemoryCloudConfig(
+                scope="platform",
+                capabilities=MemoryCloudCapabilities(
+                    chat=True,
+                    embedding=True,
+                    memory_llm=True,
+                ),
+                memory_llm_source="chat_fallback",
+                embedding_identity="emb-v1",
+                applied_embedding_identity="emb-v1",
+                revision=2,
+                model_access_key="mak_opaque",
+                rerank_access_key="mak_rr_deepinfra_opaque",
+                access_key_revision=2,
+                proxy_base_url="https://backend.example.test/v1/model",
+                source_instance_id="instance-1",
+            ),
+        )
+    else:
+        candidate = MemoryConfig(
+            enabled=True,
+            mode="custom",
+            processing=custom_processing,
+        )
+
+    sides: list[str] = []
+
+    async def probe(_provider, side, *_args):
+        sides.append(side)
+        if side == "rerank":
+            return MemoryPreflightFailure(
+                "memory_rerank_unavailable",
+                MemoryPreflightDiagnostic(side, message="invalid_candidate"),
+            )
+        return None
+
+    monkeypatch.setattr(runtime_module.EverOSPort, "_preflight_endpoint", probe)
+
+    try:
+        result = await runtime.preflight(candidate)
+    finally:
+        await runtime.close()
+
+    assert sides == expected_sides
+    assert result["ok"] is expected_ok
+    if not expected_ok:
+        assert result["error"] == "memory_rerank_unavailable"
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -10,14 +10,20 @@ import pytest
 
 import avibe_memory.runtime as runtime_module
 from avibe_memory.capture_adapter import EnabledMemoryAdapter
-from config.v2_config import MemoryEndpointConfig, MemoryProcessingConfig
+from config.v2_config import (
+    MemoryCloudCapabilities,
+    MemoryCloudConfig,
+    MemoryConfig,
+    MemoryEndpointConfig,
+    MemoryProcessingConfig,
+)
 from avibe_memory.everos import ProviderHealthSnapshot
 from avibe_memory.processing_record import (
     MaintenanceObservation,
     RuntimeHealthProjection,
     SourceObservation,
 )
-from avibe_memory.runtime import MemoryConfig, MemoryRuntime
+from avibe_memory.runtime import MemoryRuntime
 from avibe_memory.store import MemoryStore
 from avibe_memory.types import MemoryItems, MemoryListItem, MemoryListPage
 from vibe.memory_contract import MemoryRuntimeBusyError
@@ -33,6 +39,58 @@ def _runtime(tmp_path: Path) -> MemoryRuntime:
         store=store,
         effective_home=tmp_path,
     )
+
+
+def test_typed_rerank_change_reaches_sidecar_without_embedding_rebuild() -> None:
+    current = MemoryConfig(
+        enabled=True,
+        mode="platform",
+        cloud=MemoryCloudConfig(
+            scope="platform",
+            capabilities=MemoryCloudCapabilities(
+                chat=True,
+                embedding=True,
+                memory_llm=True,
+            ),
+            memory_llm_source="chat_fallback",
+            embedding_identity="emb-v1",
+            applied_embedding_identity="emb-v1",
+            model_access_key="mak_opaque",
+            rerank_access_key="mak_rr_deepinfra_opaque",
+            proxy_base_url="https://backend.example.test/v1/model",
+            source_instance_id="instance-1",
+        ),
+    )
+    candidate = MemoryConfig(
+        enabled=True,
+        mode="platform",
+        cloud=MemoryCloudConfig(
+            scope="platform",
+            capabilities=current.cloud.capabilities,
+            memory_llm_source="chat_fallback",
+            embedding_identity="emb-v1",
+            applied_embedding_identity="emb-v1",
+            model_access_key="mak_opaque",
+            rerank_access_key="mak_rr_dashscope_opaque",
+            proxy_base_url="https://backend.example.test/v1/model",
+            source_instance_id="instance-1",
+        ),
+    )
+
+    settings = runtime_module._process_settings(candidate)  # noqa: SLF001
+
+    assert current.runtime_processing() != candidate.runtime_processing()
+    assert current.runtime_embedding_identity() == candidate.runtime_embedding_identity()
+    assert runtime_module._embedding_configuration_changed(  # noqa: SLF001
+        current,
+        candidate,
+    ) is False
+    assert settings.rerank_base_url == (
+        "https://backend.example.test/v1/model/rerank/dashscope"
+    )
+    assert settings.rerank_model == "gte-rerank-v2"
+    assert settings.rerank_api_key == "mak_rr_dashscope_opaque"
+    assert settings.rerank_provider == "dashscope"
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory_sidecar.py
+++ b/tests/test_memory_sidecar.py
@@ -669,7 +669,7 @@ def test_processing_probe_builds_the_adapter_from_child_environment_only(monkeyp
     monkeypatch.setenv("EVEROS_EMBEDDING__API_KEY", "embedding-secret")
     monkeypatch.setenv("EVEROS_RERANK__BASE_URL", "https://rerank.example.test/v1/inference")
     monkeypatch.setenv("EVEROS_RERANK__MODEL", "rerank-model")
-    monkeypatch.setenv("EVEROS_RERANK__API_KEY", "rerank-secret")
+    monkeypatch.setenv("EVEROS_RERANK__API_KEY", "mak_rr_dashscope_opaque")
     monkeypatch.setenv("EVEROS_MULTIMODAL__BASE_URL", "https://vision.example.test/v1")
     monkeypatch.setenv("EVEROS_MULTIMODAL__MODEL", "vision-model")
     monkeypatch.setenv("EVEROS_MULTIMODAL__API_KEY", "vision-secret")
@@ -687,7 +687,7 @@ def test_processing_probe_builds_the_adapter_from_child_environment_only(monkeyp
         "embedding_api_key": "embedding-secret",
         "rerank_base_url": "https://rerank.example.test/v1/inference",
         "rerank_model": "rerank-model",
-        "rerank_api_key": "rerank-secret",
+        "rerank_api_key": "mak_rr_dashscope_opaque",
         "rerank_provider": None,
         "multimodal_base_url": "https://vision.example.test/v1",
         "multimodal_model": "vision-model",

--- a/tests/test_model_service.py
+++ b/tests/test_model_service.py
@@ -643,6 +643,67 @@ def test_explicit_key_bundle_paths_use_the_typed_opt_in_endpoint(
     assert state["memory"].cloud.access_key_revision == 4
 
 
+@pytest.mark.parametrize("rollback_applies", [True, False])
+def test_rotation_rollback_reconciles_the_persisted_pending_bundle(
+    rollback_applies: bool,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    current = _active_cloud_memory(
+        key="mak_original",
+        rerank_access_key="mak_rr_deepinfra_original",
+        access_key_revision=4,
+        revision=4,
+    )
+    original_embedding_identity = current.runtime_embedding_identity()
+    _save_memory_config(current, monkeypatch, tmp_path)
+    reconciled: list[MemoryConfig] = []
+
+    def request(_config, _credentials, method, suffix):
+        assert (method, suffix) == ("POST", model_service.MODEL_ACCESS_KEY_SUFFIX)
+        return _key_payload(
+            "mak_rotated",
+            rerank_access_key="mak_rr_dashscope_rotated",
+            include_typed_keys=True,
+        )
+
+    async def reconcile_memory():
+        reconciled.append(deepcopy(V2Config.load().memory))
+        applied = len(reconciled) == 2 and rollback_applies
+        return {
+            "status_code": 200 if applied else 409,
+            "body": {"ok": applied},
+        }
+
+    monkeypatch.setattr(model_service, "_paired_device_request", request)
+    monkeypatch.setattr(internal_client, "reconcile_memory", reconcile_memory)
+
+    with pytest.raises(
+        model_service.ModelServiceResolutionError,
+        match="model_access_key_apply_failed",
+    ):
+        model_service.rotate_model_access_key(_paired_model_service_config())
+
+    assert len(reconciled) == 2
+    rotated, rollback = reconciled
+    assert rotated.cloud.model_access_key == "mak_rotated"
+    assert rotated.cloud.rerank_access_key == "mak_rr_dashscope_rotated"
+    assert rotated.cloud.access_key_revision == 4
+    assert rotated.cloud.runtime_apply_pending is True
+    assert rollback.cloud.model_access_key == "mak_original"
+    assert rollback.cloud.rerank_access_key == "mak_rr_deepinfra_original"
+    assert rollback.cloud.access_key_revision == 4
+    assert rollback.cloud.runtime_apply_pending is True
+    assert rollback.runtime_embedding_identity() == original_embedding_identity
+
+    restored = V2Config.load().memory
+    assert restored.cloud.model_access_key == "mak_original"
+    assert restored.cloud.rerank_access_key == "mak_rr_deepinfra_original"
+    assert restored.cloud.access_key_revision == 4
+    assert restored.cloud.runtime_apply_pending is not rollback_applies
+    assert restored.runtime_embedding_identity() == original_embedding_identity
+
+
 def test_enterprise_attachment_pauses_custom_without_recovery_marker() -> None:
     candidate = _resolved(
         _manual_memory(),

--- a/tests/test_model_service.py
+++ b/tests/test_model_service.py
@@ -11,7 +11,9 @@ from config.v2_config import (
     MemoryConfig,
     MemoryEndpointConfig,
     MemoryProcessingConfig,
+    V2Config,
 )
+from vibe import internal_client
 from vibe import model_service
 from vibe import ui_memory_routes
 
@@ -126,6 +128,31 @@ def _active_cloud_memory(
     )
 
 
+def _save_memory_config(
+    memory: MemoryConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = V2Config.default()
+    config.memory = memory
+    config.save()
+
+
+def _paired_model_service_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        remote_access=SimpleNamespace(
+            vibe_cloud=SimpleNamespace(
+                runtime_credentials=lambda: (
+                    "https://backend.example.test",
+                    "instance-1",
+                    "device-secret",
+                )
+            )
+        )
+    )
+
+
 def test_model_access_key_parser_accepts_legacy_and_typed_responses() -> None:
     legacy = model_service._mint_from_payload(  # noqa: SLF001
         _key_payload("mak_opaque")
@@ -167,6 +194,164 @@ def test_model_access_key_parser_keeps_base_key_for_any_unusable_typed_shape(
 
     assert minted.key == "mak_opaque"
     assert minted.rerank_access_key is None
+
+
+@pytest.mark.parametrize(
+    ("existing_pending", "runtime_changed", "expected_pending"),
+    [
+        (False, False, False),
+        (False, True, True),
+        (True, False, True),
+        (True, True, True),
+    ],
+)
+def test_model_service_persistence_derives_pending_from_runtime_signature(
+    existing_pending: bool,
+    runtime_changed: bool,
+    expected_pending: bool,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    current = _active_cloud_memory()
+    current.cloud.runtime_apply_pending = existing_pending
+    _save_memory_config(current, monkeypatch, tmp_path)
+    candidate = deepcopy(current)
+    candidate.cloud.runtime_apply_pending = False
+    if runtime_changed:
+        candidate.enabled = not current.enabled
+
+    assert (
+        model_service._runtime_state_signature(candidate)  # noqa: SLF001
+        != model_service._runtime_state_signature(current)  # noqa: SLF001
+    ) is runtime_changed
+
+    saved = model_service._persist_candidate(current, candidate)  # noqa: SLF001
+
+    assert candidate.cloud.runtime_apply_pending is False
+    assert saved.memory.cloud.runtime_apply_pending is expected_pending
+    assert V2Config.load().memory.cloud.runtime_apply_pending is expected_pending
+
+
+def test_ensure_active_bundle_stays_pending_until_one_later_sync(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    current = _active_cloud_memory(
+        rerank_access_key="mak_rr_deepinfra_opaque",
+        access_key_revision=1,
+        revision=2,
+    )
+    previous_processing = current.runtime_processing()
+    previous_identity = current.runtime_embedding_identity()
+    _save_memory_config(current, monkeypatch, tmp_path)
+    requests: list[tuple[str, str]] = []
+    reconciled: list[MemoryConfig] = []
+
+    def request(_config, _credentials, method, suffix):
+        requests.append((method, suffix))
+        if suffix == model_service.MODEL_ACCESS_KEY_SUFFIX:
+            return _key_payload(
+                "mak_opaque",
+                rerank_access_key="mak_rr_dashscope_opaque",
+                include_typed_keys=True,
+            )
+        assert suffix == "model-service"
+        return _status(revision=2)
+
+    async def reconcile_memory():
+        reconciled.append(deepcopy(V2Config.load().memory))
+        return {"status_code": 200, "body": {"ok": True}}
+
+    monkeypatch.setattr(model_service, "_paired_device_request", request)
+    monkeypatch.setattr(internal_client, "reconcile_memory", reconcile_memory)
+    config = _paired_model_service_config()
+
+    ensured = model_service.ensure_model_access_key(config).memory
+
+    assert requests == [("POST", model_service.MODEL_ACCESS_KEY_SUFFIX)]
+    assert reconciled == []
+    assert ensured.cloud.access_key_revision == ensured.cloud.revision == 2
+    assert ensured.cloud.rerank_access_key == "mak_rr_dashscope_opaque"
+    assert ensured.cloud.runtime_apply_pending is True
+    assert ensured.runtime_processing() != previous_processing
+    assert ensured.runtime_embedding_identity() == previous_identity
+
+    result = model_service.sync_model_service_once(config)
+
+    applied = V2Config.load().memory
+    assert result["ok"] is True
+    assert result["changed"] is False
+    assert result["apply_pending"] is False
+    assert requests == [
+        ("POST", model_service.MODEL_ACCESS_KEY_SUFFIX),
+        ("GET", "model-service"),
+    ]
+    assert len(reconciled) == 1
+    assert reconciled[0].cloud.runtime_apply_pending is True
+    assert applied.cloud.runtime_apply_pending is False
+    assert applied.cloud.rerank_access_key == "mak_rr_dashscope_opaque"
+    assert applied.runtime_embedding_identity() == previous_identity
+
+
+@pytest.mark.parametrize("existing_pending", [False, True])
+def test_ensure_custom_bundle_preparation_only_preserves_existing_pending(
+    existing_pending: bool,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    current = _active_cloud_memory(
+        rerank_access_key="mak_rr_deepinfra_opaque",
+        access_key_revision=1,
+        revision=2,
+    )
+    current.mode = "custom"
+    current.processing = _manual_memory().processing
+    current.cloud.runtime_apply_pending = existing_pending
+    previous_signature = model_service._runtime_state_signature(current)  # noqa: SLF001
+    _save_memory_config(current, monkeypatch, tmp_path)
+
+    def request(_config, _credentials, method, suffix):
+        assert (method, suffix) == ("POST", model_service.MODEL_ACCESS_KEY_SUFFIX)
+        return _key_payload(
+            "mak_opaque",
+            rerank_access_key="mak_rr_dashscope_opaque",
+            include_typed_keys=True,
+        )
+
+    monkeypatch.setattr(model_service, "_paired_device_request", request)
+
+    ensured = model_service.ensure_model_access_key(
+        _paired_model_service_config()
+    ).memory
+
+    assert ensured.cloud.access_key_revision == ensured.cloud.revision == 2
+    assert ensured.cloud.rerank_access_key == "mak_rr_dashscope_opaque"
+    assert ensured.cloud.runtime_apply_pending is existing_pending
+    assert model_service._runtime_state_signature(ensured) == previous_signature  # noqa: SLF001
+
+
+def test_ensure_current_bundle_is_a_persistence_noop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    current = _active_cloud_memory(
+        rerank_access_key="mak_rr_deepinfra_opaque",
+        access_key_revision=2,
+        revision=2,
+    )
+    _save_memory_config(current, monkeypatch, tmp_path)
+
+    def unexpected(*_args, **_kwargs):
+        pytest.fail("current bundle performed network or persistence work")
+
+    monkeypatch.setattr(model_service, "_paired_device_request", unexpected)
+    monkeypatch.setattr(model_service, "_persist_candidate", unexpected)
+
+    ensured = model_service.ensure_model_access_key(
+        _paired_model_service_config()
+    ).memory
+
+    assert ensured == current
 
 
 @pytest.mark.parametrize(

--- a/tests/test_model_service.py
+++ b/tests/test_model_service.py
@@ -279,6 +279,121 @@ def test_key_bundle_changes_use_one_processing_reconciliation_without_embedding_
     assert state["memory"].cloud.transition_notice_pending is False
 
 
+@pytest.mark.parametrize(
+    "first_mint_outcome",
+    ["timeout", "upstream_error", "malformed"],
+)
+def test_stale_typed_rerank_is_fenced_until_matching_revision_mint(
+    first_mint_outcome: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = {
+        "memory": _active_cloud_memory(
+            rerank_access_key="mak_rr_deepinfra_opaque",
+            access_key_revision=1,
+            revision=1,
+        )
+    }
+    before = deepcopy(state["memory"])
+    requests: list[str] = []
+    reconciled: list[MemoryConfig] = []
+    mint_attempts = 0
+
+    class _Cloud:
+        @staticmethod
+        def runtime_credentials() -> tuple[str, str, str]:
+            return "https://backend.example.test", "instance-1", "device-secret"
+
+    config = SimpleNamespace(
+        remote_access=SimpleNamespace(vibe_cloud=_Cloud()),
+    )
+
+    def load() -> SimpleNamespace:
+        return SimpleNamespace(memory=deepcopy(state["memory"]))
+
+    def request(_config, _credentials, _method, suffix):
+        nonlocal mint_attempts
+        requests.append(suffix)
+        if suffix == "model-service":
+            return _status(revision=2)
+        assert suffix == model_service.MODEL_ACCESS_KEY_SUFFIX
+        mint_attempts += 1
+        if mint_attempts == 1:
+            if first_mint_outcome == "timeout":
+                raise TimeoutError("mint timed out")
+            if first_mint_outcome == "upstream_error":
+                raise model_service.ModelServiceResolutionError(
+                    "cloud_request_failed"
+                )
+            return {"key": "malformed"}
+        return _key_payload(
+            "mak_opaque",
+            rerank_access_key="mak_rr_dashscope_opaque",
+            include_typed_keys=True,
+        )
+
+    def persist(_expected, candidate):
+        state["memory"] = deepcopy(candidate)
+        return SimpleNamespace(memory=deepcopy(candidate))
+
+    def reconcile(candidate):
+        reconciled.append(deepcopy(candidate))
+        applied = deepcopy(candidate)
+        applied.cloud.runtime_apply_pending = False
+        state["memory"] = applied
+        return True
+
+    monkeypatch.setattr(model_service.V2Config, "load", load)
+    monkeypatch.setattr(model_service, "_paired_device_request", request)
+    monkeypatch.setattr(model_service, "_persist_candidate", persist)
+    monkeypatch.setattr(model_service, "_reconcile_candidate", reconcile)
+
+    with pytest.raises((TimeoutError, model_service.ModelServiceResolutionError)):
+        model_service.sync_model_service_once(config)
+
+    stale = deepcopy(state["memory"])
+    stale_processing = stale.runtime_processing()
+    assert stale.cloud.revision == 2
+    assert stale.cloud.access_key_revision == 1
+    assert stale.cloud.model_access_key == "mak_opaque"
+    assert stale.cloud.rerank_access_key == "mak_rr_deepinfra_opaque"
+    assert stale.runtime_source() == "cloud"
+    assert stale_processing.llm.complete() is True
+    assert stale_processing.embedding.complete() is True
+    assert stale_processing.rerank is None
+    assert stale.runtime_embedding_identity() == before.runtime_embedding_identity()
+    assert ui_memory_routes._memory_embedding_configuration_changed(  # noqa: SLF001
+        SimpleNamespace(memory=before),
+        SimpleNamespace(memory=stale),
+    ) is False
+    assert len(reconciled) == 1
+    assert reconciled[0].runtime_processing().rerank is None
+
+    result = model_service.sync_model_service_once(config)
+
+    restored = state["memory"]
+    rerank = restored.runtime_processing().rerank
+    assert result["ok"] is True
+    assert restored.cloud.revision == 2
+    assert restored.cloud.access_key_revision == 2
+    assert rerank is not None
+    assert rerank.provider == "dashscope"
+    assert rerank.api_key == "mak_rr_dashscope_opaque"
+    assert restored.runtime_embedding_identity() == before.runtime_embedding_identity()
+    assert ui_memory_routes._memory_embedding_configuration_changed(  # noqa: SLF001
+        SimpleNamespace(memory=stale),
+        SimpleNamespace(memory=restored),
+    ) is False
+    assert len(reconciled) == 2
+    assert reconciled[1].runtime_processing().rerank == rerank
+    assert requests == [
+        "model-service",
+        model_service.MODEL_ACCESS_KEY_SUFFIX,
+        "model-service",
+        model_service.MODEL_ACCESS_KEY_SUFFIX,
+    ]
+
+
 @pytest.mark.parametrize("operation", ["ensure", "rotate"])
 def test_explicit_key_bundle_paths_use_the_typed_opt_in_endpoint(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_model_service.py
+++ b/tests/test_model_service.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from copy import deepcopy
 from types import SimpleNamespace
 
+import pytest
+
 from config.v2_config import (
     MemoryCloudCapabilities,
     MemoryCloudConfig,
@@ -12,6 +14,23 @@ from config.v2_config import (
 )
 from vibe import model_service
 from vibe import ui_memory_routes
+
+
+def _key_payload(
+    key: str,
+    *,
+    rerank_access_key: object = None,
+    include_typed_keys: bool = False,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "key": key,
+        "created_at": "2026-08-17T00:00:00Z",
+        "rotated": False,
+        "previous_valid_until": None,
+    }
+    if include_typed_keys:
+        payload["typed_keys"] = {"rerank": rerank_access_key}
+    return payload
 
 
 def _status(
@@ -66,12 +85,7 @@ def _resolved(
     minted = None
     if key is not None:
         minted = model_service._mint_from_payload(  # noqa: SLF001
-            {
-                "key": key,
-                "created_at": "2026-08-17T00:00:00Z",
-                "rotated": False,
-                "previous_valid_until": None,
-            }
+            _key_payload(key)
         )
     return model_service._resolved_memory(  # noqa: SLF001
         current,
@@ -80,6 +94,253 @@ def _resolved(
         proxy_base_url="https://backend.example.test/v1/model",
         minted=minted,
     )
+
+
+def _active_cloud_memory(
+    *,
+    key: str = "mak_opaque",
+    rerank_access_key: str | None = None,
+    access_key_revision: int | None = 1,
+    revision: int = 1,
+) -> MemoryConfig:
+    return MemoryConfig(
+        enabled=True,
+        mode="platform",
+        cloud=MemoryCloudConfig(
+            scope="platform",
+            capabilities=MemoryCloudCapabilities(
+                chat=True,
+                embedding=True,
+                memory_llm=True,
+            ),
+            memory_llm_source="chat_fallback",
+            embedding_identity="emb-v1",
+            applied_embedding_identity="emb-v1",
+            revision=revision,
+            model_access_key=key,
+            rerank_access_key=rerank_access_key,
+            access_key_revision=access_key_revision,
+            proxy_base_url="https://backend.example.test/v1/model",
+            source_instance_id="instance-1",
+        ),
+    )
+
+
+def test_model_access_key_parser_accepts_legacy_and_typed_responses() -> None:
+    legacy = model_service._mint_from_payload(  # noqa: SLF001
+        _key_payload("mak_opaque")
+    )
+    typed = model_service._mint_from_payload(  # noqa: SLF001
+        _key_payload(
+            "mak_opaque",
+            rerank_access_key="mak_rr_dashscope_opaque",
+            include_typed_keys=True,
+        )
+    )
+
+    assert legacy.key == typed.key == "mak_opaque"
+    assert legacy.rerank_access_key is None
+    assert typed.rerank_access_key == "mak_rr_dashscope_opaque"
+    assert "mak_opaque" not in repr(typed)
+    assert "mak_rr_dashscope_opaque" not in repr(typed)
+
+
+@pytest.mark.parametrize(
+    "typed_keys",
+    [
+        None,
+        [],
+        {},
+        {"rerank": None},
+        {"rerank": "mak_rr_future_opaque"},
+        {"rerank": "mak_rr_deepinfra_"},
+        {"rerank": "mak_rr_deepinfra_different"},
+    ],
+)
+def test_model_access_key_parser_keeps_base_key_for_any_unusable_typed_shape(
+    typed_keys: object,
+) -> None:
+    payload = _key_payload("mak_opaque")
+    payload["typed_keys"] = typed_keys
+
+    minted = model_service._mint_from_payload(payload)  # noqa: SLF001
+
+    assert minted.key == "mak_opaque"
+    assert minted.rerank_access_key is None
+
+
+@pytest.mark.parametrize(
+    (
+        "current_key",
+        "current_rerank",
+        "current_key_revision",
+        "status_revision",
+        "minted_key",
+        "minted_rerank",
+    ),
+    [
+        ("mak_opaque", None, 1, 2, "mak_opaque", "mak_rr_deepinfra_opaque"),
+        (
+            "mak_opaque",
+            "mak_rr_deepinfra_opaque",
+            1,
+            2,
+            "mak_opaque",
+            None,
+        ),
+        (
+            "mak_old",
+            "mak_rr_deepinfra_old",
+            1,
+            2,
+            "mak_new",
+            "mak_rr_deepinfra_new",
+        ),
+        (
+            "mak_opaque",
+            "mak_rr_deepinfra_opaque",
+            1,
+            2,
+            "mak_opaque",
+            "mak_rr_dashscope_opaque",
+        ),
+        ("mak_opaque", None, None, 1, "mak_opaque", "mak_rr_dashscope_opaque"),
+    ],
+)
+def test_key_bundle_changes_use_one_processing_reconciliation_without_embedding_change(
+    monkeypatch: pytest.MonkeyPatch,
+    current_key: str,
+    current_rerank: str | None,
+    current_key_revision: int | None,
+    status_revision: int,
+    minted_key: str,
+    minted_rerank: str | None,
+) -> None:
+    state = {
+        "memory": _active_cloud_memory(
+            key=current_key,
+            rerank_access_key=current_rerank,
+            access_key_revision=current_key_revision,
+            revision=1,
+        )
+    }
+    prior_embedding_identity = state["memory"].runtime_embedding_identity()
+    prior_processing = state["memory"].runtime_processing()
+    requests: list[str] = []
+    reconciled: list[MemoryConfig] = []
+
+    class _Cloud:
+        @staticmethod
+        def runtime_credentials() -> tuple[str, str, str]:
+            return "https://backend.example.test", "instance-1", "device-secret"
+
+    config = SimpleNamespace(
+        remote_access=SimpleNamespace(vibe_cloud=_Cloud()),
+    )
+
+    def load() -> SimpleNamespace:
+        return SimpleNamespace(memory=deepcopy(state["memory"]))
+
+    def request(_config, _credentials, _method, suffix):
+        requests.append(suffix)
+        if suffix == "model-service":
+            return _status(revision=status_revision)
+        assert suffix == model_service.MODEL_ACCESS_KEY_SUFFIX
+        return _key_payload(
+            minted_key,
+            rerank_access_key=minted_rerank,
+            include_typed_keys=minted_rerank is not None,
+        )
+
+    def persist(_expected, candidate):
+        state["memory"] = deepcopy(candidate)
+        return SimpleNamespace(memory=deepcopy(candidate))
+
+    def reconcile(candidate):
+        reconciled.append(deepcopy(candidate))
+        return True
+
+    monkeypatch.setattr(model_service.V2Config, "load", load)
+    monkeypatch.setattr(model_service, "_paired_device_request", request)
+    monkeypatch.setattr(model_service, "_persist_candidate", persist)
+    monkeypatch.setattr(model_service, "_reconcile_candidate", reconcile)
+
+    result = model_service.sync_model_service_once(config)
+
+    assert result["ok"] is True
+    assert requests == ["model-service", model_service.MODEL_ACCESS_KEY_SUFFIX]
+    assert len(reconciled) == 1
+    assert state["memory"].cloud.model_access_key == minted_key
+    assert state["memory"].cloud.rerank_access_key == minted_rerank
+    assert state["memory"].cloud.access_key_revision == status_revision
+    assert state["memory"].runtime_processing() != prior_processing
+    assert state["memory"].runtime_embedding_identity() == prior_embedding_identity
+    assert state["memory"].cloud.applied_embedding_identity == "emb-v1"
+    assert state["memory"].cloud.transition_notice_pending is False
+
+
+@pytest.mark.parametrize("operation", ["ensure", "rotate"])
+def test_explicit_key_bundle_paths_use_the_typed_opt_in_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    state = {
+        "memory": _active_cloud_memory(
+            access_key_revision=None if operation == "ensure" else 4,
+            revision=4,
+        )
+    }
+    requests: list[tuple[str, str]] = []
+    reconciled: list[MemoryConfig] = []
+
+    class _Cloud:
+        @staticmethod
+        def runtime_credentials() -> tuple[str, str, str]:
+            return "https://backend.example.test", "instance-1", "device-secret"
+
+    config = SimpleNamespace(
+        remote_access=SimpleNamespace(vibe_cloud=_Cloud()),
+    )
+
+    def load() -> SimpleNamespace:
+        return SimpleNamespace(memory=deepcopy(state["memory"]))
+
+    def request(_config, _credentials, method, suffix):
+        requests.append((method, suffix))
+        return _key_payload(
+            "mak_rotated",
+            rerank_access_key="mak_rr_deepinfra_rotated",
+            include_typed_keys=True,
+        )
+
+    def persist(_expected, candidate):
+        state["memory"] = deepcopy(candidate)
+        return SimpleNamespace(memory=deepcopy(candidate))
+
+    def reconcile(candidate):
+        reconciled.append(deepcopy(candidate))
+        return True
+
+    monkeypatch.setattr(model_service.V2Config, "load", load)
+    monkeypatch.setattr(model_service, "_paired_device_request", request)
+    monkeypatch.setattr(model_service, "_persist_candidate", persist)
+    monkeypatch.setattr(model_service, "_reconcile_candidate", reconcile)
+
+    if operation == "ensure":
+        result = model_service.ensure_model_access_key(config)
+        assert result.memory == state["memory"]
+        assert reconciled == []
+    else:
+        result = model_service.rotate_model_access_key(config)
+        assert result["ok"] is True
+        assert len(reconciled) == 1
+
+    assert requests == [("POST", model_service.MODEL_ACCESS_KEY_SUFFIX)]
+    assert state["memory"].cloud.model_access_key == "mak_rotated"
+    assert state["memory"].cloud.rerank_access_key == (
+        "mak_rr_deepinfra_rotated"
+    )
+    assert state["memory"].cloud.access_key_revision == 4
 
 
 def test_enterprise_attachment_pauses_custom_without_recovery_marker() -> None:
@@ -111,6 +372,8 @@ def test_cloud_identity_change_keeps_last_applied_runtime_identity() -> None:
             embedding_identity="emb-v1",
             applied_embedding_identity="emb-v1",
             model_access_key="mak_first",
+            rerank_access_key="mak_rr_deepinfra_first",
+            access_key_revision=1,
             proxy_base_url="https://backend.example.test/v1/model",
             source_instance_id="instance-1",
         ),
@@ -247,6 +510,8 @@ def test_unpairing_fences_cloud_egress_and_retains_identity_baseline() -> None:
 
     assert fenced.runtime_source() == "unavailable"
     assert fenced.cloud.model_access_key is None
+    assert fenced.cloud.rerank_access_key is None
+    assert fenced.cloud.access_key_revision is None
     assert fenced.cloud.applied_embedding_identity == "emb-v1"
     assert fenced.cloud.runtime_apply_pending is True
 

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -321,7 +321,12 @@ def test_scrub_data_redacts_sensitive_values():
     event = {
         "request": {
             "headers": {"Authorization": "Bearer abc", "Cookie": "session=secret"},
-            "data": {"bot_token": "xoxb-secret", "nested": [{"client_secret": "shh"}]},
+            "data": {
+                "bot_token": "xoxb-secret",
+                "model_access_key": "mak_opaque",
+                "rerank_access_key": "mak_rr_deepinfra_opaque",
+                "nested": [{"client_secret": "shh"}],
+            },
         },
         "message": "token=abc123 and xapp-123456",
     }
@@ -331,6 +336,8 @@ def test_scrub_data_redacts_sensitive_values():
     assert scrubbed["request"]["headers"]["Authorization"] == "[Filtered]"
     assert scrubbed["request"]["headers"]["Cookie"] == "[Filtered]"
     assert scrubbed["request"]["data"]["bot_token"] == "[Filtered]"
+    assert scrubbed["request"]["data"]["model_access_key"] == "[Filtered]"
+    assert scrubbed["request"]["data"]["rerank_access_key"] == "[Filtered]"
     assert scrubbed["request"]["data"]["nested"][0]["client_secret"] == "[Filtered]"
     assert "[Filtered]" in scrubbed["message"]
 

--- a/tests/test_ui_memory_routes.py
+++ b/tests/test_ui_memory_routes.py
@@ -407,6 +407,78 @@ def test_embedding_identity_change_requires_loss_confirmation_before_preflight(
     assert V2Config.load().memory.processing.embedding.model == "embed-v1"
 
 
+def test_custom_rerank_candidate_failure_blocks_settings_persistence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(
+        MemoryConfig(
+            enabled=True,
+            mode="custom",
+            processing=MemoryProcessingConfig(
+                llm=MemoryEndpointConfig(
+                    "https://llm.example.test/v1",
+                    "chat",
+                    "llm-key",
+                ),
+                embedding=MemoryEndpointConfig(
+                    "https://embed.example.test/v1",
+                    "embed-v1",
+                    "embed-key",
+                ),
+            ),
+        )
+    )
+    preflights: list[dict[str, object]] = []
+
+    async def preflight(*, payload, user_key):
+        preflights.append({"payload": payload, "user_key": user_key})
+        return {
+            "status_code": 409,
+            "body": {
+                "ok": False,
+                "error": "memory_rerank_unavailable",
+                "diagnostic": {"side": "rerank", "message": "invalid_candidate"},
+            },
+        }
+
+    monkeypatch.setattr(internal_client, "memory_preflight", preflight)
+    client = app.test_client()
+    response = client.patch(
+        "/api/memory/settings",
+        json={
+            "processing": {
+                "rerank": {
+                    "base_url": "https://rerank.example.test/v1/inference",
+                    "model": "rerank-model",
+                    "api_key": "invalid-key",
+                    "provider": "deepinfra",
+                }
+            }
+        },
+        headers=csrf_headers(client, BASE_URL),
+        **_request_options(),
+    )
+
+    assert response.status_code == 409
+    assert response.get_json() == {
+        "status": "failed",
+        "error": "memory_rerank_unavailable",
+        "diagnostic": {"side": "rerank", "message": "invalid_candidate"},
+    }
+    assert len(preflights) == 1
+    candidate = preflights[0]["payload"]["memory"]
+    rerank = candidate["processing"]["rerank"]
+    assert rerank["base_url"] == "https://rerank.example.test/v1/inference"
+    assert rerank["model"] == "rerank-model"
+    assert rerank["api_key"] == "invalid-key"
+    assert rerank["provider"] == "deepinfra"
+    assert rerank["has_api_key"] is True
+    assert preflights[0]["user_key"] == "avibe:local"
+    assert V2Config.load().memory.processing.rerank is None
+
+
 def test_confirmed_embedding_identity_change_uses_unified_reconfigure(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,

--- a/tests/test_ui_memory_routes.py
+++ b/tests/test_ui_memory_routes.py
@@ -876,7 +876,7 @@ def test_ensured_active_bundle_remains_pending_when_settings_completion_fails(
 
 @pytest.mark.parametrize(
     "apply_outcome",
-    ["success", "concurrent_persistence", "failed"],
+    ["success", "concurrent_persistence"],
 )
 def test_successful_settings_reconcile_clears_only_the_exact_applied_bundle(
     apply_outcome: str,
@@ -899,11 +899,6 @@ def test_successful_settings_reconcile_clears_only_the_exact_applied_bundle(
                 return memory
 
             atomic_update_memory(update)
-        if apply_outcome == "failed" and len(reconciled) == 1:
-            return {
-                "status_code": 503,
-                "body": {"ok": False, "error": "memory_sidecar_unavailable"},
-            }
         return {"status_code": 200, "body": {"ok": True}}
 
     monkeypatch.setattr(
@@ -925,9 +920,8 @@ def test_successful_settings_reconcile_clears_only_the_exact_applied_bundle(
         **_request_options(),
     )
 
-    assert response.status_code == (503 if apply_outcome == "failed" else 200)
-    expected_reconciles = 2 if apply_outcome == "failed" else 1
-    assert len(reconciled) == expected_reconciles
+    assert response.status_code == 200
+    assert len(reconciled) == 1
     assert reconciled[0].cloud.rerank_access_key == "mak_rr_dashscope_opaque"
     assert reconciled[0].cloud.runtime_apply_pending is True
     persisted = V2Config.load().memory
@@ -937,6 +931,92 @@ def test_successful_settings_reconcile_clears_only_the_exact_applied_bundle(
         result = model_service.sync_model_service_once(_paired_model_service_config())
         assert result == {"ok": True, "configured": True, "changed": False}
         assert len(reconciled) == 1
+
+
+@pytest.mark.parametrize(
+    "rollback_outcome",
+    ["success", "failure", "concurrent_persistence"],
+)
+def test_failed_settings_apply_settles_only_a_successful_exact_rollback(
+    rollback_outcome: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    memory = _custom_memory_with_cloud_bundle(access_key_revision=1)
+    memory.mode = "platform"
+    memory.cloud.applied_embedding_identity = "cloud-emb-v2"
+    _save_config(memory)
+    reconciled: list[MemoryConfig] = []
+
+    async def reconcile_memory():
+        reconciled.append(deepcopy(V2Config.load().memory))
+        if len(reconciled) == 1:
+            return {
+                "status_code": 503,
+                "body": {"ok": False, "error": "memory_sidecar_unavailable"},
+            }
+        if rollback_outcome == "concurrent_persistence":
+
+            def update(memory: MemoryConfig) -> MemoryConfig:
+                memory.cloud.quota_enforced = True
+                return memory
+
+            atomic_update_memory(update)
+        applied = rollback_outcome != "failure"
+        return {
+            "status_code": 200 if applied else 503,
+            "body": {"ok": applied},
+        }
+
+    monkeypatch.setattr(
+        model_service,
+        "ensure_model_access_key",
+        _persist_refreshed_cloud_bundle,
+    )
+    monkeypatch.setattr(
+        model_service,
+        "_paired_device_request",
+        _current_model_service_status,
+    )
+    monkeypatch.setattr(internal_client, "reconcile_memory", reconcile_memory)
+    client = app.test_client()
+    response = client.patch(
+        "/api/memory/settings",
+        json={"enabled": False, "mode": "platform"},
+        headers=csrf_headers(client, BASE_URL),
+        **_request_options(),
+    )
+
+    assert response.status_code == 503
+    assert response.get_json() == {
+        "status": "failed",
+        "error": "memory_sidecar_unavailable",
+    }
+    assert len(reconciled) == 2
+    target, rollback = reconciled
+    assert target.enabled is False
+    assert rollback.enabled is True
+    for applied in (target, rollback):
+        assert applied.cloud.model_access_key == "mak_opaque"
+        assert applied.cloud.rerank_access_key == "mak_rr_dashscope_opaque"
+        assert applied.cloud.access_key_revision == 2
+        assert applied.cloud.runtime_apply_pending is True
+
+    restored = V2Config.load().memory
+    assert restored.enabled is True
+    assert restored.cloud.model_access_key == "mak_opaque"
+    assert restored.cloud.rerank_access_key == "mak_rr_dashscope_opaque"
+    assert restored.cloud.access_key_revision == 2
+    assert restored.cloud.runtime_apply_pending is (rollback_outcome != "success")
+    assert restored.cloud.quota_enforced is (
+        rollback_outcome == "concurrent_persistence"
+    )
+
+    if rollback_outcome == "success":
+        result = model_service.sync_model_service_once(_paired_model_service_config())
+        assert result == {"ok": True, "configured": True, "changed": False}
+        assert len(reconciled) == 2
 
 
 def test_successful_identity_reconfigure_clears_the_exact_applied_bundle(

--- a/tests/test_ui_memory_routes.py
+++ b/tests/test_ui_memory_routes.py
@@ -17,9 +17,10 @@ from config.v2_config import (
     RuntimeConfig,
     SlackConfig,
     V2Config,
+    atomic_update_memory,
 )
 from tests.ui_server_test_helpers import csrf_headers
-from vibe import internal_client, ui_memory_routes
+from vibe import internal_client, model_service, ui_memory_routes
 from vibe.ui_server import app
 
 
@@ -36,6 +37,48 @@ def _save_config(memory: MemoryConfig | None = None) -> None:
         agents=AgentsConfig(),
         memory=memory or MemoryConfig(),
     ).save()
+
+
+def _custom_memory_with_cloud_bundle(
+    *,
+    scope: str = "platform",
+    access_key_revision: int | None = 1,
+    transition_notice_pending: bool = False,
+) -> MemoryConfig:
+    return MemoryConfig(
+        enabled=True,
+        mode="custom",
+        processing=MemoryProcessingConfig(
+            llm=MemoryEndpointConfig(
+                "https://llm.example.test/v1",
+                "chat",
+                "llm-key",
+            ),
+            embedding=MemoryEndpointConfig(
+                "https://embed.example.test/v1",
+                "embed-v1",
+                "embed-key",
+            ),
+        ),
+        cloud=MemoryCloudConfig(
+            scope=scope,
+            capabilities=MemoryCloudCapabilities(
+                chat=True,
+                embedding=True,
+                memory_llm=True,
+            ),
+            memory_llm_source="chat_fallback",
+            embedding_identity="cloud-emb-v2",
+            applied_embedding_identity="cloud-emb-v1",
+            revision=2,
+            model_access_key="mak_opaque",
+            rerank_access_key="mak_rr_deepinfra_opaque",
+            access_key_revision=access_key_revision,
+            proxy_base_url="https://backend.example.test/v1/model",
+            source_instance_id="instance-1",
+            transition_notice_pending=transition_notice_pending,
+        ),
+    )
 
 
 def _local_headers() -> dict[str, str]:
@@ -477,6 +520,216 @@ def test_custom_rerank_candidate_failure_blocks_settings_persistence(
     assert rerank["has_api_key"] is True
     assert preflights[0]["user_key"] == "avibe:local"
     assert V2Config.load().memory.processing.rerank is None
+
+
+@pytest.mark.parametrize("access_key_revision", [None, 1])
+@pytest.mark.parametrize(
+    ("scope", "patch_payload"),
+    [
+        ("platform", {"mode": "platform", "confirm_loss": True}),
+        (
+            "organization",
+            {"acknowledge_transition": True, "confirm_loss": True},
+        ),
+    ],
+)
+def test_noncurrent_cloud_bundle_is_refreshed_before_settings_transition(
+    scope: str,
+    patch_payload: dict[str, object],
+    access_key_revision: int | None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(
+        _custom_memory_with_cloud_bundle(
+            scope=scope,
+            access_key_revision=access_key_revision,
+            transition_notice_pending=scope == "organization",
+        )
+    )
+    events: list[str] = []
+    preflights: list[dict[str, object]] = []
+    reconfigures: list[dict[str, object]] = []
+
+    def ensure(config: V2Config) -> V2Config:
+        events.append("ensure")
+        assert config.memory.mode == "custom"
+        assert config.memory.cloud.access_key_revision == access_key_revision
+
+        def refresh_bundle(memory: MemoryConfig) -> MemoryConfig:
+            memory.cloud.rerank_access_key = "mak_rr_dashscope_opaque"
+            memory.cloud.access_key_revision = 2
+            return memory
+
+        return atomic_update_memory(refresh_bundle)
+
+    async def preflight(*, payload, user_key):
+        events.append("preflight")
+        preflights.append({"payload": payload, "user_key": user_key})
+        return {"status_code": 200, "body": {"ok": True}}
+
+    async def reconfigure(*, confirm_loss, memory, expected_memory, user_key):
+        events.append("reconfigure")
+        reconfigures.append(
+            {
+                "confirm_loss": confirm_loss,
+                "memory": memory,
+                "expected_memory": expected_memory,
+                "user_key": user_key,
+            }
+        )
+        return {
+            "status_code": 200,
+            "body": {
+                "ok": True,
+                "operation": "reconfigure",
+                "state": "running",
+                "result": "completed",
+                "data_deleted": True,
+                "data_remaining": False,
+                "roots": [],
+            },
+        }
+
+    async def unexpected_reconcile():
+        pytest.fail("settings transition issued an extra reconciliation")
+
+    monkeypatch.setattr(model_service, "ensure_model_access_key", ensure)
+    monkeypatch.setattr(internal_client, "memory_preflight", preflight)
+    monkeypatch.setattr(internal_client, "memory_reconfigure", reconfigure)
+    monkeypatch.setattr(internal_client, "reconcile_memory", unexpected_reconcile)
+    client = app.test_client()
+
+    response = client.patch(
+        "/api/memory/settings",
+        json=patch_payload,
+        headers=csrf_headers(client, BASE_URL),
+        **_request_options(),
+    )
+
+    assert response.status_code == 200
+    assert events == ["ensure", "preflight", "reconfigure"]
+    assert len(preflights) == len(reconfigures) == 1
+    candidate_payload = reconfigures[0]["memory"]
+    assert preflights[0]["payload"]["memory"] == candidate_payload
+    candidate = ui_memory_routes._memory_candidate_config(  # noqa: SLF001
+        V2Config.load(),
+        candidate_payload,
+    ).memory
+    assert candidate.cloud.revision == 2
+    assert candidate.cloud.access_key_revision == 2
+    assert candidate.cloud.model_access_key == "mak_opaque"
+    assert candidate.cloud.rerank_access_key == "mak_rr_dashscope_opaque"
+    rerank = candidate.runtime_processing().rerank
+    assert candidate.runtime_source() == "cloud"
+    assert rerank is not None
+    assert rerank.api_key == "mak_rr_dashscope_opaque"
+    assert candidate.runtime_embedding_identity() == ("cloud", "cloud-emb-v2", None)
+    assert reconfigures[0]["confirm_loss"] is True
+    assert reconfigures[0]["user_key"] == "avibe:local"
+
+
+def test_current_cloud_bundle_skips_refresh_during_settings_transition(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(_custom_memory_with_cloud_bundle(access_key_revision=2))
+    events: list[str] = []
+    candidates: list[dict[str, object]] = []
+
+    def unexpected_ensure(_config: V2Config) -> V2Config:
+        raise AssertionError("current cloud bundle was refreshed")
+
+    async def preflight(*, payload, user_key):
+        events.append("preflight")
+        candidates.append(payload["memory"])
+        assert user_key == "avibe:local"
+        return {"status_code": 200, "body": {"ok": True}}
+
+    async def reconfigure(**_kwargs):
+        events.append("reconfigure")
+        return {
+            "status_code": 200,
+            "body": {
+                "ok": True,
+                "operation": "reconfigure",
+                "state": "running",
+                "result": "completed",
+                "data_deleted": True,
+                "data_remaining": False,
+                "roots": [],
+            },
+        }
+
+    monkeypatch.setattr(model_service, "ensure_model_access_key", unexpected_ensure)
+    monkeypatch.setattr(internal_client, "memory_preflight", preflight)
+    monkeypatch.setattr(internal_client, "memory_reconfigure", reconfigure)
+    client = app.test_client()
+
+    response = client.patch(
+        "/api/memory/settings",
+        json={"mode": "platform", "confirm_loss": True},
+        headers=csrf_headers(client, BASE_URL),
+        **_request_options(),
+    )
+
+    assert response.status_code == 200
+    assert events == ["preflight", "reconfigure"]
+    assert len(candidates) == 1
+    candidate = ui_memory_routes._memory_candidate_config(  # noqa: SLF001
+        V2Config.load(),
+        candidates[0],
+    ).memory
+    rerank = candidate.runtime_processing().rerank
+    assert rerank is not None
+    assert rerank.api_key == "mak_rr_deepinfra_opaque"
+
+
+def test_cloud_bundle_refresh_failure_does_not_apply_settings_transition(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    original = _custom_memory_with_cloud_bundle(access_key_revision=1)
+    _save_config(original)
+    downstream_calls: list[str] = []
+
+    def fail_ensure(_config: V2Config) -> V2Config:
+        raise model_service.ModelServiceResolutionError("cloud_request_failed")
+
+    async def preflight(**_kwargs):
+        downstream_calls.append("preflight")
+        return {"status_code": 200, "body": {"ok": True}}
+
+    async def reconfigure(**_kwargs):
+        downstream_calls.append("reconfigure")
+        return {"status_code": 200, "body": {"ok": True}}
+
+    monkeypatch.setattr(model_service, "ensure_model_access_key", fail_ensure)
+    monkeypatch.setattr(internal_client, "memory_preflight", preflight)
+    monkeypatch.setattr(internal_client, "memory_reconfigure", reconfigure)
+    client = app.test_client()
+
+    response = client.patch(
+        "/api/memory/settings",
+        json={"mode": "platform", "confirm_loss": True},
+        headers=csrf_headers(client, BASE_URL),
+        **_request_options(),
+    )
+
+    assert response.status_code == 503
+    assert response.get_json() == {
+        "status": "failed",
+        "error": "memory_store_unavailable",
+    }
+    assert downstream_calls == []
+    persisted = V2Config.load().memory
+    assert persisted.mode == "custom"
+    assert persisted.cloud.model_access_key == original.cloud.model_access_key
+    assert persisted.cloud.rerank_access_key == original.cloud.rerank_access_key
+    assert persisted.cloud.access_key_revision == 1
 
 
 def test_confirmed_embedding_identity_change_uses_unified_reconfigure(

--- a/tests/test_ui_memory_routes.py
+++ b/tests/test_ui_memory_routes.py
@@ -4,6 +4,7 @@ import ast
 import builtins
 from copy import deepcopy
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -19,9 +20,10 @@ from config.v2_config import (
     SlackConfig,
     V2Config,
     atomic_update_memory,
+    memory_config_from_payload,
 )
 from tests.ui_server_test_helpers import csrf_headers
-from vibe import internal_client, model_service, ui_memory_routes
+from vibe import api, internal_client, model_service, ui_memory_routes
 from vibe.ui_server import app
 
 
@@ -79,6 +81,48 @@ def _custom_memory_with_cloud_bundle(
             source_instance_id="instance-1",
             transition_notice_pending=transition_notice_pending,
         ),
+    )
+
+
+def _paired_model_service_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        remote_access=SimpleNamespace(
+            vibe_cloud=SimpleNamespace(
+                runtime_credentials=lambda: (
+                    "https://backend.example.test",
+                    "instance-1",
+                    "device-secret",
+                )
+            )
+        )
+    )
+
+
+def _current_model_service_status(_config, _credentials, method, suffix) -> dict:
+    assert (method, suffix) == ("GET", "model-service")
+    return {
+        "mode": "platform",
+        "capabilities": {
+            "asr": False,
+            "chat": True,
+            "embedding": True,
+            "multimodal": False,
+            "memory_llm": True,
+        },
+        "memory_llm_source": "chat_fallback",
+        "embedding_identity": "cloud-emb-v2",
+        "quota": {"enforced": False},
+        "revision": 2,
+    }
+
+
+def _persist_refreshed_cloud_bundle(config: V2Config) -> V2Config:
+    candidate = deepcopy(config.memory)
+    candidate.cloud.rerank_access_key = "mak_rr_dashscope_opaque"
+    candidate.cloud.access_key_revision = 2
+    return model_service._persist_candidate(  # noqa: SLF001
+        config.memory,
+        candidate,
     )
 
 
@@ -828,6 +872,146 @@ def test_ensured_active_bundle_remains_pending_when_settings_completion_fails(
     rerank = persisted.runtime_processing().rerank
     assert rerank is not None
     assert rerank.api_key == "mak_rr_dashscope_opaque"
+
+
+@pytest.mark.parametrize(
+    "apply_outcome",
+    ["success", "concurrent_persistence", "failed"],
+)
+def test_successful_settings_reconcile_clears_only_the_exact_applied_bundle(
+    apply_outcome: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    memory = _custom_memory_with_cloud_bundle(access_key_revision=1)
+    memory.mode = "platform"
+    memory.cloud.applied_embedding_identity = "cloud-emb-v2"
+    _save_config(memory)
+    reconciled: list[MemoryConfig] = []
+
+    async def reconcile_memory():
+        reconciled.append(deepcopy(V2Config.load().memory))
+        if apply_outcome == "concurrent_persistence" and len(reconciled) == 1:
+
+            def update(memory: MemoryConfig) -> MemoryConfig:
+                memory.cloud.quota_enforced = True
+                return memory
+
+            atomic_update_memory(update)
+        if apply_outcome == "failed" and len(reconciled) == 1:
+            return {
+                "status_code": 503,
+                "body": {"ok": False, "error": "memory_sidecar_unavailable"},
+            }
+        return {"status_code": 200, "body": {"ok": True}}
+
+    monkeypatch.setattr(
+        model_service,
+        "ensure_model_access_key",
+        _persist_refreshed_cloud_bundle,
+    )
+    monkeypatch.setattr(
+        model_service,
+        "_paired_device_request",
+        _current_model_service_status,
+    )
+    monkeypatch.setattr(internal_client, "reconcile_memory", reconcile_memory)
+    client = app.test_client()
+    response = client.patch(
+        "/api/memory/settings",
+        json={"mode": "platform"},
+        headers=csrf_headers(client, BASE_URL),
+        **_request_options(),
+    )
+
+    assert response.status_code == (503 if apply_outcome == "failed" else 200)
+    expected_reconciles = 2 if apply_outcome == "failed" else 1
+    assert len(reconciled) == expected_reconciles
+    assert reconciled[0].cloud.rerank_access_key == "mak_rr_dashscope_opaque"
+    assert reconciled[0].cloud.runtime_apply_pending is True
+    persisted = V2Config.load().memory
+    assert persisted.cloud.runtime_apply_pending is (apply_outcome != "success")
+
+    if apply_outcome == "success":
+        result = model_service.sync_model_service_once(_paired_model_service_config())
+        assert result == {"ok": True, "configured": True, "changed": False}
+        assert len(reconciled) == 1
+
+
+def test_successful_identity_reconfigure_clears_the_exact_applied_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    memory = _custom_memory_with_cloud_bundle(
+        access_key_revision=1,
+        transition_notice_pending=True,
+    )
+    memory.mode = "platform"
+    _save_config(memory)
+    reconfigured: list[MemoryConfig] = []
+    reconciled: list[MemoryConfig] = []
+
+    async def preflight(**_kwargs):
+        return {"status_code": 200, "body": {"ok": True}}
+
+    async def reconfigure(*, confirm_loss, memory, expected_memory, user_key):
+        assert confirm_loss is True
+        assert user_key == "avibe:local"
+        saved = api.save_memory_config(
+            memory,
+            expected=memory_config_from_payload(expected_memory),
+        )
+        reconfigured.append(deepcopy(saved.memory))
+        return {
+            "status_code": 200,
+            "body": {
+                "ok": True,
+                "operation": "reconfigure",
+                "state": "running",
+                "result": "completed",
+                "data_deleted": True,
+                "data_remaining": False,
+                "roots": [],
+            },
+        }
+
+    async def unexpected_reconcile():
+        reconciled.append(deepcopy(V2Config.load().memory))
+        return {"status_code": 200, "body": {"ok": True}}
+
+    monkeypatch.setattr(
+        model_service,
+        "ensure_model_access_key",
+        _persist_refreshed_cloud_bundle,
+    )
+    monkeypatch.setattr(
+        model_service,
+        "_paired_device_request",
+        _current_model_service_status,
+    )
+    monkeypatch.setattr(internal_client, "memory_preflight", preflight)
+    monkeypatch.setattr(internal_client, "memory_reconfigure", reconfigure)
+    monkeypatch.setattr(internal_client, "reconcile_memory", unexpected_reconcile)
+    client = app.test_client()
+    response = client.patch(
+        "/api/memory/settings",
+        json={"acknowledge_transition": True, "confirm_loss": True},
+        headers=csrf_headers(client, BASE_URL),
+        **_request_options(),
+    )
+
+    assert response.status_code == 200
+    assert len(reconfigured) == 1
+    assert reconfigured[0].cloud.rerank_access_key == "mak_rr_dashscope_opaque"
+    assert reconfigured[0].cloud.runtime_apply_pending is True
+    persisted = V2Config.load().memory
+    assert persisted.cloud.runtime_apply_pending is False
+
+    result = model_service.sync_model_service_once(_paired_model_service_config())
+    assert result == {"ok": True, "configured": True, "changed": False}
+    assert reconciled == []
 
 
 def test_confirmed_embedding_identity_change_uses_unified_reconfigure(

--- a/tests/test_ui_memory_routes.py
+++ b/tests/test_ui_memory_routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import builtins
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
@@ -730,6 +731,103 @@ def test_cloud_bundle_refresh_failure_does_not_apply_settings_transition(
     assert persisted.cloud.model_access_key == original.cloud.model_access_key
     assert persisted.cloud.rerank_access_key == original.cloud.rerank_access_key
     assert persisted.cloud.access_key_revision == 1
+
+
+@pytest.mark.parametrize(
+    ("downstream_outcome", "expected_status", "expected_events"),
+    [
+        ("preflight_failed", 409, ["ensure", "preflight"]),
+        ("reconfigure_failed", 500, ["ensure", "preflight", "reconfigure"]),
+        ("reconfigure_busy", 409, ["ensure", "preflight", "reconfigure"]),
+    ],
+)
+def test_ensured_active_bundle_remains_pending_when_settings_completion_fails(
+    downstream_outcome: str,
+    expected_status: int,
+    expected_events: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    memory = _custom_memory_with_cloud_bundle(
+        access_key_revision=1,
+        transition_notice_pending=True,
+    )
+    memory.mode = "platform"
+    _save_config(memory)
+    events: list[str] = []
+
+    def ensure(config: V2Config) -> V2Config:
+        events.append("ensure")
+        candidate = deepcopy(config.memory)
+        candidate.cloud.rerank_access_key = "mak_rr_dashscope_opaque"
+        candidate.cloud.access_key_revision = 2
+        return model_service._persist_candidate(  # noqa: SLF001
+            config.memory,
+            candidate,
+        )
+
+    async def preflight(**_kwargs):
+        events.append("preflight")
+        if downstream_outcome == "preflight_failed":
+            return {
+                "status_code": 409,
+                "body": {"ok": False, "error": "memory_processing_failed"},
+            }
+        return {"status_code": 200, "body": {"ok": True}}
+
+    async def reconfigure(**_kwargs):
+        events.append("reconfigure")
+        if downstream_outcome == "reconfigure_busy":
+            return {
+                "status_code": 409,
+                "body": {
+                    "ok": False,
+                    "operation": "reconfigure",
+                    "state": "busy",
+                    "result": "unchanged",
+                    "error": "memory_operation_in_progress",
+                },
+            }
+        return {
+            "status_code": 500,
+            "body": {
+                "ok": False,
+                "operation": "reconfigure",
+                "state": "failed",
+                "result": "failed",
+                "error": "memory_reconfigure_failed",
+            },
+        }
+
+    async def unexpected_reconcile():
+        pytest.fail("failed settings completion issued reconciliation")
+
+    monkeypatch.setattr(model_service, "ensure_model_access_key", ensure)
+    monkeypatch.setattr(internal_client, "memory_preflight", preflight)
+    monkeypatch.setattr(internal_client, "memory_reconfigure", reconfigure)
+    monkeypatch.setattr(internal_client, "reconcile_memory", unexpected_reconcile)
+    client = app.test_client()
+
+    response = client.patch(
+        "/api/memory/settings",
+        json={"acknowledge_transition": True, "confirm_loss": True},
+        headers=csrf_headers(client, BASE_URL),
+        **_request_options(),
+    )
+
+    assert response.status_code == expected_status
+    assert events == expected_events
+    persisted = V2Config.load().memory
+    assert persisted.mode == "platform"
+    assert persisted.cloud.transition_notice_pending is True
+    assert persisted.cloud.applied_embedding_identity == "cloud-emb-v1"
+    assert persisted.cloud.revision == persisted.cloud.access_key_revision == 2
+    assert persisted.cloud.rerank_access_key == "mak_rr_dashscope_opaque"
+    assert persisted.cloud.runtime_apply_pending is True
+    rerank = persisted.runtime_processing().rerank
+    assert rerank is not None
+    assert rerank.api_key == "mak_rr_dashscope_opaque"
 
 
 def test_confirmed_embedding_identity_change_uses_unified_reconfigure(

--- a/vibe/model_service.py
+++ b/vibe/model_service.py
@@ -431,7 +431,9 @@ def _persist_candidate(current: MemoryConfig, candidate: MemoryConfig) -> V2Conf
     )
 
 
-def _clear_apply_pending(expected: MemoryConfig) -> None:
+def clear_runtime_apply_pending(expected: MemoryConfig) -> V2Config:
+    """Clear pending only when *expected* is still the applied configuration."""
+
     from config.v2_config import atomic_update_memory
 
     def clear(current: MemoryConfig) -> MemoryConfig:
@@ -440,7 +442,7 @@ def _clear_apply_pending(expected: MemoryConfig) -> None:
         current.cloud.runtime_apply_pending = False
         return current
 
-    atomic_update_memory(clear)
+    return atomic_update_memory(clear)
 
 
 def _reconcile_candidate(candidate: MemoryConfig) -> bool:
@@ -455,7 +457,7 @@ def _reconcile_candidate(candidate: MemoryConfig) -> bool:
     if not isinstance(body, dict):
         return False
     if body.get("ok") is True:
-        _clear_apply_pending(candidate)
+        clear_runtime_apply_pending(candidate)
         return True
     return False
 
@@ -579,7 +581,7 @@ def rotate_model_access_key(config: V2Config | None = None) -> dict[str, Any]:
         if not _reconcile_candidate(saved):
             rollback = deepcopy(current)
             rollback.cloud.runtime_apply_pending = False
-            _persist_candidate(saved, rollback)
+            rollback = _persist_candidate(saved, rollback).memory
             _reconcile_candidate(rollback)
             raise ModelServiceResolutionError("model_access_key_apply_failed")
         return {

--- a/vibe/model_service.py
+++ b/vibe/model_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 import json
 import logging
@@ -18,6 +18,7 @@ from config.v2_config import (
     MemoryCloudLlmSource,
     MemoryConfig,
     V2Config,
+    managed_rerank_projection,
     memory_config_to_payload,
 )
 
@@ -26,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 MODEL_SERVICE_POLL_SECONDS = 60
 MODEL_SERVICE_REFRESH_PATH = "/api/model-service/refresh"
+MODEL_ACCESS_KEY_SUFFIX = "model-access-key?include_typed_keys=1"
 _SYNC_LOCK = threading.Lock()
 _WORKER_LOCK = threading.Lock()
 _REFRESH_EVENT = threading.Event()
@@ -51,7 +53,8 @@ class ModelServiceStatus:
 
 @dataclass(frozen=True)
 class ModelAccessKeyMint:
-    key: str
+    key: str = field(repr=False)
+    rerank_access_key: str | None = field(repr=False)
     created_at: str
     rotated: bool
     previous_valid_until: str | None
@@ -121,11 +124,15 @@ def _status_from_payload(payload: object) -> ModelServiceStatus:
 
 
 def _mint_from_payload(payload: object) -> ModelAccessKeyMint:
-    if not isinstance(payload, Mapping) or set(payload) != {
+    legacy_fields = {
         "key",
         "created_at",
         "rotated",
         "previous_valid_until",
+    }
+    if not isinstance(payload, Mapping) or set(payload) not in {
+        frozenset(legacy_fields),
+        frozenset((*legacy_fields, "typed_keys")),
     }:
         raise ModelServiceResolutionError("model_access_key_invalid_response")
     key = payload.get("key")
@@ -142,8 +149,16 @@ def _mint_from_payload(payload: object) -> ModelAccessKeyMint:
     created_at = _iso8601(payload.get("created_at"))
     previous = _iso8601(previous_valid_until, nullable=True)
     assert isinstance(created_at, str)
+    typed_keys = payload.get("typed_keys")
+    typed_rerank = typed_keys.get("rerank") if isinstance(typed_keys, Mapping) else None
+    rerank_access_key = (
+        typed_rerank
+        if managed_rerank_projection(key, typed_rerank) is not None
+        else None
+    )
     return ModelAccessKeyMint(
         key=key,
+        rerank_access_key=rerank_access_key,
         created_at=created_at,
         rotated=rotated,
         previous_valid_until=previous,
@@ -234,6 +249,8 @@ def _resolved_memory(
     if first_resolution:
         _cancel_organization_transition(candidate)
         candidate.cloud.model_access_key = None
+        candidate.cloud.rerank_access_key = None
+        candidate.cloud.access_key_revision = None
         candidate.cloud.organization_attached = False
     if candidate.mode is None:
         candidate.mode = _memory_mode_after_initialization(candidate)
@@ -248,6 +265,8 @@ def _resolved_memory(
     candidate.cloud.source_instance_id = instance_id
     if minted is not None:
         candidate.cloud.model_access_key = minted.key
+        candidate.cloud.rerank_access_key = minted.rerank_access_key
+        candidate.cloud.access_key_revision = status.revision
 
     if status.scope == "organization":
         if status.memory_available():
@@ -324,6 +343,8 @@ def _fenced_cloud_memory(current: MemoryConfig) -> MemoryConfig:
     had_cloud_state = bool(
         cloud.scope
         or cloud.model_access_key
+        or cloud.rerank_access_key
+        or cloud.access_key_revision is not None
         or cloud.proxy_base_url
         or cloud.source_instance_id
         or cloud.organization_attached
@@ -339,6 +360,8 @@ def _fenced_cloud_memory(current: MemoryConfig) -> MemoryConfig:
     candidate.cloud.revision = None
     candidate.cloud.quota_enforced = False
     candidate.cloud.model_access_key = None
+    candidate.cloud.rerank_access_key = None
+    candidate.cloud.access_key_revision = None
     candidate.cloud.proxy_base_url = None
     _cancel_organization_transition(candidate)
     candidate.cloud.runtime_apply_pending = (
@@ -478,14 +501,17 @@ def sync_model_service_once(config: V2Config | None = None) -> dict[str, Any]:
             changed = True
 
         current_key = current.cloud.model_access_key
-        if _status_needs_model_key(current, status) and not current_key:
+        if _status_needs_model_key(current, status) and (
+            not current_key
+            or current.cloud.access_key_revision != status.revision
+        ):
             try:
                 minted = _mint_from_payload(
                     _paired_device_request(
                         config,
                         credentials,
                         "POST",
-                        "model-access-key",
+                        MODEL_ACCESS_KEY_SUFFIX,
                     )
                 )
             except Exception:
@@ -533,11 +559,13 @@ def rotate_model_access_key(config: V2Config | None = None) -> dict[str, Any]:
                 config,
                 credentials,
                 "POST",
-                "model-access-key",
+                MODEL_ACCESS_KEY_SUFFIX,
             )
         )
         candidate = deepcopy(current)
         candidate.cloud.model_access_key = minted.key
+        candidate.cloud.rerank_access_key = minted.rerank_access_key
+        candidate.cloud.access_key_revision = current.cloud.revision
         candidate.cloud.runtime_apply_pending = True
         candidate.validate()
         saved = _persist_candidate(current, candidate).memory
@@ -571,18 +599,24 @@ def ensure_model_access_key(config: V2Config | None = None) -> V2Config:
             or current.cloud.scope not in {"platform", "organization"}
         ):
             raise ModelServiceResolutionError("model_service_not_configured")
-        if current.cloud.model_access_key:
+        if (
+            current.cloud.model_access_key
+            and current.cloud.access_key_revision is not None
+            and current.cloud.access_key_revision == current.cloud.revision
+        ):
             return V2Config.load()
         minted = _mint_from_payload(
             _paired_device_request(
                 config,
                 credentials,
                 "POST",
-                "model-access-key",
+                MODEL_ACCESS_KEY_SUFFIX,
             )
         )
         candidate = deepcopy(current)
         candidate.cloud.model_access_key = minted.key
+        candidate.cloud.rerank_access_key = minted.rerank_access_key
+        candidate.cloud.access_key_revision = current.cloud.revision
         candidate.validate()
         return _persist_candidate(current, candidate)
 

--- a/vibe/model_service.py
+++ b/vibe/model_service.py
@@ -416,8 +416,15 @@ def _paired_device_request(
 
 
 def _persist_candidate(current: MemoryConfig, candidate: MemoryConfig) -> V2Config:
+    """Persist a candidate with any required sidecar apply durably marked."""
+
     from vibe import api
 
+    candidate = deepcopy(candidate)
+    candidate.cloud.runtime_apply_pending = (
+        current.cloud.runtime_apply_pending
+        or _runtime_state_signature(candidate) != _runtime_state_signature(current)
+    )
     return api.save_memory_config(
         memory_config_to_payload(candidate, include_secrets=True),
         expected=current,

--- a/vibe/ui_memory_routes.py
+++ b/vibe/ui_memory_routes.py
@@ -389,7 +389,7 @@ async def _apply_memory_settings_patch(
     """Apply one settings change without durable recovery workflow state."""
 
     from config.v2_config import memory_config_to_payload
-    from vibe import api, internal_client
+    from vibe import api, internal_client, model_service
 
     async with _memory_settings_write_lock():
         try:
@@ -418,9 +418,7 @@ async def _apply_memory_settings_patch(
                 )
             )
             if needs_cloud_key:
-                from vibe.model_service import ensure_model_access_key
-
-                await asyncio.to_thread(ensure_model_access_key, current)
+                await asyncio.to_thread(model_service.ensure_model_access_key, current)
                 current = await asyncio.to_thread(V2Config.load)
                 target_payload, confirm_loss = _memory_settings_patch(
                     current,
@@ -501,7 +499,10 @@ async def _apply_memory_settings_patch(
             )
             if body.get("ok") is not True:
                 return _memory_operation_response(body, status_code)
-            latest = await asyncio.to_thread(V2Config.load)
+            latest = await asyncio.to_thread(
+                model_service.clear_runtime_apply_pending,
+                candidate.memory,
+            )
             return _memory_response(await _settings_ok_payload(latest, body))
 
         try:
@@ -549,7 +550,10 @@ async def _apply_memory_settings_patch(
                 {"status": "failed", "error": error},
                 status_code=409 if response.status_code < 500 else response.status_code,
             )
-        latest = await asyncio.to_thread(V2Config.load)
+        latest = await asyncio.to_thread(
+            model_service.clear_runtime_apply_pending,
+            saved.memory,
+        )
         return _memory_response(
             await _settings_ok_payload(latest, runtime_payload)
         )

--- a/vibe/ui_memory_routes.py
+++ b/vibe/ui_memory_routes.py
@@ -410,7 +410,12 @@ async def _apply_memory_settings_patch(
                     patch_payload.get("mode") == "platform"
                     or patch_payload.get("acknowledge_transition") is True
                 )
-                and not current.memory.cloud.model_access_key
+                and (
+                    not current.memory.cloud.model_access_key
+                    or current.memory.cloud.access_key_revision is None
+                    or current.memory.cloud.access_key_revision
+                    != current.memory.cloud.revision
+                )
             )
             if needs_cloud_key:
                 from vibe.model_service import ensure_model_access_key

--- a/vibe/ui_memory_routes.py
+++ b/vibe/ui_memory_routes.py
@@ -535,7 +535,7 @@ async def _apply_memory_settings_patch(
                 fallback="memory_sidecar_unavailable",
             )
             try:
-                await asyncio.to_thread(
+                rollback = await asyncio.to_thread(
                     api.save_memory_config,
                     memory_config_to_payload(
                         current.memory,
@@ -543,7 +543,17 @@ async def _apply_memory_settings_patch(
                     ),
                     expected=saved.memory,
                 )
-                await _memory_internal_response(internal_client.reconcile_memory)
+                rollback_payload, rollback_status = await _memory_internal_result(
+                    internal_client.reconcile_memory
+                )
+                if (
+                    rollback_status == 200
+                    and rollback_payload.get("ok") is True
+                ):
+                    await asyncio.to_thread(
+                        model_service.clear_runtime_apply_pending,
+                        rollback.memory,
+                    )
             except Exception:
                 pass
             return _memory_response(


### PR DESCRIPTION
## Outcome

Avibe now consumes managed rerank as one optional typed view of the existing Model Service access key. The key prefix selects one of the two released EverOS adapters; Avibe never receives provider credentials, upstream URLs, or real provider models.

Closes #1607. Companion producer PR: avibe-bot/avibe-backend#272 (tracks avibe-bot/avibe-backend#265).

## Governing decision

- Keep one `mak_` issuance, rotation, revocation, and refresh lifecycle.
- Accept the legacy key response and the opt-in typed bundle from the same Backend endpoint.
- Project only `mak_rr_deepinfra_` and `mak_rr_dashscope_` through one closed mapping.
- Persist only the optional typed secret, not a separate provider/capability state.
- Keep rerank optional for basic Memory while preserving agentic recall's existing fail-closed behavior.

## Important invariants

- Unknown, malformed, missing, or fenced typed keys disable only managed rerank.
- Custom rerank configuration is never overwritten.
- Typed-key changes use the existing reconciliation revision and trigger one sidecar reconcile.
- Rerank changes do not alter embedding identity, clear Memory data, or rebuild the vector index.
- Startup and basic processing health exclude rerank; agentic recall still requires a healthy reranker.
- Typed key material follows the existing Model Service secret projection and redaction boundaries.

## Scope

In scope:

- Legacy/typed model-access-key response compatibility.
- Typed secret persistence, refresh, fencing, and redaction.
- Closed projection to the DeepInfra and DashScope EverOS adapters.
- Optional-rerank startup and processing health behavior.

Explicitly deferred:

- `mak_rr_vllm_` and managed vLLM projection.
- Managed rerank UI, status objects, provider state, or a separate lifecycle.
- Changes to existing custom rerank behavior.

## Evidence

- Unit/contract: `271 passed` across the focused Model Service and Memory files.
- Broad Memory suite: `789 passed, 13 skipped` after excluding three independently environment-bound files.
- Internal client/server suite: `224 passed, 2 deselected`; the two deselections require the optional `ijson` dependency.
- Config/API suite: `149 passed`.
- Scenario: `MEMORY-SEARCH-019` covers optional rerank failure for basic Memory and fail-closed agentic recall.
- Static: Ruff passed on every changed Python file; `git diff --check` passed.
- Closed-prefix scan: no `mak_rr_vllm_` managed mapping or enumeration.

## Known by design / residual checks

- Backend #265 must deploy before this consumer change.
- New Avibe against an older Backend degrades to basic Memory with managed rerank disabled.
- No production/provider credential or deployed cross-repository E2E probe was used locally; backend-first staging verification remains the residual manual check.
