### PR TITLE
fix(model-hub): one ink height for every vendor mark

### DIFF
--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -812,10 +812,16 @@
    second px value that could be changed without the first. It is wider than it
    is tall because a mark is not: matching cap heights across a wordmark and a
    monogram needs the room the widest of them asks for, and a fixed slot is what
-   keeps the labels beside them in one column. */
+   keeps the labels beside them in one column.
+   `width: auto` is what makes "the height is the only size" true rather than
+   merely intended: a ratio decides a width only while the other one is
+   indefinite, so a drawing arriving with its own `width` attribute — every
+   lucide icon ships `width="24" height="24"` — would otherwise keep that width
+   beside the shared height and push its label out of the column. */
 .model-hub-add-key-protocol-glyph,
 .model-hub-add-key-vendor-glyph {
   height: 14px;
+  width: auto;
   aspect-ratio: 10 / 7;
   flex-shrink: 0;
 }

--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -804,12 +804,19 @@
   font-weight: 600;
 }
 /* Interface glyphs and vendor marks are one visual family at one size, so they
-   share the rule rather than each declaring 14px and drifting apart. Two names
-   because a vendor's logo is not a statement about its interface. */
+   share the rule rather than each declaring a height and drifting apart. Two
+   names because a vendor's logo is not a statement about its interface.
+   The height is the only size here: `vendorMarks.ts` boxes every mark into a
+   10:7 box holding 19 units of ink in 24, so one height is one ink height for
+   all of them, and the slot takes that shape from the ratio rather than from a
+   second px value that could be changed without the first. It is wider than it
+   is tall because a mark is not: matching cap heights across a wordmark and a
+   monogram needs the room the widest of them asks for, and a fixed slot is what
+   keeps the labels beside them in one column. */
 .model-hub-add-key-protocol-glyph,
 .model-hub-add-key-vendor-glyph {
-  width: 14px;
   height: 14px;
+  aspect-ratio: 10 / 7;
   flex-shrink: 0;
 }
 .model-hub-add-key-action {

--- a/ui/src/components/settings/models/protocolGlyph.tsx
+++ b/ui/src/components/settings/models/protocolGlyph.tsx
@@ -2,39 +2,24 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 import type { SourceProtocol } from './types';
-import { ANTHROPIC_MARK, OPENAI_MARK } from './vendorGlyph';
+import { Mark } from './vendorGlyph';
+import { ANTHROPIC_MARK, OPENAI_MARK } from './vendorMarks';
 
 type GlyphProps = React.SVGProps<SVGSVGElement>;
 
 const glyphClassName = (className?: string) => cn('model-hub-add-key-protocol-glyph', className);
 
 // A protocol family is named after the vendor that published it, so its glyph is
-// that vendor's mark. The artwork lives with the other vendor marks; this file
-// owns only the mapping from an interface to the one that stands for it.
+// that vendor's mark. The artwork lives with the other vendor marks and is drawn
+// by their `Mark`, which is what keeps one piece of artwork at one optical size
+// in a dialog that shows it as both an interface and a vendor. This file owns
+// only the mapping from an interface to the mark that stands for it.
 export const AnthropicGlyph: React.FC<GlyphProps> = ({ className, ...props }) => (
-  <svg
-    viewBox="0 0 24 24"
-    aria-hidden="true"
-    focusable="false"
-    fill="currentColor"
-    className={glyphClassName(className)}
-    {...props}
-  >
-    <path d={ANTHROPIC_MARK} />
-  </svg>
+  <Mark mark={ANTHROPIC_MARK} className={glyphClassName(className)} {...props} />
 );
 
 export const OpenAIGlyph: React.FC<GlyphProps> = ({ className, ...props }) => (
-  <svg
-    viewBox="0 0 24 24"
-    aria-hidden="true"
-    focusable="false"
-    fill="currentColor"
-    className={glyphClassName(className)}
-    {...props}
-  >
-    <path d={OPENAI_MARK} />
-  </svg>
+  <Mark mark={OPENAI_MARK} className={glyphClassName(className)} {...props} />
 );
 
 export const ProtocolGlyph: React.FC<{ protocol: SourceProtocol; className?: string }> = ({

--- a/ui/src/components/settings/models/vendorGlyph.test.tsx
+++ b/ui/src/components/settings/models/vendorGlyph.test.tsx
@@ -3,21 +3,43 @@
 // properties held here are drawn-at-all and drawn-once — asserted over whatever
 // the shipped catalog contains rather than over a list restated in the test,
 // which would keep passing for the twelve rows it knew about.
+//
+// The size properties are here for the same reason. Marks arrive filling
+// anything from 70% to 100% of the box they were authored in, so what the CSS
+// slot renders is one height only if every mark is re-boxed to the same ink
+// fraction first — and that is checkable without a browser, because the box is
+// in the DOM and the ink is recorded beside the path. What no jsdom test can
+// see is a cap height a font actually produces; that is what the proof page in
+// the PR is for.
 import { cleanup, render } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { API_KEY_VENDOR_PRESETS, CUSTOM_VENDOR } from './apiKeyVendors';
 import { VendorGlyph } from './vendorGlyph';
+import { VENDOR_MARKS } from './vendorMarks';
 
 afterEach(cleanup);
 
 /** Every choice the 服务商 field offers, including the one that is not a vendor. */
 const CHOICES = [CUSTOM_VENDOR, ...API_KEY_VENDOR_PRESETS.map((preset) => preset.id)];
 
+/** The rule `vendorMarks.ts` boxes by, restated so that changing it there has
+ *  to be a decision here too: ink filling 19 of the 24 units of a 10:7 box. */
+const INK_FRACTION = 19 / 24;
+const BOX_ASPECT = 10 / 7;
+
 const glyphOf = (vendor: string) => {
   const { container, unmount } = render(<VendorGlyph vendor={vendor} />);
   const svg = container.querySelector('svg');
-  const drawn = { className: svg?.getAttribute('class') ?? '', hidden: svg?.getAttribute('aria-hidden'), art: svg?.innerHTML ?? '', markup: svg?.outerHTML ?? '' };
+  const [x, y, width, height] = (svg?.getAttribute('viewBox') ?? '').split(' ').map(Number);
+  const drawn = {
+    className: svg?.getAttribute('class') ?? '',
+    hidden: svg?.getAttribute('aria-hidden'),
+    art: svg?.innerHTML ?? '',
+    markup: svg?.outerHTML ?? '',
+    box: { x, y, width, height },
+    letter: svg?.querySelector('text'),
+  };
   unmount();
   return drawn;
 };
@@ -35,6 +57,35 @@ describe('VendorGlyph', () => {
       // Theme-following means the ink comes from the text around it. A baked
       // channel would be a light-theme defect nobody sees while developing dark.
       expect(glyph.markup, `${vendor} bakes its own color`).not.toMatch(/#[\da-f]{3,8}\b|\b(?:rgba?|hsla?|oklch)\(/i);
+    }
+  });
+
+  it('gives every choice a box of one shape, so one CSS height is one ink height', () => {
+    for (const vendor of CHOICES) {
+      const { box, letter } = glyphOf(vendor);
+      expect(box.width / box.height, `${vendor} is drawn in a box of its own shape`)
+        .toBeCloseTo(BOX_ASPECT, 3);
+      // A letter stands in for solid artwork, so it has to carry a comparable
+      // weight: at the same height, a regular one still reads as the lighter
+      // neighbour, which is half of what made the letters look wrong at all.
+      if (letter) expect(letter.getAttribute('font-weight'), `${vendor} draws a light letter`).toBe('700');
+    }
+  });
+
+  it('centres every mark inside that box at the one ink height, and none overflows it', () => {
+    for (const [vendor, mark] of Object.entries(VENDOR_MARKS)) {
+      const [x, y, width, height] = mark!.ink;
+      const { box } = glyphOf(vendor);
+      expect(height / box.height, `${vendor} puts a different amount of ink on screen`)
+        .toBeCloseTo(INK_FRACTION, 3);
+      expect(x + width / 2, `${vendor} sits off-centre horizontally`)
+        .toBeCloseTo(box.x + box.width / 2, 2);
+      expect(y + height / 2, `${vendor} sits off-centre vertically`)
+        .toBeCloseTo(box.y + box.height / 2, 2);
+      // Ink wider than its box is ink the slot clips. Nothing shipped is close,
+      // but a wordmark could be: the box is 1.80 ink-widths per ink-height, and
+      // artwork past that needs a wider slot, not a quiet crop.
+      expect(width, `${vendor} is too wide for the shared slot`).toBeLessThanOrEqual(box.width);
     }
   });
 

--- a/ui/src/components/settings/models/vendorGlyph.tsx
+++ b/ui/src/components/settings/models/vendorGlyph.tsx
@@ -1,15 +1,10 @@
-// Vendor marks for the API-key 服务商 picker.
+// Drawing for the API-key 服务商 picker: one mark per choice, all at one size.
 //
-// One mark per catalog id, never one per protocol: DeepSeek and OpenAI sit in
-// the same list, so drawing the OpenAI flower for both would remove the only
-// thing a mark is there for. Each is the vendor's own single-path Simple Icons
-// artwork, inlined as `currentColor` geometry in the same 24-unit box as
-// `protocolGlyph.tsx` — nothing to load, no brand fill, and Light/Dark follow
-// the surrounding text.
-//
-// Anthropic and OpenAI are defined here because a protocol family is named
-// after the vendor that published it: `protocolGlyph.tsx` reads these two
-// rather than keeping a second copy of the same artwork.
+// The artwork and the optical rule it is drawn by live in `vendorMarks.ts`. This
+// file is only the three ways a choice becomes ink — a vendor's own mark, a
+// letter for the vendors that publish none, and the field's own subject for
+// 自定义 — each of which reaches that same box, so the shared CSS slot renders
+// one ink height for the whole list rather than one per drawing style.
 //
 // Five shipped vendors publish no single-color mark Simple Icons carries. They
 // draw their initial in the same box instead: a letter is honest about standing
@@ -23,45 +18,46 @@ import { Globe } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { apiKeyVendorPreset, CUSTOM_VENDOR } from './apiKeyVendors';
-
-/** The two marks `protocolGlyph.tsx` also draws: a protocol family is named
- *  after the vendor that published it, so the artwork is shared, not copied. */
-export const ANTHROPIC_MARK = 'M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z';
-
-export const OPENAI_MARK = 'M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z';
-
-const MARKS: Record<string, string | undefined> = {
-  deepseek: 'M23.748 4.651c-.254-.124-.364.113-.512.233-.051.04-.094.09-.137.137-.372.397-.806.657-1.373.626-.829-.046-1.537.214-2.163.848-.133-.782-.575-1.248-1.247-1.548-.352-.155-.708-.311-.955-.65-.172-.24-.219-.509-.305-.774-.055-.16-.11-.323-.293-.35-.2-.031-.278.136-.356.276-.313.572-.434 1.202-.422 1.84.027 1.436.633 2.58 1.838 3.393.137.094.172.187.129.323-.082.28-.18.553-.266.833-.055.179-.137.218-.328.14a5.5 5.5 0 0 1-1.737-1.179c-.857-.828-1.631-1.743-2.597-2.46a12 12 0 0 0-.689-.47c-.985-.957.13-1.743.387-1.836.27-.098.094-.433-.778-.428-.872.003-1.67.295-2.687.685a3 3 0 0 1-.465.136 9.6 9.6 0 0 0-2.883-.101c-1.885.21-3.39 1.1-4.497 2.622C.082 8.776-.231 10.854.152 13.02c.403 2.284 1.568 4.175 3.36 5.653 1.857 1.533 3.997 2.284 6.438 2.14 1.482-.085 3.132-.284 4.994-1.86.47.234.962.328 1.78.398.629.058 1.235-.031 1.705-.129.735-.155.684-.836.418-.961-2.155-1.004-1.682-.595-2.112-.926 1.095-1.295 2.768-3.598 3.284-6.733.05-.346.115-.834.108-1.114-.004-.171.035-.238.23-.257a4.2 4.2 0 0 0 1.545-.475c1.397-.763 1.96-2.016 2.093-3.517.02-.23-.004-.467-.247-.588M11.58 18.168c-2.088-1.642-3.101-2.183-3.52-2.16-.39.024-.32.472-.234.763.09.288.207.487.371.74.114.167.192.416-.113.603-.673.416-1.842-.14-1.897-.168-1.361-.801-2.5-1.86-3.301-3.306-.775-1.393-1.225-2.888-1.299-4.482-.02-.385.094-.522.477-.592a4.7 4.7 0 0 1 1.53-.038c2.131.311 3.946 1.264 5.467 2.774.868.86 1.525 1.887 2.202 2.89.72 1.066 1.494 2.082 2.48 2.915.348.291.626.513.892.677-.802.09-2.14.109-3.055-.615zm1.001-6.44a.306.306 0 0 1 .415-.287.3.3 0 0 1 .113.074.3.3 0 0 1 .086.214c0 .17-.136.307-.308.307a.303.303 0 0 1-.306-.307m3.11 1.596c-.2.081-.4.151-.591.16a1.25 1.25 0 0 1-.798-.254c-.274-.23-.47-.358-.551-.758a1.7 1.7 0 0 1 .015-.588c.07-.327-.007-.537-.238-.727-.188-.156-.426-.199-.689-.199a.6.6 0 0 1-.254-.078.253.253 0 0 1-.114-.358 1 1 0 0 1 .192-.21c.356-.202.767-.136 1.146.016.352.144.618.408 1.001.782.392.451.462.576.685.915.176.264.336.536.446.848.066.194-.02.353-.25.45',
-  qwen: 'M23.919 14.545 20.817 9.17l1.47-2.544a.56.56 0 0 0 0-.566l-1.633-2.83a.57.57 0 0 0-.49-.283h-6.207L12.487.402a.57.57 0 0 0-.49-.284H8.732a.56.56 0 0 0-.49.284L5.139 5.775h-2.94a.56.56 0 0 0-.49.284L.077 8.887a.56.56 0 0 0 0 .567L3.18 14.83l-1.47 2.545a.56.56 0 0 0 0 .566l1.634 2.83a.57.57 0 0 0 .49.283h6.205l1.47 2.545a.57.57 0 0 0 .49.284h3.266a.57.57 0 0 0 .49-.284l3.104-5.375h2.94a.57.57 0 0 0 .49-.283l1.634-2.828a.55.55 0 0 0-.004-.568M8.733.686l1.634 2.828-1.634 2.828H21.8L20.164 9.17H7.425L5.63 6.06Zm1.306 19.801-6.205-.002 1.634-2.83h3.265L2.201 6.344h3.267q3.182 5.517 6.367 11.032zm10.124-5.66L18.53 12l-6.532 11.315-1.634-2.83c2.129-3.673 4.25-7.351 6.373-11.028h3.592l3.102 5.374z',
-  kimi: 'M21.765.351C22.998.351 24 1.353 24 2.586S22.998 4.82 21.765 4.82h-1.974c-.15 0-.26-.12-.26-.26V2.586A2.237 2.237 0 0 1 21.765.35M9.41 13.388l8.447-8.377c.16-.16.07-.471-.14-.471h-4.55s-.1.02-.14.06l-9.099 9.029c-.14.14-.35.02-.35-.21V4.81c0-.15-.1-.27-.221-.27H.22c-.12 0-.22.12-.22.27v18.57c0 .15.1.27.22.27h3.137c.12 0 .22-.12.22-.27v-3.79c0-.08.03-.16.08-.21l2.826-2.796c.07-.07.16-.08.241-.03l7.546 5.551a8.9 8.9 0 0 0 4.018 1.493c.12.01.23-.11.23-.27V19.76c0-.14-.08-.25-.19-.26a5.8 5.8 0 0 1-2.355-.942l-6.533-4.73c-.14-.09-.15-.32-.03-.441',
-  openrouter: 'M16.778 1.844v1.919q-.569-.026-1.138-.032-.708-.008-1.415.037c-1.93.126-4.023.728-6.149 2.237-2.911 2.066-2.731 1.95-4.14 2.75-.396.223-1.342.574-2.185.798-.841.225-1.753.333-1.751.333v4.229s.768.108 1.61.333c.842.224 1.789.575 2.185.799 1.41.798 1.228.683 4.14 2.75 2.126 1.509 4.22 2.11 6.148 2.236.88.058 1.716.041 2.555.005v1.918l7.222-4.168-7.222-4.17v2.176c-.86.038-1.611.065-2.278.021-1.364-.09-2.417-.357-3.979-1.465-2.244-1.593-2.866-2.027-3.68-2.508.889-.518 1.449-.906 3.822-2.59 1.56-1.109 2.614-1.377 3.978-1.466.667-.044 1.418-.017 2.278.02v2.176L24 6.014Z',
-  mistral: 'M17.143 3.429v3.428h-3.429v3.429h-3.428V6.857H6.857V3.43H3.43v13.714H0v3.428h10.286v-3.428H6.857v-3.429h3.429v3.429h3.429v-3.429h3.428v3.429h-3.428v3.428H24v-3.428h-3.43V3.429z',
-  openai: OPENAI_MARK,
-  anthropic: ANTHROPIC_MARK,
-};
+import {
+  BOX_HEIGHT,
+  GLOBE_INK,
+  INK_HEIGHT,
+  markViewBox,
+  VENDOR_MARKS,
+  type VendorMark,
+} from './vendorMarks';
 
 const glyphClassName = (className?: string) => cn('model-hub-add-key-vendor-glyph', className);
 
-const Mark: React.FC<{ path: string; className?: string }> = ({ path, className }) => (
-  <svg
-    viewBox="0 0 24 24"
-    aria-hidden="true"
-    focusable="false"
-    fill="currentColor"
-    className={glyphClassName(className)}
-  >
-    <path d={path} />
+/** The one place a mark becomes pixels. `protocolGlyph.tsx` draws through this
+ *  too, so the two marks it shares cannot end up at a different size. */
+export const Mark: React.FC<{ mark: VendorMark } & React.SVGProps<SVGSVGElement>> = ({
+  mark,
+  ...props
+}) => (
+  <svg viewBox={markViewBox(mark.ink)} aria-hidden="true" focusable="false" fill="currentColor" {...props}>
+    <path d={mark.path} />
   </svg>
 );
 
+/** A letter has no ink to measure ahead of time, so it reaches the same box from
+ *  the other side: a cap height is a known fraction of a font size, ~0.70–0.73
+ *  across this app's sans stack, so 26 puts the cap at 18.2–19.2 units and the
+ *  baseline at `12 + INK_HEIGHT / 2` centres it. Weight 700 answers the other
+ *  half of the complaint this rule exists for — a regular-weight letter is not
+ *  only shorter than a solid mark, it is thinner. */
 const Monogram: React.FC<{ letter: string; className?: string }> = ({ letter, className }) => (
-  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" className={glyphClassName(className)}>
+  <svg
+    viewBox={markViewBox([0, 12 - INK_HEIGHT / 2, BOX_HEIGHT, INK_HEIGHT])}
+    aria-hidden="true"
+    focusable="false"
+    className={glyphClassName(className)}
+  >
     <text
       x="12"
-      y="12"
+      y={12 + INK_HEIGHT / 2}
       textAnchor="middle"
-      dominantBaseline="central"
-      fontSize="19"
+      fontSize="26"
       fontWeight="700"
       fill="currentColor"
     >
@@ -75,9 +71,18 @@ const Monogram: React.FC<{ letter: string; className?: string }> = ({ letter, cl
  * the field's own subject, an address you supply.
  */
 export const VendorGlyph: React.FC<{ vendor: string; className?: string }> = ({ vendor, className }) => {
-  if (vendor === CUSTOM_VENDOR) return <Globe aria-hidden="true" focusable="false" className={glyphClassName(className)} />;
-  const mark = MARKS[vendor];
-  if (mark) return <Mark path={mark} className={className} />;
+  if (vendor === CUSTOM_VENDOR) {
+    return (
+      <Globe
+        viewBox={markViewBox(GLOBE_INK)}
+        aria-hidden="true"
+        focusable="false"
+        className={glyphClassName(className)}
+      />
+    );
+  }
+  const mark = VENDOR_MARKS[vendor];
+  if (mark) return <Mark mark={mark} className={glyphClassName(className)} />;
   const label = apiKeyVendorPreset(vendor)?.label ?? vendor;
   return <Monogram letter={Array.from(label.trim())[0].toUpperCase()} className={className} />;
 };

--- a/ui/src/components/settings/models/vendorMarks.ts
+++ b/ui/src/components/settings/models/vendorMarks.ts
@@ -1,0 +1,97 @@
+// The artwork behind the API-key 服务商 picker, and the one optical rule every
+// piece of it is drawn by.
+//
+// One mark per catalog id, never one per protocol: DeepSeek and OpenAI sit in
+// the same list, so drawing the OpenAI flower for both would remove the only
+// thing a mark is there for. Each is the vendor's own single-path Simple Icons
+// artwork, inlined as `currentColor` geometry — nothing to load, no brand fill,
+// and Light/Dark follow the surrounding text.
+//
+// The rule exists because the artwork does not agree on how much of the 24-unit
+// box it ships in to fill: the OpenAI flower reaches every edge, the Anthropic A
+// is 24 wide and 17 tall, a letter drawn at font size is smaller still. So no
+// mark is drawn in the box it arrived in. Each one's measured ink is re-centred
+// in a box scaled to hold `INK_HEIGHT` of it, which leaves ink height the one
+// thing the whole set has in common — 11px of it at the shared CSS slot,
+// whatever the outline. The numbers here are measurements, not taste.
+//
+// This is a module of data and one function rather than part of `vendorGlyph.tsx`
+// because a module exporting both components and values opts out of fast
+// refresh. `protocolGlyph.tsx` reads two of these marks: a protocol family is
+// named after the vendor that published it, and both files drawing through the
+// same `Mark` is what keeps one piece of artwork at one size in one dialog.
+
+/** How much of the box's height a mark's ink occupies, and the box that holds
+ *  it. 19 of 24 leaves equal 2.5-unit margins above and below every mark; the
+ *  10:7 shape is wide enough for the widest ink here (an aspect of 1.80:1) and
+ *  is the shape `.model-hub-add-key-vendor-glyph` renders, so nothing is
+ *  letterboxed and one CSS height fixes one ink height for the whole set. */
+export const INK_HEIGHT = 19;
+export const BOX_HEIGHT = 24;
+export const BOX_ASPECT = 10 / 7;
+
+/** The bounds a drawing's ink occupies, `[x, y, width, height]`, inside the
+ *  24-unit box the artwork was authored in. Measured with `getBBox()` in a
+ *  browser — jsdom cannot compute one, and the artwork is static, so the
+ *  measurement is recorded here rather than taken at render. Re-measure if a
+ *  path changes: `vendorGlyph.test.tsx` checks the ink still fits the box the
+ *  rule gives it, not that these four numbers still describe the path. */
+export type Ink = readonly [x: number, y: number, width: number, height: number];
+
+/** A mark: the artwork, and where its ink sits. */
+export type VendorMark = { path: string; ink: Ink };
+
+/** The viewBox that puts `ink` at `INK_HEIGHT` of the box's `BOX_HEIGHT`,
+ *  centred both ways. */
+export const markViewBox = ([x, y, w, h]: Ink) => {
+  const height = (h * BOX_HEIGHT) / INK_HEIGHT;
+  const width = height * BOX_ASPECT;
+  return [x + w / 2 - width / 2, y + h / 2 - height / 2, width, height]
+    .map((n) => Number(n.toFixed(3)))
+    .join(' ');
+};
+
+/** The two marks `protocolGlyph.tsx` also draws. */
+export const ANTHROPIC_MARK: VendorMark = {
+  path: 'M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z',
+  ink: [0, 3.54, 24, 16.92],
+};
+
+export const OPENAI_MARK: VendorMark = {
+  path: 'M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z',
+  ink: [0.16, 0, 23.67, 24],
+};
+
+/** The marks the shipped catalog has artwork for. Exported whole for the
+ *  optical property `vendorGlyph.test.tsx` holds over every one of them. */
+export const VENDOR_MARKS: Record<string, VendorMark | undefined> = {
+  deepseek: {
+    path: 'M23.748 4.651c-.254-.124-.364.113-.512.233-.051.04-.094.09-.137.137-.372.397-.806.657-1.373.626-.829-.046-1.537.214-2.163.848-.133-.782-.575-1.248-1.247-1.548-.352-.155-.708-.311-.955-.65-.172-.24-.219-.509-.305-.774-.055-.16-.11-.323-.293-.35-.2-.031-.278.136-.356.276-.313.572-.434 1.202-.422 1.84.027 1.436.633 2.58 1.838 3.393.137.094.172.187.129.323-.082.28-.18.553-.266.833-.055.179-.137.218-.328.14a5.5 5.5 0 0 1-1.737-1.179c-.857-.828-1.631-1.743-2.597-2.46a12 12 0 0 0-.689-.47c-.985-.957.13-1.743.387-1.836.27-.098.094-.433-.778-.428-.872.003-1.67.295-2.687.685a3 3 0 0 1-.465.136 9.6 9.6 0 0 0-2.883-.101c-1.885.21-3.39 1.1-4.497 2.622C.082 8.776-.231 10.854.152 13.02c.403 2.284 1.568 4.175 3.36 5.653 1.857 1.533 3.997 2.284 6.438 2.14 1.482-.085 3.132-.284 4.994-1.86.47.234.962.328 1.78.398.629.058 1.235-.031 1.705-.129.735-.155.684-.836.418-.961-2.155-1.004-1.682-.595-2.112-.926 1.095-1.295 2.768-3.598 3.284-6.733.05-.346.115-.834.108-1.114-.004-.171.035-.238.23-.257a4.2 4.2 0 0 0 1.545-.475c1.397-.763 1.96-2.016 2.093-3.517.02-.23-.004-.467-.247-.588M11.58 18.168c-2.088-1.642-3.101-2.183-3.52-2.16-.39.024-.32.472-.234.763.09.288.207.487.371.74.114.167.192.416-.113.603-.673.416-1.842-.14-1.897-.168-1.361-.801-2.5-1.86-3.301-3.306-.775-1.393-1.225-2.888-1.299-4.482-.02-.385.094-.522.477-.592a4.7 4.7 0 0 1 1.53-.038c2.131.311 3.946 1.264 5.467 2.774.868.86 1.525 1.887 2.202 2.89.72 1.066 1.494 2.082 2.48 2.915.348.291.626.513.892.677-.802.09-2.14.109-3.055-.615zm1.001-6.44a.306.306 0 0 1 .415-.287.3.3 0 0 1 .113.074.3.3 0 0 1 .086.214c0 .17-.136.307-.308.307a.303.303 0 0 1-.306-.307m3.11 1.596c-.2.081-.4.151-.591.16a1.25 1.25 0 0 1-.798-.254c-.274-.23-.47-.358-.551-.758a1.7 1.7 0 0 1 .015-.588c.07-.327-.007-.537-.238-.727-.188-.156-.426-.199-.689-.199a.6.6 0 0 1-.254-.078.253.253 0 0 1-.114-.358 1 1 0 0 1 .192-.21c.356-.202.767-.136 1.146.016.352.144.618.408 1.001.782.392.451.462.576.685.915.176.264.336.536.446.848.066.194-.02.353-.25.45',
+    ink: [0, 3.17, 24, 17.66],
+  },
+  qwen: {
+    path: 'M23.919 14.545 20.817 9.17l1.47-2.544a.56.56 0 0 0 0-.566l-1.633-2.83a.57.57 0 0 0-.49-.283h-6.207L12.487.402a.57.57 0 0 0-.49-.284H8.732a.56.56 0 0 0-.49.284L5.139 5.775h-2.94a.56.56 0 0 0-.49.284L.077 8.887a.56.56 0 0 0 0 .567L3.18 14.83l-1.47 2.545a.56.56 0 0 0 0 .566l1.634 2.83a.57.57 0 0 0 .49.283h6.205l1.47 2.545a.57.57 0 0 0 .49.284h3.266a.57.57 0 0 0 .49-.284l3.104-5.375h2.94a.57.57 0 0 0 .49-.283l1.634-2.828a.55.55 0 0 0-.004-.568M8.733.686l1.634 2.828-1.634 2.828H21.8L20.164 9.17H7.425L5.63 6.06Zm1.306 19.801-6.205-.002 1.634-2.83h3.265L2.201 6.344h3.267q3.182 5.517 6.367 11.032zm10.124-5.66L18.53 12l-6.532 11.315-1.634-2.83c2.129-3.673 4.25-7.351 6.373-11.028h3.592l3.102 5.374z',
+    ink: [0, 0.12, 24, 23.77],
+  },
+  kimi: {
+    path: 'M21.765.351C22.998.351 24 1.353 24 2.586S22.998 4.82 21.765 4.82h-1.974c-.15 0-.26-.12-.26-.26V2.586A2.237 2.237 0 0 1 21.765.35M9.41 13.388l8.447-8.377c.16-.16.07-.471-.14-.471h-4.55s-.1.02-.14.06l-9.099 9.029c-.14.14-.35.02-.35-.21V4.81c0-.15-.1-.27-.221-.27H.22c-.12 0-.22.12-.22.27v18.57c0 .15.1.27.22.27h3.137c.12 0 .22-.12.22-.27v-3.79c0-.08.03-.16.08-.21l2.826-2.796c.07-.07.16-.08.241-.03l7.546 5.551a8.9 8.9 0 0 0 4.018 1.493c.12.01.23-.11.23-.27V19.76c0-.14-.08-.25-.19-.26a5.8 5.8 0 0 1-2.355-.942l-6.533-4.73c-.14-.09-.15-.32-.03-.441',
+    ink: [0, 0.35, 24, 23.3],
+  },
+  openrouter: {
+    path: 'M16.778 1.844v1.919q-.569-.026-1.138-.032-.708-.008-1.415.037c-1.93.126-4.023.728-6.149 2.237-2.911 2.066-2.731 1.95-4.14 2.75-.396.223-1.342.574-2.185.798-.841.225-1.753.333-1.751.333v4.229s.768.108 1.61.333c.842.224 1.789.575 2.185.799 1.41.798 1.228.683 4.14 2.75 2.126 1.509 4.22 2.11 6.148 2.236.88.058 1.716.041 2.555.005v1.918l7.222-4.168-7.222-4.17v2.176c-.86.038-1.611.065-2.278.021-1.364-.09-2.417-.357-3.979-1.465-2.244-1.593-2.866-2.027-3.68-2.508.889-.518 1.449-.906 3.822-2.59 1.56-1.109 2.614-1.377 3.978-1.466.667-.044 1.418-.017 2.278.02v2.176L24 6.014Z',
+    ink: [0, 1.84, 24, 20.31],
+  },
+  mistral: {
+    path: 'M17.143 3.429v3.428h-3.429v3.429h-3.428V6.857H6.857V3.43H3.43v13.714H0v3.428h10.286v-3.428H6.857v-3.429h3.429v3.429h3.429v-3.429h3.428v3.429h-3.428v3.428H24v-3.428h-3.43V3.429z',
+    ink: [0, 3.43, 24, 17.14],
+  },
+  openai: OPENAI_MARK,
+  anthropic: ANTHROPIC_MARK,
+};
+
+/** 自定义 is not a vendor, so it takes the field's own subject — an address you
+ *  supply — from the lucide set the dialog already uses. An outline where the
+ *  marks are solid, but the same rule: its ink is the 20-unit circle plus the
+ *  2-unit stroke half of which falls outside it, and the stroke narrows with the
+ *  rest of the drawing. */
+export const GLOBE_INK: Ink = [1, 1, 22, 22];


### PR DESCRIPTION
# One ink height for every vendor mark

The 服务商 picker merged in #1852 draws marks at visibly different sizes. Owner
screenshot of the merged menu: the letter fallbacks are small and light next to
the logos, and the logos do not agree with each other either.

## Why it happened

Two drawing systems, and one of them was not even self-consistent.

- **Letter fallbacks were drawn at font size inside the mark box.** A cap height
  is ~0.7 of a font size, so `fontSize="19"` in a 24-unit box put 13.8 units of
  ink on screen at regular weight — **8.06px against the OpenAI flower's
  14.00px**, and thinner as well as shorter.
- **The pictorial set was not one size either.** Simple Icons normalizes every
  path to 24 units of **width**, so ink *height* is whatever the logo's aspect
  leaves: 24.00 units for OpenAI, 20.31 for OpenRouter, 17.14 for Mistral,
  16.92 for Anthropic. Rendered into a 14px square slot that is 14.00px vs
  9.87px for two marks sitting four rows apart.

That second half is why no amount of per-glyph tuning fixes this, and why the
obvious rule does not work: fitting each mark into a 19-of-24 **square**
degenerates to `min(19/24, 19/24)` — one uniform 0.833 shrink that preserves the
spread exactly. Equalizing ink *height* in a square box is worse: Anthropic is
1.42 ink-widths per ink-height, so matching the tallest mark's cap height would
need ~27 units of width in a 24-unit box, and an SVG viewBox clips.

**Equal ink height therefore requires a box wider than tall.** That is the whole
design of this change.

## The rule

Every mark's measured ink is re-centred in a box scaled to hold `INK_HEIGHT`
(19) of `BOX_HEIGHT` (24) units of it, at a fixed `10 / 7` aspect:

- **Ink height becomes the one property the whole set shares.** 19 of 24 leaves
  equal 2.5-unit margins above and below every mark, whatever its outline.
- **The box aspect equals the slot aspect**, so `preserveAspectRatio` never
  letterboxes and the ink ratio holds unconditionally — the CSS states one
  `height: 14px` plus `aspect-ratio: 10 / 7`, and no second px value that could
  be changed without the first.
- **Ink fits iff its own aspect is under 1.8045:1.** Anthropic, the widest thing
  shipped, is 1.418:1 — 27% of headroom. A wordmark past that limit needs a
  wider slot, not a quiet crop, which is what the new test says.
- **Letters reach the same box from the other side.** No ink to measure ahead of
  time, but a cap height is a known fraction of a font size (0.70–0.73 across
  this app's sans stack), so `fontSize="26"` lands the cap at 18.2–19.2 units —
  inside the target band whichever font resolves — and weight **700** answers
  the other half of the complaint: a regular letter beside solid artwork is the
  lighter neighbour even at the right height.
- **`protocolGlyph.tsx` now draws through the vendor marks' own `Mark`.** The
  Anthropic and OpenAI artwork appears in this dialog as both an interface and a
  vendor; sharing the path string but not the drawing left the two free to
  diverge, and they had (a 24-unit box vs. a re-boxed one). Now they cannot.

## Evidence

Judged by rendered pixels, not viewBox numbers. Both rows below were produced
from the real components and the real stylesheet, measured in the browser —
`getBoundingClientRect` on each drawing's parts plus the half of any stroke that
falls outside them, and `measureText().actualBoundingBoxAscent` for a letter's
true cap.

**Ink height each glyph actually renders, in CSS px, at the shared 14px-tall slot:**

| | Anthropic | DeepSeek | Fireworks | Groq | Kimi | Mistral | OpenAI | OpenRouter | Qwen | Together | xAI | Zhipu AI | 自定义 | strip: OpenAI | strip: Anthropic |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| **before** | 9.87 | 10.30 | 8.06 | 8.17 | 13.59 | 10.00 | 14.00 | 11.85 | 13.86 | 8.06 | 8.06 | 8.06 | 12.83 | 14.00 | 9.87 |
| **after** | 11.08 | 11.08 | 11.03 | 11.18 | 11.08 | 11.09 | 11.08 | 11.08 | 11.08 | 11.03 | 11.03 | 11.03 | 11.08 | 11.08 | 11.08 |

Smallest-to-largest spread across the fifteen glyphs: **×1.74 → ×1.01**. The
residual 0.15px is the font stack's cap-height variance, not the rule.

The proof page measures the **slot** beside the ink, because an equal ink height
inside an unequal box still breaks the column: all fifteen slots are
`20.00 × 14.00px` and every menu label starts at the same x. That row exists
because it caught something — see the `width: auto` ledger entry.

- **Unit** — `vendorGlyph.test.tsx` gains the two optical properties, asserted
  over whatever the shipped catalog contains rather than a list restated in the
  test: every choice is drawn in a box of the **same shape** (so one CSS height
  is one ink height) with any letter at weight 700; and every mark's recorded
  ink is **centred** in that box at **19/24** of its height and **not wider than
  it**. 4 tests, and both new assertions were verified to bite: `INK_HEIGHT`
  19→20 fails with `deepseek puts a different amount of ink on screen: expected
  0.833 to be close to 0.792`, and dropping the horizontal centring fails with
  `deepseek sits off-centre horizontally: expected 12 to be close to 15.934`.
- **Suite** — full `ui/` vitest: 283 files / 3713 tests green.
- **Gates** — `npm run lint` clean with no baseline drift; `tsc -b` and
  `npm run build` clean.
- **Visual** — the before/after proof pages that produced the table above render
  the picker, both interface strips, and every mark in one 3× row against a band
  drawn at the target 11.08px. Before: letters far inside the band, OpenAI /
  Kimi / Qwen / globe bursting past it. After: every mark, letter and the globe
  filling it, and the two interface strips matching each other for the first
  time. PNGs are attached in the delivery thread — the GitHub API cannot upload
  an image into a PR body, so this is the one piece of evidence that is not
  inline; the numbers above are what those screenshots show.

Reproduce visually with `npm run dev` → Model Hub → Add API key → open 服务商.

## Known by design

- **The ink bounds are recorded measurements, not derived at render.** jsdom
  cannot compute a `getBBox`, and a runtime measure would add a render pass for
  static artwork. They were measured in a browser and are documented as
  re-measure-if-a-path-changes; the test asserts the *rule* holds over whatever
  is recorded, not that the four numbers still describe the path.
- **A letter's real cap height depends on the resolved font.** The stack is
  Inter (0.7273 cap/em) → SF Pro (~0.70) → Segoe UI (0.70) → Roboto (0.711), so
  the cap lands at 18.2–19.2 of the 19 units aimed at. That is the 11.03–11.18px
  spread in the table, and it is inside the target band for every font in the
  stack — a per-font correction would need a font-loaded measurement pass.
- **Kimi's ink includes a detached dot above the letterform**, so its K reads
  slightly shorter than a monogram at the same *ink* height. Normalizing its
  perceived stem instead would make its bounding ink taller than everything
  else's; that is per-mark taste, and this change is deliberately one rule.
- **The globe's stroke narrows with the drawing** (1.17px → 1.01px). It is
  lucide's outline where the rest are solid, and its 2-of-24 stroke scales like
  any other geometry rather than being corrected back — a fixed-point stroke
  correction for exactly one icon is more machinery than the difference is worth.
- **The shared slot is now 20×14px, not 14×14.** The three inline call sites in
  `AddApiKeyDialog.tsx` (segment button, success strip, idle line) shift ~6px to
  the right. `.model-hub-add-key-segments` is `width: fit-content`, so nothing
  overflows; the marks are wider than tall because the widest of them must be,
  and the fixed slot is what keeps the labels beside them in one column.
- **The rule states `width: auto`, and that is load-bearing** (thanks
  [@codex](https://github.com/avibe-bot/avibe/pull/1857#discussion_r3933810586)).
  `aspect-ratio` decides a width only while the other dimension is indefinite,
  and every lucide icon ships `width="24" height="24"`, so the CSS height alone
  left 自定义 in a 24×14 slot — measured, not argued: its label started at
  x=64.00 where the other twelve started at 60.00. `width: auto` fixes the class
  at the one declaration that owns size rather than at that call site, so an
  icon added later cannot bring its own width either. All fifteen slots now
  measure 20.00 × 14.00px; ink heights are unchanged, because a 24-wide slot was
  already height-bound by `meet` — which is exactly why an ink-only measurement
  could not see it.
- **The artwork moved to a new `vendorMarks.ts`.** Not a preference: exported
  `VendorMark` **objects** trip `react-refresh/only-export-components`, where
  the string literals they replace did not, and this repo's lint baseline
  reserves that exemption for `src/context/ApiContext.tsx` alone. Data plus the
  one boxing function on one side, the three ways a choice becomes ink on the
  other.
- **No behavior change and no new dependency.** Same catalog, same ids, same
  payloads, same fallback letters, same `aria-hidden` marks, same
  `currentColor`. `AddApiKeyDialog.tsx` is untouched.
