### PR TITLE
fix(model-hub): give the manual model draft its own two lines

### DIFF
--- a/ui/src/components/settings/models/SourceDetailPanel.test.tsx
+++ b/ui/src/components/settings/models/SourceDetailPanel.test.tsx
@@ -898,6 +898,27 @@ describe('SourceDetailPanel', () => {
     expect((add as HTMLButtonElement).disabled).toBe(true);
   });
 
+  // Where the draft's cells sit is the stylesheet's decision — it lays the band
+  // out over two lines of its own rather than in the columns the table header
+  // names — so no cell may restate the column count in its class list. Seeded in
+  // the state where every cell exists, a failed add, and asserted over whatever
+  // the band renders: a cell added later is covered without editing a list.
+  it('places every manual-draft cell without column arithmetic in the markup', async () => {
+    vi.spyOn(modelsApi, 'addCustomModel').mockRejectedValueOnce(new Error('write failed'));
+    renderPanel();
+    await userEvent.click(screen.getAllByRole('button', { name: /^Add model$|^添加模型$/i })[0]);
+    const draft = screen.getByPlaceholderText(/^Model ID$|^模型 ID$/i)
+      .closest('[data-manual-model-draft]') as HTMLElement;
+    await userEvent.type(within(draft).getByPlaceholderText(/^Model ID$|^模型 ID$/i), 'model-b');
+    await userEvent.click(within(draft).getByRole('button', { name: /^Add model$|^添加模型$/i }));
+    // The failure line is the fourth cell, and the only one that has to be
+    // waited for; the count is what proves the band is fully seeded.
+    await waitFor(() => { expect(draft.children.length).toBe(4); });
+
+    const cells = Array.from(draft.children).map((cell) => cell.className);
+    expect(cells.filter((name) => /(?:col|row)-(?:span|start|end)-/.test(name))).toEqual([]);
+  });
+
   it('keeps a failed refetch visible beside the inventory it could not replace', async () => {
     vi.spyOn(modelsApi, 'refreshSource').mockRejectedValueOnce(new Error('lost response'));
     renderPanel();

--- a/ui/src/components/settings/models/SourceDetailPanel.tsx
+++ b/ui/src/components/settings/models/SourceDetailPanel.tsx
@@ -1009,14 +1009,14 @@ export const SourceDetailPanel: React.FC<{
           <div
             data-manual-model-draft
             data-source-dialog-local-escape
-            className="model-hub-source-table-draft grid gap-3 border-y border-mint/20 bg-mint/[0.05] md:items-center md:gap-y-0"
+            className="model-hub-source-table-draft grid gap-3 border-y border-mint/20 bg-mint/[0.05] md:items-center"
             onKeyDown={(event) => {
               if (event.key !== 'Escape') return;
               event.preventDefault();
               if (!busy) setManualDraft(null);
             }}
           >
-            <span className="flex min-w-0 items-center gap-2"><Input
+            <span className="model-hub-source-draft-line flex min-w-0 items-center gap-2"><Input
                 autoFocus
                 value={manualDraft.modelId}
                 onChange={(event) => setManualDraft((current) => current ? { ...current, modelId: event.target.value, failed: false, retryRead: false } : current)}
@@ -1028,7 +1028,7 @@ export const SourceDetailPanel: React.FC<{
               <Button variant="ghost" size="xs" disabled={busy} onClick={() => setManualDraft(null)}>{t('common.cancel')}</Button>
               <Button size="xs" disabled={busy || !manualDraft.modelId.trim() || source.models.some((model) => model.id === manualDraft.modelId.trim())} onClick={() => void addManualModel()}>{manualDraft.failed ? t('settings.models.sourceDetail.retry') : t('settings.models.sourceDetail.action.addModel')}</Button>
             </div>
-            {manualDraft.failed && <p className="text-[11px] text-destructive-ink md:col-span-3">{t('settings.models.sourceDetail.fail.addModel')}</p>}
+            {manualDraft.failed && <p className="model-hub-source-draft-line text-[11px] text-destructive-ink">{t('settings.models.sourceDetail.fail.addModel')}</p>}
           </div>
         )}
         </div>

--- a/ui/src/components/settings/models/modelHubStylePolicy.test.ts
+++ b/ui/src/components/settings/models/modelHubStylePolicy.test.ts
@@ -123,4 +123,53 @@ describe('Model Hub visual token policy', () => {
 
     expect(restated).toEqual([]);
   });
+
+  // Both properties are decided by CSS that jsdom does not resolve — a grid track
+  // and a line break — so they are asserted where they are declared. They are
+  // stated as one rule each rather than as the rows that must not break: the
+  // manual-draft band broke because 手动添加 has no min-content floor to overflow
+  // against, and the same shape was already latent on any committed row whose
+  // model id was long enough to make its own pill the part that gives.
+  it('never lets a source-table pill be the part of a row that gives', () => {
+    const pill = surfaceCss.match(/\.model-hub-source-pill \{([^}]*)\}/)?.[1] ?? '';
+    expect(pill).toContain('white-space: nowrap');
+    expect(pill).toContain('flex-shrink: 0');
+
+    // And no call site hands the give back with a utility, whichever pill it draws.
+    const reopened = productFiles(__dirname).flatMap((path) => (
+      [...readFileSync(path, 'utf8').matchAll(/(['"`])((?:(?!\1)[\s\S])*)\1/g)]
+        .filter((match) => /model-hub-source-pill/.test(match[2])
+          && /(?:^|\s)(?:whitespace-(?!nowrap)|shrink(?!-0)|flex-shrink)/.test(match[2]))
+        .map((match) => `${path}:${match[2]}`)
+    ));
+
+    expect(reopened).toEqual([]);
+  });
+
+  // A column heading is a claim about the cells beneath it, so the draft either
+  // keeps the row's tracks or stops standing in them. It cannot do both: its
+  // controls are words where a row's are two 26px icons, and the only cell with
+  // room to pay the difference is the shared 1fr — which slides the tier cell
+  // out from under 推理强度. The draft takes its own two lines instead.
+  it('keeps the manual draft off the row columns and out of column arithmetic', () => {
+    // The property rather than the draft's own rule: whichever rule hands out
+    // the row template, its selector list must not name the draft. Reading only
+    // the override would pass while the shared rule still declared the token on
+    // the draft earlier and left source order to clean up after it.
+    const sharing = [...surfaceCssBody.matchAll(/([^{}]*)\{[^{}]*var\(--model-hub-source-table-columns\)[^{}]*\}/g)]
+      .map((match) => match[1]);
+    expect(sharing.some((selector) => selector.includes('model-hub-source-table-row'))).toBe(true);
+    for (const selector of sharing) expect(selector).not.toContain('model-hub-source-table-draft');
+
+    // Anchored on the preceding `}` so this is the draft's own rule, not the
+    // shared band whose selector list also ends in this class.
+    const draft = surfaceCssBody.match(/\}\s*\.model-hub-source-table-draft \{([^}]*)\}/)?.[1] ?? '';
+    expect(draft).toContain('grid-template-columns: minmax(0, 1fr) auto');
+
+    // Full width as a span to both edges, never as a count: the count has
+    // already changed once, and the cell that carried it through the change is
+    // how the failure line lands in an implicit fourth track.
+    const line = surfaceCssBody.match(/\.model-hub-source-draft-line \{([^}]*)\}/)?.[1] ?? '';
+    expect(line).toContain('grid-column: 1 / -1');
+  });
 });

--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -1248,12 +1248,19 @@
 }
 .model-hub-source-search { background: var(--model-hub-wash-05); }
 .model-hub-source-table { border-radius: var(--model-hub-source-radius); }
+/* Every band sits inside the same table edges and splits its cells by the same
+   gap, whether or not it stands in the table's columns. */
 .model-hub-source-table-head,
 .model-hub-source-table-row,
 .model-hub-source-table-draft {
-  grid-template-columns: var(--model-hub-source-table-columns);
   column-gap: var(--model-hub-source-table-gap);
   padding-inline: var(--model-hub-source-table-padding-x);
+}
+/* The columns are what a heading makes a claim about, so only the bands read
+   against that heading take them. */
+.model-hub-source-table-head,
+.model-hub-source-table-row {
+  grid-template-columns: var(--model-hub-source-table-columns);
 }
 .model-hub-source-row-action {
   width: 26px;
@@ -1281,11 +1288,23 @@
   min-height: var(--model-hub-source-table-row-height);
   padding-block: var(--model-hub-source-table-padding-y);
 }
+/* The draft is a form, not a row, so it stops claiming the row's columns.
+   Sharing them cannot work: the trailing track is cut for two 26px icon buttons,
+   the draft's controls are words instead — 取消 plus 添加模型 measure 128px, and
+   more than that in English — and the only cell with room to pay for the
+   difference is the shared 1fr, which would slide the tier cell out from under
+   the header it is read against. Two lines instead: the model id over the full
+   width, then the tier editor beside controls sized by their own labels. Height
+   follows that content, as it does for a row whose tier editor is open. */
 .model-hub-source-table-draft {
-  --model-hub-source-table-draft-height: 56px;
-  min-height: var(--model-hub-source-table-draft-height);
+  grid-template-columns: minmax(0, 1fr) auto;
   padding-block: var(--model-hub-source-table-padding-y);
 }
+/* Stated as a span to both edges rather than as a column count: the count is a
+   layout decision that has already changed once, and a cell carrying `col-span-3`
+   through that change is how the failure line ends up in an implicit fourth
+   track. Correct in the stacked band below md too, where there is one column. */
+.model-hub-source-draft-line { grid-column: 1 / -1; }
 .model-hub-source-add-hint {
   color: var(--model-hub-source-summary-ink);
   font-size: var(--model-hub-source-tier-size);
@@ -1299,10 +1318,20 @@
   --model-hub-source-manual-input-radius: 7px;
   border-radius: var(--model-hub-source-manual-input-radius);
 }
+/* A pill is a fixed label, so it is never the part of a row that gives. Both
+   declarations are load-bearing and neither works alone: `nowrap` because a
+   Chinese label has no min-content floor — it breaks between characters, so a
+   flex row that runs short turns 手动添加 into two lines instead of overflowing —
+   and `flex-shrink: 0` because nowrap alone would let the fill shrink out from
+   under text that no longer wraps. Stated here rather than at a call site: the
+   label beside a field or a truncating id is the same shape everywhere it
+   appears, and the field or the id is what should absorb the shortfall. */
 .model-hub-source-pill {
   --model-hub-source-pill-size: 10px;
   font-size: var(--model-hub-source-pill-size);
   line-height: 14px;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 .model-hub-source-tier { font-size: var(--model-hub-source-tier-size); }
 .model-hub-source-tier-chip {


### PR DESCRIPTION
## What changes

The manual add-model draft inside a source detail dialog (Model Hub → source →
模型) laid itself out wrong in two independent ways. Both are CSS; no behavior
moves.

1. **The 手动添加 origin pill wrapped.** It rendered as a tall blob with the
   label broken across two lines (手动添 / 加) between the model-id field and
   the tier editor.
2. **The draft crammed five controls onto one line.** A wide model-id input
   starved the tier editor and the 取消 / 添加模型 buttons, so the band's
   spacing and alignment did not match the committed rows above it.

## Root causes

**A Chinese label has no min-content floor to overflow against.** A flex item
whose text is `手动添加` can break between any two characters, so a row that
runs short silently turns the pill into two lines instead of pushing past its
neighbour. `.model-hub-source-pill` now declares `white-space: nowrap` **and**
`flex-shrink: 0`; neither works alone — without the second, `nowrap` lets the
rounded fill shrink out from under text that no longer wraps. Stated on the
pill rather than at a call site, because the label beside a field or beside a
truncating id is the same shape everywhere it appears, and the field or the id
is what should absorb the shortfall. That also settles the same latent wrap on
any *committed* row whose model id was long enough to squeeze its own pill —
`deepseek-v4-flash-vision-experimental-preview-1120` rendered 51px tall against
its siblings' 41px.

**A shared grid column cannot fund one band's wider controls.** The table's
trailing track is `64px`, cut for two 26px icon buttons. A draft's controls are
words instead: 取消 plus 添加模型 measure `48 + 8 + 72 = 128px`, and English
"Cancel" / "Add model" measure more. Nothing in the shared template can pay for
that difference — the only cell with room is the `1fr` the model id sits in, and
any width the trailing track takes from it *moves* the tier cell out from under
the 推理强度 heading it is read against. A fixed shared control track would
break under i18n; `subgrid` would restructure more than this fix should.

So the draft stops standing in the row's columns and takes two lines of its
own: the model id over the full width, then the tier editor beside controls
sized by their own labels (`minmax(0, 1fr) auto`). Its height follows that
content, exactly as a committed row's already does when its tier editor is
open, so the dead `--model-hub-source-table-draft-height: 56px` token is gone.
The column template now belongs only to the bands a heading makes a claim
about — head and row — rather than being handed to the draft and overwritten
three rules later.

Full-width cells say `grid-column: 1 / -1` rather than naming a column count.
That is column-count-agnostic, so it is correct both in the two-column band and
in the single-column band below `md` that the row grid already collapses to —
and it is what left the failure line's `col-span-3` behind when the count last
changed.

## Measurements

720px dialog (the real width) unless noted, headless Chrome against the built
stylesheets:

| | before | after |
|---|---|---|
| 手动添加 pill in the draft | 51.80 × 36.00, two 14px lines | **58.00 × 22.00, one line** |
| draft band | 56.00 tall, 3 cells on one line | 92.00 tall, two lines |
| draft model-id input | 352.20 | 614.00 (full width) |
| draft controls: need vs have | need 128.00, have 64.00 | need 128.00, have 128.00 |
| committed long-id row | 51.00 tall, pill 56.48 × 36.00 | 41.00 tall, pill 58.00 × 22.00 |
| narrow (468px dialog): pill / input | 52.03 × 36.00 / 367.97 | 58.00 × 22.00 / 362.00 |
| row with the tier editor expanded | 157.50 | 157.50 (untouched) |

The last line answers the third question in the brief: the expanded
`TierEditor` row is tall because of its own content inside the 180px the tier
column already gives it, not because of grid mis-sizing. It measures the same
before and after and is deliberately left alone.

`64px` of trailing track for `128px` of buttons overflows *leftward* under
`justify-end`, so `scrollWidth - clientWidth` reads `0` — the defect is only
visible as a needed-vs-have comparison, which is why the table above reports it
that way.

## Evidence

- **Rendered invariant** — `SourceDetailPanel.test.tsx`: seeded in the state
  where every draft cell exists (a failed add), asserts that *no* cell in the
  band carries column/row arithmetic in its class list. Stated over whatever
  the band renders, so a cell added later is covered without editing a list.
  Mutation-verified: re-adding `md:col-span-3` fails it.
- **Stylesheet policy** — `modelHubStylePolicy.test.ts`: the pill declares both
  no-give properties and no call site hands the give back with a utility;
  whichever rule hands out `--model-hub-source-table-columns` does not name the
  draft; the draft's full width is a span to both edges. Each assertion
  mutation-verified individually.
- **Suite** — `npm test`: 283 files / 3716 tests pass.
- **Gates** — `npm run build`, `npm run validate:theme`, `npm run lint` (798
  sources measured, no drift in any (file, rule) pair) all clean at this head.
- **Visual** — before/after captures at the 720px dialog width and at a narrow
  width, in the plain-draft state and with a tier editor expanded. Rendered
  from the real components against the real built stylesheets inside the actual
  dialog container. PNGs are attached in the delivery thread — the GitHub API
  cannot upload an image into a PR body.

## Known by design

- **The draft no longer aligns with the table's column headings.** That is the
  fix, not a residual: it is a form, and a heading is a claim about the cells
  beneath it. Aligning it would require either a control track that breaks
  under i18n or a `subgrid` restructure of the whole table.
- **The expanded `TierEditor` row stays 157.50px tall.** In scope only to
  confirm it is unchanged and intentional; the brief says not to redesign it.
- **The pill fix is stated once, for every source-table pill.** Committed rows
  currently look fine at typical id lengths, but they share the latent shape —
  the long-id row above was already 10px taller than its siblings.
- **`ui/scripts/lintBaseline.test.mjs` makes `npm run lint` non-reentrant.** It
  writes `ui/update-integrity-probe.ts` into the checkout for one test and
  removes it in `finally`, so a concurrent lint run races the deletion and
  exits ENOENT on a file that is not part of the tree. Out of this PR's scope;
  reported rather than edited. Lint is clean when not run alongside the suite.
